### PR TITLE
Add better history search (ctrl-r) to dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762756533,
-        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
+        "lastModified": 1763049705,
+        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
+        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,14 +23,18 @@
         zsh-config = pkgs.writeTextFile {
           name = "config.zsh";
           text = ''
-            # initialize shell
-            eval "$(${pkgs.starship}/bin/starship init zsh)"
-            ${pkgs.figlet}/bin/figlet -f small "Pollinations"
             # shell improvements
             source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
             source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
             fpath=(${pkgs.zsh-completions}/share/zsh/site-functions $fpath)
             autoload -U compinit && compinit
+            # fzf
+            source ${pkgs.fzf}/share/fzf/key-bindings.zsh
+            source ${pkgs.fzf}/share/fzf/completion.zsh
+            export FZF_DEFAULT_OPTS="--height 40% --layout=reverse --color=16"
+            # initialize shell
+            eval "$(${pkgs.starship}/bin/starship init zsh)"
+            ${pkgs.figlet}/bin/figlet -f small "Pollinations"
           '';
         };
 
@@ -83,6 +87,7 @@
             zsh-autosuggestions
             zsh-completions
             starship
+            fzf
             figlet
             git
             sops
@@ -115,6 +120,9 @@
           shellHook = ''
             # runs each time the shell is entered
 
+            # prevents nix from messing with the time
+            unset SOURCE_DATE_EPOCH
+
             # enable recursive globbing
             shopt -s globstar
 
@@ -127,7 +135,7 @@
             fi
 
             # decrypt and load environment variables
-            for file in **/.encrypted.env; do
+            for file in $FLAKE_PATH/**/.encrypted.env; do
               echo "Decrypting: $file"
               eval "$(sops decrypt $file \
                 | grep -v '^#' \


### PR DESCRIPTION
I got a bit tired of not having proper history search available, so i'm adding fzf to the nix dev shell.
Also improves the decryption logic a bit so that all .encrypted.env files are decrypted even when entering the shell from a subdirectory.
