### PR TITLE
fix: clean up API docs schema - remove unused params, add model-specific docs

### DIFF
--- a/enter.pollinations.ai/package-lock.json
+++ b/enter.pollinations.ai/package-lock.json
@@ -13,7 +13,7 @@
                 "@hono/standard-validator": "^0.1.5",
                 "@logtape/logtape": "^1.3.1",
                 "@polar-sh/sdk": "^0.41.5",
-                "@scalar/hono-api-reference": "^0.9.25",
+                "@scalar/hono-api-reference": "^0.9.32",
                 "@tanstack/react-router": "^1.139.3",
                 "better-auth": "^1.3.17",
                 "clsx": "^2.1.1",
@@ -4260,12 +4260,12 @@
             }
         },
         "node_modules/@scalar/core": {
-            "version": "0.3.23",
-            "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.3.23.tgz",
-            "integrity": "sha512-hop7LVR3MKB2VpS8dly3gmmbB3lBGxQRtL0pBaC77zFMRHoBv1DuB2bj8l4gxd5grzitJ1LsYduvywLAMY9F6g==",
+            "version": "0.3.30",
+            "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.3.30.tgz",
+            "integrity": "sha512-eBp1phI8u/GZR+yy9SwRTr07n3+Va+xoZJVT6tczG799eynpXiQJuUQ4S2S1cb0cmOV0ZkwHRNG3ldMQHdJgWQ==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/types": "0.5.0"
+                "@scalar/types": "0.5.6"
             },
             "engines": {
                 "node": ">=20"
@@ -4282,12 +4282,12 @@
             }
         },
         "node_modules/@scalar/hono-api-reference": {
-            "version": "0.9.25",
-            "resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.9.25.tgz",
-            "integrity": "sha512-ZEQAhvVU/FXdJs8+rVXdfWjwzkE+M6Zr+4W+zNhy8DF17BIpxFXfVL7i3OxK1V/4EtkTplkETjYGTR4ju3RFZw==",
+            "version": "0.9.32",
+            "resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.9.32.tgz",
+            "integrity": "sha512-5WC3W/3VKRXBxHP/bTwM9tRx5ZEBRSnEe4CFcLK8u7DQPvP6J6iSZCsqfZPeNvPSnrgITBQuEuBXIYsinigKYg==",
             "license": "MIT",
             "dependencies": {
-                "@scalar/core": "0.3.23"
+                "@scalar/core": "0.3.30"
             },
             "engines": {
                 "node": ">=20"
@@ -4616,15 +4616,25 @@
             "license": "MIT"
         },
         "node_modules/@scalar/types": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.5.0.tgz",
-            "integrity": "sha512-imDMuTieOc5kHM9/Kt/1lmiI5ZtusuaYlzsXTP99IsWvD8mJ7ivF73lPBRj4PKtg4vY+ta5CO/vJpvnCYandRg==",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.5.6.tgz",
+            "integrity": "sha512-yvTXYdSQPq8qmJ1zZPBRRB3RkkE2c0J3gIIMirX997yyVixrhtb0jmfM+9EZ2ZWXGx2JGLquGP10zY0nmnu75w==",
             "license": "MIT",
             "dependencies": {
+                "@scalar/helpers": "0.2.6",
                 "nanoid": "5.1.5",
                 "type-fest": "5.0.0",
-                "zod": "4.1.11"
+                "zod": "^4.1.11"
             },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@scalar/types/node_modules/@scalar/helpers": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.6.tgz",
+            "integrity": "sha512-A471YFBCj7ZOlGIkAYnU8oYgeyts82ZNX+4UicrlmKv3eAQ+kwboN3Dy0R6u1lcA/+I/zzeXi/fBObsT7P9qTA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=20"
             }
@@ -4645,15 +4655,6 @@
             },
             "engines": {
                 "node": "^18 || >=20"
-            }
-        },
-        "node_modules/@scalar/types/node_modules/zod": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-            "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/@scalar/use-hooks": {

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -36,7 +36,7 @@
         "@hono/standard-validator": "^0.1.5",
         "@logtape/logtape": "^1.3.1",
         "@polar-sh/sdk": "^0.41.5",
-        "@scalar/hono-api-reference": "^0.9.25",
+        "@scalar/hono-api-reference": "^0.9.32",
         "@tanstack/react-router": "^1.139.3",
         "better-auth": "^1.3.17",
         "clsx": "^2.1.1",

--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -56,21 +56,6 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         .optional()
         .default("worst quality, blurry")
         .meta({ description: "What to avoid in the generated image" }),
-    private: z.coerce
-        .boolean()
-        .optional()
-        .default(false)
-        .meta({ description: "Hide image from public feeds" }),
-    nologo: z.coerce
-        .boolean()
-        .optional()
-        .default(false)
-        .meta({ description: "Remove Pollinations watermark" }),
-    nofeed: z.coerce
-        .boolean()
-        .optional()
-        .default(false)
-        .meta({ description: "Don't add to public feed" }),
     safe: z.coerce
         .boolean()
         .optional()
@@ -80,19 +65,19 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         .literal(QUALITIES)
         .optional()
         .default("medium")
-        .meta({ description: "Image quality level" }),
+        .meta({ description: "Image quality level (gptimage only)" }),
     image: z
         .string()
         .transform((value: string) => {
-            if (!value) return [];
+            if (!value) return undefined;
             // Support both pipe (|) and comma (,) separators
             // Prefer pipe separator if present, otherwise use comma
             return value.includes("|") ? value.split("|") : value.split(",");
         })
         .optional()
-        .default([])
         .refine(
             (urls) =>
+                !urls ||
                 urls.every(
                     (url) =>
                         !url ||
@@ -108,25 +93,18 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
             description:
                 "Reference image URL(s). Comma/pipe separated for multiple. For veo: image[0]=first frame, image[1]=last frame (interpolation)",
         }),
-    transparent: z.coerce
-        .boolean()
-        .optional()
-        .default(false)
-        .meta({ description: "Generate with transparent background" }),
-    guidance_scale: z.coerce
-        .number()
-        .optional()
-        .meta({ description: "How closely to follow the prompt (1-20)" }),
-
-    // Video-specific params (for veo/seedance models)
-    duration: z.coerce.number().int().optional().meta({
-        description:
-            "Video duration in seconds. veo: 4, 6, or 8. seedance: 2-10",
+    transparent: z.coerce.boolean().optional().default(false).meta({
+        description: "Generate with transparent background (gptimage only)",
     }),
-    aspectRatio: z
-        .string()
-        .optional()
-        .meta({ description: "Video aspect ratio: 16:9 or 9:16" }),
+
+    // Video-specific params
+    duration: z.coerce.number().int().min(1).max(10).optional().meta({
+        description:
+            "Video duration in seconds (video models only). veo: 4, 6, or 8. seedance: 2-10",
+    }),
+    aspectRatio: z.string().optional().meta({
+        description: "Video aspect ratio: 16:9 or 9:16 (veo, seedance)",
+    }),
     audio: z.coerce
         .boolean()
         .optional()

--- a/enter.pollinations.ai/src/schemas/text.ts
+++ b/enter.pollinations.ai/src/schemas/text.ts
@@ -28,11 +28,6 @@ export const GenerateTextRequestQueryParamsSchema = z.object({
         .optional()
         .default(false)
         .meta({ description: "Stream response in real-time chunks" }),
-    private: z.coerce
-        .boolean()
-        .optional()
-        .default(false)
-        .meta({ description: "Hide from public feeds" }),
 });
 
 export type GenerateTextRequestQueryParams = z.infer<


### PR DESCRIPTION
- Remove unused params: `nologo`, `nofeed`, `private`, `guidance_scale`
- Fix `duration` param: add `min(1)`/`max(10)` constraints (fixes garbage values in docs)
- Document model-specific params:
  - `quality`: gptimage only
  - `transparent`: gptimage only
  - `duration`/`aspectRatio`/`audio`: video models only (veo, seedance)
- Remove `private` param from text schema
- Upgrade `@scalar/hono-api-reference` to 0.9.32

Fixes #6685