### PR TITLE
🚀 Configure GPT-5 Mini/Nano models and update nectar tier concurrency

### DIFF
--- a/shared/ipQueue.js
+++ b/shared/ipQueue.js
@@ -24,7 +24,7 @@ const tierCaps = {
     anonymous: 1,
     seed: 3,
     flower: 7,
-    nectar: 50,
+    nectar: 100,
 };
 
 /**

--- a/text.pollinations.ai/availableModels.js
+++ b/text.pollinations.ai/availableModels.js
@@ -19,26 +19,26 @@ import { BASE_PROMPTS } from "./prompts/systemPrompts.js";
 import { portkeyConfig } from "./configs/modelConfigs.js";
 
 const models = [
-	// {
-	// 	name: "openai",
-	// 	description: "OpenAI GPT-4.1 Mini",
-	// 	config: portkeyConfig["gpt-4.1-mini"],
-	// 	transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
-	// 	tier: "anonymous",
-	// 	community: false,
-	// 	aliases: ["gpt-4.1-mini"],
-	// 	input_modalities: ["text", "image"],
-	// 	output_modalities: ["text"],
-	// 	tools: true
-	// },
 	{
-		name: "openai-fast",
-		description: "OpenAI GPT-4.1 Nano",
-		config: portkeyConfig["gpt-4.1-nano"],
+		name: "openai",
+		description: "OpenAI GPT-5 Mini",
+		config: portkeyConfig["gpt-5-mini"],
 		transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
 		tier: "anonymous",
 		community: false,
-		aliases: ["openai"],
+		aliases: ["gpt-5-mini"],
+		input_modalities: ["text", "image"],
+		output_modalities: ["text"],
+		tools: true
+	},
+	{
+		name: "openai-fast",
+		description: "OpenAI GPT-5 Nano",
+		config: portkeyConfig["gpt-5-nano"],
+		transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
+		tier: "anonymous",
+		community: false,
+		aliases: ["gpt-5-nano"],
 		input_modalities: ["text", "image"],
 		output_modalities: ["text"],
 		tools: true

--- a/text.pollinations.ai/configs/modelConfigs.js
+++ b/text.pollinations.ai/configs/modelConfigs.js
@@ -40,9 +40,15 @@ export const portkeyConfig = {
 		),
 	"gpt-5-nano": () =>
 		createAzureModelConfig(
-			process.env.AZURE_OPENAI_NANO_5_API_KEY,
-			process.env.AZURE_OPENAI_NANO_5_ENDPOINT,
+			process.env.AZURE_MYCELI_GPT5NANO_API_KEY,
+			process.env.AZURE_MYCELI_GPT5NANO_ENDPOINT,
 			"gpt-5-nano",
+		),
+	"gpt-5-mini": () =>
+		createAzureModelConfig(
+			process.env.AZURE_MYCELI_GPT5MINI_API_KEY,
+			process.env.AZURE_MYCELI_GPT5MINI_ENDPOINT,
+			"gpt-5-mini",
 		),
 	"gpt-4.1-mini": () =>
 		createAzureModelConfig(

--- a/text.pollinations.ai/modelCost.js
+++ b/text.pollinations.ai/modelCost.js
@@ -24,10 +24,17 @@ const MODEL_COST = {
 	},
 	"gpt-5-nano-2025-08-07": {
 	  provider: "azure-openai",
-	  region: "eastus",
-	  prompt_text: 0.0,
+	  region: "eastus2",
+	  prompt_text: 0.05,
 	  prompt_cache: 0.01,
-	  completion_text: 0.40
+	  completion_text: 0.35
+	},
+	"gpt-5-mini-2025-08-07": {
+	  provider: "azure-openai",
+	  region: "eastus",
+	  prompt_text: 0.22,
+	  prompt_cache: 0.03,
+	  completion_text: 1.73
 	},
 	"gpt-4.1-2025-04-14": {
 	  provider: "azure-openai",


### PR DESCRIPTION
- Update 'openai' model to use GPT-5 Mini (Azure Myceli endpoint)
- Update 'openai-fast' model to use GPT-5 Nano (Azure Myceli endpoint)
- Add GPT-5 Mini/Nano pricing: €0.22/€1.73 and €0.05/€0.35 per 1M tokens
- Add model configurations for new Azure chat completions endpoints
- Increase nectar tier concurrency from 50 to 100 requests

Models now use chat completions API instead of responses API for better compatibility.