### PR TITLE
Fix GPT-5 temperature forcing for Azure OpenAI models

### DIFF
--- a/enter.pollinations.ai/test/integration/text.test.ts
+++ b/enter.pollinations.ai/test/integration/text.test.ts
@@ -615,6 +615,39 @@ describe("POST /generate/v1/chat/completions (tool calls)", async () => {
     );
 });
 
+// GPT-5 temperature transformation test
+test(
+    "POST /v1/chat/completions should accept temperature=0.7 for GPT-5 models (transformed to 1)",
+    { timeout: 30000 },
+    async ({ apiKey, mocks }) => {
+        await mocks.enable("polar", "tinybird", "vcr");
+        const response = await SELF.fetch(
+            `http://localhost:3000/api/generate/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "authorization": `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: "openai-fast",
+                    messages: [
+                        {
+                            role: "user",
+                            content: "Say yes",
+                        },
+                    ],
+                    temperature: 0.7,
+                    seed: testSeed(),
+                }),
+            },
+        );
+        // Should succeed - temperature is transformed to 1 for GPT-5 models
+        expect(response.status).toBe(200);
+        await response.text();
+    },
+);
+
 // Model gating tests - API keys with permissions.models restriction
 describe("Model gating by API key permissions", async () => {
     test(

--- a/text.pollinations.ai/transforms/parameterProcessor.js
+++ b/text.pollinations.ai/transforms/parameterProcessor.js
@@ -57,11 +57,13 @@ export function processParameters(messages, options) {
 
     // Force temperature=1 for reasoning models (o1, o3, o4) and GPT-5 series
     // These Azure OpenAI models only support temperature=1
-    const isReasoningOrGpt5Model =
-        requestedModel &&
-        (/^o[134](-mini|-preview)?$/i.test(requestedModel) ||
-            /^gpt-5/i.test(requestedModel));
+    // options.model is already resolved to actual model name by modelResolver
+    const model = updatedOptions.model || "";
+    const isReasoningOrGpt5Model = /^(o[134](-mini|-preview)?|gpt-5)/i.test(
+        model,
+    );
     if (isReasoningOrGpt5Model) {
+        log(`Forcing temperature=1 for reasoning/GPT-5 model: ${model}`);
         updatedOptions.temperature = 1;
     }
 


### PR DESCRIPTION
- Force `temperature=1` for GPT-5 series models (Azure only supports this value)
- Check resolved model name (`options.model`) instead of `requestedModel`
- Add integration test verifying `temperature: 0.7` requests succeed

Fixes 400 error: `"temperature" does not support 0.7 with this model`