### PR TITLE
fix: add 'labeled' trigger to app submission workflow

### DIFF
--- a/.github/workflows/pr-create-app-submission.yml
+++ b/.github/workflows/pr-create-app-submission.yml
@@ -2,7 +2,7 @@ name: PR Create App Submission
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, labeled]
   pull_request:
     paths:
       - '.github/workflows/pr-create-app-submission.yml'  # Trigger on self to bootstrap


### PR DESCRIPTION
## Problem

The PR Create App Submission workflow was being skipped when the `app:review` label was added to existing issues.

## Root Cause

The workflow only triggered on: `[opened, edited, reopened]`

When someone adds the `app:review` label to an existing issue, that's a `labeled` event, which wasn't in the trigger list.

## Solution

- Add `labeled` to the workflow trigger types
- Now the workflow will run when `app:review` label is added

## Example

Issue #5856 had the workflow skipped because the label was added after the issue was opened.

Fixes #5856