### PR TITLE
fix: change video pricing column label from 'seconds' to 'videos'

### DIFF
--- a/enter.pollinations.ai/src/client/components/pricing/ModelTable.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/ModelTable.tsx
@@ -5,234 +5,237 @@ import { isPersona } from "./model-info.ts";
 import { calculatePerPollen } from "./calculations.ts";
 
 type ModelTableProps = {
-  models: ModelPrice[];
-  type: "text" | "image" | "video";
+    models: ModelPrice[];
+    type: "text" | "image" | "video";
 };
 
 type UnifiedModelTableProps = {
-  imageModels: ModelPrice[];
-  videoModels: ModelPrice[];
-  textModels: ModelPrice[];
+    imageModels: ModelPrice[];
+    videoModels: ModelPrice[];
+    textModels: ModelPrice[];
 };
 
 // Helper to convert per pollen string to numeric value for sorting
 const getPerPollenNumeric = (perPollen: string): number => {
-  if (perPollen === "—") return -1;
+    if (perPollen === "—") return -1;
 
-  // Remove "min" suffix for audio models
-  const cleaned = perPollen.replace(" min", "");
+    // Remove "min" suffix for audio models
+    const cleaned = perPollen.replace(" min", "");
 
-  // Handle K/M suffixes
-  if (cleaned.endsWith("K")) {
-    return parseFloat(cleaned) * 1000;
-  }
-  if (cleaned.endsWith("M")) {
-    return parseFloat(cleaned) * 1000000;
-  }
+    // Handle K/M suffixes
+    if (cleaned.endsWith("K")) {
+        return parseFloat(cleaned) * 1000;
+    }
+    if (cleaned.endsWith("M")) {
+        return parseFloat(cleaned) * 1000000;
+    }
 
-  return parseFloat(cleaned) || -1;
+    return parseFloat(cleaned) || -1;
 };
 
 const sortModels = (models: ModelPrice[]) => {
-  return [...models].sort((a, b) => {
-    const aPerPollen = calculatePerPollen(a);
-    const bPerPollen = calculatePerPollen(b);
-    const aValue = getPerPollenNumeric(aPerPollen);
-    const bValue = getPerPollenNumeric(bPerPollen);
-    return bValue - aValue;
-  });
+    return [...models].sort((a, b) => {
+        const aPerPollen = calculatePerPollen(a);
+        const bPerPollen = calculatePerPollen(b);
+        const aValue = getPerPollenNumeric(aPerPollen);
+        const bValue = getPerPollenNumeric(bPerPollen);
+        return bValue - aValue;
+    });
 };
 
 type SectionHeaderProps = {
-  label: string;
-  type: "text" | "image" | "video";
-  isFirst?: boolean;
+    label: string;
+    type: "text" | "image" | "video";
+    isFirst?: boolean;
 };
 
 const SectionHeader: FC<SectionHeaderProps> = ({
-  label,
-  type,
-  isFirst = false,
+    label,
+    type,
+    isFirst = false,
 }) => (
-  <tr>
-    <td
-      className={`text-left ${isFirst ? "pt-0" : "pt-6"} pb-1 px-2 text-sm font-bold text-pink-500 align-top`}
-    >
-      <div className="flex items-center gap-2">
-        {label}
-        {type === "video" && (
-          <>
-            <span className="text-[10px] text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded-full font-medium">
-              alpha 🧪
-            </span>
-            <span className="relative inline-flex items-center group/alpha">
-              <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-pink-100 border border-pink-300 text-pink-500 hover:bg-pink-200 hover:border-pink-400 transition-colors text-[10px] font-bold cursor-pointer">
-                i
-              </span>
-              <span className="invisible group-hover/alpha:visible absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none">
-                API endpoints and parameters may change
-              </span>
-            </span>
-          </>
-        )}
-      </div>
-    </td>
-    <td className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
-      <div>1 pollen ≈</div>
-      <div className="text-xs font-normal text-pink-400 opacity-70 italic">
-        {type === "text"
-          ? "responses"
-          : type === "image"
-            ? "images"
-            : "seconds"}
-      </div>
-    </td>
-    <td className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[190px] align-top">
-      <div>Input</div>
-      <div className="text-xs font-normal text-pink-400 opacity-70 italic">
-        pollen
-      </div>
-    </td>
-    <td className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
-      <div>Output</div>
-      <div className="text-xs font-normal text-pink-400 opacity-70 italic">
-        pollen
-      </div>
-    </td>
-  </tr>
+    <tr>
+        <td
+            className={`text-left ${isFirst ? "pt-0" : "pt-6"} pb-1 px-2 text-sm font-bold text-pink-500 align-top`}
+        >
+            <div className="flex items-center gap-2">
+                {label}
+                {type === "video" && (
+                    <>
+                        <span className="text-[10px] text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded-full font-medium">
+                            alpha 🧪
+                        </span>
+                        <span className="relative inline-flex items-center group/alpha">
+                            <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-pink-100 border border-pink-300 text-pink-500 hover:bg-pink-200 hover:border-pink-400 transition-colors text-[10px] font-bold cursor-pointer">
+                                i
+                            </span>
+                            <span className="invisible group-hover/alpha:visible absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none">
+                                API endpoints and parameters may change
+                            </span>
+                        </span>
+                    </>
+                )}
+            </div>
+        </td>
+        <td className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
+            <div>1 pollen ≈</div>
+            <div className="text-xs font-normal text-pink-400 opacity-70 italic">
+                {type === "text"
+                    ? "responses"
+                    : type === "image"
+                      ? "images"
+                      : "videos"}
+            </div>
+        </td>
+        <td className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[190px] align-top">
+            <div>Input</div>
+            <div className="text-xs font-normal text-pink-400 opacity-70 italic">
+                pollen
+            </div>
+        </td>
+        <td className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
+            <div>Output</div>
+            <div className="text-xs font-normal text-pink-400 opacity-70 italic">
+                pollen
+            </div>
+        </td>
+    </tr>
 );
 
 export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
-  imageModels,
-  videoModels,
-  textModels,
+    imageModels,
+    videoModels,
+    textModels,
 }) => {
-  const sortedImageModels = sortModels(imageModels);
-  const sortedVideoModels = sortModels(videoModels);
-  const sortedTextModels = sortModels(textModels);
+    const sortedImageModels = sortModels(imageModels);
+    const sortedVideoModels = sortModels(videoModels);
+    const sortedTextModels = sortModels(textModels);
 
-  const regularTextModels = sortedTextModels.filter((m) => !isPersona(m.name));
-  const personaModels = sortedTextModels.filter((m) => isPersona(m.name));
+    const regularTextModels = sortedTextModels.filter(
+        (m) => !isPersona(m.name),
+    );
+    const personaModels = sortedTextModels.filter((m) => isPersona(m.name));
 
-  return (
-    <table className="w-full min-w-[700px]">
-      <tbody>
-        {/* Image Section */}
-        <SectionHeader label="Image" type="image" isFirst />
-        {sortedImageModels.map((model) => (
-          <ModelRow key={model.name} model={model} />
-        ))}
+    return (
+        <table className="w-full min-w-[700px]">
+            <tbody>
+                {/* Image Section */}
+                <SectionHeader label="Image" type="image" isFirst />
+                {sortedImageModels.map((model) => (
+                    <ModelRow key={model.name} model={model} />
+                ))}
 
-        {/* Video Section */}
-        <SectionHeader label="Video" type="video" />
-        {sortedVideoModels.map((model) => (
-          <ModelRow key={model.name} model={model} />
-        ))}
+                {/* Video Section */}
+                <SectionHeader label="Video" type="video" />
+                {sortedVideoModels.map((model) => (
+                    <ModelRow key={model.name} model={model} />
+                ))}
 
-        {/* Text Section */}
-        <SectionHeader label="Text" type="text" />
-        {regularTextModels.map((model) => (
-          <ModelRow key={model.name} model={model} />
-        ))}
-        {personaModels.length > 0 && (
-          <>
-            <tr>
-              <td colSpan={4} className="pt-4 pb-1 px-2">
-                <div className="text-xs font-semibold text-pink-500 opacity-60">
-                  Persona
-                </div>
-              </td>
-            </tr>
-            {personaModels.map((model) => (
-              <ModelRow key={model.name} model={model} />
-            ))}
-          </>
-        )}
-      </tbody>
-    </table>
-  );
+                {/* Text Section */}
+                <SectionHeader label="Text" type="text" />
+                {regularTextModels.map((model) => (
+                    <ModelRow key={model.name} model={model} />
+                ))}
+                {personaModels.length > 0 && (
+                    <>
+                        <tr>
+                            <td colSpan={4} className="pt-4 pb-1 px-2">
+                                <div className="text-xs font-semibold text-pink-500 opacity-60">
+                                    Persona
+                                </div>
+                            </td>
+                        </tr>
+                        {personaModels.map((model) => (
+                            <ModelRow key={model.name} model={model} />
+                        ))}
+                    </>
+                )}
+            </tbody>
+        </table>
+    );
 };
 
 export const ModelTable: FC<ModelTableProps> = ({ models, type }) => {
-  const sortedModels = sortModels(models);
+    const sortedModels = sortModels(models);
 
-  const regularModels =
-    type === "text"
-      ? sortedModels.filter((m) => !isPersona(m.name))
-      : sortedModels;
-  const personaModels =
-    type === "text" ? sortedModels.filter((m) => isPersona(m.name)) : [];
+    const regularModels =
+        type === "text"
+            ? sortedModels.filter((m) => !isPersona(m.name))
+            : sortedModels;
+    const personaModels =
+        type === "text" ? sortedModels.filter((m) => isPersona(m.name)) : [];
 
-  const tableLabel =
-    type === "text" ? "Text" : type === "image" ? "Image" : "Video";
+    const tableLabel =
+        type === "text" ? "Text" : type === "image" ? "Image" : "Video";
 
-  return (
-    <table className="w-full min-w-[700px]">
-      <thead>
-        <tr>
-          <th className="text-left pt-0 pb-1 px-2 text-sm font-bold text-pink-500 align-top">
-            <div className="flex items-center gap-2">
-              {tableLabel}
-              {type === "video" && (
-                <>
-                  <span className="text-[10px] text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded-full font-medium">
-                    alpha 🧪
-                  </span>
-                  <span className="relative inline-flex items-center group/alpha">
-                    <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-pink-100 border border-pink-300 text-pink-500 hover:bg-pink-200 hover:border-pink-400 transition-colors text-[10px] font-bold cursor-pointer">
-                      i
-                    </span>
-                    <span className="invisible group-hover/alpha:visible absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none">
-                      API endpoints and parameters may change
-                    </span>
-                  </span>
-                </>
-              )}
-            </div>
-          </th>
-          <th className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
-            <div>1 pollen ≈</div>
-            <div className="text-xs font-normal text-pink-400 opacity-70 italic">
-              {type === "text"
-                ? "responses"
-                : type === "image"
-                  ? "images"
-                  : "seconds"}
-            </div>
-          </th>
-          <th className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[190px] align-top">
-            <div>Input</div>
-            <div className="text-xs font-normal text-pink-400 opacity-70 italic">
-              pollen
-            </div>
-          </th>
-          <th className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
-            <div>Output</div>
-            <div className="text-xs font-normal text-pink-400 opacity-70 italic">
-              pollen
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {regularModels.map((model) => (
-          <ModelRow key={model.name} model={model} />
-        ))}
-        {personaModels.length > 0 && (
-          <>
-            <tr>
-              <td colSpan={4} className="pt-4 pb-1 px-2">
-                <div className="text-xs font-semibold text-pink-500 opacity-60">
-                  Persona
-                </div>
-              </td>
-            </tr>
-            {personaModels.map((model) => (
-              <ModelRow key={model.name} model={model} />
-            ))}
-          </>
-        )}
-      </tbody>
-    </table>
-  );
+    return (
+        <table className="w-full min-w-[700px]">
+            <thead>
+                <tr>
+                    <th className="text-left pt-0 pb-1 px-2 text-sm font-bold text-pink-500 align-top">
+                        <div className="flex items-center gap-2">
+                            {tableLabel}
+                            {type === "video" && (
+                                <>
+                                    <span className="text-[10px] text-purple-600 bg-purple-100 px-1.5 py-0.5 rounded-full font-medium">
+                                        alpha 🧪
+                                    </span>
+                                    <span className="relative inline-flex items-center group/alpha">
+                                        <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-pink-100 border border-pink-300 text-pink-500 hover:bg-pink-200 hover:border-pink-400 transition-colors text-[10px] font-bold cursor-pointer">
+                                            i
+                                        </span>
+                                        <span className="invisible group-hover/alpha:visible absolute left-0 top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 whitespace-nowrap z-50 pointer-events-none">
+                                            API endpoints and parameters may
+                                            change
+                                        </span>
+                                    </span>
+                                </>
+                            )}
+                        </div>
+                    </th>
+                    <th className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
+                        <div>1 pollen ≈</div>
+                        <div className="text-xs font-normal text-pink-400 opacity-70 italic">
+                            {type === "text"
+                                ? "responses"
+                                : type === "image"
+                                  ? "images"
+                                  : "videos"}
+                        </div>
+                    </th>
+                    <th className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[190px] align-top">
+                        <div>Input</div>
+                        <div className="text-xs font-normal text-pink-400 opacity-70 italic">
+                            pollen
+                        </div>
+                    </th>
+                    <th className="text-center text-sm font-bold text-pink-500 pt-0 pb-1 px-2 whitespace-nowrap w-[120px] align-top">
+                        <div>Output</div>
+                        <div className="text-xs font-normal text-pink-400 opacity-70 italic">
+                            pollen
+                        </div>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {regularModels.map((model) => (
+                    <ModelRow key={model.name} model={model} />
+                ))}
+                {personaModels.length > 0 && (
+                    <>
+                        <tr>
+                            <td colSpan={4} className="pt-4 pb-1 px-2">
+                                <div className="text-xs font-semibold text-pink-500 opacity-60">
+                                    Persona
+                                </div>
+                            </td>
+                        </tr>
+                        {personaModels.map((model) => (
+                            <ModelRow key={model.name} model={model} />
+                        ))}
+                    </>
+                )}
+            </tbody>
+        </table>
+    );
 };

--- a/operations/IONET_INSTANCES.md
+++ b/operations/IONET_INSTANCES.md
@@ -1,0 +1,83 @@
+# io.net GPU Instances
+
+Last updated: 2026-01-06
+
+## Active Instances
+
+| Instance | Public IP | SSH Port | Model | GPU 0 Port | GPU 1 Port | GPUs | Status |
+|----------|-----------|----------|-------|------------|------------|------|--------|
+| Z-Image 1 | 34.224.94.92 | 22891 | zimage | 10000→28893 | 10001→28894 | 2x RTX 4090 | ✅ Running |
+| Z-Image 2 | 3.95.36.149 | 23528 | zimage | 10000→28893 | 10001→28894 | 2x RTX 4090 | ✅ Running |
+| Z-Image 3 | 54.91.244.89 | 26345 | zimage | 10000→28893 | 10001→28894 | 2x RTX 4090 | ✅ Running |
+| Z-Image 4 | 34.224.94.92 | 31194 | zimage | 10000→28893 | 10001→28894 | 2x RTX 4090 | ✅ Running |
+| Flux | 52.205.25.210 | 25656 | flux | 10000→22182 | 10001→31535 | 2x RTX 4090 | ✅ Running |
+
+## Port Mapping Explanation
+
+- **SSH Port**: External port for SSH access (internal port 22)
+- **GPU 0/1 Port**: Format is `internal→external` (e.g., `10000→22182` means container port 10000 maps to public port 22182)
+
+## SSH Access
+
+```bash
+# Z-Image instances
+ssh -p 22891 -i ~/.ssh/thomashkey ionet@34.224.94.92
+ssh -p 23528 -i ~/.ssh/thomashkey ionet@3.95.36.149
+ssh -p 26345 -i ~/.ssh/thomashkey ionet@54.91.244.89
+ssh -p 31194 -i ~/.ssh/thomashkey ionet@34.224.94.92
+
+# Flux instance
+ssh -p 25656 -i ~/.ssh/thomashkey ionet@52.205.25.210
+```
+
+## Docker Images
+
+| Model | Docker Image | Internal Port |
+|-------|--------------|---------------|
+| zimage | voodoohop/z-image-server:latest | 8765 |
+| flux | voodoohop/flux-svdquant:latest | 8765 |
+
+## Heartbeat Registration
+
+All instances send heartbeats to `https://image.pollinations.ai/register` with:
+- `url`: Public URL (e.g., `http://52.205.25.210:22182`)
+- `type`: Service type (`flux` or `zimage`)
+
+## Systemd Services (Z-Image)
+
+Z-Image instances use systemd services:
+- `zimage-gpu0.service` - GPU 0 container
+- `zimage-gpu1.service` - GPU 1 container
+
+## Flux Container Commands
+
+```bash
+# Start Flux containers
+docker run -d --gpus '"device=0"' --name flux1 \
+  -p 10000:8765 \
+  -e PORT=8765 \
+  -e PUBLIC_IP=52.205.25.210 \
+  -e PUBLIC_PORT=22182 \
+  -e SERVICE_TYPE=flux \
+  -e HF_TOKEN=<token> \
+  -v /home/ionet/server.py:/app/server.py \
+  voodoohop/flux-svdquant:latest
+
+docker run -d --gpus '"device=1"' --name flux2 \
+  -p 10001:8765 \
+  -e PORT=8765 \
+  -e PUBLIC_IP=52.205.25.210 \
+  -e PUBLIC_PORT=31535 \
+  -e SERVICE_TYPE=flux \
+  -e HF_TOKEN=<token> \
+  -v /home/ionet/server.py:/app/server.py \
+  voodoohop/flux-svdquant:latest
+```
+
+## Capacity Summary
+
+| Model | Instances | Total GPUs | GPU Type |
+|-------|-----------|------------|----------|
+| zimage | 4 | 8 | RTX 4090 |
+| flux | 1 | 2 | RTX 4090 |
+| **Total** | **5** | **10** | RTX 4090 |


### PR DESCRIPTION
The video pricing column in the Enter dashboard was incorrectly labeled "seconds" when it actually shows the estimated number of videos per pollen.

**Changes:**
- Update column header from "seconds" to "videos" for video models
- Affects both `SectionHeader` and `ModelTable` components

**Context:**
- Token-based video models (seedance, seedance-pro) calculate `videosPerPollen`
- Only Veo uses second-based pricing (`secondsPerPollen`)
- Since 2/3 video models show videos, the column label should reflect that