### PR TITLE
Test and fix streaming (#4795)

### DIFF
--- a/enter.pollinations.ai/package-lock.json
+++ b/enter.pollinations.ai/package-lock.json
@@ -20,6 +20,7 @@
                 "clsx": "^2.1.1",
                 "date-fns": "^4.1.0",
                 "drizzle-orm": "^0.44.7",
+                "eventsource-parser": "^3.0.6",
                 "hono": "^4.10.3",
                 "hono-openapi": "^1.1.0",
                 "hono-rate-limiter": "^0.4.2",
@@ -7254,6 +7255,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/exit-hook": {

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -33,6 +33,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.44.7",
+        "eventsource-parser": "^3.0.6",
         "hono": "^4.10.3",
         "hono-openapi": "^1.1.0",
         "hono-rate-limiter": "^0.4.2",

--- a/enter.pollinations.ai/src/content-filter.ts
+++ b/enter.pollinations.ai/src/content-filter.ts
@@ -1,0 +1,72 @@
+import {
+    type ContentFilterResult,
+    type ContentFilterSeverity,
+} from "@/schemas/openai.ts";
+
+const severityOrder: Record<ContentFilterSeverity, number> = {
+    safe: 0,
+    low: 1,
+    medium: 2,
+    high: 3,
+};
+
+function getMostSevere(
+    a: ContentFilterSeverity,
+    b: ContentFilterSeverity,
+): ContentFilterSeverity {
+    return severityOrder[a] > severityOrder[b] ? a : b;
+}
+
+export function mergeContentFilterResults(
+    results: ContentFilterResult[],
+): ContentFilterResult {
+    if (results.length === 0) {
+        return {};
+    }
+
+    const merged: ContentFilterResult = {};
+
+    // Merge severity-based categories
+    const severityCategories = [
+        "hate",
+        "self_harm",
+        "sexual",
+        "violence",
+    ] as const;
+
+    for (const category of severityCategories) {
+        const categoryResults = results
+            .map((r) => r[category])
+            .filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+        if (categoryResults.length > 0) {
+            const mostSevere = categoryResults.reduce((acc, curr) => ({
+                filtered: acc.filtered || curr.filtered,
+                severity: getMostSevere(acc.severity, curr.severity),
+            }));
+            merged[category] = mostSevere;
+        }
+    }
+
+    // Merge boolean-based categories
+    const booleanCategories = [
+        "jailbreak",
+        "protected_material_text",
+        "protected_material_code",
+    ] as const;
+
+    for (const category of booleanCategories) {
+        const categoryResults = results
+            .map((r) => r[category])
+            .filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+        if (categoryResults.length > 0) {
+            merged[category] = {
+                filtered: categoryResults.some((c) => c.filtered),
+                detected: categoryResults.some((c) => c.detected),
+            };
+        }
+    }
+
+    return merged;
+}

--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -1,6 +1,9 @@
 import { PriceDefinition, TokenUsage } from "@shared/registry/registry.ts";
 import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import type { CreateChatCompletionResponse } from "@/schemas/openai";
+import type {
+    ContentFilterResult,
+    CreateChatCompletionResponse,
+} from "@/schemas/openai";
 import { removeUnset } from "@/util.ts";
 
 const eventTypeValues = ["generate.text", "generate.image"] as const;
@@ -216,14 +219,14 @@ export type GenerationEventContentFilterParams = {
     moderationCompletionProtectedMaterialCodeDetected?: boolean;
 };
 
-// biome-ignore format: custom formatting
-export function contentFilterResultsToEventParams(
-    response: CreateChatCompletionResponse,
-): GenerationEventContentFilterParams {
-    const promptFilterResults =
-        response.prompt_filter_results?.[0]?.content_filter_results;
-    const completionFilterResults = 
-        response.choices[0]?.content_filter_results;
+export function contentFilterResultsToEventParams({
+    promptFilterResults,
+    completionFilterResults,
+}: {
+    promptFilterResults: ContentFilterResult;
+    completionFilterResults: ContentFilterResult;
+}): GenerationEventContentFilterParams {
+    // biome-ignore format: custom formatting
     return {
         // prompt filter results
         moderationPromptHateSeverity: 

--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -318,7 +318,9 @@ export const ContentFilterSeveritySchema = z.enum([
     "high",
 ]);
 
-const ContentFilterResultSchema = z
+export type ContentFilterSeverity = z.infer<typeof ContentFilterSeveritySchema>;
+
+export const ContentFilterResultSchema = z
     .object({
         hate: z.object({
             filtered: z.boolean(),
@@ -353,7 +355,7 @@ const ContentFilterResultSchema = z
 
 export type ContentFilterResult = z.infer<typeof ContentFilterResultSchema>;
 
-const PromptFilterResultSchema = z.array(
+export const PromptFilterResultSchema = z.array(
     z.object({
         prompt_index: z.number().int().nonnegative(),
         content_filter_results: ContentFilterResultSchema,

--- a/enter.pollinations.ai/test/events.test.ts
+++ b/enter.pollinations.ai/test/events.test.ts
@@ -55,11 +55,8 @@ function createTextGenerationEvent(
         "generate.text",
     );
 
-    const modelUsed = getServiceDefinition(resolvedModelRequested)
-        .modelId;
-    const priceDefinition = getActivePriceDefinition(
-        resolvedModelRequested,
-    );
+    const modelUsed = getServiceDefinition(resolvedModelRequested).modelId;
+    const priceDefinition = getActivePriceDefinition(resolvedModelRequested);
     if (!priceDefinition) {
         throw new Error(
             `Failed to get price definition for model: ${modelRequested}`,

--- a/enter.pollinations.ai/test/fixtures.ts
+++ b/enter.pollinations.ai/test/fixtures.ts
@@ -48,11 +48,11 @@ export const test = base.extend<Fixtures>({
             polar: mockPolar,
             tinybird: mockTinybird,
         });
-        teardownFetchMock();
+        await teardownFetchMock();
     },
     auth: async ({}, use) => {
         const auth = createAuth();
-        use(auth);
+        await use(auth);
     },
     sessionToken: async ({ mocks: _ }, use) => {
         const signupUrl = new URL(
@@ -96,6 +96,7 @@ export const test = base.extend<Fixtures>({
             redirect: "manual",
         });
         expect(callbackResponse.status).toBe(302);
+        await callbackResponse.text();
 
         // extract session cookie
         const setCookieHeader = callbackResponse.headers.get("Set-Cookie");

--- a/enter.pollinations.ai/test/track-image.test.ts
+++ b/enter.pollinations.ai/test/track-image.test.ts
@@ -1,13 +1,23 @@
 import { expect, test } from "vitest";
 import { calculateCost, calculatePrice } from "@shared/registry/registry.ts";
-import type { TokenUsage, ModelId, ServiceId } from "@shared/registry/registry.ts";
+import type {
+    TokenUsage,
+    ModelId,
+    ServiceId,
+} from "@shared/registry/registry.ts";
 
 // Test image model cost tracking
 // Tests cost calculation properties without hardcoding specific values
 
 test("Image models should calculate costs proportionally to token count", () => {
-    const models: ModelId[] = ["flux", "nanobanana", "kontext", "turbo", "seedream"];
-    
+    const models: ModelId[] = [
+        "flux",
+        "nanobanana",
+        "kontext",
+        "turbo",
+        "seedream",
+    ];
+
     for (const model of models) {
         const usage1: TokenUsage = {
             unit: "TOKENS",
@@ -17,12 +27,15 @@ test("Image models should calculate costs proportionally to token count", () => 
             unit: "TOKENS",
             completionImageTokens: 10,
         };
-        
+
         const cost1 = calculateCost(model, usage1);
         const cost10 = calculateCost(model, usage10);
-        
+
         // Cost should scale linearly with token count
-        expect(cost10.completionImageTokens).toBeCloseTo((cost1.completionImageTokens || 0) * 10, 6);
+        expect(cost10.completionImageTokens).toBeCloseTo(
+            (cost1.completionImageTokens || 0) * 10,
+            6,
+        );
         expect(cost10.totalCost).toBeCloseTo(cost1.totalCost * 10, 6);
     }
 });
@@ -32,11 +45,11 @@ test("Models with API costs should have non-zero operational costs", () => {
         unit: "TOKENS",
         completionImageTokens: 1,
     };
-    
+
     // Flux has operational cost estimate
     const fluxCost = calculateCost("flux", usage);
     expect(fluxCost.totalCost).toBeGreaterThan(0);
-    
+
     // Nanobanana uses Vertex AI (paid API)
     const nanobanana = calculateCost("nanobanana", usage);
     expect(nanobanana.totalCost).toBeGreaterThan(0);
@@ -47,23 +60,29 @@ test("Flux should remain free for users", () => {
         unit: "TOKENS",
         completionImageTokens: 1,
     };
-    
+
     const price = calculatePrice("flux", usage);
-    
+
     // Flux is free tier - users pay $0
     expect(price.totalPrice).toBe(0);
 });
 
 test("Cost should be non-negative for all models", () => {
-    const models: ModelId[] = ["flux", "nanobanana", "kontext", "turbo", "seedream"];
+    const models: ModelId[] = [
+        "flux",
+        "nanobanana",
+        "kontext",
+        "turbo",
+        "seedream",
+    ];
     const usage: TokenUsage = {
         unit: "TOKENS",
         completionImageTokens: 1,
     };
-    
+
     for (const model of models) {
         const cost = calculateCost(model, usage);
-        
+
         expect(cost.totalCost).toBeGreaterThanOrEqual(0);
         expect(cost.completionImageTokens || 0).toBeGreaterThanOrEqual(0);
     }

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -40,6 +40,36 @@ IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
 TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
 
 
+[env.local]
+
+[[env.local.d1_databases]]
+binding = "DB"
+database_name = "development-pollinations-enter-db"
+database_id = "6345cb3c-e57a-4aab-bdd4-bca0de7bd930"
+migrations_dir = "drizzle"
+
+[[env.local.kv_namespaces]]
+# development-pollinations-enter-kv
+binding = "KV"
+id = "aa0d0aceb6bd45de93032270c7adf4ab"
+
+[env.local.vars]
+ENVIRONMENT = "local"
+LOG_LEVEL = "trace"
+ALLOW_ANONYMOUS_USAGE = false
+POLAR_SUCCESS_URL = "http://localhost:3000"
+POLAR_SERVER = "sandbox"
+TINYBIRD_INGEST_URL = "http://localhost:7181/v0/events?name=generation_event"
+# Polar product IDs for tier subscriptions
+POLAR_PRODUCT_ID_SEED = "19c3291a-e1fa-4a03-a08a-3de9ab84af5d"
+POLAR_PRODUCT_ID_FLOWER = "c675a78a-d954-4739-bfad-c0c8aa3e5576"
+POLAR_PRODUCT_ID_NECTAR = "dfe978ca-8e07-41fa-992a-ae19ab96e66c"
+IMAGE_SERVICE_URL = "http://localhost:16384"
+TEXT_SERVICE_URL = "http://localhost:16385"
+
+
+[env.staging]
+
 [[env.staging.routes]]
 pattern = "enter.pollinations.ai"
 zone_name = "pollinations.ai"
@@ -125,5 +155,5 @@ TINYBIRD_INGEST_URL = "http://localhost:7181/v0/events?name=generation_event"
 POLAR_PRODUCT_ID_SEED = "polar_product_id_seed"
 POLAR_PRODUCT_ID_FLOWER = "polar_product_id_flower"
 POLAR_PRODUCT_ID_NECTAR = "polar_product_id_nectar"
-IMAGE_SERVICE_URL = "http://127.0.0.1:16384"
-TEXT_SERVICE_URL = "http://127.0.0.1:16385"
+IMAGE_SERVICE_URL = "http://localhost:16384"
+TEXT_SERVICE_URL = "http://localhost:16385"

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -24,13 +24,13 @@ export function openaiUsageToTokenUsage(openaiUsage: {
     prompt_tokens_details?: {
         cached_tokens?: number;
         audio_tokens?: number;
-    };
+    } | null;
     completion_tokens_details?: {
         reasoning_tokens?: number;
         audio_tokens?: number;
         accepted_prediction_tokens?: number;
         rejected_prediction_tokens?: number;
-    };
+    } | null;
 }): TokenUsage {
     const promptDetailTokens =
         (openaiUsage.prompt_tokens_details?.cached_tokens || 0) +

--- a/text.pollinations.ai/transforms/parameterProcessor.js
+++ b/text.pollinations.ai/transforms/parameterProcessor.js
@@ -36,6 +36,12 @@ export function processParameters(messages, options) {
         }
     });
 
+    // Add stream_options for Azure OpenAI models
+    if (updatedOptions.stream && config.provider === "azure-openai") {
+        log("Adding stream_options for Azure OpenAI model");
+        updatedOptions.stream_options = { include_usage: true };
+    }
+
     // Apply parameter filtering if defined
     if (modelConfig.allowedParameters) {
         const allowedParams = modelConfig.allowedParameters;


### PR DESCRIPTION
Enable streaming responses with usage and content filter tracking:
- Refactor tracking middleware to support streaming responses
- Add functions to extract usage and content filter results from response streams
- Add `{ stream_options: { include_usage: true }}` to azure requests to get usage information
- Remove the trailers from text.pollinations.ai responses, as they were causing issues
- Add tests for streaming responses

Includes changes from #4941, because i was using that for development. I can rebase this after #4941 is merged to get a cleaner PR.