### PR TITLE
fix: allow empty string for finish_reason in Perplexity responses

### DIFF
--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -370,7 +370,8 @@ const CompletionChoiceSchema = z.object({
         "tool_calls",
         "content_filter",
         "function_call",
-    ]),
+        "",  // Perplexity returns empty string
+    ]).nullable().optional(),
     index: z.number().int().nonnegative(),
     message: ChatCompletionResponseMessageSchema,
     logprobs: ChatCompletionChoiceLogprobsSchema.nullish(),
@@ -430,6 +431,7 @@ export const CreateChatCompletionStreamResponseSchema = z.object({
                     "tool_calls",
                     "content_filter",
                     "function_call",
+                    "",  // Perplexity returns empty string
                 ])
                 .nullable()
                 .optional(),


### PR DESCRIPTION
- Allow empty string (`""`) for `finish_reason` field in OpenAI schema
- Perplexity API returns empty string instead of standard OpenAI values
- Fixes validation error for `perplexity-fast` and `perplexity-reasoning` models
- Updated both regular and streaming response schemas

Fixes #4983

Co-authored-by: thomash <thomash@users.noreply.github.com>