### PR TITLE
Add referrer breakdown to hourly token usage endpoint

### DIFF
--- a/text.pollinations.ai/observability/endpoints/hourly_token_usage.pipe
+++ b/text.pollinations.ai/observability/endpoints/hourly_token_usage.pipe
@@ -8,41 +8,34 @@ SQL >
     %
     SELECT
         toStartOfHour(timestamp) as hour,
-        sum(total_tokens) as total_tokens,
-        sum(prompt_tokens) as prompt_tokens,
-        sum(completion_tokens) as completion_tokens,
-        sum(cost) as total_cost,
+        referrer,
+        sum(prompt_tokens) as usage_prompt_tokens,
+        sum(completion_tokens) as usage_completion_tokens,
+        sum(prompt_tokens) + sum(completion_tokens) as total_tokens,
+        sum(cost) as total_costs,
         count() as total_requests
     FROM llm_events
-    WHERE 1=1
-        {% if defined(user) %}
-        AND user = {{String(user, 'wBrowsqq')}}
-        {% else %}
-        AND user = 'wBrowsqq'
+    WHERE
+        1 = 1
+        {% if defined(username) %} AND user = {{ String(username, 'YoussefElsafi') }}
+        {% else %} AND user = 'YoussefElsafi'
         {% end %}
-        {% if defined(start_date) %}
-        AND timestamp >= {{DateTime(start_date)}}
-        {% else %}
-        AND timestamp >= now() - interval 6 day
+        {% if defined(start_date) %} AND timestamp >= {{ DateTime(start_date) }}
+        {% else %} AND timestamp >= now() - interval 6 day
         {% end %}
-        {% if defined(end_date) %}
-        AND timestamp <= {{DateTime(end_date)}}
-        {% else %}
-        AND timestamp <= now()
+        {% if defined(end_date) %} AND timestamp <= {{ DateTime(end_date) }}
+        {% else %} AND timestamp <= now()
         {% end %}
         {% if defined(organization) and organization != [''] %}
-        AND organization IN {{Array(organization)}}
+            AND organization IN {{ Array(organization) }}
         {% end %}
-        {% if defined(project) and project != [''] %}
-        AND project IN {{Array(project)}}
-        {% end %}
+        {% if defined(project) and project != [''] %} AND project IN {{ Array(project) }} {% end %}
         {% if defined(environment) and environment != [''] %}
-        AND environment IN {{Array(environment)}}
+            AND environment IN {{ Array(environment) }}
         {% end %}
-        {% if defined(model) and model != [''] %}
-        AND model IN {{Array(model)}}
-        {% end %}
-    GROUP BY hour
-    ORDER BY hour ASC
+        {% if defined(model) and model != [''] %} AND model IN {{ Array(model) }} {% end %}
+        {% if defined(referrer) and referrer != [''] %} AND referrer IN {{ Array(referrer) }} {% end %}
+    GROUP BY hour, referrer
+    ORDER BY hour ASC, total_costs DESC
 
 TYPE endpoint


### PR DESCRIPTION
The query now groups and filters by referrer, and returns referrer in the results. Field names have been updated for clarity, and grouping is now by both hour and referrer. Ordering now prioritizes total_costs within each hour.