### PR TITLE
Add LLM cost observability endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,5 @@ text.pollinations.ai/v2/
 image.pollinations.ai/temp_logs/
 .wrangler/
 .crush/
+# Tinybird CLI configuration (contains sensitive tokens)
+.tinyb

--- a/text.pollinations.ai/observability/endpoints/cost_day.pipe
+++ b/text.pollinations.ai/observability/endpoints/cost_day.pipe
@@ -1,0 +1,37 @@
+TOKEN read_pipes READ
+
+DESCRIPTION >
+    Get exactly 24 hourly cost values for a specific day (midnight to midnight).
+    Returns fixed calendar-aligned buckets with future hours as null/0.
+
+NODE cost_day_node
+SQL >
+    %
+    WITH hour_series AS (
+        SELECT 
+            toStartOfHour(toDate({{String(date, '2025-08-01')}}) + INTERVAL number HOUR) as hour_start
+        FROM numbers(24)
+    ),
+    user_hourly_costs AS (
+        SELECT
+            toStartOfHour(timestamp) as hour_start,
+            sum(cost) as total_cost
+        FROM llm_events
+        WHERE 1=1
+            {% if defined(user) %}
+            AND user = {{String(user, 'default_user')}}
+            {% else %}
+            AND user = 'default_user'
+            {% end %}
+            AND timestamp >= toStartOfDay(toDate({{String(date, '2025-08-01')}}))
+            AND timestamp < toStartOfDay(toDate({{String(date, '2025-08-01')}}) + INTERVAL 1 DAY)
+        GROUP BY hour_start
+    )
+    SELECT 
+        hs.hour_start as hour,
+        COALESCE(uhc.total_cost, 0) as total_cost
+    FROM hour_series hs
+    LEFT JOIN user_hourly_costs uhc ON hs.hour_start = uhc.hour_start
+    ORDER BY hour ASC
+
+TYPE endpoint

--- a/text.pollinations.ai/observability/endpoints/cost_month.pipe
+++ b/text.pollinations.ai/observability/endpoints/cost_month.pipe
@@ -1,0 +1,47 @@
+TOKEN read_pipes READ
+
+DESCRIPTION >
+    Get daily cost values for a specific month (1st to end of month).
+    Returns fixed calendar-aligned buckets with future days as null/0.
+
+NODE cost_month_node
+SQL >
+    %
+    WITH month_info AS (
+        SELECT 
+            toStartOfMonth(toDate({{String(ym, '2025-08')}} || '-01')) as month_start,
+            toStartOfMonth(toDate({{String(ym, '2025-08')}} || '-01') + INTERVAL 1 MONTH) as month_end
+    ),
+    day_series AS (
+        SELECT 
+            toStartOfDay((SELECT month_start FROM month_info) + INTERVAL number DAY) as day_start
+        FROM numbers(
+            CAST(dateDiff('day', 
+                (SELECT month_start FROM month_info), 
+                (SELECT month_end FROM month_info)
+            ) AS UInt32)
+        )
+    ),
+    user_daily_costs AS (
+        SELECT
+            toStartOfDay(timestamp) as day_start,
+            sum(cost) as total_cost
+        FROM llm_events
+        WHERE 1=1
+            {% if defined(user) %}
+            AND user = {{String(user, 'default_user')}}
+            {% else %}
+            AND user = 'default_user'
+            {% end %}
+            AND timestamp >= (SELECT month_start FROM month_info)
+            AND timestamp < (SELECT month_end FROM month_info)
+        GROUP BY day_start
+    )
+    SELECT 
+        ds.day_start as day,
+        COALESCE(udc.total_cost, 0) as total_cost
+    FROM day_series ds
+    LEFT JOIN user_daily_costs udc ON ds.day_start = udc.day_start
+    ORDER BY day ASC
+
+TYPE endpoint

--- a/text.pollinations.ai/observability/endpoints/cost_week.pipe
+++ b/text.pollinations.ai/observability/endpoints/cost_week.pipe
@@ -1,0 +1,44 @@
+TOKEN read_pipes READ
+
+DESCRIPTION >
+    Get exactly 7 daily cost values for a specific ISO week (Monday to Sunday).
+    Returns fixed calendar-aligned buckets with future days as null/0.
+
+NODE cost_week_node
+SQL >
+    %
+    WITH week_start AS (
+        SELECT 
+            toMonday(toDate(concat(
+                substring({{String(isoWeek, '2025-W31')}}, 1, 4), 
+                '-01-04'
+            )) + INTERVAL (toInt32(substring({{String(isoWeek, '2025-W31')}}, 7)) - 1) * 7 DAY) as week_monday
+    ),
+    day_series AS (
+        SELECT 
+            toStartOfDay((SELECT week_monday FROM week_start) + INTERVAL number DAY) as day_start
+        FROM numbers(7)
+    ),
+    user_daily_costs AS (
+        SELECT
+            toStartOfDay(timestamp) as day_start,
+            sum(cost) as total_cost
+        FROM llm_events
+        WHERE 1=1
+            {% if defined(user) %}
+            AND user = {{String(user, 'default_user')}}
+            {% else %}
+            AND user = 'default_user'
+            {% end %}
+            AND timestamp >= (SELECT week_monday FROM week_start)
+            AND timestamp < (SELECT week_monday FROM week_start) + INTERVAL 7 DAY
+        GROUP BY day_start
+    )
+    SELECT 
+        ds.day_start as day,
+        COALESCE(udc.total_cost, 0) as total_cost
+    FROM day_series ds
+    LEFT JOIN user_daily_costs udc ON ds.day_start = udc.day_start
+    ORDER BY day ASC
+
+TYPE endpoint

--- a/text.pollinations.ai/observability/endpoints/get_llm_costs.pipe
+++ b/text.pollinations.ai/observability/endpoints/get_llm_costs.pipe
@@ -1,0 +1,15 @@
+TOKEN "read_pipes" READ
+
+NODE endpoint
+SQL >
+    %
+    SELECT
+        sum(cost) as total_cost,
+        count() as request_count
+    FROM llm_events
+    WHERE 1=1
+    {% if defined(username) and username != "" %}
+        AND user = {{String(username)}}
+    {% end %}
+
+TYPE endpoint


### PR DESCRIPTION
Introduces new endpoints for retrieving LLM usage costs by day, week, and month, as well as a summary endpoint for total cost and request count. Also updates .gitignore to exclude Tinybird CLI configuration files.