### PR TITLE
fix: rename COMMUNITY label to INBOX and skip App Submissions

### DIFF
--- a/.github/workflows/new-issue-labeler.yml
+++ b/.github/workflows/new-issue-labeler.yml
@@ -28,11 +28,15 @@ jobs:
             ];
 
             let label = null;
+            const title = context.payload.issue.title || "";
 
-            if (INTERNAL_USERS.includes(author)) {
+            // Skip App Submission issues (handled by app-review workflow)
+            if (title.startsWith("[App Submission]:")) {
+              console.log("App Submission issue, skipping INBOX label");
+            } else if (INTERNAL_USERS.includes(author)) {
               console.log(`Internal user ${author}, skipping label`);
             } else {
-              label = "COMMUNITY";
+              label = "INBOX";
             }
 
             if (label && !current.includes(label)) {


### PR DESCRIPTION
- Rename label from COMMUNITY to INBOX (focuses on workflow state, not person)
- Skip INBOX label for App Submission issues (handled by app-review workflow)