### PR TITLE
fix: increase Polar cache TTL to reduce API rate limits

### DIFF
--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -239,7 +239,7 @@ export const event = sqliteTable(
         ),
 
         // For getPendingSpend: WHERE userId = ? AND createdAt >= ?
-        // Covers the 10-minute window query for pending spend calculation
+        // Covers the 30-minute window query for pending spend calculation
         index("idx_event_user_created").on(table.userId, table.createdAt),
     ],
 );

--- a/enter.pollinations.ai/src/events.ts
+++ b/enter.pollinations.ai/src/events.ts
@@ -566,7 +566,7 @@ export async function getPendingSpend(
     db: DrizzleD1Database,
     userId: string,
 ): Promise<number> {
-    const maxPendingSpendWindowMs = 10 * 60 * 1000; // 10 minutes
+    const maxPendingSpendWindowMs = 30 * 60 * 1000; // 30 minutes
     const windowStart = new Date(Date.now() - maxPendingSpendWindowMs);
     const result = await db
         .select({

--- a/enter.pollinations.ai/src/middleware/polar.ts
+++ b/enter.pollinations.ai/src/middleware/polar.ts
@@ -57,7 +57,7 @@ export const polar = createMiddleware<PolarEnv>(async (c, next) => {
         },
         {
             log,
-            ttl: 300, // 5 minutes - safe with local pending spend tracking
+            ttl: 300, // 5 minutes - only used for subscription/tier lookups, not balance checks
             kv: c.env.KV,
             keyGenerator: (userId) => `polar:customer:state:${userId}`,
         },
@@ -98,7 +98,7 @@ export const polar = createMiddleware<PolarEnv>(async (c, next) => {
         },
         {
             log,
-            ttl: 480, // 8 minutes - safe with local pending spend tracking
+            ttl: 1500, // 25 minutes - safe with local pending spend tracking (30 min window)
             kv: c.env.KV,
             keyGenerator: (userId) => `polar:customer:meters:${userId}`,
             staleOnError: true, // Return stale cache on Polar API rate limit (429)


### PR DESCRIPTION
Reduces Polar API rate limit errors (429s) by caching customer meters longer.

**Changes:**
- Cache TTL: 8 min → 25 min
- Pending spend window: 10 min → 30 min (must exceed cache TTL for conservative balance estimates)

Works with existing `staleOnError` fallback from previous session.