### PR TITLE
fix: pass seed parameter to Seedream API

### DIFF
--- a/image.pollinations.ai/src/models/seedreamModel.ts
+++ b/image.pollinations.ai/src/models/seedreamModel.ts
@@ -153,7 +153,9 @@ export const callSeedreamProAPI = async (
         if (error instanceof HttpError) {
             throw error;
         }
-        throw new Error(`Seedream 4.5 Pro API generation failed: ${error.message}`);
+        throw new Error(
+            `Seedream 4.5 Pro API generation failed: ${error.message}`,
+        );
     }
 };
 
@@ -180,14 +182,20 @@ async function generateWithSeedream(
         size: sizeParam,
         stream: false,
         watermark: false,
+        seed: safeParams.seed,
     };
 
     // Add image-to-image support if reference images are provided
+    // Note: In image-to-image mode, Seedream API may ignore width/height parameters
+    // and use the input image dimensions instead (API limitation)
     if (safeParams.image && safeParams.image.length > 0) {
         logOps(
             "Adding reference images for image-to-image generation:",
             safeParams.image.length,
             "images",
+        );
+        logOps(
+            "Note: In image-to-image mode, output dimensions may be determined by input image, not requested size",
         );
 
         // Update progress for image processing


### PR DESCRIPTION
## Summary
- Fix seed parameter not being passed to Seedream API
- Add documentation about width/height limitation in image-to-image mode

## Problem
The `seed` parameter was missing from the Seedream API request body, causing:
- Same image generated regardless of seed value
- Caching appeared broken (different seeds = same output)

## Changes
- Add `seed: safeParams.seed` to request body in `generateWithSeedream()`
- Add note about Seedream API limitation where width/height may be ignored in image-to-image mode

## Note on Width/Height
The Seedream API may ignore `size` parameter in image-to-image mode and use input image dimensions instead. This is an upstream API limitation, not a bug in our code.

Fixes #6044

Co-authored-by: mames7544 <mames7544@users.noreply.github.com>