### PR TITLE
✨ Fix FAQ bullet points not displaying

### DIFF
--- a/enter.pollinations.ai/src/client/components/faq.tsx
+++ b/enter.pollinations.ai/src/client/components/faq.tsx
@@ -79,7 +79,7 @@ export const FAQ: FC = () => {
                             </button>
                             {openIndices.has(index) && (
                                 <div 
-                                    className="mt-3 text-gray-600 leading-relaxed prose prose-sm max-w-none"
+                                    className="mt-3 text-gray-600 leading-relaxed prose prose-sm max-w-none [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:space-y-2 [&_li]:list-item [&_li]:ml-4 [&_li]:text-gray-600 [&_p]:mb-3"
                                     dangerouslySetInnerHTML={{ __html: item.answer }}
                                 />
                             )}


### PR DESCRIPTION
## ✨ UI Fix: FAQ Bullet Points Not Visible

Fixes the issue where FAQ answers with bullet points don't show the bullet markers.

### Problem
FAQ items with lists (like "How do I get Pollen?") displayed as plain text without bullet points:
- ❌ No visual list markers
- ❌ Items run together without clear separation

### Root Cause
CSS was using `display: block` on `<li>` elements, which hides the bullet markers.

### Solution
Changed to `display: list-item` with proper spacing:
```css
[&_li]:list-item    /* Shows bullet markers */
[&_li]:ml-4         /* Adds left margin */
[&_ul]:space-y-2    /* Vertical spacing between items */
```

**File changed:** `src/client/components/faq.tsx` (line 82)

### Result
- ✅ Bullet points now visible
- ✅ Proper list formatting
- ✅ Better readability with spacing

Closes #4440