### PR TITLE
🔧 Fix text.pollinations.ai startup broken by PR #4466

### DIFF
--- a/text.pollinations.ai/package.json
+++ b/text.pollinations.ai/package.json
@@ -1,9 +1,8 @@
 {
-    "name": "text pollinations.ai",
+    "name": "text.pollinations.ai",
     "version": "1.0.0",
     "scripts": {
-        "start": "node server.js",
-        "start:ts": "tsx src/index.ts",
+        "start": "tsx startServer.js",
         "type-check": "tsc --noEmit",
         "validate-configs": "tsx configs/validateConfigKeys.ts",
         "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
- Change start script from 'node server.js' to 'tsx startServer.js'
- PR #4466 converted availableModels.js to .ts but didn't update start script
- Node.js can't import .ts files directly, need tsx runtime
- Fix package name: 'text pollinations.ai' → 'text.pollinations.ai' (remove space)
- Remove unused 'start:ts' script (src/index.ts doesn't exist)

Root cause: Commit de190f06a deleted .js files, created .ts files, but forgot to update package.json