### PR TITLE
fix(seedance): add aspectratio parameter support for seedance-pro model

### DIFF
--- a/image.pollinations.ai/src/models/seedanceVideoModel.ts
+++ b/image.pollinations.ai/src/models/seedanceVideoModel.ts
@@ -108,6 +108,10 @@ async function generateSeedanceVideo(
     // Video parameters
     const durationSeconds = safeParams.duration || 2;
     const resolution = "720p";
+    // Map aspectRatio to Seedance format: "16:9" -> "16_9", "9:16" -> "9_16"
+    const aspectRatio = safeParams.aspectRatio 
+        ? safeParams.aspectRatio.replace(":", "_") 
+        : "16_9"; // Default to 16:9
 
     // Select model based on whether we have an input image
     const hasImage = safeParams.image && safeParams.image.length > 0;
@@ -116,12 +120,14 @@ async function generateSeedanceVideo(
     logOps("Video params:", {
         durationSeconds,
         resolution,
+        aspectRatio,
         model: selectedModel,
         hasImage,
     });
 
     // Build text command with parameters (BytePlus format)
-    let textCommand = `${prompt} --resolution ${resolution} --duration ${durationSeconds} --watermark false`;
+    // Include aspectratio parameter for proper video dimensions
+    let textCommand = `${prompt} --resolution ${resolution} --duration ${durationSeconds} --aspectratio ${aspectRatio} --watermark false`;
     if (safeParams.seed !== undefined && safeParams.seed !== -1) {
         textCommand += ` --seed ${safeParams.seed}`;
     }


### PR DESCRIPTION
## Summary
The seedance-pro model was ignoring the \spectRatio\ parameter during video generation, always generating videos with default dimensions.

## Changes
- Added \spectRatio\ parameter to the BytePlus Seedance API text command
- Convert aspectRatio format from standard \16:9\/\9:16\ to BytePlus format \16_9\/\9_16\
- Default to \16:9\ aspect ratio when not specified (consistent with Veo model)
- Added aspectRatio to debug logging for troubleshooting

## Technical Details
The fix modifies \seedanceVideoModel.ts\ to include the \--aspectratio\ parameter in the text command sent to BytePlus API:

\\\	ypescript
// Before
let textCommand = \\ --resolution \ --duration \ --watermark false\;

// After  
let textCommand = \\ --resolution \ --duration \ --aspectratio \ --watermark false\;
\\\

## Test plan
- [ ] Test with \spectRatio=16:9\ - should generate landscape video
- [ ] Test with \spectRatio=9:16\ - should generate portrait video
- [ ] Test without aspectRatio - should default to 16:9

Fixes #6005

Reported by: onetap05432 via Discord

---
**Author Discord:** \abioarieira8850\ - Feel free to reach out for any questions!