### PR TITLE
fix: improve Polar customer meters caching and logging

### DIFF
--- a/enter.pollinations.ai/src/middleware/polar.ts
+++ b/enter.pollinations.ai/src/middleware/polar.ts
@@ -98,7 +98,7 @@ export const polar = createMiddleware<PolarEnv>(async (c, next) => {
         },
         {
             log,
-            ttl: 300, // 5 minutes - safe with local pending spend tracking
+            ttl: 480, // 8 minutes - safe with local pending spend tracking
             kv: c.env.KV,
             keyGenerator: (userId) => `polar:customer:meters:${userId}`,
             staleOnError: true, // Return stale cache on Polar API rate limit (429)


### PR DESCRIPTION
- Add staleOnError option to cached() for graceful rate limit handling
- Improve staleness tracking with cachedAt timestamp
- Extend storage TTL for staleOnError (12x TTL or 1 hour min)
- Increase polar customer meters TTL to 8 minutes
- Replace console.log with proper log.debug() system