### PR TITLE
fix: Terms & Conditions page routing and UI

### DIFF
--- a/pollinations.ai/public/_redirects
+++ b/pollinations.ai/public/_redirects
@@ -2,7 +2,6 @@
 /c/* / 200
 /prompt/* https://image.pollinations.ai/prompt/:splat 301
 /p/* https://image.pollinations.ai/prompt/:splat 301
-/terms / 200
 /readme / 200
 /referral / 200
 /sirius-cybernetics-elevator-challenge https://b_jhzjeywxldc.v0.build/ 301

--- a/pollinations.ai/src/Home/Footer.jsx
+++ b/pollinations.ai/src/Home/Footer.jsx
@@ -97,8 +97,7 @@ const Footer = () => {
                         sx={{ fontSize: "1.5em", fontFamily: Fonts.title }}
                     >
                         <StyledLink 
-                            href="https://enter.pollinations.ai/terms" 
-                            isExternal
+                            to="/terms" 
                             onClick={handleTermsLinkClick}
                         >
                             <LLMTextManipulator

--- a/pollinations.ai/src/components/Terms.jsx
+++ b/pollinations.ai/src/components/Terms.jsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import Markdown from "markdown-to-jsx";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import termsMarkdown from "../../TERMS_OF_SERVICE.md?raw";
 import privacyMarkdown from "../../PRIVACY_POLICY.md?raw";
 import { Colors } from "../config/global";
@@ -20,6 +21,16 @@ const LogoContainer = styled.div`
   display: flex;
   justify-content: center;
   margin-bottom: 60px;
+  
+  a {
+    display: inline-block;
+    cursor: pointer;
+    transition: opacity 0.3s ease;
+    
+    &:hover {
+      opacity: 0.8;
+    }
+  }
   
   img {
     height: 60px;
@@ -185,7 +196,9 @@ const Terms = () => {
   return (
     <PageContainer>
       <LogoContainer>
-        <img src="/logo.svg" alt="Pollinations.ai" />
+        <Link to="/">
+          <img src="/logo-text.svg" alt="Pollinations.ai" />
+        </Link>
       </LogoContainer>
 
       <ContentWrapper>

--- a/pollinations.ai/src/main.jsx
+++ b/pollinations.ai/src/main.jsx
@@ -6,6 +6,14 @@ import App from "./App";
 import { BrowserRouter } from "react-router-dom";
 import ScrollToTop from "./utils/ScrollToTop";
 
+// Disable verbose micromark debug logs
+if (typeof localStorage !== 'undefined') {
+    const currentDebug = localStorage.getItem('debug');
+    if (!currentDebug || currentDebug === '*') {
+        localStorage.setItem('debug', '*,-micromark*');
+    }
+}
+
 const theme = createTheme();
 const container = document.getElementById("root");
 const root = createRoot(container); // Create a root


### PR DESCRIPTION
## Changes

- **Update Footer link** - Use local `/terms` route with React Router `Link` component instead of external enter.pollinations.ai link
- **Fix routing** - Remove `/terms` redirect from `_redirects` that was sending users to home page
- **Full logo** - Use `logo-text.svg` (logo with text) instead of icon-only logo
- **Clickable logo** - Make logo link back to home page for better navigation
- **Suppress logs** - Disable verbose micromark debug logs in browser console

## Testing

- ✅ Click "Terms & Conditions" in footer → navigates to `/terms`
- ✅ Click logo on Terms page → navigates back to home
- ✅ Right-click link shows correct `/terms` URL
- ✅ No micromark logs in browser console

Fixes #5024