### PR TITLE
Fix server crash when invalid token is provided

### DIFF
--- a/shared/auth-utils.js
+++ b/shared/auth-utils.js
@@ -371,12 +371,20 @@ export async function shouldBypassQueue(req, { legacyTokens, allowlist }) {
       return { bypass:true, reason:'LEGACY_TOKEN', userId:null, debugInfo };
     }
     
-    // If token is provided but not valid, throw an error
+    // If token is provided but not valid, return error info instead of throwing
+    // This prevents the server from crashing while maintaining proper error handling
     debugInfo.authResult = 'INVALID_TOKEN';
-    const error = new Error('Invalid token provided');
-    error.status = 401;
-    error.details = { debugInfo };
-    throw error;
+    return { 
+      bypass: false, 
+      reason: 'INVALID_TOKEN', 
+      userId: null, 
+      debugInfo,
+      error: {
+        message: 'Invalid token provided',
+        status: 401,
+        details: { debugInfo }
+      }
+    };
   }
   
   // 3️⃣ Check for legacy token in referrer (no error thrown for invalid referrers)

--- a/shared/ipQueue.js
+++ b/shared/ipQueue.js
@@ -8,7 +8,13 @@
  */
 
 import PQueue from 'p-queue';
+import debug from 'debug';
 import { shouldBypassQueue } from './auth-utils.js';
+
+// Set up debug loggers with namespaces
+const log = debug('pollinations:queue');
+const errorLog = debug('pollinations:error');
+const authLog = debug('pollinations:auth');
 
 // In-memory queue storage
 const queues = new Map();
@@ -31,38 +37,85 @@ export async function enqueue(req, fn, { interval=6000, cap=1 }={}) {
     allowlist: process.env.ALLOWLISTED_DOMAINS ? process.env.ALLOWLISTED_DOMAINS.split(',') : []
   };
   
+  // Log authentication context
+  authLog('Authentication context created with %d legacy tokens and %d allowlisted domains', 
+          authContext.legacyTokens.length,
+          authContext.allowlist.length);
+  
+  // Extract useful request info for logging
+  const url = req.url || 'no-url';
+  const method = req.method || 'no-method';
+  const path = url.split('?')[0] || 'no-path';
+  const ip = req.headers?.get?.('cf-connecting-ip') || 
+            req.headers?.['cf-connecting-ip'] || 
+            req.ip || 
+            'unknown';
+  
+  authLog('Processing request: %s %s from IP: %s', method, path, ip);
+  
   // Get queue bypass decision with auth context
+  authLog('Calling shouldBypassQueue for request: %s', path);
   const authResult = await shouldBypassQueue(req, authContext);
+  
+  // Log the authentication result
+  authLog('Authentication result: reason=%s, bypass=%s, userId=%s', 
+          authResult.reason, 
+          authResult.bypass, 
+          authResult.userId || 'none');
   
   // Check if there's an error in the auth result (invalid token)
   if (authResult.error) {
-    console.error('Authentication error:', authResult.error.message);
+    // Detailed logging of authentication errors
+    errorLog('Authentication error: %s (status: %d)', 
+             authResult.error.message, 
+             authResult.error.status);
+    
+    // Log detailed debug info
+    if (authResult.debugInfo) {
+      authLog('Auth debug info: token source=%s, referrer=%s, authResult=%s',
+              authResult.debugInfo.tokenSource || 'none',
+              authResult.debugInfo.referrer || 'none',
+              authResult.debugInfo.authResult);
+    }
+    
     // Create a proper error object to throw
     const error = new Error(authResult.error.message);
     error.status = authResult.error.status;
     error.details = authResult.error.details;
+    
     // Add extra context for debugging
     error.queueContext = {
       authContextLength: JSON.stringify(authContext).length,
+      request: { method, path, ip },
       issuedAt: new Date().toISOString()
     };
+    
+    errorLog('Throwing authentication error with status %d for request: %s %s', 
+             error.status, method, path);
     throw error;
   }
   
   // If bypass is true, execute the function immediately
-  if (authResult.bypass) return fn();
+  if (authResult.bypass) {
+    log('Queue bypass granted for reason: %s, executing immediately', authResult.reason);
+    return fn();
+  }
   
   // Otherwise, queue the function based on IP
-  const ip = req.headers.get?.('cf-connecting-ip') || 
-             req.headers['cf-connecting-ip'] || 
-             req.ip || 
-             'unknown';
-             
+  log('Request queued for IP: %s (queue size: %d)', ip, queues.get(ip)?.size || 0);
+  
+  // Create queue for this IP if it doesn't exist
   if (!queues.has(ip)) {
+    log('Creating new queue for IP: %s with interval: %dms, cap: %d', ip, interval, cap);
     queues.set(ip, new PQueue({ concurrency: 1, interval, intervalCap: cap }));
   }
   
-  return queues.get(ip).add(fn);
+  // Add to queue and return
+  log('Adding request to queue for IP: %s', ip);
+  return queues.get(ip).add(() => {
+    log('Executing queued request for IP: %s', ip);
+    return fn();
+  });
 }
 
 /**

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pollinations-shared",
       "version": "1.0.0",
       "dependencies": {
+        "debug": "^4.4.1",
         "dotenv": "^16.5.0",
         "node-fetch": "^3.3.2",
         "p-queue": "^7.4.1"
@@ -20,6 +21,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/dotenv": {
@@ -74,6 +92,12 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
+    "debug": "^4.4.1",
     "dotenv": "^16.5.0",
     "node-fetch": "^3.3.2",
     "p-queue": "^7.4.1"

--- a/text.pollinations.ai/package-lock.json
+++ b/text.pollinations.ai/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.7.7",
         "commander": "^13.1.0",
         "cors": "^2.8.5",
+        "debug": "^4.4.1",
         "dotenv": "^16.0.3",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.2",
@@ -2512,9 +2513,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/text.pollinations.ai/package.json
+++ b/text.pollinations.ai/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.7.7",
     "commander": "^13.1.0",
     "cors": "^2.8.5",
+    "debug": "^4.4.1",
     "dotenv": "^16.0.3",
     "eventsource": "^3.0.2",
     "eventsource-parser": "^3.0.2",

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -473,14 +473,7 @@ async function processRequest(req, res, requestData) {
     }
     
     // Use shared queue for rate limiting
-    try {
-        await enqueue(req, async () => {
-            await handleRequest(req, res, requestData);
-        }, QUEUE_CONFIG);
-    } catch (error) {
-        errorLog('Error in queue processing: %s', error.message);
-        throw error;
-    }
+    await enqueue(req, () => handleRequest(req, res, requestData), QUEUE_CONFIG);
 
     // Note: We've removed the duplicate handleRequest calls that were causing the headers error
     // The shared enqueue function above now handles all queue logic, including bypass logic


### PR DESCRIPTION
## Problem
The text.pollinations.ai service crashes when an invalid authentication token is provided rather than returning a proper 401 Unauthorized response.

## Changes Made
This PR addresses two key issues:

1. **Fix server crash with invalid tokens:**
   - Modified `shouldBypassQueue` in `auth-utils.js` to return an error object instead of throwing an error
   - Updated `ipQueue.js` to handle this error information properly
   - Allows the existing endpoint handlers to use their error handling code for proper HTTP responses

2. **Enhanced debug logging:**
   - Replaced console.error with detailed debug library logging
   - Added comprehensive logging throughout the authentication flow
   - Created separate logging namespaces for different concerns:
     - pollinations:auth - General authentication info
     - pollinations:auth:token - Token-specific debugging
     - pollinations:auth:referrer - Referrer validation
     - pollinations:error - Error conditions
     - pollinations:queue - Queue operations

## Benefits
- Server remains running even when invalid tokens are provided
- Clients receive proper 401 responses with error details
- Improved debugging with more context in error logs
- Maintains the "thin proxy" design principle by enhancing observability without changing the core behavior

## Testing
Verified that:
- The server no longer crashes when an invalid token is provided
- A proper 401 response is returned with error details
- All error information is correctly logged

Fixes #2117