### PR TITLE
Fix image model provider names in x-model-used header

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -244,7 +244,7 @@ export const callComfyUI = async (
             buffer: jpegBuffer, 
             ...rest,
             trackingData: {
-                actualModel: safeParams.model || 'flux',
+                actualModel: safeParams.model,
                 usage: {
                     candidatesTokenCount: 1,
                     totalTokenCount: 1
@@ -272,7 +272,7 @@ async function callCloudflareModel(
     additionalParams: object = {},
 ): Promise<ImageGenerationResult> {
     // Use the registry model name from safeParams, not the internal Cloudflare model path
-    const registryModelName = safeParams.model || 'flux';
+    const registryModelName = safeParams.model;
     const { accountId, apiToken } = getCloudflareCredentials();
 
     if (!accountId || !apiToken) {
@@ -735,7 +735,7 @@ const callAzureGPTImageWithEndpoint = async (
         isMature: false, // Default assumption
         isChild: false, // Default assumption
         trackingData: {
-            actualModel: safeParams.model || 'gptimage',
+            actualModel: safeParams.model,
             usage: {
                 candidatesTokenCount: 1,
                 totalTokenCount: 1

--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -244,7 +244,7 @@ export const callComfyUI = async (
             buffer: jpegBuffer, 
             ...rest,
             trackingData: {
-                actualModel: 'comfyui',
+                actualModel: safeParams.model || 'flux',
                 usage: {
                     candidatesTokenCount: 1,
                     totalTokenCount: 1
@@ -271,6 +271,8 @@ async function callCloudflareModel(
     modelPath: string,
     additionalParams: object = {},
 ): Promise<ImageGenerationResult> {
+    // Use the registry model name from safeParams, not the internal Cloudflare model path
+    const registryModelName = safeParams.model || 'flux';
     const { accountId, apiToken } = getCloudflareCredentials();
 
     if (!accountId || !apiToken) {
@@ -366,7 +368,7 @@ async function callCloudflareModel(
         isMature: false, 
         isChild: false,
         trackingData: {
-            actualModel: modelPath,
+            actualModel: registryModelName,
             usage: {
                 candidatesTokenCount: 1,
                 totalTokenCount: 1
@@ -732,6 +734,13 @@ const callAzureGPTImageWithEndpoint = async (
         buffer: imageBuffer,
         isMature: false, // Default assumption
         isChild: false, // Default assumption
+        trackingData: {
+            actualModel: safeParams.model || 'gptimage',
+            usage: {
+                candidatesTokenCount: 1,
+                totalTokenCount: 1
+            }
+        }
     };
 };
 

--- a/image.pollinations.ai/src/models/bpaigenModel.ts
+++ b/image.pollinations.ai/src/models/bpaigenModel.ts
@@ -215,6 +215,13 @@ const pollBPAIGenJob = async (
                     buffer,
                     isMature: false,
                     isChild: false,
+                    trackingData: {
+                        actualModel: 'kontext',
+                        usage: {
+                            candidatesTokenCount: 1,
+                            totalTokenCount: 1
+                        }
+                    }
                 };
             } else if (statusData.status === "failed") {
                 throw new Error(`BPAIGen job failed: ${statusData.error || 'Unknown error'}`);

--- a/image.pollinations.ai/src/models/kontextModel.ts
+++ b/image.pollinations.ai/src/models/kontextModel.ts
@@ -85,6 +85,13 @@ export const callKontextAPI = async (
             buffer,
             isMature: false,
             isChild: false,
+            trackingData: {
+                actualModel: 'kontext',
+                usage: {
+                    candidatesTokenCount: 1,
+                    totalTokenCount: 1
+                }
+            }
         };
     } catch (error) {
         logError("Error calling Kontext API:", error);


### PR DESCRIPTION
Fixes the `x-model-used` header to return registry model names instead of internal provider paths, ensuring consistency with the provider registry at `enter.pollinations.ai`.

## Problem
The `x-model-used` header was returning internal provider names (like `black-forest-labs/flux-1-schnell`) instead of user-facing model names (like `flux`) that are registered in the provider registry. This caused mismatches in billing and analytics tracking.

## Models Fixed
- **flux**: Now returns `flux` instead of `black-forest-labs/flux-1-schnell`
- **turbo**: Now returns `turbo` instead of internal Cloudflare model path
- **kontext**: Now returns `kontext` instead of internal API paths
- **gptimage**: Added tracking data with registry model name
- **nanobanana** & **seedream**: Already correct

## Files Modified
- `image.pollinations.ai/src/createAndReturnImages.ts`
- `image.pollinations.ai/src/models/bpaigenModel.ts`
- `image.pollinations.ai/src/models/kontextModel.ts`

Closes #4248