### PR TITLE
Add taskfile and process-compose config for better local development across services

### DIFF
--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -14,6 +14,7 @@ directory = "dist/client"
 not_found_handling = "single-page-application"
 run_worker_first = [ "/api/*" ]
 
+
 [[d1_databases]]
 binding = "DB"
 database_name = "development-pollinations-enter-db"
@@ -38,6 +39,34 @@ POLAR_PRODUCT_ID_FLOWER = "2bfbe9e0-8395-489f-a7a1-6821d835cc08"
 POLAR_PRODUCT_ID_NECTAR = "d67b2a25-c4d7-47fa-9d64-4b2a27f0908f"
 IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
 TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+
+
+[env.local]
+
+[[env.local.d1_databases]]
+binding = "DB"
+database_name = "development-pollinations-enter-db"
+database_id = "6345cb3c-e57a-4aab-bdd4-bca0de7bd930"
+migrations_dir = "drizzle"
+
+[[env.local.kv_namespaces]]
+# development-pollinations-enter-kv
+binding = "KV"
+id = "aa0d0aceb6bd45de93032270c7adf4ab"
+
+[env.local.vars]
+ENVIRONMENT = "local"
+LOG_LEVEL = "trace"
+ALLOW_ANONYMOUS_USAGE = false
+POLAR_SUCCESS_URL = "http://localhost:3000"
+POLAR_SERVER = "sandbox"
+TINYBIRD_INGEST_URL = "http://localhost:7181/v0/events?name=generation_event"
+# Polar product IDs for tier subscriptions
+POLAR_PRODUCT_ID_SEED = "19c3291a-e1fa-4a03-a08a-3de9ab84af5d"
+POLAR_PRODUCT_ID_FLOWER = "c675a78a-d954-4739-bfad-c0c8aa3e5576"
+POLAR_PRODUCT_ID_NECTAR = "dfe978ca-8e07-41fa-992a-ae19ab96e66c"
+IMAGE_SERVICE_URL = "http://localhost:16384"
+TEXT_SERVICE_URL = "http://localhost:16385"
 
 
 [[env.staging.routes]]
@@ -98,6 +127,7 @@ POLAR_PRODUCT_ID_FLOWER = "2bfbe9e0-8395-489f-a7a1-6821d835cc08"
 POLAR_PRODUCT_ID_NECTAR = "d67b2a25-c4d7-47fa-9d64-4b2a27f0908f"
 IMAGE_SERVICE_URL = "https://image-origin.pollinations.ai"
 TEXT_SERVICE_URL = "https://text-origin.pollinations.ai"
+
 
 [env.test]
 

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,8 @@
             age
             uv
             nodejs_24
+            go-task
+            process-compose
 
             # Image processing dependencies for image.pollinations.ai
             vips
@@ -115,6 +117,9 @@
           shellHook = ''
             # runs each time the shell is entered
 
+            # disable deterministic time
+            unset SOURCE_DATE_EPOCH
+
             # enable recursive globbing
             shopt -s globstar
 
@@ -127,7 +132,7 @@
             fi
 
             # decrypt and load environment variables
-            for file in **/.encrypted.env; do
+            for file in $FLAKE_PATH/**/.encrypted.env; do
               echo "Decrypting: $file"
               eval "$(sops decrypt $file \
                 | grep -v '^#' \

--- a/image.pollinations.ai/package.json
+++ b/image.pollinations.ai/package.json
@@ -9,7 +9,7 @@
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
         "start": "tsx src/index.ts",
-        "dev": "DEBUG=pollinations:* npm start"
+        "dev": "DEBUG=pollinations:* tsx --watch src/index.ts"
     },
     "keywords": [],
     "author": "",

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -1,0 +1,24 @@
+version: 0.5
+
+processes:
+
+  text:
+    working_dir: "text.pollinations.ai"
+    command: npm run dev
+    availability:
+      restart: "always"
+
+  image:
+    working_dir: "image.pollinations.ai"
+    command: npm run dev
+    availability:
+      restart: "always"
+
+  enter:
+    working_dir: "enter.pollinations.ai"
+    command: "CLOUDFLARE_ENV=local npm run dev" 
+    availability:
+      restart: "always"
+    environment:
+      - "IMAGE_SERVICE_URL=http://localhost:16384"
+      - "TEXT_SERVICE_URL=http://localhost:16385"

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,0 +1,53 @@
+# https://taskfile.dev
+
+version: '3'
+
+concurrency: 4
+
+tasks:
+
+  install-enter:
+    desc: Install dependencies enter.pollinations.ai
+    cmds:
+      - cd enter.pollinations.ai && npm install
+
+  install-text:
+    desc: Install dependencies text.pollinations.ai
+    cmds:
+      - cd text.pollinations.ai && npm install
+
+  install-image:
+    desc: Install dependencies image.pollinations.ai
+    cmds:
+      - cd image.pollinations.ai && npm install
+
+  install:
+    desc: Install dependencies for enter, text and image services
+    deps: [install-enter, install-text, install-image]
+
+
+  test-enter:
+    desc: Run tests for enter.pollinations.ai
+    cmds:
+      - cd enter.pollinations.ai && npm run test
+
+  test-text:
+    desc: Run tests for text.pollinations.ai
+    cmds:
+      - cd text.pollinations.ai && npm run test
+
+  test-image:
+    desc: Run tests for image.pollinations.ai
+    cmds:
+      - cd image.pollinations.ai && npm run test
+
+  test:
+    desc: Run tests for enter, text and image services
+    deps: [test-enter, test-text, test-image]
+
+
+  dev:
+    desc: Starts a dev server for enter, text and image services
+    cmds:
+      - process-compose
+

--- a/text.pollinations.ai/package.json
+++ b/text.pollinations.ai/package.json
@@ -6,8 +6,7 @@
         "dev": "DEBUG=pollinations:* tsx --watch startServer.js",
         "type-check": "tsc --noEmit",
         "validate-configs": "tsx configs/validateConfigKeys.ts",
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "dev": "clear && DEBUG=pollinations:* tsx startServer.js"
+        "test": "echo \"Error: no test specified\" && exit 1"
     },
     "keywords": [],
     "author": "",


### PR DESCRIPTION
Adds repo-scoped tasks for easier development across services.
- `task install` Installs dependencies for enter, text and image services
- `task dev` Runs dev servers for enter, text and image services with automatic restart on code changes