### PR TITLE
feat(image): Improve image size handling and seedream configuration

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1064,17 +1064,16 @@ const generateImage = async (
     }
 
     if (safeParams.model === "seedream") {
-        // Seedream model requires nectar tier or higher (temporarily due to limited credits)
-        // NOTE: Skip tier check for enter.pollinations.ai requests (handled in index.ts)
-        if (!fromEnter && !hasSufficientTier(userInfo.tier, "nectar")) {
+        // Seedream model is only available from enter.pollinations.ai
+        if (!fromEnter) {
             const errorText =
-                "Access to seedream model is currently limited to users in the nectar tier or higher due to limited credits. Seedream will be available again to seed tier users in the next few days. Please authenticate at https://auth.pollinations.ai to get a token or add a referrer.";
+                "Seedream model is only available from enter.pollinations.ai";
             logError(errorText);
             progress.updateBar(
                 requestId,
                 35,
                 "Auth",
-                "Seedream temporarily requires nectar tier",
+                "Seedream only available from enter",
             );
             const error: any = new Error(errorText);
             error.status = 403;

--- a/image.pollinations.ai/src/makeParamsSafe.js
+++ b/image.pollinations.ai/src/makeParamsSafe.js
@@ -42,16 +42,17 @@ export const makeParamsSafe = ({
         model = "flux";
     }
 
-    const sideLength = MODELS[model].maxSideLength;
-    const maxPixels = sideLength * sideLength;
+    const maxSideLength = MODELS[model].maxSideLength;
+    const defaultSideLength = MODELS[model].defaultSideLength ?? maxSideLength;
+    const maxPixels = maxSideLength * maxSideLength;
 
-    // Ensure width and height are integers or default to sideLength
+    // Ensure width and height are integers or default to defaultSideLength
     width = Number.isInteger(parseInt(width))
         ? parseInt(width)
-        : sideLength;
+        : defaultSideLength;
     height = Number.isInteger(parseInt(height))
         ? parseInt(height)
-        : sideLength;
+        : defaultSideLength;
 
     // Ensure seed is a valid integer within the allowed range
     const maxSeedValue = 1844674407370955;

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -13,6 +13,7 @@ interface ImageModelConfig {
     type: string;
     enhance: boolean;
     maxSideLength: number;
+    defaultSideLength?: number; // Optional - defaults to maxSideLength if not specified
     tierCaps?: {
         seed?: number;
         flower?: number;
@@ -54,7 +55,8 @@ export const IMAGE_CONFIG: ImageModelsConfig = {
     seedream: {
         type: "seedream",
         enhance: false,
-        maxSideLength: 2048, // Seedream supports up to 4K
+        maxSideLength: 4096, // Seedream supports up to 4K
+        defaultSideLength: 1024, // Default to 1K when not specified
     },
 
     // Azure GPT Image model - gpt-image-1-minica

--- a/image.pollinations.ai/src/params.ts
+++ b/image.pollinations.ai/src/params.ts
@@ -33,18 +33,19 @@ function adjustImageSizeForModel(
     width?: number,
     height?: number,
 ): { width: number; height: number } {
-    const sideLength = MODELS[model].maxSideLength;
-    const maxPixels = sideLength * sideLength;
+    const maxSideLength = MODELS[model].maxSideLength;
+    const defaultSideLength = MODELS[model].defaultSideLength ?? maxSideLength;
+    const maxPixels = maxSideLength * maxSideLength;
 
-    // Ensure width and height are integers or default to sideLength
+    // Ensure width and height are integers or default to defaultSideLength
     var sanitizedWidth =
         width !== undefined && Number.isInteger(width)
             ? width
-            : sideLength;
+            : defaultSideLength;
     var sanitizedHeight =
         height !== undefined && Number.isInteger(height)
             ? height
-            : sideLength;
+            : defaultSideLength;
 
     // Adjust dimensions to maintain aspect ratio if exceeding maxPixels
     if (sanitizedWidth * sanitizedHeight > maxPixels) {


### PR DESCRIPTION
- Add defaultSideLength config option (separate from maxSideLength)
- Set seedream maxSideLength to 4096, defaultSideLength to 1024
- Restrict seedream model to enter.pollinations.ai only
- Apply default side length when width/height not specified