### PR TITLE
chore: remove pending spend from dashboard display

### DIFF
--- a/enter.pollinations.ai/src/client/components/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/pollen-balance.tsx
@@ -3,13 +3,11 @@ import type { FC } from "react";
 type PollenBalanceProps = {
     tierBalance: number;
     packBalance: number;
-    pendingSpend?: number;
 };
 
 export const PollenBalance: FC<PollenBalanceProps> = ({
     tierBalance,
     packBalance,
-    pendingSpend = 0,
 }) => {
     const totalPollen = Math.max(0, tierBalance + packBalance);
     const freePercentage = totalPollen > 0 ? (tierBalance / totalPollen) * 100 : 0;
@@ -23,11 +21,6 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                     {/* Pollen amount above gauge */}
                     <span className="text-4xl sm:text-5xl md:text-6xl font-bold text-green-950 tabular-nums">
                         {totalPollen.toFixed(2)} pollen
-                        {pendingSpend > 0 && (
-                            <span className="text-lg sm:text-xl text-orange-600 font-normal ml-2">
-                                (-{pendingSpend.toFixed(3)} pending)
-                            </span>
-                        )}
                     </span>
                     {/* Gauge with download button */}
                     <div className="flex items-center gap-2 w-full max-w-[540px]">

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -26,7 +26,6 @@ export const Route = createFileRoute("/")({
             customer,
             tierData,
             apiKeysResult,
-            pendingSpendResult,
             d1BalanceResult,
         ] = await Promise.all([
             apiClient.polar.customer.state
@@ -34,15 +33,11 @@ export const Route = createFileRoute("/")({
                 .then((r) => (r.ok ? r.json() : null)),
             apiClient.tiers.view.$get().then((r) => (r.ok ? r.json() : null)),
             authClient.apiKey.list(),
-            apiClient.polar.customer["pending-spend"]
-                .$get()
-                .then((r) => (r.ok ? r.json() : null)),
             apiClient.polar.customer["d1-balance"]
                 .$get()
                 .then((r) => (r.ok ? r.json() : null)),
         ]);
         const apiKeys = apiKeysResult.data || [];
-        const pendingSpend = pendingSpendResult?.pendingSpend || 0;
         const tierBalance = d1BalanceResult?.tierBalance ?? 0;
         const packBalance = d1BalanceResult?.packBalance ?? 0;
 
@@ -51,7 +46,6 @@ export const Route = createFileRoute("/")({
             customer,
             apiKeys,
             tierData,
-            pendingSpend,
             tierBalance,
             packBalance,
         };
@@ -60,7 +54,7 @@ export const Route = createFileRoute("/")({
 
 function RouteComponent() {
     const router = useRouter();
-    const { user, customer, apiKeys, tierData, pendingSpend, tierBalance, packBalance } =
+    const { user, customer, apiKeys, tierData, tierBalance, packBalance } =
         Route.useLoaderData();
 
     const [isSigningOut, setIsSigningOut] = useState(false);
@@ -240,7 +234,6 @@ function RouteComponent() {
                     <PollenBalance
                         tierBalance={tierBalance}
                         packBalance={packBalance}
-                        pendingSpend={pendingSpend}
                     />
                 </div>
                 {tierData && (


### PR DESCRIPTION
- Remove pending-spend API call from dashboard loader
- Remove pendingSpend prop from PollenBalance component
- Simplify dashboard - D1 balance is already accurate after decrement