### PR TITLE
Fix TinyBird text_moderation partitioning with minimal changes 🔧

### DIFF
--- a/text.pollinations.ai/observability/datasources/text_moderation.datasource
+++ b/text.pollinations.ai/observability/datasources/text_moderation.datasource
@@ -3,6 +3,7 @@ DESCRIPTION >
 
 SCHEMA >
     `id` String `json:$.id` DEFAULT '',
+    `timestamp` DateTime `json:$.timestamp`,
 
     -- OpenAI Moderation Parameters (severity levels and detection flags only)
     `hate_severity` LowCardinality(String) `json:$.hate.severity` DEFAULT 'safe',
@@ -13,7 +14,7 @@ SCHEMA >
     `protected_material_text_detected` Bool `json:$.protected_material_text.detected` DEFAULT false
 
 ENGINE "MergeTree" 
-ENGINE_PARTITION_KEY "id"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "id"
 ENGINE_PRIMARY_KEY "id"
 

--- a/text.pollinations.ai/observability/datasources/text_moderation.datasource
+++ b/text.pollinations.ai/observability/datasources/text_moderation.datasource
@@ -2,40 +2,19 @@ DESCRIPTION >
     Store OpenAI moderation results with cf_ray for joining with main events table
 
 SCHEMA >
-    `id` String,
-    -- NOTE: Current field mappings may not align perfectly with actual OpenAI/Azure moderation API response structure
-    -- The API returns nested content_filter_results with filtered/severity/detected flags per category
-    -- Consider updating JSON paths and field structure if ingestion issues occur
-    `timestamp` DateTime `json:$.timestamp` DEFAULT now(),
-    `choice_index` UInt8 `json:$.choice_index` DEFAULT 0,
+    `id` String `json:$.id` DEFAULT '',
 
-    -- Core moderation categories with both severity and filtered status
+    -- OpenAI Moderation Parameters (severity levels and detection flags only)
     `hate_severity` LowCardinality(String) `json:$.hate.severity` DEFAULT 'safe',
-    `hate_filtered` Bool `json:$.hate.filtered` DEFAULT false,
     `self_harm_severity` LowCardinality(String) `json:$.self_harm.severity` DEFAULT 'safe',
-    `self_harm_filtered` Bool `json:$.self_harm.filtered` DEFAULT false,
     `sexual_severity` LowCardinality(String) `json:$.sexual.severity` DEFAULT 'safe',
-    `sexual_filtered` Bool `json:$.sexual.filtered` DEFAULT false,
     `violence_severity` LowCardinality(String) `json:$.violence.severity` DEFAULT 'safe',
-    `violence_filtered` Bool `json:$.violence.filtered` DEFAULT false,
-
-    -- Protected material detection
     `protected_material_code_detected` Bool `json:$.protected_material_code.detected` DEFAULT false,
-    `protected_material_code_filtered` Bool `json:$.protected_material_code.filtered` DEFAULT false,
-    `protected_material_code_url` Nullable(String) `json:$.protected_material_code.citation.URL` DEFAULT NULL,
-    `protected_material_code_license` Nullable(String) `json:$.protected_material_code.citation.license` DEFAULT NULL,
-    `protected_material_text_detected` Bool `json:$.protected_material_text.detected` DEFAULT false,
-    `protected_material_text_filtered` Bool `json:$.protected_material_text.filtered` DEFAULT false,
-
-    -- Additional detection categories
-    `jailbreak_detected` Bool `json:$.jailbreak.detected` DEFAULT false,
-    `jailbreak_filtered` Bool `json:$.jailbreak.filtered` DEFAULT false,
-    `profanity_detected` Bool `json:$.profanity.detected` DEFAULT false,
-    `profanity_filtered` Bool `json:$.profanity.filtered` DEFAULT false
+    `protected_material_text_detected` Bool `json:$.protected_material_text.detected` DEFAULT false
 
 ENGINE "MergeTree" 
-ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
-ENGINE_SORTING_KEY "timestamp, id"
-ENGINE_PRIMARY_KEY "timestamp, id"
+ENGINE_PARTITION_KEY "id"
+ENGINE_SORTING_KEY "id"
+ENGINE_PRIMARY_KEY "id"
 
 

--- a/text.pollinations.ai/observability/datasources/text_moderation.datasource
+++ b/text.pollinations.ai/observability/datasources/text_moderation.datasource
@@ -18,4 +18,6 @@ ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "id"
 ENGINE_PRIMARY_KEY "id"
 
+FORWARD_QUERY > 
+  SELECT id, defaultValueOfTypeName('DateTime') AS timestamp, hate_severity, self_harm_severity, sexual_severity, violence_severity, protected_material_code_detected, protected_material_text_detected
 

--- a/text.pollinations.ai/observability/datasources/text_moderation.datasource
+++ b/text.pollinations.ai/observability/datasources/text_moderation.datasource
@@ -3,6 +3,7 @@ DESCRIPTION >
 
 SCHEMA >
     `id` String `json:$.id` DEFAULT '',
+    `timestamp` DateTime `json:$.timestamp`,
 
     -- OpenAI Moderation Parameters (severity levels and detection flags only)
     `hate_severity` LowCardinality(String) `json:$.hate.severity` DEFAULT 'safe',
@@ -13,7 +14,7 @@ SCHEMA >
     `protected_material_text_detected` Bool `json:$.protected_material_text.detected` DEFAULT false
 
 ENGINE "MergeTree" 
-ENGINE_PARTITION_KEY ""
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "id"
 ENGINE_PRIMARY_KEY "id"
 

--- a/text.pollinations.ai/observability/datasources/text_moderation.datasource
+++ b/text.pollinations.ai/observability/datasources/text_moderation.datasource
@@ -3,7 +3,6 @@ DESCRIPTION >
 
 SCHEMA >
     `id` String `json:$.id` DEFAULT '',
-    `timestamp` DateTime `json:$.timestamp`,
 
     -- OpenAI Moderation Parameters (severity levels and detection flags only)
     `hate_severity` LowCardinality(String) `json:$.hate.severity` DEFAULT 'safe',
@@ -14,7 +13,7 @@ SCHEMA >
     `protected_material_text_detected` Bool `json:$.protected_material_text.detected` DEFAULT false
 
 ENGINE "MergeTree" 
-ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_PARTITION_KEY ""
 ENGINE_SORTING_KEY "id"
 ENGINE_PRIMARY_KEY "id"
 

--- a/text.pollinations.ai/observability/tinybirdTracker.js
+++ b/text.pollinations.ai/observability/tinybirdTracker.js
@@ -210,7 +210,6 @@ export async function sendTinybirdEvent(eventData) {
                         "text_moderation",
                         {
                             id: tinybirdEvent.id ?? generatePollinationsId(),
-                            timestamp: tinybirdEvent.start_time || new Date().toISOString(),
                             ...cfr,
                         },
                         moderationController,

--- a/text.pollinations.ai/observability/tinybirdTracker.js
+++ b/text.pollinations.ai/observability/tinybirdTracker.js
@@ -210,6 +210,7 @@ export async function sendTinybirdEvent(eventData) {
                         "text_moderation",
                         {
                             id: tinybirdEvent.id ?? generatePollinationsId(),
+                            timestamp: tinybirdEvent.start_time || new Date().toISOString(),
                             ...cfr,
                         },
                         moderationController,


### PR DESCRIPTION
## Problem 🚨

TinyBird engineer Jordi reported rate limiting due to partitioning by high-cardinality `id` field in `text_moderation` datasource, causing "TOO_MANY_PARTS" errors.

## Solution ✅

**Minimal fix approach:**
- ✅ Reverted extensive telemetry changes from commit d5c4367
- ✅ Added only timestamp field to `text_moderation` datasource  
- ✅ Changed partition key from `"id"` to `"toYYYYMM(timestamp)"`
- ✅ Added FORWARD_QUERY for schema migration
- ✅ Updated telemetry code to send timestamp with moderation data

## Technical Details 🔧

**Files Modified:**
- `text.pollinations.ai/observability/datasources/text_moderation.datasource`
- `text.pollinations.ai/observability/tinybirdTracker.js`

**Migration Strategy:**
- FORWARD_QUERY handles existing data transformation
- Uses `defaultValueOfTypeName('DateTime')` for backfill
- Enables monthly partitioning for performance

## Why This Approach 📋

Per user request: "we did too much" - this PR contains only the minimal changes needed to fix the TinyBird partitioning issue without the extensive telemetry system refactoring.

Addresses TinyBird rate limiting while maintaining system stability.