### PR TITLE
feat: add news banner for dec 2025 update

### DIFF
--- a/enter.pollinations.ai/src/client/components/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/news-banner.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect, type FC } from "react";
+
+const NEWS_ID = "dec-2025-pollen-rebalance";
+
+export const NewsBanner: FC = () => {
+    const [dismissed, setDismissed] = useState(true); // Start hidden to avoid flash
+
+    useEffect(() => {
+        const isDismissed = localStorage.getItem(`news-dismissed-${NEWS_ID}`);
+        setDismissed(isDismissed === "true");
+    }, []);
+
+    const handleDismiss = () => {
+        localStorage.setItem(`news-dismissed-${NEWS_ID}`, "true");
+        setDismissed(true);
+    };
+
+    if (dismissed) return null;
+
+    return (
+        <div className="relative bg-gradient-to-r from-purple-50 to-amber-50 border border-purple-200/50 rounded-lg p-4 text-sm">
+            <button
+                type="button"
+                onClick={handleDismiss}
+                className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 text-lg leading-none"
+                aria-label="Dismiss"
+            >
+                ×
+            </button>
+
+            <div className="flex flex-col gap-3 pr-6">
+                <div className="flex items-center gap-2">
+                    <span className="text-xs font-mono bg-purple-100 text-purple-700 px-2 py-0.5 rounded">
+                        dec 2025
+                    </span>
+                    <span className="text-gray-500 text-xs">
+                        pollen rebalance
+                    </span>
+                </div>
+
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs font-mono text-gray-600">
+                    <span>🦠 spore 1/day</span>
+                    <span>🌱 seed 3/day</span>
+                    <span>🌸 flower 10/day</span>
+                    <span>🍯 nectar 20/day</span>
+                </div>
+
+                <div className="text-xs text-gray-500">
+                    <span className="text-purple-600">new:</span> claude opus
+                    4.5 · kimi k2 · seedream 4 · veo 3.1 · seedance
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -21,6 +21,7 @@ import { TierPanel } from "../components/tier-panel.tsx";
 import { FAQ } from "../components/faq.tsx";
 import { Header } from "../components/header.tsx";
 import { Pricing } from "../components/pricing/index.ts";
+import { NewsBanner } from "../components/news-banner.tsx";
 
 export const Route = createFileRoute("/")({
     component: RouteComponent,
@@ -155,143 +156,146 @@ function RouteComponent() {
         window.location.href = `/api/polar/checkout/${encodeURIComponent(slug)}?redirect=true`;
     };
     return (
-        <div className="flex flex-col gap-20">
-            <Header>
-                <User
-                    githubUsername={user?.githubUsername || ""}
-                    githubAvatarUrl={user?.image || ""}
-                    onSignOut={handleSignOut}
-                    onUserPortal={() => {
-                        window.location.href = "/api/polar/customer/portal";
-                    }}
-                />
-                <Button
-                    as="a"
-                    href="/api/docs"
-                    className="bg-gray-900 text-white hover:!brightness-90"
-                >
-                    API Reference
-                </Button>
-            </Header>
-            <div className="flex flex-col gap-2">
-                <div className="flex flex-col sm:flex-row justify-between gap-3">
-                    <h2 className="font-bold flex-1">Balance</h2>
-                    <div className="flex flex-wrap gap-3 items-center">
-                        <Button
-                            as="button"
-                            color="purple"
-                            weight="light"
-                            onClick={() =>
-                                handleBuyPollen("v1:product:pack:5x2")
-                            }
-                        >
-                            + $5
-                        </Button>
-                        <Button
-                            as="button"
-                            color="purple"
-                            weight="light"
-                            onClick={() =>
-                                handleBuyPollen("v1:product:pack:10x2")
-                            }
-                        >
-                            + $10
-                        </Button>
-                        <Button
-                            as="button"
-                            color="purple"
-                            weight="light"
-                            onClick={() =>
-                                handleBuyPollen("v1:product:pack:20x2")
-                            }
-                        >
-                            + $20
-                        </Button>
-                        <Button
-                            as="button"
-                            color="purple"
-                            weight="light"
-                            onClick={() =>
-                                handleBuyPollen("v1:product:pack:50x2")
-                            }
-                        >
-                            + $50
-                        </Button>
-                        <Button
-                            as="a"
-                            href="https://github.com/pollinations/pollinations/issues/4826"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="!bg-purple-200 !text-purple-900"
-                            color="purple"
-                            weight="light"
-                        >
-                            💳 Vote on payment methods
-                        </Button>
-                    </div>
-                </div>
-                <PollenBalance
-                    balances={balances}
-                    dailyPollen={tierData?.daily_pollen}
-                />
-            </div>
-            {tierData && (
+        <div className="flex flex-col gap-6">
+            <NewsBanner />
+            <div className="flex flex-col gap-20">
+                <Header>
+                    <User
+                        githubUsername={user?.githubUsername || ""}
+                        githubAvatarUrl={user?.image || ""}
+                        onSignOut={handleSignOut}
+                        onUserPortal={() => {
+                            window.location.href = "/api/polar/customer/portal";
+                        }}
+                    />
+                    <Button
+                        as="a"
+                        href="/api/docs"
+                        className="bg-gray-900 text-white hover:!brightness-90"
+                    >
+                        API Reference
+                    </Button>
+                </Header>
                 <div className="flex flex-col gap-2">
                     <div className="flex flex-col sm:flex-row justify-between gap-3">
-                        <h2 className="font-bold flex-1">Tier</h2>
-                        {tierData.should_show_activate_button && (
-                            <div className="flex gap-3">
-                                <Button
-                                    onClick={handleActivateTier}
-                                    disabled={isActivating}
-                                    color="green"
-                                    weight="light"
-                                    className="!bg-gray-50"
-                                >
-                                    {isActivating
-                                        ? "Processing..."
-                                        : `Activate ${tierData.target_tier_name}`}
-                                </Button>
-                            </div>
-                        )}
-                    </div>
-                    {activationError && (
-                        <div className="px-3 py-2 bg-red-50 border border-red-200 rounded-lg">
-                            <p className="text-sm text-red-900">
-                                ❌ <strong>Activation Failed:</strong>{" "}
-                                {activationError}
-                            </p>
+                        <h2 className="font-bold flex-1">Balance</h2>
+                        <div className="flex flex-wrap gap-3 items-center">
+                            <Button
+                                as="button"
+                                color="purple"
+                                weight="light"
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:5x2")
+                                }
+                            >
+                                + $5
+                            </Button>
+                            <Button
+                                as="button"
+                                color="purple"
+                                weight="light"
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:10x2")
+                                }
+                            >
+                                + $10
+                            </Button>
+                            <Button
+                                as="button"
+                                color="purple"
+                                weight="light"
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:20x2")
+                                }
+                            >
+                                + $20
+                            </Button>
+                            <Button
+                                as="button"
+                                color="purple"
+                                weight="light"
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:50x2")
+                                }
+                            >
+                                + $50
+                            </Button>
+                            <Button
+                                as="a"
+                                href="https://github.com/pollinations/pollinations/issues/4826"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="!bg-purple-200 !text-purple-900"
+                                color="purple"
+                                weight="light"
+                            >
+                                💳 Vote on payment methods
+                            </Button>
                         </div>
-                    )}
-                    <TierPanel
-                        status={tierData.active_tier}
-                        target_tier={tierData.target_tier}
-                        next_refill_at_utc={tierData.next_refill_at_utc}
-                        active_tier_name={tierData.active_tier_name}
-                        daily_pollen={tierData.daily_pollen}
-                        subscription_status={tierData.subscription_status}
-                        subscription_ends_at={tierData.subscription_ends_at}
-                        subscription_canceled_at={
-                            tierData.subscription_canceled_at
-                        }
-                        has_polar_error={tierData.has_polar_error}
+                    </div>
+                    <PollenBalance
+                        balances={balances}
+                        dailyPollen={tierData?.daily_pollen}
                     />
                 </div>
-            )}
-            <ApiKeyList
-                apiKeys={apiKeys}
-                onCreate={handleCreateApiKey}
-                onDelete={handleDeleteApiKey}
-            />
-            <FAQ />
-            <Pricing />
-            <div className="text-center py-8">
-                <Link
-                    to="/terms"
-                    className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-                >
-                    Terms & Conditions
-                </Link>
+                {tierData && (
+                    <div className="flex flex-col gap-2">
+                        <div className="flex flex-col sm:flex-row justify-between gap-3">
+                            <h2 className="font-bold flex-1">Tier</h2>
+                            {tierData.should_show_activate_button && (
+                                <div className="flex gap-3">
+                                    <Button
+                                        onClick={handleActivateTier}
+                                        disabled={isActivating}
+                                        color="green"
+                                        weight="light"
+                                        className="!bg-gray-50"
+                                    >
+                                        {isActivating
+                                            ? "Processing..."
+                                            : `Activate ${tierData.target_tier_name}`}
+                                    </Button>
+                                </div>
+                            )}
+                        </div>
+                        {activationError && (
+                            <div className="px-3 py-2 bg-red-50 border border-red-200 rounded-lg">
+                                <p className="text-sm text-red-900">
+                                    ❌ <strong>Activation Failed:</strong>{" "}
+                                    {activationError}
+                                </p>
+                            </div>
+                        )}
+                        <TierPanel
+                            status={tierData.active_tier}
+                            target_tier={tierData.target_tier}
+                            next_refill_at_utc={tierData.next_refill_at_utc}
+                            active_tier_name={tierData.active_tier_name}
+                            daily_pollen={tierData.daily_pollen}
+                            subscription_status={tierData.subscription_status}
+                            subscription_ends_at={tierData.subscription_ends_at}
+                            subscription_canceled_at={
+                                tierData.subscription_canceled_at
+                            }
+                            has_polar_error={tierData.has_polar_error}
+                        />
+                    </div>
+                )}
+                <ApiKeyList
+                    apiKeys={apiKeys}
+                    onCreate={handleCreateApiKey}
+                    onDelete={handleDeleteApiKey}
+                />
+                <FAQ />
+                <Pricing />
+                <div className="text-center py-8">
+                    <Link
+                        to="/terms"
+                        className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+                    >
+                        Terms & Conditions
+                    </Link>
+                </div>
             </div>
         </div>
     );

--- a/enter.pollinations.ai/src/client/routes/sign-in.tsx
+++ b/enter.pollinations.ai/src/client/routes/sign-in.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { FAQ } from "../components/faq.tsx";
 import { Button } from "../components/button.tsx";
 import { Header } from "../components/header.tsx";
+import { NewsBanner } from "../components/news-banner.tsx";
 
 export const Route = createFileRoute("/sign-in")({
     component: RouteComponent,
@@ -28,35 +29,38 @@ function RouteComponent() {
     };
 
     return (
-        <div className="flex flex-col gap-20">
-            <Header>
-                <div className="relative">
+        <div className="flex flex-col gap-6">
+            <NewsBanner />
+            <div className="flex flex-col gap-20">
+                <Header>
+                    <div className="relative">
+                        <Button
+                            as="button"
+                            onClick={handleSignIn}
+                            disabled={loading}
+                            className="bg-amber-200 text-amber-900 hover:brightness-105"
+                        >
+                            {loading ? "Signing in..." : "Sign in with Github"}
+                        </Button>
+                        <a
+                            href="https://github.com/pollinations/pollinations/issues/5543"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="absolute -bottom-4 right-0 text-xs text-gray-500 hover:text-gray-700 underline"
+                        >
+                            more options?
+                        </a>
+                    </div>
                     <Button
-                        as="button"
-                        onClick={handleSignIn}
-                        disabled={loading}
-                        className="bg-amber-200 text-amber-900 hover:brightness-105"
+                        as="a"
+                        href="/api/docs"
+                        className="bg-gray-900 text-white hover:!brightness-90"
                     >
-                        {loading ? "Signing in..." : "Sign in with Github"}
+                        API Reference
                     </Button>
-                    <a
-                        href="https://github.com/pollinations/pollinations/issues/5543"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="absolute -bottom-4 right-0 text-xs text-gray-500 hover:text-gray-700 underline"
-                    >
-                        more options?
-                    </a>
-                </div>
-                <Button
-                    as="a"
-                    href="/api/docs"
-                    className="bg-gray-900 text-white hover:!brightness-90"
-                >
-                    API Reference
-                </Button>
-            </Header>
-            <FAQ />
+                </Header>
+                <FAQ />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
- Add closable news banner component
- Show pollen rebalance (🦠1 🌱3 🌸10 🍯20)
- Display new models (claude opus 4.5, kimi k2, seedream 4, veo 3.1, seedance)
- Add to dashboard and sign-in pages
- Dismissal persists via localStorage