### PR TITLE
Disable pollen top-up buttons and remove inaccurate refill timer

### DIFF
--- a/enter.pollinations.ai/src/client/components/button.tsx
+++ b/enter.pollinations.ai/src/client/components/button.tsx
@@ -48,10 +48,12 @@ const shapes = {
     rect: "rounded-none",
 };
 
-const buttonClasses = ({ color, weight, size, shape, className }: BaseButtonProps) =>
+const buttonClasses = ({ color, weight, size, shape, className, disabled }: BaseButtonProps & { disabled?: boolean }) =>
     cn(
         "rounded-full self-center placeholder-green-950 font-medium box-border",
-        "hover:filter hover:brightness-105 cursor-pointer",
+        disabled
+            ? "opacity-50 cursor-not-allowed"
+            : "hover:filter hover:brightness-105 cursor-pointer",
         colors[color || "green"][weight || "strong"],
         weight === "outline" ? outlineSizes[size || "medium"] : sizes[size || "medium"],
         shapes[shape || "pill"],
@@ -64,6 +66,7 @@ type BaseButtonProps = {
     size?: keyof typeof sizes;
     shape?: keyof typeof shapes;
     className?: string;
+    disabled?: boolean;
 };
 
 type ButtonElement =
@@ -92,13 +95,15 @@ export function Button<T extends React.ElementType>({
     size,
     shape,
     className,
+    disabled,
     ...buttonProps
 }: ButtonProps<T>) {
     const Component = as || "button";
 
     return (
         <Component
-            className={buttonClasses({ color, weight, size, shape, className })}
+            className={buttonClasses({ color, weight, size, shape, className, disabled })}
+            disabled={disabled}
             {...buttonProps}
         >
             {children}

--- a/enter.pollinations.ai/src/client/components/tier-panel.tsx
+++ b/enter.pollinations.ai/src/client/components/tier-panel.tsx
@@ -107,10 +107,6 @@ const TierScreen: FC<{ tier: keyof typeof TIER_CONFIG; countdown: string }> = ({
                         {config.pollen} pollen/day
                     </span>
                 </div>
-
-                <div className="text-sm text-gray-700">
-                    Next refill: {countdown} <span className="text-gray-500">(00:00 UTC)</span>
-                </div>
             </div>
         </div>
     );

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -131,9 +131,9 @@ function RouteComponent() {
                 <div className="flex flex-col sm:flex-row justify-between gap-3">
                     <h2 className="font-bold flex-1">Balance</h2>
                     <div className="flex gap-3">
-                        <Button as="a" color="pink" weight="light" href="/api/polar/checkout/pollen-bundle-small" target="_blank">+ $10</Button>
-                        <Button as="a" color="blue" weight="light" href="/api/polar/checkout/pollen-bundle-medium" target="_blank">+ $25</Button>
-                        <Button as="a" color="red" weight="light" href="/api/polar/checkout/pollen-bundle-large" target="_blank">+ $50</Button>
+                        <Button as="button" color="pink" weight="light" disabled>+ $10</Button>
+                        <Button as="button" color="blue" weight="light" disabled>+ $25</Button>
+                        <Button as="button" color="red" weight="light" disabled>+ $50</Button>
                     </div>
                 </div>
                 <PollenBalance balance={balance} />


### PR DESCRIPTION
## Changes

This PR temporarily disables the pollen purchase functionality and removes an inaccurate display:

### 1. Disabled Purchase Buttons
- Made +$10, +$25, and +$50 buttons inactive
- Buttons remain visible but are now disabled
- Added visual feedback (50% opacity + not-allowed cursor)

### 2. Removed Inaccurate Refill Timer
- Removed "Next refill" countdown from tier panel
- Timer was incorrectly showing midnight UTC instead of purchase-time-based refills
- Will be properly implemented when Polar integration is added

### Technical Details
- Updated `Button` component to support disabled state styling
- Changed purchase buttons from links to disabled buttons
- Removed refill countdown display and timing text

### Files Modified
- `enter.pollinations.ai/src/client/components/button.tsx` - Added disabled state support
- `enter.pollinations.ai/src/client/components/tier-panel.tsx` - Removed refill countdown
- `enter.pollinations.ai/src/client/routes/index.tsx` - Disabled purchase buttons

Fixes #4804