### PR TITLE
Add support for detecting bad domains in referrer and origin headers with 100% ad probability

### DIFF
--- a/text.pollinations.ai/requestUtils.js
+++ b/text.pollinations.ai/requestUtils.js
@@ -16,7 +16,7 @@ export const WHITELISTED_DOMAINS = process.env.WHITELISTED_DOMAINS
  * @returns {string} - Referrer string
  */
 export function getReferrer(req, data) {
-    const referer = req.headers.referer || req.headers.referrer || data.referrer || req.headers['http-referer'] || 'unknown';
+    const referer = req.headers.referer || req.headers.referrer || req.headers.origin || data.referrer || data.origin || req.headers['http-referer'] || 'unknown';
     return referer;
 }
 


### PR DESCRIPTION
## Changes

This PR implements handling for bad domains in referrer and origin headers with 100% ad probability:

1. Added support for reading `BAD_DOMAINS` environment variable (comma-separated list)
2. Modified the referrer checking logic to detect bad domains and force 100% ad probability when found
3. Added support for checking the `origin` header when the referrer is not present
4. Improved analytics logging for bad domain detection

## Implementation Details

- Added parsing of `BAD_DOMAINS` environment variable in `initRequestFilter.js`
- Updated `getReferrer` function in `requestUtils.js` to check for origin header
- Modified `shouldShowAds` function to detect bad domains and set 100% probability
- Updated `generateAdForContent` to handle the bad domain flag
- Improved analytics logging to include origin header information

## Testing

To test this functionality:
1. Add domains to the `BAD_DOMAINS` environment variable (comma-separated)
2. Send requests with referrers or origin headers containing those domains
3. Verify that ads are shown with 100% probability

This implements the requested feature to always show ads when requests come from specified bad domains.