### PR TITLE
Update seedream model tier requirement from flower to nectar

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1011,16 +1011,16 @@ const generateImage = async (
     }
 
     if (safeParams.model === "seedream") {
-        // Seedream model requires flower tier or higher
-        if (!hasSufficientTier(userInfo.tier, "flower")) {
+        // Seedream model requires nectar tier or higher (temporarily due to limited credits)
+        if (!hasSufficientTier(userInfo.tier, "nectar")) {
             const errorText =
-                "Access to seedream model is limited to users in the flower tier or higher. Please authenticate at https://auth.pollinations.ai to get a token or add a referrer.";
+                "Access to seedream model is currently limited to users in the nectar tier or higher due to limited credits. Seedream will be available again to seed tier users in the next few days. Please authenticate at https://auth.pollinations.ai to get a token or add a referrer.";
             logError(errorText);
             progress.updateBar(
                 requestId,
                 35,
                 "Auth",
-                "Seedream model requires flower tier",
+                "Seedream temporarily requires nectar tier",
             );
             throw new Error(errorText);
         }

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -42,7 +42,7 @@ export const MODELS = {
         type: "seedream",
         enhance: false,
         maxSideLength: 2048, // Default 2048x2048, supports up to 4K resolution
-        tier: "flower",
+        tier: "nectar",
     },
 
     // Azure GPT Image model (temporarily disabled - uncomment to reactivate)


### PR DESCRIPTION
- Update seedream tier requirement from `flower` to `nectar` in models.ts
- Fix hardcoded tier check in createAndReturnImages.ts to match new requirement
- Update error messages to explain temporary credit limitations
- Add user-friendly message that seedream will return to seed tier in next few days

This change temporarily restricts seedream access to nectar tier users due to limited credits, with plans to restore seed tier access soon.