### PR TITLE
Remove community model cost definitions

### DIFF
--- a/text.pollinations.ai/modelCost.js
+++ b/text.pollinations.ai/modelCost.js
@@ -102,38 +102,6 @@ const MODEL_COST = {
 		prompt_text: 0.5,
 		prompt_cache: 0.125,
 		completion_text: 2.0
-	},
-
-	// Community models (using model names as keys)
-	"unity": {
-		prompt_text: 1.0,
-		prompt_cache: 0.25,
-		completion_text: 4.0
-	},
-	"mirexa": {
-		prompt_text: 1.0,
-		prompt_cache: 0.25,
-		completion_text: 4.0
-	},
-	"midijourney": {
-		prompt_text: 1.0,
-		prompt_cache: 0.25,
-		completion_text: 4.0
-	},
-	"rtist": {
-		prompt_text: 1.0,
-		prompt_cache: 0.25,
-		completion_text: 4.0
-	},
-	"evil": {
-		prompt_text: 1.0,
-		prompt_cache: 0.25,
-		completion_text: 4.0
-	},
-	"bidara": {
-		prompt_text: 1.0,
-		prompt_cache: 0.25,
-		completion_text: 4.0
 	}
 };
 


### PR DESCRIPTION
## Summary
This PR removes redundant cost definitions for community models from .

## Changes
- Removed cost definitions for community models: unity, mirexa, midijourney, rtist, evil, bidara
- These models use transform functions and inherit costs from their underlying models
- Simplifies cost configuration by removing redundant entries

## Rationale
Community models are wrapper models that use transform functions to modify prompts before calling underlying models (like mistral-small-3.1-24b-instruct-2503 or azure-gpt-4.1). They should inherit the cost structure from their underlying models rather than having separate cost definitions.

## Testing
- No functional changes to cost calculation logic
- Community models will now properly inherit costs from their underlying models