### PR TITLE
Prevent duplicate ads in conversations

### DIFF
--- a/text.pollinations.ai/ads/adUtils.js
+++ b/text.pollinations.ai/ads/adUtils.js
@@ -29,6 +29,38 @@ export function sendAdSkippedAnalytics(req, reason, isStreaming = false, additio
     });
 }
 
+// Ad URL patterns to detect in conversation history
+const AD_URL_PATTERNS = [
+    'nex-ad.com',
+    'pollinations.ai/redirect'
+];
+
+/**
+ * Check if a conversation already contains an ad
+ * @param {Array} messages - Conversation messages
+ * @returns {boolean} - Whether an ad was found
+ */
+function conversationContainsAd(messages) {
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+        return false;
+    }
+    
+    // Check each message for ad URLs
+    for (const message of messages) {
+        if (!message.content || typeof message.content !== 'string') continue;
+        
+        // Check for ad URL patterns in the message content
+        for (const pattern of AD_URL_PATTERNS) {
+            if (message.content.includes(pattern)) {
+                log(`Found ad URL pattern '${pattern}' in conversation history`);
+                return true;
+            }
+        }
+    }
+    
+    return false;
+}
+
 export function shouldProceedWithAd(show, req, content, messages, isStreaming) {
     // If not showing ads based on probability/markers
     if (!show) {
@@ -46,9 +78,17 @@ export function shouldProceedWithAd(show, req, content, messages, isStreaming) {
         return false;
     }
 
-    // Check if ad already exists
+    // Check if ad already exists in current content
     if (content.includes('🌸 **Ad** 🌸')) {
-        sendAdSkippedAnalytics(req, 'ad_already_exists', isStreaming);
+        sendAdSkippedAnalytics(req, 'ad_already_exists_in_content', isStreaming);
+        return false;
+    }
+    
+    // Check if conversation history already contains an ad
+    if (conversationContainsAd(messages)) {
+        sendAdSkippedAnalytics(req, 'ad_exists_in_conversation', isStreaming, {
+            conversation_length: messages?.length || 0
+        });
         return false;
     }
 


### PR DESCRIPTION
This PR adds a feature to prevent showing duplicate ads to the same user in a single conversation.

## Changes
- Added URL pattern detection to check if an ad already exists in conversation history
- System now skips showing ads to users who have already seen one in the current conversation
- Uses URL patterns ('nex-ad.com', 'pollinations.ai/redirect') for reliable detection
- Adds analytics tracking for skipped ads with reason 'ad_exists_in_conversation'

This improves the user experience by not showing too many ads in a single conversation. The implementation is simple and focused, using URL patterns which are the most reliable way to detect previous ads without complex string matching.