### PR TITLE
Add tracking pixel function with short URL redirect

### DIFF
--- a/pollinations.ai/functions/track.js
+++ b/pollinations.ai/functions/track.js
@@ -1,0 +1,37 @@
+export async function handler(event, context) {
+  // Collect all query parameters
+  const { queryStringParameters } = event;
+  
+  // Gather information about the request
+  const requestInfo = {
+    timestamp: new Date().toISOString(),
+    queryParams: queryStringParameters || {},
+    headers: event.headers || {},
+    ip: event.requestContext?.identity?.sourceIp || 'unknown',
+    userAgent: event.headers?.['user-agent'] || event.headers?.['User-Agent'] || 'unknown',
+    referer: event.headers?.referer || event.headers?.Referer || 'unknown',
+    path: event.path,
+    httpMethod: event.httpMethod,
+    requestId: event.requestContext?.requestId || context.awsRequestId || 'unknown',
+    // Add any other relevant information from the request object
+  };
+
+  // Log the tracking information
+  console.log('Tracking request:', JSON.stringify(requestInfo, null, 2));
+
+  // Return a 1x1 transparent pixel GIF
+  // This is a minimal valid GIF format for a 1x1 transparent pixel
+  const transparentPixelGif = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64');
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'image/gif',
+      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      'Pragma': 'no-cache',
+      'Expires': '0',
+    },
+    body: transparentPixelGif.toString('base64'),
+    isBase64Encoded: true
+  };
+}

--- a/pollinations.ai/netlify.toml
+++ b/pollinations.ai/netlify.toml
@@ -7,6 +7,12 @@
   status = 200
   force = true
 
+[[redirects]]
+  from = "/t/*"
+  to = "/.netlify/functions/track/:splat"
+  status = 200
+  force = true
+
 # Ensure Netlify preserves the React router paths
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
This PR adds a new serverless function `track.js` that returns a 1x1 transparent pixel GIF for tracking purposes, along with a short URL redirect configuration.

## Features
- Returns a transparent 1x1 pixel GIF image
- Collects and logs all query parameters
- Gathers comprehensive request information (IP, user agent, referer, etc.)
- Sets appropriate headers to prevent caching
- Adds a short URL redirect from `/t/*` to the tracking function

## Usage
The tracking pixel can be used by including an image tag with a short, clean URL:
```html
<img src="https://pollinations.ai/t?campaign=spring2025&source=email" alt="" style="display:none" />
```

This provides a simple way to track events, page views, email opens, and other user interactions without affecting the user experience.