### PR TITLE
fix: url encode nested image urls in instagram workflow

### DIFF
--- a/.github/scripts/instagram_generate_post.py
+++ b/.github/scripts/instagram_generate_post.py
@@ -552,13 +552,11 @@ def generate_image(prompt: str, token: str, index: int, reference_url: str = Non
             "key": token
         }
 
-        # Add reference image for I2I (must be URL-encoded, but avoid double-encoding)
+        # Add reference image for I2I (must be fully URL-encoded)
         if reference_url:
-            # Check if already encoded (contains %) to avoid double-encoding
-            if '%' in reference_url:
-                params["image"] = reference_url
-            else:
-                params["image"] = quote(reference_url, safe='')
+            # Always encode the full URL - the reference_url contains query params
+            # that must be encoded to avoid breaking the outer URL parsing
+            params["image"] = quote(reference_url, safe='')
 
         if attempt == 0:
             print(f"  Using seed: {seed}")


### PR DESCRIPTION
The i2i image chaining was breaking because the nested URL in the `image=` param wasn't being encoded properly.

When the reference URL contained query params like `&width=2048&height=2048`, they were being parsed as part of the outer URL instead of the nested one - causing validation errors like "expected number, received NaN".

Now we always encode the full reference URL so nested params stay nested.