### PR TITLE
Organize API docs with tags and hide legacy endpoint

### DIFF
--- a/enter.pollinations.ai/src/routes/polar.ts
+++ b/enter.pollinations.ai/src/routes/polar.ts
@@ -38,6 +38,7 @@ export const polarRoutes = new Hono<Env>()
     .get(
         "/customer/state",
         describeRoute({
+            tags: ["Auth"],
             description: "Get the polar customer state for the current user.",
             hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
         }),
@@ -53,6 +54,7 @@ export const polarRoutes = new Hono<Env>()
     .get(
         "/customer/events",
         describeRoute({
+            tags: ["Auth"],
             description: "Get usage events associated with the current user.",
             hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
         }),
@@ -68,6 +70,7 @@ export const polarRoutes = new Hono<Env>()
     .get(
         "/customer/portal",
         describeRoute({
+            tags: ["Auth"],
             description: [
                 "Redirects to the current users customer portal by default.",
                 "If `redirect` is set to `false`, returns JSON with the redirect url.",
@@ -96,6 +99,7 @@ export const polarRoutes = new Hono<Env>()
     .get(
         "/checkout/:slug",
         describeRoute({
+            tags: ["Auth"],
             description:
                 "Opens the polar checkout matching the product `slug`.",
             hide: ({ c }) => c?.env.ENVIRONMENT !== "development",

--- a/enter.pollinations.ai/src/routes/tiers.ts
+++ b/enter.pollinations.ai/src/routes/tiers.ts
@@ -79,6 +79,7 @@ export const tiersRoutes = new Hono<Env>()
     .get(
         "/view",
         describeRoute({
+            tags: ["Auth"],
             description: "Get the current user's tier status and daily pollen information.",
             hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
         }),
@@ -161,6 +162,7 @@ export const tiersRoutes = new Hono<Env>()
     .post(
         "/activate",
         describeRoute({
+            tags: ["Auth"],
             description: "Create a Polar checkout session to activate a tier subscription.",
             hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
         }),


### PR DESCRIPTION
## Changes

- **Add OpenAPI tags** for better organization in Scalar docs
  - Text Generation: `/v1/models`, `/text/models`, `/v1/chat/completions`, `/text/:prompt`
  - Image Generation: `/image/models`, `/image/:prompt`
  - Auth: `/polar/*`, `/tiers/*`
- **Hide legacy `/openai` endpoint** from docs (still functional for backward compatibility)
- **Add deprecation notice** in `/v1/chat/completions` mentioning legacy `/openai` path
- **Extract shared handler** for chat completions (DRY principle)
- **Eliminate "default" category** - all endpoints now properly tagged

## Result

Clean, organized API documentation with logical grouping instead of scattered endpoints.

cc @voodoohop