### PR TITLE
feat: add code-formatting skill

### DIFF
--- a/.claude/skills/code-formatting/SKILL.md
+++ b/.claude/skills/code-formatting/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-formatting
+description: Format code on the current branch using Biome. Use when asked to format, lint, or clean up code before committing or creating a PR.
+---
+
+# Code Formatting
+
+Format JS/TS/JSON files changed on the current branch using Biome.
+
+## Quick Usage
+
+```bash
+.claude/skills/code-formatting/scripts/format-branch.sh
+```
+
+This formats all `.js`, `.ts`, `.jsx`, `.tsx`, `.json`, `.jsonc` files changed compared to `main`.
+
+## Custom Base Branch
+
+```bash
+.claude/skills/code-formatting/scripts/format-branch.sh develop
+```
+
+## What It Does
+
+1. Finds files changed on current branch vs base branch
+2. Filters to JS/TS/JSON files only
+3. Runs `npx biome check --write` on those files
+4. Uses same settings as the `biome-check.yml` CI workflow
+
+## Config
+
+Biome config is at `biome.jsonc` in repo root.
+
+## Notes
+
+- Run from repo root
+- Requires Node.js/npx
+- Only formats changed files (not entire codebase)

--- a/.claude/skills/code-formatting/scripts/format-branch.sh
+++ b/.claude/skills/code-formatting/scripts/format-branch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Format only files changed on the current branch compared to main
+# Uses the same settings as the biome-check.yml workflow
+
+set -e
+
+# Get the base branch (default to main)
+BASE_BRANCH="${1:-main}"
+
+echo "🔍 Finding files changed compared to $BASE_BRANCH..."
+
+# Get changed files (same pattern as workflow)
+FILES=$(git diff --name-only "$BASE_BRANCH"...HEAD | grep -E '\.(js|ts|jsx|tsx|json|jsonc)$' || true)
+
+if [ -z "$FILES" ]; then
+    echo "✅ No JS/TS/JSON files changed on this branch"
+    exit 0
+fi
+
+echo "📝 Changed files:"
+echo "$FILES"
+echo ""
+
+echo "🔧 Running Biome format on changed files..."
+echo "$FILES" | xargs npx biome check --write
+
+echo ""
+echo "✅ Done! Files formatted."


### PR DESCRIPTION
- Adds `code-formatting` skill for branch-based Biome formatting
- Includes `format-branch.sh` script that formats only changed files vs main
- Uses same settings as `biome-check.yml` CI workflow
- Filters to `.js`, `.ts`, `.jsx`, `.tsx`, `.json`, `.jsonc` files only