### PR TITLE
fix: re-enable payment buttons

### DIFF
--- a/enter.pollinations.ai/src/client/components/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/pollen-balance.tsx
@@ -81,20 +81,6 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                     balance to update.
                 </p>
             </div>
-            {/* Temporary payment warning */}
-            <div className="bg-gradient-to-r from-amber-100 to-orange-100 rounded-xl p-4 border border-amber-400 mt-4">
-                <p className="text-sm font-bold text-amber-900">
-                    ⚠️ Payments temporarily disabled
-                </p>
-                <p className="text-sm text-amber-800 mt-1">
-                    We're fixing a bug where credits aren't applied immediately.
-                    Expected fix: today.
-                </p>
-                <p className="text-sm text-amber-800 mt-1">
-                    If you paid but didn't receive your balance, please contact
-                    us — we'll reimburse or compensate you.
-                </p>
-            </div>
         </div>
     );
 };

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -182,7 +182,9 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                disabled
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:5x2")
+                                }
                             >
                                 + $5
                             </Button>
@@ -190,7 +192,9 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                disabled
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:10x2")
+                                }
                             >
                                 + $10
                             </Button>
@@ -198,7 +202,9 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                disabled
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:20x2")
+                                }
                             >
                                 + $20
                             </Button>
@@ -206,7 +212,9 @@ function RouteComponent() {
                                 as="button"
                                 color="purple"
                                 weight="light"
-                                disabled
+                                onClick={() =>
+                                    handleBuyPollen("v1:product:pack:50x2")
+                                }
                             >
                                 + $50
                             </Button>


### PR DESCRIPTION
- Re-enable $5/$10/$20/$50 pollen purchase buttons
- Warning banner remains in place