### PR TITLE
fix: Dashboard API Key display bugs (Prefix and Copy)

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -27,6 +27,9 @@ export function createAuth(env: Cloudflare.Env) {
         enableMetadata: true,
         defaultPrefix: PUBLISHABLE_KEY_PREFIX,
         defaultKeyLength: 16, // Minimum key length for validation (matches custom generator)
+        startingCharactersConfig: {
+            charactersLength: 10, // Store more characters for display (pk_xxxxxxxxxx...)
+        },
         customKeyGenerator: (options: {
             length: number;
             prefix: string | undefined;

--- a/enter.pollinations.ai/src/client/components/api-key.tsx
+++ b/enter.pollinations.ai/src/client/components/api-key.tsx
@@ -36,9 +36,11 @@ const Cell: FC<React.ComponentProps<"div">> = ({ children, ...props }) => {
     );
 };
 
-const KeyDisplay: FC<{ fullKey: string }> = ({ fullKey }) => {
+const KeyDisplay: FC<{ fullKey: string; start: string }> = ({
+    fullKey,
+    start,
+}) => {
     const [copied, setCopied] = useState(false);
-    const suffix = fullKey.slice(-4);
 
     const handleCopy = async () => {
         try {
@@ -62,7 +64,7 @@ const KeyDisplay: FC<{ fullKey: string }> = ({ fullKey }) => {
             )}
             title={copied ? "Copied!" : "Click to copy full key"}
         >
-            {copied ? "✓ Copied!" : `...${suffix}`}
+            {copied ? "✓ Copied!" : `${start}...`}
         </button>
     );
 };
@@ -211,6 +213,10 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                         <KeyDisplay
                                                             fullKey={
                                                                 plaintextKey
+                                                            }
+                                                            start={
+                                                                apiKey.start ??
+                                                                undefined
                                                             }
                                                         />
                                                     ) : (

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -96,7 +96,7 @@ function RouteComponent() {
     const handleCreateApiKey = async (formState: CreateApiKey) => {
         const keyType = formState.keyType || "secret";
         const isPublishable = keyType === "publishable";
-        const prefix = isPublishable ? "plln_pk" : "plln_sk";
+        const prefix = isPublishable ? "pk" : "sk";
 
         // Step 1: Create key via better-auth's native API
         const createResult = await auth.apiKey.create({
@@ -116,6 +116,18 @@ function RouteComponent() {
         }
 
         const apiKey = createResult.data;
+
+        // For publishable keys, store the plaintext key in metadata for easy retrieval
+        if (isPublishable) {
+            await auth.apiKey.update({
+                keyId: apiKey.id,
+                metadata: {
+                    description: formState.description,
+                    keyType,
+                    plaintextKey: apiKey.key,
+                },
+            });
+        }
 
         // Step 2: Set permissions if restricted (allowedModels is not null)
         // null = unrestricted (all models), array = restricted to specific models


### PR DESCRIPTION
- Remove `plln_` prefix from new keys (now `pk_`/`sk_`)
- Restore `plaintextKey` storage for publishable keys via `auth.apiKey.update()`
- Show key prefix instead of suffix in dashboard display
- Configure 10 chars for `start` field via `startingCharactersConfig`

Fixes #6087