### PR TITLE
fix(react): correct seed default documentation from -1 to 42

### DIFF
--- a/pollinations-react/README.md
+++ b/pollinations-react/README.md
@@ -1,6 +1,6 @@
 # 🌸 Pollinations Generative React Hooks 🌸
 
-A simple way to generate images, text and markdown using the Pollinations API in your React projects.
+A simple way to generate images, text, audio and markdown using the Pollinations API in your React projects.
 
 ## 🚀 Quick Start
 
@@ -37,7 +37,7 @@ The usePollinationsText hook allows you to generate text from Pollinations' API 
 
 #### Options
 
-- `seed` (number, default: -1): The seed for random text generation. If -1, a random seed will be used.
+- `seed` (number, default: 42): Seed for reproducible generation. Use the same seed to get identical results.
 - `model` (string, default: 'openai'): The model to use for text generation. Options: 'openai', 'mistral'.
 - `systemPrompt` (string, optional): A system prompt to set the behavior of the AI.
 
@@ -100,7 +100,7 @@ The usePollinationsImage hook allows you to generate image URLs from Pollination
 - `width` (number, default: 1024): The width of the generated image.
 - `height` (number, default: 1024): The height of the generated image.
 - `model` (string, default: 'flux'): The model to use for image generation.
-- `seed` (number, default: -1): The seed for random image generation. If -1, a random seed will be used.
+- `seed` (number, default: 42): Seed for reproducible generation. Use the same seed to get identical results.
 - `nologo` (boolean, default: true): Whether to generate the image without a logo.
 - `enhance` (boolean, default: false): Whether to enhance the generated image.
 

--- a/pollinations-react/src/hooks/usePollinationsText.js
+++ b/pollinations-react/src/hooks/usePollinationsText.js
@@ -9,7 +9,7 @@ import memoize from "lodash.memoize";
  *
  * @param {string} prompt - The user's input prompt for text generation.
  * @param {Object} options - Configuration options for text generation.
- * @param {number} [options.seed=-1] - Seed for deterministic text generation. -1 for random.
+ * @param {number} [options.seed=42] - Seed for deterministic text generation.
  * @param {string} [options.systemPrompt] - Optional system prompt to guide the text generation.
  * @param {boolean} [options.jsonMode=false] - Whether to parse the response as JSON.
  * @param {boolean} [options.loadNull=false] - Whether to reset the text state to null before fetching new data.


### PR DESCRIPTION
- fix seed default in `usePollinationsText` and `usePollinationsImage` docs
- clarify that seed 42 provides reproducible results, not random
- add audio to package description

the old docs said `-1` for random, but `makeParamsSafe.js` rejects negative seeds and defaults to `42` so `-1` never actually worked as random.