### PR TITLE
Rename gemini-3-pro to gemini-large

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -374,8 +374,8 @@ export const TEXT_SERVICES = {
         reasoning: true,
         isSpecialized: false,
     },
-    "gemini-3-pro": {
-        aliases: ["gemini-3", "gemini-3-pro-preview"],
+    "gemini-large": {
+        aliases: ["gemini-3-pro", "gemini-3", "gemini-3-pro-preview"],
         modelId: "gemini-3-pro-preview",
         provider: "vertex-ai",
         cost: [

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -129,7 +129,7 @@ const models: ModelDefinition[] = [
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {
-        name: "gemini-3-pro",
+        name: "gemini-large",
         config: portkeyConfig["gemini-3-pro-preview"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },


### PR DESCRIPTION
## Changes

- Rename `gemini-3-pro` → `gemini-large` (primary name)
- Add `gemini-3-pro` as alias for backward compatibility

## Rationale

Aligns naming with model tier (large) rather than version number.

## Backward Compatibility

✅ All existing `gemini-3-pro` requests continue to work via alias