### PR TITLE
Update scripts to tail production logs in human-readable format

### DIFF
--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -25,7 +25,8 @@
         "decrypt-vars:production": "sops decrypt secrets/prod.vars.json --output-type dotenv > .dev.vars",
         "push-secrets:staging": "sops exec-file --no-fifo secrets/staging.vars.json 'npx wrangler secret bulk {} --env staging'",
         "push-secrets:production": "sops exec-file --no-fifo secrets/prod.vars.json 'npx wrangler secret bulk {} --env production'",
-        "tail": "wrangler tail --env production | tsx scripts/format-logs.ts"
+        "tail": "wrangler tail --env production | jq -c '.logs[].message[] | fromjson' | tsx scripts/format-logs.ts",
+        "tail:json": "wrangler tail --env production | jq '.logs[].message[] | fromjson'"
     },
     "dependencies": {
         "@ark-ui/react": "^5.29.1",

--- a/enter.pollinations.ai/scripts/format-logs.ts
+++ b/enter.pollinations.ai/scripts/format-logs.ts
@@ -1,7 +1,6 @@
 import { LogLevel, getLogger } from "@logtape/logtape";
 import { ensureConfigured } from "../src/logger.ts";
 import { createInterface } from "node:readline/promises";
-import { inspect } from "node:util";
 
 async function main() {
     await ensureConfigured({ level: "trace", format: "text" });
@@ -14,11 +13,6 @@ async function main() {
 function processLine(line: string) {
     try {
         const json = JSON.parse(line);
-
-        if (process.env.LOG_FORMAT === "json") {
-            console.log(inspect(json, { colors: true, compact: false }));
-            return;
-        }
 
         if (!json.level) {
             console.log(line);


### PR DESCRIPTION
Adds two npm scripts:
- `npm run tail`: tries to reproduce log output close to what we get in development using `scripts/format-logs.ts`
- `npm run tail:json`: extracts the structured service logs from the general cloudflare log objects and displays them as nice formatted json using `jq`

Requires `jq` to be installed (nix shell adds it by default)
