### PR TITLE
Update FAQ to align with current API requirements

### DIFF
--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -27,7 +27,9 @@ Not currently. You need to register and use an API key to access our models. All
 
 ## What do I get when I register?
 
-Registration gives you access to the Pollinations API and the **Seed tier**, which includes 5 Pollen per day to get you started. Once registered, you can **create API keys** to start making requests.
+Registration gives you access to the Pollinations API and the **Seed tier**, which includes 5 Pollen per day* to get you started. Once registered, you can **create API keys** to start making requests.
+
+*During beta only - subject to change
 
 - **Publishable Key (pk_):** Designed for client-side apps (bound to your domain). Rate limits: 3 requests/burst, 1 refill per 15 sec (~4 req/min). Access to all models, which consume Pollen based on usage.
 - **Secret Key (sk_):** For server-side apps only. No rate limits. Access to all models, which consume Pollen based on usage.


### PR DESCRIPTION
## Summary
Updates POLLEN_FAQ.md to reflect current product state where registration and authentication are required for all API access.

## Changes
- **Remove free model references** - All models now consume Pollen (no zero-cost models)
- **Merge duplicate FAQ sections** - Combined "How much Pollen do models use?" and "What can I create with 1 Pollen?" into single engaging section with emojis
- **Clarify registration requirements** - Updated "Can I try it without signing up?" to clearly state registration is required
- **Remove anonymous access concept** - Deleted references to anonymous users (no longer possible)
- **Update registration FAQ** - Changed "What changes when I register?" to "What do I get when I register?" to avoid implying optional access
- **Add accurate rate limits** - Updated with actual values from api-key.tsx:
  - Publishable Key (pk_): 3 req/burst, 1 refill per 15 sec (~4 req/min)
  - Secret Key (sk_): No rate limits

## Result
FAQ now accurately reflects that:
- Registration + API keys are required for all access
- All models consume Pollen based on usage
- Clear rate limit information for both key types

Fixes #5021