### PR TITLE
feat: improve model selection UI with dual names and better tooltip

### DIFF
--- a/enter.pollinations.ai/src/client/components/model-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/model-permissions.tsx
@@ -2,12 +2,13 @@ import { type FC, useState } from "react";
 import { cn } from "@/util.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import { getModelDisplayName } from "./model-utils.ts";
 
 // Build model lists from the shared registry (same source as pricing table)
-const textModels = Object.entries(TEXT_SERVICES)
-    .map(([id, config]) => ({
+const textModels = Object.keys(TEXT_SERVICES)
+    .map((id) => ({
         id,
-        label: config.description?.split(" - ")[0] || id,
+        label: getModelDisplayName(id),
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
 
@@ -16,9 +17,9 @@ const imageModels = Object.entries(IMAGE_SERVICES)
     .filter(([_, config]) =>
         (config.outputModalities as readonly string[]).includes("image"),
     )
-    .map(([id, config]) => ({
+    .map(([id]) => ({
         id,
-        label: config.description?.split(" - ")[0] || id,
+        label: getModelDisplayName(id),
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
 
@@ -27,9 +28,9 @@ const videoModels = Object.entries(IMAGE_SERVICES)
     .filter(([_, config]) =>
         (config.outputModalities as readonly string[]).includes("video"),
     )
-    .map(([id, config]) => ({
+    .map(([id]) => ({
         id,
-        label: config.description?.split(" - ")[0] || id,
+        label: getModelDisplayName(id),
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
 

--- a/enter.pollinations.ai/src/client/components/model-utils.ts
+++ b/enter.pollinations.ai/src/client/components/model-utils.ts
@@ -1,0 +1,14 @@
+import { TEXT_SERVICES } from "@shared/registry/text.ts";
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+
+export const getModelDisplayName = (modelId: string): string => {
+    const textService = TEXT_SERVICES[modelId as keyof typeof TEXT_SERVICES];
+    if (textService) {
+        return textService.description?.split(" - ")[0] || modelId;
+    }
+    const imageService = IMAGE_SERVICES[modelId as keyof typeof IMAGE_SERVICES];
+    if (imageService) {
+        return imageService.description?.split(" - ")[0] || modelId;
+    }
+    return modelId;
+};


### PR DESCRIPTION
## Summary

Improves the model selection UI in API key creation to display both API names and official names, making it easier for users to identify models.

## Changes

- Display both official name and API name in model selection chips
- Sort models alphabetically by official name
- Use single column layout for model chips
- Add spacing between Key Type section and Name field
- Fix Models column tooltip in API key table to show full list with fixed positioning
- Center tooltip on mobile, right-align on desktop