### PR TITLE
feat: Add apiKeyExtended plugin for HTTP permissions updates

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -8,7 +8,8 @@ import {
 } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
-import { admin, apiKey, openAPI } from "better-auth/plugins";
+import { admin, openAPI } from "better-auth/plugins";
+import { apiKeyExtended } from "./plugins/api-key-extended.ts";
 import { drizzle } from "drizzle-orm/d1";
 import * as betterAuthSchema from "./db/schema/better-auth.ts";
 
@@ -23,7 +24,7 @@ export function createAuth(env: Cloudflare.Env) {
     const PUBLISHABLE_KEY_PREFIX = "pk";
     const SECRET_KEY_PREFIX = "sk";
 
-    const apiKeyPlugin = apiKey({
+    const apiKeyPlugin = apiKeyExtended({
         enableMetadata: true,
         defaultPrefix: PUBLISHABLE_KEY_PREFIX,
         defaultKeyLength: 16, // Minimum key length for validation (matches custom generator)

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -123,14 +123,16 @@ function RouteComponent() {
             formState.allowedModels !== null &&
             formState.allowedModels !== undefined
         ) {
+            // Use our extended better-auth endpoint that allows permissions from HTTP
             const updateResponse = await fetch(
-                `/api/api-keys/${apiKey.id}/update`,
+                "/api/auth/api-key/update-permissions",
                 {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     credentials: "include",
                     body: JSON.stringify({
-                        allowedModels: formState.allowedModels,
+                        keyId: apiKey.id,
+                        permissions: { models: formState.allowedModels },
                     }),
                 },
             );

--- a/enter.pollinations.ai/src/plugins/api-key-extended.ts
+++ b/enter.pollinations.ai/src/plugins/api-key-extended.ts
@@ -1,0 +1,69 @@
+import { apiKey } from "better-auth/plugins";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
+import type { BetterAuthPlugin } from "better-auth";
+import { z } from "zod";
+
+/**
+ * Extended API Key plugin that allows setting permissions from HTTP endpoints.
+ *
+ * The base better-auth apiKey plugin marks `permissions` as server-only,
+ * meaning it can only be set via `auth.api.updateApiKey()` and not from
+ * HTTP requests to `/api/auth/api-key/update`.
+ *
+ * This extended plugin adds a new endpoint `/api/auth/api-key/update-permissions`
+ * that calls the base updateApiKey endpoint internally (as a server-side call),
+ * bypassing the SERVER_ONLY restriction.
+ */
+export const apiKeyExtended = (
+    options?: Parameters<typeof apiKey>[0],
+): BetterAuthPlugin => {
+    const basePlugin = apiKey(options);
+
+    return {
+        ...basePlugin,
+        id: "api-key-extended",
+
+        endpoints: {
+            ...basePlugin.endpoints,
+
+            // Add new endpoint that allows permissions updates from HTTP
+            updateApiKeyPermissions: createAuthEndpoint(
+                "/api-key/update-permissions",
+                {
+                    method: "POST",
+                    use: [sessionMiddleware],
+                    body: z.object({
+                        keyId: z.string(),
+                        permissions: z
+                            .record(z.string(), z.array(z.string()))
+                            .nullable()
+                            .optional(),
+                    }),
+                    metadata: {
+                        openapi: {
+                            summary: "Update API key permissions",
+                            description:
+                                "Update the permissions of an API key. Requires session authentication.",
+                            tags: ["API Key"],
+                        },
+                    },
+                },
+                async (ctx) => {
+                    const { keyId, permissions } = ctx.body;
+
+                    // Call the base updateApiKey endpoint as a server-side call
+                    // This bypasses the SERVER_ONLY check for permissions
+                    const result = await basePlugin.endpoints.updateApiKey({
+                        ...ctx,
+                        body: {
+                            keyId,
+                            permissions,
+                        },
+                    });
+
+                    return result;
+                },
+            ),
+        },
+    } satisfies BetterAuthPlugin;
+};


### PR DESCRIPTION
- Add `apiKeyExtended` plugin that wraps better-auth's `apiKey` plugin
- Add `/api/auth/api-key/update-permissions` endpoint
- Calls base `updateApiKey` internally as server-side call to bypass `SERVER_ONLY` check
- Update client to use new endpoint for setting API key permissions

## Problem
better-auth's native `updateApiKey` endpoint marks `permissions` as `SERVER_ONLY`, meaning it can only be set via `auth.api.updateApiKey()` and not from HTTP requests.

## Solution
Create an extended plugin that adds a new endpoint which calls the base endpoint internally (as a server-side call), bypassing the restriction while maintaining better-auth's internal logic.

Based on approach suggested by @eulervoid