### PR TITLE
feat: Add support for transparent background images in API

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -157,6 +157,7 @@ Generates an image based on a text description.
 | `private`  | No       | Set to `true` to prevent the image from appearing in the public feed.              | `false` |
 | `enhance`  | No       | Set to `true` to enhance the prompt using an LLM for more detail.                  | `false` |
 | `safe`     | No       | Set to `true` for strict NSFW filtering (throws error if detected).                | `false` |
+| `transparent` | No    | Set to `true` to generate images with transparent backgrounds (gptimage model only). | `false` |
 | `referrer` | No\*     | Referrer URL/Identifier. See [Referrer Section](#referrer-).                       |         |
 
 **Return:** Image file (typically JPEG) 🖼️
@@ -174,6 +175,9 @@ curl -o sunset.jpg "https://image.pollinations.ai/prompt/A%20beautiful%20sunset%
 
 # With parameters
 curl -o sunset_large.jpg "https://image.pollinations.ai/prompt/A%20beautiful%20sunset%20over%20the%20ocean?width=1280&height=720&seed=42&model=flux"
+
+# With transparent background (gptimage model only)
+curl -o logo_transparent.png "https://image.pollinations.ai/prompt/A%20company%20logo%20on%20transparent%20background?model=gptimage&transparent=true"
 ```
 
 **Python (`requests`):**
@@ -189,6 +193,7 @@ params = {
     "seed": 42,
     "model": "flux",
     # "nologo": "true", # Optional
+    # "transparent": "true", # Optional - generates transparent background (gptimage model only)
     # "referrer": "MyPythonApp" # Optional
 }
 encoded_prompt = urllib.parse.quote(prompt)

--- a/image.pollinations.ai/src/createAndReturnImages.js
+++ b/image.pollinations.ai/src/createAndReturnImages.js
@@ -413,6 +413,12 @@ const callAzureGPTImageWithEndpoint = async (prompt, safeParams, userInfo, endpo
     n: 1
   };
   
+  // Add background parameter for transparent images when using gptimage model
+  if (safeParams.transparent) {
+    requestBody.background = "transparent";
+    logCloudflare('Adding background=transparent parameter for gptimage model');
+  }
+  
   // We'll only use the requestBody for generation mode
   // For edit mode, we'll use FormData instead
   
@@ -501,6 +507,12 @@ const callAzureGPTImageWithEndpoint = async (prompt, safeParams, userInfo, endpo
     // Add other parameters
     formData.append('quality', quality);
     formData.append('n', '1');
+    
+    // Add background parameter for transparent images when using gptimage model
+    if (safeParams.transparent) {
+      formData.append('background', 'transparent');
+      logCloudflare('Adding background=transparent parameter for gptimage edit mode');
+    }
     
     // Log the endpoint and headers for debugging
     logCloudflare(`Sending edit request to endpoint: ${endpoint}`);

--- a/image.pollinations.ai/src/makeParamsSafe.js
+++ b/image.pollinations.ai/src/makeParamsSafe.js
@@ -2,10 +2,10 @@ import { MODELS } from './models.js';
 
 /**
  * Sanitizes and adjusts parameters for image generation.
- * @param {{ width: number|null, height: number|null, seed: number|string, model: string, enhance: boolean|string, nologo: boolean|string, negative_prompt: string, nofeed: boolean|string, safe: boolean|string, quality: string, image: string|null }} params
+ * @param {{ width: number|null, height: number|null, seed: number|string, model: string, enhance: boolean|string, nologo: boolean|string, negative_prompt: string, nofeed: boolean|string, safe: boolean|string, quality: string, image: string|null, transparent: boolean|string }} params
  * @returns {Object} - The sanitized parameters.
  */
-export const makeParamsSafe = ({ width = null, height = null, seed, model = "flux", enhance, nologo = false, negative_prompt = "worst quality, blurry", nofeed = false, safe = false, private:isPrivate = false, quality = 'medium', image = null }) => {
+export const makeParamsSafe = ({ width = null, height = null, seed, model = "flux", enhance, nologo = false, negative_prompt = "worst quality, blurry", nofeed = false, safe = false, private:isPrivate = false, quality = 'medium', image = null, transparent = false }) => {
     // Sanitize boolean parameters - always return a boolean value
     const sanitizeBoolean = (value) => {
         // If it's already a boolean, return it directly
@@ -20,6 +20,7 @@ export const makeParamsSafe = ({ width = null, height = null, seed, model = "flu
     nologo = sanitizeBoolean(nologo);
     nofeed = sanitizeBoolean(nofeed) || sanitizeBoolean(isPrivate);
     safe = sanitizeBoolean(safe);
+    transparent = sanitizeBoolean(transparent);
 
     // Ensure model is one of the allowed models or default to "flux"
     const allowedModels = Object.keys(MODELS);
@@ -59,5 +60,5 @@ export const makeParamsSafe = ({ width = null, height = null, seed, model = "flu
     // Always convert to array for consistency (empty array if null/undefined)
     const imageArray = image ? image.split(',') : [];
 
-    return { width, height, seed, model, enhance, nologo, negative_prompt, nofeed, safe, quality, image: imageArray };
+    return { width, height, seed, model, enhance, nologo, negative_prompt, nofeed, safe, quality, image: imageArray, transparent };
 };

--- a/image.pollinations.ai/test/unit/makeParamsSafe.test.js
+++ b/image.pollinations.ai/test/unit/makeParamsSafe.test.js
@@ -13,7 +13,8 @@ describe('makeParamsSafe', () => {
       nologo: 'false',
       negative_prompt: 'worst quality',
       nofeed: false,
-      safe: true
+      safe: true,
+      transparent: 'true'
     }
     
     const result = makeParamsSafe(input)
@@ -27,6 +28,7 @@ describe('makeParamsSafe', () => {
     expect(result.negative_prompt).toBe('worst quality')
     expect(result.nofeed).toBe(false)
     expect(result.safe).toBe(true)
+    expect(result.transparent).toBe(true)
   })
 
   it('should handle invalid inputs with defaults', () => {
@@ -42,6 +44,7 @@ describe('makeParamsSafe', () => {
     expect(result.height).toBe(1024)
     expect(result.seed).toBe(42)
     expect(result.model).toBe('flux')
+    expect(result.transparent).toBe(false)
   })
 
   it('should properly sanitize malformed boolean string values', () => {
@@ -49,7 +52,8 @@ describe('makeParamsSafe', () => {
       enhance: 'falsee',  // Malformed string as reported in Issue #1418
       nologo: 'TRUE',     // Test case insensitivity
       nofeed: 'truee',    // Another malformed string
-      safe: 'TrUe'        // Mixed case
+      safe: 'TrUe',       // Mixed case
+      transparent: 'falsee' // Test transparent with malformed string
     }
 
     const result = makeParamsSafe(input)
@@ -57,6 +61,7 @@ describe('makeParamsSafe', () => {
     expect(result.nologo).toBe(true)    // Case-insensitive check
     expect(result.nofeed).toBe(false)   // Should be false, not 'truee'
     expect(result.safe).toBe(true)      // Mixed case should work
+    expect(result.transparent).toBe(false) // Should be false, not 'falsee'
   })
 
   it('should handle null, undefined, and various types for boolean params', () => {
@@ -64,7 +69,8 @@ describe('makeParamsSafe', () => {
       enhance: null,
       nologo: undefined,
       nofeed: 0,
-      safe: 1
+      safe: 1,
+      transparent: null
     }
 
     const result = makeParamsSafe(input)
@@ -72,16 +78,19 @@ describe('makeParamsSafe', () => {
     expect(result.nologo).toBe(false)
     expect(result.nofeed).toBe(false)
     expect(result.safe).toBe(false)
+    expect(result.transparent).toBe(false)
   })
 
   it('should preserve actual boolean values', () => {
     const input = {
       enhance: true,
-      nologo: false
+      nologo: false,
+      transparent: true
     }
 
     const result = makeParamsSafe(input)
     expect(result.enhance).toBe(true)
     expect(result.nologo).toBe(false)
+    expect(result.transparent).toBe(true)
   })
 })


### PR DESCRIPTION
## Changes Made

- Introduced a new `transparent` parameter for generating images with transparent backgrounds using the gptimage model.
- Updated API documentation to include the new parameter and examples for usage.
- Modified image processing functions to handle the transparent background option.
- Enhanced unit tests to validate the new parameter functionality.