### PR TITLE
feat: add real model IDs to pricing table

### DIFF
--- a/enter.pollinations.ai/src/client/components/pricing/ModelRow.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/ModelRow.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import type { ModelPrice } from "./types.ts";
-import { hasReasoning, hasVision, hasAudioInput, getModelDescription, getRealModelId } from "./model-info.ts";
+import { hasReasoning, hasVision, hasAudioInput, getModelDescription, getTextModelId, getImageModelId } from "./model-info.ts";
 import { calculatePerPollen } from "./calculations.ts";
 import { PriceBadge } from "./PriceBadge.tsx";
 
@@ -10,7 +10,9 @@ type ModelRowProps = {
 
 export const ModelRow: FC<ModelRowProps> = ({ model }) => {
     const description = getModelDescription(model.name, model.type);
-    const realModelId = getRealModelId(model.name, model.type);
+    const realModelId = model.type === "text" 
+        ? getTextModelId(model.name as any) 
+        : getImageModelId(model.name as any);
     const genPerPollen = calculatePerPollen(model);
     
     // Get model capabilities

--- a/enter.pollinations.ai/src/client/components/pricing/model-info.ts
+++ b/enter.pollinations.ai/src/client/components/pricing/model-info.ts
@@ -6,15 +6,19 @@ import { TEXT_SERVICES } from "../../../../../shared/registry/text.ts";
 import { IMAGE_SERVICES } from "../../../../../shared/registry/image.ts";
 import type { Modalities } from "./types.ts";
 
+// Helper types for cleaner service lookups
+type TextServiceName = keyof typeof TEXT_SERVICES;
+type ImageServiceName = keyof typeof IMAGE_SERVICES;
+
 export const getModalities = (modelName: string, modelType: string): Modalities => {
     if (modelType === "text") {
-        const service = TEXT_SERVICES[modelName as keyof typeof TEXT_SERVICES] as any;
+        const service = TEXT_SERVICES[modelName as TextServiceName] as any;
         return {
             input: service?.input_modalities || ["text"],
             output: service?.output_modalities || ["text"]
         };
     } else {
-        const service = IMAGE_SERVICES[modelName as keyof typeof IMAGE_SERVICES] as any;
+        const service = IMAGE_SERVICES[modelName as ImageServiceName] as any;
         return {
             input: service?.input_modalities || ["text"],
             output: service?.output_modalities || ["image"]
@@ -24,17 +28,18 @@ export const getModalities = (modelName: string, modelType: string): Modalities 
 
 export const getModelDescription = (modelName: string, modelType: string): string | undefined => {
     if (modelType === "image") {
-        const service = IMAGE_SERVICES[modelName as keyof typeof IMAGE_SERVICES] as any;
+        const service = IMAGE_SERVICES[modelName as ImageServiceName] as any;
         return service?.description;
     } else {
-        const service = TEXT_SERVICES[modelName as keyof typeof TEXT_SERVICES] as any;
+        const service = TEXT_SERVICES[modelName as TextServiceName] as any;
         return service?.description;
     }
 };
 
 export const hasReasoning = (modelName: string, modelType: string): boolean => {
     if (modelType !== "text") return false;
-    return (TEXT_SERVICES[modelName as keyof typeof TEXT_SERVICES] as any)?.reasoning === true;
+    const service = TEXT_SERVICES[modelName as TextServiceName] as any;
+    return service?.reasoning === true;
 };
 
 export const hasVision = (modelName: string, modelType: string): boolean => {
@@ -48,13 +53,16 @@ export const hasAudioInput = (modelName: string, modelType: string): boolean => 
 };
 
 export const isPersona = (modelName: string): boolean => {
-    return (TEXT_SERVICES[modelName as keyof typeof TEXT_SERVICES] as any)?.persona === true;
+    const service = TEXT_SERVICES[modelName as TextServiceName] as any;
+    return service?.persona === true;
 };
 
-export const getRealModelId = (modelName: string, modelType: string): string | undefined => {
-    if (modelType === "text") {
-        return (TEXT_SERVICES[modelName as keyof typeof TEXT_SERVICES] as any)?.modelId;
-    } else {
-        return (IMAGE_SERVICES[modelName as keyof typeof IMAGE_SERVICES] as any)?.modelId;
-    }
+export const getTextModelId = (modelName: TextServiceName): string | undefined => {
+    const service = TEXT_SERVICES[modelName];
+    return service?.modelId as string | undefined;
+};
+
+export const getImageModelId = (modelName: ImageServiceName): string | undefined => {
+    const service = IMAGE_SERVICES[modelName];
+    return service?.modelId as string | undefined;
 };


### PR DESCRIPTION
## Changes

- Add info icon (ⓘ) next to model names in pricing table
- Shows real model ID on hover (e.g., `mistral-small-3.2-24b-instruct-2506`)
- Only displays when modelId differs from service name
- Pink design matching existing UI aesthetic

## Implementation

- Added `getRealModelId()` helper in `model-info.ts`
- Added hover tooltip with gradient background
- Conditional display to avoid redundant info

## Examples

- **mistral** → Hover shows `mistral-small-3.2-24b-instruct-2506`
- **openai** → Hover shows `gpt-5-mini-2025-08-07`
- **flux** → No icon (modelId same as service name)

Fixes #5176