### PR TITLE
feat: use Polar Events API for crypto credits

### DIFF
--- a/enter.pollinations.ai/src/client/components/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/pollen-balance.tsx
@@ -3,15 +3,13 @@ import type { FC } from "react";
 type PollenBalanceProps = {
     tierBalance: number;
     packBalance: number;
-    cryptoBalance: number;
 };
 
 export const PollenBalance: FC<PollenBalanceProps> = ({
     tierBalance,
     packBalance,
-    cryptoBalance,
 }) => {
-    const paidBalance = packBalance + cryptoBalance;
+    const paidBalance = packBalance;
     const totalPollen = Math.max(0, tierBalance + paidBalance);
     const freePercentage =
         totalPollen > 0 ? (tierBalance / totalPollen) * 100 : 0;

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -38,7 +38,6 @@ export const Route = createFileRoute("/")({
         const apiKeys = apiKeysResult.data || [];
         const tierBalance = d1BalanceResult?.tierBalance ?? 0;
         const packBalance = d1BalanceResult?.packBalance ?? 0;
-        const cryptoBalance = d1BalanceResult?.cryptoBalance ?? 0;
 
         return {
             user: context.user,
@@ -47,22 +46,14 @@ export const Route = createFileRoute("/")({
             tierData,
             tierBalance,
             packBalance,
-            cryptoBalance,
         };
     },
 });
 
 function RouteComponent() {
     const router = useRouter();
-    const {
-        user,
-        customer,
-        apiKeys,
-        tierData,
-        tierBalance,
-        packBalance,
-        cryptoBalance,
-    } = Route.useLoaderData();
+    const { user, customer, apiKeys, tierData, tierBalance, packBalance } =
+        Route.useLoaderData();
 
     const [isSigningOut, setIsSigningOut] = useState(false);
     const [paymentMethod, setPaymentMethod] = useState<"fiat" | "crypto">(
@@ -276,7 +267,6 @@ function RouteComponent() {
                     <PollenBalance
                         tierBalance={tierBalance}
                         packBalance={packBalance}
-                        cryptoBalance={cryptoBalance}
                     />
                 </div>
                 {tierData && (

--- a/enter.pollinations.ai/src/routes/polar.ts
+++ b/enter.pollinations.ai/src/routes/polar.ts
@@ -97,8 +97,9 @@ export const polarRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             // Use getBalance which includes lazy init from Polar if not set
-            const { tierBalance, packBalance, cryptoBalance } =
-                await c.var.polar.getBalance(user.id);
+            const { tierBalance, packBalance } = await c.var.polar.getBalance(
+                user.id,
+            );
             const db = drizzle(c.env.DB);
             const users = await db
                 .select({ lastTierGrant: userTable.lastTierGrant })
@@ -110,7 +111,6 @@ export const polarRoutes = new Hono<Env>()
             return c.json({
                 tierBalance,
                 packBalance,
-                cryptoBalance,
                 lastTierGrant,
             });
         },


### PR DESCRIPTION
## Summary
Refactors crypto payment integration to use Polar's Events API instead of a separate `cryptoBalance` field in D1.

## Changes
- Replace D1 `cryptoBalance` update with `polar.events.ingest` using negative units to grant credits
- Remove `cryptoBalance` from `getBalance`, `requirePositiveBalance` in middleware
- Remove `cryptoBalance` from API response and client UI
- Crypto credits now flow through Polar pack meter for unified balance tracking

## Why
- **Centralized balance tracking**: All pollen balances managed in Polar
- **Simpler architecture**: No separate D1 column for crypto purchases
- **Consistent with fiat flow**: Crypto credits behave like pack purchases
- **Better auditability**: All credits visible in Polar dashboard

## Technical Details
Uses Polar's Events API with negative `units` to grant credits:
```typescript
await polar.events.ingest({
    events: [{
        name: "crypto_credit",
        externalCustomerId: userId,
        metadata: {
            units: -pollenAmount, // Negative = grant credits
            pack,
            paymentId: String(payload.payment_id),
            paymentMethod: "nowpayments",
        },
    }],
});
```

## Note
This PR targets `feat/nowpayments-crypto-balance` (PR #6733) and should be merged into that branch first.