### PR TITLE
fix: migrate flux docker image from voodoohop to pollinations

### DIFF
--- a/image.pollinations.ai/IONET_INSTANCES.md
+++ b/image.pollinations.ai/IONET_INSTANCES.md
@@ -35,7 +35,7 @@ ssh -p 25656 -i ~/.ssh/thomashkey ionet@52.205.25.210
 | Model | Docker Image | Internal Port |
 |-------|--------------|---------------|
 | zimage | voodoohop/z-image-server:latest | 8765 |
-| flux | voodoohop/flux-svdquant:latest | 8765 |
+| flux | pollinations/flux-svdquant:latest | 8765 |
 
 ## Heartbeat Registration
 
@@ -61,7 +61,7 @@ docker run -d --gpus '"device=0"' --name flux1 \
   -e SERVICE_TYPE=flux \
   -e HF_TOKEN=<token> \
   -v /home/ionet/server.py:/app/server.py \
-  voodoohop/flux-svdquant:latest
+  pollinations/flux-svdquant:latest
 
 docker run -d --gpus '"device=1"' --name flux2 \
   -p 10001:8765 \
@@ -71,7 +71,7 @@ docker run -d --gpus '"device=1"' --name flux2 \
   -e SERVICE_TYPE=flux \
   -e HF_TOKEN=<token> \
   -v /home/ionet/server.py:/app/server.py \
-  voodoohop/flux-svdquant:latest
+  pollinations/flux-svdquant:latest
 ```
 
 ## Capacity Summary

--- a/image.pollinations.ai/nunchaku/Dockerfile
+++ b/image.pollinations.ai/nunchaku/Dockerfile
@@ -56,6 +56,7 @@ ENV NUNCHAKU_INSTALL_SM="89"
 RUN git clone --recursive https://github.com/mit-han-lab/nunchaku.git /tmp/nunchaku && \
     cd /tmp/nunchaku && \
     pip install ninja && \
+    sed -i 's/sm_targets = get_sm_targets()/sm_targets = ["89"]/' setup.py && \
     pip install --no-build-isolation -e . && \
     rm -rf /tmp/nunchaku/.git
 

--- a/image.pollinations.ai/serverConfigAndScripts/build-flux-docker.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/build-flux-docker.sh
@@ -7,11 +7,11 @@ log() {
 # Build Docker image locally
 log "Building Docker image locally"
 cd ../nunchaku
-docker build -t voodoohop/flux-svdquant:latest . || { log "ERROR: Failed to build Docker image"; exit 1; }
+docker build -t pollinations/flux-svdquant:latest . || { log "ERROR: Failed to build Docker image"; exit 1; }
 
 # If a registry push is requested
 if [ "$1" = "--push" ]; then
     log "Pushing Docker image to registry"
-    docker push voodoohop/flux-svdquant:latest || { log "ERROR: Failed to push Docker image"; exit 1; }
+    docker push pollinations/flux-svdquant:latest || { log "ERROR: Failed to push Docker image"; exit 1; }
     log "Docker image pushed successfully"
 fi

--- a/image.pollinations.ai/serverConfigAndScripts/deploy-flux-docker.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/deploy-flux-docker.sh
@@ -35,7 +35,7 @@ ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/thomashkey ubuntu@$HOST << 'EOF'
     docker rm -f flux-svdquant || true
     
     # Pull the new image
-    docker pull voodoohop/flux-svdquant:latest
+    docker pull pollinations/flux-svdquant:latest
     
     # Start the service
     sudo systemctl start pollinations-flux-docker.service

--- a/image.pollinations.ai/serverConfigAndScripts/install-services.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/install-services.sh
@@ -8,7 +8,7 @@ log "Starting service installation script"
 
 # Pull the latest Docker images
 log "Pulling latest Docker images"
-docker pull voodoohop/flux-svdquant:latest || { log "ERROR: Failed to pull flux-svdquant Docker image"; exit 1; }
+docker pull pollinations/flux-svdquant:latest || { log "ERROR: Failed to pull flux-svdquant Docker image"; exit 1; }
 docker pull libretranslate/libretranslate:latest || { log "ERROR: Failed to pull LibreTranslate Docker image"; exit 1; }
 
 # Copy service files to systemd directory

--- a/image.pollinations.ai/serverConfigAndScripts/pollinations-flux-docker.service
+++ b/image.pollinations.ai/serverConfigAndScripts/pollinations-flux-docker.service
@@ -7,7 +7,7 @@ Requires=docker.service
 User=ubuntu
 ExecStartPre=-/usr/bin/docker stop flux-svdquant
 ExecStartPre=-/usr/bin/docker rm flux-svdquant
-ExecStart=/usr/bin/docker run --name flux-svdquant --gpus all -p 8765:8765 -e PORT=8765 -e HF_HUB_ENABLE_HF_TRANSFER=1 voodoohop/flux-svdquant:latest
+ExecStart=/usr/bin/docker run --name flux-svdquant --gpus all -p 8765:8765 -e PORT=8765 -e HF_HUB_ENABLE_HF_TRANSFER=1 pollinations/flux-svdquant:latest
 ExecStop=/usr/bin/docker stop flux-svdquant
 Restart=always
 RestartSec=10

--- a/image.pollinations.ai/serverConfigAndScripts/update-flux-docker.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/update-flux-docker.sh
@@ -47,7 +47,7 @@ ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/thomashkey ubuntu@$HOST << 'EOF'
     docker rm -f flux-svdquant || true
     
     # Pull the new image
-    docker pull voodoohop/flux-svdquant:latest
+    docker pull pollinations/flux-svdquant:latest
     
     # Start the service
     sudo systemctl start pollinations-flux-docker.service


### PR DESCRIPTION
- Migrate Docker image from `voodoohop/flux-svdquant:latest` to `pollinations/flux-svdquant:latest`
- Fix Dockerfile SM target detection for builds without GPU access
- Hardcode SM 89 target for RTX 4090 compatibility

**Files updated:**
- `build-flux-docker.sh`
- `deploy-flux-docker.sh`
- `update-flux-docker.sh`
- `install-services.sh`
- `pollinations-flux-docker.service`
- `nunchaku/Dockerfile`
- `IONET_INSTANCES.md`