### PR TITLE
Add tracking headers to image service

### DIFF
--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "../../shared/auth-utils.js";
 import { extractToken, getIp } from "../../shared/extractFromRequest.js";
 import { sendImageTelemetry } from "./utils/telemetry.js";
+import { buildTrackingHeaders } from "./utils/trackingHeaders.js";
 
 // Import shared utilities
 import { enqueue } from "../../shared/ipQueue.js";
@@ -471,6 +472,16 @@ const checkCacheAndGenerate = async (
 
         // Add authentication debug headers using shared utility
         addAuthDebugHeaders(headers, authResult.debugInfo);
+
+        // Add tracking headers for enter service (GitHub issue #4170)
+        const trackingHeaders = buildTrackingHeaders(
+            safeParams.model,
+            authResult.tier,
+            authResult.userId,
+            authResult.username,
+            bufferAndMaturity.trackingData
+        );
+        Object.assign(headers, trackingHeaders);
 
         res.writeHead(200, headers);
         res.write(bufferAndMaturity.buffer);

--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -477,8 +477,6 @@ const checkCacheAndGenerate = async (
         const trackingHeaders = buildTrackingHeaders(
             safeParams.model,
             authResult.tier,
-            authResult.userId,
-            authResult.username,
             bufferAndMaturity.trackingData
         );
         Object.assign(headers, trackingHeaders);

--- a/image.pollinations.ai/src/models/seedreamModel.ts
+++ b/image.pollinations.ai/src/models/seedreamModel.ts
@@ -157,6 +157,15 @@ export const callSeedreamAPI = async (
             buffer: imageBuffer,
             isMature: false, // Seedream has built-in content filtering
             isChild: false,
+            // Include tracking data for enter service headers
+            trackingData: {
+                actualModel: 'seedream',
+                // Seedream uses unit-based pricing (1 token per image)
+                usage: {
+                    candidatesTokenCount: 1,
+                    totalTokenCount: 1
+                }
+            }
         };
 
     } catch (error) {

--- a/image.pollinations.ai/src/utils/trackingHeaders.ts
+++ b/image.pollinations.ai/src/utils/trackingHeaders.ts
@@ -1,0 +1,128 @@
+/**
+ * Utility for building tracking headers for the enter service
+ * Implements GitHub issue #4170 requirements
+ */
+
+import debug from "debug";
+
+const log = debug("pollinations:tracking-headers");
+
+export interface TrackingUsageData {
+    // Vertex AI / Gemini usage format
+    candidatesTokenCount?: number;
+    promptTokenCount?: number;
+    totalTokenCount?: number;
+    candidatesTokensDetails?: Array<{
+        modality: string;
+        tokenCount: number;
+    }>;
+}
+
+export interface ContentSafetyFlags {
+    categories?: string[];
+    severity?: string;
+    blocked?: boolean;
+}
+
+export interface TrackingData {
+    actualModel?: string;
+    usage?: TrackingUsageData;
+    promptModeration?: ContentSafetyFlags;
+    imageModeration?: ContentSafetyFlags;
+}
+
+/**
+ * Build tracking headers for the enter service
+ * @param model - The requested model name
+ * @param userTier - The user's authentication tier
+ * @param userId - The GitHub user ID (if available)
+ * @param username - The GitHub username (if available)
+ * @param trackingData - Usage and moderation data from generation
+ * @returns Headers object for HTTP response
+ */
+export function buildTrackingHeaders(
+    model: string,
+    userTier: string,
+    userId?: string | null,
+    username?: string | null,
+    trackingData?: TrackingData
+): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    // Required headers from issue #4170
+    headers['x-model-used'] = trackingData?.actualModel || model;
+    headers['x-user-tier'] = userTier || 'anonymous';
+    
+    // Token counting logic
+    let completionTokens = 1; // Default for unit-based pricing models
+    
+    if (model === 'nanobanana' && trackingData?.usage?.candidatesTokenCount) {
+        // For nanobanana, use total candidates tokens (image + text)
+        completionTokens = trackingData.usage.candidatesTokenCount;
+        log(`Nanobanana token count: ${completionTokens} (from candidatesTokenCount)`);
+    } else {
+        log(`Using default token count: ${completionTokens} for model: ${model}`);
+    }
+    
+    headers['x-completion-image-tokens'] = String(completionTokens);
+
+    // GitHub user identification (bonus headers)
+    if (userId) {
+        headers['x-github-user-id'] = userId;
+    }
+    if (username) {
+        headers['x-github-user-name'] = username;
+    }
+
+    // Moderation headers (OpenAI-compatible format)
+    if (trackingData?.promptModeration) {
+        if (trackingData.promptModeration.categories?.length) {
+            headers['x-moderation-prompt-categories'] = trackingData.promptModeration.categories.join(',');
+        }
+        if (trackingData.promptModeration.severity) {
+            headers['x-moderation-prompt-severity'] = trackingData.promptModeration.severity;
+        }
+    }
+
+    if (trackingData?.imageModeration) {
+        if (trackingData.imageModeration.categories?.length) {
+            headers['x-moderation-completion-categories'] = trackingData.imageModeration.categories.join(',');
+        }
+        if (trackingData.imageModeration.severity) {
+            headers['x-moderation-completion-severity'] = trackingData.imageModeration.severity;
+        }
+    }
+
+    log('Built tracking headers:', Object.keys(headers));
+    return headers;
+}
+
+/**
+ * Extract token count for billing purposes
+ * @param model - The model name
+ * @param usage - Usage data from the model
+ * @returns Token count for billing
+ */
+export function extractTokenCount(model: string, usage?: TrackingUsageData): number {
+    if (model === 'nanobanana' && usage?.candidatesTokenCount) {
+        return usage.candidatesTokenCount;
+    }
+    return 1; // Default for unit-based pricing
+}
+
+/**
+ * Format moderation data for OpenAI-compatible headers
+ * @param moderation - Content safety flags
+ * @returns Formatted moderation data
+ */
+export function formatModerationData(moderation?: ContentSafetyFlags): {
+    categories?: string;
+    severity?: string;
+} {
+    if (!moderation) return {};
+    
+    return {
+        categories: moderation.categories?.join(','),
+        severity: moderation.severity
+    };
+}

--- a/image.pollinations.ai/src/utils/trackingHeaders.ts
+++ b/image.pollinations.ai/src/utils/trackingHeaders.ts
@@ -35,21 +35,17 @@ export interface TrackingData {
  * Build tracking headers for the enter service
  * @param model - The requested model name
  * @param userTier - The user's authentication tier
- * @param userId - The GitHub user ID (if available)
- * @param username - The GitHub username (if available)
  * @param trackingData - Usage and moderation data from generation
  * @returns Headers object for HTTP response
  */
 export function buildTrackingHeaders(
     model: string,
     userTier: string,
-    userId?: string | null,
-    username?: string | null,
     trackingData?: TrackingData
 ): Record<string, string> {
     const headers: Record<string, string> = {};
 
-    // Required headers from issue #4170
+    // Core tracking headers
     headers['x-model-used'] = trackingData?.actualModel || model;
     headers['x-user-tier'] = userTier || 'anonymous';
     
@@ -65,33 +61,6 @@ export function buildTrackingHeaders(
     }
     
     headers['x-completion-image-tokens'] = String(completionTokens);
-
-    // GitHub user identification (bonus headers)
-    if (userId) {
-        headers['x-github-user-id'] = userId;
-    }
-    if (username) {
-        headers['x-github-user-name'] = username;
-    }
-
-    // Moderation headers (OpenAI-compatible format)
-    if (trackingData?.promptModeration) {
-        if (trackingData.promptModeration.categories?.length) {
-            headers['x-moderation-prompt-categories'] = trackingData.promptModeration.categories.join(',');
-        }
-        if (trackingData.promptModeration.severity) {
-            headers['x-moderation-prompt-severity'] = trackingData.promptModeration.severity;
-        }
-    }
-
-    if (trackingData?.imageModeration) {
-        if (trackingData.imageModeration.categories?.length) {
-            headers['x-moderation-completion-categories'] = trackingData.imageModeration.categories.join(',');
-        }
-        if (trackingData.imageModeration.severity) {
-            headers['x-moderation-completion-severity'] = trackingData.imageModeration.severity;
-        }
-    }
 
     log('Built tracking headers:', Object.keys(headers));
     return headers;

--- a/image.pollinations.ai/src/vertexAIImageGenerator.ts
+++ b/image.pollinations.ai/src/vertexAIImageGenerator.ts
@@ -281,7 +281,12 @@ export async function callVertexAIGemini(
         return {
             buffer: finalImageBuffer,
             isMature: false, // Gemini has built-in safety, assume safe
-            isChild: false   // Gemini has built-in safety, assume not child content
+            isChild: false,  // Gemini has built-in safety, assume not child content
+            // Include tracking data for enter service headers
+            trackingData: {
+                actualModel: 'nanobanana',
+                usage: result.usage // Vertex AI usage metadata
+            }
         };
 
     } catch (error) {


### PR DESCRIPTION
Implements tracking headers for the enter service as requested in #4170.

**Headers added:**
- `x-model-used` - The actual model used
- `x-user-tier` - User authentication tier  
- `x-completion-image-tokens` - Token count for billing

**Token counting:**
- Nanobanana: Uses actual Vertex AI token count (e.g., 1290 tokens)
- Other models: Uses unit-based pricing (1 token per request)

**Testing:**
All headers working correctly in production.

Closes #4170