### PR TITLE
fix: image watermark / logo was corrupted add missing RATE_LIMITER Durable Objects binding to staging

### DIFF
--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -95,6 +95,11 @@ migrations_dir = "drizzle"
 binding = "KV"
 id = "eb4ea5149a5a413db53902bf2b8c1d95"
 
+[[env.staging.durable_objects.bindings]]
+name = "RATE_LIMITER"
+class_name = "RateLimiter"
+script_name = "pollinations-enter-staging"
+
 [env.staging.vars]
 ENVIRONMENT = "staging"
 LOG_LEVEL = "debug"


### PR DESCRIPTION
## Problem

Staging environment was crashing with errors on all requests.

## Root Cause

Commit f9a97179a added Durable Objects rate limiting but only configured bindings for:
- ✅ Development environment (top-level)
- ✅ Test environment
- ❌ Staging environment (missing)

## Fix

- Add Durable Objects binding to staging in wrangler.toml
- Set proper isolation

## Testing

- ✅ Deployed to staging successfully
- ✅ Durable Objects binding now appears in deployment output
- ✅ No more errors in staging logs

## Changes

- 1 file changed
- 5 lines added to staging environment configuration

---

## Additional Fix: Image Watermark Logo

**Issue**: The watermark logo on generated images lost its color and appeared grayscale.

**Root Cause**: PR #4904 (Nov 1, 2025) consolidated PWA assets and inadvertently converted `image.pollinations.ai/logo.png` from full color RGBA to grayscale during regeneration.

**Fix**: Reverted logo to original full color version (commit b3452c37d)
- Restored: 200x31 8-bit/color RGBA format
- Ensures proper color branding on image watermarks