### PR TITLE
fix: validate GitHub repo URLs before adding links

### DIFF
--- a/pollinator-agent/project-list-scripts/generate-project-table.js
+++ b/pollinator-agent/project-list-scripts/generate-project-table.js
@@ -49,8 +49,9 @@ const formatProjectName = (project) => {
         name = `[${name}](${project.url})`;
     }
 
-    // Always add GitHub link as clickable stars if repo exists
-    if (project.repo) {
+    // Always add GitHub link as clickable stars if repo exists and is a valid URL
+    const isValidRepo = project.repo && project.repo.startsWith('http');
+    if (isValidRepo) {
         const starCount =
             project.stars >= 1000
                 ? `${(project.stars / 1000).toFixed(1)}k`


### PR DESCRIPTION
- Add URL validation to filter out invalid repo values
- Only show GitHub star links for valid http/https URLs
- Prevents 'No response' and other invalid values from appearing as links

Fixes #5018

Generated with [Claude Code](https://claude.ai/code)