### PR TITLE
Document app idea proposal workflow for Hacktoberfest 2025

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,19 @@ We are in profound need of members who can help enhance our documentation. If yo
 
 Want to build something cool for Hacktoberfest? Check out our **[hacktoberfest-2025 folder](./hacktoberfest-2025/README.md)**! 
 
+**How it works:**
+1. **Propose your app idea** by creating a GitHub issue with `[Hacktoberfest App]` in the title
+2. Describe what you want to build and which Pollinations APIs you'll use
+3. Get feedback from maintainers
+4. Build your app and submit a PR
+
 Create apps using Pollinations APIs and get them featured. Each app lives in its own folder with clear docs. Perfect for:
 - Creative tools (meme generators, art tools)
 - Productivity apps (thumbnail creators, content generators)
 - Fun projects (games, quizzes)
 - Developer tools (API playgrounds, dashboards)
 
-See the [hacktoberfest-2025 README](./hacktoberfest-2025/README.md) for guidelines and the TEMPLATE folder for a starter.
+See the [hacktoberfest-2025 README](./hacktoberfest-2025/README.md) for detailed guidelines and templates.
 
 ### 5. Code Contributions
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 - **Hacktoberfest 2025 is here!**  
   If you're participating, please check out our [Code of Conduct](./CODE_OF_CONDUCT.md) and [Contributing Guidelines](./CONTRIBUTING.md) before submitting your PRs.
+- **Build Apps with Pollinations!** 🔥  
+  Create frontend apps using our APIs and get them featured. [Propose your app idea](https://github.com/pollinations/pollinations/issues/new) with `[Hacktoberfest App]` in the title, then build it! See the [hacktoberfest-2025 folder](./hacktoberfest-2025/README.md) for templates and guidelines.
 - For event PRs, look for issues tagged with `hacktoberfest` in our [issue tracker](https://github.com/pollinations/pollinations/issues) and join the community effort!
 
 - **Pollinations Hive**  

--- a/hacktoberfest-2025/README.md
+++ b/hacktoberfest-2025/README.md
@@ -54,12 +54,36 @@ hacktoberfest-2025/
 
 ## How to Submit
 
+### Step 1: Propose Your App Idea (Recommended)
+
+Before building, **create a GitHub issue** with your app idea:
+
+1. Go to [Issues](https://github.com/pollinations/pollinations/issues/new)
+2. Title: `[Hacktoberfest App] Your App Name`
+3. Describe:
+   - What your app does
+   - Which Pollinations APIs you'll use (text/image)
+   - Why it's useful/fun/interesting
+4. Tag it with `hacktoberfest` label
+5. Wait for feedback from maintainers
+
+**Why propose first?**
+- Get early feedback on your idea
+- Avoid building something that won't be accepted
+- Maintainers can suggest improvements
+- Shows you're serious about contributing
+
+### Step 2: Build Your App
+
+Once your idea is approved (or if you're feeling confident):
+
 1. Fork this repo
 2. Create your app folder in `hacktoberfest-2025/`
 3. Build something that actually works
 4. Test it from a fresh clone (seriously, do this)
 5. PR with title: `[Hacktoberfest] Add [App Name]`
-6. Tag it `hacktoberfest`
+6. Link to your original issue in the PR description
+7. Tag it `hacktoberfest`
 
 ## Templates & Examples
 

--- a/hacktoberfest-2025/TEMPLATE-HTML/README.md
+++ b/hacktoberfest-2025/TEMPLATE-HTML/README.md
@@ -2,6 +2,8 @@
 
 > One sentence about what this does
 
+**💡 Tip:** Before building, [propose your app idea](https://github.com/pollinations/pollinations/issues/new) with `[Hacktoberfest App]` in the title to get early feedback!
+
 ## What It Does
 
 Brief explanation (2-3 sentences). What problem does it solve?

--- a/hacktoberfest-2025/TEMPLATE-REACT/README.md
+++ b/hacktoberfest-2025/TEMPLATE-REACT/README.md
@@ -2,6 +2,8 @@
 
 > One sentence about what this does
 
+**💡 Tip:** Before building, [propose your app idea](https://github.com/pollinations/pollinations/issues/new) with `[Hacktoberfest App]` in the title to get early feedback!
+
 ## What It Does
 
 Brief explanation (2-3 sentences). What problem does it solve?


### PR DESCRIPTION
## Overview

Follow-up to PR #4344 - documents the recommended workflow for contributors to **propose app ideas via GitHub issues before building**, ensuring better coordination and reducing wasted effort.

## Changes Made

### 1. **README.md** - Main Hacktoberfest Section
- Added bullet point encouraging app idea proposals
- Links to issue creation with `[Hacktoberfest App]` title format
- Directs to hacktoberfest-2025 folder for templates

### 2. **CONTRIBUTING.md** - Build Apps Section
- Added clear 4-step workflow:
  1. Propose app idea (GitHub issue)
  2. Describe what you'll build and APIs used
  3. Get feedback from maintainers
  4. Build and submit PR

### 3. **hacktoberfest-2025/README.md** - Submission Process
- Restructured into **Step 1: Propose** and **Step 2: Build**
- Detailed instructions for creating proposal issues
- Explains benefits: early feedback, avoid rejection, get suggestions
- Added step to link PR back to original issue

### 4. **Template READMEs** (HTML & React)
- Added 💡 tip at top of both templates
- Encourages proposing before building
- Direct link to create new issue

## Why This Matters

- **Prevents wasted work** - contributors get feedback before investing time
- **Better quality** - maintainers can guide direction early
- **Clear tracking** - issues linked to PRs create paper trail
- **Community engagement** - discussion happens before code

## Related

- PR #4344 - Added Hacktoberfest 2025 folder structure
- Implements the "propose first, build second" contribution pattern

## Checklist

- [x] Updated main README.md
- [x] Updated CONTRIBUTING.md
- [x] Updated hacktoberfest-2025/README.md
- [x] Updated both template READMEs
- [x] Consistent messaging across all docs
- [x] Links to issue creation included