### PR TITLE
fix: NomNom model updates - rename key, credit author, mark Alpha

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -467,17 +467,17 @@ export const TEXT_SERVICES = {
     },
     "nomnom": {
         aliases: ["gemini-scrape", "web-research"],
-        modelId: "gemini-scrape",
+        modelId: "nomnom",
         provider: "community",
         cost: [
             {
-                date: new Date("2026-01-16").getTime(),
+                date: new Date("2026-01-17").getTime(),
                 promptTextTokens: perMillion(0.0), // Free - uses Pollinations under the hood
                 completionTextTokens: perMillion(0.0),
             },
         ],
         description:
-            "NomNom - Web Research Model with Search, Scrape & Crawl Tools",
+            "NomNom by @Itachi-1824 - Web Research with Search, Scrape & Crawl (Alpha)",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -164,7 +164,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "nomnom",
-        config: portkeyConfig["gemini-scrape"],
+        config: portkeyConfig["nomnom"],
     },
 ];
 

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -264,8 +264,8 @@ export const portkeyConfig: PortkeyConfigMap = {
     // ============================================================================
     // Community Models - NomNom (web search/scrape/crawl)
     // ============================================================================
-    "gemini-scrape": () =>
+    "nomnom": () =>
         createNomNomConfig({
-            model: "gemini-scrape",
+            model: "nomnom",
         }),
 };


### PR DESCRIPTION
Follow-up to #7360 - missed commits before merge.

- Rename internal model key from `gemini-scrape` to `nomnom`
- Credit @Itachi-1824 in description
- Mark as Alpha
- Update date to 2026-01-17 so model appears as new

Co-authored-by: Itachi-1824 <859708931478388767+Itachi-1824@users.noreply.github.com>