### PR TITLE
fix: match balance API response structure

### DIFF
--- a/pollinations.ai/src/hooks/useAuth.ts
+++ b/pollinations.ai/src/hooks/useAuth.ts
@@ -12,8 +12,7 @@ interface UserProfile {
 }
 
 interface UserBalance {
-    userBalance: number;
-    keyBalance: number | null;
+    balance: number;
 }
 
 interface UseAuthReturn {
@@ -118,8 +117,7 @@ export function useAuth(): UseAuthReturn {
                 if (response.ok) {
                     const data = await response.json();
                     setBalance({
-                        userBalance: data.userBalance,
-                        keyBalance: data.keyBalance,
+                        balance: data.balance,
                     });
                 } else {
                     setBalance(null);

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -99,10 +99,9 @@ function PlayPage() {
                                         {pageCopy.loggedInCtaText}
                                     </p>
                                 )}
-                                {balance && (
+                                {balance?.balance !== undefined && (
                                     <span className="text-xs text-text-body-secondary px-2 py-0.5 bg-input-background rounded">
-                                        🌸 {balance.userBalance.toFixed(2)}{" "}
-                                        pollen
+                                        🌸 {balance.balance.toFixed(2)} pollen
                                     </span>
                                 )}
                                 <span className="font-mono text-xs bg-input-background text-text-brand px-3 py-1.5 rounded border border-border-main">


### PR DESCRIPTION
Fixes crash on PlayPage when user logs in.

**Changes:**
- Update UserBalance interface from  to 
- Add safe optional chaining for balance display ()
- Match actual API response structure from 

**Issue:**
After recent merge adding user profile to API keys, the balance API response structure changed but frontend still expected old format, causing  error.

---
*Description condensed by Claude for readability*