### PR TITLE
fix: use actual token counts for per-token image models

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -28,6 +28,7 @@ export const IMAGE_COSTS = {
         // Gemini 2.5 Flash Image via Vertex AI (currently disabled)
         {
             date: PRICING_START_DATE,
+            perToken: true, // Pricing is per actual token count from Vertex AI API (~1290 tokens/image)
             promptTextTokens: perMillion(0.30), // $0.30 per 1M input tokens
             promptImageTokens: perMillion(0.30), // $0.30 per 1M input tokens
             completionImageTokens: perMillion(30), // $30 per 1M tokens × 1290 tokens/image = $0.039 per image
@@ -44,6 +45,7 @@ export const IMAGE_COSTS = {
         // Azure gpt-image-1-mini
         {
             date: PRICING_START_DATE,
+            perToken: true, // Pricing is per actual token count from Azure OpenAI API (variable per image)
             promptTextTokens: perMillion(2.0), // $2.00 per 1M text input tokens
             promptCachedTokens: perMillion(0.20), // $0.20 per 1M cached text input tokens
             promptImageTokens: perMillion(2.50), // $2.50 per 1M image input tokens

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -33,6 +33,7 @@ export type UsagePrice = DollarConvertedUsage & {
 
 export type UsageConversionDefinition = {
     date: number;
+    perToken?: boolean; // If true, pricing is per actual token count from API; if false/undefined, pricing is per image (1 token)
 } & { [K in UsageType]?: number };
 
 export type CostDefinition = UsageConversionDefinition;


### PR DESCRIPTION
## Problem

Nanobanana and gptimage were being charged for 1 token per image instead of using actual token counts from their APIs, resulting in massive undercharging (~99.92% for nanobanana).

## Solution

- Add `perToken` flag to cost definitions in registry
- Mark `nanobanana` and `gptimage` with `perToken: true` 
- Update tracking headers to check registry flag instead of hardcoding model names

## Changes

**Registry (`shared/registry/`):**
- Add `perToken?: boolean` field to `UsageConversionDefinition` type
- Mark nanobanana: `perToken: true` (~1290 tokens/image from Vertex AI)
- Mark gptimage: `perToken: true` (variable tokens/image from Azure OpenAI)

**Tracking (`image.pollinations.ai/src/utils/trackingHeaders.ts`):**
- Add `isPerTokenPricing()` helper to check registry flag
- Use actual `candidatesTokenCount` from API for per-token models
- Default to 1 token for per-image models (flux, turbo, kontext, seedream)

## Impact

**Before:**
- Nanobanana: 1 token × $0.00003 = **$0.00003 per image** ❌
- GPTImage: 1 token × $0.000008 = **$0.00008 per image** ❌

**After:**
- Nanobanana: ~1290 tokens × $0.00003 = **$0.0387 per image** ✅
- GPTImage: ~1600 tokens × $0.000008 = **$0.0128 per image** ✅

## Testing

Tested locally with all 6 image models:
- ✅ Per-image models (flux, turbo, kontext, seedream): 1 token each
- ✅ Per-token models (nanobanana, gptimage): actual token counts from APIs
- ✅ Pricing calculations verified correct

## Architecture

Data-driven approach: pricing structure defined in registry, not hardcoded in tracking logic. Future token-based models only need registry update.