### PR TITLE
Replace Umami with Plausable

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -16,7 +16,7 @@
     <title>Pollinations.AI</title>  
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-LPZ9GEJVHR"></script>
-    <script async defer data-website-id="22ae6a7f-4a33-4a99-965a-bac1204ddcdc" src="https://umami.zencraft.studio/umami.js"></script>
+    <script defer data-domain="pollinations.ai" src="https://plausible.zencraft.studio/js/pl.js"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Replace Umami with Plausable as trial with Umami didn't went as expected. The biggest issue we had was user management with Umami, and in it's current state its not usable.

The Plausable is served from the same host that IPFS node is served from, and hit me up on discord if you'd like an account!