### PR TITLE
fix: use dynamic model validation for enter service

### DIFF
--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -4,16 +4,19 @@ import { z } from "zod";
 const QUALITIES = ["low", "medium", "high", "hd"] as const;
 const MAX_SEED_VALUE = 1844674407370955;
 
+// Use dynamic validation to avoid build-time evaluation freezing the model list
+const imageModelSchema = z.string().refine(
+    (val) => val in IMAGE_SERVICES,
+    (val) => ({
+        message: `Invalid model: ${val}. Available: ${Object.keys(IMAGE_SERVICES).join(", ")}`,
+    }),
+);
+
 export const GenerateImageRequestQueryParamsSchema = z.object({
     // Image model params
-    model: z
-        .literal(Object.keys(IMAGE_SERVICES))
-        .optional()
-        .default("flux")
-        .meta({
-            description:
-                "AI model. Image: flux, turbo, gptimage, kontext, seedream, seedream-pro, nanobanana. Video: veo, seedance, seedance-pro",
-        }),
+    model: imageModelSchema.optional().default("flux").meta({
+        description: "AI model. See /models endpoint for available models.",
+    }),
     width: z.coerce
         .number()
         .int()


### PR DESCRIPTION
## Summary
Fixes issue where adding new models to `shared/registry/image.ts` required a redeploy to update the validation.

## Problem
The Zod schema used `z.literal(Object.keys(IMAGE_SERVICES))` which gets evaluated at **build time** by Vite/esbuild. This meant the model list was "frozen" into the bundle, so new models like `zimage` weren't recognized even after deploying.

## Solution
Changed to `z.string().refine()` which validates against `IMAGE_SERVICES` at **runtime**.

```typescript
// Before (build-time evaluation)
model: z.literal(Object.keys(IMAGE_SERVICES))

// After (runtime validation)
const imageModelSchema = z.string().refine(
    (val) => val in IMAGE_SERVICES,
    (val) => ({ message: `Invalid model: ${val}. Available: ${Object.keys(IMAGE_SERVICES).join(", ")}` })
);
```

## Testing
After this fix, adding new models to the registry will work immediately after deploy without needing to update the schema.