### PR TITLE
feat: enable  payment button for credit card testing

### DIFF
--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -171,9 +171,11 @@ function RouteComponent() {
                             as="button"
                             color="purple"
                             weight="light"
-                            disabled
+                            onClick={() => {
+                                window.location.href = "/api/polar/checkout/pollen-bundle-small";
+                            }}
                         >
-                            + $10
+                            + $5
                         </Button>
                         <Button
                             as="button"
@@ -181,10 +183,10 @@ function RouteComponent() {
                             weight="light"
                             disabled
                         >
-                            + $25
+                            + $10
                         </Button>
                         <Button as="button" color="purple" weight="light" disabled>
-                            + $50
+                            + $20
                         </Button>
                         <a
                             href="https://github.com/pollinations/pollinations/issues/4826"


### PR DESCRIPTION
- Update payment buttons from // to //
- Enable  button with Polar checkout integration
- Wire up pollen-bundle-small product for payment testing
- Keep  and  buttons disabled for now