### PR TITLE
feat: add extracted fields to polar_event Tinybird schema

### DIFF
--- a/enter.pollinations.ai/observability/datasources/polar_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/polar_event.datasource
@@ -7,6 +7,9 @@ SCHEMA >
 `timestamp` DateTime `json:$.timestamp` DEFAULT now(),
 `event_type` LowCardinality(String) `json:$.event_type` DEFAULT '',
 `user_id` String `json:$.user_id` DEFAULT '',
+`customer_id` String `json:$.customer_id` DEFAULT '',
+`product_id` String `json:$.product_id` DEFAULT '',
+`data_id` String `json:$.data_id` DEFAULT '',
 `payload` String `json:$.payload`
 
 ENGINE "MergeTree"

--- a/enter.pollinations.ai/src/routes/webhooks.ts
+++ b/enter.pollinations.ai/src/routes/webhooks.ts
@@ -45,15 +45,26 @@ async function sendPolarEventToTinybird(
     // Extract fields from payload
     const p = payload as {
         type?: string;
-        data?: { customer?: { externalId?: string } };
+        data?: {
+            id?: string;
+            customer?: { id?: string; externalId?: string };
+            productId?: string;
+            product?: { id?: string };
+        };
     };
-    const userId = p?.data?.customer?.externalId ?? "";
     const eventType = p?.type ?? "";
+    const userId = p?.data?.customer?.externalId ?? "";
+    const customerId = p?.data?.customer?.id ?? "";
+    const productId = p?.data?.productId ?? p?.data?.product?.id ?? "";
+    const dataId = p?.data?.id ?? "";
 
     // Build event with extracted fields + full payload (timestamp uses DEFAULT now() in schema)
     const event = {
         event_type: eventType,
         user_id: userId,
+        customer_id: customerId,
+        product_id: productId,
+        data_id: dataId,
         payload: JSON.stringify(payload),
     };
 


### PR DESCRIPTION
- Add `customer_id`, `product_id`, `data_id` columns to polar_event datasource
- Extract fields from webhook payload in `sendPolarEventToTinybird`
- Enables direct queries without JSON parsing for common analytics

**Benefits:**
- Query by customer/product/data ID without `JSONExtract`
- Better indexing potential
- Simpler analytics queries