### PR TITLE
Fix: Ensure async/await for streaming ad integration in text.pollinations.ai

### DIFF
--- a/text.pollinations.ai/ads/streamingAdWrapper.js
+++ b/text.pollinations.ai/ads/streamingAdWrapper.js
@@ -16,7 +16,7 @@ import { shouldShowAds } from './shouldShowAds.js';
  * @param {Array} messages - The input messages
  * @returns {Stream} - A transformed stream that will add an ad at the end
  */
-export function createStreamingAdWrapper(responseStream, req, messages = []) {
+export async function createStreamingAdWrapper(responseStream, req, messages = []) {
     if (!responseStream || !responseStream.pipe) {
         log('Invalid stream provided to createStreamingAdWrapper');
         if (req) {
@@ -25,7 +25,8 @@ export function createStreamingAdWrapper(responseStream, req, messages = []) {
         return responseStream;
     }
 
-    const { shouldShowAd, markerFound, adAlreadyExists, forceAd } = shouldShowAds(null, messages, req);
+    const adCheckResult = await shouldShowAds(null, messages, req);
+    const { shouldShowAd, markerFound, adAlreadyExists, forceAd } = adCheckResult;
 
     // If p-ads marker was found, set forceAd flag
     const shouldForceAd = forceAd || false;

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -217,7 +217,7 @@ async function handleRequest(req, res, requestData) {
             log('Sending streaming response with sendAsOpenAIStream');
             // Add requestData to completion object for access in streaming ad wrapper
             completion.requestData = requestData;
-            sendAsOpenAIStream(res, completion, req);
+            await sendAsOpenAIStream(res, completion, req);
         } else {
             if (req.method === 'GET') {
                 sendContentResponse(res, completion);
@@ -416,7 +416,7 @@ async function processRequest(req, res, requestData) {
         
         if (requestData.stream) {
             // For streaming requests, send error as a stream
-            sendAsOpenAIStream(res, { error: 'Forbidden', choices: [{ message: { content: 'Forbidden' } }] }, req);
+            await sendAsOpenAIStream(res, { error: 'Forbidden', choices: [{ message: { content: 'Forbidden' } }] }, req);
             return;
         } else {
             return res.status(403).json(errorResponse);
@@ -467,7 +467,7 @@ async function processRequest(req, res, requestData) {
             
             if (requestData.stream) {
                 // For streaming requests, send error as a stream
-                sendAsOpenAIStream(res, { 
+                await sendAsOpenAIStream(res, { 
                     error: errorResponse.error, 
                     choices: [{ message: { content: errorResponse.details.message } }] 
                 }, req);
@@ -580,7 +580,7 @@ app.post('/v1/chat/completions', async (req, res) => {
     }
 })
 
-function sendAsOpenAIStream(res, completion, req = null) {
+async function sendAsOpenAIStream(res, completion, req = null) {
     log('sendAsOpenAIStream called with completion type:', typeof completion);
     if (completion) {
         log('Completion properties:', {
@@ -629,7 +629,7 @@ function sendAsOpenAIStream(res, completion, req = null) {
             log('Processing stream for ads with', messages.length, 'messages');
             
             // Create a wrapped stream that will add ads at the end
-            const wrappedStream = createStreamingAdWrapper(
+            const wrappedStream = await createStreamingAdWrapper(
                 responseStream, 
                 req, 
                 messages


### PR DESCRIPTION
This PR addresses an issue in the text.pollinations.ai streaming ad integration where ads were not being correctly appended to streaming responses due to unhandled asynchronous operations.

Key changes:
- Modified `ads/streamingAdWrapper.js` to make `createStreamingAdWrapper` an `async` function and `await` the `shouldShowAds` call.
- Modified `server.js` to make `sendAsOpenAIStream` an `async` function and `await` calls to `createStreamingAdWrapper` and subsequent `sendAsOpenAIStream` calls in `handleRequest` and `processRequest`.

These minimal changes ensure that promises are correctly handled, allowing the ad logic to execute as expected for streaming content.