### PR TITLE
Fix incorrect model in the search the web example in APIDOCS.md

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -9,7 +9,7 @@ Ready to dive in? Here are some live examples you can try right in your browser 
 
 - 🖼️ **Create an Image**: Generate a logo for Pollinations.AI [pollinations_logo](https://image.pollinations.ai/prompt/pollinations_logo)
 - 💬 **Generate Text**: Learn why donating to Pollinations.AI is a great idea [why_you_should_donate](https://text.pollinations.ai/why_you_should_donate)
-- 🔍 **Search the Web**: Find the latest news about Pollinations.AI [latest_news](https://text.pollinations.ai/latest_news)
+- 🔍 **Search the Web**: Find the latest news about Pollinations.AI [latest_news](https://text.pollinations.ai/latest_news?model=gemini-search)
 - 🎙️ **Create Audio**: Hear a fun, short hypnosis audio encouraging a donation (just for laughs!) [hypnosis_audio](https://text.pollinations.ai/hypnosis_audio?model=openai-audio&voice=nova)
 
 **How to Try These**: Just click the links above, and you’ll see the results instantly in your browser. No coding needed yet!


### PR DESCRIPTION
Change the model used in the example to a model that can actually search the web.
Old model (The default set by pollinations.ai) cannot search the web so the example in the APIDOCS does not work as expected. 
Changed the model used to gemini-search to give search functionality.

Submitted by CJ Hauser @CloudCompile 