### PR TITLE
feat(react): add usePollinationsAudio hook for text-to-speech

### DIFF
--- a/pollinations-react/README.md
+++ b/pollinations-react/README.md
@@ -41,6 +41,34 @@ The usePollinationsText hook allows you to generate text from Pollinations' API 
 - `model` (string, default: 'openai'): The model to use for text generation. Options: 'openai', 'mistral'.
 - `systemPrompt` (string, optional): A system prompt to set the behavior of the AI.
 
+### usePollinationsAudio
+
+The usePollinationsAudio hook allows you to generate text-to-speech audio URLs from Pollinations' API.
+
+    import React from 'react';
+    import { usePollinationsAudio } from '@pollinations/react';
+
+    const SpeechComponent = () => {
+      const audioUrl = usePollinationsAudio('Hello, welcome to Pollinations!', {
+        voice: 'nova',
+        seed: 42
+      });
+
+      return (
+        <div>
+          {audioUrl ? <audio controls src={audioUrl} /> : <p>Loading...</p>}
+        </div>
+      );
+    };
+
+    export default SpeechComponent;
+
+#### Options
+
+- `voice` (string, default: 'nova'): The voice to use. Options: 'alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'.
+- `model` (string, default: 'openai-audio'): The model to use for audio generation.
+- `seed` (number, default: 42): The seed for consistent audio generation.
+
 ### usePollinationsImage
 
 The usePollinationsImage hook allows you to generate image URLs from Pollinations' API and use them directly in your React components.
@@ -53,7 +81,7 @@ The usePollinationsImage hook allows you to generate image URLs from Pollination
         width: 800,
         height: 600,
         seed: 42,
-        model: 'turbo',
+        model: 'flux',
         nologo: true,
         enhance: false
       });
@@ -71,7 +99,7 @@ The usePollinationsImage hook allows you to generate image URLs from Pollination
 
 - `width` (number, default: 1024): The width of the generated image.
 - `height` (number, default: 1024): The height of the generated image.
-- `model` (string, default: 'turbo'): The model to use for image generation.
+- `model` (string, default: 'flux'): The model to use for image generation.
 - `seed` (number, default: -1): The seed for random image generation. If -1, a random seed will be used.
 - `nologo` (boolean, default: true): Whether to generate the image without a logo.
 - `enhance` (boolean, default: false): Whether to enhance the generated image.

--- a/pollinations-react/src/hooks/usePollinationsAudio.js
+++ b/pollinations-react/src/hooks/usePollinationsAudio.js
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+
+/**
+ * Custom hook to generate a Pollinations audio URL for text-to-speech.
+ *
+ * @param {string} text - The text to convert to speech.
+ * @param {Object} [options] - Optional parameters for audio generation.
+ * @param {string} [options.voice='nova'] - The voice to use (alloy, echo, fable, onyx, nova, shimmer).
+ * @param {string} [options.model='openai-audio'] - The model to use for audio generation.
+ * @param {number} [options.seed=42] - The seed for consistent audio generation.
+ * @returns {string} - The URL of the generated audio.
+ */
+const usePollinationsAudio = (text, options = {}) => {
+    const {
+        voice = "nova",
+        model = "openai-audio",
+        seed = 42,
+    } = options;
+
+    const audioUrl = useMemo(() => {
+        if (!text) return null;
+        const params = new URLSearchParams({
+            model,
+            voice,
+            seed,
+        });
+        return `https://text.pollinations.ai/${encodeURIComponent(text)}?${params.toString()}`;
+    }, [text, model, voice, seed]);
+
+    return audioUrl;
+};
+
+export default usePollinationsAudio;

--- a/pollinations-react/src/hooks/usePollinationsImage.js
+++ b/pollinations-react/src/hooks/usePollinationsImage.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 
 /**
  * Custom hook to generate a Pollinations image URL based on the given prompt and options.

--- a/pollinations-react/src/index.js
+++ b/pollinations-react/src/index.js
@@ -2,3 +2,5 @@
 export { default as usePollinationsImage } from "./hooks/usePollinationsImage.js";
 export { default as usePollinationsText } from "./hooks/usePollinationsText.js";
 export { default as usePollinationsChat } from "./hooks/usePollinationsChat.js";
+export { default as usePollinationsAudio } from "./hooks/usePollinationsAudio.js";
+


### PR DESCRIPTION
added a new `usePollinationsAudio` hook for text to speech, plus small doc and code cleanups.

## changes
- add `usePollinationsAudio` hook with voice, model, and seed options  
- fix readme default model from `turbo` to `flux`  
- remove unused react import in `usePollinationsImage.js`

## example
```js
import { usePollinationsAudio } from '@pollinations/react';

const audioUrl = usePollinationsAudio('I like bees!', {
  voice: 'nova',
  seed: 42
});

return <audio controls src={audioUrl} />;
```