### PR TITLE
fix: Use Portkey-compatible format for Gemini thinking mode

### DIFF
--- a/enter.pollinations.ai/test/integration/text.test.ts
+++ b/enter.pollinations.ai/test/integration/text.test.ts
@@ -889,6 +889,109 @@ describe("Model gating by API key permissions", async () => {
     );
 });
 
+// Gemini thinking mode tests (PR #6455)
+// Tests that thinking parameter is accepted and processed correctly
+describe("Gemini thinking mode", async () => {
+    test(
+        "Gemini should accept thinking: { type: 'disabled' } parameter",
+        { timeout: 60000 },
+        async ({ apiKey, mocks }) => {
+            await mocks.enable("polar", "tinybird", "vcr");
+            const response = await SELF.fetch(
+                `http://localhost:3000/api/generate/v1/chat/completions`,
+                {
+                    method: "POST",
+                    headers: {
+                        "content-type": "application/json",
+                        "authorization": `Bearer ${apiKey}`,
+                    },
+                    body: JSON.stringify({
+                        model: "gemini-fast", // Gemini 2.5 model
+                        messages: [
+                            {
+                                role: "user",
+                                content:
+                                    "What is 2+2? Reply with just the number.",
+                            },
+                        ],
+                        thinking: { type: "disabled" },
+                        seed: testSeed(),
+                    }),
+                },
+            );
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect((data as any).choices[0].message.content).toBeTruthy();
+        },
+    );
+
+    test(
+        "Gemini should accept thinking_budget: 0 parameter to disable thinking",
+        { timeout: 60000 },
+        async ({ apiKey, mocks }) => {
+            await mocks.enable("polar", "tinybird", "vcr");
+            const response = await SELF.fetch(
+                `http://localhost:3000/api/generate/v1/chat/completions`,
+                {
+                    method: "POST",
+                    headers: {
+                        "content-type": "application/json",
+                        "authorization": `Bearer ${apiKey}`,
+                    },
+                    body: JSON.stringify({
+                        model: "gemini-fast",
+                        messages: [
+                            {
+                                role: "user",
+                                content:
+                                    "What is 3+3? Reply with just the number.",
+                            },
+                        ],
+                        thinking_budget: 0,
+                        seed: testSeed(),
+                    }),
+                },
+            );
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect((data as any).choices[0].message.content).toBeTruthy();
+        },
+    );
+
+    test(
+        "Gemini 3 Flash should accept reasoning_effort parameter",
+        { timeout: 60000 },
+        async ({ apiKey, mocks }) => {
+            await mocks.enable("polar", "tinybird", "vcr");
+            const response = await SELF.fetch(
+                `http://localhost:3000/api/generate/v1/chat/completions`,
+                {
+                    method: "POST",
+                    headers: {
+                        "content-type": "application/json",
+                        "authorization": `Bearer ${apiKey}`,
+                    },
+                    body: JSON.stringify({
+                        model: "gemini", // Gemini 3 Flash
+                        messages: [
+                            {
+                                role: "user",
+                                content:
+                                    "What is 4+4? Reply with just the number.",
+                            },
+                        ],
+                        reasoning_effort: "low",
+                        seed: testSeed(),
+                    }),
+                },
+            );
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect((data as any).choices[0].message.content).toBeTruthy();
+        },
+    );
+});
+
 // Gemini tool schema sanitization test (Issue: Portkey Gateway #1473)
 // Tests that exclusiveMinimum/exclusiveMaximum are stripped before sending to Vertex AI
 test(

--- a/enter.pollinations.ai/test/mocks/snapshots/text-31c8be9f2811c73d5fa0594eb7a0de54.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-31c8be9f2811c73d5fa0594eb7a0de54.json
@@ -1,0 +1,78 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "gemini-fast",
+        "messages": [
+          {
+            "role": "user",
+            "content": "What is 3+3? Reply with just the number."
+          }
+        ],
+        "thinking_budget": 0,
+        "seed": 42
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "492",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 26 Dec 2025 12:08:51 GMT",
+      "etag": "W/\"1ec-5cMQkOaEw+H6OspIeHzKnbpthXw\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gemini-2.5-flash-lite",
+      "x-powered-by": "Express",
+      "x-usage-completion-text-tokens": "2",
+      "x-usage-prompt-text-tokens": "272",
+      "x-usage-total-tokens": "274"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "id": "pllns_ad38ee5b41e1187b090de221be162d6f",
+        "object": "chat.completion",
+        "created": 1766750931,
+        "model": "gemini-2.5-flash-lite",
+        "provider": "vertex-ai",
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "6\n",
+              "content_blocks": [
+                {
+                  "type": "text",
+                  "text": "6\n"
+                }
+              ]
+            },
+            "index": 0,
+            "finish_reason": "STOP"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 272,
+          "completion_tokens": 2,
+          "total_tokens": 274,
+          "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0
+          },
+          "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-5053ddc1e498949a4660f5d8d7cc1435.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-5053ddc1e498949a4660f5d8d7cc1435.json
@@ -1,0 +1,79 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "gemini",
+        "messages": [
+          {
+            "role": "user",
+            "content": "What is 4+4? Reply with just the number."
+          }
+        ],
+        "reasoning_effort": "low",
+        "seed": 42
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "493",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 26 Dec 2025 12:09:21 GMT",
+      "etag": "W/\"1ed-eF4PI88fuRgPlc5IdMii49gULZ4\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gemini-3-flash-preview",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "101",
+      "x-usage-completion-text-tokens": "1",
+      "x-usage-prompt-text-tokens": "272",
+      "x-usage-total-tokens": "374"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "id": "pllns_7c7268c6ab5c8acfc63b43b44e019805",
+        "object": "chat.completion",
+        "created": 1766750961,
+        "model": "gemini-3-flash-preview",
+        "provider": "vertex-ai",
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "8",
+              "content_blocks": [
+                {
+                  "type": "text",
+                  "text": "8"
+                }
+              ]
+            },
+            "index": 0,
+            "finish_reason": "STOP"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 272,
+          "completion_tokens": 102,
+          "total_tokens": 374,
+          "completion_tokens_details": {
+            "reasoning_tokens": 101,
+            "audio_tokens": 0
+          },
+          "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-f472a5217527cdcfe5f6a222dbfad652.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-f472a5217527cdcfe5f6a222dbfad652.json
@@ -1,0 +1,80 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "gemini-fast",
+        "messages": [
+          {
+            "role": "user",
+            "content": "What is 2+2? Reply with just the number."
+          }
+        ],
+        "thinking": {
+          "type": "disabled"
+        },
+        "seed": 42
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "492",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 26 Dec 2025 12:08:50 GMT",
+      "etag": "W/\"1ec-LOpSGpqiXhESWwCY3DVZHH/0i9s\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gemini-2.5-flash-lite",
+      "x-powered-by": "Express",
+      "x-usage-completion-text-tokens": "2",
+      "x-usage-prompt-text-tokens": "272",
+      "x-usage-total-tokens": "274"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "id": "pllns_cb83e83187562bcc594cd0ffe7f4a51a",
+        "object": "chat.completion",
+        "created": 1766750930,
+        "model": "gemini-2.5-flash-lite",
+        "provider": "vertex-ai",
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "4\n",
+              "content_blocks": [
+                {
+                  "type": "text",
+                  "text": "4\n"
+                }
+              ]
+            },
+            "index": 0,
+            "finish_reason": "STOP"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 272,
+          "completion_tokens": 2,
+          "total_tokens": 274,
+          "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0
+          },
+          "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -6,6 +6,7 @@ import {
 } from "./transforms/createSystemPromptTransform.js";
 import { pipe } from "./transforms/pipe.js";
 import { createGeminiToolsTransform } from "./transforms/createGeminiToolsTransform.ts";
+import { createGeminiThinkingTransform } from "./transforms/createGeminiThinkingTransform.ts";
 import { sanitizeToolSchemas } from "./transforms/sanitizeToolSchemas.js";
 
 // Import persona prompts
@@ -93,6 +94,7 @@ const models: ModelDefinition[] = [
             createSystemPromptTransform(BASE_PROMPTS.conversational),
             sanitizeToolSchemas(),
             createGeminiToolsTransform(["code_execution", "url_context"]),
+            createGeminiThinkingTransform("v3-flash"),
         ),
     },
     {
@@ -102,6 +104,7 @@ const models: ModelDefinition[] = [
             createSystemPromptTransform(BASE_PROMPTS.conversational),
             sanitizeToolSchemas(),
             createGeminiToolsTransform(["code_execution", "url_context"]),
+            createGeminiThinkingTransform("v2.5"),
         ),
     },
     {
@@ -110,6 +113,7 @@ const models: ModelDefinition[] = [
         transform: pipe(
             sanitizeToolSchemas(),
             createGeminiToolsTransform(["google_search"]),
+            createGeminiThinkingTransform("v2.5"),
         ),
     },
     {
@@ -144,6 +148,7 @@ const models: ModelDefinition[] = [
             createSystemPromptTransform(BASE_PROMPTS.conversational),
             sanitizeToolSchemas(),
             createGeminiToolsTransform(["code_execution", "url_context"]),
+            createGeminiThinkingTransform("v3-pro"),
         ),
     },
     {

--- a/text.pollinations.ai/transforms/createGeminiThinkingTransform.ts
+++ b/text.pollinations.ai/transforms/createGeminiThinkingTransform.ts
@@ -1,0 +1,101 @@
+import debug from "debug";
+
+const log = debug("pollinations:transforms:gemini-thinking");
+
+/**
+ * Gemini model type for thinking configuration
+ * - v2.5: Uses thinking.budget_tokens (0 to disable)
+ * - v3-flash: Uses reasoning_effort ("none" for minimal thinking)
+ * - v3-pro: Uses reasoning_effort ("low" for minimal thinking, can't fully disable)
+ */
+export type GeminiModelType = "v2.5" | "v3-flash" | "v3-pro";
+
+/**
+ * Creates a transform that handles Gemini thinking mode configuration.
+ *
+ * Portkey gateway expects OpenAI-compatible format:
+ * - `thinking: { type: "enabled", budget_tokens: N }` for Gemini 2.5
+ * - `reasoning_effort: "none"|"minimal"|"low"|"medium"|"high"` for Gemini 3
+ *
+ * The gateway translates these to Vertex AI's thinking_config internally.
+ *
+ * @param modelType - The Gemini model version to configure thinking for
+ */
+export function createGeminiThinkingTransform(
+    modelType: GeminiModelType = "v2.5",
+) {
+    return (messages: unknown[], options: Record<string, unknown>) => {
+        const updatedOptions = { ...options };
+
+        // Check if user explicitly requested thinking to be disabled
+        // This can come from:
+        // 1. thinking_budget: 0 (direct)
+        // 2. thinking: { type: "disabled" } (Anthropic-style, parsed by parameterValidators)
+        const thinkingBudget = updatedOptions.thinking_budget as
+            | number
+            | undefined;
+
+        // Only modify if thinking_budget is explicitly set
+        if (thinkingBudget !== undefined) {
+            const isDisabled = thinkingBudget === 0;
+
+            log(
+                `Configuring thinking for ${modelType}. Budget: ${thinkingBudget}, Disabled: ${isDisabled}`,
+            );
+
+            if (isDisabled) {
+                // User wants to disable thinking - use Portkey-compatible format
+                switch (modelType) {
+                    case "v3-flash":
+                        // Gemini 3 Flash: Use reasoning_effort="none" (maps to MINIMAL)
+                        // Note: MINIMAL still requires thought signatures
+                        updatedOptions.reasoning_effort = "none";
+                        break;
+                    case "v3-pro":
+                        // Gemini 3 Pro: Can't fully disable, use "low" for minimal thinking
+                        updatedOptions.reasoning_effort = "low";
+                        break;
+                    case "v2.5":
+                    default:
+                        // Gemini 2.5: Use thinking object with budget_tokens: 0
+                        // Portkey docs: { "type": "enabled", "budget_tokens": 0 } disables thinking
+                        updatedOptions.thinking = {
+                            type: "enabled",
+                            budget_tokens: 0,
+                        };
+                        break;
+                }
+            } else {
+                // User wants thinking enabled with specific budget
+                // Only set for v2.5 models that support budget_tokens
+                if (modelType === "v2.5") {
+                    updatedOptions.thinking = {
+                        type: "enabled",
+                        budget_tokens: thinkingBudget,
+                    };
+                } else {
+                    // For v3 models, map budget to reasoning_effort levels
+                    // This is a rough approximation since v3 uses levels not tokens
+                    if (thinkingBudget <= 1024) {
+                        updatedOptions.reasoning_effort = "low";
+                    } else if (thinkingBudget <= 4096) {
+                        updatedOptions.reasoning_effort = "medium";
+                    } else {
+                        updatedOptions.reasoning_effort = "high";
+                    }
+                }
+            }
+
+            // Clean up the internal thinking_budget parameter
+            // (it's not a valid OpenAI/Portkey parameter)
+            delete updatedOptions.thinking_budget;
+
+            log("Final options:", {
+                thinking: updatedOptions.thinking,
+                reasoning_effort: updatedOptions.reasoning_effort,
+            });
+        }
+
+        return { messages, options: updatedOptions };
+    };
+}


### PR DESCRIPTION
## Summary

This PR fixes the Gemini thinking mode implementation to use **Portkey-compatible format** instead of raw `thinking_config`. This is an alternative/improvement to #6455.

## Key Changes

### 1. Rewritten `createGeminiThinkingTransform.ts`
- Uses Portkey's documented API format instead of raw Vertex AI `thinking_config`
- **Gemini 2.5**: Uses `thinking: { type: "enabled", budget_tokens: 0 }` to disable
- **Gemini 3 Flash**: Uses `reasoning_effort: "none"` (Portkey maps to `thinkingLevel`)
- **Gemini 3 Pro**: Uses `reasoning_effort: "low"` (can't fully disable)
- Removes invalid `include_thoughts` parameter (not in Vertex AI API)

### 2. Updated `parameterValidators.js`
- Parses Anthropic/OpenAI-style `thinking` object to internal `thinking_budget`
- `{ type: "disabled" }` → `thinking_budget: 0`
- `{ type: "enabled", budget_tokens: N }` → `thinking_budget: N`

### 3. Added Integration Tests
- 3 new tests for Gemini thinking mode in `enter.pollinations.ai`
- Tests `thinking: { type: 'disabled' }` parameter
- Tests `thinking_budget: 0` parameter  
- Tests `reasoning_effort` parameter for Gemini 3

## Why This Approach

Per [Portkey's Gemini documentation](https://portkey.ai/docs/integrations/llms/gemini):

```python
# To disable thinking (Portkey format)
thinking={ "type": "enabled", "budget_tokens": 0 }

# Or use reasoning_effort
reasoning_effort="none"  # Options: "none", "minimal", "low", "medium", "high"
```

Portkey translates these to Vertex AI's native `thinking_config` internally. Creating raw `thinking_config` directly may be ignored or cause conflicts.

## Test Results
```
✓ Gemini should accept thinking: { type: 'disabled' } parameter (818ms)
✓ Gemini should accept thinking_budget: 0 parameter to disable thinking (386ms)
✓ Gemini 3 Flash should accept reasoning_effort parameter (476ms)
```

## Related
- Addresses #6455 (alternative implementation)
- Fixes #6450

Co-authored-by: andreykolesnikov <58930332+andreykolesnikov@users.noreply.github.com>