### PR TITLE
feat(enter): simplify tier system with automatic flower upgrade on app approval

### DIFF
--- a/enter.pollinations.ai/src/client/components/tier-panel.tsx
+++ b/enter.pollinations.ai/src/client/components/tier-panel.tsx
@@ -64,11 +64,19 @@ const NoTierScreen: FC<{ has_polar_error?: boolean }> = ({
             ) : (
                 <div className="px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">
                     <p className="text-sm text-gray-900 leading-relaxed">
-                        ⭕ <strong>No Active Subscription:</strong> You don't
-                        have an active tier subscription yet.
+                        ⭕ <strong>No Active Tier:</strong> You don't have an
+                        active tier subscription yet.
                         <br />
-                        Click the <strong>Activate Tier</strong> button above to
-                        get started.
+                        Tiers are automatically granted when your{" "}
+                        <a
+                            href="https://github.com/pollinations/pollinations/issues/new?template=app-submission.yml"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-purple-600 hover:text-purple-800 underline"
+                        >
+                            app submission
+                        </a>{" "}
+                        is approved. 🌸
                     </p>
                 </div>
             )}

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -70,8 +70,6 @@ function RouteComponent() {
     };
 
     const [isSigningOut, setIsSigningOut] = useState(false);
-    const [isActivating, setIsActivating] = useState(false);
-    const [activationError, setActivationError] = useState<string | null>(null);
 
     const handleSignOut = async () => {
         if (isSigningOut) return; // Prevent double-clicks
@@ -120,34 +118,6 @@ function RouteComponent() {
             console.error(result.error);
         }
         router.invalidate();
-    };
-
-    const handleActivateTier = async () => {
-        if (isActivating || !tierData) return;
-        setIsActivating(true);
-        setActivationError(null);
-
-        try {
-            const response = await fetch("/api/tiers/activate", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                credentials: "include",
-                body: JSON.stringify({ target_tier: tierData.target_tier }),
-            });
-
-            if (!response.ok) {
-                const error = (await response.json()) as { message?: string };
-                setActivationError(error.message || "Unknown error");
-                setIsActivating(false);
-                return;
-            }
-
-            const data = (await response.json()) as { checkout_url: string };
-            window.location.href = data.checkout_url;
-        } catch (error) {
-            setActivationError(String(error));
-            setIsActivating(false);
-        }
     };
 
     const handleBuyPollen = (slug: string) => {
@@ -238,36 +208,11 @@ function RouteComponent() {
                 </div>
                 {tierData && (
                     <div className="flex flex-col gap-2">
-                        <div className="flex flex-col sm:flex-row justify-between gap-3">
-                            <h2 className="font-bold flex-1">Tier</h2>
-                            {tierData.should_show_activate_button && (
-                                <div className="flex gap-3">
-                                    <Button
-                                        onClick={handleActivateTier}
-                                        disabled={isActivating}
-                                        color="green"
-                                        weight="light"
-                                        className="!bg-gray-50"
-                                    >
-                                        {isActivating
-                                            ? "Processing..."
-                                            : `Activate ${tierData.target_tier_name}`}
-                                    </Button>
-                                </div>
-                            )}
-                        </div>
-                        {activationError && (
-                            <div className="px-3 py-2 bg-red-50 border border-red-200 rounded-lg">
-                                <p className="text-sm text-red-900">
-                                    ❌ <strong>Activation Failed:</strong>{" "}
-                                    {activationError}
-                                </p>
-                            </div>
-                        )}
+                        <h2 className="font-bold">Tier</h2>
                         <TierPanel
-                            status={tierData.active_tier}
+                            status={tierData.tier}
                             next_refill_at_utc={tierData.next_refill_at_utc}
-                            active_tier_name={tierData.active_tier_name}
+                            active_tier_name={tierData.tier_name}
                             daily_pollen={tierData.daily_pollen}
                             subscription_status={tierData.subscription_status}
                             subscription_ends_at={tierData.subscription_ends_at}

--- a/enter.pollinations.ai/test/integration/tiers.test.ts
+++ b/enter.pollinations.ai/test/integration/tiers.test.ts
@@ -1,0 +1,97 @@
+import { SELF } from "cloudflare:test";
+import { test } from "../fixtures.ts";
+import { expect } from "vitest";
+
+const base = "http://localhost:3000/api/tiers";
+
+// Test tiers endpoint authentication (similar to polar.test.ts pattern)
+test("/view should return 401 when not authenticated", async ({ mocks }) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/view`, {
+        method: "GET",
+    });
+    expect(response.status).toBe(401);
+});
+
+test("/view should return 200 when authenticated via session cookie", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/view`, {
+        method: "GET",
+        headers: {
+            cookie: `better-auth.session_token=${sessionToken}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    // Verify response structure
+    const data = (await response.json()) as {
+        tier: string;
+        tier_name?: string;
+        daily_pollen?: number;
+        next_refill_at_utc: string;
+        has_polar_error: boolean;
+    };
+
+    expect(data).toBeDefined();
+    expect(data.tier).toBeDefined();
+    expect(typeof data.tier).toBe("string");
+    expect(data.next_refill_at_utc).toBeDefined();
+    expect(typeof data.has_polar_error).toBe("boolean");
+});
+
+test("/view should NOT be accessible via API key (session cookie only)", async ({
+    apiKey,
+    mocks,
+}) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/view`, {
+        method: "GET",
+        headers: {
+            authorization: `Bearer ${apiKey}`,
+        },
+    });
+    // Should return 401 because tiers route only allows session cookies
+    expect(response.status).toBe(401);
+});
+
+test("/view returns valid tier status values", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/view`, {
+        method: "GET",
+        headers: {
+            cookie: `better-auth.session_token=${sessionToken}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as { tier: string };
+    const validTiers = ["none", "spore", "seed", "flower", "nectar", "router"];
+    expect(validTiers).toContain(data.tier);
+});
+
+test("/view returns valid ISO timestamp for next_refill_at_utc", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/view`, {
+        method: "GET",
+        headers: {
+            cookie: `better-auth.session_token=${sessionToken}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as { next_refill_at_utc: string };
+    // Should be a valid ISO date string
+    const date = new Date(data.next_refill_at_utc);
+    expect(date.toString()).not.toBe("Invalid Date");
+    // Should be in the future
+    expect(date.getTime()).toBeGreaterThan(Date.now());
+});


### PR DESCRIPTION
## Summary

Simplifies the tier system by making Polar subscriptions the source of truth for tier status.

- Remove Activate button and manual tier selection
- Tier status now determined solely by Polar subscription
- Simplify `/api/tiers/view` endpoint (remove `/api/tiers/activate`)

## Changes

### Backend (`tiers.ts`)
- Remove `/api/tiers/activate` endpoint
- Simplify `/api/tiers/view` to read tier directly from Polar
- Remove `target_tier` concept - tier = active Polar subscription

### Frontend (`tier-panel.tsx`)
- Remove Activate button and related UI
- Update messaging for users without active tier
- Guide users to app submission for tier upgrades

### Tests
- Add integration tests for simplified `/api/tiers/view` endpoint

## New Flow
Tier is determined by Polar subscription status - no manual activation needed.

---

**Note**: Workflow automation (auto-upgrade on app approval) has been split into a separate PR: #5941