### PR TITLE
fix: expose Content-Disposition header in CORS for CSV downloads

### DIFF
--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -62,7 +62,7 @@ const app = new Hono<Env>()
             credentials: true,
             allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
             allowHeaders: ["Content-Type", "Authorization"],
-            exposeHeaders: ["Content-Length"],
+            exposeHeaders: ["Content-Length", "Content-Disposition"],
             maxAge: 600,
         }),
     )


### PR DESCRIPTION
- Add `Content-Disposition` to CORS `exposeHeaders` for auth/dashboard endpoints
- Fixes "Needs permission to download" error when downloading Usage CSV

Reported by @martinlh77 in Discord.