### PR TITLE
Switch Mistral models to use Portkey gateway and increase ad probability

### DIFF
--- a/text.pollinations.ai/ads/initRequestFilter.js
+++ b/text.pollinations.ai/ads/initRequestFilter.js
@@ -14,7 +14,7 @@ const errorLog = debug('pollinations:adfilter:error');
 const markdownRegex = /(?:\*\*.*\*\*)|(?:\[.*\]\(.*\))|(?:\#.*)|(?:\*.*\*)|(?:\`.*\`)|(?:\>.*)|(?:\-\s.*)|(?:\d\.\s.*)/;
 
 // Probability of adding referral links (10%)
-const REFERRAL_LINK_PROBABILITY = 0.03;
+const REFERRAL_LINK_PROBABILITY = 0.07;
 
 // Flag for testing ads with a specific marker
 const TEST_ADS_MARKER = "p-ads";

--- a/text.pollinations.ai/wrappedModels.js
+++ b/text.pollinations.ai/wrappedModels.js
@@ -15,7 +15,7 @@ import hypnosisTracyPrompt from "./personas/hypnosisTracy.js";
 
 export const surMistral = wrapModelWithContext(
   surSystemPrompt,
-  generateTextMistral,
+  generateTextPortkey,
   "mistral"
 );
 
@@ -27,7 +27,7 @@ export const hypnosisTracy = wrapModelWithContext(
 
 export const unityMistralLarge = wrapModelWithContext(
   unityPrompt,
-  generateTextMistral,
+  generateTextPortkey,
   "mistral"
 );
 
@@ -45,6 +45,6 @@ export const rtist = wrapModelWithContext(
 
 export const evilCommandR = wrapModelWithContext(
   evilPrompt,
-  generateTextMistral,
+  generateTextPortkey,
   "mistral"
-); 
+);


### PR DESCRIPTION
## Changes

- Switched all Mistral-based models in `wrappedModels.js` to use `generateTextPortkey` instead of `generateTextMistral`
- Increased ad referral link probability from 3% to 7% in `ads/initRequestFilter.js`

## Motivation

This change migrates Mistral models to use the Portkey gateway, which provides better integration with Cloudflare AI Workers and supports multimodal functionality. The Portkey gateway implementation is more robust and offers better performance than the direct Mistral API integration.

The ad probability increase helps improve monetization while still maintaining a good user experience.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author