### PR TITLE
fix: use inbox:github label for external issues

### DIFF
--- a/.github/workflows/new-issue-labeler.yml
+++ b/.github/workflows/new-issue-labeler.yml
@@ -32,11 +32,11 @@ jobs:
 
             // Skip App Submission issues (handled by app-review workflow)
             if (title.startsWith("[App Submission]:")) {
-              console.log("App Submission issue, skipping INBOX label");
+              console.log("App Submission issue, skipping inbox:github label");
             } else if (INTERNAL_USERS.includes(author)) {
               console.log(`Internal user ${author}, skipping label`);
             } else {
-              label = "INBOX";
+              label = "inbox:github";
             }
 
             if (label && !current.includes(label)) {


### PR DESCRIPTION
- Use lowercase inbox:github label instead of INBOX
- Follows existing label naming convention