### PR TITLE
Create redirect for elevator challenge

### DIFF
--- a/app/public/_redirects
+++ b/app/public/_redirects
@@ -4,3 +4,4 @@
 /p/* https://image.pollinations.ai/prompt/:splat 301
 /terms / 200
 /readme / 200
+/sirius-cybernetics-elevator-challenge https://b_jhzjeywxldc.v0.build/ 301


### PR DESCRIPTION
Fixes #840

Add redirect for `/sirius-cybernetics-elevator-challenge` to `https://b_jhzjeywxldc.v0.build/`.

* Modify `app/public/_redirects` to include the redirect rule `/sirius-cybernetics-elevator-challenge https://b_jhzjeywxldc.v0.build/ 301`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pollinations/pollinations/issues/840?shareId=a0cfe63b-0ef3-4cc8-94fc-e8a056c36b3e).