### PR TITLE
fix: add missing EDGE_RATE_LIMITER binding to production environment

### DIFF
--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -133,6 +133,12 @@ tag = "v2"
 # deleted_classes = ["RateLimiter"]
 new_classes = ["PollenRateLimiter"]
 
+# Edge rate limiter: ~10 req/s per IP (100 req per 10s)
+[[env.production.ratelimits]]
+name = "EDGE_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 100, period = 10 }
+
 [env.production.vars]
 ENVIRONMENT = "production"
 LOG_LEVEL = "debug"


### PR DESCRIPTION
## Problem
- Production API returning 500 error: `Cannot read properties of undefined (reading 'limit')`
- Edge rate limiter added in #5239 but only configured for base environment
- Missing `EDGE_RATE_LIMITER` binding in `env.production` section of wrangler.toml

## Solution
- Add rate limiter binding to production environment
- Config: 100 requests per 10 seconds (~10 req/s per IP)
- Matches existing base environment configuration

## Changes
- Add `[[env.production.ratelimits]]` block to wrangler.toml
- 6 lines added

## Testing
- Error reproduced: `https://enter.pollinations.ai/api/generate/v1/models`
- Fix resolves 500 errors once deployed