### PR TITLE
Fix: Enforce max_tokens as hard cap instead of allowing user overrides

### DIFF
--- a/text.pollinations.ai/transforms/limitChecker.js
+++ b/text.pollinations.ai/transforms/limitChecker.js
@@ -27,14 +27,16 @@ export function checkLimits(messages, options) {
         }
     }
 
-    // Set max_tokens if not provided
-    if (!updatedOptions.max_tokens) {
-        if (modelConfig.maxTokens) {
-            log(`Setting max_tokens to model-specific value: ${modelConfig.maxTokens}`);
-            updatedOptions.max_tokens = modelConfig.maxTokens;
-        } else if (config["max-tokens"]) {
-            log(`Setting max_tokens to default value: ${config["max-tokens"]}`);
-            updatedOptions.max_tokens = config["max-tokens"];
+    // Enforce max_tokens limits - model config takes precedence over user requests
+    const configuredMaxTokens = modelConfig.maxTokens || config["max-tokens"];
+    
+    if (configuredMaxTokens) {
+        if (updatedOptions.max_tokens && updatedOptions.max_tokens > configuredMaxTokens) {
+            log(`User requested ${updatedOptions.max_tokens} tokens, but model limit is ${configuredMaxTokens}. Capping to limit.`);
+            updatedOptions.max_tokens = configuredMaxTokens;
+        } else if (!updatedOptions.max_tokens) {
+            log(`Setting max_tokens to configured limit: ${configuredMaxTokens}`);
+            updatedOptions.max_tokens = configuredMaxTokens;
         }
     }
 


### PR DESCRIPTION
## Problem
Users could override the configured max_tokens limits in model configurations, allowing them to request more tokens than intended.

For example, the openai-large model has a configured limit of 1024 tokens, but users could request 2000+ tokens and bypass this limit.

## Solution
Updated transforms/limitChecker.js to enforce model configuration limits as hard caps:

- User requests above the configured limit are capped to the limit
- User requests below the limit are honored as requested  
- No max_tokens specified defaults to the configured limit
- Maintains backward compatibility for requests within limits

## Changes
- openai-large: Requests above 1024 tokens now capped to 1024
- All models: Configured max_tokens limits now enforced as hard caps
- Logging: Added debug logs when capping user requests

## Testing
- User requests within limit: honored as requested
- User requests at limit: honored as requested
- User requests above limit: capped to configured limit
- No max_tokens specified: defaults to configured limit

Fixes the security/resource issue where users could bypass intended token limits.