### PR TITLE
Enable Claude web search and Sequa MCP integration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,19 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "web_search"
+          mcp_config: |
+            {
+              "mcpServers": {
+                "sequa": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@sequa-ai/sequa-mcp@latest",
+                    "https://mcp.sequa.ai/v1/pollinations/contribute"
+                  ]
+                }
+              }
+            }
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "web_search"
+          # Web search requires organization-level permission in Anthropic Console
+          # allowed_tools: "web_search"
           mcp_config: |
             {
               "mcpServers": {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "web_search"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Add this to your MCP client configuration:
 npx @pollinations/model-context-protocol
 ```
 
-Community alternatives like [MCPollinations](https://github.com/pinkpixel-dev/MCPollinations) are also available.
+Community alternatives like [MCPollinations](https://github.com/pinkpixel-dev/MCPollinations) and [Sequa MCP Server](https://mcp.sequa.ai/v1/pollinations/contribute) are also available.
 
 AI assistants can:
 - Generate images from text descriptions

--- a/pollinations.ai/src/config/projects/hackAndBuild.js
+++ b/pollinations.ai/src/config/projects/hackAndBuild.js
@@ -13,6 +13,15 @@ export const hackAndBuildProjects = [
     stars: 27
   },
   {
+    name: "Sequa MCP Server",
+    url: "https://mcp.sequa.ai/v1/pollinations/contribute",
+    description: "A Model Context Protocol server from Sequa.ai that provides deep knowledge of the Pollinations codebase. Offers documentation, context, and guidance to coding agents working on Pollinations projects.",
+    author: "@sequa_ai",
+    category: "sdkLibraries",
+    submissionDate: "2025-08-22",
+    order: 1
+  },
+  {
     name: "pollinations_ai",
     url: "https://pub.dev/packages/pollinations_ai",
     description: "Dart/Flutter package for Pollinations API.",


### PR DESCRIPTION
This PR enables web search capabilities and integrates the Sequa MCP server into the Claude GitHub Actions workflow.

## Changes
- Added `allowed_tools: "web_search"` to enable web search functionality
- Integrated Sequa MCP server for deep codebase knowledge
- Tested workflow configuration with issue #3821

## Testing
- Sequa MCP server integration: ✅ Working (provides comprehensive codebase analysis)
- Web search: ⚠️ Requires organization-level permission in Anthropic Console

Generated with [Claude Code](https://claude.ai/code)