### PR TITLE
fix: correct GPT-5.2 pricing and use alias for openai-reasoning

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -43,15 +43,15 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "openai-large": {
-        aliases: ["gpt-5.2"],
+        aliases: ["gpt-5.2", "openai-reasoning", "gpt-5.2-reasoning"],
         modelId: "gpt-5.2",
         provider: "azure-openai",
         cost: [
             {
                 date: COST_START_DATE,
-                promptTextTokens: perMillion(0.5),
-                promptCachedTokens: perMillion(0.125),
-                completionTextTokens: perMillion(2.0),
+                promptTextTokens: perMillion(1.75),
+                promptCachedTokens: perMillion(0.175),
+                completionTextTokens: perMillion(14.0),
             },
         ],
         description: "OpenAI GPT-5.2 - Most Powerful & Intelligent",
@@ -134,25 +134,6 @@ export const TEXT_SERVICES = {
         inputModalities: ["text", "image", "audio"],
         outputModalities: ["audio", "text"],
         tools: true,
-        isSpecialized: false,
-    },
-    "openai-reasoning": {
-        aliases: ["gpt-5.2-reasoning"],
-        modelId: "gpt-5.2",
-        provider: "azure-openai",
-        cost: [
-            {
-                date: COST_START_DATE,
-                promptTextTokens: perMillion(0.5),
-                promptCachedTokens: perMillion(0.125),
-                completionTextTokens: perMillion(2.0),
-            },
-        ],
-        description: "OpenAI GPT-5.2 - Hybrid Reasoning Model",
-        inputModalities: ["text", "image"],
-        outputModalities: ["text"],
-        tools: true,
-        reasoning: true,
         isSpecialized: false,
     },
     "gemini": {

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -86,11 +86,6 @@ const models: ModelDefinition[] = [
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {
-        name: "openai-reasoning",
-        config: portkeyConfig["gpt-5.2"],
-        transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
-    },
-    {
         name: "gemini",
         config: portkeyConfig["gemini-2.5-flash-lite"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),


### PR DESCRIPTION
## Fixes from previous PR

Corrects issues from #5921:

- **Fix GPT-5.2 pricing** to match official OpenAI API rates:
  - Input: $0.50 → **$1.75** per million tokens
  - Cached: $0.125 → **$0.175** per million tokens
  - Output: $2.00 → **$14.00** per million tokens
  - Source: https://platform.openai.com/docs/models/gpt-5.2

- **Simplify `openai-reasoning`** by using alias instead of duplicate entry:
  - Remove duplicate `openai-reasoning` entry from registry
  - Add `openai-reasoning` and `gpt-5.2-reasoning` as aliases to `openai-large`
  - Remove from `availableModels.ts` (now resolved via alias system)

## Changes

- 2 files changed, 4 insertions, 28 deletions
- Cleaner registry with less duplication