### PR TITLE
Add `nohup.out` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+nohup.out
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json


### PR DESCRIPTION
`nohup.out` is a log file, and pushing it to the repository causes the repository's size to increase with no clear benefits.