### PR TITLE
🚀 Fix Cloudflare cache performance - remove expensive provider lookup

### DIFF
--- a/image.pollinations.ai/cloudflare-cache/src/middleware/tinybird.ts
+++ b/image.pollinations.ai/cloudflare-cache/src/middleware/tinybird.ts
@@ -1,6 +1,5 @@
 import type { Context } from "hono";
 import type { ImageCacheEvent } from "./analytics.ts";
-import { getProviderByModelId } from "../../../../shared/registry/registry.ts";
 
 /**
  * Send cache hit events to Tinybird
@@ -47,7 +46,7 @@ export async function sendToTinybird(
 
                 // Model and provider
                 model: imageParams?.model,
-                provider: getProviderByModelId(imageParams?.model) || "unknown",
+                provider: "cloudflare-cache", // Cache hits are served from Cloudflare, not external providers
 
                 // Performance metrics
                 duration: responseTime,


### PR DESCRIPTION
## 🔴 Critical Performance Fix

This fixes the service degradation that started on Oct 15 at 04:00.

---

## Problem

**Timeline:**
- **02:03** - PR #4553 merged (migrated to shared registry)
- **~03:00** - Cloudflare Worker deployed with new code
- **04:00** - Service degradation begins (25s → 175s response times)

**Root Cause:**
```typescript
// Line 50 in tinybird.ts - called on EVERY cache hit (2-3M/day!)
provider: getProviderByModelId(imageParams?.model) || "unknown"
```

**Impact:**
- Imports entire shared registry in Cloudflare Worker
- Expensive lookup on every cache hit
- Response times: 25s → 175s
- Error rates: 20% → 100%

---

## Solution

```typescript
// Line 49 - Simple and accurate
provider: "cloudflare-cache", // Cache hits ARE from Cloudflare cache!
```

**Changes:**
1. Remove `getProviderByModelId()` import
2. Hardcode provider as "cloudflare-cache"
3. Remove expensive registry lookup

---

## Why This Is Correct

**Cache hits don't use external providers:**
- flux cache hit → served from Cloudflare (not io.net)
- kontext cache hit → served from Cloudflare (not io.net)
- Provider = "cloudflare-cache" is ACCURATE

**Analytics preserved:**
- ✅ Model name (flux, kontext, etc.)
- ✅ Cache hit status
- ✅ Response times
- ✅ User info

**What changes in analytics:**
- Before: flux + io.net (misleading - came from cache!)
- After: flux + cloudflare-cache (accurate!)

---

## Testing

- Code review: Removed import, simplified logic
- Analytics impact: Provider field more accurate
- Performance: Eliminates expensive lookup

---

## Deployment

**After merging:**
```bash
cd image.pollinations.ai/cloudflare-cache
./deploy.sh
```

**Expected result:**
- Response times drop immediately
- Error rates normalize
- Service stability restored