### PR TITLE
feat(enter): add community links below header logo

### DIFF
--- a/enter.pollinations.ai/src/client/components/header.tsx
+++ b/enter.pollinations.ai/src/client/components/header.tsx
@@ -8,12 +8,49 @@ export const Header: FC<HeaderProps> = ({ children }) => {
     return (
         <>
             <div className="flex flex-col sm:flex-row justify-between gap-4 sm:items-center">
-                <img
-                    src="/logo_text_black.svg"
-                    alt="pollinations.ai"
-                    className="h-12 w-full sm:w-auto sm:flex-1 object-contain object-center sm:object-left invert"
-                />
-                <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between sm:justify-end">
+                <div className="flex flex-col gap-2">
+                    <img
+                        src="/logo_text_black.svg"
+                        alt="pollinations.ai"
+                        className="h-12 w-full sm:w-auto object-contain object-center sm:object-left invert"
+                    />
+                    <div className="flex flex-wrap justify-center sm:justify-start gap-1.5 text-xs">
+                        <a
+                            href="https://discord.gg/pollinations"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="bg-black/10 hover:bg-black/20 transition-colors rounded-full px-2 py-0.5 whitespace-nowrap"
+                        >
+                            💬 <span className="sm:hidden">Discord</span>
+                            <span className="hidden sm:inline">
+                                Join our Discord
+                            </span>
+                        </a>
+                        <a
+                            href="https://discord.com/channels/885844321461485618/1432378056126894343"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="bg-black/10 hover:bg-black/20 transition-colors rounded-full px-2 py-0.5 whitespace-nowrap"
+                        >
+                            🧪 <span className="sm:hidden">Beta</span>
+                            <span className="hidden sm:inline">
+                                #pollen-beta channel
+                            </span>
+                        </a>
+                        <a
+                            href="https://github.com/pollinations/pollinations/issues"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="bg-black/10 hover:bg-black/20 transition-colors rounded-full px-2 py-0.5 whitespace-nowrap"
+                        >
+                            🐛 <span className="sm:hidden">Report</span>
+                            <span className="hidden sm:inline">
+                                Report an issue
+                            </span>
+                        </a>
+                    </div>
+                </div>
+                <div className="flex flex-row gap-4 items-start justify-center sm:justify-end">
                     {children}
                 </div>
             </div>

--- a/enter.pollinations.ai/src/client/components/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/news-banner.tsx
@@ -1,34 +1,18 @@
-import { useState, useEffect, type FC } from "react";
+import type { FC } from "react";
 
-const NEWS_ID = "dec-2025-v4";
+// Set to true when there's a special announcement to show
+const SHOW_BANNER = false;
 
+/**
+ * News/announcement banner - hidden by default.
+ * To show: set SHOW_BANNER = true and update the content below.
+ */
 export const NewsBanner: FC = () => {
-    const [dismissed, setDismissed] = useState(true);
-
-    useEffect(() => {
-        const isDismissed = localStorage.getItem(`news-dismissed-${NEWS_ID}`);
-        setDismissed(isDismissed === "true");
-    }, []);
-
-    const handleDismiss = () => {
-        localStorage.setItem(`news-dismissed-${NEWS_ID}`, "true");
-        setDismissed(true);
-    };
-
-    if (dismissed) return null;
+    if (!SHOW_BANNER) return null;
 
     return (
-        <div className="relative bg-violet-50/60 border border-violet-200 rounded-lg p-4 text-sm">
-            <button
-                type="button"
-                onClick={handleDismiss}
-                className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 text-lg leading-none"
-                aria-label="Dismiss"
-            >
-                ×
-            </button>
-
-            <div className="flex flex-col gap-2 pr-6">
+        <div className="bg-violet-50/60 border border-violet-200 rounded-lg p-4 text-sm">
+            <div className="flex flex-col gap-2">
                 <span className="text-xs text-gray-500">
                     Dec 2025 — What's new
                 </span>
@@ -38,23 +22,8 @@ export const NewsBanner: FC = () => {
                         <span className="text-gray-400 italic">dec 1</span>
                     </li>
                     <li className="text-gray-600">
-                        🚀 <strong>Fresh models dropped:</strong>{" "}
-                        <span className="text-gray-700">Claude Opus 4.5</span> ·{" "}
-                        <span className="text-gray-700">Kimi K2</span> ·{" "}
-                        <span className="text-gray-700">Seedream 4.5</span> ·{" "}
-                        <span className="text-gray-700">VEO 3.1</span> ·{" "}
-                        <span className="text-gray-700">Seedance Pro-Fast</span>
-                    </li>
-                    <li className="text-gray-600">
-                        💬 <strong>Join the discussion:</strong>{" "}
-                        <a
-                            href="https://discord.com/channels/885844321461485618/1432378056126894343"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-purple-600 hover:text-purple-800 underline"
-                        >
-                            #pollen-beta channel
-                        </a>
+                        🚀 <strong>Fresh models dropped:</strong> Claude Opus
+                        4.5, Kimi K2, Seedream 4.5, VEO 3.1, Seedance Pro-Fast
                     </li>
                 </ul>
             </div>

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -21,7 +21,6 @@ import { TierPanel } from "../components/tier-panel.tsx";
 import { FAQ } from "../components/faq.tsx";
 import { Header } from "../components/header.tsx";
 import { Pricing } from "../components/pricing/index.ts";
-import { NewsBanner } from "../components/news-banner.tsx";
 
 export const Route = createFileRoute("/")({
     component: RouteComponent,
@@ -157,7 +156,6 @@ function RouteComponent() {
     };
     return (
         <div className="flex flex-col gap-6">
-            <NewsBanner />
             <div className="flex flex-col gap-20">
                 <Header>
                     <User

--- a/enter.pollinations.ai/src/client/routes/sign-in.tsx
+++ b/enter.pollinations.ai/src/client/routes/sign-in.tsx
@@ -39,7 +39,7 @@ function RouteComponent() {
                             as="button"
                             onClick={handleSignIn}
                             disabled={loading}
-                            className="bg-amber-200 text-amber-900 hover:brightness-105"
+                            className="bg-amber-200 text-amber-900 hover:brightness-105 whitespace-nowrap"
                         >
                             {loading ? "Signing in..." : "Sign in with Github"}
                         </Button>
@@ -47,7 +47,7 @@ function RouteComponent() {
                             href="https://github.com/pollinations/pollinations/issues/5543"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="absolute -bottom-4 right-0 text-xs text-gray-500 hover:text-gray-700 underline"
+                            className="absolute left-1/2 -translate-x-1/2 -bottom-5 text-xs text-gray-500 hover:text-gray-700 underline whitespace-nowrap"
                         >
                             more options?
                         </a>
@@ -55,9 +55,9 @@ function RouteComponent() {
                     <Button
                         as="a"
                         href="/api/docs"
-                        className="bg-gray-900 text-white hover:!brightness-90"
+                        className="bg-gray-900 text-white hover:!brightness-90 whitespace-nowrap"
                     >
-                        API Reference
+                        API Ref.
                     </Button>
                 </Header>
                 <FAQ />


### PR DESCRIPTION
## Summary
- Add community links below header logo in enter.pollinations.ai

## Changes
- **Community links**: Discord, Beta channel, Report issue buttons below logo
- **Mobile**: Short labels (Discord, Beta, Report), centered
- **Desktop**: Full text labels, left-aligned
- **Sign-in page**: Buttons aligned horizontally ('Sign in with Github' + 'API Ref.')
- **News banner**: Hidden, ready for future announcements

## Files Changed
- `header.tsx` - Community links component
- `sign-in.tsx` - Button layout improvements
- `news-banner.tsx` - Simplified hidden banner