### PR TITLE
Add MCP client configuration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,25 @@
 
 Our MCP (Model Context Protocol) server enables AI assistants like Claude to generate images and audio directly. [Learn more](./model-context-protocol/README.md)
 
-```bash
-# Run with npx (no installation required)
+#### Configuration
+
+Add this to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "pollinations": {
+      "command": "npx",
+      "args": [
+        "@pollinations/model-context-protocol"
+      ]
+    }
+  }
+}
+
+
+```
+### Run with npx (no installation required)
 npx @pollinations/model-context-protocol
 ```
 


### PR DESCRIPTION
This PR adds a JSON configuration section to the MCP Server documentation, providing users with another way to configure the Pollinations MCP server in their AI assistant clients.