### PR TITLE
feat: add repetition_penalty parameter support

### DIFF
--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -276,6 +276,7 @@ export const CreateChatCompletionRequestSchema = z.object({
         .nullable()
         .optional()
         .default(0),
+    repetition_penalty: z.number().min(0).max(2).nullable().optional(),
     logit_bias: z
         .record(z.string(), z.number().int())
         .nullable()

--- a/text.pollinations.ai/requestUtils.js
+++ b/text.pollinations.ai/requestUtils.js
@@ -87,6 +87,7 @@ export function getRequestData(req) {
         top_p: validated.top_p,
         presence_penalty: validated.presence_penalty,
         frequency_penalty: validated.frequency_penalty,
+        repetition_penalty: validated.repetition_penalty,
         referrer,
         stream: validated.stream,
         isPrivate,

--- a/text.pollinations.ai/textGenerationUtils.js
+++ b/text.pollinations.ai/textGenerationUtils.js
@@ -190,6 +190,14 @@ export function normalizeOptions(options = {}, defaults = {}) {
         );
     }
 
+    if (normalized.repetition_penalty !== undefined) {
+        // Ensure repetition_penalty is within valid range (typically 1.0 to 2.0, but allow wider)
+        normalized.repetition_penalty = Math.max(
+            0,
+            Math.min(2, normalized.repetition_penalty),
+        );
+    }
+
     // // Handle maxTokens parameter
     // if (normalized.maxTokens === undefined) {
     //   // If not provided, use default value

--- a/text.pollinations.ai/transforms/parameterProcessor.js
+++ b/text.pollinations.ai/transforms/parameterProcessor.js
@@ -24,6 +24,7 @@ export function processParameters(messages, options) {
         "top_p",
         "presence_penalty",
         "frequency_penalty",
+        "repetition_penalty",
     ];
     samplingParams.forEach((param) => {
         if (

--- a/text.pollinations.ai/utils/parameterValidators.js
+++ b/text.pollinations.ai/utils/parameterValidators.js
@@ -91,6 +91,7 @@ export const validateTextGenerationParams = (data) => {
         top_p: validateFloat(data.top_p),
         presence_penalty: validateFloat(data.presence_penalty),
         frequency_penalty: validateFloat(data.frequency_penalty),
+        repetition_penalty: validateFloat(data.repetition_penalty),
         seed: validateInt(data.seed),
         stream: validateBoolean(data.stream),
         private: validateBoolean(data.private),


### PR DESCRIPTION
- Add `repetition_penalty` parameter to text generation API
- Validate and pass through to downstream LLM providers
- Range: 0-2 (typical values 1.0-1.5)

**Files:**
- `enter.pollinations.ai/src/schemas/openai.ts` - Zod schema
- `text.pollinations.ai/utils/parameterValidators.js` - Validation
- `text.pollinations.ai/requestUtils.js` - Extraction
- `text.pollinations.ai/transforms/parameterProcessor.js` - Processing
- `text.pollinations.ai/textGenerationUtils.js` - Range validation

Fixes #6059

Co-authored-by: MarcosFRG <201380514+MarcosFRG@users.noreply.github.com>