### PR TITLE
fix: disable Cloudflare Flux fallback

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1099,13 +1099,8 @@ const generateImage = async (
     try {
         return await callComfyUI(prompt, safeParams, concurrentRequests);
     } catch (_error) {
-        progress.updateBar(
-            requestId,
-            35,
-            "Processing",
-            "Trying Cloudflare Dreamshaper...",
-        );
-        return await callCloudflareDreamshaper(prompt, safeParams);
+        // Cloudflare Flux fallback disabled
+        throw _error;
     }
 };
 


### PR DESCRIPTION
- Remove Cloudflare Dreamshaper fallback from flux model generation
- Throw error directly instead of attempting fallback
- Simplifies error handling and prevents unnecessary API calls