### PR TITLE
Update Island AI project URL

### DIFF
--- a/pollinations.ai/src/config/projects/chat.js
+++ b/pollinations.ai/src/config/projects/chat.js
@@ -15,7 +15,7 @@ export const chatProjects = [
   },
   {
     name: "Island",
-    url: "https://islandapps.dev/chat",
+    url: "https://islandai.app",
     description: "Island AI is a free, modern ChatGPT alternative featuring smart multimodal chat, integrated web search, a polished interface, and a unique Questioning Mode that asks clarifying questions before delivering precise, real-time responses.",
     author: "@techcow2",
     repo: "https://github.com/techcow2/Island",


### PR DESCRIPTION
Update Island AI project URL from https://islandapps.dev/chat to https://islandai.app as requested by the project author.

Closes #3476

🤖 Generated with [Claude Code](https://claude.ai/code)