### PR TITLE
Switch Mistral model from Cloudflare to Scaleway

### DIFF
--- a/text.pollinations.ai/generateTextPortkey.js
+++ b/text.pollinations.ai/generateTextPortkey.js
@@ -15,7 +15,7 @@ const errorLog = debug('pollinations:portkey:error');
 const MODEL_MAPPING = {
     // Azure OpenAI models
     'openai': 'gpt-4.1-nano',       // Maps to portkeyConfig['gpt-4o-mini']
-    'openai-large': 'azure-gpt-4.1-mini',  
+    'openai-large': 'azure-gpt-4.1-mini',
     'openai-xlarge': 'azure-gpt-4.1-xlarge', // Maps to the new xlarge endpoint
     'openai-reasoning': 'o4-mini', // Maps to portkeyConfig['o1-mini'],
     // 'openai-audio': 'gpt-4o-mini-audio-preview',
@@ -33,7 +33,7 @@ const MODEL_MAPPING = {
     'phi-mini': 'phi-4-mini-instruct',
     // Scaleway models
     'qwen-coder': 'qwen2.5-coder-32b-instruct',
-    'mistral': '@cf/mistralai/mistral-small-3.1-24b-instruct',  // Updated to use Cloudflare Mistral model
+    'mistral': 'mistral-small-3.1-24b-instruct-2503',  // Updated to use Scaleway Mistral model
     'deepseek-reasoning-large': 'deepseek-r1-distill-llama-70b',
     // Modal models
     'hormoz': 'Hormoz-8B',
@@ -372,9 +372,10 @@ export const portkeyConfig = {
     'llama-3.3-70b-instruct': () => createScalewayModelConfig(),
     'deepseek-r1-distill-llama-70b': () => createScalewayModelConfig(),
     // Mistral model configuration
-    '@cf/mistralai/mistral-small-3.1-24b-instruct': () => createCloudflareModelConfig({
+    'mistral-small-3.1-24b-instruct-2503': () => createMistralModelConfig({
         'max-tokens': 8192,
-        temperature: 0.3
+        temperature: 0.3,
+        'model': "mistral-small-3.1-24b-instruct-2503"
     }),
     // Modal model configurations
     'Hormoz-8B': () => createModalModelConfig(),
@@ -407,7 +408,7 @@ export const portkeyConfig = {
     }),
     'gemini-2.0-flash-thinking': () => ({
         provider: 'vertex-ai',
-        authKey: googleCloudAuth.getAccessToken, 
+        authKey: googleCloudAuth.getAccessToken,
         'vertex-project-id': process.env.GCLOUD_PROJECT_ID,
         'vertex-region': 'us-central1',
         'vertex-model-id': 'gemini-2.0-flash-thinking',
@@ -422,24 +423,24 @@ export const portkeyConfig = {
 export const generateTextPortkey = createOpenAICompatibleClient({
     // Use Portkey API Gateway URL from .env with fallback to localhost
     endpoint: () => `${process.env.PORTKEY_GATEWAY_URL || 'http://localhost:8787'}/v1/chat/completions`,
-    
+
     // Auth header configuration
     authHeaderName: 'Authorization',
     authHeaderValue: () => {
         // Use the actual Portkey API key from environment variables
         return `Bearer ${process.env.PORTKEY_API_KEY}`;
     },
-    
+
     // Additional headers will be dynamically set in transformRequest
     additionalHeaders: {},
-    
+
     // Models that don't support system messages will have system messages converted to user messages
     // This decision is made based on the model being requested
     supportsSystemMessages: (options) => {
         // Check if it's a model that doesn't support system messages
         return !['openai-reasoning', 'o4-mini', 'deepseek-reasoning'].includes(options.model);
     },
-    
+
     // Transform request to add Azure-specific headers based on the model
     transformRequest: async (requestBody) => {
         try {
@@ -449,7 +450,7 @@ export const generateTextPortkey = createOpenAICompatibleClient({
             // Check character limit
             const MAX_CHARS = 512000;
             const totalChars = countMessageCharacters(requestBody.messages);
-            
+
             if (totalChars > MAX_CHARS) {
                 errorLog('Input text exceeds maximum length of %d characters (current: %d)', MAX_CHARS, totalChars);
                 throw new Error(`Input text exceeds maximum length of ${MAX_CHARS} characters (current: ${totalChars})`);
@@ -469,14 +470,14 @@ export const generateTextPortkey = createOpenAICompatibleClient({
             // Generate headers (now async call)
             const additionalHeaders = await generatePortkeyHeaders(config);
             log('Added provider-specific headers:', JSON.stringify(additionalHeaders, null, 2));
-            
+
             // Set the headers as a property on the request object that will be used by genericOpenAIClient
             requestBody._additionalHeaders = additionalHeaders;
-            
+
             // Check if the model has a specific maxTokens limit in availableModels.js
             // Use the model name from requestBody instead of options which isn't available here
             const modelConfig = findModelByName(requestBody.model);
-            
+
             // For models with specific token limits or those using defaults
             if (!requestBody.max_tokens) {
                 if (modelConfig && modelConfig.maxTokens) {
@@ -489,21 +490,21 @@ export const generateTextPortkey = createOpenAICompatibleClient({
                     requestBody.max_tokens = config['max-tokens'];
                 }
             }
-            
+
             // Special handling for o1-mini model which requires max_completion_tokens instead of max_tokens
             if (modelName === 'o1-mini' && requestBody.max_tokens) {
                 log(`Converting max_tokens to max_completion_tokens for o1-mini model`);
                 requestBody.max_completion_tokens = requestBody.max_tokens;
                 delete requestBody.max_tokens;
             }
-            
+
             return requestBody;
         } catch (error) {
             errorLog('Error in request transformation:', error);
             throw error;
         }
     },
-    
+
     // Model mapping, system prompts, and default options
     modelMapping: MODEL_MAPPING,
     systemPrompts: SYSTEM_PROMPTS,


### PR DESCRIPTION
This PR switches the Mistral model from using Cloudflare to using Scaleway.

## Changes:

1. Changed the model mapping in MODEL_MAPPING (line 36):
   - From: `'mistral': '@cf/mistralai/mistral-small-3.1-24b-instruct'` (Cloudflare)
   - To: `'mistral': 'mistral-small-3.1-24b-instruct'` (Scaleway)

2. Changed the model configuration in portkeyConfig (lines 374-378):
   - From: Using `createCloudflareModelConfig()` with the Cloudflare model ID
   - To: Using `createMistralModelConfig()` with the Scaleway model ID
   - Kept the same parameters (`max-tokens: 8192, temperature: 0.3`)

The Mistral model will now use the Scaleway configuration instead of Cloudflare. The changes maintain the same parameters (max tokens and temperature) but switch the underlying provider.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author