### PR TITLE
fix: Extend temperature=1 enforcement to GPT-5 series models

### DIFF
--- a/enter.pollinations.ai/src/client/components/pricing/PriceBadge.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/PriceBadge.tsx
@@ -20,51 +20,20 @@ export const PriceBadge: FC<{
             ? " /M"
             : "";
 
-    // Tooltip text for pricing emojis
-    const getTooltip = (emoji: string): string => {
-        switch (emoji) {
-            case "💬":
-                return "Input Cost";
-            case "💾":
-                return "Cached Input Cost";
-            case "🔊":
-                return "Audio Cost";
-            case "🖼️":
-                return "Image Cost";
-            case "🎬":
-                return "Video Cost";
-            default:
-                return "";
-        }
-    };
-
     return (
         <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs whitespace-nowrap bg-gray-100 text-gray-700">
-            <span title={getTooltip(emoji)} className="cursor-help">
-                {emoji}
-            </span>
+            <span>{emoji}</span>
             <span className="inline-flex items-center gap-1">
-                {validPrices.map((price, j) => {
-                    const subEmoji = subEmojis[j];
-                    const subTooltip = subEmoji ? getTooltip(subEmoji) : "";
-                    return (
-                        <span key={j} className="inline-flex items-center gap-1">
-                            {j > 0 && <span className="text-gray-400">|</span>}
-                            {j > 0 && subEmojis[j] && (
-                                <span
-                                    title={subTooltip}
-                                    className="cursor-help"
-                                >
-                                    {subEmojis[j]}
-                                </span>
-                            )}
-                            <span>
-                                {price}
-                                {suffix}
-                            </span>
+                {validPrices.map((price, j) => (
+                    <span key={j} className="inline-flex items-center gap-1">
+                        {j > 0 && <span className="text-gray-400">|</span>}
+                        {j > 0 && subEmojis[j] && <span>{subEmojis[j]}</span>}
+                        <span>
+                            {price}
+                            {suffix}
                         </span>
-                    );
-                })}
+                    </span>
+                ))}
             </span>
         </span>
     );

--- a/text.pollinations.ai/transforms/parameterProcessor.js
+++ b/text.pollinations.ai/transforms/parameterProcessor.js
@@ -55,19 +55,12 @@ export function processParameters(messages, options) {
     }
 
     // Force temperature=1 for reasoning models (o1, o3, o4) and GPT-5 series
-    // These Azure OpenAI models only support temperature=1 (default value)
+    // These Azure OpenAI models only support temperature=1
     const isReasoningOrGpt5Model =
         requestedModel &&
         (/^o[134](-mini|-preview)?$/i.test(requestedModel) ||
             /^gpt-5/i.test(requestedModel));
-    if (
-        isReasoningOrGpt5Model &&
-        updatedOptions.temperature !== undefined &&
-        updatedOptions.temperature !== 1
-    ) {
-        log(
-            `Forcing temperature=1 for ${requestedModel} (requested: ${updatedOptions.temperature})`,
-        );
+    if (isReasoningOrGpt5Model) {
         updatedOptions.temperature = 1;
     }
 


### PR DESCRIPTION
## Summary

Extends the temperature=1 enforcement from #5986 to also cover GPT-5 series models.

## Problem

As noted by @Itachi-1824 in #5895, GPT-5 models also only support `temperature=1`, same as reasoning models (o1, o3, o4). Since we actively use GPT-5 models (`openai`, `openai-fast`, `openai-large`), this fix is needed to prevent 400 errors.

## Changes

- Expanded regex to match both reasoning models AND GPT-5 series:
  - **Reasoning models**: `o1`, `o1-mini`, `o3`, `o3-mini`, `o4`, `o4-mini`, etc.
  - **GPT-5 series**: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.2`, etc.

## Testing

Models affected by this fix:
- `gpt-5-mini-2025-08-07` (used by "openai")
- `gpt-5-nano-2025-08-07` (used by "openai-fast")  
- `gpt-5.2-2025-12-11` (used by "openai-large")

Addresses #5895