### PR TITLE
fix: remove /api prefix from account endpoint docs

### DIFF
--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -44,16 +44,10 @@ function transformOpenAPISchema(
     if (!paths) return schema;
 
     const newPaths: Record<string, unknown> = {};
-    const apiPaths = ["/account"]; // /api/ prefixed endpoints
 
     for (const [path, value] of Object.entries(paths)) {
         const cleanPath = path.replace(/^\/generate/, "");
-        const needsApiPrefix = apiPaths.some(
-            (p) => cleanPath === p || cleanPath.startsWith(`${p}/`),
-        );
-
-        const finalPath = needsApiPrefix ? `/api${cleanPath}` : cleanPath;
-        newPaths[finalPath] = value;
+        newPaths[cleanPath] = value;
     }
 
     // Filter aliases from the entire schema
@@ -169,15 +163,15 @@ export const createDocsRoutes = (apiRouter: Hono<Env>) => {
                             "",
                             "```bash",
                             "# Check pollen balance",
-                            "curl 'https://gen.pollinations.ai/api/account/balance' \\",
+                            "curl 'https://gen.pollinations.ai/account/balance' \\",
                             "  -H 'Authorization: Bearer YOUR_API_KEY'",
                             "",
                             "# Get profile info",
-                            "curl 'https://gen.pollinations.ai/api/account/profile' \\",
+                            "curl 'https://gen.pollinations.ai/account/profile' \\",
                             "  -H 'Authorization: Bearer YOUR_API_KEY'",
                             "",
                             "# View usage history",
-                            "curl 'https://gen.pollinations.ai/api/account/usage' \\",
+                            "curl 'https://gen.pollinations.ai/account/usage' \\",
                             "  -H 'Authorization: Bearer YOUR_API_KEY'",
                             "```",
                         ].join("\n"),


### PR DESCRIPTION
- Remove incorrect `/api` prefix from account endpoint paths in OpenAPI docs
- Fix curl examples to use `/account/*` instead of `/api/account/*`
- Simplify path transformation logic (no special handling needed for account routes)

Follow-up to #7355