### PR TITLE
fix: tooltip hover-only on desktop, click-only on mobile, fix modal z-index

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-key.tsx
+++ b/enter.pollinations.ai/src/client/components/api-key.tsx
@@ -80,12 +80,17 @@ const ModelsBadge: FC<{
     return (
         <button
             type="button"
-            className="relative inline-flex items-center group/models"
-            onClick={() => setShowTooltip(!showTooltip)}
+            className="relative inline-flex items-center"
+            onClick={(e) => {
+                e.stopPropagation();
+                setShowTooltip((prev) => !prev);
+            }}
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
             onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    setShowTooltip(!showTooltip);
+                    setShowTooltip((prev) => !prev);
                 }
             }}
             aria-label="Show allowed models"
@@ -101,7 +106,7 @@ const ModelsBadge: FC<{
                 {isAllModels ? "All" : modelCount}
             </span>
             <span
-                className={`${showTooltip ? "visible" : "invisible"} group-hover/models:visible absolute right-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 z-50 pointer-events-none whitespace-normal w-48 max-h-32 overflow-y-auto`}
+                className={`${showTooltip ? "visible" : "invisible"} absolute right-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 z-50 pointer-events-none whitespace-normal`}
             >
                 {isAllModels ? (
                     "Access to all models"
@@ -279,8 +284,8 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                 open={!!deleteId}
                 onOpenChange={({ open }) => !open && setDeleteId(null)}
             >
-                <Dialog.Backdrop className="fixed inset-0 bg-green-950/50" />
-                <Dialog.Positioner className="fixed inset-0 flex items-center justify-center p-4">
+                <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
+                <Dialog.Positioner className="fixed inset-0 flex items-center justify-center p-4 z-[100]">
                     <Dialog.Content className="bg-green-100 border-green-950 border-4 rounded-lg shadow-lg max-w-md w-full p-6">
                         <Dialog.Title className="text-lg font-semibold mb-4">
                             Delete API Key
@@ -650,8 +655,8 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                     Create new key
                 </Button>
             </Dialog.Trigger>
-            <Dialog.Backdrop className="fixed inset-0 bg-green-950/50" />
-            <Dialog.Positioner className="fixed inset-0 flex items-center justify-center p-4">
+            <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
+            <Dialog.Positioner className="fixed inset-0 flex items-center justify-center p-4 z-[100]">
                 <Dialog.Content
                     className={
                         "bg-green-100 border-green-950 border-4 rounded-lg shadow-lg max-w-lg w-full p-6 max-h-[85vh] overflow-y-auto"

--- a/enter.pollinations.ai/src/client/components/model-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/model-permissions.tsx
@@ -109,15 +109,18 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
                 <span className="text-sm font-medium">Allow all models</span>
                 <button
                     type="button"
-                    className="relative inline-flex items-center group/info"
+                    className="relative inline-flex items-center"
                     onClick={(e) => {
                         e.preventDefault();
-                        setShowTooltip(!showTooltip);
+                        e.stopPropagation();
+                        setShowTooltip((prev) => !prev);
                     }}
+                    onMouseEnter={() => setShowTooltip(true)}
+                    onMouseLeave={() => setShowTooltip(false)}
                     onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();
-                            setShowTooltip(!showTooltip);
+                            setShowTooltip((prev) => !prev);
                         }
                     }}
                     aria-label="Show model access information"
@@ -126,7 +129,7 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
                         i
                     </span>
                     <span
-                        className={`${showTooltip ? "visible" : "invisible"} group-hover/info:visible absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-normal z-50 pointer-events-none w-48`}
+                        className={`${showTooltip ? "visible" : "invisible"} absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-normal z-50 pointer-events-none`}
                     >
                         Restrict which models this API key can access. Useful
                         for limiting keys to specific use cases.

--- a/enter.pollinations.ai/src/client/components/pricing/ModelRow.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/ModelRow.tsx
@@ -20,6 +20,12 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
     const modelDescription = getModelDescription(model.name);
     const genPerPollen = calculatePerPollen(model);
     const [showTooltip, setShowTooltip] = useState(false);
+    const handleMouseEnter = () => setShowTooltip(true);
+    const handleMouseLeave = () => setShowTooltip(false);
+    const handleClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setShowTooltip((prev) => !prev);
+    };
 
     // Get model capabilities
     const showReasoning = hasReasoning(model.name);
@@ -72,12 +78,14 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                     {showDescriptionInfo && (
                         <button
                             type="button"
-                            className="relative inline-flex items-center group/info"
-                            onClick={() => setShowTooltip(!showTooltip)}
+                            className="relative inline-flex items-center"
+                            onClick={handleClick}
+                            onMouseEnter={handleMouseEnter}
+                            onMouseLeave={handleMouseLeave}
                             onKeyDown={(e) => {
                                 if (e.key === "Enter" || e.key === " ") {
                                     e.preventDefault();
-                                    setShowTooltip(!showTooltip);
+                                    setShowTooltip((prev) => !prev);
                                 }
                             }}
                             aria-label="Show model information"
@@ -86,7 +94,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                                 i
                             </span>
                             <span
-                                className={`${showTooltip ? "visible" : "invisible"} group-hover/info:visible absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none`}
+                                className={`${showTooltip ? "visible" : "invisible"} absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none`}
                             >
                                 {tooltipContent}
                             </span>

--- a/enter.pollinations.ai/src/client/components/pricing/Tooltip.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/Tooltip.tsx
@@ -1,15 +1,31 @@
-import type { FC, ReactNode } from "react";
+import { type FC, type ReactNode, useState } from "react";
 
 type TooltipProps = {
     children: ReactNode;
     text: string;
 };
 
-export const Tooltip: FC<TooltipProps> = ({ children, text }) => (
-    <span className="relative group/tip cursor-default">
-        <span>{children}</span>
-        <span className="invisible group-hover/tip:visible absolute left-1/2 -translate-x-1/2 top-full mt-1 px-2 py-1 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none">
-            {text}
+export const Tooltip: FC<TooltipProps> = ({ children, text }) => {
+    const [showTooltip, setShowTooltip] = useState(false);
+
+    return (
+        <span
+            className="relative cursor-default"
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+            onClick={(e) => {
+                e.stopPropagation();
+                setShowTooltip((prev) => !prev);
+            }}
+        >
+            <span className="md:cursor-default cursor-pointer">{children}</span>
+            <span
+                className={`${
+                    showTooltip ? "visible" : "invisible"
+                } absolute left-1/2 -translate-x-1/2 top-full mt-1 px-2 py-1 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none`}
+            >
+                {text}
+            </span>
         </span>
-    </span>
-);
+    );
+};


### PR DESCRIPTION
## Changes

- Update Tooltip component to use state-based visibility with hover/click
- Remove `group-hover` pattern from all tooltip implementations  
- Remove scrollbar constraints (`w-48 max-h-32 overflow-y-auto`)
- Add `z-[100]` to dialog modals to appear above `z-50` tooltips
- Fix KeyDisplay to show start prefix instead of suffix

## Behavior

- **Desktop**: Hover shows/hides tooltip (no click needed)
- **Mobile**: Tap toggles visibility (since hover doesn't exist)
- **Modals**: Now properly overlay above tooltip badges in the background

## Files Changed

- `Tooltip.tsx` - Reusable tooltip component
- `ModelRow.tsx` - Model info tooltips in pricing table
- `api-key.tsx` - ModelsBadge tooltip + dialog z-index fix
- `model-permissions.tsx` - Info tooltip for model restrictions