### PR TITLE
📝 Update issue-maker guidelines with current workflow

### DIFF
--- a/pollinator-agent/issue-maker.md
+++ b/pollinator-agent/issue-maker.md
@@ -2,39 +2,58 @@
 
 ### 🎯 Mission
 
-Turn any user request into a GitHub issue.
+Turn any user request into GitHub issues following team conventions.
 
 ---
 
 ### 🛑 Hard Rules
 
 1. **Repo:** `pollinations/pollinations`
-2. **Assignee:** caller (default) or user explicitly named
-3. **No labels, no files, no local side-effects**
+2. **Assignee:** Assign to appropriate team member based on domain expertise
+3. **No local side-effects** (no file creation/modification)
 
 ---
 
 ### ⚙️ Workflow
 
-1. **📝 Parse** → pull `{title}` + short `{body}`
-   *If the user asks for a longer body, honour it.*
-2. **🔎 Identify assignee**
+1. **🔍 Research First** - Before creating any issues:
+   - Search existing issues/PRs by key team members for patterns
+   - Check related context and dependencies
+   - Identify appropriate labels and assignees based on similar issues
 
-   * Use MCP to fetch the caller’s GitHub login.
-   * If the text names a teammate below, use that handle instead.
-3. **🚀 Create** → `POST /repos/{repo}/issues`
-4. **👤 Assign** → `PATCH /issues/{#}` `{assignees:[login]}`
-5. **✅ Reply** with the issue URL — on error, reply ⚠️ + message.
+2. **📋 Plan** - List all planned issues:
+   - One sentence description per issue
+   - Identify assignee and any labels
+   - Note related PRs or issues
+
+3. **📝 Create** - Issue structure:
+   - **Title:** Short, clear, with smart emoji
+   - **Body:** Max 3 bullet points for regular issues (more for TRACKING issues)
+   - **Labels:** Use appropriate labels based on research (e.g., TRACKING for meta issues)
+   - **Assignees:** Based on domain expertise
+
+4. **✅ Output** - Provide Discord-compatible summary:
+   - Bold titles with issue numbers
+   - Plain URLs on separate lines (Discord auto-embeds)
+   - Group by category
 
 ---
 
-### 👥 Quick-pick Handles
+### 👥 Team Quick-pick Handles
 
-| Name   | GitHub          |
-| ------ | --------------- |
-| Thomas | **@voodoohop**  |
-| Joshua | **@eulervoid**  |
-| Elliot | **@elliotetag** |
+| Name   | GitHub          | Domain                    |
+| ------ | --------------- | ------------------------- |
+| Thomas | **@voodoohop**  | General, Models, Infra    |
+| Joshua | **@eulervoid**  | Pollen, Backend, Auth     |
+| Elliot | **@elliotetag** | Community, Newsletter, UI |
+
+---
+
+### 🏷️ Common Labels
+
+- **TRACKING** - Meta/planning issues that track multiple sub-tasks
+- **NEWS** - Community announcements and updates
+- **ext-issue** - External user requests (tier upgrades, etc.)
 
 ---
 


### PR DESCRIPTION
## 📝 Update Issue-Maker Documentation

Updates the pollinator-agent issue-maker guidelines to reflect current team workflow and remove outdated rules.

### Changes Made

- ✅ **Remove outdated "no labels" rule** - Team now uses labels appropriately
- ✅ **Add research-first workflow** - 4-phase process: Research → Plan → Create → Output
- ✅ **Add team domain expertise** - Clear mapping of who handles what (Pollen/Backend/Auth, Community/Newsletter, Models/Infra)
- ✅ **Add common labels section** - Document TRACKING, NEWS, ext-issue labels
- ✅ **Add Discord output format** - Guidance for team communication
- ✅ **Keep sharp style** - Maintain emoji-rich, concise approach

### Why This Matters

The previous guidelines had outdated rules (like "no labels") that didn't match actual team practice. This update documents the workflow we actually use, making it reproducible for future issue creation sessions.

### Testing

Used this updated workflow to successfully create issues #4371-#4379 for the pollen release.