### PR TITLE
Update image model costs: adjust nanobanana, seedream, and gptimage p…

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -30,21 +30,21 @@ export const IMAGE_COSTS = {
     "nanobanana": [
         {
             date: PRICING_START_DATE,
-            completionImageTokens: fromDPMT(30),
+            completionImageTokens: fromDPMT(30000),
         },
     ],
     "seedream": [
         // Estimated
         {
             date: PRICING_START_DATE,
-            completionImageTokens: fromDPMT(5000),
+            completionImageTokens: fromDPMT(30000),
         },
     ],
     "gptimage": [
         // Azure GPT Image model
         {
             date: PRICING_START_DATE,
-            completionImageTokens: fromDPMT(2500),
+            completionImageTokens: fromDPMT(10000),
         },
     ],
 } as const satisfies ModelRegistry;


### PR DESCRIPTION
…ricing

- nanobanana: 30 → 30000 DPMT
- seedream: 5000 → 30000 DPMT
- gptimage: 2500 → 10000 DPMT