### PR TITLE
Fix openai-fast to use GPT-5 Nano and correct pricing

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -19,9 +19,9 @@ export const TEXT_COSTS = {
     "gpt-5-nano-2025-08-07": [
         {
             date: PRICING_START_DATE,
-            promptTextTokens: perMillion(0.06),
-            promptCachedTokens: perMillion(0.01),
-            completionTextTokens: perMillion(0.44),
+            promptTextTokens: perMillion(0.05),
+            promptCachedTokens: perMillion(0.005),
+            completionTextTokens: perMillion(0.4),
         },
     ],
     "gpt-5-chat-latest": [

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -58,8 +58,8 @@ const models: ModelDefinition[] = [
     },
     {
         name: "openai-fast",
-        description: "OpenAI GPT-4.1 Nano",
-        config: portkeyConfig["gpt-4.1-nano-2025-04-14"],
+        description: "OpenAI GPT-5 Nano",
+        config: portkeyConfig["gpt-5-nano-2025-08-07"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
         community: false,
         input_modalities: ["text", "image"],


### PR DESCRIPTION
## Summary
Fixes configuration mismatch where `openai-fast` was using GPT-4.1 Nano instead of GPT-5 Nano, and corrects pricing to match OpenAI's official rates.

## Changes Made

### Model Configuration (`text.pollinations.ai/availableModels.ts`)
- **Fixed `openai-fast` model**: Changed from `gpt-4.1-nano-2025-04-14` to `gpt-5-nano-2025-08-07`
- **Updated description**: "OpenAI GPT-4.1 Nano" → "OpenAI GPT-5 Nano"
- **Registry alignment**: Now matches the registry definition which points to GPT-5 Nano
- **Environment variables verified**: `AZURE_OPENAI_NANO_5_ENDPOINT` correctly points to `gpt-5-nano` deployment

### Pricing Corrections (`shared/registry/text.ts`)
Updated `gpt-5-nano-2025-08-07` pricing to match OpenAI's official rates:
- **Input tokens**: $0.06 → **$0.05** per 1M tokens (20% reduction)
- **Cached tokens**: $0.01 → **$0.005** per 1M tokens (50% reduction, 90% discount from input)
- **Output tokens**: $0.44 → **$0.40** per 1M tokens (10% reduction)

## Verification
- ✅ Pricing verified against multiple sources ([GPT Breeze](https://gptbreeze.io/blog/gpt-5-nano-pricing-guide/), [Cursor IDE](https://www.cursor-ide.com/blog/gpt-5-api))
- ✅ Azure endpoint verified: `/deployments/gpt-5-nano/` in `AZURE_OPENAI_NANO_5_ENDPOINT`
- ✅ Config points to correct environment variables

## Notes
- Pricing based on OpenAI direct API rates
- Azure OpenAI pricing may differ and should be verified against actual billing
- Environment variables required: `AZURE_OPENAI_NANO_5_API_KEY`, `AZURE_OPENAI_NANO_5_ENDPOINT`

## Impact
- Users requesting `openai-fast` will now get GPT-5 Nano (as expected) instead of GPT-4.1 Nano
- More accurate cost tracking for GPT-5 Nano usage
- Reduced pricing estimates align with OpenAI's competitive rates