### PR TITLE
Add simplified GET text endpoint

### DIFF
--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -1,6 +1,7 @@
 import { PriceDefinition, TokenUsage } from "@shared/registry/registry.ts";
 import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import type { ContentFilterResult, OpenAIResponse } from "@/usage.ts";
+import type { CreateChatCompletionResponse } from "@/schemas/openai";
+import { removeUnset } from "@/util.ts";
 
 const eventTypeValues = ["generate.text", "generate.image"] as const;
 export type EventType = (typeof eventTypeValues)[number];
@@ -217,10 +218,10 @@ export type GenerationEventContentFilterParams = {
 
 // biome-ignore format: custom formatting
 export function contentFilterResultsToEventParams(
-    response: OpenAIResponse,
+    response: CreateChatCompletionResponse,
 ): GenerationEventContentFilterParams {
     const promptFilterResults =
-        response.prompt_filter_results[0]?.content_filter_results;
+        response.prompt_filter_results?.[0]?.content_filter_results;
     const completionFilterResults = 
         response.choices[0]?.content_filter_results;
     return {

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -9,9 +9,8 @@ import {
     ModelId,
 } from "@shared/registry/registry.ts";
 import { parseUsageHeaders } from "@shared/registry/usage-headers.ts";
-import { ModelUsage, transformOpenAIUsage } from "@/usage.ts";
 import {
-    CompletionUsage,
+    ContentFilterSeveritySchema,
     CreateChatCompletionResponseSchema,
     type CreateChatCompletionResponse,
 } from "@/schemas/openai.ts";
@@ -32,6 +31,13 @@ import type {
 import type { AuthVariables } from "@/middleware/auth.ts";
 import { PolarVariables } from "./polar.ts";
 import { z } from "zod";
+import { TokenUsage } from "../../../shared/registry/registry.js";
+import { removeUnset } from "@/util.ts";
+
+export type ModelUsage = {
+    model: ModelId;
+    usage: TokenUsage;
+};
 
 export type TrackVariables = {
     track: {
@@ -68,27 +74,18 @@ export const track = (eventType: EventType) =>
         await next();
 
         const referrerInfo = extractReferrerInfo(c);
-        const cacheInfo = extractCacheInfo(c);
+        const cacheInfo = extractCacheHeaders(c);
         const tokenPrice = getActivePriceDefinition(resolvedModelRequested);
         if (!tokenPrice) {
             throw new Error(
                 `Failed to get price definition for model: ${resolvedModelRequested}`,
             );
         }
-        let openaiResponse, modelUsage, cost, price;
+        let modelUsage, cost, price;
         if (c.res.ok) {
-            if (eventType === "generate.text") {
-                const responseBody = await c.res.clone().json();
-                openaiResponse =
-                    CreateChatCompletionResponseSchema.parse(responseBody);
-            }
             if (!cacheInfo.cacheHit) {
-                modelUsage = extractUsage(
-                    eventType,
-                    modelRequested,
-                    c,
-                    openaiResponse,
-                );
+                modelUsage = extractUsage(c);
+                validateUsage(modelUsage, isFreeUsage);
 
                 log.debug("[COST] Model usage extracted: {modelUsage}", {
                     modelUsage,
@@ -143,7 +140,7 @@ export const track = (eventType: EventType) =>
 
             ...priceToEventParams(tokenPrice),
             ...usageToEventParams(modelUsage?.usage),
-            ...extractContentFilterResults(eventType, openaiResponse),
+            ...extractContentFilterResults(c.res.headers),
 
             totalCost: cost?.totalCost || 0,
             totalPrice: price?.totalPrice || 0,
@@ -182,39 +179,30 @@ async function extractModelRequested(
     return null;
 }
 
-function extractUsage(
-    eventType: EventType,
-    modelRequested: string | null,
-    c: Context<TrackEnv>,
-    response?: CreateChatCompletionResponse,
-): ModelUsage {
-    if (eventType === "generate.image") {
-        const log = c.get("log");
-        const usage = parseUsageHeaders(c.res.headers);
-
-        // Read actual model used from x-model-used header
-        const modelUsedHeader = c.res.headers.get("x-model-used");
-        const model = (modelUsedHeader || modelRequested || "flux") as ModelId;
-
-        log.info("[COST] Extracted headers: model: {model}, usage: {usage}", {
-            model,
-            usage,
-        });
-
-        return {
-            model,
-            usage,
-        };
+function extractUsage(c: Context<TrackEnv>): ModelUsage {
+    const log = c.get("log");
+    const usage = parseUsageHeaders(c.res.headers);
+    const modelUsed = c.res.headers.get("x-model-used");
+    if (!modelUsed) {
+        throw new Error(
+            "Failed to determine model: x-model-used header was missing",
+        );
     }
-    if (response) {
-        return {
-            model: response?.model as ModelId,
-            usage: transformOpenAIUsage(response.usage),
-        };
+    log.debug("[COST] Extracted headers: model: {model}, usage: {usage}", {
+        model: modelUsed,
+        usage,
+    });
+    return {
+        model: modelUsed as ModelId,
+        usage,
+    };
+}
+
+function validateUsage(usage: ModelUsage, isFreeUsage: boolean) {
+    const includedUsageTypes = Object.keys(usage.usage);
+    if (!isFreeUsage && includedUsageTypes.length === 0) {
+        throw new Error("No usage headers where present for a non-free model");
     }
-    throw new Error(
-        "Failed to extract usage: generate.text event without valid response object",
-    );
 }
 
 function extractUserTier(c: Context<TrackEnv>): string | undefined {
@@ -222,13 +210,17 @@ function extractUserTier(c: Context<TrackEnv>): string | undefined {
 }
 
 function extractContentFilterResults(
-    eventType: EventType,
-    response?: CreateChatCompletionResponse,
+    headers: Headers | Record<string, string>,
 ): GenerationEventContentFilterParams {
-    if (eventType === "generate.text" && response) {
-        return contentFilterResultsToEventParams(response);
+    const plainHeaders =
+        headers instanceof Headers
+            ? Object.fromEntries(headers.entries())
+            : headers;
+    const parseResult =
+        ContentFilterResultHeadersSchema.safeParse(plainHeaders);
+    if (parseResult.success) {
+        return parseResult.data;
     }
-    // TODO: use x-moderation headers for image generations once implemented
     return {};
 }
 
@@ -240,7 +232,7 @@ type CacheInfo = {
     cacheSemanticThreshold?: number;
 };
 
-function extractCacheInfo(c: Context<TrackEnv>): CacheInfo {
+function extractCacheHeaders(c: Context<TrackEnv>): CacheInfo {
     return {
         cacheHit: c.res.headers.get("x-cache") === "HIT",
         cacheKey: c.res.headers.get("x-cache-key") || undefined,
@@ -274,3 +266,54 @@ function safeUrl(url: string): URL | null {
         return null;
     }
 }
+
+// biome-ignore format: custom formatting
+const ContentFilterResultHeadersSchema = z
+    .object({
+        "x-moderation-prompt-hate-severity": 
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-prompt-self-harm-severity": 
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-prompt-sexual-severity": 
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-prompt-violence-severity": 
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-prompt-jailbreak-detected": 
+            z.boolean().optional().catch(undefined),
+        "x-moderation-completion-hate-severity": 
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-completion-self-harm-severity":
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-completion-sexual-severity": 
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-completion-violence-severity":
+            ContentFilterSeveritySchema.optional().catch(undefined),
+        "x-moderation-completion-protected-material-text-detected": 
+            z.boolean().optional().catch(undefined),
+        "x-moderation-completion-protected-material-code-detected": 
+            z.boolean().optional().catch(undefined),
+    })
+    .transform((headers) => removeUnset({
+        moderationPromptHateSeverity:
+            headers["x-moderation-prompt-hate-severity"],
+        moderationPromptSelfHarmSeverity:
+            headers["x-moderation-prompt-self-harm-severity"],
+        moderationPromptSexualSeverity:
+            headers["x-moderation-prompt-sexual-severity"],
+        moderationPromptViolenceSeverity:
+            headers["x-moderation-prompt-violence-severity"],
+        moderationPromptJailbreakDetected:
+            headers["x-moderation-prompt-jailbreak-detected"],
+        moderationCompletionHateSeverity:
+            headers["x-moderation-completion-hate-severity"],
+        moderationCompletionSelfHarmSeverity:
+            headers["x-moderation-completion-self-harm-severity"],
+        moderationCompletionSexualSeverity:
+            headers["x-moderation-completion-sexual-severity"],
+        moderationCompletionViolenceSeverity:
+            headers["x-moderation-completion-violence-severity"],
+        moderationCompletionProtectedMaterialTextDetected:
+            headers["x-moderation-completion-protected-material-text-detected"],
+        moderationCompletionProtectedMaterialCodeDetected:
+            headers["x-moderation-completion-protected-material-code-detected"],
+    }));

--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -243,18 +243,15 @@ const ChatCompletionMessageContentBlockSchema = z.union([
 
 const ChatCompletionResponseMessageSchema = z.object({
     content: z.string().nullable(),
-    tool_calls: ChatCompletionMessageToolCallsSchema.optional(),
+    tool_calls: ChatCompletionMessageToolCallsSchema.nullish(),
     role: z.literal("assistant"),
     function_call: z
         .object({
             arguments: z.string(),
             name: z.string(),
         })
-        .optional(),
-    content_blocks: z
-        .array(ChatCompletionMessageContentBlockSchema)
-        .nullable()
-        .optional(),
+        .nullish(),
+    content_blocks: z.array(ChatCompletionMessageContentBlockSchema).nullish(),
 });
 
 const ChatCompletionTokenTopLogprobSchema = z.object({
@@ -293,20 +290,25 @@ export const CompletionUsageSchema = z.object({
                 .nonnegative()
                 .optional(),
         })
-        .optional(),
+        .nullish(),
     prompt_tokens: z.number().int().nonnegative(),
     prompt_tokens_details: z
         .object({
             audio_tokens: z.number().int().nonnegative().optional(),
-            cached_tokens: z.number().int().nonnegative(),
+            cached_tokens: z.number().int().nonnegative().optional(),
         })
-        .optional(),
+        .nullish(),
     total_tokens: z.number().int().nonnegative(),
 });
 
 export type CompletionUsage = z.infer<typeof CompletionUsageSchema>;
 
-const ContentFilterSeveritySchema = z.enum(["safe", "low", "medium", "high"]);
+export const ContentFilterSeveritySchema = z.enum([
+    "safe",
+    "low",
+    "medium",
+    "high",
+]);
 
 const ContentFilterResultSchema = z
     .object({
@@ -363,17 +365,17 @@ const CompletionChoiceSchema = z.object({
     ]),
     index: z.number().int().nonnegative(),
     message: ChatCompletionResponseMessageSchema,
-    logprobs: ChatCompletionChoiceLogprobsSchema.optional(),
-    content_filter_results: ContentFilterResultSchema,
+    logprobs: ChatCompletionChoiceLogprobsSchema.nullish(),
+    content_filter_results: ContentFilterResultSchema.nullish(),
 });
 
 export const CreateChatCompletionResponseSchema = z.object({
     id: z.string(),
     choices: z.array(CompletionChoiceSchema),
-    prompt_filter_results: PromptFilterResultSchema,
+    prompt_filter_results: PromptFilterResultSchema.nullish(),
     created: z.number().int(),
     model: z.string(),
-    system_fingerprint: z.string().optional(),
+    system_fingerprint: z.string().nullish(),
     object: z.literal("chat.completion"),
     usage: CompletionUsageSchema,
     user_tier: UserTierSchema.optional(),
@@ -428,7 +430,7 @@ export const CreateChatCompletionStreamResponseSchema = z.object({
     ),
     created: z.number().int(),
     model: z.string(),
-    system_fingerprint: z.string().optional(),
+    system_fingerprint: z.string().nullish(),
     object: z.literal("chat.completion.chunk"),
     usage: z
         .object({

--- a/enter.pollinations.ai/test/models.test.ts
+++ b/enter.pollinations.ai/test/models.test.ts
@@ -4,12 +4,24 @@ import { test } from "./fixtures.ts";
 import { describe, beforeEach, expect } from "vitest";
 import { env } from "cloudflare:workers";
 
+const DISABLE_CACHE = false;
+
 const anonymousTestCases = (allowAnoymous: boolean) => {
     return getTextServices().map((serviceId) => [
         serviceId,
         isFreeService(serviceId) && allowAnoymous ? 200 : 401,
     ]);
 };
+
+const randomString = (length: number) => {
+    return crypto.getRandomValues(new Uint8Array(length)).join("");
+};
+
+function testMessageContent() {
+    return DISABLE_CACHE
+        ? `Do you like this random string: ${randomString(10)}? Only answer yes or no.`
+        : "Do you prefer 0, or 1? Just answer with 0 or 1.";
+}
 
 // Send a request to each text model without authentication
 // and makes sure that the response status is in line with
@@ -36,7 +48,7 @@ describe.for([true, false])(
                             messages: [
                                 {
                                     role: "user",
-                                    content: "Hello, whats going on today?",
+                                    content: testMessageContent(),
                                 },
                             ],
                         }),
@@ -67,7 +79,7 @@ test.for(getTextServices())(
                     messages: [
                         {
                             role: "user",
-                            content: "Hello, whats going on today?",
+                            content: testMessageContent(),
                         },
                     ],
                 }),

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -1,17 +1,17 @@
-import { TokenUsage, UsageType } from './registry.js';
+import { TokenUsage, UsageType } from "./registry.js";
 
 /**
  * Mapping from TokenUsage field names to HTTP header names
  */
-const USAGE_TYPE_TO_HEADER: Record<UsageType, string> = {
-    promptTextTokens: 'x-usage-prompt-text-tokens',
-    promptCachedTokens: 'x-usage-prompt-cached-tokens',
-    promptAudioTokens: 'x-usage-prompt-audio-tokens',
-    promptImageTokens: 'x-usage-prompt-image-tokens',
-    completionTextTokens: 'x-usage-completion-text-tokens',
-    completionReasoningTokens: 'x-usage-completion-reasoning-tokens',
-    completionAudioTokens: 'x-usage-completion-audio-tokens',
-    completionImageTokens: 'x-usage-completion-image-tokens',
+export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
+    promptTextTokens: "x-usage-prompt-text-tokens",
+    promptCachedTokens: "x-usage-prompt-cached-tokens",
+    promptAudioTokens: "x-usage-prompt-audio-tokens",
+    promptImageTokens: "x-usage-prompt-image-tokens",
+    completionTextTokens: "x-usage-completion-text-tokens",
+    completionReasoningTokens: "x-usage-completion-reasoning-tokens",
+    completionAudioTokens: "x-usage-completion-audio-tokens",
+    completionImageTokens: "x-usage-completion-image-tokens",
 };
 
 /**
@@ -35,21 +35,30 @@ export function openaiUsageToTokenUsage(openaiUsage: {
     const promptDetailTokens =
         (openaiUsage.prompt_tokens_details?.cached_tokens || 0) +
         (openaiUsage.prompt_tokens_details?.audio_tokens || 0);
-    
+
     const completionDetailTokens =
-        (openaiUsage.completion_tokens_details?.accepted_prediction_tokens || 0) +
-        (openaiUsage.completion_tokens_details?.rejected_prediction_tokens || 0) +
+        (openaiUsage.completion_tokens_details?.accepted_prediction_tokens ||
+            0) +
+        (openaiUsage.completion_tokens_details?.rejected_prediction_tokens ||
+            0) +
         (openaiUsage.completion_tokens_details?.audio_tokens || 0) +
         (openaiUsage.completion_tokens_details?.reasoning_tokens || 0);
-    
+
+    // biome-ignore format: custom formatting
     return {
         unit: "TOKENS",
-        promptTextTokens: openaiUsage.prompt_tokens - promptDetailTokens,
-        promptCachedTokens: openaiUsage.prompt_tokens_details?.cached_tokens || 0,
-        promptAudioTokens: openaiUsage.prompt_tokens_details?.audio_tokens || 0,
-        completionTextTokens: openaiUsage.completion_tokens - completionDetailTokens,
-        completionAudioTokens: openaiUsage.completion_tokens_details?.audio_tokens || 0,
-        completionReasoningTokens: openaiUsage.completion_tokens_details?.reasoning_tokens || 0,
+        promptTextTokens: 
+            openaiUsage.prompt_tokens - promptDetailTokens,
+        promptCachedTokens:
+            openaiUsage.prompt_tokens_details?.cached_tokens || 0,
+        promptAudioTokens: 
+            openaiUsage.prompt_tokens_details?.audio_tokens || 0,
+        completionTextTokens:
+            openaiUsage.completion_tokens - completionDetailTokens,
+        completionAudioTokens:
+            openaiUsage.completion_tokens_details?.audio_tokens || 0,
+        completionReasoningTokens:
+            openaiUsage.completion_tokens_details?.reasoning_tokens || 0,
     };
 }
 
@@ -59,56 +68,60 @@ export function openaiUsageToTokenUsage(openaiUsage: {
  */
 export function buildUsageHeaders(
     modelUsed: string,
-    usage: TokenUsage
+    usage: TokenUsage,
 ): Record<string, string> {
     const headers: Record<string, string> = {
-        'x-model-used': modelUsed
+        "x-model-used": modelUsed,
     };
-    
+
     let totalTokens = 0;
-    
+
     // Iterate over all usage types
-    for (const [usageType, headerName] of Object.entries(USAGE_TYPE_TO_HEADER)) {
+    for (const [usageType, headerName] of Object.entries(USAGE_TYPE_HEADERS)) {
         const value = usage[usageType as UsageType];
         if (value && value > 0) {
             headers[headerName] = String(value);
             totalTokens += value;
         }
     }
-    
+
     if (totalTokens > 0) {
-        headers['x-usage-total-tokens'] = String(totalTokens);
+        headers["x-usage-total-tokens"] = String(totalTokens);
     }
-    
+
     return headers;
 }
 
 /**
  * Parse usage headers back to TokenUsage object
  */
-export function parseUsageHeaders(headers: Headers | Record<string, string>): TokenUsage {
+export function parseUsageHeaders(
+    headers: Headers | Record<string, string>,
+): TokenUsage {
     const usage: TokenUsage = { unit: "TOKENS" };
-    
-    const getHeader = (name: string) => 
+
+    const getHeader = (name: string) =>
         headers instanceof Headers ? headers.get(name) : headers[name];
-    
+
     // Iterate in reverse to parse headers back to usage
-    for (const [usageType, headerName] of Object.entries(USAGE_TYPE_TO_HEADER)) {
+    for (const [usageType, headerName] of Object.entries(USAGE_TYPE_HEADERS)) {
         const value = getHeader(headerName);
         if (value) {
             usage[usageType as UsageType] = parseInt(value, 10);
         }
     }
-    
+
     return usage;
 }
 
 /**
  * Helper for image services: create TokenUsage with only image tokens
  */
-export function createImageTokenUsage(completionImageTokens: number): TokenUsage {
+export function createImageTokenUsage(
+    completionImageTokens: number,
+): TokenUsage {
     return {
         unit: "TOKENS",
-        completionImageTokens
+        completionImageTokens,
     };
 }


### PR DESCRIPTION
- Add `/api/generate/text/:prompt`
- Add moderation data as headers
- Read usage data from headers

I'm currently adding the moderation headers in the text endpoint as a shortcut, we should add them in the upstream services in a future pr.
