### PR TITLE
feat: Add Gemini 3 Flash as default gemini model

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -137,6 +137,27 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "gemini": {
+        aliases: ["gemini-3-flash", "gemini-3-flash-preview"],
+        modelId: "gemini-3-flash-preview",
+        provider: "vertex-ai",
+        cost: [
+            {
+                date: COST_START_DATE,
+                promptTextTokens: perMillion(0.5),
+                promptCachedTokens: perMillion(0.05),
+                completionTextTokens: perMillion(3.0),
+            },
+        ],
+        description:
+            "Google Gemini 3 Flash - Pro-Grade Reasoning at Flash Speed",
+        inputModalities: ["text", "image", "audio", "video"],
+        outputModalities: ["text"],
+        tools: true,
+        search: true,
+        codeExecution: true,
+        isSpecialized: false,
+    },
+    "gemini-fast": {
         aliases: ["gemini-2.5-flash-lite"],
         modelId: "gemini-2.5-flash-lite",
         provider: "vertex-ai",
@@ -148,10 +169,13 @@ export const TEXT_SERVICES = {
                 completionTextTokens: perMillion(0.4),
             },
         ],
-        description: "Google Gemini 2.5 Flash Lite - Fast & Multimodal",
+        description:
+            "Google Gemini 2.5 Flash Lite - Ultra Fast & Cost-Effective",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,
+        search: true,
+        codeExecution: true,
         isSpecialized: false,
     },
     "deepseek": {
@@ -196,22 +220,23 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "gemini-search": {
-        aliases: ["gemini-2.5-flash-lite-search"],
-        modelId: "gemini-2.5-flash-lite",
+        aliases: ["gemini-3-flash-search"],
+        modelId: "gemini-3-flash-preview",
         provider: "vertex-ai",
         cost: [
             {
                 date: COST_START_DATE,
-                promptTextTokens: perMillion(0.1),
-                promptCachedTokens: perMillion(0.01),
-                completionTextTokens: perMillion(0.4),
+                promptTextTokens: perMillion(0.5),
+                promptCachedTokens: perMillion(0.05),
+                completionTextTokens: perMillion(3.0),
             },
         ],
-        description: "Google Gemini 2.5 Flash Lite - With Google Search",
+        description: "Google Gemini 3 Flash - With Google Search",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: false,
         search: true,
+        codeExecution: true,
         isSpecialized: false,
     },
     "chickytutor": {
@@ -375,6 +400,8 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
+        search: true,
+        codeExecution: false, // Disabled - was breaking gemini-large
         isSpecialized: false,
     },
     "nova-micro": {

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -88,6 +88,14 @@ const models: ModelDefinition[] = [
     },
     {
         name: "gemini",
+        config: portkeyConfig["gemini-3-flash-preview"],
+        transform: pipe(
+            createSystemPromptTransform(BASE_PROMPTS.conversational),
+            createGeminiToolsTransform(),
+        ),
+    },
+    {
+        name: "gemini-fast",
         config: portkeyConfig["gemini-2.5-flash-lite"],
         transform: pipe(
             createSystemPromptTransform(BASE_PROMPTS.conversational),
@@ -96,7 +104,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "gemini-search",
-        config: portkeyConfig["gemini-2.5-flash-lite"],
+        config: portkeyConfig["gemini-3-flash-preview"],
         transform: pipe(createGoogleSearchTransform()),
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -155,6 +155,14 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // Google Vertex AI configurations
+    "gemini-3-flash-preview": () => ({
+        provider: "vertex-ai",
+        authKey: googleCloudAuth.getAccessToken,
+        "vertex-project-id": process.env.GCLOUD_PROJECT_ID,
+        "vertex-region": "us-central1",
+        "vertex-model-id": "gemini-3-flash-preview",
+        "strict-openai-compliance": "false",
+    }),
     "gemini-2.5-flash-lite": () => ({
         provider: "vertex-ai",
         authKey: googleCloudAuth.getAccessToken,


### PR DESCRIPTION
- `gemini` → Gemini 3 Flash ($0.50/$3.00 per M tokens)
- `gemini-fast` (NEW) → Gemini 2.5 Flash Lite ($0.10/$0.40 per M tokens)
- `gemini-search` → Updated to Gemini 3 Flash
- Added `search`/`codeExecution` properties to gemini models
- `gemini-large` keeps `codeExecution: false` (was breaking)