### PR TITLE
fix: add label_trigger to app-review workflow

### DIFF
--- a/.github/workflows/app-review-submission.yml
+++ b/.github/workflows/app-review-submission.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           anthropic_api_key: "ccr-pollinations"
           github_token: ${{ steps.token.outputs.token }}
+          label_trigger: "TIER-APP"
           prompt: "/app-review #${{ steps.issue.outputs.number }}"
           allowed_non_write_users: ${{ github.event.issue.user.login }}
           claude_args: |


### PR DESCRIPTION
- Add `label_trigger: TIER-APP` so the action recognizes issues with this label as valid triggers
- The action defaults to looking for `@claude` trigger which was causing 'No trigger was met' errors