### PR TITLE
Refine ad formats and styling for text service ads

### DIFF
--- a/text.pollinations.ai/ads/adLlmMapper.js
+++ b/text.pollinations.ai/ads/adLlmMapper.js
@@ -222,21 +222,7 @@ export async function generateAffiliateAd(affiliateId, content = '', messages = 
         if (affiliate.ad_text) {
             adTextSource = `\n---\n\n🌸 **Ad** 🌸\n${affiliate.ad_text.replace('{url}', referralLink)}`;
         }
-        // Use description if available
-        else if (affiliate.description) {
-            log(`Using description for ${affiliate.name} (${affiliateId})`);
-            adTextSource = `\n---\n\n🌸 **Ad** 🌸\n${affiliate.description} [Learn more](${referralLink})`;
-        }
-        // Use product name if available
-        else if (affiliate.product) {
-            log(`Using product name for ${affiliate.name} (${affiliateId})`);
-            adTextSource = `\n---\n\n🌸 **Ad** 🌸\nLearn more about ${affiliate.product} [Learn more](${referralLink})`;
-        }
-        // Fallback to generic text
-        else {
-            log(`Using name only for ${affiliate.name} (${affiliateId})`);
-            adTextSource = `\n---\n\n🌸 **Ad** 🌸\nLearn more about ${affiliate.name} [Learn more](${referralLink})`;
-        }
+    
 
         // First, contextualize and translate ad text if content is provided
         if (content && content.trim().length > 0) {
@@ -308,8 +294,8 @@ RESPONSE:`;
         // Always use standard format without image
         // Use different prefix for Ko-fi (direct support) vs sponsors
         const prefix = affiliateId === 'kofi' 
-            ? '**Support Pollinations.AI directly:**' 
-            : '**Support Pollinations.AI by visiting our sponsor:**';
+            ? '**Support Pollinations.AI:**' 
+            : '**Sponsor:**';
         adText = `\n\n---\n\n${prefix}\n${adTextSource}`;
         log(`Generated standard ad for ${affiliate.name} (${affiliateId})`);
         

--- a/text.pollinations.ai/ads/nexAdFormatter.js
+++ b/text.pollinations.ai/ads/nexAdFormatter.js
@@ -61,7 +61,7 @@ export function formatNexAd(nexAdData) {
     }
     
     // Format with our standard ad prefix
-    const formattedAd = `\n---\n\n**Support Pollinations.AI by visiting our sponsor:**\n${markdownContent}`;
+    const formattedAd = `\n\n---\n\n**Sponsor**\n${markdownContent}`;
     
     log('Formatted ad:', formattedAd);
     


### PR DESCRIPTION
This PR contains improvements to the ad formats in the text service:

## Changes
1. **Simplified ad prefixes**:
   - Changed "Support Pollinations.AI by visiting our sponsor:" to just "Sponsor:"
   - Customized prefix for Ko-fi to "Support Pollinations.AI:"
   - Removed colon from Nex.ad sponsor text

2. **Fixed formatting**:
   - Added consistent line breaks before section dividers
   - Made formats uniform across ad sources

3. **Removed fallback ad text options**:
   - Removed unused fallback options for affiliate ads
   - Now affiliate ads will only display if they have ad_text configured

These changes make the ads more concise and consistent in appearance.