### PR TITLE
feat: Completely disable kontext model on legacy image API

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1023,17 +1023,16 @@ const generateImage = async (
     }
 
     if (safeParams.model === "kontext") {
-        // Azure Flux Kontext model requires seed tier or higher
-        // NOTE: Allow bypass for enter.pollinations.ai requests
-        if (!fromEnter && !hasSufficientTier(userInfo.tier, "nectar")) {
+        // Kontext model is only available on enter.pollinations.ai
+        if (!fromEnter) {
             const errorText =
-                "Access to kontext model is limited to users in the nectar tier or higher. Please visit https://enter.pollinations.ai to get started.";
+                "Kontext model is only available on https://enter.pollinations.ai";
             logError(errorText);
             progress.updateBar(
                 requestId,
                 35,
                 "Auth",
-                "Kontext model requires seed tier",
+                "Kontext model disabled on legacy API",
             );
             const error: any = new Error(errorText);
             error.status = 403;

--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -467,12 +467,10 @@ const checkCacheAndGenerate = async (
                     queueConfig = { interval: 90000 }; // 90 second interval
                     logAuth(`${modelName} model - 90 second interval, ${remaining}/${HOURLY_LIMIT} images remaining this hour${fromEnter ? ' (enter request - no hourly limit)' : ''}`);
                 } else if (modelName === "kontext") {
-                    // Kontext model requires seed tier or higher (checked via registry)
-                    // NOTE: Skip tier check for enter.pollinations.ai requests
-                    // (rate limiting is handled separately by ipQueue)
+                    // Kontext model is only available on enter.pollinations.ai
                     const fromEnter = isEnterRequest(req);
-                    if (!fromEnter && !canAccessService("kontext", authResult.tier)) {
-                        throw new Error("Kontext model requires nectar tier or higher. Visit https://enter.pollinations.ai to get started.");
+                    if (!fromEnter) {
+                        throw new Error("Kontext model is only available on https://enter.pollinations.ai");
                     }
                     // 30 second interval with tier-based cap from model config
                     const cap = IMAGE_CONFIG.kontext.tierCaps?.[authResult.tier] || 1;

--- a/text.pollinations.ai/infinite_loop.sh
+++ b/text.pollinations.ai/infinite_loop.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PID_OF_CHILD=0
+DONE=0
+cleanup ()
+{
+echo killing $PID_OF_CHILD
+DONE=1
+kill -s SIGTERM $PID_OF_CHILD
+exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+
+while (( DONE != 1 ))
+do
+        echo "(Re)Starting $1..."
+        bash -c "$1" &
+        PID_OF_CHILD=$!
+        wait $PID_OF_CHILD
+        sleep 10
+done


### PR DESCRIPTION
- Kontext now only available on enter.pollinations.ai
- Legacy API (image.pollinations.ai) rejects all kontext requests
- Updated error messages to direct users to enter.pollinations.ai
- Removed tier-based access logic from legacy API