### PR TITLE
Add Safe Mode for NSFW Content Filtering

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -65,7 +65,7 @@ Docs: https://pollinations.ai/react-hooks
 - nologo: Set to 'true' to turn off the rendering of the logo. Default: false
 - private: Set to 'true' to prevent the image from appearing in the public feed. Default: false
 - enhance: Set to 'true' to turn on prompt enhancing (passes prompts through an LLM to add detail). Default: false
-- safe: Set to 'true' to enable strict NSFW content filtering. Default: false
+- safe: Set to 'true' to enable strict NSFW content filtering, throwing an error if NSFW content is detected. Default: false
 
 **Return:** Image file (typically JPEG or PNG)
 

--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -5,7 +5,7 @@
 ### Image Generation API (Default model: 'flux')
 
 Generate Image: `GET https://image.pollinations.ai/prompt/{prompt}`
-- Params: prompt*, model, seed, width, height, nologo, private, enhance
+- Params: prompt*, model, seed, width, height, nologo, private, enhance, safe
 - Return: Image file
 
 List Models: `GET https://image.pollinations.ai/models`
@@ -65,6 +65,7 @@ Docs: https://pollinations.ai/react-hooks
 - nologo: Set to 'true' to turn off the rendering of the logo. Default: false
 - private: Set to 'true' to prevent the image from appearing in the public feed. Default: false
 - enhance: Set to 'true' to turn on prompt enhancing (passes prompts through an LLM to add detail). Default: false
+- safe: Set to 'true' to enable strict NSFW content filtering. Default: false
 
 **Return:** Image file (typically JPEG or PNG)
 

--- a/image.pollinations.ai/src/createAndReturnImages.js
+++ b/image.pollinations.ai/src/createAndReturnImages.js
@@ -299,6 +299,11 @@ export async function createAndReturnImageCached(prompt, safeParams, concurrentR
   const isChild = Object.values(concept?.special_scores || {})?.some(score => score > -0.05);
   console.error("isMature", isMature, "concepts", isChild);
 
+  // Throw error if NSFW content is detected and safe mode is enabled
+  if (safeParams.safe && (isMature || isChild)) {
+    throw new Error("NSFW content detected. This request cannot be fulfilled when safe mode is enabled.");
+  }
+
   const logoPath = getLogoPath(safeParams, isChild, isMature);
   let bufferWithLegend = !logoPath ? bufferAndMaturity.buffer : await addPollinationsLogoWithImagemagick(bufferAndMaturity.buffer, logoPath, safeParams);
 

--- a/image.pollinations.ai/src/makeParamsSafe.js
+++ b/image.pollinations.ai/src/makeParamsSafe.js
@@ -2,15 +2,16 @@ import { MODELS } from './models.js';
 
 /**
  * Sanitizes and adjusts parameters for image generation.
- * @param {{ width: number|null, height: number|null, seed: number|string, model: string, enhance: boolean|string, nologo: boolean|string, negative_prompt: string, nofeed: boolean|string }} params
+ * @param {{ width: number|null, height: number|null, seed: number|string, model: string, enhance: boolean|string, nologo: boolean|string, negative_prompt: string, nofeed: boolean|string, safe: boolean|string }} params
  * @returns {Object} - The sanitized parameters.
  */
-export const makeParamsSafe = ({ width = null, height = null, seed, model = "flux", enhance, nologo = false, negative_prompt = "worst quality, blurry", nofeed = false }) => {
+export const makeParamsSafe = ({ width = null, height = null, seed, model = "flux", enhance, nologo = false, negative_prompt = "worst quality, blurry", nofeed = false, safe = false }) => {
     // Sanitize boolean parameters
     const sanitizeBoolean = (value) => value?.toLowerCase?.() === "true" ? true : value?.toLowerCase?.() === "false" ? false : value;
     enhance = sanitizeBoolean(enhance);
     nologo = sanitizeBoolean(nologo);
     nofeed = sanitizeBoolean(nofeed);
+    safe = sanitizeBoolean(safe);
 
     // Ensure model is one of the allowed models or default to "flux"
     const allowedModels = Object.keys(MODELS);
@@ -29,8 +30,6 @@ export const makeParamsSafe = ({ width = null, height = null, seed, model = "flu
     const maxSeedValue = 1844674407370955;
     seed = Number.isInteger(parseInt(seed)) ? parseInt(seed) : 42;
 
-
-
     if (seed < 0 || seed > maxSeedValue) {
         seed = 42;
     }
@@ -42,6 +41,5 @@ export const makeParamsSafe = ({ width = null, height = null, seed, model = "flu
         height = Math.floor(height * ratio);
     }
 
-
-    return { width, height, seed, model, enhance, nologo, negative_prompt, nofeed };
+    return { width, height, seed, model, enhance, nologo, negative_prompt, nofeed, safe };
 };

--- a/pollinations.ai/src/pages/Home/CodeExamples.js
+++ b/pollinations.ai/src/pages/Home/CodeExamples.js
@@ -39,7 +39,7 @@ const CODE_EXAMPLES = {
 ### Image Generation API (Default model: 'flux')
 
 Generate Image: \`GET https://image.pollinations.ai/prompt/{prompt}\`
-- Params: prompt*, model, seed, width, height, nologo, private, enhance
+- Params: prompt*, model, seed, width, height, nologo, private, enhance, safe
 - Return: Image file
 
 List Models: \`GET https://image.pollinations.ai/models\`
@@ -459,4 +459,3 @@ export function CodeExamples({ image }) {
 }
 
 const shorten = (str) => (str.length > 60 ? str.slice(0, 60) + "..." : str)
-


### PR DESCRIPTION
# NSFW Content Filtering: Safe Mode Parameter

## Overview
This PR adds a new `safe` parameter that enables strict NSFW content filtering. When enabled, the API will throw an error instead of returning images that are detected as NSFW or child-related content.

## Changes
- Added new `safe` parameter to `makeParamsSafe` function (defaults to `false`)
- Modified `createAndReturnImageCached` to throw an error when `safe=true` and NSFW content is detected
- Updated error message to clarify when safe mode is enabled

## Usage

**Default behavior (allows NSFW):**
```
https://image.pollinations.ai/prompt/your_prompt
```

**Safe mode (blocks NSFW):**
```
https://image.pollinations.ai/prompt/your_prompt?safe=true
```

## Testing Checklist

- [ ] Verify default behavior remains unchanged (NSFW images allowed, metadata preserved)
- [ ] Verify safe mode blocks NSFW content with appropriate error message
- [ ] Verify NSFW metadata is still included in:
  - Analytics
  - Feed listeners
  - Image EXIF data
- [ ] Test with various image generation models (flux, meoow, etc.)

## Impact
This change is backward compatible:
- No changes to existing behavior when safe parameter is not used
- All NSFW detection and metadata functionality remains intact
- Only adds new error-throwing behavior when explicitly enabled

## Example Error Message
When safe mode is enabled and NSFW content is detected:
```
NSFW content detected. This request cannot be fulfilled when safe mode is enabled.
```

## Implementation Details
- Implement error throw for NSFW content when safe mode is enabled
- Add 'safe' parameter to makeParamsSafe function
- Ensure 'safe' parameter is sanitized and included in return object