### PR TITLE
feat: Add flux as alias to zimage in registry

### DIFF
--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -503,6 +503,10 @@ function proxyUrl(
     // Copy query parameters but exclude the 'key' parameter (used for enter.pollinations.ai auth only)
     const searchParams = new URLSearchParams(incomingUrl.search);
     searchParams.delete("key");
+    // Replace model with resolved model (handles aliases like flux -> zimage)
+    if (c.var.model?.resolved && searchParams.has("model")) {
+        searchParams.set("model", c.var.model.resolved);
+    }
     targetUrl.search = searchParams.toString();
     return targetUrl;
 }

--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -1,18 +1,24 @@
-import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import { IMAGE_SERVICES, DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import { z } from "zod";
 
 const QUALITIES = ["low", "medium", "high", "hd"] as const;
 const MAX_SEED_VALUE = 1844674407370955;
 
+// Build list of valid model names: service IDs + all aliases
+const VALID_IMAGE_MODELS = [
+    ...Object.keys(IMAGE_SERVICES),
+    ...Object.values(IMAGE_SERVICES).flatMap((service) => service.aliases),
+] as const;
+
 export const GenerateImageRequestQueryParamsSchema = z.object({
     // Image model params
     model: z
-        .literal(Object.keys(IMAGE_SERVICES))
+        .literal(VALID_IMAGE_MODELS)
         .optional()
-        .default("flux")
+        .default(DEFAULT_IMAGE_MODEL)
         .meta({
             description:
-                "AI model. Image: flux, turbo, gptimage, kontext, seedream, seedream-pro, nanobanana. Video: veo, seedance, seedance-pro",
+                "AI model. Image: zimage (or flux alias), turbo, gptimage, kontext, seedream, seedream-pro, nanobanana. Video: veo, seedance, seedance-pro",
         }),
     width: z.coerce
         .number()

--- a/image.pollinations.ai/src/availableServers.ts
+++ b/image.pollinations.ai/src/availableServers.ts
@@ -298,7 +298,7 @@ export const fetchFromLeastBusyServer = async (
 ): Promise<Response> => {
     const maxRetries = 3; // Try up to 3 different servers
     let lastError: Error | null = null;
-    
+
     for (let attempt = 0; attempt < maxRetries; attempt++) {
         const serverUrl = await getNextServerUrl(type);
         const server = SERVERS[type].find((s) => s.url === serverUrl);
@@ -312,26 +312,37 @@ export const fetchFromLeastBusyServer = async (
                 async () => {
                     server.totalRequests++;
                     try {
-                        const response = await fetch(`${serverUrl}/generate`, options);
+                        const response = await fetch(
+                            `${serverUrl}/generate`,
+                            options,
+                        );
                         if (!response.ok) {
                             server.errors++;
-                            
+
                             // Capture detailed error information
-                            let errorBody = '';
+                            let errorBody = "";
                             try {
                                 errorBody = await response.text();
                             } catch (e) {
-                                errorBody = 'Could not read error response body';
+                                errorBody =
+                                    "Could not read error response body";
                             }
-                            
-                            console.error(`[${type}] Server ${serverUrl} returned ${response.status}:`, {
-                                status: response.status,
-                                statusText: response.statusText,
-                                headers: Object.fromEntries(response.headers.entries()),
-                                body: errorBody.substring(0, 500) // Limit to first 500 chars
-                            });
-                            
-                            throw new Error(`HTTP error! status: ${response.status}, body: ${errorBody.substring(0, 200)}`);
+
+                            console.error(
+                                `[${type}] Server ${serverUrl} returned ${response.status}:`,
+                                {
+                                    status: response.status,
+                                    statusText: response.statusText,
+                                    headers: Object.fromEntries(
+                                        response.headers.entries(),
+                                    ),
+                                    body: errorBody.substring(0, 500), // Limit to first 500 chars
+                                },
+                            );
+
+                            throw new Error(
+                                `HTTP error! status: ${response.status}, body: ${errorBody.substring(0, 200)}`,
+                            );
                         }
                         return response;
                     } catch (error) {
@@ -347,20 +358,22 @@ export const fetchFromLeastBusyServer = async (
             );
         } catch (error) {
             lastError = error as Error;
-            
+
             // Only retry on 500 errors
-            if (error.message && error.message.includes('status: 500')) {
-                console.error(`[${type}] Attempt ${attempt + 1}/${maxRetries} failed with 500 error, trying different server...`);
+            if (error.message && error.message.includes("status: 500")) {
+                console.error(
+                    `[${type}] Attempt ${attempt + 1}/${maxRetries} failed with 500 error, trying different server...`,
+                );
                 continue;
             }
-            
+
             // For non-500 errors, throw immediately
             throw error;
         }
     }
-    
+
     // If we exhausted all retries, throw the last error
-    throw lastError || new Error('All server attempts failed');
+    throw lastError || new Error("All server attempts failed");
 };
 
 // Wrapper for backward compatibility

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -23,12 +23,6 @@ type ImageModelsConfig = {
 };
 
 export const IMAGE_CONFIG = {
-    flux: {
-        type: "pollinations",
-        enhance: true,
-        defaultSideLength: 768,
-    },
-
     // Azure Flux Kontext - general purpose model
     kontext: {
         type: "kontext",
@@ -117,7 +111,8 @@ export const IMAGE_CONFIG = {
         defaultResolution: "720p",
     },
 
-    // Z-Image-Turbo - Fast 6B parameter image generation (AWS)
+    // Z-Image - Fast 6B parameter image generation with SPAN 2x upscaling (IO.net)
+    // Default model - "flux" is an alias that resolves to zimage
     zimage: {
         type: "zimage",
         enhance: false,

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1,26 +1,12 @@
 import { COST_START_DATE, perMillion } from "./price-helpers";
 import type { ServiceDefinition } from "./registry";
 
-export const DEFAULT_IMAGE_MODEL = "flux" as const;
+export const DEFAULT_IMAGE_MODEL = "zimage" as const;
 
 export type ImageServiceId = keyof typeof IMAGE_SERVICES;
 export type ImageModelId = (typeof IMAGE_SERVICES)[ImageServiceId]["modelId"];
 
 export const IMAGE_SERVICES = {
-    "flux": {
-        aliases: [],
-        modelId: "flux", // Provider returns this - used for cost lookup
-        provider: "io.net",
-        cost: [
-            {
-                date: COST_START_DATE,
-                completionImageTokens: 0.00012, // $0.0088¢ per image (GPU cluster cost - September avg)
-            },
-        ],
-        description: "Flux - Fast and high-quality image generation",
-        inputModalities: ["text"],
-        outputModalities: ["image"],
-    },
     "kontext": {
         aliases: [],
         modelId: "kontext",
@@ -153,19 +139,19 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
     },
     "zimage": {
-        aliases: ["z-image", "z-image-turbo"],
+        aliases: ["z-image", "z-image-turbo", "flux"],
         modelId: "zimage",
-        provider: "aws",
+        provider: "io.net",
         cost: [
-            // Z-Image-Turbo (6B params, 9 steps)
-            // AWS (L40S), ~0.9s for 512x512, ~3.5s for 1024x1024
+            // Z-Image-Turbo (6B params, 9 steps) with SPAN 2x upscaling
+            // IO.net cluster (10x RTX 4090), ~1s for 768x768, ~2s for 1536x1536
             {
                 date: COST_START_DATE,
                 completionImageTokens: 0.0002, // ~$0.0002 per image (GPU cost estimate)
             },
         ],
         description:
-            "Z-Image-Turbo - Fast 6B parameter image generation (alpha)",
+            "Z-Image - Fast 6B parameter image generation with SPAN 2x upscaling",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },


### PR DESCRIPTION
- Remove `flux` as separate model, add as alias to `zimage`
- Change `DEFAULT_IMAGE_MODEL` to `zimage`
- Update schema to accept model aliases (flux, z-image, z-image-turbo)
- Fix proxy to pass resolved model to backend

Users requesting `model=flux` will now use Z-Image servers.