### PR TITLE
fix: use global region for gemini-3-flash-preview

### DIFF
--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -159,7 +159,7 @@ export const portkeyConfig: PortkeyConfigMap = {
         provider: "vertex-ai",
         authKey: googleCloudAuth.getAccessToken,
         "vertex-project-id": process.env.GCLOUD_PROJECT_ID,
-        "vertex-region": "us-central1",
+        "vertex-region": "global",
         "vertex-model-id": "gemini-3-flash-preview",
         "strict-openai-compliance": "false",
     }),


### PR DESCRIPTION
## Summary
- Fix 404 errors for `gemini` and `gemini-search` models by using `global` region instead of `us-central1`

## Problem
After PR #6144 introduced Gemini 3 Flash, the `gemini` and `gemini-search` models were returning 404 errors because `gemini-3-flash-preview` requires the **global endpoint**, not `us-central1`.

## Fix
Changed `vertex-region` from `us-central1` to `global` for `gemini-3-flash-preview` config.

## Testing
Verified locally - all gemini models now working:
- ✅ `gemini` → `gemini-3-flash-preview` (200)
- ✅ `gemini-fast` → `gemini-2.5-flash-lite` (200)
- ✅ `gemini-search` → `gemini-3-flash-preview` (200)
- ✅ `gemini-large` → `gemini-3-pro-preview` (200)

Addresses Discord reports in #pollen-beta channel.