### PR TITLE
800 add flux pro model from meoow

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,7 +13,7 @@
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.2",
         "@mui/material": "^6.1.0",
-        "@pollinations/react": "^2.0.5",
+        "@pollinations/react": "^2.0.6",
         "debug": "^4.3.2",
         "front-matter": "^4.0.2",
         "json5": "^2.2.1",
@@ -3358,9 +3358,9 @@
       }
     },
     "node_modules/@pollinations/react": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@pollinations/react/-/react-2.0.5.tgz",
-      "integrity": "sha512-ygsTX7kEhC5+sA1mZbHQpNkUWsDQ1PgFYLO4LHNdTMXttQ5W47W0T/gAWfc5h0YnA43axUgN1yidS3EGJN0W3Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@pollinations/react/-/react-2.0.6.tgz",
+      "integrity": "sha512-WlK8wz75u0wwSzyIzeoRGq/asWzjPnmTlhYTI+A61359Nck6qhuMESs4XY41hSxZQCnfYwLMv2Y/GKO8LtsvLw==",
       "dependencies": {
         "lodash.memoize": "^4.1.2",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.2",
     "@mui/material": "^6.1.0",
-    "@pollinations/react": "^2.0.5",
+    "@pollinations/react": "^2.0.6",
     "debug": "^4.3.2",
     "front-matter": "^4.0.2",
     "json5": "^2.2.1",

--- a/app/src/pages/Home/ImageFeed/ImageEditor.js
+++ b/app/src/pages/Home/ImageFeed/ImageEditor.js
@@ -95,11 +95,12 @@ export function ImageEditor({
               onClose={() => handleMenuClose(null)}
               MenuListProps={{ style: { textAlign: "left", backgroundColor: "black" } }}
             >
-              <MenuItem onClick={() => handleMenuClose("turbo")}>Turbo</MenuItem>
               <MenuItem onClick={() => handleMenuClose("flux")}>Flux</MenuItem>
+              <MenuItem onClick={() => handleMenuClose("flux-pro")}>Flux-Pro</MenuItem>
               <MenuItem onClick={() => handleMenuClose("flux-realism")}>Flux-Realism</MenuItem>
               <MenuItem onClick={() => handleMenuClose("flux-anime")}>Flux-Anime</MenuItem>
               <MenuItem onClick={() => handleMenuClose("flux-3d")}>Flux-3D</MenuItem>
+              <MenuItem onClick={() => handleMenuClose("turbo")}>Turbo</MenuItem>
             </Menu>
           </Grid>
           <Grid item xs={4}>

--- a/app/src/pages/Home/ImageHeading.js
+++ b/app/src/pages/Home/ImageHeading.js
@@ -36,7 +36,6 @@ export const ImageURLHeading = styled(
 
     const translatedPrompt = usePollinationsText("Translate the following text to i18n: '" + navigator.language.split("-")[0] + "'. If the text is already in English, just return the text. Don't give any explanation. Text:" + children, { seed: 45 });
 
-    console.log("imgtranslatedPrompt", translatedPrompt);
     const defaultPrompt = `An image with the text "${translatedPrompt || children}" displayed in an elegant, decorative serif font. The font has high contrast between thick and thin strokes, that give the text a sophisticated and stylized appearance. The text is in ${foregroundColor}, set against a solid ${backgroundColor} background, creating a striking and bold visual contrast. Incorporate elements related to pollinations, digital circuitry, such as flowers, chips, insects, wafers, and other organic forms into the design of the font. Each letter features unique, creative touches that make the typography stand out. Incorporate elements related to pollinations, digital circuitry, and organic forms into the design of the font.`;
     const prompt = encodeURIComponent(customPrompt || defaultPrompt);
 

--- a/image.pollinations.ai/src/groqPimp.js
+++ b/image.pollinations.ai/src/groqPimp.js
@@ -1,5 +1,6 @@
 "use strict";
 import fetch from 'node-fetch';
+import urldecode from 'urldecode';
 
 /**
  * Main function to get and print chat completion from Pollinations Text API.
@@ -18,6 +19,12 @@ async function main() {
  * @returns {Promise<string>} The chat completion response.
  */
 async function pimpPromptRaw(prompt, seed) {
+    try {
+        prompt = urldecode(prompt);
+    } catch (error) {
+        console.error("Error decoding prompt:", error);
+        // If decoding fails, use the original prompt
+    }
     let response = "";
     console.log("pimping prompt", prompt);
     const startTime = Date.now();

--- a/image.pollinations.ai/src/imageOperations.js
+++ b/image.pollinations.ai/src/imageOperations.js
@@ -85,7 +85,7 @@ export async function resizeImage(buffer, width, height) {
 * @returns {string|null} - The path to the logo file or null if no logo should be added.
 */
 export function getLogoPath(safeParams, isChild, isMature) {
-    if (MODELS[safeParams.model].type !== 'meoow' && (safeParams["nologo"] || safeParams["nofeed"] || isChild || isMature)) {
+    if (MODELS[safeParams.model].type.startsWith('meoow') && (safeParams["nologo"] || safeParams["nofeed"] || isChild || isMature)) {
         return null;
     }
     return MODELS[safeParams.model].type === 'meoow' ? 'logo_meoow.png' : 'logo.png';

--- a/image.pollinations.ai/src/imageOperations.js
+++ b/image.pollinations.ai/src/imageOperations.js
@@ -85,7 +85,7 @@ export async function resizeImage(buffer, width, height) {
 * @returns {string|null} - The path to the logo file or null if no logo should be added.
 */
 export function getLogoPath(safeParams, isChild, isMature) {
-    if (MODELS[safeParams.model].type.startsWith('meoow') && (safeParams["nologo"] || safeParams["nofeed"] || isChild || isMature)) {
+    if (MODELS[safeParams.model].type.startsWith('meoow') || (safeParams["nologo"] || safeParams["nofeed"] || isChild || isMature)) {
         return null;
     }
     return MODELS[safeParams.model].type === 'meoow' ? 'logo_meoow.png' : 'logo.png';

--- a/image.pollinations.ai/src/models.js
+++ b/image.pollinations.ai/src/models.js
@@ -4,5 +4,6 @@ export const MODELS = {
     "flux-anime": { type: "meoow", enhance: false, maxSideLength: 1384 },
     "flux-3d": { type: "meoow", enhance: false, maxSideLength: 1384 },
     "any-dark": { type: "meoow", enhance: false, maxSideLength: 1384 },
-    "turbo": { type: "pollinations", enhance: false, maxSideLength: 1024 } // Assuming 'turbo' is of type 'sd'
+    "flux-pro": { type: "meoow-2", enhance: false, maxSideLength: 1512 },
+    "turbo": { type: "pollinations", enhance: true, maxSideLength: 1024 } // Assuming 'turbo' is of type 'sd'
 };

--- a/pollinations-react/package.json
+++ b/pollinations-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/react",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "React components and hooks for Pollinations AI",
   "main": "./src/index.js",
   "module": "./src/index.js",

--- a/pollinations-react/src/hooks/usePollinationsImage.js
+++ b/pollinations-react/src/hooks/usePollinationsImage.js
@@ -16,7 +16,6 @@ import React, { useMemo } from 'react';
 const usePollinationsImage = (prompt, options = {}) => {
     const { width = 1024, height = 1024, model = 'flux', seed = 42, nologo = true, enhance = false } = options;
 
-    console.log("prompt", prompt);
     const imageUrl = useMemo(() => {
         const params = new URLSearchParams({ width, height, model, seed, nologo, enhance });
         return `https://pollinations.ai/p/${encodeURIComponent(prompt)}?${params.toString()}`;


### PR DESCRIPTION
# Add Flux Pro model from Meoow

## Description
This pull request introduces support for the Flux Pro model from Meoow-2 API integration. It includes updates to the image generation pipeline, UI components, and necessary configurations to accommodate the new model.

## Changes
1. Added support for Meoow-2 API integration in `createAndReturnImages.js`
2. Updated `ImageEditor.js` to include the Flux-Pro option in the model selection menu
3. Modified `imageOperations.js` to handle logo placement for Meoow-based models
4. Updated `models.js` to include the Flux-Pro model configuration
5. Implemented URL decoding for prompts in `groqPimp.js`

## Details
- Introduced a new API endpoint and authentication for Meoow-2
- Implemented `callMeoow2` function to handle requests to the new API
- Updated model selection logic to route requests to the appropriate API based on the chosen model
- Adjusted logo handling to accommodate Meoow and Meoow-2 based models
- Added URL decoding for prompts to ensure proper handling of encoded characters

## Testing
- Tested image generation with the new Flux-Pro model
- Verified correct logo placement for Meoow-based models
- Ensured backward compatibility with existing models and APIs

## Notes
- The Meoow-2 API key is stored in an environment variable `MEOOW_2_API_KEY`. Ensure this is properly set in the deployment environment.
- The maximum side length for Flux-Pro model images is set to 1512 pixels.

## Reviewers
@voodoohop

Please review the changes and let me know if any adjustments or additional information is needed.