### PR TITLE
fix: disable $5 top-up button

### DIFF
--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -171,9 +171,7 @@ function RouteComponent() {
                             as="button"
                             color="purple"
                             weight="light"
-                            onClick={() => {
-                                window.location.href = "/api/polar/checkout/pollen-bundle-small";
-                            }}
+                            disabled
                         >
                             + $5
                         </Button>


### PR DESCRIPTION
- Disables $5 pollen top-up button to match $10 and $20
- Removes onClick handler from $5 button
- All payment buttons now consistently disabled