### PR TITLE
Fix: Allow POST requests to root path to be cached

### DIFF
--- a/text.pollinations.ai/cloudflare-cache/src/index.js
+++ b/text.pollinations.ai/cloudflare-cache/src/index.js
@@ -236,11 +236,12 @@ export default {
             // Log request information
             log("request", `🚀 ${request.method} ${url.pathname}`);
 
-            // Let origin handle root requests (e.g. redirects) without caching
-            if (url.pathname === "/" || url.pathname === "") {
+            // Let origin handle GET root requests (e.g. redirects) without caching
+            // But allow POST requests to root to be cached
+            if ((url.pathname === "/" || url.pathname === "") && request.method === "GET") {
                 log(
                     "request",
-                    "Proxying root request directly to origin without caching",
+                    "Proxying GET root request directly to origin without caching",
                 );
                 return await proxyRequest(request, env);
             }


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The cache worker was excluding ALL requests to the root path (`/`) from caching, including POST requests with request bodies. This meant API requests to `https://text.pollinations.ai/` were never cached.

### Root Cause
Line 240 in `src/index.js` was checking only the path, not the HTTP method:
```javascript
// OLD - BUGGY
if (url.pathname === '/' || url.pathname === '') {
    return await proxyRequest(request, env);
}
```

### Solution
Now only GET requests to root path bypass cache (for redirects, health checks):
```javascript
// NEW - FIXED
if ((url.pathname === '/' || url.pathname === '') && request.method === 'GET') {
    return await proxyRequest(request, env);
}
```

### Testing Results
- **First POST request:** ~20s (cache miss)
- **Second POST request:** ~0.02s (cache hit)
- **Speed improvement:** 1,000x+ faster ⚡

### Deployment
Already deployed to production:
- Version ID: `6e303a52-0e4b-4d10-8cb8-1007261f3d5b`
- Worker: `pollinations-text-cache`

### Impact
- ✅ POST requests to root path now properly cached
- ✅ GET requests to root path still bypass cache (correct behavior)
- ✅ Massive performance improvement for cached API requests
- ✅ No breaking changes