### PR TITLE
Add Ai drafterplus to chat projects and update project submission template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-submission.yml
+++ b/.github/ISSUE_TEMPLATE/project-submission.yml
@@ -57,12 +57,13 @@ body:
       label: Project Category
       description: Select the category under which your project should be posted
       options:
-        - LLM Integrations
-        - Creative & Interactive Applications
-        - Tools & Interfaces
-        - Social Bots
-        - SDK & Libraries
-        - Tutorials
+        - Chat Projects 💬
+        - Creative Projects 🎨
+        - Games 🎮
+        - Hack & Build 🛠️
+        - Learn 📚
+        - Social Bots 🤖
+        - Vibe Coding 🌈
     validations:
       required: true
 
@@ -78,6 +79,7 @@ body:
       value: |
         ### Implementation Instructions
 
-        For the being implementing this issue:
-        - Add the new project to the top of the appropriate section in README.md and pollinations.ai/src/config/projectList.js
-        - Add a new UTF-8 icon to the title or where appropriate
+        For the person implementing this issue:
+        - Add the new project to the top of the appropriate file in pollinations.ai/src/config/projects/ based on the selected category
+        - Ensure the project entry includes all necessary fields (name, url, description, author, submissionDate, etc.)
+        - Make sure to maintain proper JSON formatting with commas between entries

--- a/pollinations.ai/src/config/projects/chat.js
+++ b/pollinations.ai/src/config/projects/chat.js
@@ -5,6 +5,14 @@
 
 export const chatProjects = [
   {
+    name: "Ai drafterplus",
+    url: "https://ai.drafterplus.nl/",
+    description: "A ChatGPT-like interface with multiple AI models. Completely free and saves conversations in the browser using localStorage.",
+    author: "@dexvisser_",
+    submissionDate: "2025-06-07",
+    order: 1
+  },
+  {
     name: "PixPax",
     url: "https://pixpal.chat",
     description: "A user-friendly chatbot that lets you analyze images, remix existing images or create new images, all through simple chat.",


### PR DESCRIPTION
This PR addresses issue #2345 by:

1. Adding the "Ai drafterplus" project to the chat projects list
2. Updating the project submission template (.github/ISSUE_TEMPLATE/project-submission.yml) to reflect the current project categories in the codebase
3. Improving the implementation instructions in the template

The project was added to the chat category since it's a ChatGPT-like interface with multiple AI models.

Closes #2345