### PR TITLE
fix: add missing import for callAzureFluxKontext

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -37,7 +37,7 @@ import type { ProgressManager } from "./progressBar.ts";
 // Import model handlers
 import { callBPAIGenWithKontextFallback } from "./models/bpaigenModel.ts";
 import { callSeedreamAPI } from "./models/seedreamModel.ts";
-import type { ImageGenerationResult as FluxImageGenerationResult } from "./models/azureFluxKontextModel.js";
+import { callAzureFluxKontext, type ImageGenerationResult as FluxImageGenerationResult } from "./models/azureFluxKontextModel.js";
 
 dotenv.config();
 


### PR DESCRIPTION
- Adds missing `callAzureFluxKontext` function import in createAndReturnImages.ts
- Function was called but never imported, only the type was imported
- Fixes kontext model image generation/editing on master branch
- Backport of #5083