### PR TITLE
Update package versions and dependencies

### DIFF
--- a/pollinations-react/package-lock.json
+++ b/pollinations-react/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "pollinations-react",
-  "version": "1.1.6",
+  "name": "@pollinations/react",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pollinations-react",
-      "version": "1.1.6",
+      "name": "@pollinations/react",
+      "version": "1.4.6",
       "license": "ISC",
       "dependencies": {
+        "lodash.memoize": "^4.1.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-markdown": ">=7.0.0 <9.0.0"
@@ -1423,6 +1424,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/pollinations-react/package.json
+++ b/pollinations-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/react",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "description": "React components and hooks for Pollinations AI",
   "main": "./src/index.js",
   "module": "./src/index.js",
@@ -27,8 +27,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
+    "lodash.memoize": "^4.1.2",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-markdown": ">=7.0.0 <9.0.0"
   },
   "devDependencies": {

--- a/pollinations-react/src/components/PollinationsMarkdown.js
+++ b/pollinations-react/src/components/PollinationsMarkdown.js
@@ -10,8 +10,8 @@ import usePollinationsText from '../hooks/usePollinationsText';
  * @param {number} [props.seed=-1] - The seed for random text generation.
  * @returns {JSX.Element} - The PollinationsMarkdown component.
  */
-const PollinationsMarkdown = ({ children, seed = -1, promptPrefix = MARKDOWN_PROMPT_PREFIX, ...props }) => {
-    const markdown = usePollinationsText(promptPrefix + children, { seed });
+const PollinationsMarkdown = ({ children, seed = -1, model = null, promptPrefix = MARKDOWN_PROMPT_PREFIX, ...props }) => {
+    const markdown = usePollinationsText(promptPrefix + children, { seed, model });
 
     return React.createElement(ReactMarkdown, props, markdown);
 };

--- a/pollinations-react/src/hooks/usePollinationsChat.js
+++ b/pollinations-react/src/hooks/usePollinationsChat.js
@@ -9,7 +9,7 @@ import { useState, useCallback } from 'react';
  * @returns {Array} - The array of messages with the assistant's response added.
  */
 const usePollinationsChat = (initMessages = [], options = {}) => {
-    const { seed = 42, jsonMode = false, model = "gpt-4o" } = options;
+    const { seed = 42, jsonMode = false, model = "openai" } = options;
 
     const [messages, setMessages] = useState(initMessages);
 

--- a/pollinations-react/src/hooks/usePollinationsText.js
+++ b/pollinations-react/src/hooks/usePollinationsText.js
@@ -42,7 +42,7 @@ const memoizedFetchPollinationsText = memoize(fetchPollinationsText, JSON.string
  */
 const usePollinationsText = (prompt, options = {}) => {
     // Destructure options with default values
-    const { seed = -1, systemPrompt, model = "gpt-4o" } = options;
+    const { seed = -1, systemPrompt, model } = options;
 
     // State to hold the generated text
     const [text, setText] = useState("");


### PR DESCRIPTION
- Change package name to @pollinations/react
- Update version to 1.4.8
- Add lodash.memoize dependency
- Allow react and react-dom versions 16.8.0, 17.0.0, and 18.0.0
- Modify PollinationsMarkdown to accept model prop
- Change default model in usePollinationsChat to "openai"
- Remove default model in usePollinationsText options