### PR TITLE
fix: migrate flux docker image from voodoohop to pollinations

### DIFF
--- a/image.pollinations.ai/nunchaku/Dockerfile
+++ b/image.pollinations.ai/nunchaku/Dockerfile
@@ -66,11 +66,14 @@ RUN pip3 install --no-cache-dir \
     pydantic
 
 # Clone and install nunchaku
+# Patch setup.py to hardcode SM 89 target since GPU detection doesn't work during Docker build
 WORKDIR /app
+ENV TORCH_CUDA_ARCH_LIST="8.9"
 RUN git clone https://github.com/mit-han-lab/nunchaku.git \
     && cd nunchaku \
     && git submodule init \
     && git submodule update \
+    && sed -i 's/sm_targets = get_sm_targets()/sm_targets = ["89"]/' setup.py \
     && python3 -m pip install -e .
 
 # Install hf_transfer separately to keep cache layers

--- a/image.pollinations.ai/serverConfigAndScripts/build-flux-docker.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/build-flux-docker.sh
@@ -7,11 +7,11 @@ log() {
 # Build Docker image locally
 log "Building Docker image locally"
 cd ../nunchaku
-docker build -t voodoohop/flux-svdquant:latest . || { log "ERROR: Failed to build Docker image"; exit 1; }
+docker build -t pollinations/flux-svdquant:latest . || { log "ERROR: Failed to build Docker image"; exit 1; }
 
 # If a registry push is requested
 if [ "$1" = "--push" ]; then
     log "Pushing Docker image to registry"
-    docker push voodoohop/flux-svdquant:latest || { log "ERROR: Failed to push Docker image"; exit 1; }
+    docker push pollinations/flux-svdquant:latest || { log "ERROR: Failed to push Docker image"; exit 1; }
     log "Docker image pushed successfully"
 fi

--- a/image.pollinations.ai/serverConfigAndScripts/deploy-flux-docker.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/deploy-flux-docker.sh
@@ -35,7 +35,7 @@ ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/thomashkey ubuntu@$HOST << 'EOF'
     docker rm -f flux-svdquant || true
     
     # Pull the new image
-    docker pull voodoohop/flux-svdquant:latest
+    docker pull pollinations/flux-svdquant:latest
     
     # Start the service
     sudo systemctl start pollinations-flux-docker.service

--- a/image.pollinations.ai/serverConfigAndScripts/install-services.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/install-services.sh
@@ -8,7 +8,7 @@ log "Starting service installation script"
 
 # Pull the latest Docker images
 log "Pulling latest Docker images"
-docker pull voodoohop/flux-svdquant:latest || { log "ERROR: Failed to pull flux-svdquant Docker image"; exit 1; }
+docker pull pollinations/flux-svdquant:latest || { log "ERROR: Failed to pull flux-svdquant Docker image"; exit 1; }
 docker pull libretranslate/libretranslate:latest || { log "ERROR: Failed to pull LibreTranslate Docker image"; exit 1; }
 
 # Copy service files to systemd directory

--- a/image.pollinations.ai/serverConfigAndScripts/pollinations-flux-docker.service
+++ b/image.pollinations.ai/serverConfigAndScripts/pollinations-flux-docker.service
@@ -7,7 +7,7 @@ Requires=docker.service
 User=ubuntu
 ExecStartPre=-/usr/bin/docker stop flux-svdquant
 ExecStartPre=-/usr/bin/docker rm flux-svdquant
-ExecStart=/usr/bin/docker run --name flux-svdquant --gpus all -p 8765:8765 -e PORT=8765 -e HF_HUB_ENABLE_HF_TRANSFER=1 voodoohop/flux-svdquant:latest
+ExecStart=/usr/bin/docker run --name flux-svdquant --gpus all -p 8765:8765 -e PORT=8765 -e HF_HUB_ENABLE_HF_TRANSFER=1 pollinations/flux-svdquant:latest
 ExecStop=/usr/bin/docker stop flux-svdquant
 Restart=always
 RestartSec=10

--- a/image.pollinations.ai/serverConfigAndScripts/update-flux-docker.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/update-flux-docker.sh
@@ -47,7 +47,7 @@ ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/thomashkey ubuntu@$HOST << 'EOF'
     docker rm -f flux-svdquant || true
     
     # Pull the new image
-    docker pull voodoohop/flux-svdquant:latest
+    docker pull pollinations/flux-svdquant:latest
     
     # Start the service
     sudo systemctl start pollinations-flux-docker.service


### PR DESCRIPTION
- Migrate Docker image from `voodoohop/flux-svdquant:latest` to `pollinations/flux-svdquant:latest`
- Fix Dockerfile SM target detection for builds without GPU access
- Hardcode SM 89 target for RTX 4090 compatibility

**Files updated:**
- `build-flux-docker.sh`
- `deploy-flux-docker.sh`
- `update-flux-docker.sh`
- `install-services.sh`
- `pollinations-flux-docker.service`
- `nunchaku/Dockerfile`