### PR TITLE
Fix pk_ key authentication and seedream pricing

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -23,6 +23,7 @@ export function createAuth(env: Cloudflare.Env) {
     const apiKeyPlugin = apiKey({
         enableMetadata: true,
         defaultPrefix: 'pk', // Default prefix for publishable keys
+        defaultKeyLength: 22, // Minimum key length for validation (pk_ = 22 chars, sk_ = 64 chars)
         customKeyGenerator: (options: { length: number; prefix: string | undefined; }) => {
             // Publishable keys (pk_) are SHORT (22 chars), Secret keys (sk_) are LONG (64 chars)
             const keyLength = options.prefix === 'pk' ? 22 : 64;

--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -5,7 +5,6 @@ import { fileTypeFromBuffer } from "file-type";
 // Import shared authentication utilities
 import sharp from "sharp";
 import { hasSufficientTier } from "../../shared/tier-gating.js";
-import { isEnterRequest } from "../../shared/auth-utils.js";
 import {
     fetchFromLeastBusyFluxServer,
     getNextTurboServerUrl,
@@ -1066,7 +1065,8 @@ const generateImage = async (
 
     if (safeParams.model === "seedream") {
         // Seedream model requires nectar tier or higher (temporarily due to limited credits)
-        if (!hasSufficientTier(userInfo.tier, "nectar")) {
+        // NOTE: Skip tier check for enter.pollinations.ai requests (handled in index.ts)
+        if (!fromEnter && !hasSufficientTier(userInfo.tier, "nectar")) {
             const errorText =
                 "Access to seedream model is currently limited to users in the nectar tier or higher due to limited credits. Seedream will be available again to seed tier users in the next few days. Please authenticate at https://auth.pollinations.ai to get a token or add a referrer.";
             logError(errorText);

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -50,6 +50,13 @@ export const IMAGE_CONFIG: ImageModelsConfig = {
         maxSideLength: 768,
     },
 
+    // ByteDance ARK Seedream - high quality image generation
+    seedream: {
+        type: "seedream",
+        enhance: false,
+        maxSideLength: 2048, // Seedream supports up to 4K
+    },
+
     // Azure GPT Image model - gpt-image-1-minica
     gptimage: {
         type: "azure",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -33,10 +33,10 @@ export const IMAGE_COSTS = {
         },
     ],
     "seedream": [
-        // ByteDance ARK Seedream 4.0 (currently disabled)
+        // ByteDance ARK Seedream 4.0
         {
             date: PRICING_START_DATE,
-            completionImageTokens: perMillion(30), // Estimated token-based pricing
+            completionImageTokens: 0.03, // $0.03 per image (3 cents)
         },
     ],
     "gptimage": [
@@ -73,12 +73,12 @@ export const IMAGE_SERVICES = {
     //     provider: "vertex-ai",
     //     tier: "nectar",
     // },
-    // seedream: {
-    //     aliases: [],
-    //     modelId: "seedream",
-    //     provider: "bytedance-ark",
-    //     tier: "flower",
-    // },
+    seedream: {
+        aliases: [],
+        modelId: "seedream",
+        provider: "bytedance-ark",
+        tier: "nectar",
+    },
     "gptimage": {
         aliases: ["gpt-image", "gpt-image-1-mini"],
         modelId: "gptimage",


### PR DESCRIPTION
## Summary
Fixes publishable key (pk_) authentication and corrects seedream model pricing.

## Changes
- **Fix pk_ key authentication**: Set `defaultKeyLength: 22` in better-auth apiKey plugin to allow short publishable keys
- **Fix seedream pricing**: Correct from $0.00003 to $0.03 per image (1000x correction)
- **Enable seedream**: Activate seedream model in registry with nectar tier

## Testing
- ✅ Both pk_ and sk_ keys authenticate successfully
- ✅ Seedream images now charge correct $0.03 per image
- ✅ Pollen balance decreases properly