### PR TITLE
docs: add missing query parameters to /generate/image/{prompt} endpoint

### DIFF
--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -257,6 +257,29 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "API keys can be created from your dashboard at enter.pollinations.ai.",
             ].join("\n"),
+            request: {
+                query: resolver(GenerateImageRequestQueryParamsSchema),
+            },
+            responses: {
+                200: {
+                    description: "Success - Returns the generated image",
+                    content: {
+                        "image/jpeg": {
+                            schema: {
+                                type: "string",
+                                format: "binary",
+                            },
+                        },
+                        "image/png": {
+                            schema: {
+                                type: "string",
+                                format: "binary",
+                            },
+                        },
+                    },
+                },
+                ...errorResponses(400, 401, 500),
+            },
         }),
         validator("query", GenerateImageRequestQueryParamsSchema),
         async (c) => {


### PR DESCRIPTION
Fixes #5191

- Add request.query schema with all parameters (model, width, height, seed, nologo, private, enhance, safe, etc.)
- Add response definitions for image/jpeg and image/png
- Fixes missing parameter documentation in OpenAPI spec

Generated with [Claude Code](https://claude.ai/code)