### PR TITLE
fix: correct vite base path for model-monitor deployment

### DIFF
--- a/apps/model-monitor/vite.config.js
+++ b/apps/model-monitor/vite.config.js
@@ -3,5 +3,5 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
     plugins: [react()],
-    base: "/model-monitor/",
+    base: "/",
 });


### PR DESCRIPTION
- Fix vite base path from `/model-monitor/` to `/` for Cloudflare Pages
- App is served from root at `model-monitor.pollinations.ai`, not a subdirectory
- This was causing all assets to 404 on the deployed site