### PR TITLE
fix: enable all audio voices for openai-audio model

### DIFF
--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -1,7 +1,10 @@
 // AI generated based on `https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml` and adaped
 
 import { z } from "zod";
-import { DEFAULT_TEXT_MODEL } from "../../../shared/registry/text.ts";
+import {
+    DEFAULT_TEXT_MODEL,
+    AUDIO_VOICES,
+} from "../../../shared/registry/text.ts";
 
 const FunctionParametersSchema = z.record(z.string(), z.any());
 
@@ -258,14 +261,7 @@ export const CreateChatCompletionRequestSchema = z.object({
     modalities: z.array(z.enum(["text", "audio"])).optional(),
     audio: z
         .object({
-            voice: z.enum([
-                "alloy",
-                "echo",
-                "fable",
-                "onyx",
-                "nova",
-                "shimmer",
-            ]),
+            voice: z.enum(AUDIO_VOICES),
             format: z.enum(["wav", "mp3", "flac", "opus", "pcm16"]),
         })
         .optional(),

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,6 +1,25 @@
 import { COST_START_DATE, perMillion } from "./price-helpers";
 import type { ServiceDefinition } from "./registry";
 
+// Voices available for openai-audio model - exported for schema validation
+export const AUDIO_VOICES = [
+    "alloy",
+    "echo",
+    "fable",
+    "onyx",
+    "nova",
+    "shimmer",
+    "coral",
+    "verse",
+    "ballad",
+    "ash",
+    "sage",
+    "amuch",
+    "dan",
+] as const;
+
+export type AudioVoice = (typeof AUDIO_VOICES)[number];
+
 export const DEFAULT_TEXT_MODEL = "openai" as const;
 export type TextServiceId = keyof typeof TEXT_SERVICES;
 export type TextModelId = (typeof TEXT_SERVICES)[TextServiceId]["modelId"];
@@ -116,21 +135,7 @@ export const TEXT_SERVICES = {
             },
         ],
         description: "OpenAI GPT-4o Mini Audio - Voice Input & Output",
-        voices: [
-            "alloy",
-            "echo",
-            "fable",
-            "onyx",
-            "nova",
-            "shimmer",
-            "coral",
-            "verse",
-            "ballad",
-            "ash",
-            "sage",
-            "amuch",
-            "dan",
-        ],
+        voices: [...AUDIO_VOICES],
         inputModalities: ["text", "image", "audio"],
         outputModalities: ["audio", "text"],
         tools: true,


### PR DESCRIPTION
- Export `AUDIO_VOICES` constant from shared registry for DRY
- Import and use in enter.pollinations.ai schema validation
- Adds 7 new voices: coral, verse, ballad, ash, sage, amuch, dan
- Tested locally with dev server

Fixes #6158