### PR TITLE
fix: remove sops decrypt from start script

### DIFF
--- a/image.pollinations.ai/package.json
+++ b/image.pollinations.ai/package.json
@@ -9,7 +9,8 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
-        "start": "npm run decrypt-vars && npx tsx src/index.ts",
+        "start": "npx tsx src/index.ts",
+        "start:dev": "npm run decrypt-vars && npx tsx src/index.ts",
         "dev": "npm run decrypt-vars && DEBUG=pollinations:* npx tsx --watch src/index.ts"
     },
     "keywords": [],

--- a/text.pollinations.ai/package.json
+++ b/text.pollinations.ai/package.json
@@ -3,7 +3,8 @@
     "version": "1.0.0",
     "scripts": {
         "decrypt-vars": "sops decrypt secrets/env.json --output-type dotenv > .env",
-        "start": "npm run decrypt-vars && npx tsx startServer.js",
+        "start": "npx tsx startServer.js",
+        "start:dev": "npm run decrypt-vars && npx tsx startServer.js",
         "dev": "npm run decrypt-vars && DEBUG=pollinations:* npx tsx startServer.js",
         "type-check": "tsc --noEmit",
         "validate-configs": "tsx configs/validateConfigKeys.ts",


### PR DESCRIPTION
- Remove `npm run decrypt-vars` from `start` script
- Add `start:dev` script for local development with decryption
- Workflow already decrypts and copies `.env` files to server
- Fixes deploy failure: `sops: not found` on production server