### PR TITLE
fix: Add pollen balance check to prevent negative balances

### DIFF
--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -129,14 +129,7 @@ export const proxyRoutes = new Hono<Env>()
                 allowAnonymous:
                     c.var.track.isFreeUsage && c.env.ALLOW_ANONYMOUS_USAGE,
             });
-            
-            // Check balance for paid models
-            if (!c.var.track.isFreeUsage && c.var.auth.user?.id) {
-                await c.var.polar.requirePositiveBalance(
-                    c.var.auth.user.id,
-                    "Insufficient pollen balance to use this model"
-                );
-            }
+            await checkBalanceForPaidModel(c);
             
             const textServiceUrl =
                 c.env.TEXT_SERVICE_URL || "https://text.pollinations.ai";
@@ -271,14 +264,7 @@ export const proxyRoutes = new Hono<Env>()
                 allowAnonymous:
                     c.var.track.isFreeUsage && c.env.ALLOW_ANONYMOUS_USAGE,
             });
-            
-            // Check balance for paid models
-            if (!c.var.track.isFreeUsage && c.var.auth.user?.id) {
-                await c.var.polar.requirePositiveBalance(
-                    c.var.auth.user.id,
-                    "Insufficient pollen balance to use this model"
-                );
-            }
+            await checkBalanceForPaidModel(c);
             
             const targetUrl = proxyUrl(c, `${c.env.IMAGE_SERVICE_URL}/prompt`);
             targetUrl.pathname = joinPaths(
@@ -411,4 +397,13 @@ export function contentFilterResultsToHeaders(
             completionFilterResults?.protected_material_code?.detected,
         ),
     });
+}
+
+async function checkBalanceForPaidModel(c: Context<Env & import("@/middleware/auth.ts").AuthEnv & import("@/middleware/polar.ts").PolarEnv & import("@/middleware/track.ts").TrackEnv>) {
+    if (!c.var.track.isFreeUsage && c.var.auth.user?.id) {
+        await c.var.polar.requirePositiveBalance(
+            c.var.auth.user.id,
+            "Insufficient pollen balance to use this model"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Users were accumulating negative pollen balances on paid models because balance checks weren't enforced before API calls.

## Solution

Added pre-paid balance validation using existing `requirePositiveBalance` function:
- Checks balance before proxying requests to backend services
- Only applies to paid models (free models like flux unaffected)
- Returns `403 Forbidden` with clear error message when balance ≤ 0

## Changes

- **Text generation** (`/openai` endpoint) - Balance check added
- **Image generation** (`/image/:prompt` endpoint) - Balance check added

## Testing

Tested locally with two API keys:
- ✅ **Zero balance** → Paid models blocked with 403, free models work
- ✅ **Positive balance** → All models work normally

## Impact

- ✅ Prevents new negative balances from occurring
- ✅ Users get clear error message to add pollen
- ✅ Free tier completely unaffected
- ✅ Existing negative balances won't worsen

@voodoohop Ready for review

Addresses #4934