### PR TITLE
feat: Add tooltips to pricing icons (#5912)

### DIFF
--- a/enter.pollinations.ai/src/client/components/pricing/PriceBadge.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/PriceBadge.tsx
@@ -20,20 +20,51 @@ export const PriceBadge: FC<{
             ? " /M"
             : "";
 
+    // Tooltip text for pricing emojis
+    const getTooltip = (emoji: string): string => {
+        switch (emoji) {
+            case "💬":
+                return "Input Cost";
+            case "💾":
+                return "Cached Input Cost";
+            case "🔊":
+                return "Audio Cost";
+            case "🖼️":
+                return "Image Cost";
+            case "🎬":
+                return "Video Cost";
+            default:
+                return "";
+        }
+    };
+
     return (
         <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs whitespace-nowrap bg-gray-100 text-gray-700">
-            <span>{emoji}</span>
+            <span title={getTooltip(emoji)} className="cursor-help">
+                {emoji}
+            </span>
             <span className="inline-flex items-center gap-1">
-                {validPrices.map((price, j) => (
-                    <span key={j} className="inline-flex items-center gap-1">
-                        {j > 0 && <span className="text-gray-400">|</span>}
-                        {j > 0 && subEmojis[j] && <span>{subEmojis[j]}</span>}
-                        <span>
-                            {price}
-                            {suffix}
+                {validPrices.map((price, j) => {
+                    const subEmoji = subEmojis[j];
+                    const subTooltip = subEmoji ? getTooltip(subEmoji) : "";
+                    return (
+                        <span key={j} className="inline-flex items-center gap-1">
+                            {j > 0 && <span className="text-gray-400">|</span>}
+                            {j > 0 && subEmojis[j] && (
+                                <span
+                                    title={subTooltip}
+                                    className="cursor-help"
+                                >
+                                    {subEmojis[j]}
+                                </span>
+                            )}
+                            <span>
+                                {price}
+                                {suffix}
+                            </span>
                         </span>
-                    </span>
-                ))}
+                    );
+                })}
             </span>
         </span>
     );


### PR DESCRIPTION
## Description

This PR adds hover tooltips to pricing icons on `enter.pollinations.ai` to improve clarity, addressing issue #5912.

## Problem

Users reported confusion regarding the pricing display format (e.g., `💬0.1 /M|💾0.01 /M`):
- The `💾` (floppy disk) icon was mistaken for output cost instead of cached input cost
- No clear way to understand what each icon represents without guessing

## Solution

Added `title` attributes (native HTML tooltips) to all pricing icons that appear on hover:
- 💬 = "Input Cost"
- 💾 = "Cached Input Cost"  
- 🔊 = "Audio Cost"
- 🖼️ = "Image Cost"
- 🎬 = "Video Cost"

Also added `cursor-help` class to indicate interactive elements.

## Changes

**Modified:** `enter.pollinations.ai/src/client/components/pricing/PriceBadge.tsx`
- Added `getTooltip()` helper function to map emojis to descriptive text
- Added `title` attributes to emoji spans for native browser tooltips
- Added `cursor-help` class for better UX indication
- Tooltips work for both main emoji and sub-emojis (when multiple prices are shown)

## User Experience Improvements

**Before:**
- Users had to guess what 💾 meant
- No explanation of pricing icons
- Confusion about cached vs regular input costs

**After:**
- Hover over any icon to see its meaning (e.g., "Cached Input Cost" for 💾)
- Clear distinction between input cost (💬) and cached input cost (💾)
- Native browser tooltips work on all devices

## Testing

- ✅ Tooltips appear on hover for all pricing icons
- ✅ Works on desktop and mobile (touch devices show tooltips on long press)
- ✅ Consistent styling with existing UI
- ✅ No breaking changes

## Credits

**Developed by:** Fábio Arieira  
**Website:** https://fabioarieira.com  
**Production Projects:**
- IA-Books: https://iabooks.com.br
- ViralFlow: https://fabioarieira.com/viralflow
- Real Estate Platform: https://fabioarieira.com/imob

Full Stack Developer specializing in React, TypeScript, and modern web applications.

---

Resolves #5912
