### PR TITLE
feat: enable reasoning token passthrough

### DIFF
--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -216,6 +216,8 @@ export const CreateChatCompletionRequestSchema = z.object({
     stream: z.boolean().nullable().optional().default(false),
     stream_options: ChatCompletionStreamOptionsSchema,
     thinking: ThinkingSchema,
+    reasoning_effort: z.enum(["low", "medium", "high"]).optional(),
+    thinking_budget: z.number().int().min(0).optional(),
     temperature: z.number().min(0).max(2).nullable().optional().default(1),
     top_p: z.number().min(0).max(1).nullable().optional().default(1),
     tools: z.array(ChatCompletionToolSchema).optional(),
@@ -260,6 +262,8 @@ const ChatCompletionResponseMessageSchema = z.object({
             expires_at: z.number().int().optional(),
         })
         .nullish(),
+    // DeepSeek reasoning format
+    reasoning_content: z.string().nullish(),
 });
 
 const ChatCompletionTokenTopLogprobSchema = z.object({
@@ -421,6 +425,9 @@ const ChatCompletionStreamResponseDeltaSchema = z.object({
         .optional(),
     tool_calls: z.array(ChatCompletionMessageToolCallChunkSchema).optional(),
     role: z.enum(["system", "user", "assistant", "tool"]).optional(),
+    // Reasoning/thinking fields for streaming
+    reasoning_content: z.string().optional(),
+    content_blocks: z.array(ChatCompletionMessageContentBlockSchema).optional(),
 });
 
 export const CreateChatCompletionStreamResponseSchema = z.object({

--- a/text.pollinations.ai/portkeyUtils.js
+++ b/text.pollinations.ai/portkeyUtils.js
@@ -71,7 +71,10 @@ async function generatePortkeyHeaders(config) {
     }
 
     // Generate headers by prefixing config properties with 'x-portkey-'
-    const headers = {};
+    const headers = {
+        // Set to false to receive reasoning/thinking tokens from models
+        "x-portkey-strict-openai-compliance": "false",
+    };
     for (const [key, value] of Object.entries(config)) {
         // Skip special properties that aren't headers
         if (key === "removeSeed" || key === "authKey") continue;

--- a/text.pollinations.ai/requestUtils.js
+++ b/text.pollinations.ai/requestUtils.js
@@ -73,6 +73,7 @@ export function getRequestData(req) {
         modalities,
         audio,
         reasoning_effort: validated.reasoning_effort,
+        thinking_budget: validated.thinking_budget,
         response_format,
     };
 }

--- a/text.pollinations.ai/utils/parameterValidators.js
+++ b/text.pollinations.ai/utils/parameterValidators.js
@@ -97,6 +97,7 @@ export const validateTextGenerationParams = (data) => {
         model: validateString(data.model, "openai-fast"),
         voice: validateString(data.voice, "alloy"),
         reasoning_effort: validateString(data.reasoning_effort),
+        thinking_budget: validateInt(data.thinking_budget),
         jsonMode: validateJsonMode(data),
     };
 };


### PR DESCRIPTION
## Enable Reasoning Token Passthrough

Enables reasoning/thinking tokens from o1/o3, DeepSeek R1, Claude 3.7, and Gemini 2.5 models.

### Changes

**Portkey Configuration**
- Set `x-portkey-strict-openai-compliance: false` globally in `portkeyUtils.js`
- Enables reasoning token passthrough from all providers

**Request Parameters**
- Add `reasoning_effort` validation (OpenAI o1/o3: "low" | "medium" | "high")
- Add `thinking_budget` validation (Gemini: integer, 0=off, -1=auto, max 8192)
- Pass both parameters through to API

**Response Schemas**
- Add `reasoning_content` field (DeepSeek format)
- Add `reasoning_content` and `content_blocks` to streaming delta
- Existing: `content_blocks`, `reasoning_tokens`, `thinking` parameter

### Result

Models now return reasoning tokens in responses. Pure passthrough - no extraction logic.

Closes #5197