### PR TITLE
Update user preferences defaults with ads:true trigger

### DIFF
--- a/auth.pollinations.ai/.gitignore
+++ b/auth.pollinations.ai/.gitignore
@@ -5,3 +5,4 @@ dist/
 .dev.vars.prod
 .env
 *.log
+backups/

--- a/auth.pollinations.ai/migrations/alter_preferences_default.sql
+++ b/auth.pollinations.ai/migrations/alter_preferences_default.sql
@@ -1,0 +1,26 @@
+-- This migration modifies the default value for the preferences column
+-- without recreating the table, preserving foreign key relationships
+
+-- First, let's ensure all existing users have the proper preferences
+UPDATE users 
+SET preferences = '{"ads": true}'
+WHERE preferences = '{}' OR preferences IS NULL;
+
+-- For SQLite, we can't directly alter the default value of a column
+-- We need to use a trigger instead to set default values for new users
+
+-- First, drop the trigger if it already exists
+DROP TRIGGER IF EXISTS set_default_preferences;
+
+-- Create a trigger that sets the default preferences for new users
+CREATE TRIGGER set_default_preferences
+AFTER INSERT ON users
+WHEN NEW.preferences IS NULL OR NEW.preferences = '{}'
+BEGIN
+    UPDATE users
+    SET preferences = '{"ads": true}'
+    WHERE github_user_id = NEW.github_user_id;
+END;
+
+-- Add index for ads preference if it doesn't exist
+CREATE INDEX IF NOT EXISTS idx_users_preferences_ads ON users(json_extract(preferences, '$.ads'));

--- a/auth.pollinations.ai/migrations/set_default_ads_preference.sql
+++ b/auth.pollinations.ai/migrations/set_default_ads_preference.sql
@@ -1,0 +1,21 @@
+-- Migration to set ads: true for all users who don't have it defined yet
+-- This ensures all users have ads enabled by default
+
+-- Update users where preferences doesn't have a 'ads' key or it's NULL
+UPDATE users 
+SET preferences = json_set(
+  CASE 
+    -- If preferences is NULL or not valid JSON, start with empty object
+    WHEN preferences IS NULL OR json_valid(preferences) = 0 THEN '{}'
+    ELSE preferences
+  END, 
+  '$.ads', 
+  -- Only set ads:true if it doesn't already exist
+  CASE
+    WHEN json_extract(preferences, '$.ads') IS NULL THEN 1
+    ELSE json_extract(preferences, '$.ads')
+  END
+);
+
+-- Create index for ads preference if it doesn't exist
+CREATE INDEX IF NOT EXISTS idx_users_preferences_ads ON users(json_extract(preferences, '$.ads'));

--- a/auth.pollinations.ai/migrations/update_empty_preferences_to_ads_true.sql
+++ b/auth.pollinations.ai/migrations/update_empty_preferences_to_ads_true.sql
@@ -1,0 +1,15 @@
+-- Migration to update all empty preferences objects to have ads: true
+-- This ensures all users with empty preferences have ads enabled
+
+-- Update users where preferences is exactly '{}'
+UPDATE users 
+SET preferences = '{"ads": true}'
+WHERE preferences = '{}';
+
+-- Also update any NULL preferences to be {"ads": true}
+UPDATE users
+SET preferences = '{"ads": true}'
+WHERE preferences IS NULL;
+
+-- Add index for ads preference if it doesn't exist already
+CREATE INDEX IF NOT EXISTS idx_users_preferences_ads ON users(json_extract(preferences, '$.ads'));

--- a/auth.pollinations.ai/scripts/deploy-with-migrations.js
+++ b/auth.pollinations.ai/scripts/deploy-with-migrations.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Get environment file path from ENV_FILE environment variable or use default
+const envFile = process.env.ENV_FILE || '.dev.vars.prod';
+const devVarsPath = path.join(__dirname, '..', envFile);
+
+// Check if environment file exists
+if (!fs.existsSync(devVarsPath)) {
+  console.error(`Error: ${envFile} file not found!`);
+  process.exit(1);
+}
+
+// Read and parse .dev.vars file
+const devVarsContent = fs.readFileSync(devVarsPath, 'utf-8');
+const envVars = {};
+
+// Parse each line in the .dev.vars file
+devVarsContent.split('\n').forEach(line => {
+  // Skip empty lines and comments
+  if (!line || line.startsWith('#')) return;
+  
+  // Parse key=value pairs
+  const match = line.match(/^([^=]+)=(.*)$/);
+  if (match) {
+    const [, key, value] = match;
+    envVars[key.trim()] = value.trim();
+  }
+});
+
+// Check required environment variables
+const requiredVars = ['GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'JWT_SECRET', 'ADMIN_API_KEY'];
+const missingVars = requiredVars.filter(varName => !envVars[varName]);
+
+if (missingVars.length > 0) {
+  console.error(`Error: Missing required environment variables: ${missingVars.join(', ')}`);
+  process.exit(1);
+}
+
+// Database ID from wrangler.toml
+const databaseId = "4145d600-1df6-44a2-9769-5d5f731deb77";
+const databaseName = "github_auth";
+
+console.log('Starting deployment process...');
+
+try {
+  // Step 1: Check if user_tiers table exists
+  console.log('\n🔍 Checking if user_tiers table exists...');
+  
+  // First, check migration status
+  console.log('\n📋 Listing migration status:');
+  execSync(`npx wrangler d1 migrations list ${databaseName} --env production`, { 
+    stdio: 'inherit',
+    shell: true 
+  });
+  
+  // Apply only the user_tiers.sql migration if needed
+  console.log('\n🔄 Applying only the user_tiers migration...');
+  execSync(`npx wrangler d1 execute ${databaseName} --env production --command "SELECT name FROM sqlite_master WHERE type='table' AND name='user_tiers';"`, {
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  console.log('\n⚠️ If the user_tiers table does not exist, we need to apply the migration.');
+  console.log('\n⚠️ To manually apply just the user_tiers migration, run:');
+  console.log(`npx wrangler d1 execute ${databaseName} --env production --file ../migrations/user_tiers.sql`);
+  
+  const userInput = process.argv[2];
+  if (userInput === '--apply-user-tiers') {
+    console.log('\n🔄 Applying user_tiers migration...');
+    execSync(`npx wrangler d1 execute ${databaseName} --env production --file ../migrations/user_tiers.sql`, {
+      stdio: 'inherit',
+      shell: true
+    });
+    console.log('✅ user_tiers migration applied successfully!');
+  }
+  
+  // Step 2: Build the deploy command with full path to npx
+  console.log('\n🚀 Deploying worker...');
+  const npxPath = 'npx';
+  let deployCommand = `${npxPath} wrangler deploy --env production`;
+
+  // Add environment variables to the command
+  Object.entries(envVars).forEach(([key, value]) => {
+    // Only include the required variables
+    if (requiredVars.includes(key)) {
+      // Escape special characters in the value
+      const escapedValue = value.replace(/"/g, '\\"');
+      deployCommand += ` --var "${key}:${escapedValue}"`;
+    }
+  });
+
+  // Execute the deploy command
+  execSync(deployCommand, { stdio: 'inherit', shell: true });
+  console.log('✅ Worker deployed successfully!');
+  
+  // Step 3: Test the tier endpoint
+  console.log('\n🧪 Testing tier endpoint...');
+  console.log('To test the tier endpoint, run the following command:');
+  console.log(`curl -X POST "https://auth.pollinations.ai/api/user-tier" \\
+  -H "Authorization: Bearer ${envVars.ADMIN_API_KEY}" \\
+  -H "Content-Type: application/json" \\
+  -d '{"user_id": "5099901", "tier": "flower"}'`);
+  
+  console.log('\n✨ Deployment process completed successfully!');
+} catch (error) {
+  console.error('❌ Deployment failed:', error.message);
+  process.exit(1);
+}

--- a/auth.pollinations.ai/scripts/deploy.js
+++ b/auth.pollinations.ai/scripts/deploy.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Get environment file path from ENV_FILE environment variable or use default
+const envFile = process.env.ENV_FILE || '.dev.vars.prod';
+const devVarsPath = path.join(__dirname, envFile);
+
+// Check if environment file exists
+if (!fs.existsSync(devVarsPath)) {
+  console.error(`Error: ${envFile} file not found!`);
+  process.exit(1);
+}
+
+// Read and parse .dev.vars file
+const devVarsContent = fs.readFileSync(devVarsPath, 'utf-8');
+const envVars = {};
+
+// Parse each line in the .dev.vars file
+devVarsContent.split('\n').forEach(line => {
+  // Skip empty lines and comments
+  if (!line || line.startsWith('#')) return;
+  
+  // Parse key=value pairs
+  const match = line.match(/^([^=]+)=(.*)$/);
+  if (match) {
+    const [, key, value] = match;
+    envVars[key.trim()] = value.trim();
+  }
+});
+
+// Check required environment variables
+const requiredVars = ['GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'JWT_SECRET', 'ADMIN_API_KEY'];
+const missingVars = requiredVars.filter(varName => !envVars[varName]);
+
+if (missingVars.length > 0) {
+  console.error(`Error: Missing required environment variables: ${missingVars.join(', ')}`);
+  process.exit(1);
+}
+
+// Build the deploy command with full path to npx
+const npxPath = 'npx';
+let deployCommand = `${npxPath} wrangler deploy --env production`;
+
+// Add environment variables to the command
+Object.entries(envVars).forEach(([key, value]) => {
+  // Only include the required variables
+  if (requiredVars.includes(key)) {
+    // Escape special characters in the value
+    const escapedValue = value.replace(/"/g, '\\"');
+    deployCommand += ` --var "${key}:${escapedValue}"`;
+  }
+});
+
+console.log(`Deploying with environment variables from ${envFile}...`);
+
+try {
+  // Execute the deploy command
+  // Use shell: true to allow the shell to handle the command
+  execSync(deployCommand, { stdio: 'inherit', shell: true });
+  console.log('Deployment completed successfully!');
+} catch (error) {
+  console.error('Deployment failed:', error.message);
+  process.exit(1);
+}

--- a/auth.pollinations.ai/scripts/set-default-preferences.js
+++ b/auth.pollinations.ai/scripts/set-default-preferences.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+// Script to set default preferences to { "ads": true } for all new users
+// This modifies the database schema to change the default value
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Database info
+const databaseName = "github_auth";
+
+// Path to the migration file
+const migrationFilePath = path.join(__dirname, '..', 'migrations', 'alter_preferences_default.sql');
+
+console.log('Starting migration to set default preferences to { "ads": true } for new users...');
+console.log(`Using migration file: ${migrationFilePath}`);
+
+try {
+  // Execute the SQL file against the D1 database
+  console.log('\n🔄 Applying migration to change default preferences...');
+  execSync(`npx wrangler d1 execute ${databaseName} --env production --remote --file ${migrationFilePath}`, {
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  console.log('\n✅ Migration completed successfully!');
+  console.log('Default preferences for all new users set to { "ads": true }');
+  console.log('A trigger has been created to automatically set preferences for new users.');
+  console.log('This approach preserves all foreign key relationships in the database.');
+} catch (error) {
+  console.error('\n❌ Migration failed:', error.message);
+  process.exit(1);
+}

--- a/auth.pollinations.ai/scripts/set-tier.js
+++ b/auth.pollinations.ai/scripts/set-tier.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+
+// Configuration
+const userId = process.argv[2] || '5099901'; // Default to voodoohop's GitHub ID
+const tier = process.argv[3] || 'flower';    // Default to 'flower' tier
+const databaseName = 'github_auth';
+
+// Validate tier
+if (!['seed', 'flower', 'nectar'].includes(tier)) {
+  console.error('Error: Tier must be one of: seed, flower, nectar');
+  process.exit(1);
+}
+
+console.log(`Setting tier for user ${userId} to ${tier}...`);
+
+// SQL command to create the table if it doesn't exist
+const createTableCommand = `
+CREATE TABLE IF NOT EXISTS user_tiers (
+  user_id TEXT PRIMARY KEY,
+  tier TEXT NOT NULL DEFAULT 'seed',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`;
+
+// SQL command to insert or update the user tier
+const sqlCommand = `
+INSERT INTO user_tiers (user_id, tier, updated_at)
+VALUES ('${userId}', '${tier}', CURRENT_TIMESTAMP)
+ON CONFLICT(user_id) DO UPDATE SET
+  tier = '${tier}',
+  updated_at = CURRENT_TIMESTAMP;
+`;
+
+try {
+  // First create the table if it doesn't exist
+  console.log('Creating user_tiers table if it doesn\'t exist...');
+  execSync(`npx wrangler d1 execute ${databaseName} --remote --command "${createTableCommand}"`, {
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  // Then execute the SQL command to set the tier
+  console.log('Setting user tier...');
+  execSync(`npx wrangler d1 execute ${databaseName} --remote --command "${sqlCommand}"`, {
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  console.log(`✅ Successfully set tier for user ${userId} to ${tier}`);
+  
+  // Verify the tier was set correctly
+  console.log('\nVerifying tier...');
+  execSync(`npx wrangler d1 execute ${databaseName} --remote --command "SELECT * FROM user_tiers WHERE user_id = '${userId}'"`, {
+    stdio: 'inherit',
+    shell: true
+  });
+} catch (error) {
+  console.error('❌ Error setting tier:', error.message);
+  process.exit(1);
+}

--- a/auth.pollinations.ai/scripts/update-empty-preferences.js
+++ b/auth.pollinations.ai/scripts/update-empty-preferences.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+// Script to update all empty preferences objects to { "ads": true }
+// Directly executes the SQL migration using wrangler
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Database info from deploy-with-migrations.js
+const databaseName = "github_auth";
+
+// Path to the migration file
+const migrationFilePath = path.join(__dirname, '..', 'migrations', 'update_empty_preferences_to_ads_true.sql');
+
+console.log('Starting update of empty preferences to { "ads": true }...');
+console.log(`Using migration file: ${migrationFilePath}`);
+
+try {
+  // Execute the SQL file against the D1 database
+  console.log('\n🔄 Applying migration to update empty preferences...');
+  execSync(`npx wrangler d1 execute ${databaseName} --env production --remote --file ${migrationFilePath}`, {
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  console.log('\n✅ Migration completed successfully!');
+  console.log('All empty preference objects have been updated to { "ads": true }');
+} catch (error) {
+  console.error('\n❌ Migration failed:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
This PR updates how user preferences are handled:

1. Creates a database trigger to automatically set {"ads": true} for new users
2. Updates all existing users with empty preferences to have {"ads": true}
3. Reorganizes utility scripts into a scripts/ directory
4. Adds backups/ directory to .gitignore

The approach uses SQLite triggers to avoid breaking foreign key relationships while ensuring all new users get the correct default preferences. This solves the foreign key constraint error that was encountered with the previous table recreation approach.