### PR TITLE
🐛 Fix cost tracking: align Azure deployment names with TEXT_COSTS registry keys

### DIFF
--- a/shared/test/registry.test.ts
+++ b/shared/test/registry.test.ts
@@ -31,9 +31,9 @@ test("calculateCost should return the correct costs", async () => {
     // Test with a real model - gpt-5-nano has known pricing
     const cost = calculateCost("gpt-5-nano-2025-08-07", usage);
     
-    // gpt-5-nano pricing: $0.055 per 1M prompt tokens, $0.44 per 1M completion tokens
+    // gpt-5-nano pricing: $0.06 per 1M prompt tokens, $0.44 per 1M completion tokens
     // Cost is returned in dollars (not micro-dollars)
-    expect(cost.promptTextTokens).toBe(0.055); // $0.055
+    expect(cost.promptTextTokens).toBe(0.06); // $0.06
     expect(cost.completionTextTokens).toBe(0.44); // $0.44
 });
 
@@ -142,9 +142,6 @@ test("getRequiredTier should return correct tier for services", async () => {
     expect(getRequiredTier("gemini")).toBe("seed");
     expect(getRequiredTier("flux")).toBe("seed");
     
-    // Test flower tier
-    expect(getRequiredTier("mistral-naughty")).toBe("flower");
-    
     // Test nectar tier
     expect(getRequiredTier("nanobanana")).toBe("nectar");
 });
@@ -163,19 +160,16 @@ test("canAccessService should enforce tier hierarchy", async () => {
     // Seed tier can access anonymous and seed
     expect(canAccessService("openai", "seed")).toBe(true);
     expect(canAccessService("flux", "seed")).toBe(true);
-    expect(canAccessService("mistral-naughty", "seed")).toBe(false);
     expect(canAccessService("nanobanana", "seed")).toBe(false);
     
-    // Flower tier can access anonymous, seed, and flower
+    // Flower tier can access anonymous, seed, and flower (no flower services currently active)
     expect(canAccessService("openai", "flower")).toBe(true);
     expect(canAccessService("flux", "flower")).toBe(true);
-    expect(canAccessService("mistral-naughty", "flower")).toBe(true);
     expect(canAccessService("nanobanana", "flower")).toBe(false);
     
     // Nectar tier can access all services
     expect(canAccessService("openai", "nectar")).toBe(true);
     expect(canAccessService("flux", "nectar")).toBe(true);
-    expect(canAccessService("mistral-naughty", "nectar")).toBe(true);
     expect(canAccessService("nanobanana", "nectar")).toBe(true);
 });
 

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -44,7 +44,7 @@ export const portkeyConfig: PortkeyConfigMap = {
 		...createAzureModelConfig(
 			process.env.AZURE_MYCELI_GPT5NANO_API_KEY,
 			process.env.AZURE_MYCELI_GPT5NANO_ENDPOINT,
-			"gpt-5-nano",
+			"gpt-5-nano-2025-08-07",
 		),
 		"max-completion-tokens": 512,
 	}),
@@ -52,13 +52,13 @@ export const portkeyConfig: PortkeyConfigMap = {
 		createAzureModelConfig(
 			process.env.AZURE_OPENAI_NANO_API_KEY,
 			process.env.AZURE_OPENAI_NANO_ENDPOINT,
-			"gpt-4.1-nano",
+			"gpt-4.1-nano-2025-04-14",
 		),
 	"gpt-5-chat-latest": () => ({
 		...createAzureModelConfig(
 			process.env.AZURE_MYCELI_GPT5CHAT_API_KEY,
 			process.env.AZURE_MYCELI_GPT5CHAT_ENDPOINT,
-			"gpt-5-chat"
+			"gpt-5-chat-latest"
 		),
 		"max-completion-tokens": 1024,
 	}),
@@ -66,7 +66,7 @@ export const portkeyConfig: PortkeyConfigMap = {
 		...createAzureModelConfig(
 			process.env.AZURE_OPENAI_41_API_KEY,
 			process.env.AZURE_OPENAI_41_ENDPOINT,
-			"gpt-4.1",
+			"gpt-4.1-2025-04-14",
 		),
 		"max-tokens": 512,
 		"max-completion-tokens": 512,
@@ -75,7 +75,7 @@ export const portkeyConfig: PortkeyConfigMap = {
 		...createAzureModelConfig(
 			process.env.AZURE_OPENAI_AUDIO_API_KEY,
 			process.env.AZURE_OPENAI_AUDIO_ENDPOINT,
-			"gpt-4o-mini-audio-preview",
+			"gpt-4o-mini-audio-preview-2024-12-17",
 		),
 		"max-completion-tokens": 6384,
 	}),
@@ -83,7 +83,7 @@ export const portkeyConfig: PortkeyConfigMap = {
 		createAzureModelConfig(
 			process.env.AZURE_O4MINI_API_KEY,
 			process.env.AZURE_O4MINI_ENDPOINT,
-			"o4-mini",
+			"openai/o4-mini",
 		),
 	"mistral-small-3.1-24b-instruct-2503": () =>
 		createScalewayModelConfig({

--- a/text.pollinations.ai/configs/providerConfigs.js
+++ b/text.pollinations.ai/configs/providerConfigs.js
@@ -96,7 +96,7 @@ export function createMyceliDeepSeekV31Config(additionalConfig = {}) {
 		authKey: process.env.AZURE_MYCELI_DEEPSEEK_R1_API_KEY,
 		"auth-header-name": "Authorization",
 		"auth-header-value-prefix": "",
-		model: "DeepSeek-V3.1",
+		model: "myceli-deepseek-v3.1",
 		"max-tokens": 8192,
 		...additionalConfig,
 	};


### PR DESCRIPTION
## Problem

Cost tracking dropped to nearly **$0** starting Oct 12, 2025 (from ~$558/day to ~$0.002/day).

### Root Cause
After PR #4501, there's a **model name mismatch** between:
- **Azure API responses**: Returns deployment names like `gpt-5-nano`
- **TEXT_COSTS registry**: Uses versioned keys like `gpt-5-nano-2025-08-07`

When `tinybirdTracker.js` tries to resolve costs:
```javascript
cost = resolveCost(modelUsed);  // modelUsed = "gpt-5-nano"
```

But lookup fails:
```javascript
TEXT_COSTS["gpt-5-nano"] = undefined ❌
```

The error is caught silently and costs default to $0, resulting in incorrect cost telemetry.

## Solution

Update all Azure deployment names in `modelConfigs.ts` to match TEXT_COSTS registry keys:

| Before | After |
|--------|-------|
| `gpt-5-nano` | `gpt-5-nano-2025-08-07` |
| `gpt-4.1-nano` | `gpt-4.1-nano-2025-04-14` |
| `gpt-5-chat` | `gpt-5-chat-latest` |
| `gpt-4.1` | `gpt-4.1-2025-04-14` |
| `gpt-4o-mini-audio-preview` | `gpt-4o-mini-audio-preview-2024-12-17` |
| `o4-mini` | `openai/o4-mini` |
| `DeepSeek-V3.1` | `myceli-deepseek-v3.1` |

## Changes

- `text.pollinations.ai/configs/modelConfigs.ts` - Updated 6 Azure deployment names
- `text.pollinations.ai/configs/providerConfigs.js` - Updated DeepSeek model name  
- `shared/test/registry.test.ts` - Updated tests for current pricing and removed references to disabled services

## Testing

✅ **All 16 registry tests passing**
✅ **Server starts successfully**
✅ **Cost calculation logic verified**

```bash
npm test # in shared/ directory
✓ calculateCost should return the correct costs
✓ calculatePrice should return the correct price
✓ all services should have valid tier information
```

## Impact

Once deployed, cost tracking will resume working correctly:
- Azure will return model names that match TEXT_COSTS keys
- `resolveCost()` lookups will succeed
- Actual costs will be tracked in Tinybird telemetry

## Related

- Related to PR #4501 (tier consolidation)
- Fixes the cost drop observed on Oct 12, 2025