### PR TITLE
fix: replace POLLI_PAT with POLLY_BOT app token

### DIFF
--- a/.github/workflows/issue-add-to-project.yml
+++ b/.github/workflows/issue-add-to-project.yml
@@ -8,7 +8,15 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Polly Bot Token
+        id: polly-bot
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.POLLY_BOT_APP_ID }}
+          private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
+          owner: pollinations
+
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/pollinations/projects/20
-          github-token: ${{ secrets.POLLI_PAT }}
+          github-token: ${{ steps.polly-bot.outputs.token }}

--- a/.github/workflows/issue-close-discarded.yml
+++ b/.github/workflows/issue-close-discarded.yml
@@ -9,10 +9,18 @@ jobs:
   close-discarded:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Polly Bot Token
+        id: polly-bot
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.POLLY_BOT_APP_ID }}
+          private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
+          owner: pollinations
+
       - name: Close issues in "Discarded" column
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.POLLI_PAT }}
+          github-token: ${{ steps.polly-bot.outputs.token }}
           script: |
             const ORG = 'pollinations';
             const PROJECT_NUMBER = 20;

--- a/.github/workflows/pr-update-project-status.yml
+++ b/.github/workflows/pr-update-project-status.yml
@@ -8,17 +8,25 @@ jobs:
   update-project-status:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Polly Bot Token
+        id: polly-bot
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.POLLY_BOT_APP_ID }}
+          private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
+          owner: pollinations
+
       - name: Add to Project
         uses: actions/add-to-project@v1.0.2
         id: add-project
         with:
           project-url: https://github.com/orgs/pollinations/projects/20
-          github-token: ${{ secrets.POLLI_PAT }}
+          github-token: ${{ steps.polly-bot.outputs.token }}
 
       - name: Update Status Field
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.POLLI_PAT }}
+          github-token: ${{ steps.polly-bot.outputs.token }}
           script: |
             const PROJECT_ID = '${{ steps.add-project.outputs.itemId }}';
             const PR = context.payload.pull_request;


### PR DESCRIPTION
## Summary

Fixes the 'Resource not accessible by personal access token' error in project workflows.

## Changes

- Replace `POLLI_PAT` (personal access token) with `POLLY_BOT` GitHub App token
- Uses existing app secrets: `POLLY_BOT_APP_ID` + `POLLY_BOT_PRIVATE_KEY`

## Workflows Updated

- `issue-add-to-project.yml`
- `issue-close-discarded.yml`
- `pr-update-project-status.yml`

## Why

GitHub Apps are org-owned and don't depend on personal accounts. The POLLY_BOT app is already used by other workflows.