### PR TITLE
🐛 Fix API key description not persisting to metadata

### DIFF
--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -54,7 +54,9 @@ function RouteComponent() {
     const handleCreateApiKey = async (formState: CreateApiKey) => {
         const createKeyDate = {
             name: formState.name,
-            description: formState.description,
+            metadata: {
+                description: formState.description,
+            },
         };
         const result = await auth.apiKey.create(createKeyDate);
         if (result.error) {


### PR DESCRIPTION
## 🐛 Bug Fix: API Key Description Not Displaying

Fixes the issue where entering a description when creating an API key doesn't show up in the table.

### Problem
When creating an API key with a description:
- ✅ User enters description in the form
- ❌ Description is not saved
- ❌ Table shows "—" instead of the description

### Root Cause
The frontend was sending:
```js
{ name: "...", description: "..." }
```

But the backend expects (because `enableMetadata: true` in the API key plugin):
```js
{ name: "...", metadata: { description: "..." } }
```

### Solution
Wrapped the description in a `metadata` object in `handleCreateApiKey` before sending to `auth.apiKey.create()`.

**File changed:** `src/client/routes/index.tsx` (lines 57-59)

### Testing
- ✅ Create API key with description → description now appears in table
- ✅ Create API key without description → shows "—" as before
- ✅ Existing keys without metadata still work

Closes #4435