### PR TITLE
Add authentication to feed listeners for secure access

### DIFF
--- a/image.pollinations.ai/src/feedListeners.js
+++ b/image.pollinations.ai/src/feedListeners.js
@@ -1,8 +1,10 @@
 import { parse } from 'url';
 import debug from 'debug';
 import { isMature } from './utils/mature.js';
+import 'dotenv/config';
 
 const logFeed = debug('pollinations:feed');
+const logAuth = debug('pollinations:auth');
 
 let feedListeners = [];
 let lastStates = [];
@@ -23,8 +25,15 @@ export const registerFeedListener = async (req, res) => {
     'Connection': 'keep-alive'
   });
 
-  // add listener to feedListeners - NSFW parameter is now ignored
-  feedListeners = [...feedListeners, { res }];
+  // Check if the password query parameter matches the FEED_PASSWORD
+  const isAuthenticated = query.password === process.env.FEED_PASSWORD;
+
+  if (isAuthenticated) {
+    logAuth('Authenticated feed access granted');
+  }
+
+  // add listener to feedListeners with authentication status
+  feedListeners = [...feedListeners, { res, isAuthenticated }];
 
   // remove listener when connection closes
   req.on('close', () => {
@@ -36,7 +45,7 @@ export const registerFeedListener = async (req, res) => {
   const statesToSend = lastStates.slice(-pastResults);
 
   for (const lastState of statesToSend) {
-    await sendToListener(res, lastState);
+    await sendToListener(res, lastState, isAuthenticated);
   }
 };
 
@@ -45,26 +54,29 @@ export const sendToFeedListeners = (data, options = {}) => {
   if (data?.prompt && !data?.isMature) {
     data.isMature = isMature(data.prompt);
   }
-  
+
   if (options.saveAsLastState) {
     lastStates.push(data);
   }
-  feedListeners.forEach(listener => sendToListener(listener.res, data));
+  feedListeners.forEach(listener => sendToListener(listener.res, data, listener.isAuthenticated));
 };
 
-function sendToListener(listener, data) {
-  // Always filter out mature content regardless of client preferences
-  if (
-    data?.private || 
-    data?.nsfw || 
-    data?.isChild || 
-    data?.isMature || 
-    data?.maturity?.nsfw || 
-    data?.maturity?.isChild || 
-    data?.maturity?.isMature || 
-    (data?.prompt && isMature(data?.prompt))
-  ) return;
-  
-  logFeed("data", data);
+function sendToListener(listener, data, isAuthenticated = false) {
+  // If authenticated with the correct password, send all data without filtering
+  if (!isAuthenticated) {
+    // Filter out mature content for non-authenticated users
+    if (
+      data?.private ||
+      data?.nsfw ||
+      data?.isChild ||
+      data?.isMature ||
+      data?.maturity?.nsfw ||
+      data?.maturity?.isChild ||
+      data?.maturity?.isMature ||
+      (data?.prompt && isMature(data?.prompt))
+    ) return;
+  }
+
+  logFeed("data", isAuthenticated ? "[authenticated]" : "", data);
   return listener.write(`data: ${JSON.stringify(data)}\n\n`);
 }


### PR DESCRIPTION
## Description
This PR adds authentication to the feed listeners system, allowing for secure access to the feed data.

### Changes
- Added password-based authentication to feed listeners
- Implemented different behavior for authenticated vs. non-authenticated users
- Authenticated users can see all feed data, including mature content
- Non-authenticated users continue to have mature content filtered out
- Added logging for authentication events

### Implementation Details
- Uses an environment variable `FEED_PASSWORD` to store the authentication password
- Checks the password query parameter against the environment variable
- Tracks authentication status in the feed listener object
- Modifies the sending logic to respect authentication status

### Security Considerations
- Ensures mature content is only visible to authenticated users
- Logs authentication events for monitoring
- Maintains backward compatibility for existing users

This change enhances security while providing a way for authorized users to access the complete feed data.