### PR TITLE
Kontext rate limiting + GPTImage violation threshold update

### DIFF
--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -14,6 +14,7 @@ import { buildTrackingHeaders } from "./utils/trackingHeaders.js";
 
 // Import shared utilities
 import { enqueue } from "../../shared/ipQueue.js";
+import { canAccessService } from "../../shared/registry/registry.ts";
 import { countFluxJobs, handleRegisterEndpoint } from "./availableServers.js";
 import { cacheImagePromise } from "./cacheGeneratedImages.js";
 import {
@@ -468,8 +469,12 @@ const checkCacheAndGenerate = async (
                     queueConfig = { interval: 360000 }; // 6 minute interval
                     logAuth(`${modelName} model - 6 minute interval, ${remaining}/${HOURLY_LIMIT} images remaining this hour`);
                 } else if (modelName === "kontext") {
-                    // Kontext model - 30 second interval
-                    queueConfig = { interval: 30000 }; // 30 second interval
+                    // Kontext model requires seed tier or higher (checked via registry)
+                    if (!canAccessService("kontext", authResult.tier)) {
+                        throw new Error("Kontext model requires authentication (seed tier or higher). Visit https://auth.pollinations.ai");
+                    }
+                    // 30 second interval with tier-based caps
+                    queueConfig = { interval: 30000 };
                     logAuth(`${modelName} model - 30 second interval`);
                 } else if (modelName === "gptimage") {
                     // GPTImage model - 150 second interval with strict concurrency (cap=1, forceCap=true)
@@ -502,7 +507,7 @@ const checkCacheAndGenerate = async (
                         progress.setProcessing(requestId);
                         return generateImage();
                     },
-                    { ...queueConfig, forceQueue: true, maxQueueSize: 5, model: safeParams.model },
+                    { ...queueConfig, forceQueue: true, model: safeParams.model },
                 );
 
                 return result;

--- a/shared/ipQueue.js
+++ b/shared/ipQueue.js
@@ -206,7 +206,7 @@ export async function enqueue(req, fn, { interval = 6000, cap = 1, forceCap = fa
 				log('Using kontext priority user cap: %d for user: %s', cap, authResult.userId);
 			} else {
 				cap = kontextTierCaps[authResult.tier] || 1;
-				log('Using kontext tier-based cap: %d for tier: %s (strict limits)', cap, authResult.tier);
+				log('Using kontext tier-based cap: %d for tier: %s (2x for flower tier)', cap, authResult.tier);
 			}
 		} else {
 			cap = tierCaps[authResult.tier] || 1;


### PR DESCRIPTION
## Kontext Model Rate Limiting

**Configuration:**
- 30s interval between requests
- Tier caps: seed=1, flower=2, nectar=2
- Max queue: 5 (seed), 10 (flower/nectar)
- Priority user support via `PRIORITY_MODEL_USERS`

**Changes:**
- Add registry-based tier check - reject anonymous users early
- Remove hardcoded `maxQueueSize=5` - let ipQueue calculate `cap * 5`
- Update log message: "(2x for flower tier)" instead of "(strict limits)"

**Impact:**
- Anonymous users get clear rejection instead of undefined behavior
- Flower/nectar tiers now get correct queue capacity (10 slots vs hardcoded 5)
- All models benefit from proper tier-based queue sizing