### PR TITLE
Support multiple reference images in Azure GPT Image edit mode

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.js
+++ b/image.pollinations.ai/src/createAndReturnImages.js
@@ -506,10 +506,8 @@ export const callAzureGPTImage = async (prompt, safeParams) => {
             }
             
             const buffer = await imageResponse.buffer();
-            // Use a unique field name for each image (image, image1, image2, etc.)
-            // First image has no suffix to maintain backward compatibility
-            const fieldName = i === 0 ? 'image' : `image${i}`;
-            formData.append(fieldName, buffer, { filename: `image${i}.png` });
+            // Use the image[] array notation as required by Azure OpenAI API
+            formData.append('image[]', buffer, { filename: `image${i}.png` });
         }
       } catch (error) {
         logError('Error processing image for editing:', error);

--- a/image.pollinations.ai/src/createAndReturnImages.js
+++ b/image.pollinations.ai/src/createAndReturnImages.js
@@ -485,23 +485,31 @@ export const callAzureGPTImage = async (prompt, safeParams) => {
       // Add the prompt
       formData.append('prompt', sanitizeString(prompt));
       
-      // Handle the image based on its type
+      // Handle images based on their type
       try {
-        // Use the first image URL from the array (backward compatible with string type)
-        const imageUrl = Array.isArray(safeParams.image) ? safeParams.image[0] : safeParams.image;
+        // Convert to array if it's a string (backward compatible)
+        const imageUrls = Array.isArray(safeParams.image) ? safeParams.image : [safeParams.image];
         
-        if (imageUrl) {
-            // Fetch image from URL
-            logCloudflare(`Fetching image from URL: ${imageUrl}`);
+        if (imageUrls.length === 0) {
+            // Handle errors for missing image
+            throw new Error('Image URL is required for GPT Image edit mode but was not provided');
+        }
+        
+        // Process each image in the array
+        for (let i = 0; i < imageUrls.length; i++) {
+            const imageUrl = imageUrls[i];
+            logCloudflare(`Fetching image ${i+1}/${imageUrls.length} from URL: ${imageUrl}`);
+            
             const imageResponse = await fetch(imageUrl);
             if (!imageResponse.ok) {
                 throw new Error(`Failed to fetch image from URL: ${imageUrl}`);
             }
+            
             const buffer = await imageResponse.buffer();
-            formData.append('image', buffer, { filename: 'image.png' });
-        } else {
-            // Handle errors for missing image
-            throw new Error('Image URL is required for GPT Image edit mode but was not provided');
+            // Use a unique field name for each image (image, image1, image2, etc.)
+            // First image has no suffix to maintain backward compatibility
+            const fieldName = i === 0 ? 'image' : `image${i}`;
+            formData.append(fieldName, buffer, { filename: `image${i}.png` });
         }
       } catch (error) {
         logError('Error processing image for editing:', error);


### PR DESCRIPTION
## Description
This PR adds support for multiple reference images when using the Azure GPT Image API in edit mode. Previously, only the first image in the array was used even when multiple images were provided via comma-separated URLs.

## Changes
- Modified `callAzureGPTImage` function to process all images in the array
- Used unique field names for each image in the FormData:
  - First image uses field name `image` (for backward compatibility)
  - Additional images use field names `image1`, `image2`, etc.
- Added logging to show progress for each image being fetched

## Testing
Verified that both images are properly fetched and sent to the Azure API when multiple images are specified in the URL parameter with comma separation.

Example request URL that triggered this issue:
`/prompt/...?image=https://raw.githubusercontent.com/pollinations/catgpt/refs/heads/main/images/original-catgpt.png,https://www.purapep.de/wp-content/uploads/purapep-produkte-benefits.webp`

## Implementation Notes
This follows the "thin proxy" design principle by maintaining minimal processing while adding the new functionality to handle multiple images correctly.