### PR TITLE
feat: add Claude Sonnet 4.5 as claude-large

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -236,6 +236,11 @@ export const TEXT_SERVICES = {
         modelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         provider: "aws-bedrock",
     },
+    "claude-large": {
+        aliases: ["sonnet", "claude-4.5", "claude-sonnet-4.5", "claude-sonnet"],
+        modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        provider: "aws-bedrock",
+    },
     "perplexity-fast": {
         aliases: ["sonar"],
         modelId: "sonar",

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -163,6 +163,16 @@ const models: ModelDefinition[] = [
         tools: true,
     },
     {
+        name: "claude-large",
+        description: "Claude Sonnet 4.5",
+        config: portkeyConfig["us.anthropic.claude-sonnet-4-5-20250929-v1:0"],
+        transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
+        community: false,
+        input_modalities: ["text", "image"],
+        output_modalities: ["text"],
+        tools: true,
+    },
+    {
         name: "openai-reasoning",
         description: "OpenAI o4 Mini",
         config: portkeyConfig["openai/o4-mini"],

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -133,7 +133,7 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
         }),
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": () =>
-        createBedrockLambdaModelConfig({
+        createBedrockFargateModelConfig({
             model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         }),
     "us.anthropic.claude-sonnet-4-20250514-v1:0": () =>


### PR DESCRIPTION
## Add Claude Sonnet 4.5

### Changes
- Add `claude-large` model (Claude Sonnet 4.5)
- Model ID: `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
- Endpoint: AWS Bedrock Fargate
- Pricing: $3/M input, $15/M output tokens

### Aliases
- `sonnet`
- `claude-4.5`
- `claude-sonnet-4.5`
- `claude-sonnet`

### Features
- ✅ Vision support (text + image input)
- ✅ Tool calling
- ✅ Conversational system prompt

### Testing
- ✅ Verified with `curl localhost:16385/say_hi?model=claude-large`
- ✅ Model responds correctly