### PR TITLE
fix: use pull_request_target for PR assign workflow

### DIFF
--- a/.github/workflows/pr-assign-author.yml
+++ b/.github/workflows/pr-assign-author.yml
@@ -1,7 +1,7 @@
 name: PR Assign Author
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
- Fix secrets not available for PRs from forks
- Change `pull_request` to `pull_request_target` to run in base repo context
- Allows workflow to assign authors for all PRs (external contributors will still fail gracefully if they can't be assigned)