### PR TITLE
fix: deduplicate DEFAULT_API_KEY and update to new key

### DIFF
--- a/pollinations.ai/src/api.config.ts
+++ b/pollinations.ai/src/api.config.ts
@@ -4,7 +4,7 @@
 // Direct calls to gen.pollinations.ai with publishable key.
 // No proxy needed - publishable keys are safe to expose on frontend.
 
-export const DEFAULT_API_KEY = "pk_WQYvjz9SpSpAcJdR";
+export const DEFAULT_API_KEY = "pk_NGG18T1EUVVmvVBz";
 export const API_BASE = "https://gen.pollinations.ai";
 
 // Re-export for backward compatibility (use getApiKey() from useAuth for dynamic key)

--- a/pollinations.ai/src/hooks/useAuth.ts
+++ b/pollinations.ai/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
+import { DEFAULT_API_KEY } from "../api.config";
 
 const STORAGE_KEY = "pollinations_api_key";
-const DEFAULT_API_KEY = "pk_WQYvjz9SpSpAcJdR";
 const ENTER_URL = "https://enter.pollinations.ai";
 
 interface UseAuthReturn {


### PR DESCRIPTION
- Remove duplicate `DEFAULT_API_KEY` definition from `useAuth.ts`
- Import `DEFAULT_API_KEY` from `api.config.ts` instead
- Update API key to new value