### PR TITLE
Update image cost and pricing logic (rebased)

### DIFF
--- a/enter.pollinations.ai/drizzle/0000_nice_omega_red.sql
+++ b/enter.pollinations.ai/drizzle/0000_nice_omega_red.sql
@@ -118,6 +118,7 @@ CREATE TABLE `event` (
 	`token_count_completion_reasoning` integer NOT NULL,
 	`token_count_completion_audio` integer NOT NULL,
 	`token_count_completion_image` integer NOT NULL,
+	`cost_type` text,
 	`total_cost` real NOT NULL,
 	`total_price` real NOT NULL,
 	`moderation_hate_severity` text,

--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -17,7 +17,6 @@ SCHEMA >
 `referrer_url`    String                 `json:$.referrerUrl` DEFAULT 'undefined',
 `referrer_domain` LowCardinality(String) `json:$.referrerDomain` DEFAULT 'undefined',
 
-`model_provider`       LowCardinality(String) `json:$.modelProvider` DEFAULT 'undefined',
 `model_requested`      LowCardinality(String) `json:$.modelRequested` DEFAULT 'undefined',
 `model_used`           LowCardinality(String) `json:$.modelUsed` DEFAULT 'undefined',
 `is_billed_usage`      Bool                   `json:$.isBilledUsage`,
@@ -42,6 +41,7 @@ SCHEMA >
 `token_count_completion_audio`     UInt32   `json:$.tokenCountCompletionAudio` DEFAULT 0,
 `token_count_completion_image`     UInt32   `json:$.tokenCountCompletionImage` DEFAULT 0,
 
+`cost_type`     LowCardinality(String) `json:$.costType` DEFAULT 'undefined',
 `total_cost`    Float64 `json:$.totalCost` DEFAULT 0,
 `total_price`   Float64 `json:$.totalPrice` DEFAULT 0,
 
@@ -64,6 +64,3 @@ ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(start_time)"
 ENGINE_SORTING_KEY "start_time, environment, user_id, user_tier"
 ENGINE_PRIMARY_KEY "start_time, environment, user_id"
-
-FORWARD_QUERY >
-  SELECT request_id, start_time, end_time, response_time, CAST(response_status, 'UInt32') AS response_status, environment, event_type, user_id, user_tier, referrer_url, referrer_domain, model_provider, model_requested, model_used, is_billed_usage, token_price_prompt_text, token_price_prompt_cached, token_price_prompt_audio, token_price_prompt_image, token_price_completion_text, token_price_completion_reasoning, token_price_completion_audio, token_price_completion_image, token_count_prompt_text, token_count_prompt_audio, token_count_prompt_cached, token_count_prompt_image, token_count_completion_text, token_count_completion_reasoning, token_count_completion_audio, token_count_completion_image, total_cost, total_price, moderation_hate_severity, moderation_self_harm_severity, moderation_sexual_severity, moderation_violence_severity, moderation_protected_material_code_detected, moderation_protected_material_text_detected, cache_hit, cache_type, cache_semantic_similarity, cache_semantic_threshold, cache_key

--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -1,4 +1,4 @@
-import { PriceDefinition, TokenUsage } from "@/registry/registry";
+import { PriceDefinition, TokenUsage, CostType } from "@/registry/registry";
 import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 const eventTypeValues = ["generate.text", "generate.image"] as const;
@@ -83,8 +83,11 @@ export const event = sqliteTable("event", {
         "token_count_completion_image",
     ).notNull(),
 
-    // Cost and Price
+    // Cost
+    costType: text("cost_type").$type<CostType>(),
     totalCost: real("total_cost").notNull(),
+
+    // Price
     totalPrice: real("total_price").notNull(),
 
     // Moderation results

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -58,10 +58,11 @@ export const track = (eventType: EventType) =>
                 `Failed to get price definition for model: ${serviceOrDefault}`,
             );
         }
-        let modelUsage, cost, price;
+        let modelUsage, costType, cost, price;
         if (c.res.ok) {
             if (!cacheInfo.cacheHit) {
                 modelUsage = await extractUsage(c, eventType);
+                costType = REGISTRY.getCostType(modelUsage.model as ProviderId);
                 cost = REGISTRY.calculateCost(
                     modelUsage.model as ProviderId,
                     modelUsage.usage,
@@ -106,6 +107,7 @@ export const track = (eventType: EventType) =>
             ...priceToEventParams(tokenPrice),
             ...usageToEventParams(modelUsage?.usage),
 
+            costType,
             totalCost: cost?.totalCost || 0,
             totalPrice: price?.totalPrice || 0,
 

--- a/enter.pollinations.ai/src/registry/image.ts
+++ b/enter.pollinations.ai/src/registry/image.ts
@@ -7,36 +7,39 @@ import type {
 export const IMAGE_MODELS = {
     "flux": {
         displayName: "Flux",
+        costType: "fixed_operational_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
                 completionImageTokens: {
-                    unit: "DPMT",
-                    rate: 1,
+                    unit: "DPT",
+                    rate: 0, // fixed weekly cost
                 },
             },
         ],
     },
     "kontext": {
         displayName: "Flux Kontext",
+        costType: "fixed_operational_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
                 completionImageTokens: {
-                    unit: "DPMT",
-                    rate: 1,
+                    unit: "DPT",
+                    rate: 0, // fixed weekly cost
                 },
             },
         ],
     },
     "turbo": {
         displayName: "Turbo",
+        costType: "fixed_operational_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
                 completionImageTokens: {
-                    unit: "DPMT",
-                    rate: 1,
+                    unit: "DPT",
+                    rate: 0, // fixed weekly cost
                 },
             },
         ],
@@ -52,7 +55,7 @@ export const IMAGE_SERVICES = {
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
                 completionImageTokens: {
-                    unit: "DPMT",
+                    unit: "DPT",
                     rate: 0.0,
                 },
             },
@@ -62,13 +65,29 @@ export const IMAGE_SERVICES = {
         displayName: "Flux Kontext",
         aliases: [],
         modelProviders: ["kontext"],
-        price: costAsPrice("kontext"),
+        price: [
+            {
+                date: new Date("2025-08-01 00:00:00").getTime(),
+                completionImageTokens: {
+                    unit: "DPT",
+                    rate: 0.015,
+                },
+            },
+        ],
     },
     "turbo": {
         displayName: "Turbo",
         aliases: [],
         modelProviders: ["turbo"],
-        price: costAsPrice("turbo"),
+        price: [
+            {
+                date: new Date("2025-08-01 00:00:00").getTime(),
+                completionImageTokens: {
+                    unit: "DPT",
+                    rate: 0.015,
+                },
+            },
+        ],
     },
 } as const satisfies ServiceRegistry<typeof IMAGE_MODELS>;
 

--- a/enter.pollinations.ai/src/registry/registry.ts
+++ b/enter.pollinations.ai/src/registry/registry.ts
@@ -5,11 +5,20 @@ import { EventType } from "@/db/schema/event.ts";
 
 const PRECISION = 8;
 
+const COST_TYPES = ["fixed_operational_cost", "per_generation_cost"] as const;
+export type CostType = (typeof COST_TYPES)[number];
+
 const UNITS = {
     DPMT: {
         description: "dollars per million tokens",
         convert: (tokens: number, rate: number): number => {
             return safeRound((tokens / 1_000_000) * rate, PRECISION);
+        },
+    },
+    DPT: {
+        description: "dollars per token",
+        convert: (tokens: number, rate: number): number => {
+            return safeRound(tokens * rate, PRECISION);
         },
     },
 } as const;
@@ -75,6 +84,7 @@ export type CostDefinition = UsageConversionDefinition;
 
 export type ModelProviderDefinition = {
     displayName: string;
+    costType: CostType;
     cost: CostDefinition[];
 };
 
@@ -372,6 +382,9 @@ export function createRegistry<
             providerId: ProviderId<TP>,
         ): ModelProviderDefinition => {
             return providerRegistry[providerId];
+        },
+        getCostType: (providerId: ProviderId<TP>): CostType => {
+            return providerRegistry[providerId].costType;
         },
         getActiveCostDefinition: (
             providerId: ProviderId<TP>,

--- a/enter.pollinations.ai/src/registry/text.ts
+++ b/enter.pollinations.ai/src/registry/text.ts
@@ -7,6 +7,7 @@ import type {
 export const TEXT_MODELS = {
     "gpt-5-nano-2025-08-07": {
         displayName: "OpenAI GPT-5 Nano (Azure)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -27,6 +28,7 @@ export const TEXT_MODELS = {
     },
     "gpt-4.1-2025-04-14": {
         displayName: "OpenAI GPT-4.1 (Azure)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -47,6 +49,7 @@ export const TEXT_MODELS = {
     },
     "gpt-4.1-nano-2025-04-14": {
         displayName: "OpenAI GPT-4.1 Nano (Azure)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -67,6 +70,7 @@ export const TEXT_MODELS = {
     },
     "gpt-4o-mini-audio-preview-2024-12-17": {
         displayName: "OpenAI GPT-4o Mini Audio Preview (Azure)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -95,6 +99,7 @@ export const TEXT_MODELS = {
     },
     "qwen2.5-coder-32b-instruct": {
         displayName: "Qwen 2.5 Coder 32B (Scaleway)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -115,6 +120,7 @@ export const TEXT_MODELS = {
     },
     "mistral-small-3.1-24b-instruct-2503": {
         displayName: "Mistral Small 3.1 24B (Scaleway)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -135,6 +141,7 @@ export const TEXT_MODELS = {
     },
     "mistral.mistral-small-2402-v1:0": {
         displayName: "Mistral Small",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -155,6 +162,7 @@ export const TEXT_MODELS = {
     },
     "us.deepseek.r1-v1:0": {
         displayName: "DeepSeek R1",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -175,6 +183,7 @@ export const TEXT_MODELS = {
     },
     "amazon.nova-micro-v1:0": {
         displayName: "Amazon Nova Micro (Bedrock)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -195,6 +204,7 @@ export const TEXT_MODELS = {
     },
     "us.meta.llama3-1-8b-instruct-v1:0": {
         displayName: "Meta Llama 3.1 8B Instruct (Bedrock)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -215,6 +225,7 @@ export const TEXT_MODELS = {
     },
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
         displayName: "Claude 3.5 Haiku (Bedrock)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -235,6 +246,7 @@ export const TEXT_MODELS = {
     },
     "openai/o4-mini": {
         displayName: "OpenAI o4 Mini (API Navy)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -255,6 +267,7 @@ export const TEXT_MODELS = {
     },
     "google/gemini-2.5-flash-lite": {
         displayName: "Google Gemini 2.5 Flash Lite (API Navy)",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),
@@ -275,6 +288,7 @@ export const TEXT_MODELS = {
     },
     "gemini-2.5-flash-lite-search": {
         displayName: "Google Gemini 2.5 Flash Lite Search",
+        costType: "per_generation_cost",
         cost: [
             {
                 date: new Date("2025-08-01 00:00:00").getTime(),


### PR DESCRIPTION
- Handle image generations as 1 token per generation
- Add DPT unit to conveniently enter price per image
- Add `cost_type` to tracking events to record if the cost is a fixed weekly cost or per generation
