### PR TITLE
Update condense-descriptions.yml to correct version of github-action-debouncer

### DIFF
--- a/.github/workflows/condense-descriptions.yml
+++ b/.github/workflows/condense-descriptions.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Debounce - Wait for edits to settle
-        uses: zachary95/github-actions-debounce@v1
+        uses: zachary95/github-actions-debounce@v0.1.0
         with:
           wait: 180  # Wait 3 minutes for edits to stop
           


### PR DESCRIPTION
Changed version to correct version "v0.1.0"
<img width="437" height="107" alt="Screenshot 2025-10-27 2 50 33 PM" src="https://github.com/user-attachments/assets/9d5e16cd-b077-4dad-b9dd-4dc386e20b29" />
