### PR TITLE
feat: Move kontext model to nectar tier and redirect to enter.pollinations.ai

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1025,9 +1025,9 @@ const generateImage = async (
     if (safeParams.model === "kontext") {
         // Azure Flux Kontext model requires seed tier or higher
         // NOTE: Allow bypass for enter.pollinations.ai requests
-        if (!fromEnter && !hasSufficientTier(userInfo.tier, "seed")) {
+        if (!fromEnter && !hasSufficientTier(userInfo.tier, "nectar")) {
             const errorText =
-                "Access to kontext model is limited to users in the seed tier or higher. Please authenticate at https://auth.pollinations.ai to get a token or add a referrer.";
+                "Access to kontext model is limited to users in the nectar tier or higher. Please visit https://enter.pollinations.ai to get started.";
             logError(errorText);
             progress.updateBar(
                 requestId,

--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -472,7 +472,7 @@ const checkCacheAndGenerate = async (
                     // (rate limiting is handled separately by ipQueue)
                     const fromEnter = isEnterRequest(req);
                     if (!fromEnter && !canAccessService("kontext", authResult.tier)) {
-                        throw new Error("Kontext model requires authentication (seed tier or higher). Visit https://auth.pollinations.ai");
+                        throw new Error("Kontext model requires nectar tier or higher. Visit https://enter.pollinations.ai to get started.");
                     }
                     // 30 second interval with tier-based cap from model config
                     const cap = IMAGE_CONFIG.kontext.tierCaps?.[authResult.tier] || 1;

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -64,7 +64,7 @@ export const IMAGE_SERVICES = {
         aliases: [],
         modelId: "kontext",
         provider: "azure",
-        tier: "seed",
+        tier: "nectar",
     },
     "turbo": {
         aliases: [],


### PR DESCRIPTION
- Upgrade kontext model tier requirement from seed to nectar
- Update error messages to direct users to https://enter.pollinations.ai
- Improve UX with clearer tier requirement messaging
- Update tier checks in createAndReturnImages.ts and index.ts