### PR TITLE
fix: add Azure GPT Image 1.5 credentials for gptimage-large model

### DIFF
--- a/image.pollinations.ai/secrets/env.json
+++ b/image.pollinations.ai/secrets/env.json
@@ -15,6 +15,8 @@
 	"PLN_PROMPT_ENHANCER_KEY": "ENC[AES256_GCM,data:E35Wrss6AYhDwAg7mUKMdg==,iv:ngJ7kQlsS4lD1B7R81ElLu93dZXnEzW3KqnYCeYwcLc=,tag:bnq1rQbzFLp6cLPgPSPVjA==,type:str]",
 	"PLN_ENTER_TOKEN": "ENC[AES256_GCM,data:u0O6iALK8GSXD6ZztNzdLQQEiVORA9fbLP6vHLNf0W/z7H7abAgqqVcmj+c7jo+k,iv:/K/lEvcUs7pfHUT53+IgbL88bJZpkXpS6zaQlk4tUSA=,tag:pXLpnB4qk6UgUNsr9XY0uQ==,type:str]",
 	"PLN_FEED_PASSWORD": "ENC[AES256_GCM,data:ytqBSGBAVpE+wnIx,iv:VYTnW5Tw6pGams9AvJGYBxfJd414ZckTqFcE2CIICuQ=,tag:m+xlWYWk4p/ptXukqdO3Bw==,type:str]",
+	"AZURE_MYCELI_GPTIMAGE_LARGE_ENDPOINT": "ENC[AES256_GCM,data:2erF+bbRucjIwsyLjtnFZ7GjNNzlf1D4ZOPijnxKzv/TC8NIaKN3D5FPLnjOJhYx4VgNA9wiksmlvA8fyshX2gejwgNCjclHFJ1pBwdo/EXLKXsFsQ+vV5MVhFncRoGDk/0aOqzCxaf9yrjAEz7fJNzbTO41RlR657CHb94Ydm0WMIZnpw==,iv:FFZ/o3TdHh/d0UT3xUpBldvo71N+o+k3kq1HnGOaA24=,tag:6NQE/VfNH3jNemPxzBudNQ==,type:str]",
+	"AZURE_MYCELI_GPTIMAGE_LARGE_API_KEY": "ENC[AES256_GCM,data:Jj66/ugDy8uE0GPb9PqsSLiMzZSRiR5PtsrYc+EZUnhY/u7r9lmXROyQHinakqA0wOH9gG629DHqQcdYpQxS3w5+sSBpeCqRmCNrR6vaNDy4DRIa,iv:O8IVQ/InBICUwvtiFK0Yk8HB4E0vAFK90vvLoaJXPdM=,tag:ipsH5uiWWqHzuGk++w9V6w==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -22,8 +24,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYb0pjM3lWcW9td09lMHJR\nRkVaMEtaUHFSYjc0cjF6ZVZMTmZoMXBzNTBrCmFRWDY0VXFRcm5kWDdDdmdndGIw\nbE11enlLaWxMdTZoUnFweDVSaXdmRGMKLS0tIC9qczJSaVBYVFVtcHNmVVU4aTRZ\nalR6dVU3U1I4TUJYTGZRN3VtQXBhQUkKqRcbBEQUjNcZpjgHwIBgVnrBJniieunf\n0gpTR3681d1RUKZKsaRRfUaSLNP2qXVqBLwN6qGY/4rhOCfgoqJWbQ==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2025-12-19T15:30:23Z",
-		"mac": "ENC[AES256_GCM,data:aFM5iEs/5PKsHLE2s+7wyxKArXIzBnS/LwisP/VDTJU1DJ+IGz4mzFnYUkkVVK0L+2AoaOAn9ChdAD10l507SCnifnP7AOD84okgDSnfFmS8rECadTIdeY+X5QHt3iWcOvGyDM4OP0297lV0ulm6/46HAMV4o9Rjc+uEmIYeqOA=,iv:JsxpkbsgKILaWwWgzjGg3+5zfkWBtZvry2vy5AEFpsU=,tag:bQCjPrseoo93d7J0D8rmug==,type:str]",
+		"lastmodified": "2025-12-24T03:54:59Z",
+		"mac": "ENC[AES256_GCM,data:p/x5t12gG4UMfKcRrgSQ+BYCIagM2X/sLe+jh9i1lgLQgfYOyZTCBZcFeSme33CZlf0oiFlbeIacSNlAS3Z67xMUUOyNwCkG/gOLfXZRyeg02F9GXT/dWf/DoY4snArPFuHF2QSy/UgOP04idZgseDqLzDhEBTPt7SlRXf+ljEo=,iv:e4aVMOZ2a6YQo8CZ9PnffHIqohpwcTQ4TqwKPccDR1Y=,tag:DvOxhYhHiqTAnqNA89wztw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
- Adds missing `AZURE_MYCELI_GPTIMAGE_LARGE_ENDPOINT` and `AZURE_MYCELI_GPTIMAGE_LARGE_API_KEY` to encrypted env.json
- Fixes "Azure API key or endpoint not found" error for `gptimage-large` model
- Reported by HikitaniSan on Discord