### PR TITLE
fix(docs): Add min/max constraints to prevent garbage values in OpenAPI examples

### DIFF
--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -115,11 +115,13 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         .meta({ description: "Generate with transparent background" }),
     guidance_scale: z.coerce
         .number()
+        .nonnegative()
+        .max(20)
         .optional()
-        .meta({ description: "How closely to follow the prompt (1-20)" }),
+        .meta({ description: "How closely to follow the prompt (0-20)" }),
 
     // Video-specific params (for veo/seedance models)
-    duration: z.coerce.number().int().optional().meta({
+    duration: z.coerce.number().int().min(1).max(10).optional().meta({
         description:
             "Video duration in seconds. veo: 4, 6, or 8. seedance: 2-10",
     }),


### PR DESCRIPTION
## Summary

- Add min/max constraints to numeric schema fields to fix garbage values in generated curl examples

## Changes

| Field | Before | After |
|-------|--------|-------|
| `duration` | Any integer | 1-10 |
| `guidance_scale` | Any number | 0-20 |

## Problem

The Scalar docs UI generates curl examples using OpenAPI schema min/max values. Without constraints, it defaulted to `Number.MIN_SAFE_INTEGER` (-9007199254740991):

```
curl '...?duration=-9007199254740991&...'
```

## Fix

Added proper constraints matching documented ranges:
- `duration`: `.min(1).max(10)` - matches veo (4/6/8) and seedance (2-10)
- `guidance_scale`: `.nonnegative().max(20)` - matches documented range

Fixes #6685