### PR TITLE
fix: remove GitHub star incentive from Pollen FAQ

### DIFF
--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -9,7 +9,7 @@ Pollen is our prepaid credit system. **$1 ≈ 1 Pollen** (pricing may evolve). Y
 There are three ways to add Pollen to your balance:
 1.  **Buy It:** Purchase Pollen packs directly with a credit card. This Pollen goes into your wallet and never expires. (Want other payment options? [Vote here](https://github.com/pollinations/pollinations/issues/4826)!)
 2.  **Get Daily Pollen:** During and after beta, registered developers receive daily Pollen grants to support experimentation based on their tier *(seed, flower, or nectar)*.
-3.  **Earn It:** Complete one-time community rewards, like starring our GitHub repo or helping solve a technical issue.
+3.  **Earn It:** Complete one-time community rewards, like helping solve a technical issue or contributing to the project.
 
 ## What payment methods do you accept?
 


### PR DESCRIPTION
- Removes mention of starring GitHub repo from community rewards section
- Keeps general concept of earning Pollen through contributions
- Updates wording to "helping solve technical issues or contributing to project"
- Ensures compliance with GitHub ToS on star gamification