### PR TITLE
fix: update claude-code-action inputs for app-review workflow

### DIFF
--- a/.github/workflows/app-review-submission.yml
+++ b/.github/workflows/app-review-submission.yml
@@ -133,16 +133,11 @@ jobs:
         with:
           anthropic_api_key: "ccr-pollinations"
           github_token: ${{ steps.token.outputs.token }}
-          direct_prompt: "/app-review #${{ steps.issue.outputs.number }}"
-          allowed_tools: |
-            Bash
-            Read
-            Edit
-            Write
-            Glob
-            Grep
-            WebFetch
-          timeout_minutes: 10
+          prompt: "/app-review #${{ steps.issue.outputs.number }}"
+          allowed_non_write_users: ${{ github.event.issue.user.login }}
+          claude_args: |
+            --allowedTools Bash,Read,Edit,Write,Glob,Grep,WebFetch
+            --max-turns 30
 
   app-handle-outcome:
     if: |


### PR DESCRIPTION
- `direct_prompt` → `prompt` (valid input name)
- `allowed_tools` → `claude_args` with `--allowedTools` flag
- `timeout_minutes` → `--max-turns 30`
- Add `allowed_non_write_users` for external submitters

Fixes the workflow error where external users without write permissions couldn't trigger app reviews.