### PR TITLE
fix: add max-tokens limit for Llama 3.1 8B (mistral-fast)

### DIFF
--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -121,6 +121,7 @@ export const portkeyConfig: PortkeyConfigMap = {
     "us.meta.llama3-1-8b-instruct-v1:0": () =>
         createBedrockLambdaModelConfig({
             model: "us.meta.llama3-1-8b-instruct-v1:0",
+            "max-tokens": 4096, // Llama 3.1 8B has 8192 limit
         }),
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": () =>
         createBedrockLambdaModelConfig({


### PR DESCRIPTION
- Fixes Bedrock ValidationException for `mistral-fast` model
- Default max_tokens exceeded Llama 3.1 8B limit of 8192
- Sets explicit 4096 limit in modelConfigs.ts

Found while testing PR #5411 (CI workflows).