### PR TITLE
✨ Add nectar tier benefits for gptimage model

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -545,8 +545,14 @@ const callAzureGPTImageWithEndpoint = async (
     // Map safeParams to Azure API parameters
     const size = `${safeParams.width}x${safeParams.height}`;
 
-    // Force medium quality for gptimage to reduce costs
-    const quality = "medium";
+    // Allow nectar users to use high quality, others get medium quality to reduce costs
+    const quality = userInfo?.tier === "nectar" && safeParams.quality === "high" 
+        ? "high" 
+        : "medium";
+    
+    if (quality === "high") {
+        logCloudflare(`Nectar tier user - using high quality for gptimage`);
+    }
 
     // Set output format to png if model is gptimage, otherwise jpeg
     const outputFormat = "png";

--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -477,9 +477,15 @@ const checkCacheAndGenerate = async (
                     queueConfig = { interval: 30000 };
                     logAuth(`${modelName} model - 30 second interval`);
                 } else if (modelName === "gptimage") {
-                    // GPTImage model - 150 second interval with strict concurrency (cap=1, forceCap=true)
-                    queueConfig = { interval: 150000, cap: 1, forceCap: true, model: modelName };
-                    logAuth("GPTImage model - 150 second interval, cap=1 (forced)");
+                    // GPTImage model - tier-based limits
+                    // Nectar tier: 60s interval, cap=3 | Other tiers: 150s interval, cap=1
+                    if (authResult.tier === "nectar") {
+                        queueConfig = { interval: 60000, cap: 3, forceCap: true, model: modelName };
+                        logAuth("GPTImage model (nectar tier) - 60 second interval, cap=3 (forced)");
+                    } else {
+                        queueConfig = { interval: 150000, cap: 1, forceCap: true, model: modelName };
+                        logAuth("GPTImage model - 150 second interval, cap=1 (forced)");
+                    }
                 } else if (hasValidToken) {
                     // Token authentication for other models - 7s minimum interval with tier-based caps
                     queueConfig = { interval: 7000 }; // cap will be set by ipQueue based on tier


### PR DESCRIPTION
## Changes

**Nectar tier users now get premium benefits for gptimage:**

- **High quality option**: Nectar users can request `quality=high` (others limited to medium for cost control)
- **Faster rate limits**: 60s interval with cap=3 concurrent requests (vs 150s interval, cap=1 for other tiers)

## Files Modified

- `image.pollinations.ai/src/createAndReturnImages.ts` - Quality tier logic
- `image.pollinations.ai/src/index.ts` - Rate limit tier logic

## Impact

- Better UX for premium tier users
- Cost control maintained for other tiers
- Incentivizes nectar tier adoption