### PR TITLE
fix: add DEBUG=pollinations:error to systemd service templates

### DIFF
--- a/enter.pollinations.ai/scripts/setup-services.sh
+++ b/enter.pollinations.ai/scripts/setup-services.sh
@@ -58,6 +58,7 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=text-pollinations
 Environment="NODE_ENV=production"
+Environment="DEBUG=pollinations:error"
 
 [Install]
 WantedBy=multi-user.target
@@ -80,6 +81,7 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=image-pollinations
 Environment="NODE_ENV=production"
+Environment="DEBUG=pollinations:error"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Add `DEBUG=pollinations:error` to both text and image service systemd templates
- Prevents verbose debug logging that filled 110GB of syslog
- Error-only logging persists across redeploys

Fixes disk space issue on enter-services server.