### PR TITLE
fix: cap random seed to INT32_MAX for Vertex AI compatibility

### DIFF
--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -2,7 +2,8 @@ import { IMAGE_SERVICES, DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import { z } from "zod";
 
 const QUALITIES = ["low", "medium", "high", "hd"] as const;
-const MAX_SEED_VALUE = 1844674407370955;
+// Maximum seed value - use INT32_MAX for compatibility with strict providers like Vertex AI
+const MAX_SEED_VALUE = 2147483647; // INT32_MAX (2^31 - 1)
 
 // Build list of valid model names: service IDs + all aliases
 const VALID_IMAGE_MODELS = [

--- a/image.pollinations.ai/src/params.ts
+++ b/image.pollinations.ai/src/params.ts
@@ -8,8 +8,8 @@ type ModelName = keyof typeof MODELS;
 
 const allowedModels = Object.keys(MODELS) as Array<keyof typeof MODELS>;
 const validQualities = ["low", "medium", "high", "hd"] as const;
-const maxSeedValue = 1844674407370955;
-const MAX_RANDOM_SEED = 4294967296; // 2^32 for random seed generation
+// Maximum seed value - use INT32_MAX for compatibility with strict providers like Vertex AI
+const MAX_RANDOM_SEED = 2147483647; // INT32_MAX (2^31 - 1)
 
 const sanitizedBoolean = z
     .union([z.string(), z.boolean()])

--- a/text.pollinations.ai/utils/parameterValidators.js
+++ b/text.pollinations.ai/utils/parameterValidators.js
@@ -27,8 +27,8 @@ export const validateInt = (value) => {
     return parsed;
 };
 
-// Maximum seed value supported by most LLM/image providers (32-bit integer)
-const MAX_SEED_VALUE = 4294967296; // 2^32
+// Maximum seed value - use INT32_MAX for compatibility with strict providers like Vertex AI
+const MAX_SEED_VALUE = 2147483647; // INT32_MAX (2^31 - 1)
 
 /**
  * Processes seed value, converting -1 to a random seed (parity with image generation)


### PR DESCRIPTION
Fixes #6849

## Problem
`seed=-1` generates random values up to 2^32 (4,294,967,296), but Vertex AI requires **Signed INT32** (max 2,147,483,647).

## Changes
- Cap `MAX_SEED_VALUE` to `2147483647` (INT32_MAX) in text generation
- Cap `MAX_RANDOM_SEED` to `2147483647` in image generation  
- Cap schema validation max to `2147483647` in enter gateway
- Remove unused `maxSeedValue` constant from image params