### PR TITLE
Fix: Replace fromDPMT with perMillion in global Claude Haiku pricing

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -130,8 +130,8 @@ export const TEXT_COSTS = {
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": [
         {
             date: PRICING_START_DATE,
-            promptTextTokens: fromDPMT(1.0),
-            completionTextTokens: fromDPMT(5.0),
+            promptTextTokens: perMillion(1.0),
+            completionTextTokens: perMillion(5.0),
         },
     ],
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": [


### PR DESCRIPTION
Fixes ReferenceError where `fromDPMT` was used instead of `perMillion` in the global.anthropic.claude-haiku-4-5-20251001-v1:0 pricing configuration.