### PR TITLE
[text.] server: Raise JSON body size limit.

### DIFF
--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -91,7 +91,7 @@ app.use((req, res, next) => {
 });
 
 // Remove the custom JSON parsing middleware and use the standard bodyParser
-app.use(bodyParser.json({ limit: "5mb" }));
+app.use(bodyParser.json({ limit: "20mb" }));
 app.use(cors());
 // New route handler for root path
 app.get("/", (req, res) => {


### PR DESCRIPTION
* The previous 5MB cap often wasn’t enough for high-resolution images, especially those coming from the camera or used in vision model inputs. Since Base64 encoding increases the payload size by around 33%, even a 5MB image could turn into something much larger once wrapped in JSON. This led to failed requests, server hangs, or 413 errors when the payload went over the limit.

* With the new limit, the server can now handle larger image payloads more reliably, which is especially helpful when dealing with full-quality images for OpenAI-compatible API endpoint or other use cases where resolution matters.