### PR TITLE
✨ Auto-close discarded issues

### DIFF
--- a/.github/workflows/close-discarded-issues.yml
+++ b/.github/workflows/close-discarded-issues.yml
@@ -1,0 +1,90 @@
+name: Close Discarded Issues
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  project_card:
+    types: [moved, created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  close-discarded:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issue if status is Discarded
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = context.payload.issue?.number || context.payload.project_card?.content_url?.match(/\d+$/)?.[0];
+            if (!issueNumber) return;
+            
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            
+            // Check if issue status is "Discarded" via project items
+            const query = `
+              query($owner: String!, $repo: String!, $issueNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $issueNumber) {
+                    projectItems(first: 10) {
+                      nodes {
+                        fieldValues(first: 10) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              name
+                              field {
+                                ... on ProjectV2SingleSelectField {
+                                  name
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+            
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: parseInt(issueNumber)
+            });
+            
+            // Check if status is "Discarded"
+            let isDiscarded = false;
+            const projectItems = result.repository.issue.projectItems.nodes;
+            for (const item of projectItems) {
+              for (const fieldValue of item.fieldValues.nodes) {
+                if (fieldValue.field?.name === 'Status' && fieldValue.name === 'Discarded') {
+                  isDiscarded = true;
+                  break;
+                }
+              }
+              if (isDiscarded) break;
+            }
+            
+            // Close issue if status is Discarded and issue is still open
+            if (isDiscarded && issue.state === 'open') {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+              console.log(`Closed issue #${issueNumber} (Status: Discarded)`);
+            } else if (isDiscarded) {
+              console.log(`Issue #${issueNumber} already closed`);
+            } else {
+              console.log(`Issue #${issueNumber} status is not Discarded, skipping`);
+            }


### PR DESCRIPTION
Adds GitHub Actions workflow to automatically close issues when their status is set to "Discarded" in the project board.

- Triggers on project status changes
- Uses GraphQL to check if issue Status = "Discarded"
- Automatically closes issue with "not_planned" reason
- Only acts on open issues