### PR TITLE
Enable multimodal support for Cloudflare Workers AI models

### DIFF
--- a/text.pollinations.ai/availableModels.js
+++ b/text.pollinations.ai/availableModels.js
@@ -69,7 +69,7 @@ const models = [
     handler: generateTextPortkey,
     //    details: "Llama 4 Scout model optimized for efficient text generation.",
     provider: "Cloudflare",
-    input_modalities: ["text"],
+    input_modalities: ["text", "image"],
     output_modalities: ["text"],
   },
   {


### PR DESCRIPTION
This PR enables multimodal support for Cloudflare Workers AI models (Mistral and Llama 4 Scout) through the Portkey gateway.

## Changes

- Updated the Cloudflare model configuration in `generateTextPortkey.js` to use the Workers AI provider instead of OpenAI
- Added the `fn: 'chatComplete'` parameter to Mistral and Llama 4 Scout model configurations
- Updated the `availableModels.js` file to correctly identify Llama 4 Scout as supporting image inputs

These changes allow the Portkey gateway to properly handle image inputs for Cloudflare-hosted models by using the Workers AI provider implementation instead of the OpenAI-compatible one.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author