### PR TITLE
feat: add login provider voting issue + update tier pollen values

### DIFF
--- a/.claude/skills/tier-management/SKILL.md
+++ b/.claude/skills/tier-management/SKILL.md
@@ -20,11 +20,24 @@ Must run from the `pollinations` repo root with access to `enter.pollinations.ai
 
 | Tier | Emoji | Pollen/Day | Criteria |
 |------|-------|------------|----------|
-| spore | 🍄 | 5 | Default (new accounts) |
-| seed | 🌱 | 10 | GitHub engagement |
-| flower | 🌸 | 15 | Contributed code/project |
+| spore | 🍄 | 1 | Default (new signups) |
+| seed | 🌱 | 3 | GitHub engagement |
+| flower | 🌸 | 10 | Contributed code/project |
 | nectar | 🍯 | 20 | Strategic partners |
-| router | 🔌 | 100 | Infrastructure partners |
+
+---
+
+# Upgrade Paths
+
+## 🍄 Spore → 🌱 Seed
+- ⭐ Starred the pollinations repo
+- 💬 Opened an issue or PR
+- 💳 Made a purchase
+
+## 🌱 Seed → 🌸 Flower
+- 🛠️ Pushed code to pollinations/pollinations
+- 📦 Has a project in our showcase
+- 🌐 Built something open-source using our API
 
 ---
 

--- a/enter.pollinations.ai/src/client/routes/sign-in.tsx
+++ b/enter.pollinations.ai/src/client/routes/sign-in.tsx
@@ -30,15 +30,29 @@ function RouteComponent() {
     return (
         <div className="flex flex-col gap-20">
             <Header>
+                <div className="relative">
+                    <Button
+                        as="button"
+                        onClick={handleSignIn}
+                        disabled={loading}
+                        className="bg-amber-200 text-amber-900 hover:brightness-105"
+                    >
+                        {loading ? "Signing in..." : "Sign in with Github"}
+                    </Button>
+                    <a
+                        href="https://github.com/pollinations/pollinations/issues/5543"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="absolute -bottom-4 right-0 text-xs text-gray-500 hover:text-gray-700 underline"
+                    >
+                        more options?
+                    </a>
+                </div>
                 <Button
-                    as="button"
-                    onClick={handleSignIn}
-                    disabled={loading}
-                    className="bg-amber-200 text-amber-900 hover:brightness-105"
+                    as="a"
+                    href="/api/docs"
+                    className="bg-gray-900 text-white hover:!brightness-90"
                 >
-                    {loading ? "Signing in..." : "Sign in with Github"}
-                </Button>
-                <Button as="a" href="/api/docs" className="bg-gray-900 text-white hover:!brightness-90">
                     API Reference
                 </Button>
             </Header>


### PR DESCRIPTION
- Add voting issue #5543 for login providers (Google, Discord, Email, Phone, WeChat, Wallet)
- Add subtle "more options?" link under GitHub login button in sign-in page
- Update tier-management skill with correct pollen values (1/3/10/20)
- Add upgrade paths section to tier skill

Addresses community feedback on login options for users in India, China, and other regions.