### PR TITLE
fix: strip 'stop' parameter for GPT-5 series models

### DIFF
--- a/text.pollinations.ai/transforms/parameterProcessor.js
+++ b/text.pollinations.ai/transforms/parameterProcessor.js
@@ -63,6 +63,15 @@ export function processParameters(messages, options) {
     if (isReasoningOrGpt5Model) {
         log(`Forcing temperature=1 for reasoning/GPT-5 model: ${model}`);
         updatedOptions.temperature = 1;
+
+        // GPT-5 series and reasoning models don't support the 'stop' parameter
+        // Azure returns 400: "Unsupported parameter: 'stop' is not supported with this model."
+        if (updatedOptions.stop !== undefined) {
+            log(
+                `Removing unsupported 'stop' parameter for reasoning/GPT-5 model: ${model}`,
+            );
+            delete updatedOptions.stop;
+        }
     }
 
     return { messages, options: updatedOptions };


### PR DESCRIPTION
Fixes #6887

**Changes:**
- Strip `stop` parameter for GPT-5 series and reasoning models (o1, o3, o4)
- Azure OpenAI returns 400 error: "Unsupported parameter: 'stop' is not supported with this model."

**Root cause:**
GPT-5 series models on Azure OpenAI don't support the `stop` parameter, causing API errors when clients (like BlitzScript engine) send stop sequences.

**Solution:**
Silently remove the `stop` parameter in `parameterProcessor.js` for affected models, matching existing pattern for `temperature=1` enforcement.