### PR TITLE
Set permanent redirect for text.pollinations.ai root

### DIFF
--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -100,7 +100,7 @@ app.use(bodyParser.json({ limit: "20mb" }));
 app.use(cors());
 // New route handler for root path
 app.get("/", (req, res) => {
-	res.redirect("https://github.com/pollinations/pollinations/blob/master/APIDOCS.md");
+        res.redirect(301, "https://github.com/pollinations/pollinations/blob/master/APIDOCS.md");
 });
 
 // Serve crossdomain.xml for Flash connections


### PR DESCRIPTION
## Summary
- update the text service root route to issue a permanent redirect to the GitHub API documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64202ad20832e8745d1b6022436bd