### PR TITLE
fix: Download and convert Seedream reference images to base64

### DIFF
--- a/image.pollinations.ai/src/models/seedreamModel.ts
+++ b/image.pollinations.ai/src/models/seedreamModel.ts
@@ -85,15 +85,59 @@ export const callSeedreamAPI = async (
         if (safeParams.image && safeParams.image.length > 0) {
             logOps("Adding reference images for image-to-image generation:", safeParams.image.length, "images");
             
+            // Update progress for image processing
+            progress.updateBar(requestId, 40, "Processing", "Downloading reference images...");
+            
             // Seedream 4.0 supports up to 10 reference images
             const imageUrls = Array.isArray(safeParams.image) 
                 ? safeParams.image.slice(0, 10) // Limit to max 10 images
                 : [safeParams.image];
             
-            // For single image, pass as string; for multiple images, pass as array
-            requestBody.image = imageUrls.length === 1 ? imageUrls[0] : imageUrls;
+            // Download and convert images to base64 to bypass hosting provider blocks
+            const processedImages: string[] = [];
             
-            logOps("Image-to-image mode enabled with", imageUrls.length, "reference image(s)");
+            for (let i = 0; i < imageUrls.length; i++) {
+                const imageUrl = imageUrls[i];
+                try {
+                    logOps(`Downloading reference image ${i + 1}/${imageUrls.length} from: ${imageUrl}`);
+                    
+                    // Download the image
+                    const imageResponse = await withTimeoutSignal(
+                        (signal) => fetch(imageUrl, { signal }),
+                        30000, // 30 second timeout
+                    );
+                    
+                    if (!imageResponse.ok) {
+                        logError(`Failed to fetch reference image ${i + 1}: ${imageResponse.status}`);
+                        continue; // Skip this image and continue with others
+                    }
+                    
+                    // Convert to base64
+                    const imageBuffer = await imageResponse.arrayBuffer();
+                    const base64Data = Buffer.from(imageBuffer).toString('base64');
+                    
+                    // Determine MIME type from response headers
+                    const contentType = imageResponse.headers.get('content-type') || 'image/jpeg';
+                    
+                    // Create data URL format: data:image/jpeg;base64,<base64data>
+                    const dataUrl = `data:${contentType};base64,${base64Data}`;
+                    processedImages.push(dataUrl);
+                    
+                    logOps(`Successfully processed reference image ${i + 1}: ${contentType}, ${base64Data.length} chars`);
+                } catch (error) {
+                    logError(`Error processing reference image ${i + 1}:`, error.message);
+                    // Continue with other images
+                }
+            }
+            
+            if (processedImages.length === 0) {
+                throw new Error("Failed to download any reference images");
+            }
+            
+            // For single image, pass as string; for multiple images, pass as array
+            requestBody.image = processedImages.length === 1 ? processedImages[0] : processedImages;
+            
+            logOps("Image-to-image mode enabled with", processedImages.length, "processed reference image(s)");
         }
 
         logOps("Seedream API request body:", JSON.stringify(requestBody, null, 2));


### PR DESCRIPTION
- Download reference images on server before sending to Seedream API
- Convert to base64 data URLs to bypass hosting provider blocks
- Fixes image-to-image failures with Cloudflare R2 blocking ByteDance
- Graceful error handling: skip failed images, continue with others
- Progress updates during download

Fixes #5142