### PR TITLE
fix: use cached Polar API calls to prevent rate limiting

### DIFF
--- a/enter.pollinations.ai/src/routes/polar.ts
+++ b/enter.pollinations.ai/src/routes/polar.ts
@@ -41,10 +41,7 @@ export const polarRoutes = new Hono<Env>()
         }),
         async (c) => {
             const user = c.var.auth.requireUser();
-            const polar = c.var.polar.client;
-            const result = await polar.customers.getStateExternal({
-                externalId: user.id,
-            });
+            const result = await c.var.polar.getCustomerState(user.id);
             return c.json(result);
         },
     )

--- a/enter.pollinations.ai/src/routes/tiers.ts
+++ b/enter.pollinations.ai/src/routes/tiers.ts
@@ -125,7 +125,6 @@ export const tiersRoutes = new Hono<Env>()
         async (c) => {
             const log = c.get("log");
             const user = c.var.auth.requireUser();
-            const polar = c.var.polar.client;
 
             // Get tier assigned in Cloudflare DB
             log.debug(`User tier from DB: ${user.tier}, email: ${user.email}`);
@@ -140,10 +139,10 @@ export const tiersRoutes = new Hono<Env>()
             let subscription_canceled_at: string | undefined;
 
             try {
-                // Get customer state from Polar
-                const customerState = await polar.customers.getStateExternal({
-                    externalId: user.id,
-                });
+                // Get customer state from Polar (cached)
+                const customerState = await c.var.polar.getCustomerState(
+                    user.id,
+                );
 
                 const activeSubs = customerState.activeSubscriptions || [];
 


### PR DESCRIPTION
## Summary
- Fix Polar API rate limiting (429 errors) by using cached functions

## Changes
- `routes/polar.ts`: Use cached `getCustomerState()` instead of direct `polar.customers.getStateExternal()`
- `routes/tiers.ts`: Use cached `getCustomerState()` instead of direct API call
- Remove unused `polar` client variable from tiers.ts

## Root Cause
Routes were bypassing the existing KV cache and making direct Polar API calls, causing 429 rate limit errors (Polar limit: 300 req/min).

Fixes #5474