### PR TITLE
fix: migrate tier-app-submission to gen.pollinations.ai

### DIFF
--- a/.github/workflows/tier-app-submission.yml
+++ b/.github/workflows/tier-app-submission.yml
@@ -120,7 +120,7 @@ jobs:
           for i in $(seq 1 $MAX_RETRIES); do
             HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/response.json -X POST "https://gen.pollinations.ai/v1/chat/completions" \
               -H "Content-Type: application/json" \
-              -H "Authorization: Bearer ${{ secrets.POLLINATIONS_API_KEY }}" \
+              -H "Authorization: Bearer ${{ secrets.POLLINATIONS_TOKEN }}" \
               -d "$PAYLOAD")
             
             if [ "$HTTP_CODE" = "200" ]; then


### PR DESCRIPTION
- Replace legacy text.pollinations.ai with gen.pollinations.ai/v1/chat/completions
- Add retry logic (3 attempts with exponential backoff) for 429 rate limits
- Fix JSON mode: jsonMode -> response_format: { type: "json_object" }
- Use existing POLLINATIONS_TOKEN secret

Fixes the 429 error in #6291