### PR TITLE
promo: Seedream 99% off until Dec 31

### DIFF
--- a/NEWS/transformed/highlights.md
+++ b/NEWS/transformed/highlights.md
@@ -1,3 +1,4 @@
+- **2025-12-30** – **🎉 Seedream 99% Off Promo (ends Dec 31)** Generate stunning images with `seedream` (0.03¢) and `seedream-pro` (0.04¢) at almost-free pricing until midnight Dec 31! [Try it](https://enter.pollinations.ai)
 - **2025-12-29** – **🚀 New Model: gptimage-large** Access GPT Image 1.5 for high-fidelity generations via the API. [API Docs](https://enter.pollinations.ai/api/docs)
 - **2025-12-29** – **🤖 DeepSeek V3.2** Upgraded to the latest DeepSeek V3.2 for smarter, faster chat responses. [Try it](https://hello.pollinations.ai)
 - **2025-12-29** – **🎥 Veo Image-to-Video** Turn images into videos using the updated `veo` model capabilities. [API Docs](https://enter.pollinations.ai/api/docs)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ We've launched **https://gen.pollinations.ai** — a single endpoint for all you
 
 ## 🆕 Latest News
 
+- **2025-12-30** – **🎉 Seedream 99% Off Promo (ends Dec 31)** Generate stunning images with `seedream` (0.03¢) and `seedream-pro` (0.04¢) at almost-free pricing until midnight Dec 31! [Try it](https://enter.pollinations.ai)
 - **2025-12-29** – **🚀 New Model: gptimage-large** Access GPT Image 1.5 for high-fidelity generations via the API. [API Docs](https://enter.pollinations.ai/api/docs)
 - **2025-12-29** – **🤖 DeepSeek V3.2** Upgraded to the latest DeepSeek V3.2 for smarter, faster chat responses. [Try it](https://hello.pollinations.ai)
 - **2025-12-29** – **🎥 Veo Image-to-Video** Turn images into videos using the updated `veo` model capabilities. [API Docs](https://enter.pollinations.ai/api/docs)

--- a/enter.pollinations.ai/src/client/components/pricing/ModelRow.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/ModelRow.tsx
@@ -16,10 +16,14 @@ type ModelRowProps = {
     model: ModelPrice;
 };
 
+// Temporary promo models (ends Dec 31, 2025)
+const PROMO_MODELS = ["seedream", "seedream-pro"];
+
 export const ModelRow: FC<ModelRowProps> = ({ model }) => {
     const modelDescription = getModelDescription(model.name);
     const genPerPollen = calculatePerPollen(model);
     const [showTooltip, setShowTooltip] = useState(false);
+    const isPromo = PROMO_MODELS.includes(model.name);
     const handleMouseEnter = () => setShowTooltip(true);
     const handleMouseLeave = () => setShowTooltip(false);
     const handleClick = (e: React.MouseEvent) => {
@@ -75,6 +79,11 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
             <td className="py-2 px-2 text-sm font-mono text-gray-700 whitespace-nowrap relative group">
                 <div className="flex items-center gap-2">
                     {model.name}
+                    {isPromo && (
+                        <span className="text-[10px] text-white bg-red-500 px-1.5 py-0.5 rounded-full font-bold animate-pulse">
+                            99% OFF
+                        </span>
+                    )}
                     {showDescriptionInfo && (
                         <button
                             type="button"
@@ -136,7 +145,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
             <td className="py-2 px-2 text-sm">
                 <div className="flex justify-center">
                     <span
-                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r from-yellow-100 to-orange-100 text-orange-900 border border-orange-200 ${model.type === "image" ? "uppercase" : ""}`}
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${isPromo ? "bg-gradient-to-r from-red-100 to-red-200 text-red-700 border border-red-300" : "bg-gradient-to-r from-yellow-100 to-orange-100 text-orange-900 border border-orange-200"} ${model.type === "image" ? "uppercase" : ""}`}
                     >
                         {genPerPollen}
                     </span>

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -76,13 +76,13 @@ export const IMAGE_SERVICES = {
         modelId: "seedream",
         provider: "bytedance",
         cost: [
-            // ByteDance ARK Seedream 4.0 - $0.03 per image
+            // ByteDance ARK Seedream 4.0 - PROMO: 1% of normal price (almost free!)
             {
                 date: COST_START_DATE,
-                completionImageTokens: 0.03, // $0.03 per image (3 cents)
+                completionImageTokens: 0.0003, // $0.0003 per image (0.03 cents) - PROMO 99% OFF
             },
         ],
-        description: "Seedream 4.0 - ByteDance ARK (better quality)",
+        description: "Seedream 4.0 - ByteDance ARK (better quality) [PROMO]",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
     },
@@ -91,13 +91,14 @@ export const IMAGE_SERVICES = {
         modelId: "seedream-pro",
         provider: "bytedance",
         cost: [
-            // ByteDance ARK Seedream 4.5 - $0.04 per image
+            // ByteDance ARK Seedream 4.5 - PROMO: 1% of normal price (almost free!)
             {
                 date: COST_START_DATE,
-                completionImageTokens: 0.04, // $0.04 per image (4 cents)
+                completionImageTokens: 0.0004, // $0.0004 per image (0.04 cents) - PROMO 99% OFF
             },
         ],
-        description: "Seedream 4.5 Pro - ByteDance ARK (4K, Multi-Image)",
+        description:
+            "Seedream 4.5 Pro - ByteDance ARK (4K, Multi-Image) [PROMO]",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
     },


### PR DESCRIPTION
- Reduce seedream prices to 1% of original (0.03¢ and 0.04¢ per image)
- Add pulsing "99% OFF" badge on pricing page
- Add promo announcement to NEWS and README
- Expires midnight Dec 31, 2025