### PR TITLE
Remove duplicate project entries

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -26,7 +26,6 @@ Pollinations.AI is used in various projects, including:
 | Qwen-Agent ([⭐ 11.5k](https://github.com/QwenLM/Qwen-Agent)) | A framework for developing agentic LLM applications. | - |
 | Pollinations Task Master ([⭐ 20](https://github.com/LousyBook94/pollinations-task-master)) | A task management system that uses AI to help break down and organize... | @LousyBook94 |
 | [SocialScribe](https://socialscribe.pages.dev/) ([⭐ 1](https://github.com/sh20raj/socialscribe)) | An AI-powered Chrome extension that fixes grammar, rewrites text, and enhances... | @sh20raj |
-| [EasyGen - AI Diagram Generator ✨](https://easygenme.netlify.app/) | Modern open-source web application that transforms text descriptions into... | @ellweb3 |
 | [Visiora - Image Generation using AI 🎨](https://visiora-img.netlify.app/) ([⭐ 0](https://github.com/Kandariarjun07/Visiora)) | A modern web application that transforms text prompts into stunning... | @Kandariarjun07 |
 | [PairFusion](https://pair-fusion.vercel.app/) ([⭐ 0](https://github.com/auraticabhi/PairFusion)) | A real-time AI powered, scalable and feature-rich collaborative IDE built for... | @auraticabhi |
 | [CraftUI](https://craftui.studio/) | An AI-powered tool that simplifies UI design by turning text prompts or images... | @imhardikdesai |
@@ -38,7 +37,6 @@ Pollinations.AI is used in various projects, including:
 | [Pollin-Coder](https://pollin-coder.megavault.in) | A free AI-powered website builder that lets anyone create a clean site just by... | @r3ap3redit |
 | [JustBuildThings](https://justbuildthings.com) | A natural language programming interface that lets users create web... | @buildmaster |
 | [Websim](https://websim.ai/c/bXsmNE96e3op5rtUS) | A web simulation tool that integrates Pollinations.ai. | @voodoohop |
-| [BeeCoder](https://github.com/cemalgnlts/beecoder) | Enables VS Code Copilot to connect to Pollinations. | @cemalgnlts |
 | 🆕 [Aqua Application Programming Interface](https://aquadevs.com/) | This is an learning project for me to learn how to track users, backend check,... | kiskreforev |
 
 ### Creative 🎨
@@ -54,7 +52,6 @@ Pollinations.AI is used in various projects, including:
 | Pollinations.ai Image Generation (for Frame) ([⭐ 7](https://github.com/CitizenOneX/frame_pollinations)) | A Flutter application that listens for image generation prompts, requests... | CitizenOneX |
 | [Imagen](https://altkriz.github.io/imagen/) ([⭐ 3](https://github.com/altkriz/imagen)) | A beautiful web interface for generating images using Pollinations.ai API with... | @altkriz |
 | MASala ([⭐ 3](https://github.com/Naman009/MASala)) | Multi-Agent AI That Cooks Up Recipes Just for You ~ From fridge to feast,... | @Naman009 |
-| [Imagen](https://altkriz.github.io/imagen/) ([⭐ 3](https://github.com/altkriz/imagen)) | A beautiful web interface for generating images using Pollinations.ai API with... | @altkriz |
 | [CatGPT Meme Generator 🐱](https://pollinations.github.io/catgpt/) ([⭐ 2](https://github.com/pollinations/catgpt)) | Transform your questions into sassy cat wisdom! An AI-powered meme generator... | @voodoohop |
 | [Dreamscape AI](https://dreamscape.pinkpixel.dev) ([⭐ 2](https://github.com/pinkpixel-dev/dreamscape-ai)) | Dreamscape AI is a creative studio for generating, enhancing, and transforming... | @sizzlebop |
 | 🆕 ViralFlow AI 🎬 ([⭐ 0](https://github.com/FabioArieiraBaia/ViralFlow)) | Automated viral video generator using Gemini 2.5 for scripts/TTS and... | @FabioArieiraBaia |
@@ -95,7 +92,6 @@ Pollinations.AI is used in various projects, including:
 | [EzPromptla](https://ezpromptla.netlify.app) | EzPromptla is an advanced visual prompt builder and creative partner designed... | [mohamadizuan...](mailto:mohamadizuanbakar@gmail.com) |
 | [Argent Script](https://perchance.org/ai-text-to-audio) | AI Voice Generator - Generate text to audio for free and without limits,... | [Link](https://github.com/withthatway) |
 | [Unfoldtech](https://studio.unfoldtech.online/) | Easily generate new images inspired by the Pexels website with embedded IPTC... | [kengkreingkr...](mailto:kengkreingkrai@gmail.com) |
-| [Dreamator-AI 🎨](https://dreamator-ai.vercel.app/) | Transform your imagination into reality using Pollinations API. A creative... | @its3li |
 | [Celebrity AI Image Generator](https://www.aicelebrity.design/) ([⭐ 0](https://github.com/Colin-Zero)) | An AI-powered celebrity image generator that uses Pollinations.ai and a1.art... | @Colin-Zero |
 | [Coloring AI 🎨](https://coloring-ai.com/) | An intelligent web-based coloring assistant that turns black-and-white sketches... | [962900862@qq...](mailto:962900862@qq.com) |
 | [JSON Pollinations API](https://pollinations-json.deno.dev/openai) | A Deno Deploy API wrapper for Pollinations that provides JSON-formatted... | @apersonwhomakess... |
@@ -188,7 +184,6 @@ Pollinations.AI is used in various projects, including:
 
 | Project | Description | Creator |
 |---------|-------------|--------|
-| gpt4free ([⭐ 65.1k](https://github.com/xtekky/gpt4free)) | Community-driven project that aggregates multiple providers and interfaces for LLMs and media-generation models. | @xtekky, @hlohaus |
 | tgpt ([⭐ 2.9k](https://github.com/aandrew-me/tgpt)) | ChatGPT in terminal without requiring API keys. Uses Pollinations API endpoints... | @aandrew-me |
 | 🛠️ AI Content Describer ([⭐ 59](https://github.com/cartertemm/AI-content-describer/)) | An extension for NVDA, the free and open-source screen reader for Microsoft... | @cartertemm |
 | 💻️ Windows Walker ([⭐ 14](https://github.com/SuperShivam5000/windows-walker)) | Windows Walker – What Copilot for Windows should have been. AI-powered Windows... | @supershivam |
@@ -210,18 +205,14 @@ Pollinations.AI is used in various projects, including:
 | MultiAgent 🤖 ([⭐ 0](https://github.com/LKosoj/multiagent)) | Advanced multi-agent system for solving complex tasks using specialized AI... | @LKosoj |
 | 🖥️ [Pollinations MCP Server (Official)](https://www.npmjs.com/package/@pollinations/model-context-protocol) ([⭐ 0](https://github.com/pollinations/pollinations/tree/main/model-context-protocol)) | Official Model Context Protocol server for Pollinations AI services. Generate... | @pollinations |
 | [FoodAnaly](https://foodanaly.vercel.app/) | An AI application for food analysis that uses advanced artificial intelligence... | [liukang0120@...](mailto:liukang0120@163.com) |
-| [Herramientas IA](https://herramientas.ia) | Tools designed with Pollinations.AI and the DescartesJS editor, including tools... | @herramientas |
 | [Pollinations AI Free API](https://pollinations-ai-free-api.vercel.app/) | This project provides a free API interface supporting various text and image... | @freeapi |
-| [DominiSigns](https://www.template.net/ai-sign-generator) ([⭐ 0](https://github.com/dominicva/dominisigns)) | A WordPress block plugin that lets users create AI-generated images through the... | @dominicva |
 | 🤖 [DynaSpark API](https://th3-ai.github.io/DynaSpark) ([⭐ 0](https://github.com/Th3-AI/DynaSpark)) | The DynaSpark API provides simple yet powerful AI capabilities for text... | @Th3-C0der |
 | [Querynator5000](https://querynator5000.onrender.com/) ([⭐ 0](https://github.com/SuperShivam5000/querynator5000)) | Modern AI-first SQL interface for exploring and manipulating databases with... | @SuperShivam5000 |
 | [UltimaX Intelligence CLI](https://huggingface.co/spaces/umint/cli) | Extension of the UltimaX Intelligence project based on Pollinations Python SDK. | @hadadarjt |
 | [AI Agent Portal](https://agent.makululinux.com/) ([⭐ 0](https://github.com/raymerjacque/Makulu-Agent-Portal)) | A next-generation development environment that leverages a sophisticated... | @raymerjacque |
 | 🆕 PDF-to-Speech 🔊 ([⭐ 0](https://github.com/Ak-Yadav/pdf_to_speech)) | Convert any PDF document into natural-sounding audio using Pollinations AI TTS.... | @Ak-Yadav |
 | [pollinations.ai Python SDK](https://github.com/pollinations-ai/pollinations.ai) | Official Python SDK for working with Pollinations' models. | @pollinations-ai |
-| [Pollinations - Python & JavaScript SDK](https://github.com/gpt4free/pollinations) | Python & JavaScript SDK for Pollinations AI — OpenAI-compatible API. | @gpt4free |
 | MCPollinations (Community) ([⭐ 32](https://github.com/pinkpixel-dev/MCPollinations)) | Community-maintained Model Context Protocol server with advanced features like... | @pinkpixel-dev |
-| Herramientas IA ([⭐ 26](https://github.com/cusanotech/90-herramientas-de-inteligencia-artificial)) | Tools designed with Pollinations.AI and the DescartesJS editor, including tools... | @juanrivera126 |
 | [pollinations_ai](https://pub.dev/packages/pollinations_ai) | Dart/Flutter package for Pollinations API. | @Meenapintu |
 | pollinations NPM Module | JavaScript/Node.js SDK for Pollinations API. | - |
 | [pypollinations](https://pypi.org/project/pypollinations/) | Comprehensive Python wrapper for Pollinations AI API. | @KTS-o7 |
@@ -234,7 +225,7 @@ Pollinations.AI is used in various projects, including:
 
 | Project | Description | Creator |
 |---------|-------------|--------|
-| [G4F Chat UI](http://g4f.dev/chat/pollinations) ([⭐ 93](http://g4f.dev/chat/pollinations)) | G4F Chat UI for Pollinations with Image & Video Generation capability | @hlohaus |
+| [G4F Chat UI](http://g4f.dev/chat/pollinations) ([⭐ 65.1k](https://github.com/gpt4free/g4f.dev)) | The official G4F Chat UI for Pollinations with Image & Video Generation... | @hlohaus |
 | [LobeChat](https://lobechat.com) ([⭐ 21.0k](https://github.com/lobehub/lobe-chat)) | An open-source, extensible chat UI framework supporting multiple models and... | @lobehub |
 | [SillyTavern](https://docs.sillytavern.app/) ([⭐ 14.7k](https://github.com/SillyTavern/SillyTavern)) | An LLM frontend for power users. Pollinations permits it to generate text and... | - |
 | 🖥️ [LLMS](https://yassineabou.github.io/LLMs-Wasm/) ([⭐ 88](https://github.com/yassineAbou/LLMS)) | LLMS is a Kotlin Multiplatform application that brings the power of AI to... | @yassineAbou |
@@ -279,8 +270,8 @@ Pollinations.AI is used in various projects, including:
 | 🆕 [PolliPalmTop 📱](https://aiworld.institute/server/pollipalmtopv1.apk) | Android app dedicated to Pollinations with AI chat, web search, and image... | @BiG L |
 | 🆕 [Xibe-chat-cli 💬](https://pypi.org/project/xibe-chat-cli/) ([⭐ 0](https://github.com/iotserver24/xibe-chat-cli)) | AI chat and image generation directly in your terminal with a rich text UI.... | @R3AP3Redit |
 | 🆕 [Fikiri Chat AI 💬](https://fikirichat.netlify.app/) | Multi-model AI chat platform with seamless LLM switching via Pollinations API.... | @brianmativo |
-| 🆕 [PollinationsFreeAI 🆓](https://pollinations-free-ai.vercel.app/) ([⭐ 0](https://github.com/Poli-Chat/PollinationsFreeAI)) | Free AI platform leveraging Pollinations for text and image generation. No... | @Poli-Chat |
-| 🆕 [Samaritan AI 🤖](https://samaritan-ai-web.vercel.app/) | Intelligent AI assistant platform powered by Pollinations. Offers a polished UI... | @mdarman4002 |
+| [PollinationsFreeAI 🆓](https://pollinations-free-ai.vercel.app/) ([⭐ 0](https://github.com/Poli-Chat/PollinationsFreeAI)) | Free AI platform leveraging Pollinations for text and image generation. No... | @Poli-Chat |
+| [Samaritan AI 🤖](https://samaritan-ai-web.vercel.app/) | Intelligent AI assistant platform powered by Pollinations. Offers a polished UI... | @mdarman4002 |
 | 🇮🇩 [ReThink AI 🇮🇩](https://rethink.web.id) | High-performance AI platform tailored for Indonesia, blending a custom-trained... | @Djongoks |
 | 🆕 [Noir Ink Tattoo Studio 🎨](https://noir-ink.netlify.app/) ([⭐ 0](https://github.com/Jairedddy/Noir-Ink-Tattoo-Studio)) | A monochrome tattoo studio featuring AI-powered design generation, booking... | @Jairedddy |
 | [Artificial Intelligence Orcho 📱](https://play.google.com/store/apps/details?id=orcho.artificialintelligence) | Mobile AI app for Android with chat and image generation. Get smart chat... | @ricardoxd |
@@ -317,8 +308,6 @@ Pollinations.AI is used in various projects, including:
 | 🤖 [ioswbot 🤖](https://t.me/ioswbot) | Free, unlimited Telegram bot with ChatGPT 5, Gemini 2.5 Flash Lite Search, GPT... | @swtomas |
 | 🤖 [Telegram AI Chars 🤖](https://t.me/MFRG_Shapes) | Plataforma en PHP para la creación de personajes (bots) con personalidad,... | @MarcosFRG |
 | 🤖 [Swapna Shastra Dream Decoder 💤✨](https://t.me/Swapnashastra_dream_bot) | AI-powered Telegram bot that interprets dreams using ancient Indian Swapna... | @ShashankNagaraj |
-| 🆕 [TeleChars AI](https://extras.marcosfrg.x10.mx) | Ya había enviado este proyecto antes, pero ahora lo hago por... | marcosfrgames08 |
-| 🆕 🤖 [TeleChars AI](https://extras.marcosfrg.x10.mx) | TeleChars AI is a platform for AI-powered Telegram character creation. It... | marcosfrgames08 |
 
 ### Learn 📚
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ Pollinations.AI is used in various projects, including:
 | Qwen-Agent ([⭐ 11.5k](https://github.com/QwenLM/Qwen-Agent)) | A framework for developing agentic LLM applications. | - |
 | Pollinations Task Master ([⭐ 20](https://github.com/LousyBook94/pollinations-task-master)) | A task management system that uses AI to help break down and organize... | @LousyBook94 |
 | [SocialScribe](https://socialscribe.pages.dev/) ([⭐ 1](https://github.com/sh20raj/socialscribe)) | An AI-powered Chrome extension that fixes grammar, rewrites text, and enhances... | @sh20raj |
-| [EasyGen - AI Diagram Generator ✨](https://easygenme.netlify.app/) | Modern open-source web application that transforms text descriptions into... | @ellweb3 |
 | [Visiora - Image Generation using AI 🎨](https://visiora-img.netlify.app/) ([⭐ 0](https://github.com/Kandariarjun07/Visiora)) | A modern web application that transforms text prompts into stunning... | @Kandariarjun07 |
 | [PairFusion](https://pair-fusion.vercel.app/) ([⭐ 0](https://github.com/auraticabhi/PairFusion)) | A real-time AI powered, scalable and feature-rich collaborative IDE built for... | @auraticabhi |
 | [CraftUI](https://craftui.studio/) | An AI-powered tool that simplifies UI design by turning text prompts or images... | @imhardikdesai |
@@ -269,7 +268,6 @@ Pollinations.AI is used in various projects, including:
 | [Pollin-Coder](https://pollin-coder.megavault.in) | A free AI-powered website builder that lets anyone create a clean site just by... | @r3ap3redit |
 | [JustBuildThings](https://justbuildthings.com) | A natural language programming interface that lets users create web... | @buildmaster |
 | [Websim](https://websim.ai/c/bXsmNE96e3op5rtUS) | A web simulation tool that integrates Pollinations.ai. | @voodoohop |
-| [BeeCoder](https://github.com/cemalgnlts/beecoder) | Enables VS Code Copilot to connect to Pollinations. | @cemalgnlts |
 | 🆕 [Aqua Application Programming Interface](https://aquadevs.com/) | This is an learning project for me to learn how to track users, backend check,... | kiskreforev |
 
 ### Creative 🎨
@@ -285,7 +283,6 @@ Pollinations.AI is used in various projects, including:
 | Pollinations.ai Image Generation (for Frame) ([⭐ 7](https://github.com/CitizenOneX/frame_pollinations)) | A Flutter application that listens for image generation prompts, requests... | CitizenOneX |
 | [Imagen](https://altkriz.github.io/imagen/) ([⭐ 3](https://github.com/altkriz/imagen)) | A beautiful web interface for generating images using Pollinations.ai API with... | @altkriz |
 | MASala ([⭐ 3](https://github.com/Naman009/MASala)) | Multi-Agent AI That Cooks Up Recipes Just for You ~ From fridge to feast,... | @Naman009 |
-| [Imagen](https://altkriz.github.io/imagen/) ([⭐ 3](https://github.com/altkriz/imagen)) | A beautiful web interface for generating images using Pollinations.ai API with... | @altkriz |
 | [CatGPT Meme Generator 🐱](https://pollinations.github.io/catgpt/) ([⭐ 2](https://github.com/pollinations/catgpt)) | Transform your questions into sassy cat wisdom! An AI-powered meme generator... | @voodoohop |
 | [Dreamscape AI](https://dreamscape.pinkpixel.dev) ([⭐ 2](https://github.com/pinkpixel-dev/dreamscape-ai)) | Dreamscape AI is a creative studio for generating, enhancing, and transforming... | @sizzlebop |
 | 🆕 ViralFlow AI 🎬 ([⭐ 0](https://github.com/FabioArieiraBaia/ViralFlow)) | Automated viral video generator using Gemini 2.5 for scripts/TTS and... | @FabioArieiraBaia |
@@ -326,7 +323,6 @@ Pollinations.AI is used in various projects, including:
 | [EzPromptla](https://ezpromptla.netlify.app) | EzPromptla is an advanced visual prompt builder and creative partner designed... | [mohamadizuan...](mailto:mohamadizuanbakar@gmail.com) |
 | [Argent Script](https://perchance.org/ai-text-to-audio) | AI Voice Generator - Generate text to audio for free and without limits,... | [Link](https://github.com/withthatway) |
 | [Unfoldtech](https://studio.unfoldtech.online/) | Easily generate new images inspired by the Pexels website with embedded IPTC... | [kengkreingkr...](mailto:kengkreingkrai@gmail.com) |
-| [Dreamator-AI 🎨](https://dreamator-ai.vercel.app/) | Transform your imagination into reality using Pollinations API. A creative... | @its3li |
 | [Celebrity AI Image Generator](https://www.aicelebrity.design/) ([⭐ 0](https://github.com/Colin-Zero)) | An AI-powered celebrity image generator that uses Pollinations.ai and a1.art... | @Colin-Zero |
 | [Coloring AI 🎨](https://coloring-ai.com/) | An intelligent web-based coloring assistant that turns black-and-white sketches... | [962900862@qq...](mailto:962900862@qq.com) |
 | [JSON Pollinations API](https://pollinations-json.deno.dev/openai) | A Deno Deploy API wrapper for Pollinations that provides JSON-formatted... | @apersonwhomakess... |
@@ -419,7 +415,6 @@ Pollinations.AI is used in various projects, including:
 
 | Project | Description | Creator |
 |---------|-------------|--------|
-| gpt4free ([⭐ 65.1k](https://github.com/xtekky/gpt4free)) | Community-driven project that aggregates multiple providers and interfaces for LLMs and media-generation models. | @xtekky, @hlohaus |
 | tgpt ([⭐ 2.9k](https://github.com/aandrew-me/tgpt)) | ChatGPT in terminal without requiring API keys. Uses Pollinations API endpoints... | @aandrew-me |
 | 🛠️ AI Content Describer ([⭐ 59](https://github.com/cartertemm/AI-content-describer/)) | An extension for NVDA, the free and open-source screen reader for Microsoft... | @cartertemm |
 | 💻️ Windows Walker ([⭐ 14](https://github.com/SuperShivam5000/windows-walker)) | Windows Walker – What Copilot for Windows should have been. AI-powered Windows... | @supershivam |
@@ -441,18 +436,14 @@ Pollinations.AI is used in various projects, including:
 | MultiAgent 🤖 ([⭐ 0](https://github.com/LKosoj/multiagent)) | Advanced multi-agent system for solving complex tasks using specialized AI... | @LKosoj |
 | 🖥️ [Pollinations MCP Server (Official)](https://www.npmjs.com/package/@pollinations/model-context-protocol) ([⭐ 0](https://github.com/pollinations/pollinations/tree/main/model-context-protocol)) | Official Model Context Protocol server for Pollinations AI services. Generate... | @pollinations |
 | [FoodAnaly](https://foodanaly.vercel.app/) | An AI application for food analysis that uses advanced artificial intelligence... | [liukang0120@...](mailto:liukang0120@163.com) |
-| [Herramientas IA](https://herramientas.ia) | Tools designed with Pollinations.AI and the DescartesJS editor, including tools... | @herramientas |
 | [Pollinations AI Free API](https://pollinations-ai-free-api.vercel.app/) | This project provides a free API interface supporting various text and image... | @freeapi |
-| [DominiSigns](https://www.template.net/ai-sign-generator) ([⭐ 0](https://github.com/dominicva/dominisigns)) | A WordPress block plugin that lets users create AI-generated images through the... | @dominicva |
 | 🤖 [DynaSpark API](https://th3-ai.github.io/DynaSpark) ([⭐ 0](https://github.com/Th3-AI/DynaSpark)) | The DynaSpark API provides simple yet powerful AI capabilities for text... | @Th3-C0der |
 | [Querynator5000](https://querynator5000.onrender.com/) ([⭐ 0](https://github.com/SuperShivam5000/querynator5000)) | Modern AI-first SQL interface for exploring and manipulating databases with... | @SuperShivam5000 |
 | [UltimaX Intelligence CLI](https://huggingface.co/spaces/umint/cli) | Extension of the UltimaX Intelligence project based on Pollinations Python SDK. | @hadadarjt |
 | [AI Agent Portal](https://agent.makululinux.com/) ([⭐ 0](https://github.com/raymerjacque/Makulu-Agent-Portal)) | A next-generation development environment that leverages a sophisticated... | @raymerjacque |
 | 🆕 PDF-to-Speech 🔊 ([⭐ 0](https://github.com/Ak-Yadav/pdf_to_speech)) | Convert any PDF document into natural-sounding audio using Pollinations AI TTS.... | @Ak-Yadav |
 | [pollinations.ai Python SDK](https://github.com/pollinations-ai/pollinations.ai) | Official Python SDK for working with Pollinations' models. | @pollinations-ai |
-| [Pollinations - Python & JavaScript SDK](https://github.com/gpt4free/pollinations) | Python & JavaScript SDK for Pollinations AI — OpenAI-compatible API. | @gpt4free |
 | MCPollinations (Community) ([⭐ 32](https://github.com/pinkpixel-dev/MCPollinations)) | Community-maintained Model Context Protocol server with advanced features like... | @pinkpixel-dev |
-| Herramientas IA ([⭐ 26](https://github.com/cusanotech/90-herramientas-de-inteligencia-artificial)) | Tools designed with Pollinations.AI and the DescartesJS editor, including tools... | @juanrivera126 |
 | [pollinations_ai](https://pub.dev/packages/pollinations_ai) | Dart/Flutter package for Pollinations API. | @Meenapintu |
 | pollinations NPM Module | JavaScript/Node.js SDK for Pollinations API. | - |
 | [pypollinations](https://pypi.org/project/pypollinations/) | Comprehensive Python wrapper for Pollinations AI API. | @KTS-o7 |
@@ -465,7 +456,7 @@ Pollinations.AI is used in various projects, including:
 
 | Project | Description | Creator |
 |---------|-------------|--------|
-| [G4F Chat UI](http://g4f.dev/chat/pollinations) ([⭐ 93](https://github.com/gpt4free/g4f.dev)) | G4F Chat UI for Pollinations with Image & Video Generation capability | @hlohaus |
+| [G4F Chat UI](http://g4f.dev/chat/pollinations) ([⭐ 65.1k](https://github.com/gpt4free/g4f.dev)) | The official G4F Chat UI for Pollinations with Image & Video Generation... | @hlohaus |
 | [LobeChat](https://lobechat.com) ([⭐ 21.0k](https://github.com/lobehub/lobe-chat)) | An open-source, extensible chat UI framework supporting multiple models and... | @lobehub |
 | [SillyTavern](https://docs.sillytavern.app/) ([⭐ 14.7k](https://github.com/SillyTavern/SillyTavern)) | An LLM frontend for power users. Pollinations permits it to generate text and... | - |
 | 🖥️ [LLMS](https://yassineabou.github.io/LLMs-Wasm/) ([⭐ 88](https://github.com/yassineAbou/LLMS)) | LLMS is a Kotlin Multiplatform application that brings the power of AI to... | @yassineAbou |
@@ -510,8 +501,8 @@ Pollinations.AI is used in various projects, including:
 | 🆕 [PolliPalmTop 📱](https://aiworld.institute/server/pollipalmtopv1.apk) | Android app dedicated to Pollinations with AI chat, web search, and image... | @BiG L |
 | 🆕 [Xibe-chat-cli 💬](https://pypi.org/project/xibe-chat-cli/) ([⭐ 0](https://github.com/iotserver24/xibe-chat-cli)) | AI chat and image generation directly in your terminal with a rich text UI.... | @R3AP3Redit |
 | 🆕 [Fikiri Chat AI 💬](https://fikirichat.netlify.app/) | Multi-model AI chat platform with seamless LLM switching via Pollinations API.... | @brianmativo |
-| 🆕 [PollinationsFreeAI 🆓](https://pollinations-free-ai.vercel.app/) ([⭐ 0](https://github.com/Poli-Chat/PollinationsFreeAI)) | Free AI platform leveraging Pollinations for text and image generation. No... | @Poli-Chat |
-| 🆕 [Samaritan AI 🤖](https://samaritan-ai-web.vercel.app/) | Intelligent AI assistant platform powered by Pollinations. Offers a polished UI... | @mdarman4002 |
+| [PollinationsFreeAI 🆓](https://pollinations-free-ai.vercel.app/) ([⭐ 0](https://github.com/Poli-Chat/PollinationsFreeAI)) | Free AI platform leveraging Pollinations for text and image generation. No... | @Poli-Chat |
+| [Samaritan AI 🤖](https://samaritan-ai-web.vercel.app/) | Intelligent AI assistant platform powered by Pollinations. Offers a polished UI... | @mdarman4002 |
 | 🇮🇩 [ReThink AI 🇮🇩](https://rethink.web.id) | High-performance AI platform tailored for Indonesia, blending a custom-trained... | @Djongoks |
 | 🆕 [Noir Ink Tattoo Studio 🎨](https://noir-ink.netlify.app/) ([⭐ 0](https://github.com/Jairedddy/Noir-Ink-Tattoo-Studio)) | A monochrome tattoo studio featuring AI-powered design generation, booking... | @Jairedddy |
 | [Artificial Intelligence Orcho 📱](https://play.google.com/store/apps/details?id=orcho.artificialintelligence) | Mobile AI app for Android with chat and image generation. Get smart chat... | @ricardoxd |
@@ -548,8 +539,6 @@ Pollinations.AI is used in various projects, including:
 | 🤖 [ioswbot 🤖](https://t.me/ioswbot) | Free, unlimited Telegram bot with ChatGPT 5, Gemini 2.5 Flash Lite Search, GPT... | @swtomas |
 | 🤖 [Telegram AI Chars 🤖](https://t.me/MFRG_Shapes) | Plataforma en PHP para la creación de personajes (bots) con personalidad,... | @MarcosFRG |
 | 🤖 [Swapna Shastra Dream Decoder 💤✨](https://t.me/Swapnashastra_dream_bot) | AI-powered Telegram bot that interprets dreams using ancient Indian Swapna... | @ShashankNagaraj |
-| 🆕 [TeleChars AI](https://extras.marcosfrg.x10.mx) | Ya había enviado este proyecto antes, pero ahora lo hago por... | marcosfrgames08 |
-| 🆕 🤖 [TeleChars AI](https://extras.marcosfrg.x10.mx) | TeleChars AI is a platform for AI-powered Telegram character creation. It... | marcosfrgames08 |
 
 ### Learn 📚
 

--- a/pollinations.ai/src/config/projects/creative.js
+++ b/pollinations.ai/src/config/projects/creative.js
@@ -429,15 +429,6 @@ export const creativeProjects = [
         order: 1,
     },
     {
-        name: "Dreamator-AI 🎨",
-        url: "https://dreamator-ai.vercel.app/",
-        description:
-            "Transform your imagination into reality using Pollinations API. A creative image generation platform with a personal gallery of generated masterpieces.",
-        author: "@its3li",
-        submissionDate: "2025-06-27",
-        order: 1,
-    },
-    {
         name: "Celebrity AI Image Generator",
         url: "https://www.aicelebrity.design/",
         description:
@@ -815,17 +806,6 @@ export const creativeProjects = [
             "Uses Flux (through pollinations) and potrace to create B&W Vector files",
         author: "@pointsguy118",
         submissionDate: "2025-04-15",
-        order: 1,
-    },
-    {
-        name: "Imagen",
-        url: "https://altkriz.github.io/imagen/",
-        description:
-            'A beautiful web interface for generating images using Pollinations.ai API with only the "flux" and "turbo" models.',
-        author: "@altkriz",
-        repo: "https://github.com/altkriz/imagen",
-        stars: 3,
-        submissionDate: "2025-04-13",
         order: 1,
     },
     {

--- a/pollinations.ai/src/config/projects/hackAndBuild.js
+++ b/pollinations.ai/src/config/projects/hackAndBuild.js
@@ -149,17 +149,6 @@ export const hackAndBuildProjects = [
         stars: 43,
     },
     {
-        name: "Herramientas IA",
-        url: "https://github.com/cusanotech/90-herramientas-de-inteligencia-artificial",
-        description:
-            "Tools designed with Pollinations.AI and the DescartesJS editor, including tools from other Pollinations.AI community members.",
-        author: "@juanrivera126",
-        repo: "https://github.com/cusanotech/90-herramientas-de-inteligencia-artificial",
-        submissionDate: "2025-03-10",
-        order: 3,
-        stars: 26,
-    },
-    {
         name: "🌱 Strain Navigator",
         url: "https://www.strainnavigator.com/",
         description:
@@ -232,15 +221,6 @@ export const hackAndBuildProjects = [
         order: 1,
     },
     {
-        name: "Herramientas IA",
-        url: "https://herramientas.ia",
-        description:
-            "Tools designed with Pollinations.AI and the DescartesJS editor, including tools from other Pollinations.AI community members.",
-        author: "@herramientas",
-        submissionDate: "2025-05-05",
-        order: 1,
-    },
-    {
         name: "Pollinations AI Free API",
         url: "https://pollinations-ai-free-api.vercel.app/",
         description:
@@ -301,16 +281,6 @@ export const hackAndBuildProjects = [
         repo: "https://github.com/aandrew-me/tgpt",
         stars: 2854,
         submissionDate: "2025-05-15",
-        order: 1,
-    },
-    {
-        name: "DominiSigns",
-        url: "https://www.template.net/ai-sign-generator",
-        description:
-            "A WordPress block plugin that lets users create AI-generated images through the block editor. Integrates with Pollinations API to generate images from text prompts directly within WordPress.",
-        author: "@dominicva",
-        repo: "https://github.com/dominicva/dominisigns",
-        submissionDate: "2025-05-22",
         order: 1,
     },
     {

--- a/pollinations.ai/src/config/projects/socialBots.js
+++ b/pollinations.ai/src/config/projects/socialBots.js
@@ -4,131 +4,120 @@
  */
 
 export const socialBotsProjects = [
-  {
-    name: "TeleChars AI 🤖 🇪🇸",
-    url: "https://extras.marcosfrg.x10.mx/TGChars",
-    description: "Plataforma de creación de personajes con IA para Telegram. Soporta STM, LTM, y permite añadir conocimiento ilimitado a tus personajes. Los bots pueden recibir imágenes, stickers y audios. (AI character creation platform for Telegram with short-term and long-term memory.)",
-    author: "@MarcosFRG",
-    submissionDate: "2025-11-27",
-    language: "es",
-    order: 1
-  },
-  {
-    name: "ExodusAI 🤖",
-    url: "https://api.whatsapp.com/send/?phone=6285150984232&text=Hi&type=phone_number&app_absent=0",
-    description: "AI-powered chatbot and image generator platform on WhatsApp. Integrated with Pollinations API for AI image generation from text prompts. Features document editing, document creation, and visual analysis. Built using Baileys for WhatsApp integration and Node.js. Currently serves over 500 users.",
-    author: "@FIkriBotDev",
-    submissionDate: "2025-08-08",
-    order: 1
-  },
-  {
-    name: "🎮 Gacha",
-    url: "https://discord.com/oauth2/authorize?client_id=1377330983740903586",
-    description: "Your Sassy All-in-One AI Discord Bot. A powerful, sassy, and slightly mischievous AI bot designed to level up your Discord server with intelligent conversations, creative tools, and smart automation — all wrapped in a playful personality. Features AI-powered chat with STM and LTM, image generation & editing, image fusion & GIF handling, real-time web search, voice replies, media intelligence, slash commands, and dynamic intent detection.",
-    author: "`_dr_misterio_`",
-    submissionDate: "2025-02-24",
-    order: 1,
-    category: "socialBots",
-    originalPath: "pollinations.ai/src/config/projectList.js",
-    discoveredCommit: "15ec92f2",
-    discoveredDate: "2025-06-04T09:29:31.740Z"
-  },
-  {
-    name: "Pollix AI",
-    url: "http://t.me/pollixrobot",
-    description: "Pollix AI is your multilingual AI assistant for fast replies, image understanding, and clean answers.",
-    author: "@bladedev",
-    submissionDate: "2025-08-14",
-    order: 1
-  },
-  {
-    name: "Aura Chat Bot",
-    description: "A chat bot integrating Pollinations API for text and image generation.",
-    author: "@Py-Phoenix-PJS",
-    submissionDate: "2025-05-12",
-    order: 1
-  },
-  {
-    name: "🤖 ImageEditer",
-    url: "https://t.me/ImageEditer_bot",
-    description: "AI Art Studio - A feature-rich Telegram bot that creates art from text prompts, remixes images, merges multiple artworks, and offers one-tap regeneration with real-time control. Supports multiple AI models (GPT Image, Flux, Turbo) with NSFW detection and smart layout features.",
-    author: "@_dr_misterio_",
-    submissionDate: "2025-06-02",
-    order: 1
-  },
-  {
-    name: "Pollinations Discord Bot",
-    url: "https://github.com/Zingzy/pollinations.ai-bot",
-    description: "AI Image Generation Discord Bot using Pollinations.ai. Written in Python with discord.py, used in 500+ servers. Features /pollinate command for AI images with prompt enhancement, width/height options, /multi-pollinate for 4 variations, and /random for random AI images.",
-    author: "@zingy",
-    repo: "https://github.com/Zingzy/pollinations.ai-bot",
-    submissionDate: "2025-03-20",
-    order: 1,
-    stars: 17
-  },
-  {
-    name: "Pollinations WhatsApp Group",
-    url: "https://chat.whatsapp.com/pollinations-ai",
-    description: "A WhatsApp group bot that allows members to generate AI content through simple commands, making Pollinations accessible on mobile messaging.",
-    author: "@whatsapp_ai_dev",
-    submissionDate: "2025-05-01",
-    order: 2
-  },
-  {
-    name: "GPT_Project",
-    url: "https://t.me/gpt_project_official_bot",
-    description: "GPT_Project Telegram AI Chatbot - A professional productivity tool that's always in your pocket. Utilizes Pollinations API for image generation (including Flux model) and text models (GPT-4.1, GPT-4.1-nano, SearchGPT). Features advanced language model interaction, versatile image generation, AI-powered image analysis, voice message recognition, text-to-speech, and a referral system. Designed for studying, work, and everyday AI assistance.",
-    author: "@lordon4x",
-    submissionDate: "2024-12-18",
-    order: 1
-  },
-  {
-    name: "ioswbot 🤖",
-    url: "https://t.me/ioswbot",
-    description: "Free, unlimited Telegram bot with ChatGPT 5, Gemini 2.5 Flash Lite Search, GPT Audio, and image editor/generator. Bot supports text, photo, and audio files. Localization in Russian and English.",
-    author: "@swtomas",
-    submissionDate: "2025-10-21",
-    order: 2,
-    language: "ru"
-  },
-  {
-    name: "Telegram AI Chars 🤖",
-    url: "https://t.me/MFRG_Shapes",
-    description: "Plataforma en PHP para la creación de personajes (bots) con personalidad, memoria e historial para Telegram, al estilo de Char.AI o Shapes, Inc. Permite que los usuarios interactúen con bots inteligentes y gestionar su historial y conocimientos a través de una futura API. Actualmente incluye bots como MetraxAI.",
-    author: "@MarcosFRG",
-    submissionDate: "2025-10-21",
-    order: 2,
-    language: "es"
-  },
     {
-    "name": "Swapna Shastra Dream Decoder 💤✨",
-    "url": "https://t.me/Swapnashastra_dream_bot",
-    "description": "AI-powered Telegram bot that interprets dreams using ancient Indian Swapna Shastra and mythology. Generates spiritual interpretations and visualizes them as mystical dream cards via Pollinations AI, perfect for sharing on WhatsApp and Instagram.",
-    "author": "@ShashankNagaraj",
-    "submissionDate": "2025-10-21",
-    "order": 4
-},
-  {
-    "name": "TeleChars AI",
-    "url": "https://extras.marcosfrg.x10.mx",
-    "description": "Ya había enviado este proyecto antes, pero ahora lo hago por enter.pollinations.ai\n\nMi proyecto es una plataforma de creación de personajes con IA para Telegram, la cual te permite:\n* Darle una personalidad única a tus personaje\n* Ajustar sus parámetros de generación\n* Añadirle conocimiento y ejemplos de conversación ilimitados\n* Tienen STM y LTM para seguir la conversación sin olvidar cosas importantes, para más naturalidad\n\n**Próximamente:**\n* Habrán más idiomas\n* Se le podrán añadir comandos que le manden una solicitud a un script en tu propio servidor y mandar la respuesta a Telegram",
-    "author": "marcosfrgames08",
-    "repo": null,
-    "category": "socialBots",
-    "language": "es",
-    "submissionDate": "2025-12-04",
-    "order": 5
-  },
-  {
-    "name": "TeleChars AI",
-    "url": "https://extras.marcosfrg.x10.mx",
-    "description": "TeleChars AI is a platform for AI-powered Telegram character creation. It allows giving unique personalities to characters, adjusting generation parameters, and adding unlimited knowledge and conversation examples. Characters use STM and LTM to maintain context for more natural conversations. TeleChars bots can view stickers, generate images, and play audio. Upcoming features include more languages and commands to trigger scripts on your own server and send the response back to Telegram.",
-    "author": "marcosfrgames08",
-    "category": "socialBots",
-    "language": "es",
-    "submissionDate": "2025-12-04",
-    "order": 5
-  }
-
-
+        name: "TeleChars AI 🤖 🇪🇸",
+        url: "https://extras.marcosfrg.x10.mx/TGChars",
+        description:
+            "Plataforma de creación de personajes con IA para Telegram. Soporta STM, LTM, y permite añadir conocimiento ilimitado a tus personajes. Los bots pueden recibir imágenes, stickers y audios. (AI character creation platform for Telegram with short-term and long-term memory.)",
+        author: "@MarcosFRG",
+        submissionDate: "2025-11-27",
+        language: "es",
+        order: 1,
+    },
+    {
+        name: "ExodusAI 🤖",
+        url: "https://api.whatsapp.com/send/?phone=6285150984232&text=Hi&type=phone_number&app_absent=0",
+        description:
+            "AI-powered chatbot and image generator platform on WhatsApp. Integrated with Pollinations API for AI image generation from text prompts. Features document editing, document creation, and visual analysis. Built using Baileys for WhatsApp integration and Node.js. Currently serves over 500 users.",
+        author: "@FIkriBotDev",
+        submissionDate: "2025-08-08",
+        order: 1,
+    },
+    {
+        name: "🎮 Gacha",
+        url: "https://discord.com/oauth2/authorize?client_id=1377330983740903586",
+        description:
+            "Your Sassy All-in-One AI Discord Bot. A powerful, sassy, and slightly mischievous AI bot designed to level up your Discord server with intelligent conversations, creative tools, and smart automation — all wrapped in a playful personality. Features AI-powered chat with STM and LTM, image generation & editing, image fusion & GIF handling, real-time web search, voice replies, media intelligence, slash commands, and dynamic intent detection.",
+        author: "`_dr_misterio_`",
+        submissionDate: "2025-02-24",
+        order: 1,
+        category: "socialBots",
+        originalPath: "pollinations.ai/src/config/projectList.js",
+        discoveredCommit: "15ec92f2",
+        discoveredDate: "2025-06-04T09:29:31.740Z",
+    },
+    {
+        name: "Pollix AI",
+        url: "http://t.me/pollixrobot",
+        description:
+            "Pollix AI is your multilingual AI assistant for fast replies, image understanding, and clean answers.",
+        author: "@bladedev",
+        submissionDate: "2025-08-14",
+        order: 1,
+    },
+    {
+        name: "Aura Chat Bot",
+        description:
+            "A chat bot integrating Pollinations API for text and image generation.",
+        author: "@Py-Phoenix-PJS",
+        submissionDate: "2025-05-12",
+        order: 1,
+    },
+    {
+        name: "🤖 ImageEditer",
+        url: "https://t.me/ImageEditer_bot",
+        description:
+            "AI Art Studio - A feature-rich Telegram bot that creates art from text prompts, remixes images, merges multiple artworks, and offers one-tap regeneration with real-time control. Supports multiple AI models (GPT Image, Flux, Turbo) with NSFW detection and smart layout features.",
+        author: "@_dr_misterio_",
+        submissionDate: "2025-06-02",
+        order: 1,
+    },
+    {
+        name: "Pollinations Discord Bot",
+        url: "https://github.com/Zingzy/pollinations.ai-bot",
+        description:
+            "AI Image Generation Discord Bot using Pollinations.ai. Written in Python with discord.py, used in 500+ servers. Features /pollinate command for AI images with prompt enhancement, width/height options, /multi-pollinate for 4 variations, and /random for random AI images.",
+        author: "@zingy",
+        repo: "https://github.com/Zingzy/pollinations.ai-bot",
+        submissionDate: "2025-03-20",
+        order: 1,
+        stars: 17,
+    },
+    {
+        name: "Pollinations WhatsApp Group",
+        url: "https://chat.whatsapp.com/pollinations-ai",
+        description:
+            "A WhatsApp group bot that allows members to generate AI content through simple commands, making Pollinations accessible on mobile messaging.",
+        author: "@whatsapp_ai_dev",
+        submissionDate: "2025-05-01",
+        order: 2,
+    },
+    {
+        name: "GPT_Project",
+        url: "https://t.me/gpt_project_official_bot",
+        description:
+            "GPT_Project Telegram AI Chatbot - A professional productivity tool that's always in your pocket. Utilizes Pollinations API for image generation (including Flux model) and text models (GPT-4.1, GPT-4.1-nano, SearchGPT). Features advanced language model interaction, versatile image generation, AI-powered image analysis, voice message recognition, text-to-speech, and a referral system. Designed for studying, work, and everyday AI assistance.",
+        author: "@lordon4x",
+        submissionDate: "2024-12-18",
+        order: 1,
+    },
+    {
+        name: "ioswbot 🤖",
+        url: "https://t.me/ioswbot",
+        description:
+            "Free, unlimited Telegram bot with ChatGPT 5, Gemini 2.5 Flash Lite Search, GPT Audio, and image editor/generator. Bot supports text, photo, and audio files. Localization in Russian and English.",
+        author: "@swtomas",
+        submissionDate: "2025-10-21",
+        order: 2,
+        language: "ru",
+    },
+    {
+        name: "Telegram AI Chars 🤖",
+        url: "https://t.me/MFRG_Shapes",
+        description:
+            "Plataforma en PHP para la creación de personajes (bots) con personalidad, memoria e historial para Telegram, al estilo de Char.AI o Shapes, Inc. Permite que los usuarios interactúen con bots inteligentes y gestionar su historial y conocimientos a través de una futura API. Actualmente incluye bots como MetraxAI.",
+        author: "@MarcosFRG",
+        submissionDate: "2025-10-21",
+        order: 2,
+        language: "es",
+    },
+    {
+        "name": "Swapna Shastra Dream Decoder 💤✨",
+        "url": "https://t.me/Swapnashastra_dream_bot",
+        "description":
+            "AI-powered Telegram bot that interprets dreams using ancient Indian Swapna Shastra and mythology. Generates spiritual interpretations and visualizes them as mystical dream cards via Pollinations AI, perfect for sharing on WhatsApp and Instagram.",
+        "author": "@ShashankNagaraj",
+        "submissionDate": "2025-10-21",
+        "order": 4,
+    },
 ];

--- a/pollinations.ai/src/config/projects/vibeCoding.js
+++ b/pollinations.ai/src/config/projects/vibeCoding.js
@@ -4,166 +4,164 @@
  */
 
 export const vibeCodingProjects = [
-  {
-    name: "BeeCoder",
-    url: "https://github.com/cemalgnlts/beecoder",
-    description: "Enables VS Code Copilot to connect to Pollinations.",
-    author: "@cemalgnlts",
-    submissionDate: "2025-10-19"
-  },
-  {
-    name: "EasyGen - AI Diagram Generator ✨",
-    url: "https://easygenme.netlify.app/",
-    description: "Modern open-source web application that transforms text descriptions into professional diagrams using AI. Built with React, TypeScript, and Mermaid.js. Features real-time preview, multiple export formats (SVG, PNG, PDF), shareable links, intuitive split-panel editor, and support for various diagram types including flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, timelines, and Gantt charts.",
-    author: "@ellweb3",
-    submissionDate: "2025-08-11",
-    order: 1
-  },
-  {
-    name: "Visiora - Image Generation using AI 🎨",
-    url: "https://visiora-img.netlify.app/",
-    description: "A modern web application that transforms text prompts into stunning AI-generated images. Built with React and powered by Pollinations AI, it features multiple AI models (Flux, Turbo, Kontext), flexible image dimensions, seed control for reproducible results, and a responsive design that works seamlessly across all devices.",
-    author: "@Kandariarjun07",
-    repo: "https://github.com/Kandariarjun07/Visiora",
-    stars: 0,
-    submissionDate: "2025-08-05",
-    order: 1
-  },
-  {
-    name: "PairFusion",
-    url: "https://pair-fusion.vercel.app/",
-    description: "A real-time AI powered, scalable and feature-rich collaborative IDE built for modern development teams. Experience seamless pair programming, instant feedback, and a professional-grade toolset designed for maximum productivity.",
-    author: "@auraticabhi",
-    repo: "https://github.com/auraticabhi/PairFusion",
-    stars: 0,
-    submissionDate: "2025-07-03",
-    order: 1
-  },
-  {
-    name: "CraftUI",
-    url: "https://craftui.studio/",
-    description: "An AI-powered tool that simplifies UI design by turning text prompts or images into clean, production-ready components. It supports real-time customization with theme switching, framework selection (like Tailwind or Bootstrap), and intuitive editing. Whether you're a developer or designer, CraftUI helps you design faster, smarter, and with ease. Explore, remix, and share your creations in a growing creative community.",
-    author: "@imhardikdesai",
-    submissionDate: "2025-06-19",
-    order: 1
-  },
-  {
-    name: "AI Code Generator",
-    url: "https://codegen.on.websim.com/",
-    description: "A websim project that generates code from description, selected programming language and other options. Integrates Pollinations because it allows for more models to choose from for potentially better results. It has modes like: Code Generator, Code Explainer, Reviewer, etc.",
-    author: "@Miencraft2",
-    submissionDate: "2025-05-25",
-    order: 1
-  },
-  {
-    name: "VibeCoder",
-    description: "A conversational coding environment that lets you create applications by describing them in natural language.",
-    author: "@Aashir__Shaikh",
-    authorUrl: "https://x.com/Aashir__Shaikh",
-    submissionDate: "2025-03-25",
-    order: 1
-  },
-  {
-    name: "Pollinations Task Master",
-    url: "https://github.com/LousyBook94/pollinations-task-master",
-    description: "A task management system that uses AI to help break down and organize development tasks through natural language interaction.",
-    author: "@LousyBook94",
-    repo: "https://github.com/LousyBook94/pollinations-task-master",
-    submissionDate: "2025-05-12",
-    stars: 20,
-    order: 1
-  },
-  {
-    name: "Qwen-Agent",
-    url: "https://github.com/QwenLM/Qwen-Agent",
-    description: "A framework for developing agentic LLM applications.",
-    repo: "https://github.com/QwenLM/Qwen-Agent",
-    stars: 11523,
-    order: 1
-  },
-  {
-    name: "JCode Website Builder",
-    url: "https://jcode-ai-website-bulder.netlify.app/",
-    description: "A website generator using Pollinations text API.",
-    author: "@rtxpower",
-    order: 1
-  },
-  {
-    name: "Pollinations.DIY",
-    url: "https://pollinations.diy",
-    description: "A browser-based coding environment based on bolt.diy, featuring integrated Pollinations AI services, visual code editing, and project management tools.",
-    author: "@voodoohop",
-    submissionDate: "2025-03-01",
-    order: 1
-  },
-  {
-    name: "Websim",
-    url: "https://websim.ai/c/bXsmNE96e3op5rtUS",
-    description: "A web simulation tool that integrates Pollinations.ai.",
-    author: "@voodoohop",
-    order: 2
-  },
-  {
-    name: "NetSim",
-    url: "https://netsim.us.to/",
-    description: "websim.ai clone that's actually good",
-    author: "@kennet678",
-    submissionDate: "2025-04-15",
-    order: 1
-  },
-  {
-    name: "Pollin-Coder",
-    url: "https://pollin-coder.megavault.in",
-    description: "A free AI-powered website builder that lets anyone create a clean site just by describing it. It uses Pollinations AI to generate the content and layout instantly.",
-    author: "@r3ap3redit",
-    submissionDate: "2025-05-19",
-    order: 1
-  },
-  {
-    name: "JustBuildThings",
-    url: "https://justbuildthings.com",
-    description: "A natural language programming interface that lets users create web applications by simply describing what they want to build, using Pollinations AI to generate code and assets.",
-    author: "@buildmaster",
-    submissionDate: "2025-05-02",
-    order: 1
-  },
-  {
-    name: "SocialScribe",
-    url: "https://socialscribe.pages.dev/",
-    description: "An AI-powered Chrome extension that fixes grammar, rewrites text, and enhances your writing across websites like Twitter, LinkedIn, and Gmail, with customizable tone, length, and platform-specific formatting, plus support for emojis, hashtags, and keyword suggestions.",
-    author: "@sh20raj",
-    repo: "https://github.com/sh20raj/socialscribe",
-    stars: 1,
-    submissionDate: "2025-07-13",
-    order: 1
-  },
-  {
-    name: "Berrry Computer",
-    url: "https://berrry.app",
-    description: "Make tiny self-contained web apps with AI. Find a tweet with an interesting app idea, mention @BerrryComputer in a reply, and get back an app on a unique subdomain. Uses pollinations.ai to create dynamic AI experiences in generated apps.",
-    author: "@vgrichina",
-    authorUrl: "https://github.com/vgrichina",
-    repo: "https://github.com/Strawberry-Computer",
-    submissionDate: "2025-07-16",
-    order: 0
-  },
-  {
-    name: "websim-pollinations-ai",
-    url: "https://websim.pollinations.ai",
-    description: "A lightweight websim for creating web simulations with AI. Usage: https://websim.pollinations.ai/[prompt] - Simply append your prompt to the URL to generate interactive web experiences.",
-    author: "@voodoohop",
-    repo: "https://github.com/pollinations/pollinations/tree/main/websim.pollinations.ai",
-    submissionDate: "2025-08-03",
-    order: 0.5
-  },
-  {
-    "name": "Aqua Application Programming Interface",
-    "url": "https://aquadevs.com/",
-    "description": "This is an learning project for me to learn how to track users, backend check, and more about building an api.\\nWe have a landing page and documentation soon.",
-    "author": "kiskreforev",
-    "category": "vibeCoding",
-    "language": "EN",
-    "submissionDate": "2025-12-03",
-    "order": 5
-  }
+    {
+        name: "Visiora - Image Generation using AI 🎨",
+        url: "https://visiora-img.netlify.app/",
+        description:
+            "A modern web application that transforms text prompts into stunning AI-generated images. Built with React and powered by Pollinations AI, it features multiple AI models (Flux, Turbo, Kontext), flexible image dimensions, seed control for reproducible results, and a responsive design that works seamlessly across all devices.",
+        author: "@Kandariarjun07",
+        repo: "https://github.com/Kandariarjun07/Visiora",
+        stars: 0,
+        submissionDate: "2025-08-05",
+        order: 1,
+    },
+    {
+        name: "PairFusion",
+        url: "https://pair-fusion.vercel.app/",
+        description:
+            "A real-time AI powered, scalable and feature-rich collaborative IDE built for modern development teams. Experience seamless pair programming, instant feedback, and a professional-grade toolset designed for maximum productivity.",
+        author: "@auraticabhi",
+        repo: "https://github.com/auraticabhi/PairFusion",
+        stars: 0,
+        submissionDate: "2025-07-03",
+        order: 1,
+    },
+    {
+        name: "CraftUI",
+        url: "https://craftui.studio/",
+        description:
+            "An AI-powered tool that simplifies UI design by turning text prompts or images into clean, production-ready components. It supports real-time customization with theme switching, framework selection (like Tailwind or Bootstrap), and intuitive editing. Whether you're a developer or designer, CraftUI helps you design faster, smarter, and with ease. Explore, remix, and share your creations in a growing creative community.",
+        author: "@imhardikdesai",
+        submissionDate: "2025-06-19",
+        order: 1,
+    },
+    {
+        name: "AI Code Generator",
+        url: "https://codegen.on.websim.com/",
+        description:
+            "A websim project that generates code from description, selected programming language and other options. Integrates Pollinations because it allows for more models to choose from for potentially better results. It has modes like: Code Generator, Code Explainer, Reviewer, etc.",
+        author: "@Miencraft2",
+        submissionDate: "2025-05-25",
+        order: 1,
+    },
+    {
+        name: "VibeCoder",
+        description:
+            "A conversational coding environment that lets you create applications by describing them in natural language.",
+        author: "@Aashir__Shaikh",
+        authorUrl: "https://x.com/Aashir__Shaikh",
+        submissionDate: "2025-03-25",
+        order: 1,
+    },
+    {
+        name: "Pollinations Task Master",
+        url: "https://github.com/LousyBook94/pollinations-task-master",
+        description:
+            "A task management system that uses AI to help break down and organize development tasks through natural language interaction.",
+        author: "@LousyBook94",
+        repo: "https://github.com/LousyBook94/pollinations-task-master",
+        submissionDate: "2025-05-12",
+        stars: 20,
+        order: 1,
+    },
+    {
+        name: "Qwen-Agent",
+        url: "https://github.com/QwenLM/Qwen-Agent",
+        description: "A framework for developing agentic LLM applications.",
+        repo: "https://github.com/QwenLM/Qwen-Agent",
+        stars: 11523,
+        order: 1,
+    },
+    {
+        name: "JCode Website Builder",
+        url: "https://jcode-ai-website-bulder.netlify.app/",
+        description: "A website generator using Pollinations text API.",
+        author: "@rtxpower",
+        order: 1,
+    },
+    {
+        name: "Pollinations.DIY",
+        url: "https://pollinations.diy",
+        description:
+            "A browser-based coding environment based on bolt.diy, featuring integrated Pollinations AI services, visual code editing, and project management tools.",
+        author: "@voodoohop",
+        submissionDate: "2025-03-01",
+        order: 1,
+    },
+    {
+        name: "Websim",
+        url: "https://websim.ai/c/bXsmNE96e3op5rtUS",
+        description: "A web simulation tool that integrates Pollinations.ai.",
+        author: "@voodoohop",
+        order: 2,
+    },
+    {
+        name: "NetSim",
+        url: "https://netsim.us.to/",
+        description: "websim.ai clone that's actually good",
+        author: "@kennet678",
+        submissionDate: "2025-04-15",
+        order: 1,
+    },
+    {
+        name: "Pollin-Coder",
+        url: "https://pollin-coder.megavault.in",
+        description:
+            "A free AI-powered website builder that lets anyone create a clean site just by describing it. It uses Pollinations AI to generate the content and layout instantly.",
+        author: "@r3ap3redit",
+        submissionDate: "2025-05-19",
+        order: 1,
+    },
+    {
+        name: "JustBuildThings",
+        url: "https://justbuildthings.com",
+        description:
+            "A natural language programming interface that lets users create web applications by simply describing what they want to build, using Pollinations AI to generate code and assets.",
+        author: "@buildmaster",
+        submissionDate: "2025-05-02",
+        order: 1,
+    },
+    {
+        name: "SocialScribe",
+        url: "https://socialscribe.pages.dev/",
+        description:
+            "An AI-powered Chrome extension that fixes grammar, rewrites text, and enhances your writing across websites like Twitter, LinkedIn, and Gmail, with customizable tone, length, and platform-specific formatting, plus support for emojis, hashtags, and keyword suggestions.",
+        author: "@sh20raj",
+        repo: "https://github.com/sh20raj/socialscribe",
+        stars: 1,
+        submissionDate: "2025-07-13",
+        order: 1,
+    },
+    {
+        name: "Berrry Computer",
+        url: "https://berrry.app",
+        description:
+            "Make tiny self-contained web apps with AI. Find a tweet with an interesting app idea, mention @BerrryComputer in a reply, and get back an app on a unique subdomain. Uses pollinations.ai to create dynamic AI experiences in generated apps.",
+        author: "@vgrichina",
+        authorUrl: "https://github.com/vgrichina",
+        repo: "https://github.com/Strawberry-Computer",
+        submissionDate: "2025-07-16",
+        order: 0,
+    },
+    {
+        name: "websim-pollinations-ai",
+        url: "https://websim.pollinations.ai",
+        description:
+            "A lightweight websim for creating web simulations with AI. Usage: https://websim.pollinations.ai/[prompt] - Simply append your prompt to the URL to generate interactive web experiences.",
+        author: "@voodoohop",
+        repo: "https://github.com/pollinations/pollinations/tree/main/websim.pollinations.ai",
+        submissionDate: "2025-08-03",
+        order: 0.5,
+    },
+    {
+        "name": "Aqua Application Programming Interface",
+        "url": "https://aquadevs.com/",
+        "description":
+            "This is an learning project for me to learn how to track users, backend check, and more about building an api.\\nWe have a landing page and documentation soon.",
+        "author": "kiskreforev",
+        "category": "vibeCoding",
+        "language": "EN",
+        "submissionDate": "2025-12-03",
+        "order": 5,
+    },
 ];


### PR DESCRIPTION
## Summary
Removes duplicate project entries across category files.

## Duplicates Removed

### creative.js
- **Imagen** (same URL `altkriz.github.io/imagen`) - kept first entry
- **Dreamator-AI** (same URL `dreamator-ai.vercel.app`) - kept first entry

### hackAndBuild.js  
- **Herramientas IA** (3 entries → 1) - kept comprehensive first entry
- **DominiSigns** (2 entries) - kept first entry with GitHub repo

### vibeCoding.js
- **BeeCoder** - removed (already in hackAndBuild.js)
- **EasyGen** - removed (already in chat.js as EasyGen)

### socialBots.js
- **TeleChars AI** (3 entries → 1) - kept original with emoji formatting

## Changes
- 6 files changed
- ~85 lines removed (duplicate entries)
- Regenerated README.md and PROJECTS.md