### PR TITLE
Hide pricing before login

### DIFF
--- a/enter.pollinations.ai/src/client/routes/sign-in.tsx
+++ b/enter.pollinations.ai/src/client/routes/sign-in.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { FAQ } from "../components/faq.tsx";
 import { Button } from "../components/button.tsx";
 import { Header } from "../components/header.tsx";
-import { Pricing } from "../components/pricing/index.ts";
 
 export const Route = createFileRoute("/sign-in")({
     component: RouteComponent,
@@ -37,7 +36,6 @@ function RouteComponent() {
                 </Button>
             </Header>
             <FAQ />
-            <Pricing />
         </div>
     );
 }


### PR DESCRIPTION
- Remove pricing component from sign-in page
- Pricing still visible after login on main page

Fixes #5012

Generated with [Claude Code](https://claude.ai/code)