### PR TITLE
Improve mobile responsive design

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-key.tsx
+++ b/enter.pollinations.ai/src/client/components/api-key.tsx
@@ -57,8 +57,8 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                     />
                 </div>
                 {apiKeys.length ? (
-                    <div className="bg-emerald-100 rounded-2xl p-8 border border-pink-300">
-                        <div className="grid grid-cols-[1fr_1fr_1fr_1fr_60px] gap-2">
+                    <div className="bg-emerald-100 rounded-2xl p-8 border border-pink-300 overflow-x-auto scrollbar-hide">
+                        <div className="grid grid-cols-[1fr_1fr_1fr_1fr_60px] gap-2 min-w-[600px]">
                             <span className="font-bold text-pink-400 mb-2">Name</span>
                             <span className="font-bold text-pink-400 mb-2">Description</span>
                             <span className="font-bold text-pink-400 mb-2">Start</span>

--- a/enter.pollinations.ai/src/client/components/header.tsx
+++ b/enter.pollinations.ai/src/client/components/header.tsx
@@ -1,0 +1,20 @@
+import type { FC, ReactNode } from "react";
+
+type HeaderProps = {
+    children: ReactNode;
+};
+
+export const Header: FC<HeaderProps> = ({ children }) => {
+    return (
+        <div className="flex flex-col sm:flex-row justify-between gap-4 sm:items-center">
+            <img 
+                src="/logo_text_black.svg" 
+                alt="pollinations.ai" 
+                className="h-12 w-full sm:w-auto sm:flex-1 object-contain object-center sm:object-left" 
+            />
+            <div className="flex gap-4 items-center justify-between sm:justify-end">
+                {children}
+            </div>
+        </div>
+    );
+};

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -12,6 +12,7 @@ import { config } from "../config.ts";
 import { User } from "../components/user.tsx";
 import { PollenBalance } from "../components/pollen-balance.tsx";
 import { FAQ } from "../components/faq.tsx";
+import { Header } from "../components/header.tsx";
 
 export const Route = createFileRoute("/")({
     component: RouteComponent,
@@ -77,8 +78,7 @@ function RouteComponent() {
 
     return (
         <div className="flex flex-col gap-20">
-            <div className="flex justify-between gap-4 items-center">
-                <img src="/logo_text_black.svg" alt="pollinations.ai" className="h-12 flex-1 object-contain object-left" />
+            <Header>
                 <Button as="a" href="/api/docs" weight="outline">
                     API Docs →
                 </Button>
@@ -90,37 +90,15 @@ function RouteComponent() {
                         window.location.href = "/api/polar/customer/portal";
                     }}
                 />
-            </div>
+            </Header>
             <div className="flex flex-col gap-2">
-                <div className="flex justify-between gap-3">
+                <div className="flex flex-col sm:flex-row justify-between gap-3">
                     <h2 className="font-bold flex-1">Balance</h2>
-                    <Button
-                        as={"a"}
-                        color="pink"
-                        weight="light"
-                        href="/api/polar/checkout/pollen-bundle-small"
-                        target="_blank"
-                    >
-                        + $10
-                    </Button>
-                    <Button
-                        as="a"
-                        color="blue"
-                        weight="light"
-                        href="/api/polar/checkout/pollen-bundle-medium"
-                        target="_blank"
-                    >
-                        + $25
-                    </Button>
-                    <Button
-                        as="a"
-                        color="red"
-                        weight="light"
-                        href="/api/polar/checkout/pollen-bundle-large"
-                        target="_blank"
-                    >
-                        + $50    
-                    </Button>
+                    <div className="flex gap-3">
+                        <Button as="a" color="pink" weight="light" href="/api/polar/checkout/pollen-bundle-small" target="_blank">+ $10</Button>
+                        <Button as="a" color="blue" weight="light" href="/api/polar/checkout/pollen-bundle-medium" target="_blank">+ $25</Button>
+                        <Button as="a" color="red" weight="light" href="/api/polar/checkout/pollen-bundle-large" target="_blank">+ $50</Button>
+                    </div>
                 </div>
                 <PollenBalance balance={balance} />
             </div>

--- a/enter.pollinations.ai/src/client/routes/sign-in.tsx
+++ b/enter.pollinations.ai/src/client/routes/sign-in.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 import { FAQ } from "../components/faq.tsx";
 import { Button } from "../components/button.tsx";
+import { Header } from "../components/header.tsx";
 
 export const Route = createFileRoute("/sign-in")({
     component: RouteComponent,
@@ -28,20 +29,12 @@ function RouteComponent() {
 
     return (
         <div className="flex flex-col gap-20">
-            <div className="flex justify-between gap-4 items-center">
-                <img src="/logo_text_black.svg" alt="pollinations.ai" className="h-12 flex-1 object-contain object-left" />
-                <Button as="a" href="/api/docs">
-                    API Reference
-                </Button>
-                <Button 
-                    as="button" 
-                    onClick={handleSignIn} 
-                    disabled={loading}
-                    weight="light"
-                >
+            <Header>
+                <Button as="a" href="/api/docs">API Reference</Button>
+                <Button as="button" onClick={handleSignIn} disabled={loading} weight="light">
                     {loading ? "Signing in..." : "Sign in with Github"}
                 </Button>
-            </div>
+            </Header>
             <FAQ />
         </div>
     );

--- a/enter.pollinations.ai/src/client/style.css
+++ b/enter.pollinations.ai/src/client/style.css
@@ -76,12 +76,12 @@
     html,
     body {
         @apply text-green-950 bg-emerald-100 font-body text-base;
-        @apply py-8 min-h-screen font-medium;
+        @apply pb-8 min-h-screen font-medium;
     }
 
     body {
         max-width: 800px;
-        @apply mx-auto;
+        @apply mx-auto px-4 sm:px-6 md:px-8 pt-4;
     }
 
     h1 {
@@ -100,5 +100,15 @@
     h5,
     h6 {
         @apply text-xl;
+    }
+
+    /* Hide scrollbars while keeping functionality */
+    .scrollbar-hide {
+        -ms-overflow-style: none;  /* IE and Edge */
+        scrollbar-width: none;  /* Firefox */
+    }
+
+    .scrollbar-hide::-webkit-scrollbar {
+        display: none;  /* Chrome, Safari and Opera */
     }
 }


### PR DESCRIPTION
- Add horizontal padding to prevent content touching screen edges
- Make header responsive with logo on top for mobile
- Reduce top padding for better space usage
- Create reusable Header component to reduce code duplication
- Make API keys table horizontally scrollable on mobile
- Add .scrollbar-hide utility for hidden but functional scrolling

Fixes #4457

<img width="1014" height="374" alt="image" src="https://github.com/user-attachments/assets/74554940-5b00-4c99-9e93-5b4bab6837b4" />

@voodoohop check