### PR TITLE
feat: update tier explanations with Seed requirement and beta notice

### DIFF
--- a/enter.pollinations.ai/src/client/components/tier-explanation.tsx
+++ b/enter.pollinations.ai/src/client/components/tier-explanation.tsx
@@ -110,8 +110,8 @@ export const TierExplanation: FC = () => {
                                 Publish an app
                             </a>
                         </p>
-                        <p className="text-[10px] text-gray-400">
-                            or contribute to the ecosystem
+                        <p className="text-[10px] text-amber-600 mt-0.5">
+                            🌱 Must be Seed first
                         </p>
                     </div>
                 </div>

--- a/pollinations.ai/src/copy/content/hello.ts
+++ b/pollinations.ai/src/copy/content/hello.ts
@@ -32,19 +32,20 @@ export const HELLO_PAGE = {
         "Ship an app, help in Discord, fix bugs, improve docs — every contribution earns you Pollen. We notice and we share.",
 
     // Earn Pollen: Sponsorship Tiers
-    tiersSubtitle: "Grow",
-    tiersDescription: "Start small, contribute, watch your Pollen grow:",
-    tierSporeTitle: "Spore — Just arrived",
-    tierSporeDescription: "Welcome! Here's some Pollen to play with.",
-    tierSeedTitle: "Seed — Part of the community",
+    tiersSubtitle: "Grow Through Our Tier System",
+    tiersBetaNote:
+        "⚠️ We're in beta — tiers, rewards, and values may change as we fine-tune the ecosystem.",
+    tierSporeTitle: "Spore — 1 pollen/day",
+    tierSporeDescription: "You just signed up. Welcome to the community!",
+    tierSeedTitle: "Seed — 3 pollen/day",
     tierSeedDescription:
-        "You're on GitHub or Discord, you've said hi. More Pollen for you.",
-    tierFlowerTitle: "Flower — You shipped something",
+        "Auto-upgraded daily based on your GitHub activity (account age, commits, repos, stars).",
+    tierFlowerTitle: "Flower — 10 pollen/day",
     tierFlowerDescription:
-        "You built an app with pollinations.ai. Nice! Even more Pollen.",
-    tierNectarTitle: "Nectar — Community pillar",
+        "Submit an app to our showcase. Requires Seed tier first.",
+    tierNectarTitle: "Nectar — 20 pollen/day",
     tierNectarDescription:
-        "Your work helps others. You're part of what makes this place good.",
+        "Reserved for maintainers and major contributors. Coming soon.",
 
     // Earn Pollen: Quests
     questsSubtitle: "Ways to Contribute",
@@ -107,6 +108,8 @@ export const HELLO_PAGE = {
     viewPricingButton: "View Pricing",
     exploreTiersButton: "Learn More About Tiers",
     seeAppsButton: "See Featured Apps",
+    contributeOnGitHubButton: "Contribute on GitHub",
+    submitYourAppButton: "Submit Your App",
 
     // Badges
     newBadge: "New",

--- a/pollinations.ai/src/ui/pages/HelloPage.tsx
+++ b/pollinations.ai/src/ui/pages/HelloPage.tsx
@@ -134,7 +134,7 @@ function HelloPage() {
                                     variant="secondary"
                                     size="sm"
                                 >
-                                    Contribute on GitHub
+                                    {pageCopy.contributeOnGitHubButton}
                                     <ExternalLinkIcon className="w-3 h-3 text-text-body-main" />
                                 </Button>
                                 <Button
@@ -145,7 +145,7 @@ function HelloPage() {
                                     variant="secondary"
                                     size="sm"
                                 >
-                                    Submit Your App
+                                    {pageCopy.submitYourAppButton}
                                     <ExternalLinkIcon className="w-3 h-3 text-text-body-main" />
                                 </Button>
                             </div>
@@ -163,9 +163,6 @@ function HelloPage() {
                             >
                                 {pageCopy.tiersSubtitle}
                             </Heading>
-                            <Body size="sm" spacing="comfortable">
-                                {pageCopy.tiersDescription}
-                            </Body>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                                 <TierCard
                                     tier="spore"
@@ -192,6 +189,10 @@ function HelloPage() {
                                     description={pageCopy.tierNectarDescription}
                                 />
                             </div>
+                            {/* Beta note */}
+                            <p className="text-sm text-text-highlight mt-4">
+                                {pageCopy.tiersBetaNote}
+                            </p>
                             {/* Tiers CTA */}
                             <div className="mt-4">
                                 <Button


### PR DESCRIPTION
- Enter dashboard: add '🌱 Must be Seed first' note on Flower tier
- pollinations.ai: update tier descriptions with pollen amounts
- pollinations.ai: add beta disclaimer below tier cards
- pollinations.ai: move hardcoded strings to copy file for translation
- pollinations.ai: use semantic design tokens instead of hardcoded colors