### PR TITLE
Update text.pollinations.ai root redirect to API documentation

### DIFF
--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -98,7 +98,7 @@ app.use(bodyParser.json({ limit: "20mb" }));
 app.use(cors());
 // New route handler for root path
 app.get("/", (req, res) => {
-	res.redirect("https://sur.pollinations.ai");
+	res.redirect("https://github.com/pollinations/pollinations/blob/master/APIDOCS.md");
 });
 
 // Serve crossdomain.xml for Flash connections


### PR DESCRIPTION
Changes the root path redirect from the outdated sur.pollinations.ai community UI to the official API documentation on GitHub.

This provides users with comprehensive and maintained API reference instead of potentially outdated third-party UI.

Closes #3960

Generated with [Claude Code](https://claude.ai/code)