### PR TITLE
fix: remove code_execution from gemini-fast

### DIFF
--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -103,7 +103,6 @@ const models: ModelDefinition[] = [
         transform: pipe(
             createSystemPromptTransform(BASE_PROMPTS.conversational),
             sanitizeToolSchemas(),
-            createGeminiToolsTransform(["code_execution"]),
             createGeminiThinkingTransform("v2.5"),
         ),
     },


### PR DESCRIPTION
Fixes #6532

## Problem
`gemini-fast` was failing with larger payloads that included `response_format` (structured output/JSON schema).

**Error:** `"controlled generation is not supported with Code Execution tool"`

## Root Cause
- Pollinations auto-adds `code_execution` tool to `gemini-fast` requests
- Gemini 2.5 Flash Lite does NOT support combining structured output with code_execution
- Only Gemini 3 models support this combination

## Fix
- Remove `code_execution` from `gemini-fast` default tools
- Users can still explicitly pass `tools` if they need code execution (without structured output)