### PR TITLE
🐛 Fix API key description not saving to metadata

### DIFF
--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -54,7 +54,9 @@ function RouteComponent() {
     const handleCreateApiKey = async (formState: CreateApiKey) => {
         const createKeyDate = {
             name: formState.name,
-            description: formState.description,
+            metadata: {
+                description: formState.description,
+            },
         };
         const result = await auth.apiKey.create(createKeyDate);
         if (result.error) {


### PR DESCRIPTION
## 🐛 Bug Fix: API Key Description Not Displaying

Fixes the issue where entering a description when creating an API key doesn't show up in the table.

### Problem
When creating an API key with a description:
- User enters description in the form ✅
- Description is not saved ❌
- Table shows "—" instead of the description ❌

### Root Cause
The frontend was sending:
```js
{ name: "...", description: "..." }
```

But the backend expects (because `enableMetadata: true` in the API key plugin):
```js
{ name: "...", metadata: { description: "..." } }
```

### Solution
Wrapped the description in a `metadata` object before sending to `auth.apiKey.create()`.

### Testing
- ✅ Create API key with description
- ✅ Description now appears in the table
- ✅ Existing keys without metadata still work

Closes #4433