### PR TITLE
feat: migrate DeepSeek V3.2 from Azure/Myceli to Google Vertex AI

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -187,12 +187,12 @@ export const TEXT_SERVICES = {
     },
     "deepseek": {
         aliases: ["deepseek-v3", "deepseek-reasoning"],
-        modelId: "deepseek-v3.2",
-        provider: "azure",
+        modelId: "deepseek-ai/deepseek-v3.2-maas",
+        provider: "google",
         cost: [
             {
                 date: COST_START_DATE,
-                promptTextTokens: perMillion(0.58),
+                promptTextTokens: perMillion(0.56),
                 completionTextTokens: perMillion(1.68),
             },
         ],

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -61,7 +61,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "deepseek",
-        config: portkeyConfig["myceli-deepseek-v3.2"],
+        config: portkeyConfig["deepseek-v3.2-maas"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -5,7 +5,6 @@ import {
     createScalewayModelConfig,
     createBedrockLambdaModelConfig,
     createBedrockNativeConfig,
-    createMyceliDeepSeekV32Config,
     createMyceliGrok4FastConfig,
     createPerplexityModelConfig,
     createOVHcloudModelConfig,
@@ -47,7 +46,13 @@ export const portkeyConfig: PortkeyConfigMap = {
         ),
         "max-completion-tokens": 2048,
     }),
-    "myceli-deepseek-v3.2": () => createMyceliDeepSeekV32Config(),
+    "deepseek-v3.2-maas": () => ({
+        provider: "openai",
+        authKey: googleCloudAuth.getAccessToken,
+        "custom-host": `https://aiplatform.googleapis.com/v1/projects/${process.env.GOOGLE_PROJECT_ID}/locations/global/endpoints/openapi`,
+        "strict-openai-compliance": "false",
+        model: "deepseek-ai/deepseek-v3.2-maas",
+    }),
     "myceli-grok-4-fast": () => createMyceliGrok4FastConfig(),
 
     // ============================================================================


### PR DESCRIPTION
- Migrate DeepSeek V3.2 from Myceli (Azure) to Google Vertex AI MaaS
- Update provider from `azure` to `google` in registry
- Update pricing: input $0.58 → $0.56/M tokens (output unchanged at $1.68/M)
- Uses existing `GOOGLE_PROJECT_ID` env var and `googleCloudAuth` (same as Gemini/Kimi K2)

**Tested locally** - model responds correctly via Vertex AI endpoint.