### PR TITLE
fix: Add missing reasoning_effort values (none, minimal, xhigh)

### DIFF
--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -317,7 +317,9 @@ export const CreateChatCompletionRequestSchema = z.object({
     stream: z.boolean().nullable().optional().default(false),
     stream_options: ChatCompletionStreamOptionsSchema,
     thinking: ThinkingSchema,
-    reasoning_effort: z.enum(["low", "medium", "high"]).optional(),
+    reasoning_effort: z
+        .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
+        .optional(),
     thinking_budget: z.number().int().min(0).optional(),
     temperature: z.number().min(0).max(2).nullable().optional().default(1),
     top_p: z.number().min(0).max(1).nullable().optional().default(1),


### PR DESCRIPTION
- Add `none`, `minimal`, `xhigh` to reasoning_effort enum in OpenAI schema
- OpenAI API supports: none, minimal, low, medium, high, xhigh
- Schema only had: low, medium, high

Fixes #6508

Co-authored-by: snz2 <21010696+snz2@users.noreply.github.com>