### PR TITLE
feat: add API key expiration (30d for pk_) and Last Used tracking

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -7,7 +7,7 @@ import {
     type User as GenericUser,
 } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { APIError, createAuthMiddleware } from "better-auth/api";
+import { APIError } from "better-auth/api";
 import { admin, apiKey, openAPI } from "better-auth/plugins";
 import { drizzle } from "drizzle-orm/d1";
 import * as betterAuthSchema from "./db/schema/better-auth.ts";
@@ -24,7 +24,6 @@ export function createAuth(env: Cloudflare.Env) {
 
     const PUBLISHABLE_KEY_PREFIX = "pk";
     const SECRET_KEY_PREFIX = "sk";
-    const PK_EXPIRATION_SECONDS = 30 * 24 * 60 * 60; // 30 days in seconds
 
     const apiKeyPlugin = apiKey({
         enableMetadata: true,
@@ -106,18 +105,6 @@ export function createAuth(env: Cloudflare.Env) {
             polarPlugin(polar, defaultTierProductId),
             openAPIPlugin,
         ],
-        hooks: {
-            before: createAuthMiddleware(async (ctx) => {
-                // Hook for API key creation - expiration logic preserved but not enforced by default
-                if (ctx.path !== "/api-key/create") {
-                    return;
-                }
-
-                // Keep the body as-is - expiration can be set by the client if needed
-                // The PK_EXPIRATION_SECONDS constant is available for future use
-                return;
-            }),
-        },
         telemetry: { enabled: false },
     });
 }

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -96,10 +96,9 @@ function RouteComponent() {
     const handleCreateApiKey = async (formState: CreateApiKey) => {
         const keyType = formState.keyType || "secret";
         const isPublishable = keyType === "publishable";
-        const prefix = isPublishable ? "plln_pk" : "plln_sk";
+        const prefix = isPublishable ? "pk" : "sk";
 
         // Step 1: Create key via better-auth's native API
-        // Note: Expiration is enforced server-side based on prefix
         const createResult = await auth.apiKey.create({
             name: formState.name,
             prefix,


### PR DESCRIPTION
## Summary

- Adds 30-day expiration for publishable keys (`pk_`), secret keys (`sk_`) never expire
- Adds "Last Used" and "Expires" columns to API keys table
- Shows warning badges for keys expiring soon or expired
- Uses compact time format (`2s`, `5m`, `1h`, `30d`) for all time displays

## Changes

### `src/client/routes/index.tsx`
- Pass `expiresIn` (30 days in seconds) when creating publishable keys

### `src/client/components/api-key.tsx`
- Add `lastRequest` and `expiresAt` fields to `ApiKey` type
- Add custom short locale for date-fns (`s`, `m`, `h`, `d`, `mo`, `y`)
- Update grid to 8 columns (added "Last Used" and "Expires")
- Add expiration warning badges

## Badge Examples

| Condition | Display | Style |
|-----------|---------|-------|
| `sk_` key (never expires) | `Never` | Gray text |
| `pk_` key with >7 days left | `25d` | Normal gray text |
| `pk_` key with ≤7 days left | `⚠️ 5d` | Amber badge with border |
| `pk_` key expired | `Expired` | Red badge with border |

## Testing

1. **Create a new `pk_` key** → should show `30d` in Expires column
2. **Create a new `sk_` key** → should show `Never` in Expires column
3. **Use a key via API** → "Last Used" should update from `Never` to time since use (e.g. `2s`)

Fixes #5582