### PR TITLE
[PATCH]: Fix the `discord-post-weekly-news` trigger 

### DIFF
--- a/.github/workflows/discord-post-weekly-news.yml
+++ b/.github/workflows/discord-post-weekly-news.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'social/news/*.md'
+      - 'social/news/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md'
   workflow_dispatch:  # Manual trigger for testing
 
 jobs:


### PR DESCRIPTION
## Change made:- 

- only YYYY-MM-DD.md formatted files will trigger the weekly news workflow now 
- or else editing any other .md like LINKS.md would falsely trigger the workflow 