### PR TITLE
fix: enable horizontal scroll for model monitor table on mobile/tablet #6074

### DIFF
--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -612,7 +612,7 @@ function App() {
                 <GatewayHealth stats={gatewayStats} />
 
                 {/* Model Table */}
-                <div className="border border-gray-200 rounded-lg bg-white shadow-sm overflow-hidden">
+                <div className="border border-gray-200 rounded-lg bg-white shadow-sm overflow-x-auto">
                     <table className="w-full text-sm">
                         <thead className="bg-gray-50 text-[10px] text-gray-500 uppercase tracking-wide">
                             <tr>


### PR DESCRIPTION
#6074   This PR resolves the issue where the Model Monitor table was cut off on mobile and tablet devices, making it impossible to see columns like Latency (P50/P95), Error Rates, and Sparklines.
 Changes
- Table Container : Updated the wrapping div for the model table in App.jsx to use overflow-x-auto instead of overflow-hidden .
- UX Improvement : Users on smaller screens can now swipe horizontally to view the full set of metrics without breaking the overall page layout. Verification
- Verified that the overflow-x-auto property is correctly applied to the table container.
- Confirmed the table remains responsive and contained within its parent on desktop while allowing scroll on narrow viewports.