### PR TITLE
fix: temporarily disable payment buttons

### DIFF
--- a/enter.pollinations.ai/src/client/components/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/pollen-balance.tsx
@@ -81,6 +81,20 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                     balance to update.
                 </p>
             </div>
+            {/* Temporary payment warning */}
+            <div className="bg-gradient-to-r from-amber-100 to-orange-100 rounded-xl p-4 border border-amber-400 mt-4">
+                <p className="text-sm font-bold text-amber-900">
+                    ⚠️ Payments temporarily disabled
+                </p>
+                <p className="text-sm text-amber-800 mt-1">
+                    We're fixing a bug where credits aren't applied immediately.
+                    Expected fix: today.
+                </p>
+                <p className="text-sm text-amber-800 mt-1">
+                    If you paid but didn't receive your balance, please contact
+                    us — we'll reimburse or compensate you.
+                </p>
+            </div>
         </div>
     );
 };

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -182,9 +182,7 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                onClick={() =>
-                                    handleBuyPollen("v1:product:pack:5x2")
-                                }
+                                disabled
                             >
                                 + $5
                             </Button>
@@ -192,9 +190,7 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                onClick={() =>
-                                    handleBuyPollen("v1:product:pack:10x2")
-                                }
+                                disabled
                             >
                                 + $10
                             </Button>
@@ -202,9 +198,7 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                onClick={() =>
-                                    handleBuyPollen("v1:product:pack:20x2")
-                                }
+                                disabled
                             >
                                 + $20
                             </Button>
@@ -212,9 +206,7 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                onClick={() =>
-                                    handleBuyPollen("v1:product:pack:50x2")
-                                }
+                                disabled
                             >
                                 + $50
                             </Button>


### PR DESCRIPTION
- Disable $5/$10/$20/$50 pollen purchase buttons
- Add warning banner about payment sync issue
- Include support message for affected users

Temporary fix while investigating credits not being applied immediately after purchase.