### PR TITLE
fix: prevent infinite loop in tier-app-submission workflow

### DIFF
--- a/.github/workflows/tier-app-submission.yml
+++ b/.github/workflows/tier-app-submission.yml
@@ -25,10 +25,11 @@ jobs:
   tier-parse-issue:
     if: |
       (github.event_name == 'workflow_dispatch' ||
-      contains(github.event.issue.labels.*.name, 'tier:review') ||
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'tier:review')) ||
       (github.event_name == 'issue_comment' && 
-       contains(github.event.issue.labels.*.name, 'tier:info-needed') &&
-       github.event.comment.user.type != 'Bot')) &&
+       github.event.comment.user.type != 'Bot' &&
+       (contains(github.event.issue.labels.*.name, 'tier:review') ||
+        contains(github.event.issue.labels.*.name, 'tier:info-needed')))) &&
       !contains(github.event.issue.labels.*.name, 'tier:done') &&
       !contains(github.event.issue.labels.*.name, 'tier:flower') &&
       github.event.issue.state == 'open'


### PR DESCRIPTION
- Bot comments now never trigger the workflow
- tier:review label only triggers on issue events (opened/edited/reopened)
- All issue_comment events check for Bot user type first

**Label audit:** All 5 tier labels verified safe:
- `tier:review`, `tier:info-needed` - bot-filtered
- `tier:flower`, `tier:done`, `tier:rejected` - terminal/blocking

Fixes #6630