### PR TITLE
feat: add API docs markdown generation

### DIFF
--- a/enter.pollinations.ai/APIDOCS.md
+++ b/enter.pollinations.ai/APIDOCS.md
@@ -1,0 +1,1891 @@
+# Pollinations.AI API
+
+- **OpenAPI Version:** `3.1.0`
+- **API Version:** `0.3.0`
+
+Documentation for `gen.pollinations.ai` - the Pollinations.AI API gateway.
+
+[📝 Edit docs](https://github.com/pollinations/pollinations/edit/master/enter.pollinations.ai/src/routes/docs.ts)
+
+## Quick Start
+
+Get your API key at <https://enter.pollinations.ai>
+
+### Image Generation
+
+```bash
+curl 'https://gen.pollinations.ai/image/a%20cat?model=flux' \
+  -H 'Authorization: Bearer YOUR_API_KEY'
+```
+
+### Text Generation
+
+```bash
+curl 'https://gen.pollinations.ai/v1/chat/completions' \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "openai", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+**Note:** `gemini` model has `code_execution`, `google_search`, `url_context` tools enabled by default. Pass your own `tools` array to override.
+
+### Simple Text Endpoint
+
+```bash
+curl 'https://gen.pollinations.ai/text/hello?key=YOUR_API_KEY'
+```
+
+### Streaming
+
+```bash
+curl 'https://gen.pollinations.ai/v1/chat/completions' \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "openai", "messages": [{"role": "user", "content": "Write a poem"}], "stream": true}' \
+  --no-buffer
+```
+
+### Model Discovery
+
+**Always check available models before testing:**
+
+- **Image models:** [/image/models](https://gen.pollinations.ai/image/models)
+- **Text models:** [/v1/models](https://gen.pollinations.ai/v1/models)
+
+## Authentication
+
+**Two key types:**
+
+- **Publishable Keys (`pk_`):** Client-side safe, IP rate-limited (3 req/burst, 1/15sec refill)
+- **Secret Keys (`sk_`):** Server-side only, no rate limits, can spend Pollen
+
+**Auth methods:**
+
+1. Header: `Authorization: Bearer YOUR_API_KEY`
+2. Query param: `?key=YOUR_API_KEY`
+
+## Servers
+
+- **URL:** `https://gen.pollinations.ai`
+
+## Operations
+
+### GET /v1/models
+
+- **Method:** `GET`
+- **Path:** `/v1/models`
+- **Tags:** gen.pollinations.ai
+
+Get available text models (OpenAI-compatible).
+
+#### Responses
+
+##### Status: 200 Success
+
+###### Content-Type: application/json
+
+**Array of:**
+
+- **`audio` (required)**
+
+  `boolean`
+
+- **`community` (required)**
+
+  `boolean`
+
+- **`description` (required)**
+
+  `string`
+
+- **`input_modalities` (required)**
+
+  `array`
+
+  **Items:**
+
+  `string`, possible values: `"text", "image", "audio"`
+
+- **`name` (required)**
+
+  `string`
+
+- **`output_modalities` (required)**
+
+  `array`
+
+  **Items:**
+
+  `string`, possible values: `"text", "image", "audio"`
+
+- **`tier` (required)**
+
+  `string`, possible values: `"anonymous", "seed", "flower", "nectar"`
+
+- **`tools` (required)**
+
+  `boolean`
+
+- **`vision` (required)**
+
+  `boolean`
+
+- **`aliases`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`maxInputChars`**
+
+  `number`
+
+- **`reasoning`**
+
+  `boolean`
+
+- **`supportsSystemMessages`**
+
+  `boolean`
+
+- **`uncensored`**
+
+  `boolean`
+
+- **`voices`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+**Example:**
+
+```json
+[
+  {
+    "name": "",
+    "description": "",
+    "tier": "anonymous",
+    "community": true,
+    "aliases": [
+      ""
+    ],
+    "input_modalities": [
+      "text"
+    ],
+    "output_modalities": [
+      "text"
+    ],
+    "tools": true,
+    "vision": true,
+    "audio": true,
+    "maxInputChars": 1,
+    "reasoning": true,
+    "voices": [
+      ""
+    ],
+    "uncensored": true,
+    "supportsSystemMessages": true
+  }
+]
+```
+
+##### Status: 500 Oh snap, something went wrong on our end. We're on it!
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 500,
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Oh snap, something went wrong on our end. We're on it!",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+### GET /image/models
+
+- **Method:** `GET`
+- **Path:** `/image/models`
+- **Tags:** gen.pollinations.ai
+
+Get a list of available image generation models with pricing, capabilities, and metadata. Use this endpoint to discover which models are available and their costs before making generation requests. Response includes `aliases` (alternative names you can use), pricing per image, and supported modalities.
+
+#### Responses
+
+##### Status: 200 Success
+
+###### Content-Type: application/json
+
+**Array of:**
+
+- **`aliases` (required)**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`name` (required)**
+
+  `string`
+
+- **`pricing` (required)**
+
+  `object`
+
+  - **`currency` (required)**
+
+    `string`
+
+  - **`audio_input_price`**
+
+    `number`
+
+  - **`audio_output_price`**
+
+    `number`
+
+  - **`cached_token_price`**
+
+    `number`
+
+  - **`image_price`**
+
+    `number`
+
+  - **`input_token_price`**
+
+    `number`
+
+  - **`output_token_price`**
+
+    `number`
+
+- **`context_window`**
+
+  `number`
+
+- **`description`**
+
+  `string`
+
+- **`input_modalities`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`is_specialized`**
+
+  `boolean`
+
+- **`output_modalities`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`reasoning`**
+
+  `boolean`
+
+- **`tools`**
+
+  `boolean`
+
+- **`voices`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+**Example:**
+
+```json
+[
+  {
+    "name": "",
+    "aliases": [
+      ""
+    ],
+    "pricing": {
+      "input_token_price": 1,
+      "output_token_price": 1,
+      "cached_token_price": 1,
+      "image_price": 1,
+      "audio_input_price": 1,
+      "audio_output_price": 1,
+      "currency": "pollen"
+    },
+    "description": "",
+    "input_modalities": [
+      ""
+    ],
+    "output_modalities": [
+      ""
+    ],
+    "tools": true,
+    "reasoning": true,
+    "context_window": 1,
+    "voices": [
+      ""
+    ],
+    "is_specialized": true
+  }
+]
+```
+
+##### Status: 500 Oh snap, something went wrong on our end. We're on it!
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 500,
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Oh snap, something went wrong on our end. We're on it!",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+### GET /text/models
+
+- **Method:** `GET`
+- **Path:** `/text/models`
+- **Tags:** gen.pollinations.ai
+
+Get a list of available text generation models with pricing, capabilities, and metadata. Use this endpoint to discover which models are available and their costs before making generation requests. Response includes `aliases` (alternative names you can use), token pricing, supported modalities (text, image, audio), and capabilities (tools, reasoning).
+
+#### Responses
+
+##### Status: 200 Success
+
+###### Content-Type: application/json
+
+**Array of:**
+
+- **`aliases` (required)**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`name` (required)**
+
+  `string`
+
+- **`pricing` (required)**
+
+  `object`
+
+  - **`currency` (required)**
+
+    `string`
+
+  - **`audio_input_price`**
+
+    `number`
+
+  - **`audio_output_price`**
+
+    `number`
+
+  - **`cached_token_price`**
+
+    `number`
+
+  - **`image_price`**
+
+    `number`
+
+  - **`input_token_price`**
+
+    `number`
+
+  - **`output_token_price`**
+
+    `number`
+
+- **`context_window`**
+
+  `number`
+
+- **`description`**
+
+  `string`
+
+- **`input_modalities`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`is_specialized`**
+
+  `boolean`
+
+- **`output_modalities`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`reasoning`**
+
+  `boolean`
+
+- **`tools`**
+
+  `boolean`
+
+- **`voices`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+**Example:**
+
+```json
+[
+  {
+    "name": "",
+    "aliases": [
+      ""
+    ],
+    "pricing": {
+      "input_token_price": 1,
+      "output_token_price": 1,
+      "cached_token_price": 1,
+      "image_price": 1,
+      "audio_input_price": 1,
+      "audio_output_price": 1,
+      "currency": "pollen"
+    },
+    "description": "",
+    "input_modalities": [
+      ""
+    ],
+    "output_modalities": [
+      ""
+    ],
+    "tools": true,
+    "reasoning": true,
+    "context_window": 1,
+    "voices": [
+      ""
+    ],
+    "is_specialized": true
+  }
+]
+```
+
+##### Status: 500 Oh snap, something went wrong on our end. We're on it!
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 500,
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Oh snap, something went wrong on our end. We're on it!",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+### POST /v1/chat/completions
+
+- **Method:** `POST`
+- **Path:** `/v1/chat/completions`
+- **Tags:** gen.pollinations.ai
+
+OpenAI-compatible chat completions endpoint.
+
+**Legacy endpoint:** `/openai` (deprecated, use `/v1/chat/completions` instead)
+
+**Authentication (Secret Keys Only):**
+
+Include your API key in the `Authorization` header as a Bearer token:
+
+`Authorization: Bearer YOUR_API_KEY`
+
+API keys can be created from your dashboard at enter.pollinations.ai. Secret keys provide the best rate limits and can spend Pollen.
+
+#### Request Body
+
+##### Content-Type: application/json
+
+- **`messages` (required)**
+
+  `array`
+
+  **Items:**
+
+  **Any of:**
+
+  - **`content` (required)**
+
+    `object`
+
+  - **`role` (required)**
+
+    `string`
+
+  - **`cache_control`**
+
+    `object`
+
+    - **`type` (required)**
+
+      `string`, possible values: `"ephemeral"`
+
+  - **`name`**
+
+    `string`
+
+  * **`content` (required)**
+
+    `object`
+
+  * **`role` (required)**
+
+    `string`
+
+  * **`cache_control`**
+
+    `object`
+
+    - **`type` (required)**
+
+      `string`, possible values: `"ephemeral"`
+
+  * **`name`**
+
+    `string`
+
+  - **`content` (required)**
+
+    `object`
+
+  - **`role` (required)**
+
+    `string`
+
+  - **`name`**
+
+    `string`
+
+  * **`role` (required)**
+
+    `string`
+
+  * **`cache_control`**
+
+    `object`
+
+    - **`type` (required)**
+
+      `string`, possible values: `"ephemeral"`
+
+  * **`content`**
+
+    `object`
+
+  * **`function_call`**
+
+    `object`
+
+  * **`name`**
+
+    `string`
+
+  * **`tool_calls`**
+
+    `array`
+
+    **Items:**
+
+    - **`function` (required)**
+
+      `object`
+
+      - **`arguments` (required)**
+
+        `string`
+
+      - **`name` (required)**
+
+        `string`
+
+    - **`id` (required)**
+
+      `string`
+
+    - **`type` (required)**
+
+      `string`
+
+  - **`content` (required)**
+
+    `object`
+
+  - **`role` (required)**
+
+    `string`
+
+  - **`tool_call_id` (required)**
+
+    `string`
+
+  - **`cache_control`**
+
+    `object`
+
+    - **`type` (required)**
+
+      `string`, possible values: `"ephemeral"`
+
+  * **`content` (required)**
+
+    `object`
+
+  * **`name` (required)**
+
+    `string`
+
+  * **`role` (required)**
+
+    `string`
+
+- **`audio`**
+
+  `object`
+
+  - **`format` (required)**
+
+    `string`, possible values: `"wav", "mp3", "flac", "opus", "pcm16"`
+
+  - **`voice` (required)**
+
+    `string`, possible values: `"alloy", "echo", "fable", "onyx", "nova", "shimmer", "coral", "verse", "ballad", "ash", "sage", "amuch", "dan"`
+
+- **`frequency_penalty`**
+
+  `object`, default: `0`
+
+- **`function_call`**
+
+  `object`
+
+- **`functions`**
+
+  `array`
+
+  **Items:**
+
+  - **`name` (required)**
+
+    `string`
+
+  - **`description`**
+
+    `string`
+
+  - **`parameters`**
+
+    `object`
+
+- **`logit_bias`**
+
+  `object`, default: `null`
+
+- **`logprobs`**
+
+  `object`, default: `false`
+
+- **`max_tokens`**
+
+  `object`
+
+- **`modalities`**
+
+  `array`
+
+  **Items:**
+
+  `string`, possible values: `"text", "audio"`
+
+- **`model`**
+
+  `string`, default: `"openai"`
+
+- **`parallel_tool_calls`**
+
+  `boolean`, default: `true`
+
+- **`presence_penalty`**
+
+  `object`, default: `0`
+
+- **`reasoning_effort`**
+
+  `string`, possible values: `"low", "medium", "high"`
+
+- **`repetition_penalty`**
+
+  `object`
+
+- **`response_format`**
+
+  `object`
+
+- **`seed`**
+
+  `object`
+
+- **`stop`**
+
+  `object`
+
+- **`stream`**
+
+  `object`, default: `false`
+
+- **`stream_options`**
+
+  `object`
+
+- **`temperature`**
+
+  `object`, default: `1`
+
+- **`thinking`**
+
+  `object`
+
+- **`thinking_budget`**
+
+  `integer`
+
+- **`tool_choice`**
+
+  `object`
+
+- **`tools`**
+
+  `array`
+
+  **Items:**
+
+  **Any of:**
+
+  - **`function` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`description`**
+
+      `string`
+
+    - **`parameters`**
+
+      `object`
+
+    - **`strict`**
+
+      `object`, default: `false`
+
+  - **`type` (required)**
+
+    `string`
+
+  * **`type` (required)**
+
+    `string`, possible values: `"code_execution", "google_search", "google_maps", "url_context", "computer_use", "file_search"`
+
+- **`top_logprobs`**
+
+  `object`
+
+- **`top_p`**
+
+  `object`, default: `1`
+
+- **`user`**
+
+  `string`
+
+**Example:**
+
+```json
+{
+  "messages": [
+    {
+      "content": "",
+      "role": "system",
+      "name": "",
+      "cache_control": {
+        "type": "ephemeral"
+      }
+    }
+  ],
+  "model": "openai",
+  "modalities": [
+    "text"
+  ],
+  "audio": {
+    "voice": "alloy",
+    "format": "wav"
+  },
+  "frequency_penalty": 0,
+  "repetition_penalty": 0,
+  "logit_bias": null,
+  "logprobs": false,
+  "top_logprobs": 0,
+  "max_tokens": 0,
+  "presence_penalty": 0,
+  "response_format": {
+    "type": "text"
+  },
+  "seed": 0,
+  "stop": "",
+  "stream": false,
+  "stream_options": {
+    "include_usage": true
+  },
+  "thinking": {
+    "type": "disabled",
+    "budget_tokens": 1
+  },
+  "reasoning_effort": "low",
+  "thinking_budget": 0,
+  "temperature": 1,
+  "top_p": 1,
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "description": "",
+        "name": "",
+        "parameters": {
+          "propertyName*": "anything"
+        },
+        "strict": false
+      }
+    }
+  ],
+  "tool_choice": "none",
+  "parallel_tool_calls": true,
+  "user": "",
+  "function_call": "none",
+  "functions": [
+    {
+      "description": "",
+      "name": "",
+      "parameters": {
+        "propertyName*": "anything"
+      }
+    }
+  ]
+}
+```
+
+#### Responses
+
+##### Status: 200 Success
+
+###### Content-Type: application/json
+
+- **`choices` (required)**
+
+  `array`
+
+  **Items:**
+
+  - **`content_filter_results`**
+
+    `object`
+
+  - **`finish_reason`**
+
+    `object`
+
+  - **`index`**
+
+    `integer`
+
+  - **`logprobs`**
+
+    `object`
+
+  - **`message`**
+
+    `object`
+
+    - **`role` (required)**
+
+      `string`
+
+    - **`audio`**
+
+      `object`
+
+    - **`content`**
+
+      `object`
+
+    - **`content_blocks`**
+
+      `object`
+
+    - **`function_call`**
+
+      `object`
+
+    - **`reasoning_content`**
+
+      `object`
+
+    - **`tool_calls`**
+
+      `object`
+
+- **`created` (required)**
+
+  `integer`
+
+- **`id` (required)**
+
+  `string`
+
+- **`model` (required)**
+
+  `string`
+
+- **`object` (required)**
+
+  `string`
+
+- **`usage` (required)**
+
+  `object`
+
+  - **`completion_tokens` (required)**
+
+    `integer`
+
+  - **`prompt_tokens` (required)**
+
+    `integer`
+
+  - **`total_tokens` (required)**
+
+    `integer`
+
+  - **`completion_tokens_details`**
+
+    `object`
+
+  - **`prompt_tokens_details`**
+
+    `object`
+
+- **`citations`**
+
+  `array`
+
+  **Items:**
+
+  `string`
+
+- **`prompt_filter_results`**
+
+  `object`
+
+- **`system_fingerprint`**
+
+  `object`
+
+- **`user_tier`**
+
+  `string`, possible values: `"anonymous", "seed", "flower", "nectar"`
+
+**Example:**
+
+```json
+{
+  "id": "",
+  "choices": [
+    {
+      "finish_reason": "",
+      "index": 0,
+      "message": {
+        "content": "",
+        "tool_calls": [
+          {
+            "id": "",
+            "type": "function",
+            "function": {
+              "name": "",
+              "arguments": ""
+            }
+          }
+        ],
+        "role": "assistant",
+        "function_call": {
+          "arguments": "",
+          "name": ""
+        },
+        "content_blocks": [
+          {
+            "type": "text",
+            "text": "",
+            "cache_control": {
+              "type": "ephemeral"
+            }
+          }
+        ],
+        "audio": {
+          "transcript": "",
+          "data": "",
+          "id": "",
+          "expires_at": -9007199254740991
+        },
+        "reasoning_content": ""
+      },
+      "logprobs": {
+        "content": [
+          {
+            "token": "",
+            "logprob": 1,
+            "bytes": [
+              "[Max Depth Exceeded]"
+            ],
+            "top_logprobs": [
+              {
+                "token": "[Max Depth Exceeded]",
+                "logprob": "[Max Depth Exceeded]",
+                "bytes": "[Max Depth Exceeded]"
+              }
+            ]
+          }
+        ]
+      },
+      "content_filter_results": {
+        "hate": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "jailbreak": {
+          "filtered": true,
+          "detected": true
+        },
+        "protected_material_text": {
+          "filtered": true,
+          "detected": true
+        },
+        "protected_material_code": {
+          "filtered": true,
+          "detected": true
+        }
+      }
+    }
+  ],
+  "prompt_filter_results": [
+    {
+      "prompt_index": 0,
+      "content_filter_results": {
+        "hate": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": true,
+          "severity": "safe"
+        },
+        "jailbreak": {
+          "filtered": true,
+          "detected": true
+        },
+        "protected_material_text": {
+          "filtered": true,
+          "detected": true
+        },
+        "protected_material_code": {
+          "filtered": true,
+          "detected": true
+        }
+      }
+    }
+  ],
+  "created": -9007199254740991,
+  "model": "",
+  "system_fingerprint": "",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 0,
+    "completion_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0
+    },
+    "prompt_tokens": 0,
+    "prompt_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 0
+    },
+    "total_tokens": 0
+  },
+  "user_tier": "anonymous",
+  "citations": [
+    ""
+  ]
+}
+```
+
+##### Status: 400 Something was wrong with the input data, check the details for more info.
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`fieldErrors` (required)**
+
+      `object`
+
+    - **`formErrors` (required)**
+
+      `array`
+
+      **Items:**
+
+      `string`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 400,
+  "success": false,
+  "error": {
+    "code": "BAD_REQUEST",
+    "message": "Something was wrong with the input data, check the details for more info.",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": "",
+      "formErrors": [
+        ""
+      ],
+      "fieldErrors": {
+        "propertyName*": [
+          ""
+        ]
+      }
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+##### Status: 401 You need to authenticate by providing a session cookie or Authorization header (Bearer token).
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 401,
+  "success": false,
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "You need to authenticate by providing a session cookie or Authorization header (Bearer token).",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+##### Status: 500 Oh snap, something went wrong on our end. We're on it!
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 500,
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Oh snap, something went wrong on our end. We're on it!",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+### GET /text/{prompt}
+
+- **Method:** `GET`
+- **Path:** `/text/{prompt}`
+- **Tags:** gen.pollinations.ai
+
+Generates text from text prompts.
+
+**Authentication:**
+
+Include your API key either:
+
+- In the `Authorization` header as a Bearer token: `Authorization: Bearer YOUR_API_KEY`
+- As a query parameter: `?key=YOUR_API_KEY`
+
+API keys can be created from your dashboard at enter.pollinations.ai.
+
+#### Responses
+
+##### Status: 200 Generated text response
+
+###### Content-Type: text/plain
+
+`string`
+
+**Example:**
+
+```json
+true
+```
+
+### GET /image/{prompt}
+
+- **Method:** `GET`
+- **Path:** `/image/{prompt}`
+- **Tags:** gen.pollinations.ai
+
+Generate an image or video from a text prompt.
+
+**Image Models:** `flux` (default), `turbo`, `gptimage`, `kontext`, `seedream`, `nanobanana`, `nanobanana-pro`
+
+**Video Models:** `veo`, `seedance`
+
+- `veo`: Text-to-video only (4-8 seconds)
+- `seedance`: Text-to-video and image-to-video (2-10 seconds)
+
+**Authentication:**
+
+Include your API key either:
+
+- In the `Authorization` header as a Bearer token: `Authorization: Bearer YOUR_API_KEY`
+- As a query parameter: `?key=YOUR_API_KEY`
+
+API keys can be created from your dashboard at enter.pollinations.ai.
+
+#### Responses
+
+##### Status: 200 Success - Returns the generated image or video
+
+###### Content-Type: image/jpeg
+
+`string`, format: `binary`
+
+**Example:**
+
+```json
+{}
+```
+
+###### Content-Type: image/png
+
+`string`, format: `binary`
+
+**Example:**
+
+```json
+{}
+```
+
+###### Content-Type: video/mp4
+
+`string`, format: `binary`
+
+**Example:**
+
+```json
+{}
+```
+
+##### Status: 400 Something was wrong with the input data, check the details for more info.
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`fieldErrors` (required)**
+
+      `object`
+
+    - **`formErrors` (required)**
+
+      `array`
+
+      **Items:**
+
+      `string`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 400,
+  "success": false,
+  "error": {
+    "code": "BAD_REQUEST",
+    "message": "Something was wrong with the input data, check the details for more info.",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": "",
+      "formErrors": [
+        ""
+      ],
+      "fieldErrors": {
+        "propertyName*": [
+          ""
+        ]
+      }
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+##### Status: 401 You need to authenticate by providing a session cookie or Authorization header (Bearer token).
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 401,
+  "success": false,
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "You need to authenticate by providing a session cookie or Authorization header (Bearer token).",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```
+
+##### Status: 500 Oh snap, something went wrong on our end. We're on it!
+
+###### Content-Type: application/json
+
+- **`error` (required)**
+
+  `object`
+
+  - **`code` (required)**
+
+    `string`
+
+  - **`details` (required)**
+
+    `object`
+
+    - **`name` (required)**
+
+      `string`
+
+    - **`stack`**
+
+      `string`
+
+  - **`message` (required)**
+
+    `object`
+
+  - **`timestamp` (required)**
+
+    `string`
+
+  - **`cause`**
+
+    `object`
+
+  - **`requestId`**
+
+    `string`
+
+- **`status` (required)**
+
+  `number`
+
+- **`success` (required)**
+
+  `boolean`
+
+**Example:**
+
+```json
+{
+  "status": 500,
+  "success": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Oh snap, something went wrong on our end. We're on it!",
+    "timestamp": "",
+    "details": {
+      "name": "",
+      "stack": ""
+    },
+    "requestId": "",
+    "cause": null
+  }
+}
+```

--- a/enter.pollinations.ai/package-lock.json
+++ b/enter.pollinations.ai/package-lock.json
@@ -40,6 +40,7 @@
                 "@cloudflare/vitest-pool-workers": "^0.10.10",
                 "@drizzle-team/brocli": "^0.11.0",
                 "@hono/node-server": "^1.19.6",
+                "@scalar/openapi-to-markdown": "^0.3.11",
                 "@tailwindcss/typography": "^0.5.19",
                 "@tailwindcss/vite": "^4.1.17",
                 "@tanstack/react-router-devtools": "^1.139.3",
@@ -164,7 +165,6 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -884,7 +884,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.1.tgz",
             "integrity": "sha512-N4kyRdA472WGLoCjsJpUeYdZZvpoBDgP65hUeQQxTQYwBTqD9O17Tokax9CdNbkb4g34sTfxaJCfcncE3Hy4SA==",
-            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "zod": "^4.1.12"
@@ -914,14 +913,12 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
             "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@better-fetch/fetch": {
             "version": "1.1.18",
             "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.18.tgz",
-            "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==",
-            "peer": true
+            "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="
         },
         "node_modules/@chevrotain/cst-dts-gen": {
             "version": "10.5.0",
@@ -3130,6 +3127,61 @@
             "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
             "license": "MIT"
         },
+        "node_modules/@floating-ui/vue": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.9.tgz",
+            "integrity": "sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.7.4",
+                "@floating-ui/utils": "^0.2.10",
+                "vue-demi": ">=0.13.0"
+            }
+        },
+        "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+            "version": "0.14.10",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@headlessui/vue": {
+            "version": "1.7.23",
+            "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
+            "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/vue-virtual": "^3.0.0-beta.60"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "vue": "^3.2.0"
+            }
+        },
         "node_modules/@hono-rate-limiter/cloudflare": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/@hono-rate-limiter/cloudflare/-/cloudflare-0.2.2.tgz",
@@ -3158,7 +3210,6 @@
             "resolved": "https://registry.npmjs.org/@hono/standard-validator/-/standard-validator-0.1.5.tgz",
             "integrity": "sha512-EIyZPPwkyLn6XKwFj5NBEWHXhXbgmnVh2ceIFo5GO7gKI9WmzTjPDKnppQB0KrqKeAkq3kpoW4SIbu5X1dgx3w==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@standard-schema/spec": "1.0.0",
                 "hono": ">=3.9.0"
@@ -3549,7 +3600,6 @@
             "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.0.tgz",
             "integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@swc/helpers": "^0.5.0"
             }
@@ -3593,6 +3643,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -3675,6 +3736,13 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@phosphor-icons/core": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@phosphor-icons/core/-/core-2.1.1.tgz",
+            "integrity": "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@polar-sh/sdk": {
             "version": "0.41.5",
             "resolved": "https://registry.npmjs.org/@polar-sh/sdk/-/sdk-0.41.5.tgz",
@@ -3730,7 +3798,6 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=16.13"
             },
@@ -4114,6 +4181,82 @@
                 "win32"
             ]
         },
+        "node_modules/@scalar/code-highlight": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@scalar/code-highlight/-/code-highlight-0.2.2.tgz",
+            "integrity": "sha512-sr2nV0ngVEw3hUPWISj6t0VRztUIbFqNxZNY8ZwpvYj6YoU99c1cng9+4njxi3d7F7YgbNMPL2PQ2bWQLQEknQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hast-util-to-text": "^4.0.2",
+                "highlight.js": "^11.9.0",
+                "highlightjs-curl": "^1.3.0",
+                "lowlight": "^3.1.0",
+                "rehype-external-links": "^3.0.0",
+                "rehype-format": "^5.0.0",
+                "rehype-parse": "^9.0.0",
+                "rehype-raw": "^7.0.0",
+                "rehype-sanitize": "^6.0.0",
+                "rehype-stringify": "^10.0.0",
+                "remark-gfm": "^4.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.1.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.4",
+                "unist-util-visit": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/components": {
+            "version": "0.16.11",
+            "resolved": "https://registry.npmjs.org/@scalar/components/-/components-0.16.11.tgz",
+            "integrity": "sha512-QnFuC5ZfZJ/jzDURFVjKHRHohY+2TW02xjL7MdlUq1rzUuZPWkw09ddM1rnm2tPoMHcpsN3Df/NjhVDxutzdGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/utils": "0.2.10",
+                "@floating-ui/vue": "1.1.9",
+                "@headlessui/vue": "1.7.23",
+                "@scalar/code-highlight": "0.2.2",
+                "@scalar/helpers": "0.2.4",
+                "@scalar/icons": "0.5.2",
+                "@scalar/oas-utils": "0.6.11",
+                "@scalar/themes": "0.13.26",
+                "@scalar/use-hooks": "0.3.3",
+                "@scalar/use-toasts": "0.9.1",
+                "@vueuse/core": "13.9.0",
+                "cva": "1.0.0-beta.2",
+                "nanoid": "5.1.5",
+                "pretty-bytes": "^6.1.1",
+                "radix-vue": "^1.9.3",
+                "vue": "^3.5.21",
+                "vue-component-type-helpers": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/components/node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            }
+        },
         "node_modules/@scalar/core": {
             "version": "0.3.23",
             "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.3.23.tgz",
@@ -4122,6 +4265,16 @@
             "dependencies": {
                 "@scalar/types": "0.5.0"
             },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/helpers": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.4.tgz",
+            "integrity": "sha512-G7oGybO2QXM+MIxa4OZLXaYsS9mxKygFgOcY4UOXO6xpVoY5+8rahdak9cPk7HNj8RZSt4m/BveoT8g5BtnXxg==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=20"
             }
@@ -4140,6 +4293,325 @@
             "peerDependencies": {
                 "hono": "^4.10.3"
             }
+        },
+        "node_modules/@scalar/icons": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@scalar/icons/-/icons-0.5.2.tgz",
+            "integrity": "sha512-jN0qXmaR1zGW9vZ5HUkhD1StM+52t+GONYstbo199h7tDYSsY+oWxtkuYqdWESiNg1VtNyJ9PruMmTi/PVyq/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@phosphor-icons/core": "^2.1.1",
+                "@types/node": "^22.9.0",
+                "chalk": "^5.4.1",
+                "vue": "^3.5.21"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/icons/node_modules/@types/node": {
+            "version": "22.19.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+            "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@scalar/icons/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@scalar/json-magic": {
+            "version": "0.8.8",
+            "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.8.8.tgz",
+            "integrity": "sha512-BUyBfXrbwRrpjqPXHbUTYQD06KRtonoWIVTxCylQmS4kbp91k9G7SUCnJe9txX1GrpD6CwkBvyQ/Q9oNy1HTaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "yaml": "^2.8.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/oas-utils": {
+            "version": "0.6.11",
+            "resolved": "https://registry.npmjs.org/@scalar/oas-utils/-/oas-utils-0.6.11.tgz",
+            "integrity": "sha512-D67hWzjqcd0p5imqptxRJqferZklLx3uGpSm4FBiAekYt39KI5E+WK+O37sI1FNE57Vgpm/j6VrUFqi2evlpAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "@scalar/json-magic": "0.8.8",
+                "@scalar/object-utils": "1.2.18",
+                "@scalar/openapi-types": "0.5.3",
+                "@scalar/themes": "0.13.26",
+                "@scalar/types": "0.5.4",
+                "@scalar/workspace-store": "0.24.1",
+                "flatted": "^3.3.3",
+                "type-fest": "5.0.0",
+                "yaml": "^2.8.0",
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/oas-utils/node_modules/@scalar/types": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.5.4.tgz",
+            "integrity": "sha512-5FNQH/zx3tnERzxfpErscPHfRxLCuhncmhFYiaSz196Xi2iG1YI08BtxTV2slfT6of52epJ/MrKerarplKf9eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "nanoid": "5.1.5",
+                "type-fest": "5.0.0",
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/oas-utils/node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            }
+        },
+        "node_modules/@scalar/object-utils": {
+            "version": "1.2.18",
+            "resolved": "https://registry.npmjs.org/@scalar/object-utils/-/object-utils-1.2.18.tgz",
+            "integrity": "sha512-GJXHh5ijVESR/ohgH4dSulzV+cCIMz0tOrnnj48k50TKsKcczJNucN4AEzb5zx3xbPCEImHKOYi39bCuXMVCpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "flatted": "^3.3.3",
+                "just-clone": "^6.2.0",
+                "ts-deepmerge": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/openapi-parser": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.23.9.tgz",
+            "integrity": "sha512-0fMsZtTKKEXy9q4TDJnJa3DYXe450FcpZilaIYMJmjjEBVW78op8GnHJjuxvaYIw1gkj2Stz71qzvnoz1VomBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/json-magic": "0.8.8",
+                "@scalar/openapi-types": "0.5.3",
+                "@scalar/openapi-upgrader": "0.1.6",
+                "ajv": "^8.17.1",
+                "ajv-draft-04": "^1.0.0",
+                "ajv-formats": "^3.0.1",
+                "jsonpointer": "^5.0.1",
+                "leven": "^4.0.0",
+                "yaml": "^2.8.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/openapi-to-markdown": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-to-markdown/-/openapi-to-markdown-0.3.11.tgz",
+            "integrity": "sha512-JNoXqqlXXx1zQFKsAWzIwRq5MY47VzKpInJDBLUeQ4IAEOVk7vn/xeITYOGZqGp1HfKAKQ3xGp+M1FStwKMtWQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/components": "0.16.11",
+                "@scalar/helpers": "0.2.4",
+                "@scalar/oas-utils": "0.6.11",
+                "@scalar/openapi-parser": "0.23.9",
+                "@scalar/openapi-types": "0.5.3",
+                "@scalar/openapi-upgrader": "0.1.6",
+                "@scalar/types": "0.5.4",
+                "html-minifier-terser": "^7.2.0",
+                "rehype-parse": "^9.0.0",
+                "rehype-remark": "^10.0.1",
+                "rehype-sanitize": "^6.0.0",
+                "remark-gfm": "^4.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.4",
+                "vue": "^3.5.21"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/openapi-to-markdown/node_modules/@scalar/types": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.5.4.tgz",
+            "integrity": "sha512-5FNQH/zx3tnERzxfpErscPHfRxLCuhncmhFYiaSz196Xi2iG1YI08BtxTV2slfT6of52epJ/MrKerarplKf9eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "nanoid": "5.1.5",
+                "type-fest": "5.0.0",
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/openapi-to-markdown/node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            }
+        },
+        "node_modules/@scalar/openapi-types": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.5.3.tgz",
+            "integrity": "sha512-m4n/Su3K01d15dmdWO1LlqecdSPKuNjuokrJLdiQ485kW/hRHbXW1QP6tJL75myhw/XhX5YhYAR+jrwnGjXiMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/openapi-upgrader": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@scalar/openapi-upgrader/-/openapi-upgrader-0.1.6.tgz",
+            "integrity": "sha512-XdrNZUr0ASLfR89OS2zP6enbq9f7UGQQxov+a3WF1Wz9DClniAL2ChJ2fbGOrqL5F2kjbV6Fw/iO3bsBTMyLZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/openapi-types": "0.5.3"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/snippetz": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@scalar/snippetz/-/snippetz-0.6.1.tgz",
+            "integrity": "sha512-vMk3FIoZQIgg/V2pjyn2VQI8/7TPWHTJ8U/q9L25MptZGtOVggcCyzMyL8JPRCv/rEChJQftUYSf4RabMtmKQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/types": "0.5.4",
+                "js-base64": "^3.7.8",
+                "stringify-object": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/snippetz/node_modules/@scalar/types": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.5.4.tgz",
+            "integrity": "sha512-5FNQH/zx3tnERzxfpErscPHfRxLCuhncmhFYiaSz196Xi2iG1YI08BtxTV2slfT6of52epJ/MrKerarplKf9eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "nanoid": "5.1.5",
+                "type-fest": "5.0.0",
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/snippetz/node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            }
+        },
+        "node_modules/@scalar/themes": {
+            "version": "0.13.26",
+            "resolved": "https://registry.npmjs.org/@scalar/themes/-/themes-0.13.26.tgz",
+            "integrity": "sha512-uS4gek85aDYH663DAiXaXmEMz/NuzBDL6oIGvb+Z8KNYGb7GSSTbFJky+l13ru7juyuDqZIwJ9isk1SnGzm1Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "5.1.5"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/themes/node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            }
+        },
+        "node_modules/@scalar/typebox": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@scalar/typebox/-/typebox-0.1.1.tgz",
+            "integrity": "sha512-Mhhubu4zj1PiXhtgvNbz34zniedtO6PYdD80haMkIjOJwV9aWejxXILr2elHGBMsLfdhH3s9qxux6TL6X8Q6/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@scalar/types": {
             "version": "0.5.0",
@@ -4180,6 +4652,109 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@scalar/use-hooks": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@scalar/use-hooks/-/use-hooks-0.3.3.tgz",
+            "integrity": "sha512-JjGICXVXFVhNfnu9phefS5xvJ/9hkOU2jQhv3ftPiongLDIpqFA4gPc8L62PlZN8y7Ct3iUsJIW9GIG7y8pEAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/use-toasts": "0.9.1",
+                "@vueuse/core": "13.9.0",
+                "cva": "1.0.0-beta.2",
+                "tailwind-merge": "^2.5.5",
+                "vue": "^3.5.21",
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/use-hooks/node_modules/tailwind-merge": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+            "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
+        },
+        "node_modules/@scalar/use-toasts": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@scalar/use-toasts/-/use-toasts-0.9.1.tgz",
+            "integrity": "sha512-t8QoQO4ZWekiSdJ2O7C+PbXfv7x2fmhv3C7t/iITdNpOyLv4jAhlELGpxQHkWsU0ZwRrLU8e+rV0jJcKWE6vYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vue": "^3.5.21",
+                "vue-sonner": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/workspace-store": {
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/@scalar/workspace-store/-/workspace-store-0.24.1.tgz",
+            "integrity": "sha512-Dpp20iKzD2rp1zQix1ZFhrh/ZuSpKT0HvA9xMlhZVdyQV2CFwDMChfeL2C4IaGuQKJhTMYs0q3cNnCfO4gJhbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/code-highlight": "0.2.2",
+                "@scalar/helpers": "0.2.4",
+                "@scalar/json-magic": "0.8.8",
+                "@scalar/object-utils": "1.2.18",
+                "@scalar/openapi-upgrader": "0.1.6",
+                "@scalar/snippetz": "0.6.1",
+                "@scalar/themes": "0.13.26",
+                "@scalar/typebox": "0.1.1",
+                "@scalar/types": "0.5.4",
+                "github-slugger": "^2.0.0",
+                "type-fest": "5.0.0",
+                "vue": "^3.5.21",
+                "yaml": "^2.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@scalar/workspace-store/node_modules/@scalar/types": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.5.4.tgz",
+            "integrity": "sha512-5FNQH/zx3tnERzxfpErscPHfRxLCuhncmhFYiaSz196Xi2iG1YI08BtxTV2slfT6of52epJ/MrKerarplKf9eg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@scalar/helpers": "0.2.4",
+                "nanoid": "5.1.5",
+                "type-fest": "5.0.0",
+                "zod": "^4.1.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/workspace-store/node_modules/nanoid": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+            "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
             }
         },
         "node_modules/@sindresorhus/is": {
@@ -4300,8 +4875,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
             "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.17",
@@ -4615,7 +5189,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.139.3.tgz",
             "integrity": "sha512-lhqK0DnbA7PgHOnmhzOoWVzx8qd8oEpR4cOUbxAjwb3+ExFQWrEvRf9+ZdSxs49ZrtZL2S2UltxBv3vBV4Si5g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tanstack/history": "1.139.0",
                 "@tanstack/react-store": "^0.8.0",
@@ -4688,7 +5261,6 @@
             "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.139.3.tgz",
             "integrity": "sha512-j3v1e739jmozBdtnmA45xHQHjCC2aKqBtfkMT3t2ZPijVrueaVP6qNRIAWmDK4ZSqd67TF5wP8vyqeTShJsEQQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tanstack/history": "1.139.0",
                 "@tanstack/store": "^0.8.0",
@@ -4868,6 +5440,17 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.13.13",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.13.tgz",
+            "integrity": "sha512-uQFoSdKKf5S8k51W5t7b2qpfkyIbdHMzAn+AMQvHPxKUPeo1SsGaA4JRISQT87jm28b7z8OEqPcg1IOZagQHcA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
         "node_modules/@tanstack/virtual-file-routes": {
             "version": "1.139.0",
             "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.139.0.tgz",
@@ -4880,6 +5463,23 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/vue-virtual": {
+            "version": "3.13.13",
+            "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.13.tgz",
+            "integrity": "sha512-Cf2xIEE8nWAfsX0N5nihkPYMeQRT+pHt4NEkuP8rNCn6lVnLDiV8rC8IeIxbKmQC0yPnj4SIBLwXYVf86xxKTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/virtual-core": "3.13.13"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "vue": "^2.7.0 || ^3.0.0"
             }
         },
         "node_modules/@types/babel__core": {
@@ -5016,7 +5616,6 @@
             "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "pg-protocol": "*",
@@ -5028,7 +5627,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -5047,6 +5645,13 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
+        "node_modules/@types/web-bluetooth": {
+            "version": "0.0.21",
+            "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+            "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@ungap/structured-clone": {
@@ -5139,7 +5744,6 @@
             "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.2.4",
                 "pathe": "^2.0.3",
@@ -5155,7 +5759,6 @@
             "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/pretty-format": "3.2.4",
                 "magic-string": "^0.30.17",
@@ -5191,6 +5794,183 @@
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
+            "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.5",
+                "@vue/shared": "3.5.26",
+                "entities": "^7.0.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
+            "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
+            "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.26",
+                "@vue/shared": "3.5.26"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
+            "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.5",
+                "@vue/compiler-core": "3.5.26",
+                "@vue/compiler-dom": "3.5.26",
+                "@vue/compiler-ssr": "3.5.26",
+                "@vue/shared": "3.5.26",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.21",
+                "postcss": "^8.5.6",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
+            "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.26",
+                "@vue/shared": "3.5.26"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
+            "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.26"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
+            "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.26",
+                "@vue/shared": "3.5.26"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
+            "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.26",
+                "@vue/runtime-core": "3.5.26",
+                "@vue/shared": "3.5.26",
+                "csstype": "^3.2.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
+            "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.26",
+                "@vue/shared": "3.5.26"
+            },
+            "peerDependencies": {
+                "vue": "3.5.26"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
+            "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vueuse/core": {
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+            "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/web-bluetooth": "^0.0.21",
+                "@vueuse/metadata": "13.9.0",
+                "@vueuse/shared": "13.9.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
+            }
+        },
+        "node_modules/@vueuse/metadata": {
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+            "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vueuse/shared": {
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+            "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
             }
         },
         "node_modules/@zag-js/accordion": {
@@ -6111,6 +6891,56 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -6159,6 +6989,19 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/aria-hidden": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+            "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/assertion-error": {
@@ -6290,7 +7133,6 @@
             "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.0.tgz",
             "integrity": "sha512-7CecYG+yN8J1uBJni/Mpjryp8bW/YySYsrGEWgFe048ORASjq17keGjbKI2kHEOSc6u8pi11UxzkJ7jIovQw6w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@better-auth/utils": "^0.3.0",
                 "@better-fetch/fetch": "^1.1.4",
@@ -6305,7 +7147,6 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "bindings": "^1.5.0",
                 "prebuild-install": "^7.1.1"
@@ -6399,7 +7240,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.25",
                 "caniuse-lite": "^1.0.30001754",
@@ -6529,6 +7369,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/camel-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pascal-case": "^3.1.2",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/caniuse-lite": {
@@ -6706,6 +7557,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/clean-css": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "source-map": "~0.6.0"
+            },
+            "engines": {
+                "node": ">= 10.0"
+            }
+        },
+        "node_modules/clean-css/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6852,8 +7726,28 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
+        },
+        "node_modules/cva": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/cva/-/cva-1.0.0-beta.2.tgz",
+            "integrity": "sha512-dqcOFe247I5pKxfuzqfq3seLL5iMYsTgo40Uw7+pKZAntPgFtR7Tmy59P5IVIq/XgB0NQWoIvYDt9TwHkuK8Cg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "clsx": "^2.1.1"
+            },
+            "funding": {
+                "url": "https://polar.sh/cva"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.5.5 < 6"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/date-fns": {
             "version": "4.1.0",
@@ -7034,6 +7928,17 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/dotenv": {
@@ -7248,6 +8153,19 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/error-stack-parser-es": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
@@ -7272,7 +8190,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -7432,11 +8349,35 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-sha256": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
             "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
             "license": "Unlicense"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
@@ -7457,6 +8398,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/flatted": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
@@ -7498,6 +8446,19 @@
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-own-enumerable-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
+            "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-port": {
@@ -7551,6 +8512,13 @@
             "devOptional": true,
             "license": "MIT"
         },
+        "node_modules/github-slugger": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+            "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -7595,6 +8563,239 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/hast-util-embedded": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+            "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-is-element": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-format": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
+            "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-embedded": "^3.0.0",
+                "hast-util-minify-whitespace": "^1.0.0",
+                "hast-util-phrasing": "^3.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "html-whitespace-sensitive-tag-names": "^3.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-html": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+            "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "devlop": "^1.1.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "parse5": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "devlop": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-location": "^5.0.0",
+                "web-namespaces": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-has-property": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+            "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-is-body-ok-link": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+            "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-minify-whitespace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+            "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-embedded": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-phrasing": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+            "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-embedded": "^3.0.0",
+                "hast-util-has-property": "^3.0.0",
+                "hast-util-is-body-ok-link": "^3.0.0",
+                "hast-util-is-element": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-raw": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "hast-util-to-parse5": "^8.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "parse5": "^7.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-sanitize": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+            "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "unist-util-position": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-html": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+            "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "stringify-entities": "^4.0.0",
+                "zwitch": "^2.0.4"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-to-jsx-runtime": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -7622,6 +8823,70 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hast-util-to-mdast": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+            "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-phrasing": "^3.0.0",
+                "hast-util-to-html": "^9.0.0",
+                "hast-util-to-text": "^4.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "rehype-minify-whitespace": "^6.0.0",
+                "trim-trailing-lines": "^2.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-text": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+            "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "unist-util-find-after": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-whitespace": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -7635,12 +8900,46 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "11.11.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+            "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/highlightjs-curl": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/highlightjs-curl/-/highlightjs-curl-1.3.0.tgz",
+            "integrity": "sha512-50UEfZq1KR0Lfk2Tr6xb/MUIZH3h10oNC0OTy9g7WELcs5Fgy/mKN1vEhuKTkKbdo8vr5F9GXstu2eLhApfQ3A==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/hono": {
             "version": "4.10.6",
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
             "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -7676,10 +8975,64 @@
                 "hono": "^4.1.1"
             }
         },
+        "node_modules/html-minifier-terser": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+            "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camel-case": "^4.1.2",
+                "clean-css": "~5.3.2",
+                "commander": "^10.0.0",
+                "entities": "^4.4.0",
+                "param-case": "^3.0.4",
+                "relateurl": "^0.2.7",
+                "terser": "^5.15.1"
+            },
+            "bin": {
+                "html-minifier-terser": "cli.js"
+            },
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/html-minifier-terser/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/html-url-attributes": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
             "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/html-void-elements": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/html-whitespace-sensitive-tag-names": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
+            "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -7726,6 +9079,19 @@
             "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
             "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
             "license": "MIT"
+        },
+        "node_modules/is-absolute-url": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+            "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/is-alphabetical": {
             "version": "2.0.1",
@@ -7869,10 +9235,36 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-obj": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
+            "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-plain-obj": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
             "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-regexp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+            "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -7921,10 +9313,16 @@
             "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.2.tgz",
             "integrity": "sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
+        },
+        "node_modules/js-base64": {
+            "version": "3.7.8",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+            "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -7946,6 +9344,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7958,6 +9363,23 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/jsonpointer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+            "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/just-clone": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+            "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/kleur": {
             "version": "3.0.3",
@@ -7974,9 +9396,21 @@
             "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.8.tgz",
             "integrity": "sha512-QUOgl5ZrS9IRuhq5FvOKFSsD/3+IA6MLE81/bOOTRA/YQpKDza2sFdN5g6JCB9BOpqMJDGefLCQ9F12hRS13TA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "node_modules/leven": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-4.1.0.tgz",
+            "integrity": "sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lightningcss": {
@@ -8273,6 +9707,32 @@
             "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/lowlight": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+            "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "devlop": "^1.0.0",
+                "highlight.js": "~11.11.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -9252,7 +10712,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^20.0.0 || >=22.0.0"
             }
@@ -9274,6 +10733,17 @@
             },
             "optionalDependencies": {
                 "@rollup/rollup-linux-x64-gnu": "^4.24.0"
+            }
+        },
+        "node_modules/no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/node-abi": {
@@ -9393,6 +10863,17 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/param-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+            "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/parse-entities": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -9417,6 +10898,43 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
             "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
             "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/pascal-case": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
         },
         "node_modules/path-to-regexp": {
             "version": "6.3.0",
@@ -9461,7 +10979,6 @@
             "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.9.1",
                 "pg-pool": "^3.10.1",
@@ -9750,6 +11267,19 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/pretty-bytes": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+            "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/prisma": {
             "version": "5.22.0",
             "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
@@ -9757,7 +11287,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@prisma/engines": "5.22.0"
             },
@@ -9838,6 +11367,129 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/radix-vue": {
+            "version": "1.9.17",
+            "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.17.tgz",
+            "integrity": "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.6.7",
+                "@floating-ui/vue": "^1.1.0",
+                "@internationalized/date": "^3.5.4",
+                "@internationalized/number": "^3.5.3",
+                "@tanstack/vue-virtual": "^3.8.1",
+                "@vueuse/core": "^10.11.0",
+                "@vueuse/shared": "^10.11.0",
+                "aria-hidden": "^1.2.4",
+                "defu": "^6.1.4",
+                "fast-deep-equal": "^3.1.3",
+                "nanoid": "^5.0.7"
+            },
+            "peerDependencies": {
+                "vue": ">= 3.2.0"
+            }
+        },
+        "node_modules/radix-vue/node_modules/@types/web-bluetooth": {
+            "version": "0.0.20",
+            "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+            "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/radix-vue/node_modules/@vueuse/core": {
+            "version": "10.11.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+            "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/web-bluetooth": "^0.0.20",
+                "@vueuse/metadata": "10.11.1",
+                "@vueuse/shared": "10.11.1",
+                "vue-demi": ">=0.14.8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/radix-vue/node_modules/@vueuse/core/node_modules/vue-demi": {
+            "version": "0.14.10",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/radix-vue/node_modules/@vueuse/metadata": {
+            "version": "10.11.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+            "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/radix-vue/node_modules/@vueuse/shared": {
+            "version": "10.11.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+            "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vue-demi": ">=0.14.8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/radix-vue/node_modules/@vueuse/shared/node_modules/vue-demi": {
+            "version": "0.14.10",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+            "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -9870,7 +11522,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9880,7 +11531,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -9987,6 +11637,146 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/rehype-external-links": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+            "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "is-absolute-url": "^4.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-format": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
+            "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-format": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-minify-whitespace": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+            "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-minify-whitespace": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-parse": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+            "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-from-html": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-raw": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+            "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-raw": "^9.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-remark": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+            "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "hast-util-to-mdast": "^10.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-sanitize": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+            "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-sanitize": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-stringify": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+            "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-to-html": "^9.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/relateurl": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+            "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/remark-gfm": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -10057,6 +11847,16 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10179,7 +11979,6 @@
             "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.0.tgz",
             "integrity": "sha512-BdrNXdzlofomLTiRnwJTSEAaGKyHHZkbMXIywOh7zlzp4uZnXErEwl9XZ+N1hJSNpeTtNxWvVwN0wUzAIQ4Hpg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -10319,6 +12118,7 @@
             "integrity": "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.1.0",
                 "seroval": "~1.3.0",
@@ -10342,6 +12142,7 @@
             "integrity": "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -10484,6 +12285,24 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/stringify-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
+            "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "get-own-enumerable-keys": "^1.0.0",
+                "is-obj": "^3.0.0",
+                "is-regexp": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/yeoman/stringify-object?sponsor=1"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -10584,8 +12403,7 @@
             "version": "4.1.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
             "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/tapable": {
             "version": "2.3.0",
@@ -10630,6 +12448,45 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/terser": {
+            "version": "5.44.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
+            "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.15.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser/node_modules/acorn": {
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tiny-invariant": {
             "version": "1.3.3",
@@ -10698,7 +12555,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -10759,6 +12615,17 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/trim-trailing-lines": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+            "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/trough": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -10767,6 +12634,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/ts-deepmerge": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz",
+            "integrity": "sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14.13.1"
             }
         },
         "node_modules/tsconfck": {
@@ -10850,7 +12727,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10882,7 +12758,6 @@
             "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pathe": "^2.0.3"
             }
@@ -10913,6 +12788,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/unist-util-find-after": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+            "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/unist-util-is": {
@@ -11092,6 +12982,21 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/vfile-location": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/vfile-message": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -11112,7 +13017,6 @@
             "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -11249,7 +13153,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11263,7 +13166,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -11342,6 +13244,53 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vue": {
+            "version": "3.5.26",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
+            "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.26",
+                "@vue/compiler-sfc": "3.5.26",
+                "@vue/runtime-dom": "3.5.26",
+                "@vue/server-renderer": "3.5.26",
+                "@vue/shared": "3.5.26"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vue-component-type-helpers": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.1.8.tgz",
+            "integrity": "sha512-oaowlmEM6BaYY+8o+9D9cuzxpWQWHqHTMKakMxXu0E+UCIOMTljyIPO15jcnaCwJtZu/zWDotK7mOIHvWD9mcw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vue-sonner": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/vue-sonner/-/vue-sonner-1.3.2.tgz",
+            "integrity": "sha512-UbZ48E9VIya3ToiRHAZUbodKute/z/M1iT8/3fU8zEbwBRE11AKuHikssv18LMk2gTTr6eMQT4qf6JoLHWuj/A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/web-namespaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+            "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/webpack-virtual-modules": {
@@ -12156,6 +14105,22 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -26,7 +26,8 @@
         "push-secrets:staging": "sops exec-file --no-fifo secrets/staging.vars.json 'npx wrangler secret bulk {} --env staging'",
         "push-secrets:production": "sops exec-file --no-fifo secrets/prod.vars.json 'npx wrangler secret bulk {} --env production'",
         "tail": "wrangler tail --env production | jq -c '.logs[].message[] | fromjson' | tsx scripts/format-logs.ts",
-        "tail:json": "wrangler tail --env production | jq '.logs[].message[] | fromjson'"
+        "tail:json": "wrangler tail --env production | jq '.logs[].message[] | fromjson'",
+        "docs:generate": "tsx scripts/generate-apidocs.ts"
     },
     "dependencies": {
         "@ark-ui/react": "^5.29.1",
@@ -61,6 +62,7 @@
         "@cloudflare/vitest-pool-workers": "^0.10.10",
         "@drizzle-team/brocli": "^0.11.0",
         "@hono/node-server": "^1.19.6",
+        "@scalar/openapi-to-markdown": "^0.3.11",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.17",
         "@tanstack/react-router-devtools": "^1.139.3",

--- a/enter.pollinations.ai/scripts/generate-apidocs.ts
+++ b/enter.pollinations.ai/scripts/generate-apidocs.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env tsx
+
+import { createMarkdownFromOpenApi } from "@scalar/openapi-to-markdown";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = join(__dirname, "..", "APIDOCS.md");
+const OPENAPI_URL =
+    process.env.OPENAPI_URL ||
+    "https://enter.pollinations.ai/api/docs/open-api/generate-schema";
+
+async function main() {
+    console.log(`Fetching OpenAPI spec from ${OPENAPI_URL}...`);
+    const spec = await fetch(OPENAPI_URL).then((r) => r.json());
+
+    console.log("Generating markdown...");
+    const markdown = await createMarkdownFromOpenApi(spec);
+
+    writeFileSync(OUTPUT_PATH, markdown);
+    console.log(`✅ Saved to ${OUTPUT_PATH} (${markdown.length} bytes)`);
+}
+
+main().catch((err) => {
+    console.error("❌ Error:", err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
- Add `@scalar/openapi-to-markdown` for LLM-friendly docs
- Add `scripts/generate-apidocs.ts` to fetch and convert OpenAPI spec
- Add npm script: `npm run docs:generate`
- Generate `APIDOCS.md` (1891 lines)