### PR TITLE
fix: replace xargs with sed in tier-app-submission workflow

### DIFF
--- a/.github/workflows/tier-app-submission.yml
+++ b/.github/workflows/tier-app-submission.yml
@@ -142,8 +142,8 @@ jobs:
           APP_URL=$(echo "$PROJECT_JSON" | jq -r '.url')
           APP_REPO=$(echo "$PROJECT_JSON" | jq -r '.repo // empty')
           
-          # Normalize for comparison
-          NORMALIZED_NAME=$(echo "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | xargs)
+          # Normalize for comparison (avoid xargs which chokes on quotes)
+          NORMALIZED_NAME=$(echo "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
           
           DUPLICATE_FOUND=""
           SIMILAR_APPS=""
@@ -186,9 +186,9 @@ jobs:
             # Markdown table format: | Emoji | Name | Description | Language | Category | GitHub | Repo | Stars | Discord | Other | Submitted |
             PREV_APPS_TEXT=""
             while IFS='|' read -r emoji name desc lang cat github repo stars discord other submitted; do
-            github=$(echo "$github" | xargs)
-            name=$(echo "$name" | xargs)
-            desc=$(echo "$desc" | xargs)
+            github=$(echo "$github" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            name=$(echo "$name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            desc=$(echo "$desc" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
             
             if [ "$github" = "@$GITHUB_USERNAME" ]; then
                 clean_name=$(echo "$name" | sed 's/\[//g; s/\].*//g')


### PR DESCRIPTION
- Replace `xargs` with `sed` for whitespace trimming in duplicate check
- `xargs` fails on apostrophes/quotes in app descriptions (e.g., `kids' coloring books`)
- Fixes issue #6573 workflow failure

**Root cause:** When parsing `APPS.md` to check for duplicates, `xargs` interprets `'` as an unterminated quote and crashes.