### PR TITLE
Add Cloudflare deployment workflow for enter.pollinations.ai

### DIFF
--- a/.github/workflows/deploy-enter-cloudflare.yml
+++ b/.github/workflows/deploy-enter-cloudflare.yml
@@ -3,7 +3,6 @@ name: Deploy enter.pollinations.ai
 on:
   push:
     branches:
-      - main
       - staging
     paths:
       - 'enter.pollinations.ai/**'


### PR DESCRIPTION
- Adds dedicated workflow for deploying enter.pollinations.ai to Cloudflare Workers
- Triggers on push t staging branches when enter.pollinations.ai/** files change
- Includes build step to generate dist/client assets before deployment