### PR TITLE
fix: gemini-large use code_execution + url_context

### DIFF
--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -141,7 +141,8 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["gemini-3-pro-preview"],
         transform: pipe(
             createSystemPromptTransform(BASE_PROMPTS.conversational),
-            createGeminiToolsTransform(["google_search", "url_context"]),
+            // code_execution + url_context (both non-search tools, can be combined)
+            createGeminiToolsTransform(["code_execution", "url_context"]),
         ),
     },
     {


### PR DESCRIPTION
- Fix gemini-large 400 error by using `code_execution` + `url_context` tools
- `google_search` + `url_context` fails because `url_context` is NOT a search tool on Vertex AI

**Vertex AI tool rules:**
- Search tools (`google_search`) cannot be mixed with non-search tools
- Non-search tools (`code_execution`, `url_context`) can be combined