### PR TITLE
fix: gptimage model ignores seed parameter (#6892)

### DIFF
--- a/enter.pollinations.ai/src/utils/image-cache.ts
+++ b/enter.pollinations.ai/src/utils/image-cache.ts
@@ -9,40 +9,13 @@ import { removeUnset } from "@/util.ts";
 import { Logger } from "@logtape/logtape";
 
 /**
- * Apply model-specific caching rules to the URL
- * @param {URL} url - The URL object to transform
- * @returns {URL} - The transformed URL object
- */
-function applyModelSpecificRules(url: URL): URL {
-    // Get the model parameter
-    const model = url.searchParams.get("model");
-
-    // Define model-specific rules that return new URL parameters
-    const modelRules: Record<string, (currentUrl: URL) => URL> = {
-        gptimage: (currentUrl: URL) => {
-            // For gptimage, always use the same seed for consistent caching
-            const newUrl = new URL(currentUrl);
-            newUrl.searchParams.set("seed", "42");
-            return newUrl;
-        },
-        // Add more model rules here as needed
-    };
-
-    // Apply the rule if it exists for this model, otherwise return original
-    return model && modelRules[model] ? modelRules[model](url) : url;
-}
-
-/**
  * Generate a consistent cache key from URL
  * @param {URL} url - The URL object
  * @returns {string} - The cache key
  */
 export function generateCacheKey(url: URL): string {
-    // Apply model-specific rules first
-    const transformedUrl = applyModelSpecificRules(url);
-
     // Normalize the URL by sorting query parameters
-    const normalizedUrl = new URL(transformedUrl);
+    const normalizedUrl = new URL(url);
     const params = Array.from(normalizedUrl.searchParams.entries()).sort(
         ([keyA], [keyB]) => keyA.localeCompare(keyB),
     );


### PR DESCRIPTION
Fixes #6892

**Root Cause:**
The `gptimage` model had a cache rule that forced all requests to use `seed=42` for cache key generation. This caused all gptimage requests with the same prompt to return the same cached image, regardless of the seed parameter provided.

**Changes:**
- Remove gptimage-specific cache rule in `enter.pollinations.ai/src/utils/image-cache.ts`

**Notes:**
- The Azure GPT Image API doesn't support the seed parameter for deterministic generation
- However, users expect different requests to produce different images
- Each unique request now generates a fresh image instead of returning cached results