### PR TITLE
fix: Rename catch parameter to prevent variable shadowing in gptImageLogger

### DIFF
--- a/image.pollinations.ai/src/utils/gptImageLogger.ts
+++ b/image.pollinations.ai/src/utils/gptImageLogger.ts
@@ -128,8 +128,8 @@ export async function logGptImageError(
         await fsPromises.appendFile(logFile, `${logEntry}\n`);
 
         logOps("Logged gptimage error to", logFile);
-    } catch (logError) {
+    } catch (error) {
         // Non-blocking error handling for logging
-        logError("Error logging gptimage error:", logError.message);
+        logError("Error logging gptimage error:", error.message);
     }
 }


### PR DESCRIPTION
Fixes "logError2 is not a function" error by renaming catch parameter to avoid shadowing the outer logError function.

Changed catch parameter from `logError` to `error` in `logGptImageError` and `logGptImagePrompt`.

Closes #5889