### PR TITLE
feat: add /api/generate/text/models endpoint

### DIFF
--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -162,6 +162,32 @@ export const proxyRoutes = new Hono<Env>()
         },
     )
     .get(
+        "/text/models",
+        describeRoute({
+            description: "Get available text models.",
+            responses: {
+                200: {
+                    description: "Success",
+                    content: {
+                        "application/json": {
+                            schema: resolver(
+                                z.array(z.string()).meta({
+                                    description: "List of available models",
+                                }),
+                            ),
+                        },
+                    },
+                },
+                ...errorResponses(500),
+            },
+        }),
+        async (c) => {
+            const textServiceUrl =
+                c.env.TEXT_SERVICE_URL || "https://text.pollinations.ai";
+            return await proxy(`${textServiceUrl}/models`);
+        },
+    )
+    .get(
         "/text/:prompt",
         describeRoute({
             description: [
@@ -216,32 +242,6 @@ export const proxyRoutes = new Hono<Env>()
                     ...contentFilterHeaders,
                 },
             );
-        },
-    )
-    .get(
-        "/text/models",
-        describeRoute({
-            description: "Get available text models.",
-            responses: {
-                200: {
-                    description: "Success",
-                    content: {
-                        "application/json": {
-                            schema: resolver(
-                                z.array(z.string()).meta({
-                                    description: "List of available models",
-                                }),
-                            ),
-                        },
-                    },
-                },
-                ...errorResponses(500),
-            },
-        }),
-        async (c) => {
-            const textServiceUrl =
-                c.env.TEXT_SERVICE_URL || "https://text.pollinations.ai";
-            return await proxy(`${textServiceUrl}/models`);
         },
     )
     .get(


### PR DESCRIPTION
- Adds text models endpoint matching image models pattern
- Proxies to text.pollinations.ai/models
- No auth required for model discovery

Fixes #4972

Generated with [Claude Code](https://claude.ai/code)