### PR TITLE
Fix signup when a polar customer already exists

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -107,10 +107,28 @@ function onBeforeUserCreate(polar: Polar) {
                 });
             }
 
+            // if the customer already exists, link the new account
+            const { result } = await polar.customers.list({
+                email: user.email,
+            });
+            const existingCustomer = result.items[0];
+            if (existingCustomer?.externalId) {
+                return {
+                    data: {
+                        ...user,
+                        id: existingCustomer.externalId,
+                    },
+                };
+            }
+
             await polar.customers.create({
                 email: user.email,
                 name: user.name,
             });
+
+            return {
+                data: user,
+            };
         } catch (e: unknown) {
             const messageOrError = e instanceof Error ? e.message : e;
             throw new APIError("INTERNAL_SERVER_ERROR", {


### PR DESCRIPTION
When signing up, a polar customer for each user gets created. This PR makes it so that if a customer with this email address already exists, it is linked to the new account. This is mostly relevant for development, where the staging environment uses the same sandbox as the dev environment, but should also make the production version more robuts.
