### PR TITLE
fix: Tier panel showing "Unknown Tier" and "0 pollen/day"

### DIFF
--- a/enter.pollinations.ai/src/routes/tiers.ts
+++ b/enter.pollinations.ai/src/routes/tiers.ts
@@ -183,7 +183,7 @@ export const tiersRoutes = new Hono<Env>()
 
                     // Fetch product details for the active subscription
                     try {
-                        const product = (await polar.products.get({
+                        const product = (await c.var.polar.client.products.get({
                             id: activeProductId,
                         })) as PolarProductMinimal;
                         active_tier_name = product.name;
@@ -225,13 +225,15 @@ export const tiersRoutes = new Hono<Env>()
                         c.env,
                         target_tier as ActivatableTier,
                     );
-                    const assignedProduct = (await polar.products.get({
-                        id: assignedProductId,
-                    })) as PolarProductMinimal;
+                    const assignedProduct =
+                        (await c.var.polar.client.products.get({
+                            id: assignedProductId,
+                        })) as PolarProductMinimal;
                     target_tier_name = assignedProduct.name;
                 } catch (error) {
-                    log.warn("Failed to fetch target tier product", {
+                    log.warn("Failed to fetch target tier product: {error}", {
                         tier: target_tier,
+                        error,
                     });
                 }
             }


### PR DESCRIPTION
## Problem
- Tier panel displayed "Unknown Tier" and "0 pollen/day" despite active subscription
- `active_tier_name` and `daily_pollen` missing from `/api/tiers/view` response

## Root Cause
- `polar` import is the Hono middleware, not the Polar SDK client
- `polar.products.get()` silently failed → product details never fetched

## Fix
- Use `c.var.polar.client.products.get()` instead of `polar.products.get()`

## Files Changed
- `src/routes/tiers.ts` - 2 occurrences fixed