### PR TITLE
fix: wrangler deploy with Vite-generated config

### DIFF
--- a/.github/workflows/deploy-enter-cloudflare.yml
+++ b/.github/workflows/deploy-enter-cloudflare.yml
@@ -29,5 +29,7 @@ jobs:
       - name: Build and deploy to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: npm run deploy:production
+        run: |
+          npm run build:production
+          npx wrangler deploy
         working-directory: ./enter.pollinations.ai


### PR DESCRIPTION
## Fix Cloudflare Worker Deployment

- Remove environment flag from `wrangler deploy` command
- Vite already bakes environment into generated config during build
- Fixes error: "You have specified the environment 'production', but are using a redirected configuration"

**Root Cause:**
When using `@cloudflare/vite-plugin`, the environment is set during the build step (`CLOUDFLARE_ENV=production vite build`), not during deployment. Wrangler should deploy the pre-configured build output without additional env flags.

**Changes:**
- Split `npm run deploy:production` into separate build and deploy steps
- Use `npx wrangler deploy` without env specification