### PR TITLE
Fix: Allow nectar tier users to bypass queue regardless of auth method

### DIFF
--- a/shared/ipQueue.js
+++ b/shared/ipQueue.js
@@ -99,7 +99,8 @@ export async function enqueue(req, fn, { interval=6000, cap=1, forceQueue=false,
   }
   
   // Check if this is a nectar tier user - they skip the queue entirely
-  if (authResult.tokenAuth && authResult.tier === 'nectar') {
+  // Allow all nectar tier users to bypass the queue regardless of authentication method
+  if (authResult.tier === 'nectar') {
     log('Nectar tier user detected - skipping queue entirely');
     return fn(); // Execute immediately, skipping the queue
   }


### PR DESCRIPTION
## 🌸 Nectar Tier Queue Bypass Fix 🌸

This PR fixes an issue with how nectar tier users are handled in the queue system.

### Current Behavior
Currently, only nectar tier users who are authenticated via token can completely bypass the queue:
```javascript
// Check if this is a nectar tier user - they skip the queue entirely
if (authResult.tokenAuth && authResult.tier === 'nectar') {
  log('Nectar tier user detected - skipping queue entirely');
  return fn(); // Execute immediately, skipping the queue
}
```

This means nectar tier users who are authenticated via referrer (from auth.pollinations.ai database) are still being queued, just with zero interval.

### Fixed Behavior
Allow all nectar tier users to bypass the queue completely, regardless of whether they're authenticated by token or referrer:
```javascript
// Check if this is a nectar tier user - they skip the queue entirely
// Allow all nectar tier users to bypass the queue regardless of authentication method
if (authResult.tier === 'nectar') {
  log('Nectar tier user detected - skipping queue entirely');
  return fn(); // Execute immediately, skipping the queue
}
```

### Impact
- No more queue for nectar tier users from auth.pollinations.ai database
- Better performance for nectar tier users with registered domains
- More consistent application of the tier benefits

### Testing
Tested using a request from pollinations.github.io which is registered to a nectar tier user in the auth database. Verified in the logs that the request is now completely bypassing the queue system.

✨ This gives all nectar tier users the same premium experience regardless of auth method! ✨