### PR TITLE
feat: add an authed public endpoint to return customer balance

### DIFF
--- a/enter.pollinations.ai/src/routes/polar.ts
+++ b/enter.pollinations.ai/src/routes/polar.ts
@@ -36,8 +36,22 @@ export function productUrlParamToSlug(slug: string): string {
 }
 
 export const polarRoutes = new Hono<Env>()
-    .use("*", auth({ allowApiKey: false, allowSessionCookie: true }))
     .use("*", polar)
+    .get(
+        "/customer/balance",
+        auth({ allowApiKey: true, allowSessionCookie: true }),
+        describeRoute({
+            tags: ["Auth"],
+            description:
+                "Get the current balance, pending spend, and effective balance for the user.",
+        }),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const result = await c.var.polar.getBalances(user.id);
+            return c.json(result);
+        },
+    )
+    .use("*", auth({ allowApiKey: false, allowSessionCookie: true }))
     .get(
         "/customer/state",
         describeRoute({

--- a/enter.pollinations.ai/test/integration/polar.test.ts
+++ b/enter.pollinations.ai/test/integration/polar.test.ts
@@ -1,14 +1,15 @@
-import { SELF } from "cloudflare:test";
-import { test } from "../fixtures.ts";
 import { productSlugToUrlParam } from "@/routes/polar.ts";
 import { packProductSlugs } from "@/utils/polar.ts";
+import { SELF } from "cloudflare:test";
 import { expect } from "vitest";
+import { test } from "../fixtures.ts";
 
 const base = "http://localhost:3000/api/polar";
 const customerRoutes = [
     "/customer/state",
     "/customer/events",
     "/customer/portal",
+    "/customer/balance",
 ];
 const checkoutRoutes = packProductSlugs.map(
     (slug) => `/checkout/${productSlugToUrlParam(slug)}`,
@@ -34,4 +35,42 @@ test.for(
         redirect: "manual",
     });
     expect(sessionCookieResponse.status).toBeOneOf([200, 302]);
+});
+
+test("/customer/balance should be accessible via API key", async ({
+    apiKey,
+    mocks,
+}) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/customer/balance`, {
+        method: "GET",
+        headers: {
+            authorization: `Bearer ${apiKey}`,
+        },
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty("effectiveBalance");
+    expect(data).toHaveProperty("currentBalance");
+    expect(data).toHaveProperty("pendingSpend");
+});
+
+test("/customer/balance should return correct balance structure", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("polar", "tinybird");
+    const response = await SELF.fetch(`${base}/customer/balance`, {
+        method: "GET",
+        headers: {
+            cookie: `better-auth.session_token=${sessionToken}`,
+        },
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(typeof data.effectiveBalance).toBe("number");
+    expect(typeof data.currentBalance).toBe("number");
+    expect(typeof data.pendingSpend).toBe("number");
+    // effectiveBalance should equal currentBalance minus pendingSpend
+    expect(data.effectiveBalance).toBe(data.currentBalance - data.pendingSpend);
 });


### PR DESCRIPTION
## Summary

Add a new public GET endpoint `/api/polar/customer/balance` to retrieve the authenticated user's current balance, pending spend, and effective balance. This endpoint supports both API key and session cookie authentication, enabling programmatic access for server-to-server integrations.

Associated Issues:
- #6563
- #5892
- #5806 

## Changes

- **New endpoint**: `GET /api/polar/customer/balance`
  - Returns `{ effectiveBalance, currentBalance, pendingSpend }`
    - Effective balance = current balance - pending spend (accounts for unprocessed usage)
  - Supports authentication via API key (`Authorization: Bearer <key>`) or session cookie

- **New middleware function**: `getBalances(userId)` in `polar.ts`
  - Fetches customer meters from Polar API (cached for 8 minutes)
  - Retrieves pending spend from local D1 database
  - Calculates effective balance by subtracting pending spend from current meter balances

## Testing
- Added test coverage for `/customer/balance` endpoint in `polar.test.ts`