### PR TITLE
fix: remove unused n parameter from Text API

### DIFF
--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -281,7 +281,6 @@ export const CreateChatCompletionRequestSchema = z.object({
     logprobs: z.boolean().nullable().optional().default(false),
     top_logprobs: z.number().int().min(0).max(20).nullable().optional(),
     max_tokens: z.number().int().min(0).nullable().optional(),
-    n: z.number().int().min(1).max(128).nullable().optional().default(1),
     presence_penalty: z
         .number()
         .min(-2)

--- a/text.pollinations.ai/requestUtils.js
+++ b/text.pollinations.ai/requestUtils.js
@@ -65,9 +65,6 @@ export function getRequestData(req) {
     // Extract logit_bias for token bias
     const logit_bias = data.logit_bias || undefined;
 
-    // Extract n for number of completions
-    const n = data.n || undefined;
-
     // Extract user identifier
     const user = data.user || undefined;
 
@@ -106,7 +103,6 @@ export function getRequestData(req) {
         logprobs,
         top_logprobs,
         logit_bias,
-        n,
         user,
     };
 }


### PR DESCRIPTION
- Remove `n` parameter extraction from `text.pollinations.ai/requestUtils.js`
- Remove `n` from `CreateChatCompletionRequestSchema` in `enter.pollinations.ai`
- Pollinations always generates single completions

Fixes #6176