### PR TITLE
feat: add auto-deploy workflow for pollinations.ai

### DIFF
--- a/.github/workflows/deploy-pollinations-ai-cloudflare.yml
+++ b/.github/workflows/deploy-pollinations-ai-cloudflare.yml
@@ -1,0 +1,32 @@
+name: Deploy pollinations.ai
+
+on:
+  push:
+    branches:
+      - production
+    paths:
+      - 'pollinations.ai/**'
+      - '.github/workflows/deploy-pollinations-ai-cloudflare.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./pollinations.ai
+
+      - name: Build and deploy to Cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npm run deploy:production
+        working-directory: ./pollinations.ai

--- a/pollinations.ai/package.json
+++ b/pollinations.ai/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "deploy:production": "npm run build && wrangler deploy"
     },
     "dependencies": {
         "@types/webfontloader": "^1.6.38",


### PR DESCRIPTION
- Adds GitHub Actions workflow to auto-deploy pollinations.ai to Cloudflare
- Triggers on push to `production` branch with changes in `pollinations.ai/**`
- Adds `deploy:production` script to package.json
- Uses existing `CLOUDFLARE_API_TOKEN` secret

Mirrors the enter.pollinations.ai deployment workflow.