### PR TITLE
refactor: Rename flux-klein to klein

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1128,8 +1128,8 @@ const generateImage = async (
         }
     }
 
-    if (safeParams.model === "flux-klein") {
-        // Flux Klein - Fast 4B model on Modal (text-to-image + image editing)
+    if (safeParams.model === "klein") {
+        // Klein - Fast 4B model on Modal (text-to-image + image editing)
         try {
             return await callFluxKleinAPI(
                 prompt,

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -125,9 +125,9 @@ export const IMAGE_CONFIG = {
         defaultSideLength: 1024,
     },
 
-    // Flux Klein - Fast 4B parameter model on Modal (text-to-image + image editing)
-    "flux-klein": {
-        type: "modal-flux-klein",
+    // Klein - Fast 4B parameter model on Modal (text-to-image + image editing)
+    klein: {
+        type: "modal-klein",
         enhance: false,
         defaultSideLength: 1024,
     },

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -219,9 +219,9 @@ export const IMAGE_SERVICES = {
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },
-    "flux-klein": {
-        aliases: ["klein"],
-        modelId: "flux-klein",
+    "klein": {
+        aliases: ["flux-klein"],
+        modelId: "klein",
         provider: "modal",
         cost: [
             // Flux Klein on Modal L40S GPU


### PR DESCRIPTION
- Rename primary model name from `flux-klein` to `klein` (shorter, cleaner)
- Keep `flux-klein` as alias for backward compatibility
- Update routing in createAndReturnImages.ts
- Update model config in models.ts

**Usage:**
```bash
# Primary name
curl "https://gen.pollinations.ai/image/cat?model=klein"

# Alias still works
curl "https://gen.pollinations.ai/image/cat?model=flux-klein"
```