### PR TITLE
🤖 Add GitHub Action to auto-regenerate project documentation

### DIFF
--- a/.github/workflows/update-project-list.yml
+++ b/.github/workflows/update-project-list.yml
@@ -16,9 +16,6 @@ jobs:
     permissions:
       contents: write
     
-    # Skip if the commit was made by the bot to avoid infinite loops
-    if: github.actor != 'github-actions[bot]'
-    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Auto-regenerates PROJECTS.md and README.md when projectList.js changes.

**What it does:**
- Triggers on PR/push when pollinations.ai/src/config/projectList.js modified
- Runs generate-project-table.js --update-readme
- Commits updated docs back to same branch
- Uses existing script from pollinator-agent/project-list-scripts/

**Benefits:**
- No manual doc updates needed
- Docs always stay in sync
- GITHUB_TOKEN prevents infinite loops

---
*Description condensed by Claude for readability*