### PR TITLE
fix: Group api-keys and usage endpoints under Auth tag in docs

### DIFF
--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -7,6 +7,7 @@ import { drizzle } from "drizzle-orm/d1";
 import * as schema from "../db/schema/better-auth.ts";
 import { eq, and } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
+import { describeRoute } from "hono-openapi";
 
 /**
  * Schema for updating an API key.
@@ -29,48 +30,57 @@ export const apiKeysRoutes = new Hono<Env>()
      * Update an API key's permissions.
      * Uses auth.api.updateApiKey() which supports server-only fields like permissions.
      */
-    .post("/:id/update", validator("json", UpdateApiKeySchema), async (c) => {
-        const user = c.var.auth.requireUser();
-        const authClient = c.var.auth.client;
-        const { id } = c.req.param();
-        const { allowedModels } = c.req.valid("json");
+    .post(
+        "/:id/update",
+        describeRoute({
+            tags: ["Auth"],
+            description: "Update an API key's permissions (allowed models).",
+            hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
+        }),
+        validator("json", UpdateApiKeySchema),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const authClient = c.var.auth.client;
+            const { id } = c.req.param();
+            const { allowedModels } = c.req.valid("json");
 
-        // Verify ownership before updating
-        const db = drizzle(c.env.DB, { schema });
-        const existingKey = await db.query.apikey.findFirst({
-            where: and(
-                eq(schema.apikey.id, id),
-                eq(schema.apikey.userId, user.id),
-            ),
-        });
+            // Verify ownership before updating
+            const db = drizzle(c.env.DB, { schema });
+            const existingKey = await db.query.apikey.findFirst({
+                where: and(
+                    eq(schema.apikey.id, id),
+                    eq(schema.apikey.userId, user.id),
+                ),
+            });
 
-        if (!existingKey) {
-            throw new HTTPException(404, { message: "API key not found" });
-        }
+            if (!existingKey) {
+                throw new HTTPException(404, { message: "API key not found" });
+            }
 
-        // Build permissions object
-        // null = remove restrictions (all models allowed)
-        // [] or [...models] = restricted to specific models
-        const permissions =
-            allowedModels === null
-                ? null
-                : allowedModels && allowedModels.length > 0
-                  ? { models: allowedModels }
-                  : undefined;
+            // Build permissions object
+            // null = remove restrictions (all models allowed)
+            // [] or [...models] = restricted to specific models
+            const permissions =
+                allowedModels === null
+                    ? null
+                    : allowedModels && allowedModels.length > 0
+                      ? { models: allowedModels }
+                      : undefined;
 
-        // Use better-auth's server API to update permissions
-        // userId is required for server-side calls to bypass auth checks
-        const updatedKey = await authClient.api.updateApiKey({
-            body: {
-                keyId: id,
-                userId: user.id,
-                permissions,
-            },
-        });
+            // Use better-auth's server API to update permissions
+            // userId is required for server-side calls to bypass auth checks
+            const updatedKey = await authClient.api.updateApiKey({
+                body: {
+                    keyId: id,
+                    userId: user.id,
+                    permissions,
+                },
+            });
 
-        return c.json({
-            id: updatedKey.id,
-            name: updatedKey.name,
-            permissions: updatedKey.permissions,
-        });
-    });
+            return c.json({
+                id: updatedKey.id,
+                name: updatedKey.name,
+                permissions: updatedKey.permissions,
+            });
+        },
+    );

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -22,8 +22,6 @@ function transformOpenAPISchema(
     return {
         ...schema,
         paths: newPaths,
-        // Scalar extension: group tags to prevent "Authentication" grouping
-        "x-tagGroups": [{ name: "API", tags: ["gen.pollinations.ai"] }],
     };
 }
 


### PR DESCRIPTION
- Remove `x-tagGroups` from docs schema (was filtering out Auth endpoints)
- Add `describeRoute` with Auth tag to api-keys update endpoint
- Change usage endpoint tag from Usage to Auth for consistent grouping
- Add hide condition to show these endpoints only in development mode