### PR TITLE
Allow browsers to connect through CORS

### DIFF
--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -1,5 +1,6 @@
 import { Context, Hono } from "hono";
 import { proxy } from "hono/proxy";
+import { cors } from "hono/cors";
 import { authenticate } from "@/middleware/authenticate";
 import { polar } from "@/middleware/polar.ts";
 import type { Env } from "../env.ts";
@@ -48,6 +49,12 @@ function errorResponses(...codes: ErrorStatusCode[]) {
 }
 
 export const proxyRoutes = new Hono<Env>()
+    // Enable CORS for browser requests with Authorization headers
+    .use('*', cors({
+        origin: '*',
+        allowHeaders: ['authorization', 'content-type'],
+        allowMethods: ['GET', 'POST', 'OPTIONS'],
+    }))
     .get(
         "/openai/models",
         describeRoute({


### PR DESCRIPTION
## Problem
Browser requests to `/api/generate/image/*` and `/api/generate/openai/*` with `Authorization` headers were failing due to CORS preflight issues.

## Solution
Added CORS middleware to `proxyRoutes` to:
- Handle OPTIONS preflight requests
- Allow `Authorization` and `Content-Type` headers
- Support `GET`, `POST`, and `OPTIONS` methods
- Allow all origins (`*`)

## Changes
- Added `cors` import from `hono/cors`
- Applied CORS middleware to all proxy routes with wildcard pattern (`'*'`)

## Testing
Browser requests with `Authorization: Bearer <token>` should now work without CORS errors.

---

**Note:** This is a clean PR with only the CORS changes. Previous PR #4755 was closed as it included unrelated changes from another branch.