### PR TITLE
fix: use /about for image service health check

### DIFF
--- a/.github/workflows/deploy-enter-services.yml
+++ b/.github/workflows/deploy-enter-services.yml
@@ -105,8 +105,8 @@ jobs:
             fi
             echo "✅ Text service responding (HTTP 200)"
             
-            # Check image service health
-            IMAGE_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" -H "x-enter-token: $ENTER_TOKEN" http://localhost:16384/models || echo "000")
+            # Check image service health (use /about - /models returns 410 deprecated)
+            IMAGE_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" -H "x-enter-token: $ENTER_TOKEN" http://localhost:16384/about || echo "000")
             if [ "$IMAGE_HEALTH" != "200" ]; then
               echo "❌ Image service health check failed (HTTP $IMAGE_HEALTH)"
               exit 1


### PR DESCRIPTION
Fixes the image service health check in the enter-services deploy workflow.

**Problem:**
- Image service doesn't have `/openai/models` endpoint
- `/models` returns HTTP 410 (deprecated)
- Deploy fails with "Image service health check failed (HTTP 410)"

**Fix:**
- Use `/about` endpoint which returns model info and HTTP 200