### PR TITLE
feat: add Cohere Rerank 3.5 model support via AWS Bedrock

### DIFF
--- a/enter.pollinations.ai/.dev.vars.example
+++ b/enter.pollinations.ai/.dev.vars.example
@@ -13,6 +13,9 @@ POLAR_WEBHOOK_SECRET=your_polar_webhook_secret
 TINYBIRD_ACCESS_TOKEN=your_tinybird_access_token
 TINYBIRD_INGEST_TOKEN=your_tinybird_ingest_token
 
+# External API Keys
+COHERE_API_KEY=your_cohere_api_key
+
 # Testing
 TESTING_REFERRER=optional_testing_referrer
 PLN_ENTER_TOKEN=optional_pln_enter_token

--- a/enter.pollinations.ai/.dev.vars.example
+++ b/enter.pollinations.ai/.dev.vars.example
@@ -20,4 +20,7 @@ PLN_ENTER_TOKEN=optional_pln_enter_token
 # Cohere (for rerank API)
 COHERE_API_KEY=your_cohere_api_key
 
+# Portkey Gateway (for routing to providers)
+PORTKEY_GATEWAY_URL=https://rubeus.thomash-efd.workers.dev
+
 # Tip: Run `sops decrypt secrets/dev.vars.json > .dev.vars` to get all secrets

--- a/enter.pollinations.ai/.dev.vars.example
+++ b/enter.pollinations.ai/.dev.vars.example
@@ -13,11 +13,11 @@ POLAR_WEBHOOK_SECRET=your_polar_webhook_secret
 TINYBIRD_ACCESS_TOKEN=your_tinybird_access_token
 TINYBIRD_INGEST_TOKEN=your_tinybird_ingest_token
 
-# External API Keys
-COHERE_API_KEY=your_cohere_api_key
-
 # Testing
 TESTING_REFERRER=optional_testing_referrer
 PLN_ENTER_TOKEN=optional_pln_enter_token
+
+# Cohere (for rerank API)
+COHERE_API_KEY=your_cohere_api_key
 
 # Tip: Run `sops decrypt secrets/dev.vars.json > .dev.vars` to get all secrets

--- a/enter.pollinations.ai/secrets/dev.vars.json
+++ b/enter.pollinations.ai/secrets/dev.vars.json
@@ -8,6 +8,7 @@
 	"PLN_ENTER_TOKEN": "ENC[AES256_GCM,data:XxMud5k/Q1cw/aJDIN/3cxKxpealdSuracoiKNB+rXZDMmYLNx0208wbQ2tZpu1W,iv:nPoD9070aNChkGWGBFy6xbgNMzIwIVqeoGdYyL+Xp18=,tag:T/BtMqWbSfbf11v+7/L8DA==,type:str]",
 	"POLAR_WEBHOOK_SECRET": "ENC[AES256_GCM,data:6dqGtC6tAzUl3MnfO6Bozxmi5bqg5L6YxlLQjYxoavJ75/KivkWZhZMtCOMVkQe0bInBteM=,iv:De3p+d5AyFLZIdJdMNmNTJ0TO+jPNW7J1j4jloqHVeU=,tag:WaF/No9M1470IAvBEFsz4Q==,type:str]",
 	"TINYBIRD_INGEST_TOKEN": "ENC[AES256_GCM,data:87WJeoFzisFYh/fDxfast2dGJWnoGbWolqxO3Jsj1nWBtBZsf6feNhMeFrMdUIQyls+0Xv/ggWcPtaGBvTE5S1MwOT9pTZK8oLrN2UrnQqD69RUng/d6Wz002gAS0MHGSyHH1Et/htSNyzaqSlLX14sSy5+ozAzGCQRqiRPBpWPMM5XKfVCUbXJMYeO882r8yubaDkKB55mkvn7zfCthfWhvGaVS/pWNn/0kEummvs7ejiPlrv+qqhX+/Iy01CewQks1S7jGFoixB/EunA==,iv:AYllkhJx6vgN1hkRnu14ggpOK/PONJyY5ihCKSwBJLo=,tag:BCtzFUMGz8udUMABweNFhg==,type:str]",
+	"COHERE_API_KEY": "ENC[AES256_GCM,data:UXa0df35K2SF2AOiPBfrdyK3rSVZ1f4deEO3Y00df2EWMLDFNELOAQ==,iv:AhrgweoUt01aGUzqfr3H5EKO5buMEpBWZXPi0rmXDec=,tag:1kUIEvd8UHnHsnbcALvZTQ==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -15,8 +16,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzM1BNSVQ4R0l0MElOcUow\ndVZSSE5DWDYvWG4wUDRUUjVGRWFCdDBOdVFzCkNrVXBPVWdqS2h5ZUJ4SFBMeHJq\nMXNNL01PSitKQjc1aThuNHhZY2xmZHcKLS0tIHdCVWdQNW9Wc212Qjgwcm1UYnFD\nQmN0WVpvdzBDTUkzVTdNRzlqNkpuNlEKvh+Z2sR0OlygWexLtWZ+PvaQoBYFDipm\nOf/X7/aYFr0M6v9EVH11z56z3uJralViHHizHPziK/xy4SH4ohVjBA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-01-09T22:35:22Z",
-		"mac": "ENC[AES256_GCM,data:s2XimjEv3HIYjIuazdmoQSHx3WXTDxJhgSXljLe4ulILewHFPI+1INnLAGyPyopv2v6tcNaKqAAXiqIB+1urUUbzWNi/PiIbj84C2C+WFS1GGN86G7g8smI6luIMEl+QzgdaPTV3blx3xnwrwFgW1sUtzGpu/EkwOUn7Nwodo6k=,iv:5IcUu9eK0ExPHYKzk6PPckL4T8rcAFWKRAcb7mCiTdg=,tag:0+KPWqjdInwgFEzTo3UgLQ==,type:str]",
+		"lastmodified": "2026-01-10T23:05:48Z",
+		"mac": "ENC[AES256_GCM,data:3jBfAP/OCEr4eCJ2AYDvmZV9HkFZStM1o7oWYH0+s2xaxEXAgqTrgpsMif4+Yj1Rymym0QCQ0mZxVHklU7pgPd8fo7fd6bhGFUNvmoakgJ1p6AcvPwjjWVLeIC3eF/n/KH88Z8r2MtKodqWTQaPReLRm08UFSwdjANWcQDoIgps=,iv:UMbjHgxxgeyCmjfqrAclrdn/3kb2TxOhm4WZdVuMb9s=,tag:nYpQgXAs7KtxxGEoyS5WrQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/enter.pollinations.ai/secrets/env.json
+++ b/enter.pollinations.ai/secrets/env.json
@@ -3,6 +3,7 @@
 	"POLAR_ACCESS_TOKEN": "ENC[AES256_GCM,data:8Qm/UZrOaDp4dhbJ8DFM9KsKZkl+phvgBEB+Jt9skOxDV2t0mEDy4o9H0+BcfJmtWWJL598=,iv:Pq8IQ0mfmrCvyyy+AwCrxDUsFpoQbZ1TApBDa6A7kgE=,tag:AYV6LlhokNewDZpbIhlOdQ==,type:str]",
 	"CLOUDFLARE_ACCOUNT_ID": "ENC[AES256_GCM,data:iOvfoBvWdeo8MqgPip4JGmNOwvCIh65TP8ZQduS0Xx0=,iv:fRqALTb+HMfzmqY0oChnCIUymwFXK19UYd4VP417wUM=,tag:EGmUXAvGQ2hu0jE5gdP4ug==,type:str]",
 	"CLOUDFLARE_OBSERVABILITY_TOKEN": "ENC[AES256_GCM,data:Ht0gUOiDpNbzVlLVQJnR1FMBV6bpDB6QxoY/fxtgzweppnZqipiOkw==,iv:Yv+GV/oC+PmCKDnC8vFkwM+trhf4iUtkr+5BYrupiY8=,tag:WLI1HjntoHpfDFKn0QSLyg==,type:str]",
+	"COHERE_API_KEY": "ENC[AES256_GCM,data:FrGK2GISNdz7psABR84vdA+vlaYNQn52qtrqWjz3uEcmh7QWeVT4tA==,iv:OqtsTmYILcteiewS0EcZQk9fKI25MDLSnNOFYurKD9A=,tag:ORCKlQuNyfz4v4Y+Pe1Ljw==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -10,8 +11,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNEpnU0owQjUvQjI5R3Jk\ncGhoZ3lsVUdGNEJhSUVGaE5sT2lKTWlxNkc0CjdiRkNibU1tMHdKQ3J5ZGY4bG9j\na1F3VDQxdFlaUE0wbWM5N0RVajdOMnMKLS0tIDRjQXpnamxXdCt2M0ZPYlg0SlpK\nM2lsU0dKOHBXYTZkR1ZNOVlyWUVZTGcKQLgQX2Ey4WihbLe8GUnpmC1wAY8vO/Bl\nWeOhWA+OSsVRRtdQl9CAX5ByDgeUEJ0AchlXEUSXuqS65D1ufyOFmg==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2025-12-22T11:02:34Z",
-		"mac": "ENC[AES256_GCM,data:l8GzgOzJ71YGxcF1Dfw358Cj3hRJUazRdLbNONc1Px5KcQfYIOTEAIxJYsb6wmWP7OdRzbLNarcLEnh7Pl/mQzy1p6LvzjEN8NqRYDEGidLgSI2WyXN7YZnrPyyTyY7haIGGfUJRF0e6m22Mq7lDpD0d197ITK2KNy9E+t3nOdw=,iv:CQ8C/GHm6mjb5ohDNFaRfavGHGC8T3QBkL8Uka1BRQ4=,tag:usxWjR/np7iceQ8hOh0pwQ==,type:str]",
+		"lastmodified": "2026-01-10T22:58:02Z",
+		"mac": "ENC[AES256_GCM,data:T8WZfBSzM9Zlc4WT6AqSx9kcT5gXBNAm3cCwKZARXSpoQxNtE1ZuHA4hga4+CK2YRX9iX6VziJZHpquc7PgK7wCUz5CFuPIeK3daNeDi5iHgX1OwkFD+aXs9idIe3I+B1ZBQFyQAjh9Jli0I700bABfQs5aYVlHPmlEkIJBUu6g=,iv:3ihRf4QZrmE/lHDpN7LpyT4iG4XGle7tFzxcEFHVG3o=,tag:02c3Ug/VNw2QPgbdf34efA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -497,7 +497,7 @@ export const proxyRoutes = new Hono<Env>()
                 docCount: documents.length,
             });
 
-            // Cohere Rerank API - thin proxy, forward request directly
+            // Direct proxy to Cohere API (like Whisper does with OVHcloud)
             const response = await fetch("https://api.cohere.com/v1/rerank", {
                 method: "POST",
                 headers: {
@@ -530,10 +530,7 @@ export const proxyRoutes = new Hono<Env>()
             }
 
             return new Response(response.body, {
-                headers: {
-                    ...Object.fromEntries(response.headers),
-                    "x-model-used": model || "rerank-v3.5",
-                },
+                headers: Object.fromEntries(response.headers),
             });
         },
     );

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -469,7 +469,7 @@ export const proxyRoutes = new Hono<Env>()
             return response;
         },
     )
-    // Cohere Rerank endpoint - semantic document ranking via Cohere API directly
+    // Cohere Rerank endpoint - semantic document ranking via Portkey -> Cohere
     .post(
         "/v1/rerank",
         auth({ allowApiKey: true, allowSessionCookie: false }),
@@ -497,12 +497,16 @@ export const proxyRoutes = new Hono<Env>()
                 docCount: documents.length,
             });
 
-            // Direct proxy to Cohere API (like Whisper does with OVHcloud)
-            const response = await fetch("https://api.cohere.com/v1/rerank", {
+            // Proxy to Cohere via Portkey gateway
+            const portkeyUrl =
+                c.env.PORTKEY_GATEWAY_URL ||
+                "https://rubeus.thomash-efd.workers.dev";
+            const response = await fetch(`${portkeyUrl}/rerank`, {
                 method: "POST",
                 headers: {
-                    Authorization: `Bearer ${c.env.COHERE_API_KEY}`,
                     "Content-Type": "application/json",
+                    Authorization: `Bearer ${c.env.COHERE_API_KEY}`,
+                    "x-portkey-provider": "cohere",
                 },
                 body: JSON.stringify({
                     model: model || "rerank-v3.5",

--- a/enter.pollinations.ai/worker-bindings.d.ts
+++ b/enter.pollinations.ai/worker-bindings.d.ts
@@ -62,6 +62,7 @@ declare namespace Cloudflare {
         POLAR_WEBHOOK_SECRET: string;
         TINYBIRD_INGEST_TOKEN: string;
         TINYBIRD_READ_TOKEN: string;
+        COHERE_API_KEY: string;
         POLLEN_RATE_LIMITER: DurableObjectNamespace /* PollenRateLimiter from pollinations-enter */;
         IMAGE_BUCKET: R2Bucket;
         DB: D1Database;

--- a/enter.pollinations.ai/worker-bindings.d.ts
+++ b/enter.pollinations.ai/worker-bindings.d.ts
@@ -63,6 +63,7 @@ declare namespace Cloudflare {
         TINYBIRD_INGEST_TOKEN: string;
         TINYBIRD_READ_TOKEN: string;
         COHERE_API_KEY: string;
+        PORTKEY_GATEWAY_URL: string;
         POLLEN_RATE_LIMITER: DurableObjectNamespace /* PollenRateLimiter from pollinations-enter */;
         IMAGE_BUCKET: R2Bucket;
         DB: D1Database;

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -464,4 +464,22 @@ export const TEXT_SERVICES = {
         contextWindow: 200000,
         isSpecialized: false,
     },
+    "cohere-rerank": {
+        aliases: ["rerank", "rerank-3.5"],
+        modelId: "cohere.rerank-v3-5:0",
+        provider: "aws",
+        cost: [
+            {
+                date: COST_START_DATE,
+                // Bedrock Cohere Rerank: $1.00 per 1,000 search units
+                // A search unit = 1 query + up to 100 documents
+                promptTextTokens: perMillion(1000), // ~$0.001 per search unit
+            },
+        ],
+        description: "Cohere Rerank 3.5 - Semantic Document Ranking (Bedrock)",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: false,
+        isSpecialized: false,
+    },
 } as const satisfies Record<string, ServiceDefinition<string>>;

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -466,8 +466,8 @@ export const TEXT_SERVICES = {
     },
     "cohere-rerank": {
         aliases: ["rerank", "rerank-3.5"],
-        modelId: "cohere.rerank-v3-5:0",
-        provider: "aws",
+        modelId: "rerank-v3.5",
+        provider: "cohere",
         cost: [
             {
                 date: COST_START_DATE,
@@ -476,7 +476,7 @@ export const TEXT_SERVICES = {
                 promptTextTokens: perMillion(1000), // ~$0.001 per search unit
             },
         ],
-        description: "Cohere Rerank 3.5 - Semantic Document Ranking (Bedrock)",
+        description: "Cohere Rerank 3.5 - Semantic Document Ranking",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: false,

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -471,7 +471,7 @@ export const TEXT_SERVICES = {
         cost: [
             {
                 date: COST_START_DATE,
-                // Bedrock Cohere Rerank: $1.00 per 1,000 search units
+                // Cohere Rerank: $1.00 per 1,000 search units
                 // A search unit = 1 query + up to 100 documents
                 promptTextTokens: perMillion(1000), // ~$0.001 per search unit
             },


### PR DESCRIPTION
- Add `cohere-rerank` model to text registry with Bedrock provider
- Add `/v1/rerank` endpoint to enter gateway proxy
- Follows Cohere rerank API format (query + documents array)

## Usage

```bash
curl 'https://gen.pollinations.ai/v1/rerank' \
  -H 'Authorization: Bearer YOUR_API_KEY' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "cohere-rerank",
    "query": "What is the capital of the United States?",
    "documents": [
      "Carson City is the capital of Nevada.",
      "Washington, D.C. is the capital of the United States.",
      "Capital punishment exists in the United States."
    ],
    "top_n": 3,
    "return_documents": true
  }'
```

## TODO (not in this PR)
- Add text service `/v1/rerank` handler to forward to Bedrock
- Test with actual Bedrock Cohere Rerank model