### PR TITLE
added the dockerfile + ignore + docker-compose for the text+image api

### DIFF
--- a/image.pollinations.ai/.dockerignore
+++ b/image.pollinations.ai/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.env
+test

--- a/image.pollinations.ai/docker-compose.yml
+++ b/image.pollinations.ai/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  image:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: pollinations-image
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/image.pollinations.ai/dockerfile
+++ b/image.pollinations.ai/dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["npm", "start"]

--- a/text.pollinations.ai/.dockerignore
+++ b/text.pollinations.ai/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.env
+test

--- a/text.pollinations.ai/docker-compose.yml
+++ b/text.pollinations.ai/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  text:
+    build:
+      context: .
+      dockerfile: dockerfile
+    container_name: pollinations-text
+    ports:
+      - "16385:16385"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/text.pollinations.ai/dockerfile
+++ b/text.pollinations.ai/dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 16385
+CMD ["npm", "start"]


### PR DESCRIPTION
This pull request introduces Dockerization for two services, `image.pollinations.ai` and `text.pollinations.ai`, to standardize their deployment and improve maintainability. It includes Dockerfiles, `docker-compose.yml` configurations, and `.dockerignore` files for both services.

### Dockerization of `image.pollinations.ai`:

* Added a `.dockerignore` file to exclude unnecessary files and directories (`node_modules`, `npm-debug.log`, `.env`, `test`) from the Docker build context.
* Created a `docker-compose.yml` file to define the service configuration, including port mapping (`8080:8080`), environment variables, and restart policy.
* Added a `Dockerfile` to build the service using a Node.js 20 Alpine image, install production dependencies, and expose port 8080.

### Dockerization of `text.pollinations.ai`:

* Added a `.dockerignore` file to exclude unnecessary files and directories (`node_modules`, `npm-debug.log`, `.env`, `test`) from the Docker build context.
* Created a `docker-compose.yml` file to define the service configuration, including port mapping (`16385:16385`), environment variables, and restart policy.
* Added a `Dockerfile` to build the service using a Node.js 20 Alpine image, install production dependencies, and expose port 16385.