### PR TITLE
fix: simplify header and fix social icon visibility

### DIFF
--- a/pollinations.ai/src/Home/Header.jsx
+++ b/pollinations.ai/src/Home/Header.jsx
@@ -1,55 +1,13 @@
 import React from "react";
-import styled from "@emotion/styled"; // Added to style our ReactSVG icon
 import { Box, useTheme } from "@mui/material";
-import { SectionBG, Colors, Fonts } from "../config/global";
+import { SectionBG } from "../config/global";
 import { SectionContainer } from "../components/SectionContainer";
 import { NavLink } from "react-router-dom";
 import { SocialLinks } from "../components/SocialLinks";
 import PollinationsLogo from "../logo/logo-text.svg?react";
 import { useMediaQuery } from "@mui/material";
 import { trackEvent } from "../config/analytics";
-import { GeneralButton } from "../components/GeneralButton";
-import { ICONS } from "../icons/icons.js"; // Import the ICONS map
-import { ReactSVG } from "react-svg";
 
-// Styled icon component to control fill color
-const AboutUsIcon = styled(ReactSVG)(() => ({
-    width: "20px",
-    height: "20px",
-    marginRight: "0.5em",
-    color: Colors.offblack,
-    "& svg": {
-        fill: Colors.offblack,
-        transition: "fill 0.6s",
-    },
-}));
-
-// About Us button with hover styles
-const AboutUsButton = styled(GeneralButton)(() => ({
-    fontSize: "1em",
-    fontFamily: Fonts.title,
-    fontWeight: 600,
-    marginRight: "1em",
-    borderRadius: "3em",
-    height: "40px",
-    minHeight: "40px",
-    display: "flex",
-    alignItems: "center",
-    minWidth: "150px",
-    border: `2px solid ${Colors.offblack}`,
-    color: Colors.offblack,
-    transition: "color 0.3s, background-color 0.3s",
-    "& svg path": {
-        transition: "fill 0.3s",
-    },
-    "&:hover": {
-        color: "white",
-        backgroundColor: Colors.offblack,
-        "& svg path": {
-            fill: "white",
-        },
-    },
-}));
 
 const Header = () => {
     const theme = useTheme(); // Use the useTheme hook to access the theme
@@ -62,17 +20,6 @@ const Header = () => {
         });
     };
 
-    const handleAboutUsClick = (e) => {
-        e.preventDefault();
-        trackEvent({
-            action: "click_linkedin",
-            category: "header",
-        });
-        window.open(
-            "https://www.linkedin.com/company/pollinations-ai",
-            "_blank",
-        );
-    };
 
     return (
         <SectionContainer backgroundConfig={SectionBG.header}>
@@ -103,25 +50,7 @@ const Header = () => {
                         }}
                     />
                 </NavLink>
-                <Box
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                    }}
-                >
-                    <AboutUsButton
-                        handleClick={handleAboutUsClick}
-                        isLoading={false}
-                    >
-                        <AboutUsIcon
-                            src={ICONS.linkedin}
-                            wrapper="span"
-                            aria-label="linkedin-icon"
-                        />
-                        About Us
-                    </AboutUsButton>
-                    <SocialLinks medium gap="1em" invert location="header" />
-                </Box>
+                <SocialLinks medium gap="1em" invert location="header" />
             </Box>
         </SectionContainer>
     );

--- a/pollinations.ai/src/components/SocialLinks.jsx
+++ b/pollinations.ai/src/components/SocialLinks.jsx
@@ -17,13 +17,13 @@ const SocialLinksContainer = styled("div")(({ gap }) => ({
 const LinkItem = styled(Link, {
     // Prevent forwarding isHovered to the DOM
     shouldForwardProp: (prop) => !["isHovered", "invert"].includes(prop),
-})(({ isHovered, invert }) => ({
+})(({ isHovered }) => ({
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
     borderRadius: "50%",
-    border: invert ? `1px solid ${isHovered ? Colors.offwhite : 'transparent'}` : `2px solid ${Colors.offblack}`,
-    backgroundColor: isHovered ? (invert ? Colors.offblack : Colors.offblack) : "transparent",
+    border: `2px solid ${Colors.offblack}`,
+    backgroundColor: isHovered ? Colors.offblack : "transparent",
     width: "40px",
     height: "40px",
     transition: "all 0.6s ease",
@@ -33,9 +33,9 @@ const LinkItem = styled(Link, {
 // Replacing the <img> with a Styled ReactSVG to control the svg fill dynamically
 const StyledReactSVG = styled(ReactSVG, {
     shouldForwardProp: (prop) => !["isHovered", "invert"].includes(prop),
-})(({ isHovered, invert }) => ({
+})(({ isHovered }) => ({
     "& svg": {
-        fill: invert ? Colors.offwhite : (isHovered ? Colors.offwhite : Colors.offblack),
+        fill: isHovered ? Colors.offwhite : Colors.offblack,
         transition: "fill 0.6s ease",
         width: "100%",
         height: "100%",

--- a/pollinations.ai/src/config/socialLinksList.js
+++ b/pollinations.ai/src/config/socialLinksList.js
@@ -15,7 +15,13 @@ export const SOCIAL_LINKS = {
         width: "25px",
         height: "25px",
     },
-
+    linkedin: {
+        label: "LinkedIn",
+        icon: ICONS.linkedin,
+        url: "https://www.linkedin.com/company/pollinations-ai",
+        width: "22px",
+        height: "22px",
+    },
     instagram: {
         label: "Instagram",
         icon: ICONS.instagram,
@@ -36,12 +42,5 @@ export const SOCIAL_LINKS = {
         url: "https://tiktok.com/@pollinations.ai",
         width: "27px",
         height: "27px",
-    },
-    linkedin: {
-        label: "LinkedIn",
-        icon: ICONS.linkedin,
-        url: "#",
-        width: "22px",
-        height: "22px",
     },
 };


### PR DESCRIPTION
## Changes

- Remove large About Us button, replace with LinkedIn icon in social links
- Fix social icons being invisible when not hovered (icons now dark by default)
- Add consistent 2px border to all social icons matching previous About Us button style
- Move LinkedIn to third position after Discord and GitHub
- Update LinkedIn URL to company page

## Before/After

**Before:**
- Large "About Us" button with LinkedIn icon
- Social icons invisible when not hovered (white on white background)
- LinkedIn at end of social links with placeholder URL

**After:**
- Simplified header with just social icons
- All icons visible with dark fill and border when not hovered
- LinkedIn in third position with correct company URL
- Consistent styling across all icons