### PR TITLE
Fix Flux steps calculation and concurrent request counting

### DIFF
--- a/image.pollinations.ai/src/availableServers.ts
+++ b/image.pollinations.ai/src/availableServers.ts
@@ -88,13 +88,15 @@ setInterval(decayErrors, 60 * 1000); // Every 1 minute
 setInterval(() => console.table(serverQueueInfo(SERVERS)), 10000);
 
 /**
- * Returns the total number of jobs for a specific type
+ * Returns the total load (pending + queued jobs) for a specific type
+ * Only counts active servers (with recent heartbeats)
  * @param {ServerType} type - The type of service (default: 'flux')
- * @returns {number} Total number of jobs (size + pending) across all queues
+ * @returns {number} Total load across all active servers (pending + queued)
  */
 export const countJobs = (type: ServerType = "flux"): number => {
     const servers = SERVERS[type] || [];
-    return servers.reduce((total, server) => {
+    const activeServers = filterActiveServers(servers);
+    return activeServers.reduce((total, server) => {
         return total + server.queue.size + server.queue.pending;
     }, 0);
 };

--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -125,10 +125,11 @@ export const callComfyUI = async (
             safeParams,
         );
 
-        // Linear scaling of steps between 6 (at concurrentRequests=2) and 1 (at concurrentRequests=36)
+        // Scale steps from 4 down to 1, dropping more gradually
+        // 4 steps up to 20 concurrent, then gradually down to 1 at 50+ concurrent
         const steps = Math.max(
             1,
-            Math.round(4 - ((concurrentRequests - 2) * (3 - 1)) / (10 - 2)),
+            Math.round(4 - Math.max(0, concurrentRequests - 20) / 10)
         );
         logOps("calculated_steps", steps);
 


### PR DESCRIPTION
## Problem
- Flux images were using too few steps (dropping to 1 step at only 10-14 concurrent requests)
- Concurrent request count was inflated (showing 141-268 instead of actual ~10-20)
- Dead GPU servers with stale heartbeats were still being counted

## Solution
- **Improved step formula**: Maintains 4 steps up to 20 concurrent requests, then gradually drops to 1 at 50+
- **Fixed `countJobs()`**: Now filters out inactive servers (>45s since last heartbeat) before counting
- **Better image quality**: Under normal load, Flux will use 4 steps instead of 1

## Changes
- `availableServers.ts`: Added `filterActiveServers()` call in `countJobs()` to exclude dead servers
- `createAndReturnImages.ts`: Updated step calculation formula for more gradual degradation

## Impact
- 0-20 concurrent: **4 steps** (high quality)
- 30 concurrent: **3 steps**
- 40 concurrent: **2 steps**
- 50+ concurrent: **1 step** (minimum)

Previously was dropping to 1 step at just 10-14 concurrent due to counting dead servers.