### PR TITLE
fix: trigger enter.pollinations.ai deploy on registry changes

### DIFF
--- a/.github/workflows/deploy-enter-cloudflare.yml
+++ b/.github/workflows/deploy-enter-cloudflare.yml
@@ -6,6 +6,7 @@ on:
       - staging
     paths:
       - 'enter.pollinations.ai/**'
+      - 'shared/registry/**'
       - '.github/workflows/deploy-enter-cloudflare.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Fix Cloudflare deployment trigger

### Issue
- enter.pollinations.ai wasn't redeploying when models/pricing changed
- Workflow only triggered on `enter.pollinations.ai/**` changes
- Missed `shared/registry/**` changes (pricing, model configs)

### Fix
- Add `shared/registry/**` to deployment trigger paths
- Ensures Cloudflare worker redeploys when pricing/models update

### Impact
- ✅ Model additions now trigger enter.pollinations.ai deployment
- ✅ Pricing updates automatically deploy to production