### PR TITLE
Update Pollen FAQ with images-per-pollen pricing format

### DIFF
--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -26,23 +26,50 @@ Yep! Just hit the API — no signup needed. Free models work instantly, no Polle
 
 You keep the free models (with rate limits) and unlock paid models (no rate limits, just costs Pollen). Plus you get daily free Pollen grants.
 
-## How do daily grants work?
+## How do daily Pollen grants work?
 
-Every day at 00:00 UTC, registered users get free Pollen. It's spent before your purchased balance.
+Every day, registered users get free Pollen automatically. This daily Pollen is spent before your purchased Pollen balance, maximizing your value.
 
 We have three tiers: **Seed** (default), **Flower**, and **Nectar**. Higher tiers get more daily Pollen. You can request an upgrade in your dashboard.
 
 ## How much Pollen do models use?
 
-Each model uses different amounts of Pollen based on what it costs us to run. We'll have a Pollen cost page launching soon where you can see what each model uses. Free models always cost 0 Pollen.
+Each model uses different amounts of Pollen based on what it costs us to run. Here's what you can generate per Pollen (remember: **1 Pollen = $1**):
+
+**Image Models:**
+- **flux**: ∞ images per Pollen (always free!)
+- **turbo**: ~333 images per Pollen (quick iterations)
+- **kontext**: ~200 images per Pollen (balanced quality)
+- **gptimage**: ~77 images per Pollen (GPT-powered)
+- **nanobanana**: ~50 images per Pollen (popular for premium quality)
+
+**Text Models:**
+- **Basic responses**: 100,000+ per Pollen
+- **Premium responses**: ~1,000 per Pollen
+
+Free models always cost 0 Pollen.
+
+## What can I create with 10 Pollen?
+
+With just 10 Pollen (=$10), you can generate:
+
+- **500 nanobanana images** — premium quality AI art that's perfect for professional projects
+- **3,300 turbo images** — rapid prototyping and quick iterations  
+- **2,000 kontext images** — balanced quality for most use cases
+- **770 gptimage images** — GPT-powered visual generation
+- **100,000+ basic text responses** — chatbot conversations, content generation
+- **10,000 premium text responses** — advanced reasoning and analysis
+- **Unlimited flux images** — completely free, always!
+
+Remember: your daily Pollen grants keep adding up, so registered users can create even more without spending their purchased Pollen balance.
 
 ## Will free models always be free?
 
 Yes! Free models remain free forever for all users. We're committed to keeping AI accessible. Paid options only apply to premium models that offer additional capabilities.
 
-## How does my wallet work?
+## How does my Pollen wallet work?
 
-One wallet for all your apps. Top up anytime, use it anywhere.
+One Pollen wallet for all your apps. Top up with Pollen anytime, use it anywhere across the Pollinations ecosystem.
 
 ## What's coming next?
 


### PR DESCRIPTION
Addresses issue #4493 feedback by updating the Pollen FAQ format.

- Convert pricing from cents per image to images per Pollen/dollar format
- Add clear explanation that 1 Pollen = $1
- Include compelling '10 Pollen' usage examples highlighting nanobanana
- Remove undecided timing specifics (daily grant timing)
- Use Pollen terminology more frequently throughout
- Maintain focus on signup incentives with concrete usage numbers

Generated with [Claude Code](https://claude.ai/code)