### PR TITLE
Add safe_mode parameter to handle NSFW content

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.js
+++ b/image.pollinations.ai/src/createAndReturnImages.js
@@ -245,6 +245,10 @@ export async function createAndReturnImageCached(prompt, safeParams, concurrentR
   const isChild = Object.values(concept?.special_scores || {})?.some(score => score > -0.05);
   console.error("isMature", isMature, "concepts", isChild);
 
+  if (safeParams.safe_mode && isMature) {
+    throw new Error("NSFW content detected in safe mode.");
+  }
+
   const logoPath = getLogoPath(safeParams, isChild, isMature);
   let bufferWithLegend = !logoPath ? bufferAndMaturity.buffer : await addPollinationsLogoWithImagemagick(bufferAndMaturity.buffer, logoPath, safeParams);
 

--- a/image.pollinations.ai/src/makeParamsSafe.js
+++ b/image.pollinations.ai/src/makeParamsSafe.js
@@ -2,16 +2,17 @@ import { MODELS } from './models.js';
 
 /**
  * Sanitizes and adjusts parameters for image generation.
- * @param {{ width: number|null, height: number|null, seed: number|string, model: string, enhance: boolean|string, refine: boolean|string, nologo: boolean|string, negative_prompt: string, nofeed: boolean|string }} params
+ * @param {{ width: number|null, height: number|null, seed: number|string, model: string, enhance: boolean|string, refine: boolean|string, nologo: boolean|string, negative_prompt: string, nofeed: boolean|string, safe_mode: boolean|string }} params
  * @returns {Object} - The sanitized parameters.
  */
-export const makeParamsSafe = ({ width = null, height = null, seed, model = "flux", enhance, refine = false, nologo = false, negative_prompt = "worst quality, blurry", nofeed = false }) => {
+export const makeParamsSafe = ({ width = null, height = null, seed, model = "flux", enhance, refine = false, nologo = false, negative_prompt = "worst quality, blurry", nofeed = false, safe_mode = false }) => {
     // Sanitize boolean parameters
     const sanitizeBoolean = (value) => value?.toLowerCase?.() === "true" ? true : value?.toLowerCase?.() === "false" ? false : value;
     refine = sanitizeBoolean(refine);
     enhance = sanitizeBoolean(enhance);
     nologo = sanitizeBoolean(nologo);
     nofeed = sanitizeBoolean(nofeed);
+    safe_mode = sanitizeBoolean(safe_mode);
 
     // Ensure model is one of the allowed models or default to "flux"
     const allowedModels = Object.keys(MODELS);
@@ -30,19 +31,16 @@ export const makeParamsSafe = ({ width = null, height = null, seed, model = "flu
     const maxSeedValue = 1844674407370955;
     seed = Number.isInteger(parseInt(seed)) ? parseInt(seed) : 42;
 
-
-
     if (seed < 0 || seed > maxSeedValue) {
         seed = 42;
     }
 
-    // // Adjust dimensions to maintain aspect ratio if exceeding maxPixels
+    // Adjust dimensions to maintain aspect ratio if exceeding maxPixels
     if (width * height > maxPixels) {
         const ratio = Math.sqrt(maxPixels / (width * height));
         width = Math.floor(width * ratio);
         height = Math.floor(height * ratio);
     }
 
-
-    return { width, height, seed, model, enhance, refine, nologo, negative_prompt, nofeed };
+    return { width, height, seed, model, enhance, refine, nologo, negative_prompt, nofeed, safe_mode };
 };


### PR DESCRIPTION
Related to #865

Add `safe_mode` parameter to handle NSFW content by throwing an error.

* **`image.pollinations.ai/src/createAndReturnImages.js`**
  - Add a check for `safe_mode` parameter in the `createAndReturnImageCached` function.
  - Throw an error if `safe_mode` is enabled and NSFW content is detected.

* **`image.pollinations.ai/src/makeParamsSafe.js`**
  - Add `safe_mode` parameter to the `makeParamsSafe` function.
  - Ensure the `safe_mode` parameter is properly handled and validated.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pollinations/pollinations/issues/865?shareId=609e7e19-71e1-4300-9d4a-60598877d790).