### PR TITLE
refactor: remove 'as any' casts and improve type safety

### DIFF
--- a/enter.pollinations.ai/src/client/components/pricing/data.ts
+++ b/enter.pollinations.ai/src/client/components/pricing/data.ts
@@ -2,61 +2,52 @@
  * Data fetching and transformation for pricing
  */
 
-import {
-    TEXT_COSTS,
-    TEXT_SERVICES,
-} from "../../../../../shared/registry/text.ts";
-import {
-    IMAGE_COSTS,
-    IMAGE_SERVICES,
-} from "../../../../../shared/registry/image.ts";
-import type { ModelPrice } from "./types.ts";
+import { IMAGE_SERVICES } from "../../../../../shared/registry/image.ts";
+import type { CostDefinition } from "../../../../../shared/registry/registry.ts";
+import { TEXT_SERVICES } from "../../../../../shared/registry/text.ts";
 import {
     formatPrice,
     formatPricePer1M,
     formatPricePerImage,
 } from "./formatters.ts";
+import type { ModelPrice } from "./types.ts";
 
 export const getModelPrices = (): ModelPrice[] => {
     const prices: ModelPrice[] = [];
 
     // Add text models
     for (const [serviceName, serviceConfig] of Object.entries(TEXT_SERVICES)) {
-        const modelId = serviceConfig.modelId;
-        const costHistory = TEXT_COSTS[modelId as keyof typeof TEXT_COSTS];
+        const costHistory = serviceConfig.cost;
         if (!costHistory) continue;
 
-        const latestCost = costHistory[0];
-        if (!latestCost) continue;
-
-        const latestCostAny = latestCost as any;
+        const latestCost: CostDefinition = costHistory[0];
 
         prices.push({
             name: serviceName,
             type: "text",
             perToken: true,
             promptTextPrice: formatPrice(
-                latestCostAny.promptTextTokens,
+                latestCost.promptTextTokens,
                 formatPricePer1M,
             ),
             promptCachedPrice: formatPrice(
-                latestCostAny.promptCachedTokens,
+                latestCost.promptCachedTokens,
                 formatPricePer1M,
             ),
             promptAudioPrice: formatPrice(
-                latestCostAny.promptAudioTokens,
+                latestCost.promptAudioTokens,
                 formatPricePer1M,
             ),
             completionTextPrice: formatPrice(
-                latestCostAny.completionTextTokens,
+                latestCost.completionTextTokens,
                 formatPricePer1M,
             ),
             completionAudioPrice: formatPrice(
-                latestCostAny.completionAudioTokens,
+                latestCost.completionAudioTokens,
                 formatPricePer1M,
             ),
             completionAudioTokens: formatPrice(
-                latestCostAny.completionAudioTokens,
+                latestCost.completionAudioTokens,
                 formatPricePer1M,
             ),
         });
@@ -64,20 +55,15 @@ export const getModelPrices = (): ModelPrice[] => {
 
     // Add image models
     for (const [serviceName, serviceConfig] of Object.entries(IMAGE_SERVICES)) {
-        const modelId = serviceConfig.modelId;
-        const costHistory = IMAGE_COSTS[modelId as keyof typeof IMAGE_COSTS];
+        const costHistory = serviceConfig.cost;
         if (!costHistory) continue;
 
-        const latestCost = costHistory[0];
-        if (!latestCost) continue;
-
-        const costAny = latestCost as any;
+        const latestCost: CostDefinition = costHistory[0];
 
         // Auto-detect token-based pricing: models with promptTextTokens or promptImageTokens
-        // This aligns with the unified image token tracking (see commit cc058f3)
         const isTokenBased =
-            costAny.promptTextTokens !== undefined ||
-            costAny.promptImageTokens !== undefined;
+            latestCost.promptTextTokens !== undefined ||
+            latestCost.promptImageTokens !== undefined;
 
         if (isTokenBased) {
             // Token-based pricing (e.g., gptimage, nanobanana)
@@ -86,15 +72,15 @@ export const getModelPrices = (): ModelPrice[] => {
                 type: "image",
                 perToken: true,
                 promptTextPrice: formatPrice(
-                    costAny.promptTextTokens,
+                    latestCost.promptTextTokens,
                     formatPricePer1M,
                 ),
                 promptImagePrice: formatPrice(
-                    costAny.promptImageTokens,
+                    latestCost.promptImageTokens,
                     formatPricePer1M,
                 ),
                 completionImagePrice: formatPrice(
-                    costAny.completionImageTokens,
+                    latestCost.completionImageTokens,
                     formatPricePer1M,
                 ),
             });
@@ -105,7 +91,7 @@ export const getModelPrices = (): ModelPrice[] => {
                 type: "image",
                 perToken: false,
                 perImagePrice: formatPrice(
-                    costAny.completionImageTokens,
+                    latestCost.completionImageTokens,
                     formatPricePerImage,
                 ),
             });

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1,5 +1,5 @@
 import type { ModelRegistry } from "./registry";
-import { PRICING_START_DATE, perMillion } from "./price-helpers";
+import { COST_START_DATE, perMillion } from "./price-helpers";
 
 export const DEFAULT_IMAGE_MODEL = "flux" as const;
 
@@ -10,7 +10,7 @@ export const IMAGE_SERVICES = {
         provider: "io.net",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 completionImageTokens: 0.00012, // $0.0088¢ per image (GPU cluster cost - September avg)
             },
         ],
@@ -21,7 +21,7 @@ export const IMAGE_SERVICES = {
         provider: "azure",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 completionImageTokens: 0.04, // $0.04 per image (Azure pricing)
             },
         ],
@@ -32,7 +32,7 @@ export const IMAGE_SERVICES = {
         provider: "scaleway",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 completionImageTokens: 0.0003,
             },
         ],
@@ -44,7 +44,7 @@ export const IMAGE_SERVICES = {
         cost: [
             // Gemini 2.5 Flash Image via Vertex AI (currently disabled)
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.3), // $0.30 per 1M input tokens
                 promptImageTokens: perMillion(0.3), // $0.30 per 1M input tokens
                 completionImageTokens: perMillion(30), // $30 per 1M tokens × 1290 tokens/image = $0.039 per image
@@ -58,7 +58,7 @@ export const IMAGE_SERVICES = {
         cost: [
             // ByteDance ARK Seedream 4.0
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 completionImageTokens: 0.03, // $0.03 per image (3 cents)
             },
         ],
@@ -70,7 +70,7 @@ export const IMAGE_SERVICES = {
         cost: [
             // Azure gpt-image-1-mini
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(2.0), // $2.00 per 1M text input tokens
                 promptCachedTokens: perMillion(0.2), // $0.20 per 1M cached text input tokens
                 promptImageTokens: perMillion(2.5), // $2.50 per 1M image input tokens

--- a/shared/registry/price-helpers.ts
+++ b/shared/registry/price-helpers.ts
@@ -1,16 +1,10 @@
 import type { UsageConversionDefinition } from "./registry.ts";
 
 /**
- * The start date for zero pricing (legacy period).
- * All services before this date had zero cost.
- */
-export const ZERO_PRICE_START_DATE = new Date("2020-01-01 00:00:00").getTime();
-
-/**
  * The start date when pricing was introduced.
- * Services after this date may have associated costs.
+ * All services use this date for their initial cost definitions.
  */
-export const PRICING_START_DATE = new Date("2025-08-01 00:00:00").getTime();
+export const COST_START_DATE = new Date("2025-08-01 00:00:00").getTime();
 
 /**
  * Converts dollars per million units to dollars per unit.
@@ -34,25 +28,3 @@ export function perMillion(dollarsPerMillion: number): number {
     return dollarsPerMillion / 1_000_000;
 }
 
-/**
- * A zero-cost price definition for free services.
- * All token types are set to 0.0 cost.
- * 
- * @example
- * ```ts
- * // Use for free service definitions
- * const freeService = {
- *   displayName: "Free Service",
- *   price: [ZERO_PRICE]
- * };
- * ```
- */
-export const ZERO_PRICE: UsageConversionDefinition = {
-    date: ZERO_PRICE_START_DATE,
-    promptTextTokens: 0.0,
-    promptCachedTokens: 0.0,
-    completionTextTokens: 0.0,
-    promptAudioTokens: 0.0,
-    completionAudioTokens: 0.0,
-    completionImageTokens: 0.0,
-};

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -45,7 +45,7 @@ export type ModelRegistry = Record<string, ModelDefinition>;
 export type ServiceDefinition<T extends ModelRegistry> = {
     aliases: readonly string[];
     modelId: keyof T;
-    provider?: string; // Optional provider identifier (e.g., "azure-openai", "aws-bedrock")
+    provider: string; // Provider identifier (e.g., "azure-openai", "aws-bedrock")
     cost: readonly CostDefinition[]; // Cost data embedded in service
 };
 
@@ -236,8 +236,8 @@ export function getModels(): ModelId[] {
 /**
  * Get model definition by ID
  */
-export function getModelDefinition(modelId: ModelId): ModelDefinition {
-    return MODEL_REGISTRY[modelId];
+export function getModelDefinition(modelId: string): ModelDefinition | undefined {
+    return MODEL_REGISTRY[modelId as ModelId];
 }
 
 /**

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,5 +1,5 @@
 import type { ModelRegistry } from "./registry";
-import { PRICING_START_DATE, perMillion } from "./price-helpers";
+import { COST_START_DATE, perMillion } from "./price-helpers";
 
 export const DEFAULT_TEXT_MODEL = "openai" as const;
 
@@ -10,7 +10,7 @@ export const TEXT_SERVICES = {
         provider: "azure-openai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.25),
                 promptCachedTokens: perMillion(0.025),
                 completionTextTokens: perMillion(2.0),
@@ -23,7 +23,7 @@ export const TEXT_SERVICES = {
         provider: "azure-openai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.05),
                 promptCachedTokens: perMillion(0.005),
                 completionTextTokens: perMillion(0.4),
@@ -36,7 +36,7 @@ export const TEXT_SERVICES = {
         provider: "azure-openai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(1.25),
                 promptCachedTokens: perMillion(0.13),
                 completionTextTokens: perMillion(10.0),
@@ -49,7 +49,7 @@ export const TEXT_SERVICES = {
         provider: "scaleway",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.9),
                 completionTextTokens: perMillion(0.9),
             },
@@ -61,7 +61,7 @@ export const TEXT_SERVICES = {
         provider: "scaleway",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.15),
                 completionTextTokens: perMillion(0.35),
             },
@@ -73,7 +73,7 @@ export const TEXT_SERVICES = {
         provider: "aws-bedrock",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.22),
                 completionTextTokens: perMillion(0.22),
             },
@@ -91,7 +91,7 @@ export const TEXT_SERVICES = {
         provider: "azure-openai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.165),
                 completionTextTokens: perMillion(0.66),
                 promptAudioTokens: perMillion(11.0),
@@ -105,7 +105,7 @@ export const TEXT_SERVICES = {
         provider: "api-navy",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(1.21),
                 promptCachedTokens: perMillion(0.31),
                 completionTextTokens: perMillion(4.84),
@@ -118,7 +118,7 @@ export const TEXT_SERVICES = {
         provider: "vertex-ai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.1),
                 promptCachedTokens: perMillion(0.01),
                 completionTextTokens: perMillion(0.4),
@@ -136,7 +136,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(1.25),
                 completionTextTokens: perMillion(5.0),
             },
@@ -148,7 +148,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.2),
                 completionTextTokens: perMillion(0.5),
             },
@@ -160,7 +160,7 @@ export const TEXT_SERVICES = {
         provider: "vertex-ai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.1),
                 promptCachedTokens: perMillion(0.01),
                 completionTextTokens: perMillion(0.4),
@@ -173,7 +173,7 @@ export const TEXT_SERVICES = {
         provider: "aws-bedrock",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(0.8),
                 completionTextTokens: perMillion(4.0),
             },
@@ -185,7 +185,7 @@ export const TEXT_SERVICES = {
         provider: "azure-openai",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(2.2),
                 promptCachedTokens: perMillion(0.55),
                 completionTextTokens: perMillion(8.8),
@@ -204,7 +204,7 @@ export const TEXT_SERVICES = {
         provider: "aws-bedrock",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(1.0),
                 completionTextTokens: perMillion(5.0),
             },
@@ -216,7 +216,7 @@ export const TEXT_SERVICES = {
         provider: "aws-bedrock",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(3.0),
                 completionTextTokens: perMillion(15.0),
             },
@@ -228,7 +228,7 @@ export const TEXT_SERVICES = {
         provider: "perplexity",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(1.0),
                 completionTextTokens: perMillion(1.0),
             },
@@ -240,7 +240,7 @@ export const TEXT_SERVICES = {
         provider: "perplexity",
         cost: [
             {
-                date: PRICING_START_DATE,
+                date: COST_START_DATE,
                 promptTextTokens: perMillion(1.0),
                 completionTextTokens: perMillion(5.0),
             },

--- a/shared/test/registry.test.ts
+++ b/shared/test/registry.test.ts
@@ -5,7 +5,7 @@ import {
     calculatePrice,
     SERVICE_REGISTRY
 } from "../registry/registry.ts";
-import { perMillion, ZERO_PRICE, ZERO_PRICE_START_DATE, PRICING_START_DATE } from "../registry/price-helpers.ts";
+import { perMillion, COST_START_DATE } from "../registry/price-helpers.ts";
 import { expect, test } from "vitest";
 import type { TokenUsage } from "../registry/registry.ts";
 
@@ -84,20 +84,8 @@ test("perMillion should correctly convert dollars per million tokens", async () 
     expect(totalCost).toBe(50_000);
 });
 
-test("ZERO_PRICE constant should have all zero values", async () => {
-    expect(ZERO_PRICE.promptTextTokens).toBe(0.0);
-    expect(ZERO_PRICE.promptCachedTokens).toBe(0.0);
-    expect(ZERO_PRICE.completionTextTokens).toBe(0.0);
-    expect(ZERO_PRICE.promptAudioTokens).toBe(0.0);
-    expect(ZERO_PRICE.completionAudioTokens).toBe(0.0);
-    expect(ZERO_PRICE.completionImageTokens).toBe(0.0);
-    expect(ZERO_PRICE.date).toBe(ZERO_PRICE_START_DATE);
-});
-
 test("Date constants should be properly defined", async () => {
-    expect(ZERO_PRICE_START_DATE).toBe(new Date("2020-01-01 00:00:00").getTime());
-    expect(PRICING_START_DATE).toBe(new Date("2025-08-01 00:00:00").getTime());
-    expect(PRICING_START_DATE).toBeGreaterThan(ZERO_PRICE_START_DATE);
+    expect(COST_START_DATE).toBe(new Date("2025-08-01 00:00:00").getTime());
 });
 
 test("resolveServiceId should throw on invalid service", async () => {

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -16,13 +16,14 @@ import chickyTutorPrompt from "./personas/chickytutor.js";
 import { BASE_PROMPTS } from "./prompts/systemPrompts.js";
 
 // Import model configs
-import { portkeyConfig, type ValidModelId } from "./configs/modelConfigs.js";
+import { portkeyConfig } from "./configs/modelConfigs.js";
 
 // Import registry for validation and aliases
 import type { TEXT_SERVICES } from "../shared/registry/text.js";
 import {
     resolveServiceId,
     getServiceAliases,
+    type ModelId,
 } from "../shared/registry/registry.js";
 
 // Type constraint: model names must exist in registry
@@ -31,7 +32,7 @@ type ValidServiceName = keyof typeof TEXT_SERVICES;
 interface ModelDefinition {
     name: ValidServiceName;
     description: string;
-    config: (typeof portkeyConfig)[ValidModelId]; // ✅ Type-safe: must be a valid model ID from TEXT_COSTS
+    config: (typeof portkeyConfig)[ModelId]; // ✅ Type-safe: must be a valid model ID from MODEL_REGISTRY
     transform?: any;
     community?: boolean;
     // aliases removed - now sourced from registry

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -20,20 +20,17 @@ import {
     createApiNavyModelConfig,
     createPerplexityModelConfig,
 } from "./providerConfigs.js";
-import type { TEXT_COSTS } from "../../shared/registry/text.js";
+import type { ModelId } from "../../shared/registry/registry.js";
 
 const log = debug("pollinations:portkey");
 
 dotenv.config();
 
-// Type constraint: export ValidModelId so availableModels.ts can use it
-export type ValidModelId = keyof typeof TEXT_COSTS;
-
-// Type-safe config object: all keys must be valid model IDs from TEXT_COSTS
+// Type-safe config object: all keys must be valid model IDs from MODEL_REGISTRY
 type PortkeyConfigMap = {
-    [K in ValidModelId]: () => any;
+    [K in ModelId]: () => any;
 } & {
-    [key: string]: () => any; // Allow additional legacy configs not in TEXT_COSTS
+    [key: string]: () => any; // Allow additional legacy configs not in MODEL_REGISTRY
 };
 
 // Unified flat Portkey configuration for all providers and models - using functions that return fresh configurations

--- a/text.pollinations.ai/observability/costCalculator.ts
+++ b/text.pollinations.ai/observability/costCalculator.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import { TEXT_COSTS } from "../../shared/registry/text.js";
+import { getModelDefinition } from "../../shared/registry/registry.js";
 
 const log = debug("text.pollinations.ai:costCalculator");
 
@@ -40,7 +40,7 @@ export function resolveCost(responseModel: string): CostRates {
         throw new Error("No model name provided for cost resolution");
     }
 
-    const costs = TEXT_COSTS[responseModel as keyof typeof TEXT_COSTS];
+    const costs = getModelDefinition(responseModel);
     if (!costs) {
         throw new Error(
             `Missing cost data for model "${responseModel}". Please contact support@pollinations.ai`,


### PR DESCRIPTION
## Changes

- Change `getModelDefinition()` to accept `string` and return `ModelDefinition | undefined`
- Remove all `as any` casts from pricing data and cost calculator
- Use proper `CostDefinition` type annotations
- Remove unused `ZERO_PRICE` legacy code
- Rename `PRICING_START_DATE` → `COST_START_DATE`
- Remove `ValidModelId` re-export, use `ModelId` directly
- Clean up dead code and format with Biome

## Testing

- ✅ All registry tests passing (10/10)
- ✅ Type checking clean
- ✅ Enter tests: 36/42 passing (6 pre-existing failures)

## Stats

9 files changed: +62 insertions, -118 deletions