### PR TITLE
feat: migrate DeepSeek V3.2 to Fireworks AI

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -187,12 +187,13 @@ export const TEXT_SERVICES = {
     },
     "deepseek": {
         aliases: ["deepseek-v3", "deepseek-reasoning"],
-        modelId: "deepseek-ai/deepseek-v3.2-maas",
-        provider: "google",
+        modelId: "accounts/fireworks/models/deepseek-v3p2",
+        provider: "fireworks",
         cost: [
             {
                 date: COST_START_DATE,
                 promptTextTokens: perMillion(0.56),
+                promptCachedTokens: perMillion(0.28),
                 completionTextTokens: perMillion(1.68),
             },
         ],

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -61,7 +61,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "deepseek",
-        config: portkeyConfig["deepseek-v3.2-maas"],
+        config: portkeyConfig["accounts/fireworks/models/deepseek-v3p2"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -253,16 +253,18 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // ============================================================================
-    // Fireworks AI - glm-4.7, minimax-m2.1
+    // Fireworks AI - glm-4.7, minimax-m2.1, deepseek-v3.2
     // ============================================================================
     "accounts/fireworks/models/glm-4p7": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/glm-4p7",
-            "max-tokens": 25344,
         }),
     "accounts/fireworks/models/minimax-m2p1": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/minimax-m2p1",
-            "max-tokens": 25600,
+        }),
+    "accounts/fireworks/models/deepseek-v3p2": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/deepseek-v3p2",
         }),
 };


### PR DESCRIPTION
- Switch deepseek from Google Vertex AI MaaS to Fireworks
- Update modelId to `accounts/fireworks/models/deepseek-v3p2`
- Add cached token pricing ($0.28/1M)
- Remove unnecessary max-tokens overrides from Fireworks models

**Tested locally** - confirmed model response shows Fireworks endpoint.