### PR TITLE
fix: YAML syntax error in tier-app-submission PR body

### DIFF
--- a/.github/workflows/tier-app-submission.yml
+++ b/.github/workflows/tier-app-submission.yml
@@ -301,23 +301,15 @@ jobs:
           
           EXISTING_PR=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
           if [ -z "$EXISTING_PR" ]; then
-            # Build PR body with app details
-            PR_BODY="## 🆕 New App: $PROJECT_NAME
-
-**Category:** $CATEGORY
-**URL:** $URL
-**Description:** $SHORT_DESC"
-            [ -n "$REPO" ] && PR_BODY="$PR_BODY
-**Repo:** $REPO"
-            [ -n "$DISCORD" ] && PR_BODY="$PR_BODY
-**Discord:** $DISCORD"
-            [ -n "$LANGUAGE" ] && PR_BODY="$PR_BODY
-**Language:** $LANGUAGE"
-            PR_BODY="$PR_BODY
-
----
-Co-authored-by: $ISSUE_AUTHOR <${ISSUE_AUTHOR_ID}+${ISSUE_AUTHOR}@users.noreply.github.com>
-Fixes #$ISSUE_NUMBER"
+            # Build PR body with app details (using printf to avoid YAML parsing issues)
+            PR_BODY=$(printf '## 🆕 New App: %s\n\n' "$PROJECT_NAME")
+            PR_BODY="${PR_BODY}$(printf 'Category: %s\n' "$CATEGORY")"
+            PR_BODY="${PR_BODY}$(printf 'URL: %s\n' "$URL")"
+            PR_BODY="${PR_BODY}$(printf 'Description: %s\n' "$SHORT_DESC")"
+            [ -n "$REPO" ] && PR_BODY="${PR_BODY}$(printf 'Repo: %s\n' "$REPO")"
+            [ -n "$DISCORD" ] && PR_BODY="${PR_BODY}$(printf 'Discord: %s\n' "$DISCORD")"
+            [ -n "$LANGUAGE" ] && PR_BODY="${PR_BODY}$(printf 'Language: %s\n' "$LANGUAGE")"
+            PR_BODY="${PR_BODY}$(printf '\n---\nCo-authored-by: %s <%s+%s@users.noreply.github.com>\nFixes #%s' "$ISSUE_AUTHOR" "$ISSUE_AUTHOR_ID" "$ISSUE_AUTHOR" "$ISSUE_NUMBER")"
 
             gh pr create --title "Add $PROJECT_NAME to $CATEGORY" \
               --body "$PR_BODY" \


### PR DESCRIPTION
Fixes YAML syntax error that was breaking the entire app submission workflow.

**Problem:** The `**` markdown syntax in PR body was being interpreted as YAML alias reference.

**Solution:** Use printf to build PR body string, avoiding problematic characters.

**Impact:** App submissions via issue form weren't creating PRs since this was merged.