### PR TITLE
fix: set strict-open-ai-compliance to true for Claude Vertex AI

### DIFF
--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -114,7 +114,7 @@ export const portkeyConfig: PortkeyConfigMap = {
         "vertex-project-id": process.env.GOOGLE_PROJECT_ID,
         "vertex-region": "europe-west1",
         "vertex-model-id": "anthropic.claude-opus-4-5@20251101",
-        "strict-openai-compliance": "false",
+        "strict-open-ai-compliance": "true",
     }),
     "claude-sonnet-4-5-vertex": () => ({
         provider: "vertex-ai",
@@ -122,7 +122,7 @@ export const portkeyConfig: PortkeyConfigMap = {
         "vertex-project-id": process.env.GOOGLE_PROJECT_ID,
         "vertex-region": "europe-west1",
         "vertex-model-id": "anthropic.claude-sonnet-4-5@20250929",
-        "strict-openai-compliance": "false",
+        "strict-open-ai-compliance": "true",
     }),
     "amazon.nova-micro-v1:0": () =>
         createBedrockLambdaModelConfig({


### PR DESCRIPTION
Fixes enter.pollinations.ai validation error for Claude models on Vertex AI.

**Problem:**
- Vertex AI Claude returns `content` as array (Anthropic format) when `strict-open-ai-compliance: false`
- enter.pollinations.ai expects `content` as string (OpenAI format)
- This caused 500 errors with ZodError validation failures

**Fix:**
- Set `strict-open-ai-compliance: "true"` for Claude Vertex AI models
- Uses correct header key format (`strict-open-ai` not `strict-openai`)

**Models affected:**
- `claude-opus-4-5-vertex`
- `claude-sonnet-4-5-vertex`