### PR TITLE
Fix: Ensure image service requests always go through queue

### DIFF
--- a/image.pollinations.ai/src/index.js
+++ b/image.pollinations.ai/src/index.js
@@ -309,7 +309,7 @@ const checkCacheAndGenerate = async (req, res) => {
         // Update progress and process the image
         progress.setProcessing();
         return generateImage();
-      }, queueConfig);
+      }, { ...queueConfig, forceQueue: true });
 
       return result;
     });


### PR DESCRIPTION
## Summary
This PR fixes issue #2130 where authenticated requests to the image service were bypassing the queue and running in parallel.

## Problem
Authenticated requests to the gptimage model were being processed in parallel instead of being queued sequentially. This occurred because the shared ipQueue utility was bypassing the queue entirely for authenticated requests.

## Solution
1. Added a `forceQueue` parameter to the `enqueue` function in `ipQueue.js`
   - When `forceQueue: true`, the queue is enforced even for authenticated requests
   - Default behavior remains unchanged for other services
2. Modified the image service to pass `forceQueue: true` when calling enqueue
   - Ensures all image requests go through the queue
   - Authenticated requests still benefit from reduced interval delays

## Changes
- `shared/ipQueue.js`: Added `forceQueue` parameter to prevent queue bypass
- `image.pollinations.ai/src/index.js`: Pass `forceQueue: true` to enqueue

## Impact
- ✅ All image service requests now properly go through the queue
- ✅ Authenticated requests still benefit from reduced interval delays (100ms vs 10s)
- ✅ Requests from the same IP are properly serialized by PQueue's concurrency control
- ✅ No impact on other services that use the shared queue utility

## Testing
The fix should be tested by:
1. Making multiple concurrent authenticated requests to gptimage from the same IP
2. Verifying that requests are processed sequentially, not in parallel
3. Confirming that authenticated requests still get reduced delay benefits

Fixes #2130