### PR TITLE
Replace default pricing with error throwing for missing cost data

### DIFF
--- a/text.pollinations.ai/modelCost.js
+++ b/text.pollinations.ai/modelCost.js
@@ -199,8 +199,3 @@ export function getAllCost() {
 }
 
 
-// BACKWARD COMPATIBILITY: Export functions with original names for external APIs
-export const resolvePricing = resolveCost;
-export const getPricingWithDefaults = getCost;
-export const hasPricing = hasCost;
-export const getAllPricing = getAllCost;

--- a/text.pollinations.ai/observability/costCalculator.js
+++ b/text.pollinations.ai/observability/costCalculator.js
@@ -25,8 +25,6 @@ export function resolveCost(responseModel) {
     return null;
 }
 
-// BACKWARD COMPATIBILITY: Export function with original name for external APIs
-export const resolvePricing = resolveCost;
 
 /**
  * Calculate the total cost for an LLM request based on token usage and pricing


### PR DESCRIPTION
## Summary
Replace default pricing fallback behavior with clear error messages when cost data is missing for models.

## Changes Made
- **Removed `DEFAULT_COST` constant** - No more fallback to default values
- **Updated `resolveCost()`** - Now throws error instead of returning null when no cost found
- **Renamed `getCostWithDefaults()` → `getCost()`** - Function name now accurately reflects behavior
- **Removed `getDefaultCost()` function** - No longer needed
- **Clear error messages** - Directs users to contact support@pollinations.ai

## Error Messages
- `"Missing cost data. Please contact support@pollinations.ai"` (no model name)
- `"Missing cost data for model "{modelName}". Please contact support@pollinations.ai"` (model not found)

## Impact
When a model has missing cost data, the system will now throw a clear error instead of silently using default pricing values. This ensures cost tracking accuracy and alerts us to missing model configurations.

## Testing
- Error will bubble up through tinybirdTracker.js → costCalculator.js → modelCost.js
- Existing models with proper cost data continue to work normally
- Missing cost data now results in actionable error messages