### PR TITLE
Fix trailofbits.python.pickles-in-pytorch.pickles-in-pytorch--tmp-80b76e23-113c-4755-9ed2-6f69e5f5609b-image.pollinations.ai-image_gen_dmd2-combined_predict.py

### DIFF
--- a/image.pollinations.ai/image_gen_dmd2/combined_predict.py
+++ b/image.pollinations.ai/image_gen_dmd2/combined_predict.py
@@ -4072,7 +4072,7 @@ class Predictor(BasePredictor):
             connect_list=["32", "64", "128", "256"],
         ).to(self.device)
         ckpt_path = "weights/CodeFormer/codeformer.pth"
-        checkpoint = torch.load(ckpt_path)[
+        checkpoint = torch.load(ckpt_path, map_location="cpu")[
             "params_ema"
         ]  # update file permission if cannot load
         self.net.load_state_dict(checkpoint)
@@ -4358,7 +4358,7 @@ class Predictor(BasePredictor):
             connect_list=["32", "64", "128", "256"],
         ).to(self.device)
         ckpt_path = "weights/CodeFormer/codeformer.pth"
-        checkpoint = torch.load(ckpt_path)[
+        checkpoint = torch.load(ckpt_path, map_location="cpu")[
             "params_ema"
         ]  # update file permission if cannot load
         self.net.load_state_dict(checkpoint)


### PR DESCRIPTION
This PR fixes trailofbits.python.pickles-in-pytorch.pickles-in-pytorch--tmp-80b76e23-113c-4755-9ed2-6f69e5f5609b-image.pollinations.ai-image_gen_dmd2-combined_predict.py.