### PR TITLE
fix: add Worker entry point for API proxy

### DIFF
--- a/hello.pollinations.ai/src/worker.ts
+++ b/hello.pollinations.ai/src/worker.ts
@@ -1,0 +1,73 @@
+/**
+ * Worker entry point for hello.pollinations.ai
+ * Handles /api/* routes by proxying to enter.pollinations.ai with secret key
+ * All other requests are served from static assets
+ */
+
+interface Env {
+    POLLINATIONS_API_KEY: string;
+    ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+const ENTER_BASE_URL = "https://enter.pollinations.ai/api";
+
+export default {
+    async fetch(request: Request, env: Env): Promise<Response> {
+        const url = new URL(request.url);
+
+        // Handle CORS preflight
+        if (request.method === "OPTIONS") {
+            return new Response(null, {
+                headers: {
+                    "Access-Control-Allow-Origin": "*",
+                    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                    "Access-Control-Allow-Headers":
+                        "Content-Type, Authorization",
+                },
+            });
+        }
+
+        // Proxy /api/* requests to enter.pollinations.ai
+        if (url.pathname.startsWith("/api/")) {
+            const targetPath = url.pathname.replace(/^\/api/, "");
+            const targetUrl = `${ENTER_BASE_URL}${targetPath}${url.search}`;
+
+            // Clone headers and add auth
+            const headers = new Headers(request.headers);
+            headers.set("Authorization", `Bearer ${env.POLLINATIONS_API_KEY}`);
+
+            const proxyRequest = new Request(targetUrl, {
+                method: request.method,
+                headers,
+                body:
+                    request.method !== "GET" && request.method !== "HEAD"
+                        ? request.body
+                        : undefined,
+            });
+
+            try {
+                const response = await fetch(proxyRequest);
+
+                // Return response with CORS headers
+                const responseHeaders = new Headers(response.headers);
+                responseHeaders.set("Access-Control-Allow-Origin", "*");
+
+                return new Response(response.body, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: responseHeaders,
+                });
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : "Unknown error";
+                return new Response(JSON.stringify({ error: message }), {
+                    status: 500,
+                    headers: { "Content-Type": "application/json" },
+                });
+            }
+        }
+
+        // For all other requests, serve static assets
+        return env.ASSETS.fetch(request);
+    },
+};

--- a/hello.pollinations.ai/wrangler.toml
+++ b/hello.pollinations.ai/wrangler.toml
@@ -1,5 +1,6 @@
 name = "pollinations-hello"
 compatibility_date = "2025-11-01"
+main = "src/worker.ts"
 
 [[routes]]
 pattern = "hello.pollinations.ai"
@@ -8,7 +9,9 @@ custom_domain = true
 
 [assets]
 directory = "dist"
+binding = "ASSETS"
 not_found_handling = "single-page-application"
+run_worker_first = ["/api/*"]
 
-# API Proxy is handled by Pages Functions in functions/api/[[path]].ts
-# The POLLINATIONS_API_KEY secret must be set in Cloudflare dashboard
+# API Proxy handled by Worker in src/worker.ts
+# The POLLINATIONS_API_KEY secret must be set via: npx wrangler secret put POLLINATIONS_API_KEY


### PR DESCRIPTION
## Summary

Fixes the API proxy setup for hello.pollinations.ai. The previous PR (#6121) used `functions/` directory which is for Cloudflare Pages, but this project is a Worker with static assets.

## Changes

- Add `src/worker.ts` - Worker entry point that proxies `/api/*` to enter.pollinations.ai
- Update `wrangler.toml`:
  - Add `main = "src/worker.ts"`
  - Add `binding = "ASSETS"`
  - Add `run_worker_first = ["/api/*"]`

## How It Works

```
Browser → /api/* → Worker (adds secret key) → enter.pollinations.ai
Browser → /* → Static assets (dist/)
```

## Deployment

After merge, deploy via:
```bash
cd hello.pollinations.ai
npm run build && npx wrangler deploy
```

Secret already set via `npx wrangler secret put POLLINATIONS_API_KEY`