### PR TITLE
Add GitHub email and API key name logging to event buffer and Tinybird

### DIFF
--- a/enter.pollinations.ai/drizzle/0003_add_user_github_email_and_api_key_name.sql
+++ b/enter.pollinations.ai/drizzle/0003_add_user_github_email_and_api_key_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `event` ADD `user_github_email` text;--> statement-breakpoint
+ALTER TABLE `event` ADD `api_key_name` text;

--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -52,7 +52,9 @@ export const event = sqliteTable("event", {
     // User information
     userId: text("user_id"),
     userTier: text("user_tier"),
+    userGithubEmail: text("user_github_email"),
     apiKeyId: text("api_key_id"),
+    apiKeyName: text("api_key_name"),
     apiKeyType: text("api_key_type", {
         enum: apiKeyTypeValues,
     }).$type<ApiKeyType>(),

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -129,7 +129,9 @@ export const track = (eventType: EventType) =>
                     userTier: c.var.auth.user?.tier,
                     userGithubId: c.var.auth.user?.githubId,
                     userGithubName: c.var.auth.user?.githubUsername,
+                    userGithubEmail: c.var.auth.user?.email,
                     apiKeyId: c.var.auth.apiKey?.id,
+                    apiKeyName: c.var.auth.apiKey?.name,
                     apiKeyType: c.var.auth.apiKey?.metadata
                         ?.keyType as ApiKeyType,
                 };


### PR DESCRIPTION
## Summary
Implements logging of GitHub email and API key name to event buffer and Tinybird analytics.

## Changes
- **Event Schema**: Added `userGithubEmail` and `apiKeyName` fields
- **Tracking Middleware**: Updated to capture email from `c.var.auth.user?.email` and API key name from `c.var.auth.apiKey?.name`
- **Database Migration**: Created migration file `0003_add_user_github_email_and_api_key_name.sql`

## Context
Previously tracking:
- ✅ GitHub username (`userGithubName`)
- ✅ GitHub ID (`userGithubId`)
- ✅ API key ID (`apiKeyId`)
- ✅ API key type (`apiKeyType`)

Now also tracking:
- ✅ GitHub email (`userGithubEmail`)
- ✅ API key name (`apiKeyName`)

## Testing
The implementation follows the existing pattern for user tracking. All fields are optional (nullable) to handle cases where users may not have authenticated or may not have API keys.

Closes #5149