### PR TITLE
Add hourly token usage endpoint

### DIFF
--- a/text.pollinations.ai/observability/endpoints/hourly_token_usage_new.pipe
+++ b/text.pollinations.ai/observability/endpoints/hourly_token_usage_new.pipe
@@ -1,0 +1,35 @@
+TOKEN read_pipes READ
+
+DESCRIPTION >
+    Get hourly token usage for a specific user
+
+NODE hourly_token_usage_node
+SQL >
+    %
+    SELECT
+        toStartOfHour(timestamp) as hour,
+        referrer,
+        sum(token_count_prompt_text + token_count_prompt_audio + token_count_prompt_cached) as usage_prompt_tokens,
+        sum(token_count_completion_text + token_count_completion_audio) as usage_completion_tokens,
+        sum(token_count_prompt_text + token_count_prompt_audio + token_count_prompt_cached + token_count_completion_text + token_count_completion_audio) as total_tokens,
+        sum(cost) as total_costs,
+        count() as total_requests
+    FROM text_events
+    WHERE
+        1 = 1
+        {% if defined(username) and username != [''] %} AND user IN {{ Array(username) }} {% end %}
+        {% if defined(start_date) %} AND timestamp >= {{ DateTime(start_date) }}
+        {% else %} AND timestamp >= now() - interval 6 day
+        {% end %}
+        {% if defined(end_date) %} AND timestamp <= {{ DateTime(end_date) }}
+        {% else %} AND timestamp <= now()
+        {% end %}
+        {% if defined(environment) and environment != [''] %}
+            AND environment IN {{ Array(environment) }}
+        {% end %}
+        {% if defined(model) and model != [''] %} AND model_requested IN {{ Array(model) }} {% end %}
+        {% if defined(referrer) and referrer != [''] %} AND referrer IN {{ Array(referrer) }} {% end %}
+    GROUP BY hour, referrer
+    ORDER BY hour ASC, total_costs DESC
+
+TYPE endpoint


### PR DESCRIPTION
Introduces a new endpoint to retrieve hourly token usage statistics for a specific user, including prompt and completion tokens, total costs, and request counts. Supports filtering by username, date range, environment, model, and referrer.