### PR TITLE
feat(enter): Add tier field to user table

### DIFF
--- a/enter.pollinations.ai/drizzle/0001_add_user_tier.sql
+++ b/enter.pollinations.ai/drizzle/0001_add_user_tier.sql
@@ -1,0 +1,7 @@
+-- Migration: Add tier column to user table
+-- Date: 2025-10-07
+-- Description: Add tier field with default 'seed' value and create index for performance
+
+ALTER TABLE user ADD COLUMN tier TEXT DEFAULT 'seed' NOT NULL;
+
+CREATE INDEX idx_user_tier ON user(tier);

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -58,6 +58,11 @@ export function createAuth(env: Cloudflare.Env) {
                     type: "string",
                     input: false,
                 },
+                tier: {
+                    type: "string",
+                    defaultValue: "seed",
+                    input: false,
+                },
             },
         },
         socialProviders: {

--- a/enter.pollinations.ai/src/db/schema/better-auth.ts
+++ b/enter.pollinations.ai/src/db/schema/better-auth.ts
@@ -21,6 +21,7 @@ export const user = sqliteTable("user", {
   banExpires: integer("ban_expires", { mode: "timestamp" }),
   githubId: integer("github_id"),
   githubUsername: text("github_username"),
+  tier: text("tier").default("seed").notNull(),
 });
 
 export const session = sqliteTable("session", {

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -211,8 +211,17 @@ function extractUserTier(
         return headerTier;
     }
     
-    // Fall back to response object for text generations
-    return response?.user_tier;
+    // Try response object for text generations
+    if (response?.user_tier) {
+        return response.user_tier;
+    }
+    
+    // Try user tier from auth context (new field we just added)
+    if (c.var.auth.user?.tier) {
+        return c.var.auth.user.tier;
+    }
+    
+    return undefined;
 }
 
 function extractContentFilterResults(


### PR DESCRIPTION
- Add `tier` column to user schema with default `"seed"` value
- Add tier to better-auth user additional fields
- Update tracking middleware to extract tier from user object
- Add migration script with tier index for performance

Tier is now stored as user metadata and automatically tracked in all generation events. Usage/enforcement will be determined later.