### PR TITLE
Feature/model donation wrapper

### DIFF
--- a/text.pollinations.ai/availableModels.js
+++ b/text.pollinations.ai/availableModels.js
@@ -3,6 +3,7 @@ import { generateDeepseek } from './generateDeepseek.js';
 import { generateTextSearch } from './generateTextSearch.js';
 import { generateTextPortkey } from './generateTextPortkey.js';
 import wrapModelWithContext from './wrapModelWithContext.js';
+import wrapModelWithDonationMessage from './modelDonationWrapper.js';
 
 // Import persona prompts
 import surSystemPrompt from './personas/sur.js';
@@ -136,7 +137,14 @@ export const availableModels = [
         censored: true,
         description: 'Claude 3.5 Haiku',
         baseModel: true,
-        handler: (messages, options) => generateTextPortkey(messages, {...options, model: 'claude'})
+        handler: wrapModelWithDonationMessage(
+            (messages, options) => generateTextPortkey(messages, {...options, model: 'claude'}),
+            'Claude 3.5 Haiku',
+            {
+                threshold: 50,
+                currentDonations: 47
+            }
+        )
     },
     {
         name: 'deepseek-r1',

--- a/text.pollinations.ai/modelDonationWrapper.js
+++ b/text.pollinations.ai/modelDonationWrapper.js
@@ -1,0 +1,102 @@
+/**
+ * modelDonationWrapper.js
+ * 
+ * This module provides a wrapper for model handlers to catch errors and return 
+ * a donation message when models run out of credits.
+ */
+
+import debug from 'debug';
+
+const log = debug('pollinations:donation-wrapper');
+const errorLog = debug('pollinations:donation-wrapper:error');
+
+/**
+ * Creates a wrapped version of a model handler that catches errors
+ * and returns a donation message.
+ * 
+ * @param {Function} modelHandler - The original model handler function
+ * @param {string} modelName - The name of the model being wrapped
+ * @param {Object} options - Options for the wrapper
+ * @returns {Function} A wrapped handler function
+ */
+export function wrapModelWithDonationMessage(modelHandler, modelName, options = {}) {
+    // Donation message configuration
+    const donationConfig = {
+        threshold: options.threshold || 50,
+        currentDonations: options.currentDonations || 47,
+        kofiLink: options.kofiLink || 'https://ko-fi.com/pollinationsai',
+        ...options
+    };
+
+    // Return the wrapped handler function
+    return async function wrappedHandler(messages, handlerOptions = {}) {
+        try {
+            // Attempt to run the original model handler
+            return await modelHandler(messages, handlerOptions);
+        } catch (error) {
+            // Log the original error
+            errorLog(`Error in ${modelName} model:`, error);
+
+            // Create a user-friendly message about the error
+            const errorMessage = {
+                id: `donation-${Date.now()}`,
+                object: "chat.completion",
+                created: Math.floor(Date.now() / 1000),
+                model: modelName,
+                choices: [
+                    {
+                        index: 0,
+                        message: {
+                            role: "assistant",
+                            content: formatDonationMessage(modelName, donationConfig)
+                        },
+                        finish_reason: "stop"
+                    }
+                ],
+                usage: {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    total_tokens: 0
+                },
+                donation_request: true
+            };
+
+            log(`Returning donation message for ${modelName}`);
+            return errorMessage;
+        }
+    };
+}
+
+/**
+ * Formats a donation message for the specified model
+ * 
+ * @param {string} modelName - The model that needs donations
+ * @param {Object} config - Donation configuration
+ * @returns {string} Formatted donation message
+ */
+function formatDonationMessage(modelName, config) {
+    const remainingNeeded = config.threshold - config.currentDonations;
+    
+    return `
+## ⚠️ ${modelName} credits have run out
+
+We need your help to keep this service running! Our AI models rely on external APIs that require credits.
+
+### We're so close!
+
+We need to reach **$${config.threshold}** to reactivate ${modelName} for everyone.
+**$${config.currentDonations}** has already been donated - we're only **$${remainingNeeded}** away!
+
+**Your donation can make the difference!** Even a small contribution of $3 could bring ${modelName} back online.
+
+### Our Promise
+
+When we reach our goal, ${modelName} will be guaranteed to remain online for a full week for all users.
+
+[💰 Donate Now at Ko-fi](${config.kofiLink})
+
+Thank you for helping keep Pollinations.AI free and accessible for everyone! 🙏
+`;
+}
+
+export default wrapModelWithDonationMessage;

--- a/text.pollinations.ai/modelDonationWrapper.js
+++ b/text.pollinations.ai/modelDonationWrapper.js
@@ -32,7 +32,12 @@ export function wrapModelWithDonationMessage(modelHandler, modelName, options = 
     return async function wrappedHandler(messages, handlerOptions = {}) {
         try {
             // Attempt to run the original model handler
-            return await modelHandler(messages, handlerOptions);
+            const result = await modelHandler(messages, handlerOptions);
+
+            // console.log("rrresult", result)
+            if (result?.error)
+                throw result.error;
+            return result;
         } catch (error) {
             // Log the original error
             errorLog(`Error in ${modelName} model:`, error);
@@ -78,24 +83,26 @@ function formatDonationMessage(modelName, config) {
     const remainingNeeded = config.threshold - config.currentDonations;
     
     return `
-## ⚠️ ${modelName} credits have run out
+## Claude is powered by Pollinations.ai
 
-We need your help to keep this service running! Our AI models rely on external APIs that require credits.
+We're currently experiencing high demand for ${modelName}. Our AI models rely on external APIs that require credits.
 
-### We're so close!
+### Current Status
 
-We need to reach **$${config.threshold}** to reactivate ${modelName} for everyone.
-**$${config.currentDonations}** has already been donated - we're only **$${remainingNeeded}** away!
+We're aiming to reach **$${config.threshold}** to keep ${modelName} available for everyone.
+**$${config.currentDonations}** has been donated so far - we're **$${remainingNeeded}** away from our goal.
 
-**Your donation can make the difference!** Even a small contribution of $3 could bring ${modelName} back online.
+If you'd like to support this service, a contribution of any size would be appreciated. 
 
-### Our Promise
+### Our Commitment
 
-When we reach our goal, ${modelName} will be guaranteed to remain online for a full week for all users.
+When we reach our goal, ${modelName} will be available for a full week for all users.
 
-[💰 Donate Now at Ko-fi](${config.kofiLink})
+Donate at: ${config.kofiLink}
 
-Thank you for helping keep Pollinations.AI free and accessible for everyone! 🙏
+**Note:** The other models are still available if you'd like to continue using Pollinations.ai without donating.
+
+Thank you for your understanding and support in keeping Pollinations.ai accessible! 🙏
 `;
 }
 

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -150,12 +150,58 @@ export function getQueue(ip) {
 
 // Function to get IP address
 export function getIp(req) {
-    const ip = req.headers["x-bb-ip"] || req.headers["x-nf-client-connection-ip"] || req.headers["x-real-ip"] || req.headers['x-forwarded-for'] || req.headers['referer'] || req.socket.remoteAddress;
+    // Prioritize standard proxy headers and add cloudflare-specific headers
+    const ip = req.headers["x-bb-ip"] || 
+               req.headers["x-nf-client-connection-ip"] || 
+               req.headers["x-real-ip"] || 
+               req.headers['x-forwarded-for'] || 
+               req.headers['cf-connecting-ip'] ||
+               (req.socket ? req.socket.remoteAddress : null);
+    
     if (!ip) return null;
-    const ipSegments = ip.split('.').slice(0, 3).join('.');
-    // if (ipSegments === "128.116")
-    //     throw new Error('Pollinations cloud credits exceeded. Please try again later.');
-    return ipSegments;
+    
+    // Handle x-forwarded-for which can contain multiple IPs (client, proxy1, proxy2, ...)
+    // The client IP is typically the first one in the list
+    const cleanIp = ip.split(',')[0].trim();
+    
+    // Check if IPv4 or IPv6
+    if (cleanIp.includes(':')) {
+        // IPv6 address
+        // For IPv6, the first 4 segments (64 bits) typically identify the network
+        // This is usually the global routing prefix (48 bits) + subnet ID (16 bits)
+        // We'll take the first 4 segments to identify the network while preserving privacy
+        
+        // Handle special IPv6 formats like ::1 or 2001::
+        const segments = cleanIp.split(':');
+        let normalizedSegments = [];
+        
+        // Handle :: notation (compressed zeros)
+        if (cleanIp.includes('::')) {
+            const parts = cleanIp.split('::');
+            const leftPart = parts[0] ? parts[0].split(':') : [];
+            const rightPart = parts[1] ? parts[1].split(':') : [];
+            
+            // Calculate how many zero segments are represented by ::
+            const missingSegments = 8 - leftPart.length - rightPart.length;
+            
+            normalizedSegments = [
+                ...leftPart,
+                ...Array(missingSegments).fill('0'),
+                ...rightPart
+            ];
+        } else {
+            normalizedSegments = segments;
+        }
+        
+        // Take the first 4 segments (64 bits) which typically represent the network prefix
+        return normalizedSegments.slice(0, 4).join(':');
+    } else {
+        // IPv4 address - take first 3 segments as before
+        const ipv4Segments = cleanIp.split('.').slice(0, 3).join('.');
+        // if (ipv4Segments === "128.116")
+        //     throw new Error('Pollinations cloud credits exceeded. Please try again later.');
+        return ipv4Segments;
+    }
 }
 
 // GET /models request handler

--- a/text.pollinations.ai/tools/searchTool.js
+++ b/text.pollinations.ai/tools/searchTool.js
@@ -18,7 +18,7 @@ export const searchToolDefinition = {
     type: "function",
     function: {
         name: "web_search",
-        description: "Search the web for current information about a topic. Try to get as many results as possible (minimum 20, maximum 100).",
+        description: "Search the web for current information about a topic. Try to get as many results as possible (minimum 1, maximum 7).",
         parameters: {
             type: "object",
             properties: {
@@ -28,8 +28,8 @@ export const searchToolDefinition = {
                 },
                 num_results: {
                     type: "number",
-                    description: "Number of results to return (min 20, max 100)",
-                    default: 20
+                    description: "Number of results to return (min 1, max 7)",
+                    default: 3
                 }
             },
             required: ["query"]


### PR DESCRIPTION
PR: Feature - Model Donation Wrapper
Changes
Added a model donation wrapper system to handle API credit limitations
Implements a mechanism to show donation messages when models run out of credits
Added token usage tracking by referrer and IP address in the feed-filter-cli
Improved IP address handling to better support both IPv4 and IPv6 formats
Reduced the default number of search results from 20 to 3 (max from 100 to 7)
The wrapper appears to target Claude 3.5 Haiku specifically, showing a donation request when API credits are depleted. The system tracks progress toward a $50 donation goal (currently at $47) to keep the model available for all users.