### PR TITLE
Add image generation for ads with p-ads marker and improve ad contextualization

### DIFF
--- a/text.pollinations.ai/ads/initRequestFilter.js
+++ b/text.pollinations.ai/ads/initRequestFilter.js
@@ -301,7 +301,7 @@ async function generateAdForContent(content, req, messages, markerFound = false,
                 }
 
                 // Generate the ad string for Ko-fi
-                const adString = await generateAffiliateAd("kofi", content, messages);
+                const adString = await generateAffiliateAd("kofi", content, messages, markerFound || detectedMarker);
 
                 if (adString) {
                     // Extract info for analytics
@@ -346,13 +346,13 @@ async function generateAdForContent(content, req, messages, markerFound = false,
         // If affiliate data is found, generate the ad string
         if (affiliateData) {
             // Pass content and messages to enable language matching
-            const adString = await generateAffiliateAd(affiliateData.id, content, messages);
+            const adString = await generateAffiliateAd(affiliateData.id, content, messages, markerFound || detectedMarker);
 
             // If ad generation failed but we should force an ad (p-ads marker present)
             if (!adString && shouldForceAd) {
                 log('Ad generation failed, but p-ads marker is present. Using Ko-fi as fallback.');
                 // Try with Ko-fi as a fallback
-                const kofiAdString = await generateAffiliateAd("kofi", content, messages);
+                const kofiAdString = await generateAffiliateAd("kofi", content, messages, markerFound || detectedMarker);
 
                 if (kofiAdString && req) {
                     // Extract info for analytics

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -825,7 +825,19 @@ async function generateTextBasedOnModel(messages, options) {
         }
         
         // Apply Roblox-specific fix if needed
-        const processedMessages = handleRobloxSpecificFix(messages, model);
+        const robloxFixedMessages = handleRobloxSpecificFix(messages, model);
+        
+        // Remove p-ads marker from messages to prevent it from affecting the LLM context
+        const processedMessages = robloxFixedMessages.map(msg => {
+            if (msg.content && typeof msg.content === 'string') {
+                // Remove the p-ads marker from the message content
+                return {
+                    ...msg,
+                    content: msg.content.replace(/p-ads/g, '')
+                };
+            }
+            return msg;
+        });
         
         // Log the messages being sent
         log('Sending messages to model handler:', JSON.stringify(processedMessages.map(m => ({ role: m.role, content: typeof m.content === 'string' ? m.content.substring(0, 50) + '...' : '[non-string content]' }))));


### PR DESCRIPTION
This PR enhances the ad system with the following improvements:

1. **Image Generation for Ads**: When the `p-ads` marker is detected in content, ads will now include a contextually relevant image
   - Images are generated based on the affiliate data and ad text
   - Images are displayed in a styled div alongside the ad text
   - Image size is set to 120x120px for a clean, compact appearance

2. **Improved Ad Contextualization**: Enhanced the ad generation process to create more personalized ads
   - Added a better prompt with explicit instructions for creating short, concise, and contextually relevant ads
   - Added a system role message to the LLM to improve ad quality
   - Improved logging to better track the contextualization process

3. **P-ads Marker Handling**: Added functionality to remove the `p-ads` marker from messages before they're sent to the LLM
   - This prevents the marker from contaminating the LLM's context
   - The marker is still detected and used to trigger the ad generation functionality
   - All calls to `generateAffiliateAd` now pass the `markerFound` parameter

These changes provide a more robust ad system with better visual appeal while ensuring the `p-ads` marker doesn't affect the LLM's responses.