### PR TITLE
fix: gemini-fast tools (code_execution, google_search, url_context) not working

### DIFF
--- a/text.pollinations.ai/transforms/createGeminiToolsTransform.ts
+++ b/text.pollinations.ai/transforms/createGeminiToolsTransform.ts
@@ -3,6 +3,19 @@ import { addDefaultTools } from "./pipe.js";
 export type GeminiToolName = "code_execution" | "google_search" | "url_context";
 
 /**
+ * Converts a Gemini tool name to the OpenAI function format expected by Portkey gateway
+ * The gateway only processes tools with type === "function" and transforms them to Vertex AI format
+ */
+function toOpenAIFunctionFormat(name: GeminiToolName) {
+    return {
+        type: "function" as const,
+        function: {
+            name,
+        },
+    };
+}
+
+/**
  * Creates a transform that adds Gemini tools for enhanced capabilities
  * Only applies if user hasn't passed their own tools
  */
@@ -13,5 +26,5 @@ export function createGeminiToolsTransform(
         "url_context",
     ],
 ) {
-    return addDefaultTools(toolNames.map((name) => ({ type: name })));
+    return addDefaultTools(toolNames.map(toOpenAIFunctionFormat));
 }

--- a/text.pollinations.ai/transforms/parameterProcessor.js
+++ b/text.pollinations.ai/transforms/parameterProcessor.js
@@ -14,8 +14,6 @@ export function processParameters(messages, options) {
     }
 
     const config = options.modelConfig;
-    const modelConfig = options.modelDef;
-    const requestedModel = options.requestedModel;
     const updatedOptions = { ...options };
 
     // Apply model-specific sampling parameter defaults
@@ -65,43 +63,6 @@ export function processParameters(messages, options) {
     if (isReasoningOrGpt5Model) {
         log(`Forcing temperature=1 for reasoning/GPT-5 model: ${model}`);
         updatedOptions.temperature = 1;
-    }
-
-    // Apply parameter filtering if defined
-    if (modelConfig.allowedParameters) {
-        const allowedParams = modelConfig.allowedParameters;
-        log(
-            `Applying parameter filter for model ${requestedModel}, allowing only: ${allowedParams.join(", ")}`,
-        );
-
-        const filteredOptions = {};
-
-        // Only include allowed parameters
-        for (const param of allowedParams) {
-            if (updatedOptions[param] !== undefined) {
-                filteredOptions[param] = updatedOptions[param];
-            }
-        }
-
-        // Preserve internal properties and stream_options
-        if (updatedOptions.additionalHeaders) {
-            filteredOptions.additionalHeaders =
-                updatedOptions.additionalHeaders;
-        }
-        if (updatedOptions.modelConfig) {
-            filteredOptions.modelConfig = updatedOptions.modelConfig;
-        }
-        if (updatedOptions.modelDef) {
-            filteredOptions.modelDef = updatedOptions.modelDef;
-        }
-        if (updatedOptions.requestedModel) {
-            filteredOptions.requestedModel = updatedOptions.requestedModel;
-        }
-        if (updatedOptions.stream_options) {
-            filteredOptions.stream_options = updatedOptions.stream_options;
-        }
-
-        return { messages, options: filteredOptions };
     }
 
     return { messages, options: updatedOptions };


### PR DESCRIPTION
**Problem:**
- `gemini-fast` model wasn't using web search, code execution, or URL context despite having tools configured
- `gemini-search` worked correctly

**Root Cause:**
- Portkey gateway only processes tools with `type === "function"` format
- `createGeminiToolsTransform` was using `{ type: "code_execution" }` instead of `{ type: "function", function: { name: "code_execution" } }`

**Changes:**
- Fix tool format in `createGeminiToolsTransform.ts` to match OpenAI function format
- Remove unused `allowedParameters` functionality from `parameterProcessor.js`

Fixes #6152