### PR TITLE
Filter text feed to only display entries with no referrer

### DIFF
--- a/pollinations.ai/src/utils/useTextFeedLoader.js
+++ b/pollinations.ai/src/utils/useTextFeedLoader.js
@@ -62,7 +62,11 @@ export function useTextFeedLoader(onNewEntry, setLastEntry) {
                 !data.parameters?.messages
               );
               
-              if (isGetRequest) {
+              // Check if referrer is not set
+              const hasNoReferrer = !data.referrer || data.referrer === '' || 
+                                   (!data.parameters?.referrer || data.parameters?.referrer === '');
+              
+              if (isGetRequest && hasNoReferrer) {
                 // Ensure required properties exist
                 const processedData = {
                   ...data,
@@ -73,23 +77,24 @@ export function useTextFeedLoader(onNewEntry, setLastEntry) {
                 setLastEntry(processedData);
                 onNewEntry(processedData);
               } else {
-                console.log("Skipping non-GET last entry:", 
+                console.log("Skipping entry:", 
                   data.parameters?.method, 
                   data.parameters?.type,
-                  data.parameters?.messages ? "has messages" : "no messages"
+                  data.parameters?.messages ? "has messages" : "no messages",
+                  hasNoReferrer ? "no referrer" : "has referrer"
                 );
                 
-                // If the last entry is not a GET request, try to load another one
+                // If the entry doesn't meet our criteria, try to load another one
                 if (retryCount < MAX_RETRIES) {
                   retryCount++;
-                  console.log(`Retry ${retryCount}/${MAX_RETRIES} to find GET entry`);
+                  console.log(`Retry ${retryCount}/${MAX_RETRIES} to find suitable entry`);
                   setTimeout(fetchLastEntry, 1000);
                 } else {
-                  console.log(`Failed to find GET entry after ${MAX_RETRIES} retries`);
+                  console.log(`Failed to find suitable entry after ${MAX_RETRIES} retries`);
                   // Create a fallback entry if needed
                   const fallbackEntry = {
                     response: "Welcome to Pollinations Text Feed. Enter a prompt to get started.",
-                    referrer: "pollinations.ai",
+                    referrer: "",
                     parameters: {
                       method: "GET",
                       type: "fallback"

--- a/pollinations.ai/src/utils/useTextSSEFeed.js
+++ b/pollinations.ai/src/utils/useTextSSEFeed.js
@@ -45,7 +45,11 @@ export const useTextSlideshow = (mode) => {
         !newEntry.parameters?.messages
       );
       
-      if (isGetRequest) {
+      // Check if referrer is not set
+      const hasNoReferrer = !newEntry.referrer || newEntry.referrer === '' || 
+                           (!newEntry.parameters?.referrer || newEntry.parameters?.referrer === '');
+      
+      if (isGetRequest && hasNoReferrer) {
         const processedEntry = processEntry(newEntry);
         setPendingEntries(entries => [...entries, processedEntry]);
         
@@ -54,10 +58,11 @@ export const useTextSlideshow = (mode) => {
           detail: { entry: processedEntry } 
         }));
       } else {
-        console.log("Skipping non-GET entry:", 
+        console.log("Skipping entry:", 
           newEntry.parameters?.method, 
           newEntry.parameters?.type,
-          newEntry.parameters?.messages ? "has messages" : "no messages"
+          newEntry.parameters?.messages ? "has messages" : "no messages",
+          hasNoReferrer ? "no referrer" : "has referrer"
         );
       }
     }


### PR DESCRIPTION
This PR modifies the text feed to only display entries where the referrer is not set.

## Changes
1. Modified `useTextSSEFeed.js` to add a `hasNoReferrer` check that filters out entries with a referrer
2. Modified `useTextFeedLoader.js` to apply the same filter to the initial entry loading
3. Updated the fallback entry to have an empty referrer string
4. Improved logging to indicate when entries are skipped due to having a referrer

These changes maintain the \"thin proxy\" design principle by making minimal modifications to the existing code structure while adding the new filtering capability.

## Testing
The text feed will now only display entries where the referrer is not set. Console logs will show which entries are being filtered out.