### PR TITLE
feat: Add pollen balance API endpoint (#5892)

### DIFF
--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -7,6 +7,7 @@ import { processEvents } from "./events.ts";
 import { polarRoutes } from "./routes/polar.ts";
 import { proxyRoutes } from "./routes/proxy.ts";
 import { tiersRoutes } from "./routes/tiers.ts";
+import { pollenRoutes } from "./routes/pollen.ts";
 import { createDocsRoutes } from "./routes/docs.ts";
 import { requestId } from "hono/request-id";
 import { logger } from "./middleware/logger.ts";
@@ -22,6 +23,7 @@ export const api = new Hono<Env>()
     .route("/auth", authRoutes)
     .route("/polar", polarRoutes)
     .route("/tiers", tiersRoutes)
+    .route("/pollen", pollenRoutes)
     .route("/generate", proxyRoutes);
 
 const docsRoutes = createDocsRoutes(api);
@@ -33,6 +35,16 @@ const app = new Hono<Env>()
         cors({
             origin: "*",
             allowMethods: ["GET", "POST", "OPTIONS"],
+            allowHeaders: ["Content-Type", "Authorization"],
+            exposeHeaders: ["Content-Length"],
+            maxAge: 600,
+        }),
+    )
+    .use(
+        "/api/pollen/*",
+        cors({
+            origin: "*",
+            allowMethods: ["GET", "OPTIONS"],
             allowHeaders: ["Content-Type", "Authorization"],
             exposeHeaders: ["Content-Length"],
             maxAge: 600,

--- a/enter.pollinations.ai/src/routes/pollen.ts
+++ b/enter.pollinations.ai/src/routes/pollen.ts
@@ -1,0 +1,129 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { auth } from "../middleware/auth.ts";
+import { polar } from "../middleware/polar.ts";
+import { describeRoute } from "hono-openapi";
+import type { Env } from "../env.ts";
+
+/**
+ * Pollen Balance API Route
+ * 
+ * Provides an endpoint to check the remaining pollen balance for an API key.
+ * This allows applications to:
+ * - Check balance before making requests
+ * - Implement fallback logic when balance is low
+ * - Provide better UX by warning users before balance runs out
+ * 
+ * @see https://github.com/pollinations/pollinations/issues/5892
+ */
+export const pollenRoutes = new Hono<Env>()
+    .use(auth({ allowSessionCookie: false, allowApiKey: true }))
+    .use(polar)
+    .get(
+        "/balance",
+        describeRoute({
+            tags: ["API"],
+            description: [
+                "Get the current pollen balance for the API key.",
+                "Returns both tier (free) and pack (purchased) pollen balances.",
+                "This endpoint is useful for applications to check balance before making requests",
+                "and implement fallback logic when balance is low.",
+            ].join(" "),
+            responses: {
+                200: {
+                    description: "Pollen balance information",
+                    content: {
+                        "application/json": {
+                            schema: {
+                                type: "object",
+                                properties: {
+                                    pollen: {
+                                        type: "number",
+                                        description: "Total available pollen (tier + pack)",
+                                    },
+                                    tier: {
+                                        type: "number",
+                                        description: "Free pollen from tier subscription",
+                                    },
+                                    pack: {
+                                        type: "number",
+                                        description: "Purchased pollen from packs",
+                                    },
+                                    account_id: {
+                                        type: "string",
+                                        description: "User account ID",
+                                    },
+                                    last_updated: {
+                                        type: "string",
+                                        format: "date-time",
+                                        description: "ISO timestamp of last balance update",
+                                    },
+                                },
+                                required: ["pollen", "tier", "pack", "account_id"],
+                            },
+                        },
+                    },
+                },
+                401: {
+                    description: "Invalid or missing API key",
+                },
+                402: {
+                    description: "Insufficient pollen balance (if balance is 0)",
+                },
+            },
+        }),
+        async (c) => {
+            const log = c.get("log");
+            const user = c.var.auth.requireUser();
+
+            log.debug(`Fetching pollen balance for user: ${user.id}, email: ${user.email}`);
+
+            try {
+                // Get customer state from Polar (includes meter balances)
+                const customerState = await c.var.polar.getCustomerState(user.id);
+                
+                // Extract meter balances
+                const meters = customerState.meters || [];
+                
+                // Find tier and pack meters using the configured meter IDs
+                // Meter IDs are environment-specific (see client/config.ts)
+                const meterIds = c.env.ENVIRONMENT === "production"
+                    ? { pollenTierMeterId: "b7f3e925-d6c8-4bc8-b40a-291f2793512e", pollenPackMeterId: "0960354f-1ad5-40ab-93dd-7b1930913a38" }
+                    : { pollenTierMeterId: "1593243f-f646-4df2-9f55-30da37cbc3a0", pollenPackMeterId: "9bd156bb-2f2e-4e25-b1c0-1308c076c365" };
+
+                const tierMeter = meters.find((m) => m.meterId === meterIds.pollenTierMeterId);
+                const packMeter = meters.find((m) => m.meterId === meterIds.pollenPackMeterId);
+
+                const tierBalance = tierMeter?.balance || 0;
+                const packBalance = packMeter?.balance || 0;
+                const totalPollen = tierBalance + packBalance;
+
+                log.debug(`Pollen balance - Tier: ${tierBalance}, Pack: ${packBalance}, Total: ${totalPollen}`);
+
+                return c.json({
+                    pollen: totalPollen,
+                    tier: tierBalance,
+                    pack: packBalance,
+                    account_id: user.id,
+                    last_updated: new Date().toISOString(),
+                });
+            } catch (error) {
+                log.error("Failed to fetch pollen balance: {error}", {
+                    error,
+                    userId: user.id,
+                });
+
+                // If it's a balance-related error, return 402
+                if (error instanceof HTTPException && error.status === 402) {
+                    throw error;
+                }
+
+                // For other errors, return 500
+                throw new HTTPException(500, {
+                    message: "Failed to fetch pollen balance. Please try again later.",
+                });
+            }
+        },
+    );
+
+export type PollenRoutes = typeof pollenRoutes;


### PR DESCRIPTION
## Descrição

Esta PR implementa o endpoint `/api/pollen/balance` solicitado na issue #5892.

## O que foi implementado

- ✅ Novo endpoint `GET /api/pollen/balance` que retorna o saldo de pollen
- ✅ Suporte para autenticação via API key
- ✅ Retorna balance de tier (gratuito) e pack (comprado)
- ✅ CORS configurado para acesso público via API
- ✅ Documentação OpenAPI incluída
- ✅ Tratamento de erros adequado

## Resposta da API

```json
{
  "pollen": 12.5,
  "tier": 3.0,
  "pack": 9.5,
  "account_id": "user_123",
  "last_updated": "2025-12-13T21:00:00.000Z"
}
```

## Casos de Uso

Este endpoint permite que aplicações:
1. Verifiquem o balance antes de fazer requisições
2. Implementem fallback para modelos mais baratos quando o balance está baixo
3. Alertem usuários proativamente antes do balance acabar
4. Implementem rate limiting inteligente baseado no balance disponível

## Exemplo de Uso

```typescript
const response = await fetch('https://enter.pollinations.ai/api/pollen/balance', {
  headers: {
    'Authorization': `Bearer ${apiKey}`
  }
});
const balance = await response.json();
console.log(`Available pollen: ${balance.pollen}`);
```

## Testes

- [x] Endpoint retorna balance correto para API keys válidas
- [x] Retorna 401 para API keys inválidas
- [x] CORS configurado corretamente
- [x] Documentação OpenAPI gerada automaticamente

## Créditos

Desenvolvido por **Fábio Arieira** (https://fabioarieira.com)  
Full Stack Developer especializado em integrações de API e desenvolvimento de aplicações web modernas.

---

Resolves #5892
