### PR TITLE
fix: remove mistral-fast model and fix Bedrock max_tokens

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -98,27 +98,6 @@ export const TEXT_SERVICES = {
         tools: true,
         isSpecialized: false,
     },
-    "mistral-fast": {
-        aliases: [
-            "llama-3.1-8b-instruct",
-            "llama-3.1-8b",
-            "meta-llama-3.1-8b-instruct",
-        ],
-        modelId: "us.meta.llama3-1-8b-instruct-v1:0",
-        provider: "aws-bedrock",
-        cost: [
-            {
-                date: COST_START_DATE,
-                promptTextTokens: perMillion(0.22),
-                completionTextTokens: perMillion(0.22),
-            },
-        ],
-        description: "Meta Llama 3.1 8B - Fast & Lightweight",
-        inputModalities: ["text"],
-        outputModalities: ["text"],
-        tools: true,
-        isSpecialized: false,
-    },
     "openai-audio": {
         aliases: [
             "gpt-4o-mini-audio-preview",

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -57,11 +57,6 @@ const models: ModelDefinition[] = [
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {
-        name: "mistral-fast",
-        config: portkeyConfig["us.meta.llama3-1-8b-instruct-v1:0"],
-        transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
-    },
-    {
         name: "deepseek",
         config: portkeyConfig["myceli-deepseek-v3.1"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),

--- a/text.pollinations.ai/configs/providerConfigs.js
+++ b/text.pollinations.ai/configs/providerConfigs.js
@@ -242,7 +242,7 @@ export function createBedrockLambdaModelConfig(additionalConfig = {}) {
         "custom-host":
             "https://s4gu3klsuhlqkol3x3qq6bv6em0cwqnu.lambda-url.us-east-1.on.aws/api/v1",
         authKey: process.env.AWS_BEARER_TOKEN_BEDROCK,
-        defaultOptions: { max_tokens: 16384 },
+        defaultOptions: { max_tokens: 8192 },
         ...additionalConfig,
     };
 }
@@ -261,7 +261,7 @@ export function createBedrockNativeConfig(additionalConfig = {}) {
         "aws-access-key-id": process.env.AWS_ACCESS_KEY_ID,
         "aws-secret-access-key": process.env.AWS_SECRET_ACCESS_KEY,
         "aws-region": process.env.AWS_REGION || "us-east-1",
-        defaultOptions: { max_tokens: 16384 },
+        defaultOptions: { max_tokens: 8192 },
         ...additionalConfig,
     };
 }


### PR DESCRIPTION
- Remove `mistral-fast` model (was misleadingly named - actually Llama 3.1 8B, not Mistral)
- Fix Bedrock default `max_tokens` from 16384 to 8192
- Fixes test failures for `chickytutor` model ("maximum tokens exceeds model limit of 8192")