### PR TITLE
feat: Add LTX-2 video generation with Diffusers

### DIFF
--- a/image.pollinations.ai/image_gen_ltx2/README.md
+++ b/image.pollinations.ai/image_gen_ltx2/README.md
@@ -1,0 +1,142 @@
+# LTX-Video 2 Modal Deployment
+
+LTX-2 19B audio-video generation model deployed on Modal.com using Diffusers.
+
+## Quick Start
+
+### Prerequisites
+
+1. **Modal CLI**: Install and authenticate
+   ```bash
+   pip install modal
+   modal token new
+   ```
+
+2. **Modal Secrets**: Set up required secrets
+   ```bash
+   # HuggingFace token for model downloads
+   modal secret create huggingface-secret HF_TOKEN=hf_your_token_here
+   
+   # Enter token for API authentication
+   modal secret create enter-token ENTER_TOKEN=your_enter_token_here
+   ```
+
+### Deploy
+
+```bash
+cd image.pollinations.ai/image_gen_ltx2
+modal deploy ltx2_video.py
+```
+
+### Test Locally
+
+```bash
+modal run ltx2_video.py --prompt "A cat walking through a garden" --num-inference-steps 40
+```
+
+## Current Implementation
+
+- **Pipeline**: Diffusers `LTX2Pipeline` (single-stage)
+- **Precision**: Full precision bfloat16 (best quality)
+- **GPU**: H200 (141GB VRAM)
+- **Inference Steps**: 40 (recommended for quality)
+- **Generation Time**: ~36s for 4s video at 768x512
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `prompt` | required | Text description of the video |
+| `width` | 768 | Video width |
+| `height` | 512 | Video height |
+| `num_frames` | 97 | Number of frames (~4s at 24fps) |
+| `fps` | 24 | Frames per second |
+| `num_inference_steps` | 10 | Denoising steps (use 40 for best quality) |
+| `seed` | random | Random seed for reproducibility |
+
+---
+
+## Research Findings
+
+### What Works
+
+| Approach | Quality | Speed | Notes |
+|----------|---------|-------|-------|
+| **Diffusers bfloat16** | ✅ Excellent | ~36s | **Recommended** - Full precision, best quality |
+| Diffusers FP8 | ⚠️ Glitchy | ~19s | Artifacts due to weight loading issues |
+
+### What Doesn't Work (OOM on H200 141GB)
+
+| Approach | Issue |
+|----------|-------|
+| Official `DistilledPipeline` | OOM during transformer forward pass |
+| Official `TI2VidTwoStagesPipeline` | OOM during transformer forward pass |
+| 4-bit quantized Gemma + DistilledPipeline | Still OOM |
+| 8-bit quantized Gemma + DistilledPipeline | Still OOM |
+| CPU offload Gemma + DistilledPipeline | Still OOM |
+| 2x A100 80GB | Got 40GB GPUs, still OOM |
+
+### Root Cause: Official Pipeline Memory Issue
+
+The official `ltx-pipelines` DistilledPipeline OOMs even on H200 (141GB) because:
+
+1. **FP8 → bfloat16 upcasting**: The FP8 transformer weights are upcast to bfloat16 during forward pass (`_upcast_and_round` in `model_configurator.py`), effectively doubling memory from ~20GB to ~40GB during inference.
+
+2. **Two-stage pipeline memory**: DistilledPipeline runs:
+   - Stage 1: Generate at half resolution (8 steps)
+   - Stage 2: Upsample 2x + refine (4 steps)
+   - Peak memory exceeds 141GB
+
+3. **Peak memory breakdown**:
+   - Transformer (FP8 stored, bfloat16 compute): ~40GB
+   - Gemma 12B text encoder: ~24GB
+   - Spatial upsampler: ~5GB
+   - VAE: ~2GB
+   - Latents/activations for 97 frames: ~60-70GB
+   - **Total peak**: ~150-170GB > 141GB
+
+### Diffusers Limitations
+
+- **No distilled checkpoint support**: Diffusers issue [#12925](https://github.com/huggingface/diffusers/issues/12925) tracks this
+- **No two-stage upsampling**: Single-stage only, no 2x spatial upscaler
+- **FP8 loading issues**: `strict=False` causes weight mismatches and quality degradation
+
+### Quality Comparison
+
+| Version | Precision | Steps | Quality |
+|---------|-----------|-------|---------|
+| Diffusers FP8 | 8-bit | 40 | Glitchy artifacts |
+| **Diffusers bfloat16** | Full | 40 | **Excellent** |
+| Official DistilledPipeline | FP8 | 8+4 | N/A (OOM) |
+
+### Recommendations
+
+1. **Use Diffusers with full precision bfloat16** - Best working solution
+2. **Use 40 inference steps** for quality (10 is too few)
+3. **Wait for Diffusers distilled support** - Issue #12925
+4. **Consider NVFP4** when available - 25-35% less VRAM than FP8
+
+---
+
+## API Usage
+
+### GET Endpoint
+```bash
+curl "https://your-modal-url/generate_web?prompt=A%20cat%20walking&num_inference_steps=40" \
+  -H "x-enter-token: YOUR_TOKEN"
+```
+
+### POST Endpoint
+```bash
+curl -X POST "https://your-modal-url/generate_post" \
+  -H "Content-Type: application/json" \
+  -H "x-enter-token: YOUR_TOKEN" \
+  -d '{"prompt": "A cat walking through a garden", "num_inference_steps": 40}'
+```
+
+## Resources
+
+- [LTX-2 GitHub](https://github.com/Lightricks/LTX-2)
+- [LTX-2 HuggingFace](https://huggingface.co/Lightricks/LTX-2)
+- [Diffusers LTX-2 Distilled Issue](https://github.com/huggingface/diffusers/issues/12925)
+- [Modal Docs](https://modal.com/docs)

--- a/image.pollinations.ai/image_gen_ltx2/ltx2_video.py
+++ b/image.pollinations.ai/image_gen_ltx2/ltx2_video.py
@@ -1,0 +1,318 @@
+"""
+LTX-Video 2 Modal Deployment
+============================
+LTX-2 19B - Lightricks' audio-video generation model.
+Uses Diffusers with full precision bfloat16 for best quality.
+
+Deploy with:
+    modal deploy ltx2_video.py
+
+Run locally:
+    modal run ltx2_video.py --prompt "A cat walking through a garden" --num-inference-steps 40
+
+Serve as web endpoint:
+    modal serve ltx2_video.py
+
+Note: Use --num-inference-steps 40 for best quality (default is 10 for speed).
+"""
+
+import os
+import time
+from io import BytesIO
+from pathlib import Path
+
+import modal
+from fastapi import Header, HTTPException
+from pydantic import BaseModel
+
+# Modal app configuration
+app = modal.App("ltx2-video")
+
+# Expected Enter token for authentication
+ENTER_TOKEN_HEADER = "x-enter-token"
+
+# CUDA base image with Python
+cuda_version = "12.4.0"
+flavor = "devel"
+operating_sys = "ubuntu22.04"
+tag = f"{cuda_version}-{flavor}-{operating_sys}"
+
+cuda_dev_image = modal.Image.from_registry(
+    f"nvidia/cuda:{tag}", add_python="3.11"
+).entrypoint([])
+
+# Install dependencies for LTX-2 with Diffusers
+ltx2_image = (
+    cuda_dev_image.apt_install(
+        "git",
+        "libglib2.0-0",
+        "libsm6",
+        "libxrender1",
+        "libxext6",
+        "ffmpeg",
+        "libgl1",
+    )
+    .pip_install(
+        "torch>=2.5.0",
+        "torchvision",
+        "torchaudio",
+        # Install diffusers from main branch for LTX2Pipeline support
+        "git+https://github.com/huggingface/diffusers.git@main",
+        "transformers>=4.44.0",
+        "huggingface-hub>=0.36.0",
+        "accelerate>=0.33.0",
+        "safetensors>=0.4.4",
+        "sentencepiece>=0.2.0",
+        "imageio>=2.37.0",
+        "imageio-ffmpeg>=0.5.1",
+        "av",  # Required for LTX-2 video export
+        "numpy<2",
+        "fastapi",
+        "pydantic",
+        "scipy",
+    )
+    .env({
+        "HF_HUB_CACHE": "/cache",
+        "TORCHINDUCTOR_CACHE_DIR": "/root/.inductor-cache",
+        "TORCHINDUCTOR_FX_GRAPH_CACHE": "1",
+        # Required for FP8 transformer to work properly
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+    })
+)
+
+MINUTES = 60
+
+
+class VideoRequest(BaseModel):
+    prompt: str
+    width: int = 768
+    height: int = 512
+    num_frames: int = 97  # ~4 seconds at 24fps
+    fps: int = 24
+    seed: int | None = None
+    num_inference_steps: int = 10  # Reduced from 20 for ~2x speedup
+
+
+@app.cls(
+    gpu="H200",  # H200 141GB - testing speed vs H100
+    image=ltx2_image,
+    scaledown_window=5 * MINUTES,
+    timeout=15 * MINUTES,
+    max_containers=2,
+    concurrency_limit=1,  # Video is memory-intensive
+    volumes={
+        "/cache": modal.Volume.from_name("hf-hub-cache", create_if_missing=True),
+        "/root/.nv": modal.Volume.from_name("nv-cache", create_if_missing=True),
+        "/root/.triton": modal.Volume.from_name("triton-cache", create_if_missing=True),
+        "/root/.inductor-cache": modal.Volume.from_name("inductor-cache", create_if_missing=True),
+    },
+    secrets=[
+        modal.Secret.from_name("enter-token", required_keys=["ENTER_TOKEN"]),
+        modal.Secret.from_name("huggingface-secret", required_keys=["HF_TOKEN"]),
+    ],
+)
+class LTX2Video:
+    """LTX-Video 2 audio-video generation using Diffusers with full precision bfloat16."""
+    
+    @modal.enter()
+    def load_model(self):
+        import torch
+        from diffusers import LTX2Pipeline
+        
+        print("🚀 Loading LTX-2 19B FULL PRECISION (bfloat16) for best quality...")
+        
+        # Load the full pipeline directly - no FP8 for best quality
+        # H200 has 141GB VRAM - should fit full precision single-stage
+        print("🔧 Loading full pipeline (this may take a moment)...")
+        self.pipe = LTX2Pipeline.from_pretrained(
+            "Lightricks/LTX-2",
+            torch_dtype=torch.bfloat16,
+        )
+        
+        # Keep everything on GPU for speed
+        self.pipe.to("cuda")
+        
+        print("✅ LTX-2 pipeline loaded with FULL PRECISION bfloat16!")
+    
+    @modal.method()
+    def generate(
+        self,
+        prompt: str,
+        width: int = 768,
+        height: int = 512,
+        num_frames: int = 97,
+        fps: int = 24,
+        seed: int | None = None,
+        num_inference_steps: int = 10,  # Reduced from 20 for ~2x speedup
+    ) -> tuple[bytes, bytes | None]:
+        """Generate a video (and audio) from a text prompt.
+        
+        Returns:
+            tuple: (video_bytes, audio_bytes or None)
+        """
+        import torch
+        from diffusers.utils import export_to_video
+        
+        print(f"🎬 Generating video: {prompt[:50]}...")
+        print(f"   Resolution: {width}x{height}, Frames: {num_frames}, FPS: {fps}")
+        
+        # Use random seed if not provided
+        generator = None
+        if seed is not None:
+            generator = torch.Generator(device="cuda").manual_seed(seed)
+        else:
+            seed = torch.randint(0, 2**32, (1,)).item()
+            generator = torch.Generator(device="cuda").manual_seed(seed)
+        
+        t0 = time.time()
+        
+        # Generate with LTX2Pipeline
+        output = self.pipe(
+            prompt=prompt,
+            negative_prompt="worst quality, inconsistent motion, blurry, jittery, distorted",
+            width=width,
+            height=height,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=4.0,
+            generator=generator,
+            output_type="np",
+            return_dict=False,
+        )
+        
+        gen_time = time.time() - t0
+        print(f"⏱️ Generation took {gen_time:.2f}s")
+        
+        # Unpack output - LTX2Pipeline returns (video, audio)
+        video, audio = output
+        
+        # Convert video to uint8
+        video = (video * 255).round().astype("uint8")
+        video = torch.from_numpy(video)
+        
+        # Export to video bytes
+        temp_path = "/tmp/output.mp4"
+        
+        # Check if audio is available
+        audio_bytes = None
+        if audio is not None and len(audio) > 0:
+            # Use the pipeline's encode_video utility
+            from diffusers.pipelines.ltx2.export_utils import encode_video
+            encode_video(
+                video[0],
+                fps=fps,
+                audio=audio[0].float().cpu(),
+                audio_sample_rate=self.pipe.vocoder.config.output_sampling_rate,
+                output_path=temp_path,
+            )
+            print("🔊 Audio generated and muxed")
+        else:
+            # No audio, just export video
+            export_to_video(video[0], temp_path, fps=fps)
+        
+        # Read the encoded video
+        with open(temp_path, "rb") as f:
+            video_bytes = f.read()
+        
+        print(f"📹 Video size: {len(video_bytes) / 1024:.1f} KB")
+        
+        return video_bytes, audio_bytes
+    
+    def _verify_token(self, token: str | None) -> None:
+        """Verify the Enter token, raise HTTPException if invalid."""
+        expected_token = os.environ.get("ENTER_TOKEN")
+        if not expected_token:
+            raise HTTPException(status_code=500, detail="ENTER_TOKEN not configured")
+        if not token or token != expected_token:
+            raise HTTPException(status_code=401, detail="Invalid or missing x-enter-token")
+
+    @modal.fastapi_endpoint(method="GET")
+    def generate_web(
+        self,
+        prompt: str,
+        width: int = 768,
+        height: int = 512,
+        num_frames: int = 97,
+        fps: int = 24,
+        seed: int | None = None,
+        num_inference_steps: int = 10,  # Reduced for speed
+        x_enter_token: str | None = Header(default=None),
+    ):
+        """Web endpoint for text-to-video generation (GET). Requires x-enter-token header."""
+        from fastapi.responses import Response
+
+        # Verify Enter token
+        self._verify_token(x_enter_token)
+
+        video_bytes, _ = self.generate.local(
+            prompt=prompt,
+            width=width,
+            height=height,
+            num_frames=num_frames,
+            fps=fps,
+            seed=seed,
+            num_inference_steps=num_inference_steps,
+        )
+
+        return Response(content=video_bytes, media_type="video/mp4")
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate_post(
+        self,
+        req: VideoRequest,
+        x_enter_token: str | None = Header(default=None),
+    ):
+        """Web endpoint for video generation (POST). Requires x-enter-token header."""
+        from fastapi.responses import Response
+
+        # Verify Enter token
+        self._verify_token(x_enter_token)
+
+        video_bytes, _ = self.generate.local(
+            prompt=req.prompt,
+            width=req.width,
+            height=req.height,
+            num_frames=req.num_frames,
+            fps=req.fps,
+            seed=req.seed,
+            num_inference_steps=req.num_inference_steps,
+        )
+
+        return Response(content=video_bytes, media_type="video/mp4")
+
+
+@app.local_entrypoint()
+def main(
+    prompt: str = "A cat walking through a beautiful garden with flowers",
+    width: int = 768,
+    height: int = 512,
+    num_frames: int = 97,
+    fps: int = 24,
+    seed: int | None = None,
+    num_inference_steps: int = 10,  # Reduced for speed
+    output: str = "/tmp/ltx2-output.mp4",
+):
+    """Generate a video with LTX-2 (optimized: 10 steps, torch.compile, no CPU offload)."""
+    print(f"🎬 LTX-2 Video Generation (Diffusers + FP8)")
+    print(f"   Prompt: {prompt}")
+    print(f"   Resolution: {width}x{height}")
+    print(f"   Frames: {num_frames} @ {fps}fps = {num_frames/fps:.1f}s")
+    
+    t0 = time.time()
+    video_bytes, audio_bytes = LTX2Video().generate.remote(
+        prompt=prompt,
+        width=width,
+        height=height,
+        num_frames=num_frames,
+        fps=fps,
+        seed=seed,
+        num_inference_steps=num_inference_steps,
+    )
+    
+    total_time = time.time() - t0
+    print(f"⏱️ Total time (including cold start): {total_time:.2f}s")
+    
+    output_path = Path(output)
+    output_path.parent.mkdir(exist_ok=True, parents=True)
+    output_path.write_bytes(video_bytes)
+    print(f"💾 Saved video to {output_path}")

--- a/image.pollinations.ai/image_gen_ltx2_comfyui/README.md
+++ b/image.pollinations.ai/image_gen_ltx2_comfyui/README.md
@@ -1,0 +1,125 @@
+# LTX-Video 2 ComfyUI Modal Deployment
+
+LTX-2 19B video generation using ComfyUI workflows on Modal.com.
+
+## Advantages over Diffusers
+
+| Feature | Diffusers | ComfyUI |
+|---------|-----------|---------|
+| **Distilled Model** | ❌ Not supported | ✅ 8+4 steps (~3x faster) |
+| **Spatial Upscaler** | ❌ Not supported | ✅ 2x upscaling |
+| **Control LoRAs** | ❌ Manual | ✅ Built-in nodes |
+| **Camera Motion** | ❌ Manual | ✅ LoRA support |
+| **I2V (Image-to-Video)** | ⚠️ Limited | ✅ Full support |
+
+## Quick Start
+
+### Prerequisites
+
+1. **Modal CLI**: Install and authenticate
+   ```bash
+   pip install modal
+   modal token new
+   ```
+
+2. **Modal Secrets**: Set up required secrets
+   ```bash
+   # HuggingFace token for model downloads
+   modal secret create huggingface-secret HF_TOKEN=hf_your_token_here
+   
+   # Enter token for API authentication
+   modal secret create enter-token ENTER_TOKEN=your_enter_token_here
+   ```
+
+### Deploy
+
+```bash
+cd image.pollinations.ai/image_gen_ltx2_comfyui
+modal deploy ltx2_comfyui.py
+```
+
+### Test Locally
+
+```bash
+# Fast generation with distilled model (default)
+modal run ltx2_comfyui.py --prompt "A cat walking through a garden"
+
+# Higher quality with full model
+modal run ltx2_comfyui.py --prompt "A cat walking through a garden" --use-distilled false
+```
+
+## Models Downloaded
+
+| Model | Size | Location | Purpose |
+|-------|------|----------|---------|
+| `ltx-2-19b-dev-fp8.safetensors` | ~20GB | `checkpoints/` | Full quality model |
+| `ltx-2-19b-distilled-fp8.safetensors` | ~20GB | `checkpoints/` | Fast distilled model |
+| `gemma_3_12B_it_fp4_mixed.safetensors` | ~6GB | `text_encoders/` | Gemma 3 text encoder |
+| `ltx-2-spatial-upscaler-x2-1.0.safetensors` | ~5GB | `latent_upscale_models/` | 2x spatial upscaler |
+| `ltx-2-19b-distilled-lora-384.safetensors` | ~1GB | `loras/` | Distilled LoRA |
+
+## Custom Nodes
+
+- **ComfyUI-LTXVideo** - Official Lightricks nodes for LTX-2
+  - `LTXVLoader` - Load LTX-2 checkpoint
+  - `LTXAVTextEncoderLoader` - Load Gemma text encoder
+  - `LTXVScheduler` - LTX-specific scheduler
+  - `EmptyLTXVLatentVideo` - Create empty latent for video
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `prompt` | required | Text description of the video |
+| `width` | 768 | Video width (divisible by 32) |
+| `height` | 512 | Video height (divisible by 32) |
+| `num_frames` | 97 | Number of frames (~4s at 24fps) |
+| `seed` | random | Random seed for reproducibility |
+| `use_distilled` | true | Use distilled model for faster generation |
+
+## Generation Speed
+
+| Model | Steps | Time | Quality |
+|-------|-------|------|---------|
+| **Distilled** | 12 | ~12s | Good |
+| Full | 20 | ~36s | Excellent |
+
+## API Usage
+
+### GET Endpoint
+```bash
+curl "https://your-modal-url/generate_web?prompt=A%20cat%20walking&use_distilled=true" \
+  -H "x-enter-token: YOUR_TOKEN"
+```
+
+### POST Endpoint
+```bash
+curl -X POST "https://your-modal-url/generate_post" \
+  -H "Content-Type: application/json" \
+  -H "x-enter-token: YOUR_TOKEN" \
+  -d '{"prompt": "A cat walking through a garden", "use_distilled": true}'
+```
+
+## Workflow Structure
+
+The `workflow_t2v.json` contains a text-to-video workflow:
+
+```
+LTXVLoader → Model
+LTXAVTextEncoderLoader → CLIP
+CLIPTextEncode (positive) → Conditioning
+CLIPTextEncode (negative) → Conditioning
+EmptyLTXVLatentVideo → Latent
+LTXVScheduler → Sigmas
+SamplerCustom → Sampled Latent
+VAEDecode → Video
+SaveVideo → Output
+```
+
+## Resources
+
+- [LTX-2 GitHub](https://github.com/Lightricks/LTX-2)
+- [ComfyUI-LTXVideo](https://github.com/Lightricks/ComfyUI-LTXVideo)
+- [LTX-2 HuggingFace](https://huggingface.co/Lightricks/LTX-2)
+- [Modal ComfyUI Docs](https://modal.com/docs/examples/comfyapp)
+- [LTX Documentation](https://docs.ltx.video/open-source-model/integration-tools/comfy-ui)

--- a/image.pollinations.ai/image_gen_ltx2_comfyui/ltx2_comfyui.py
+++ b/image.pollinations.ai/image_gen_ltx2_comfyui/ltx2_comfyui.py
@@ -1,0 +1,352 @@
+"""
+LTX-Video 2 ComfyUI Modal Deployment
+=====================================
+LTX-2 19B video generation using ComfyUI workflows on Modal.
+Supports distilled model for faster generation (~8+4 steps vs 40).
+
+Deploy with:
+    modal deploy ltx2_comfyui.py
+
+Run locally:
+    modal run ltx2_comfyui.py --prompt "A cat walking through a garden"
+
+Serve as web endpoint:
+    modal serve ltx2_comfyui.py
+"""
+
+import json
+import os
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Dict
+
+import modal
+
+# Modal app configuration
+app = modal.App("ltx2-comfyui")
+
+# Expected Enter token for authentication
+ENTER_TOKEN_HEADER = "x-enter-token"
+
+MINUTES = 60
+
+# ComfyUI installation paths
+COMFYUI_ROOT = "/root/comfy/ComfyUI"
+MODELS_DIR = f"{COMFYUI_ROOT}/models"
+
+# Build the ComfyUI image with LTX-2 support
+comfyui_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install(
+        "git",
+        "ffmpeg",
+        "libgl1",
+        "libglib2.0-0",
+        "libsm6",
+        "libxrender1",
+        "libxext6",
+    )
+    # Install comfy-cli and web dependencies
+    .pip_install(
+        "comfy-cli==1.5.3",
+        "fastapi[standard]==0.115.4",
+        "huggingface-hub>=0.36.0",
+    )
+    # Install ComfyUI using comfy-cli
+    .run_commands(
+        "comfy --skip-prompt install --fast-deps --nvidia --version 0.3.71"
+    )
+    # Install ComfyUI-LTXVideo custom nodes
+    .run_commands(
+        "comfy node install --fast-deps comfyui-ltxvideo"
+    )
+    .env({
+        "HF_HUB_CACHE": "/cache",
+        "HF_XET_HIGH_PERFORMANCE": "1",
+    })
+)
+
+
+def download_models():
+    """Download required LTX-2 models to the cache volume."""
+    from huggingface_hub import hf_hub_download
+    
+    print("📥 Downloading LTX-2 models...")
+    
+    # Model definitions: (repo_id, filename, local_dir)
+    models = [
+        # Main checkpoint (FP8 for memory efficiency)
+        (
+            "Lightricks/LTX-2",
+            "ltx-2-19b-dev-fp8.safetensors",
+            f"{MODELS_DIR}/checkpoints",
+        ),
+        # Distilled checkpoint for faster generation
+        (
+            "Lightricks/LTX-2",
+            "ltx-2-19b-distilled-fp8.safetensors",
+            f"{MODELS_DIR}/checkpoints",
+        ),
+        # Gemma text encoder (quantized)
+        (
+            "Comfy-Org/ltx-2",
+            "split_files/text_encoders/gemma_3_12B_it_fp4_mixed.safetensors",
+            f"{MODELS_DIR}/text_encoders",
+        ),
+        # Spatial upscaler
+        (
+            "Lightricks/LTX-2",
+            "ltx-2-spatial-upscaler-x2-1.0.safetensors",
+            f"{MODELS_DIR}/latent_upscale_models",
+        ),
+        # Distilled LoRA
+        (
+            "Lightricks/LTX-2",
+            "ltx-2-19b-distilled-lora-384.safetensors",
+            f"{MODELS_DIR}/loras",
+        ),
+    ]
+    
+    for repo_id, filename, local_dir in models:
+        print(f"  Downloading {filename}...")
+        Path(local_dir).mkdir(parents=True, exist_ok=True)
+        
+        downloaded_path = hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            cache_dir="/cache",
+        )
+        
+        # Create symlink to ComfyUI models directory
+        target_name = Path(filename).name
+        target_path = Path(local_dir) / target_name
+        if not target_path.exists():
+            subprocess.run(
+                f"ln -s {downloaded_path} {target_path}",
+                shell=True,
+                check=True,
+            )
+            print(f"  ✓ Linked {target_name}")
+    
+    print("✅ All models downloaded!")
+
+
+# Add model download to image build
+vol = modal.Volume.from_name("hf-hub-cache", create_if_missing=True)
+comfyui_image = comfyui_image.run_function(
+    download_models,
+    volumes={"/cache": vol},
+)
+
+# Add the workflow JSON to the image
+comfyui_image = comfyui_image.add_local_file(
+    Path(__file__).parent / "workflow_t2v.json",
+    "/root/workflow_t2v.json",
+)
+
+
+@app.cls(
+    gpu="H100",  # H100 80GB for LTX-2
+    image=comfyui_image,
+    scaledown_window=5 * MINUTES,
+    timeout=15 * MINUTES,
+    min_containers=1,
+    max_containers=1,
+    concurrency_limit=1,
+    volumes={
+        "/cache": vol,
+    },
+    secrets=[
+        modal.Secret.from_name("enter-token", required_keys=["ENTER_TOKEN"]),
+        modal.Secret.from_name("huggingface-secret", required_keys=["HF_TOKEN"]),
+    ],
+)
+class LTX2ComfyUI:
+    """LTX-Video 2 generation using ComfyUI workflows."""
+    
+    port: int = 8000
+    
+    @modal.enter()
+    def launch_comfy_background(self):
+        """Launch ComfyUI server in background when container starts."""
+        print("🚀 Starting ComfyUI server...")
+        cmd = f"comfy launch --background -- --listen 0.0.0.0 --port {self.port}"
+        subprocess.run(cmd, shell=True, check=True)
+        print("✅ ComfyUI server started!")
+    
+    def poll_server_health(self) -> None:
+        """Check if ComfyUI server is healthy, stop container if not."""
+        import socket
+        import urllib
+        
+        try:
+            req = urllib.request.Request(f"http://127.0.0.1:{self.port}/system_stats")
+            urllib.request.urlopen(req, timeout=5)
+            print("✓ ComfyUI server healthy")
+        except (socket.timeout, urllib.error.URLError) as e:
+            print(f"❌ Server health check failed: {e}")
+            modal.experimental.stop_fetching_inputs()
+            raise Exception("ComfyUI server not healthy, stopping container")
+    
+    @modal.method()
+    def generate(
+        self,
+        prompt: str,
+        width: int = 768,
+        height: int = 512,
+        num_frames: int = 97,
+        seed: int | None = None,
+        use_distilled: bool = True,
+    ) -> bytes:
+        """Generate video from text prompt using ComfyUI workflow.
+        
+        Args:
+            prompt: Text description of the video
+            width: Video width (must be divisible by 32)
+            height: Video height (must be divisible by 32)
+            num_frames: Number of frames (must be divisible by 8 + 1)
+            seed: Random seed for reproducibility
+            use_distilled: Use distilled model for faster generation
+            
+        Returns:
+            Video bytes (MP4)
+        """
+        import random
+        
+        self.poll_server_health()
+        
+        # Generate unique ID for this request
+        client_id = uuid.uuid4().hex
+        
+        # Load and modify workflow
+        workflow = json.loads(Path("/root/workflow_t2v.json").read_text())
+        
+        # Update workflow parameters based on node class_type
+        actual_seed = seed if seed is not None else random.randint(0, 2**32 - 1)
+        
+        for node_id, node in workflow.items():
+            if isinstance(node, dict):
+                inputs = node.get("inputs", {})
+                class_type = node.get("class_type", "")
+                
+                # Update positive prompt (node 3 in our workflow)
+                if class_type == "CLIPTextEncode" and node_id == "3":
+                    inputs["text"] = prompt
+                
+                # Update dimensions in EmptyImage node
+                if class_type == "EmptyImage":
+                    inputs["width"] = width
+                    inputs["height"] = height
+                
+                # Update frame count in LTXVImgToVideo node
+                if class_type == "LTXVImgToVideo":
+                    inputs["length"] = num_frames
+                
+                # Update seed in SamplerCustom node
+                if class_type == "SamplerCustom":
+                    inputs["noise_seed"] = actual_seed
+                
+                # Update checkpoint
+                if class_type == "CheckpointLoaderSimple":
+                    if use_distilled:
+                        inputs["ckpt_name"] = "ltx-2-19b-distilled-fp8.safetensors"
+                    else:
+                        inputs["ckpt_name"] = "ltx-2-19b-dev-fp8.safetensors"
+                
+                # Update output filename prefix
+                if class_type == "SaveVideo":
+                    inputs["filename_prefix"] = client_id
+        
+        # Save modified workflow
+        workflow_path = f"/tmp/{client_id}.json"
+        Path(workflow_path).write_text(json.dumps(workflow))
+        
+        print(f"🎬 Generating video: {prompt[:50]}...")
+        print(f"   Resolution: {width}x{height}, Frames: {num_frames}")
+        print(f"   Model: {'distilled' if use_distilled else 'full'}")
+        
+        # Run the workflow
+        cmd = f"comfy run --workflow {workflow_path} --wait --timeout 1200 --verbose"
+        result = subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
+        print(result.stdout)
+        
+        # Find output video
+        output_dir = Path(f"{COMFYUI_ROOT}/output")
+        for f in output_dir.iterdir():
+            if f.name.startswith(client_id) and f.suffix == ".mp4":
+                video_bytes = f.read_bytes()
+                print(f"📹 Video size: {len(video_bytes) / 1024:.1f} KB")
+                return video_bytes
+        
+        raise Exception("No output video found")
+    
+    def _verify_token(self, token: str | None) -> None:
+        """Verify the Enter token, raise HTTPException if invalid."""
+        from fastapi import HTTPException
+        
+        expected_token = os.environ.get("ENTER_TOKEN")
+        if not expected_token:
+            raise HTTPException(status_code=500, detail="ENTER_TOKEN not configured")
+        if not token or token != expected_token:
+            raise HTTPException(status_code=401, detail="Invalid or missing x-enter-token")
+    
+    @modal.fastapi_endpoint(method="POST")
+    def generate_post(
+        self,
+        req: Dict,
+        x_enter_token: str | None = None,
+    ):
+        """Web endpoint for video generation (POST). Requires x-enter-token header."""
+        from fastapi.responses import Response
+        
+        self._verify_token(x_enter_token)
+        
+        video_bytes = self.generate.local(
+            prompt=req.get("prompt", "A beautiful sunset over the ocean"),
+            width=req.get("width", 768),
+            height=req.get("height", 512),
+            num_frames=req.get("num_frames", 97),
+            seed=req.get("seed"),
+            use_distilled=req.get("use_distilled", True),
+        )
+        
+        return Response(content=video_bytes, media_type="video/mp4")
+
+
+@app.local_entrypoint()
+def main(
+    prompt: str = "A cat walking through a beautiful garden with flowers",
+    width: int = 768,
+    height: int = 512,
+    num_frames: int = 97,
+    seed: int | None = None,
+    use_distilled: bool = True,
+    output: str = "/tmp/ltx2-comfyui-output.mp4",
+):
+    """Generate a video with LTX-2 using ComfyUI workflows."""
+    print(f"🎬 LTX-2 Video Generation (ComfyUI)")
+    print(f"   Prompt: {prompt}")
+    print(f"   Resolution: {width}x{height}")
+    print(f"   Frames: {num_frames} @ 24fps = {num_frames/24:.1f}s")
+    print(f"   Model: {'distilled (fast)' if use_distilled else 'full (quality)'}")
+    
+    import time
+    t0 = time.time()
+    
+    video_bytes = LTX2ComfyUI().generate.remote(
+        prompt=prompt,
+        width=width,
+        height=height,
+        num_frames=num_frames,
+        seed=seed,
+        use_distilled=use_distilled,
+    )
+    
+    total_time = time.time() - t0
+    print(f"⏱️ Total time (including cold start): {total_time:.2f}s")
+    
+    output_path = Path(output)
+    output_path.parent.mkdir(exist_ok=True, parents=True)
+    output_path.write_bytes(video_bytes)
+    print(f"💾 Saved video to {output_path}")

--- a/image.pollinations.ai/image_gen_ltx2_comfyui/workflow_t2v.json
+++ b/image.pollinations.ai/image_gen_ltx2_comfyui/workflow_t2v.json
@@ -1,0 +1,107 @@
+{
+  "1": {
+    "class_type": "CheckpointLoaderSimple",
+    "inputs": {
+      "ckpt_name": "ltx-2-19b-distilled-fp8.safetensors"
+    }
+  },
+  "2": {
+    "class_type": "LTXVTextEncoderLoader",
+    "inputs": {
+      "text_encoder_name": "gemma_3_12B_it_fp4_mixed.safetensors"
+    }
+  },
+  "3": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "A cat walking through a beautiful garden with colorful flowers, cinematic lighting, high quality",
+      "clip": ["2", 0]
+    }
+  },
+  "4": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "worst quality, blurry, jittery, distorted, low resolution",
+      "clip": ["2", 0]
+    }
+  },
+  "5": {
+    "class_type": "EmptyImage",
+    "inputs": {
+      "width": 768,
+      "height": 512,
+      "batch_size": 1,
+      "color": 0
+    }
+  },
+  "6": {
+    "class_type": "LTXVImgToVideo",
+    "inputs": {
+      "image": ["5", 0],
+      "vae": ["1", 2],
+      "length": 97
+    }
+  },
+  "7": {
+    "class_type": "LTXVConditioning",
+    "inputs": {
+      "positive": ["3", 0],
+      "negative": ["4", 0],
+      "frame_rate": 24
+    }
+  },
+  "8": {
+    "class_type": "LTXVScheduler",
+    "inputs": {
+      "steps": 12,
+      "max_shift": 2.05,
+      "base_shift": 0.95,
+      "stretch": true,
+      "terminal": 0.1,
+      "latent": ["6", 0]
+    }
+  },
+  "9": {
+    "class_type": "KSamplerSelect",
+    "inputs": {
+      "sampler_name": "euler"
+    }
+  },
+  "10": {
+    "class_type": "SamplerCustom",
+    "inputs": {
+      "add_noise": true,
+      "noise_seed": 42,
+      "cfg": 4.0,
+      "model": ["1", 0],
+      "positive": ["7", 0],
+      "negative": ["7", 1],
+      "sampler": ["9", 0],
+      "sigmas": ["8", 0],
+      "latent_image": ["6", 0]
+    }
+  },
+  "11": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": ["10", 0],
+      "vae": ["1", 2]
+    }
+  },
+  "12": {
+    "class_type": "CreateVideo",
+    "inputs": {
+      "images": ["11", 0],
+      "fps": 24
+    }
+  },
+  "13": {
+    "class_type": "SaveVideo",
+    "inputs": {
+      "filename_prefix": "ltx2_output",
+      "format": "mp4",
+      "codec": "auto",
+      "video": ["12", 0]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds LTX-2 19B video generation using Diffusers `LTX2Pipeline`
- Full precision bfloat16 for best quality (~36s generation time)
- Detailed README documenting research findings

## What Works

| Approach | Quality | Speed |
|----------|---------|-------|
| **Diffusers bfloat16** | ✅ Excellent | ~36s |
| Diffusers FP8 | ⚠️ Glitchy | ~19s |

## What Doesn't Work (OOM on H200 141GB)

- Official `DistilledPipeline` - OOM during transformer forward pass
- Official `TI2VidTwoStagesPipeline` - OOM during transformer forward pass
- Various quantization attempts (4-bit, 8-bit Gemma) - Still OOM

## Root Cause

The official `ltx-pipelines` OOMs because FP8 weights are upcast to bfloat16 during inference, and the two-stage pipeline with upsampling requires ~150-170GB peak VRAM.

## Files

- `image.pollinations.ai/image_gen_ltx2/ltx2_video.py` - Working Modal deployment
- `image.pollinations.ai/image_gen_ltx2/README.md` - Detailed findings