### PR TITLE
Fix: Remove dimension scaling limits from image generation

### DIFF
--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -655,7 +655,7 @@ const server = http.createServer((req, res) => {
         const modelDetails = Object.entries(MODELS).map(([name, config]) => ({
             name,
             enhance : config.enhance || false,
-            maxSideLength: config.maxSideLength,
+            defaultSideLength: config.defaultSideLength ?? 1024,
         }));
         res.end(JSON.stringify(modelDetails));
         return;

--- a/image.pollinations.ai/src/makeParamsSafe.js
+++ b/image.pollinations.ai/src/makeParamsSafe.js
@@ -42,11 +42,9 @@ export const makeParamsSafe = ({
         model = "flux";
     }
 
-    const maxSideLength = MODELS[model].maxSideLength;
-    const defaultSideLength = MODELS[model].defaultSideLength ?? maxSideLength;
-    const maxPixels = maxSideLength * maxSideLength;
+    const defaultSideLength = MODELS[model].defaultSideLength ?? 1024;
 
-    // Ensure width and height are integers or default to defaultSideLength
+    // Use provided dimensions or default - no scaling/limiting
     width = Number.isInteger(parseInt(width))
         ? parseInt(width)
         : defaultSideLength;
@@ -60,13 +58,6 @@ export const makeParamsSafe = ({
 
     if (seed < 0 || seed > maxSeedValue) {
         seed = 42;
-    }
-
-    // // Adjust dimensions to maintain aspect ratio if exceeding maxPixels
-    if (width * height > maxPixels) {
-        const ratio = Math.sqrt(maxPixels / (width * height));
-        width = Math.floor(width * ratio);
-        height = Math.floor(height * ratio);
     }
 
     // Validate quality parameter - only allow specific values

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -12,8 +12,7 @@ type ImageServiceName = keyof typeof IMAGE_SERVICES;
 interface ImageModelConfig {
     type: string;
     enhance: boolean;
-    maxSideLength: number;
-    defaultSideLength?: number; // Optional - defaults to maxSideLength if not specified
+    defaultSideLength?: number; // Optional - defaults to 1024 if not specified
 }
 
 type ImageModelsConfig = {
@@ -24,36 +23,34 @@ export const IMAGE_CONFIG: ImageModelsConfig = {
     flux: {
         type: "pollinations",
         enhance: true,
-        maxSideLength: 768,
+        defaultSideLength: 768,
     },
 
     // Azure Flux Kontext - general purpose model
     kontext: {
         type: "kontext",
         enhance: true,
-        maxSideLength: 1024, // Azure Flux Kontext standard resolution
+        defaultSideLength: 1024,
     },
 
     // Assuming 'turbo' is of type 'sd'
     turbo: {
         type: "pollinations",
         enhance: true,
-        maxSideLength: 768,
+        defaultSideLength: 768,
     },
 
     // ByteDance ARK Seedream - high quality image generation
     seedream: {
         type: "seedream",
         enhance: false,
-        maxSideLength: 4096, // Seedream supports up to 4K
-        defaultSideLength: 1024, // Default to 1K when not specified
+        defaultSideLength: 1024,
     },
 
     // Gemini 2.5 Flash Image via Vertex AI - image-to-image generation
     nanobanana: {
         type: "vertex-ai",
         enhance: false,
-        maxSideLength: 2048, // Gemini supports up to 2K
         defaultSideLength: 1024,
     },
 
@@ -61,14 +58,13 @@ export const IMAGE_CONFIG: ImageModelsConfig = {
     gptimage: {
         type: "azure",
         enhance: false,
-        maxSideLength: 1024,
         defaultSideLength: 1021, // Prime number to detect default size for "auto" mode
     },
 };
 
 /**
  * Legacy MODELS export for backward compatibility
- * Combines registry data with local config (enhance, maxSideLength)
+ * Combines registry data with local config (enhance, defaultSideLength)
  * @deprecated Use IMAGE_SERVICES from registry, IMAGE_CONFIG for implementation details
  */
 export const MODELS = Object.fromEntries(

--- a/image.pollinations.ai/src/params.ts
+++ b/image.pollinations.ai/src/params.ts
@@ -33,26 +33,17 @@ function adjustImageSizeForModel(
     width?: number,
     height?: number,
 ): { width: number; height: number } {
-    const maxSideLength = MODELS[model].maxSideLength;
-    const defaultSideLength = MODELS[model].defaultSideLength ?? maxSideLength;
-    const maxPixels = maxSideLength * maxSideLength;
+    const defaultSideLength = MODELS[model].defaultSideLength ?? 1024;
 
-    // Ensure width and height are integers or default to defaultSideLength
-    var sanitizedWidth =
+    // Use provided dimensions or default - no scaling/limiting
+    const sanitizedWidth =
         width !== undefined && Number.isInteger(width)
             ? width
             : defaultSideLength;
-    var sanitizedHeight =
+    const sanitizedHeight =
         height !== undefined && Number.isInteger(height)
             ? height
             : defaultSideLength;
-
-    // Adjust dimensions to maintain aspect ratio if exceeding maxPixels
-    if (sanitizedWidth * sanitizedHeight > maxPixels) {
-        const ratio = Math.sqrt(maxPixels / (sanitizedWidth * sanitizedHeight));
-        sanitizedWidth = Math.floor(sanitizedWidth * ratio);
-        sanitizedHeight = Math.floor(sanitizedHeight * ratio);
-    }
 
     return { width: sanitizedWidth, height: sanitizedHeight };
 }


### PR DESCRIPTION
## Problem
- GPT Image fails with valid 1536x1024 dimensions
- System scales to invalid 1254x836 (exceeds maxPixels limit)
- Azure API rejects: "Invalid value: '1254x836'"

## Solution
- Remove dimension scaling logic entirely
- Remove `maxSideLength` from all model configs
- Keep `defaultSideLength` for unspecified dimensions
- Pass user dimensions through without modification

## Changes
- `src/params.ts` - Remove scaling in `adjustImageSizeForModel()`
- `src/makeParamsSafe.js` - Remove maxPixels calculation and scaling
- `src/models.ts` - Remove `maxSideLength`, keep only `defaultSideLength`
- `src/index.ts` - Update `/models` endpoint response

## Result
- User dimensions passed through unchanged
- Backend APIs validate their own constraints
- Simpler, more predictable behavior
- Fixes gptimage 1536x1024 support

Fixes #5037