### PR TITLE
feat(react): add usePollinationsAudio TypeScript definition

### DIFF
--- a/pollinations-react/types/index.d.ts
+++ b/pollinations-react/types/index.d.ts
@@ -23,4 +23,13 @@ declare module "@pollinations/react" {
         prompt: string,
         options: { seed: number; model: string; systemPrompt?: string },
     ): string;
+
+    export function usePollinationsAudio(
+        text: string,
+        options?: {
+            voice?: string;
+            model?: string;
+            seed?: number;
+        },
+    ): string | null;
 }


### PR DESCRIPTION
- add type definition for the `usePollinationsAudio` hook
- options parameter is optional, matching the JS implementation