### PR TITLE
fix(gateway): preserve Portkey API Authorization; send provider token via x-portkey-authorization

### DIFF
--- a/text.pollinations.ai/portkeyUtils.js
+++ b/text.pollinations.ai/portkeyUtils.js
@@ -79,21 +79,20 @@ async function generatePortkeyHeaders(config) {
         headers[`x-portkey-${key}`] = value;
     }
 
-    // Add Authorization header if needed
+    // Add provider Authorization for Portkey as a custom header to avoid overwriting the Gateway API key
     if (config.authKey) {
         try {
             // Check if authKey is a function (for dynamic tokens)
             if (typeof config.authKey === "function") {
-                // Check if the function returns a Promise (async function)
                 const token = config.authKey();
                 if (token instanceof Promise) {
-                    headers["Authorization"] = `Bearer ${await token}`;
+                    headers["x-portkey-authorization"] = `Bearer ${await token}`;
                 } else {
-                    headers["Authorization"] = `Bearer ${token}`;
+                    headers["x-portkey-authorization"] = `Bearer ${token}`;
                 }
             } else {
                 // Regular string token
-                headers["Authorization"] = `Bearer ${config.authKey}`;
+                headers["x-portkey-authorization"] = `Bearer ${config.authKey}`;
             }
         } catch (error) {
             errorLog("Error getting auth token:", error);

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -217,6 +217,8 @@ async function handleRequest(req, res, requestData) {
 				referrer: requestData.referrer || "unknown",
 				cf_ray: req.headers["cf-ray"] || "",
 			},
+			// Preserve the originally requested model for telemetry and logging
+			originalRequestedModel: requestData.model,
 		};
 
 		const completion = await generateTextBasedOnModel(


### PR DESCRIPTION
## Summary
Ensure the Portkey gateway always receives its own API key in the `Authorization` header while forwarding the provider token via a dedicated header. This prevents the provider token from overwriting the gateway auth locally and in other environments.

## Changes
- File: `text.pollinations.ai/portkeyUtils.js`
  - Send provider token in `x-portkey-authorization` instead of `Authorization`.
- File: `text.pollinations.ai/server.js`
  - Preserve `originalRequestedModel` on options for downstream telemetry (no behavior change unless used by callers).

## Why
`genericOpenAIClient()` sets `Authorization: Bearer <PORTKEY_API_KEY>`. Our header generator later overwrote it with `Authorization: Bearer <provider_token>`, which caused the gateway to respond 404 locally. Using a Portkey-specific header for provider auth avoids that conflict.

## Testing
- Local GET/POST for `openai` and `gemini-search` returned 200 OK after this change.
- Telemetry shows `model_requested` and `model_used` correctly when the upstream responds.

## Risk
Low. The change is scoped to headers passed to the gateway and preserves existing behavior for other fields. The gateway should already support `x-portkey-authorization` or analogous custom headers for provider routing.
