### PR TITLE
feat: Add Kimi K2 Thinking and Gemini 3 Pro models

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -355,4 +355,42 @@ export const TEXT_SERVICES = {
         reasoning: true,
         persona: false,
     },
+    "kimi-k2-thinking": {
+        aliases: ["kimi-k2", "kimi-thinking"],
+        modelId: "kimi-k2-thinking-maas",
+        provider: "vertex-ai",
+        cost: [
+            {
+                date: COST_START_DATE,
+                promptTextTokens: perMillion(0.0), // Free until Nov 17, 2025
+                completionTextTokens: perMillion(0.0),
+            },
+        ],
+        description:
+            "Moonshot Kimi K2 Thinking - Deep Reasoning & Tool Orchestration (Free Preview)",
+        input_modalities: ["text"],
+        output_modalities: ["text"],
+        tools: true,
+        reasoning: true,
+        isSpecialized: false,
+    },
+    "gemini-3-pro": {
+        aliases: ["gemini-3", "gemini-3-pro-preview"],
+        modelId: "gemini-3-pro-preview",
+        provider: "vertex-ai",
+        cost: [
+            {
+                date: COST_START_DATE,
+                promptTextTokens: perMillion(2.0),
+                completionTextTokens: perMillion(12.0),
+            },
+        ],
+        description:
+            "Google Gemini 3 Pro - Most Intelligent Model with 1M Context (Preview)",
+        input_modalities: ["text", "image", "audio", "video"],
+        output_modalities: ["text"],
+        tools: true,
+        reasoning: true,
+        isSpecialized: false,
+    },
 } as const;

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -123,6 +123,16 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["sonar-reasoning"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
+    {
+        name: "kimi-k2-thinking",
+        config: portkeyConfig["kimi-k2-thinking-maas"],
+        transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
+    },
+    {
+        name: "gemini-3-pro",
+        config: portkeyConfig["gemini-3-pro-preview"],
+        transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
+    },
 ];
 
 // Export models - metadata is in registry (single source of truth)

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -156,6 +156,21 @@ export const portkeyConfig: PortkeyConfigMap = {
         "vertex-model-id": "gemini-2.5-flash-lite",
         "strict-openai-compliance": "false",
     }),
+    "gemini-3-pro-preview": () => ({
+        provider: "vertex-ai",
+        authKey: googleCloudAuth.getAccessToken,
+        "vertex-project-id": process.env.GCLOUD_PROJECT_ID,
+        "vertex-region": "global",
+        "vertex-model-id": "gemini-3-pro-preview",
+        "strict-openai-compliance": "false",
+    }),
+    "kimi-k2-thinking-maas": () => ({
+        provider: "openai",
+        authKey: googleCloudAuth.getAccessToken,
+        "custom-host": `https://aiplatform.googleapis.com/v1/projects/${process.env.GCLOUD_PROJECT_ID}/locations/global/endpoints/openapi`,
+        "strict-openai-compliance": "false",
+        model: "moonshotai/kimi-k2-thinking-maas",
+    }),
     // Note: gemini-search service uses same config as gemini, just adds Google Search transform
     "deepseek-ai/deepseek-v3.1-maas": () => ({
         provider: "openai",


### PR DESCRIPTION
## New Models

- **Kimi K2 Thinking** (`kimi-k2-thinking`)
  - Moonshot AI's reasoning model via Vertex AI MAAS
  - Free until Nov 17, 2025
  - 256K context, tool orchestration, deep reasoning
  
- **Gemini 3 Pro Preview** (`gemini-3-pro`)
  - Google's most intelligent model
  - $2/$12 per M tokens (≤200K context)
  - 1M token context, multimodal (text/image/audio/video)

## Technical Details

- Kimi K2: MAAS endpoint via OpenAI-compatible API
- Gemini 3 Pro: Native Vertex AI endpoint (global region)
- Both support reasoning and tool use

## Testing

- ✅ Kimi K2: Tested with reasoning queries
- ✅ Gemini 3 Pro: Tested with complex questions
- ✅ Both models responding correctly