### PR TITLE
fix: preserve Gemini text responses in error handling

### DIFF
--- a/image.pollinations.ai/src/vertexAIImageGenerator.ts
+++ b/image.pollinations.ai/src/vertexAIImageGenerator.ts
@@ -333,6 +333,12 @@ export async function callVertexAIGemini(
         // Log error for analysis (especially content policy violations) - use original prompt
         await logNanoBananaError(prompt, safeParams, userInfo, error, errorResponseData, refusalDetails);
         
+        // Preserve Gemini's text response if it's already formatted (starts with "Gemini:")
+        const errorMessage = error.message;
+        if (errorMessage.startsWith("Gemini:")) {
+            throw error; // Re-throw as-is to preserve the original response
+        }
+        
         throw new Error(`Vertex AI Gemini image generation failed: ${error.message}`);
     }
 }


### PR DESCRIPTION
- Return model's actual refusal message instead of generic error
- Detect 'Gemini:' prefixed errors and re-throw without wrapping
- Improves UX for content policy violations with helpful feedback