### PR TITLE
[text.]: Link BIDARA with gpt-4.1-nano.

### DIFF
--- a/text.pollinations.ai/availableModels.js
+++ b/text.pollinations.ai/availableModels.js
@@ -506,7 +506,7 @@ const models = [
 		name: "bidara",
 		description: "BIDARA (Biomimetic Designer and Research Assistant by NASA)",
 		handler: bidara,
-		// openai-large
+		// openai-fast
 		provider: "azure",
 		tier: "anonymous",
 		community: true,
@@ -514,9 +514,9 @@ const models = [
 		output_modalities: ["text"],
 		tools: true,
 		pricing: {
-			prompt_text: 1.71,
-			prompt_cache: 0.43,
-			completion_text: 6.84,
+			prompt_text: 0.09,
+			prompt_cache: 0.03,
+			completion_text: 0.35,
 		},
 	},
 ];

--- a/text.pollinations.ai/availableModels_new.js
+++ b/text.pollinations.ai/availableModels_new.js
@@ -547,7 +547,7 @@ const models = [
 		original_name: "gpt-4.1-2025-04-14",
 		description: "BIDARA (Biomimetic Designer and Research Assistant by NASA)",
 		handler: bidara,
-		// openai-large
+		// openai-fast
 		provider: "azure",
 		tier: "anonymous",
 		community: true,
@@ -555,9 +555,9 @@ const models = [
 		output_modalities: ["text"],
 		tools: true,
 		pricing: {
-			prompt_text: 1.71,
-			prompt_cache: 0.43,
-			completion_text: 6.84,
+			prompt_text: 0.09,
+			prompt_cache: 0.03,
+			completion_text: 0.35,
 		},
 	},
 ];

--- a/text.pollinations.ai/wrappedModels.js
+++ b/text.pollinations.ai/wrappedModels.js
@@ -57,5 +57,5 @@ export const generateTextMirexa = wrapModelWithContext(
 export const bidara = wrapModelWithContext(
     bidaraSystemPrompt,
     generateTextPortkey,
-    "openai-large",
+    "openai-fast",
 );


### PR DESCRIPTION
* Because openai-large / GPT-4.1 has a maximum input limit of 5000 characters, the process fails.

  Logs on BIDARA request:

  ``` {"error":"Input text exceeds maximum length of 5000 characters for model azure-gpt-4.1 (current: 13516)","status":500} ```

* In this case, the model mapping system appears to consider the system prompt as user input, resulting in a failed response within the limits set by the openai-large model.

[I] Since BIDARA use GPT-4 based, switching to the nano variant likely
    won't significantly impact its response.

Reff:
1. https://github.com/nasa-petal/bidara
2. https://ntrs.nasa.gov/citations/20240008030