### PR TITLE
[text.]: Handle non-string message content in sanitizer.

### DIFF
--- a/text.pollinations.ai/transforms/messageSanitizer.js
+++ b/text.pollinations.ai/transforms/messageSanitizer.js
@@ -16,12 +16,19 @@ function sanitizeMessagesWithPlaceholder(messages, modelConfig, virtualModelName
 
     let replacedCount = 0;
     const sanitized = messages.map(message => {
-        if (message.role === 'user' && (!message.content || message.content.trim() === '')) {
-            replacedCount++;
-            return {
-                ...message,
-                content: 'Please provide a response.'
-            };
+        if (message.role === 'user') {
+            // Check if content is empty, considering different types
+            const isEmpty = !message.content || 
+                           (typeof message.content === 'string' && message.content.trim() === '') ||
+                           (Array.isArray(message.content) && message.content.length === 0);
+            
+            if (isEmpty) {
+                replacedCount++;
+                return {
+                    ...message,
+                    content: 'Please provide a response.'
+                };
+            }
         }
         return message;
     });


### PR DESCRIPTION
* Add type checking before calling .trim() on message.content.

* Handle array content for multimodal input.

* Check for empty arrays when content is an array type.