### PR TITLE
refactor: simplify usage types (TokenUsage → Usage)

### DIFF
--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -1,4 +1,4 @@
-import type { PriceDefinition, TokenUsage } from "@shared/registry/registry.ts";
+import type { PriceDefinition, Usage } from "@shared/registry/registry.ts";
 import type { ContentFilterResult } from "@/schemas/openai";
 
 export type EventType = "generate.text" | "generate.image";
@@ -159,9 +159,7 @@ export function priceToEventParams(
     };
 }
 
-export function usageToEventParams(
-    usage?: TokenUsage,
-): GenerationEventUsageParams {
+export function usageToEventParams(usage?: Usage): GenerationEventUsageParams {
     return {
         tokenCountPromptText: usage?.promptTextTokens || 0,
         tokenCountPromptCached: usage?.promptCachedTokens || 0,

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -1,5 +1,5 @@
 import { getLogger } from "@logtape/logtape";
-import type { TokenUsage } from "@shared/registry/registry.ts";
+import type { Usage } from "@shared/registry/registry.ts";
 import {
     calculateCost,
     calculatePrice,
@@ -12,7 +12,7 @@ import {
     type UsagePrice,
 } from "@shared/registry/registry.ts";
 import {
-    openaiUsageToTokenUsage,
+    openaiUsageToUsage,
     parseUsageHeaders,
 } from "@shared/registry/usage-headers.ts";
 import { eq, sql } from "drizzle-orm";
@@ -61,7 +61,7 @@ import type { FrontendKeyRateLimitVariables } from "./rate-limit-durable.ts";
 
 export type ModelUsage = {
     model: ModelId;
-    usage: TokenUsage;
+    usage: Usage;
 };
 
 type RequestTrackingData = {
@@ -79,7 +79,7 @@ type ResponseTrackingData = {
     cacheData: CacheData;
     isBilledUsage: boolean;
     modelUsed?: string;
-    usage?: TokenUsage;
+    usage?: Usage;
     cost?: UsageCost;
     price?: UsagePrice;
     contentFilterResults?: GenerationEventContentFilterParams;
@@ -656,7 +656,7 @@ async function extractUsageAndContentFilterResultsStream(
     return {
         modelUsage: {
             model: model as ModelId,
-            usage: openaiUsageToTokenUsage(usage),
+            usage: openaiUsageToUsage(usage),
         },
         contentFilterResults,
     };

--- a/enter.pollinations.ai/src/usage.ts
+++ b/enter.pollinations.ai/src/usage.ts
@@ -1,7 +1,7 @@
-import type { ModelId, TokenUsage } from "@shared/registry/registry.ts";
+import type { ModelId, Usage } from "@shared/registry/registry.ts";
 import type { CompletionUsage } from "@/schemas/openai.ts";
 
-export function transformOpenAIUsage(usage: CompletionUsage): TokenUsage {
+export function transformOpenAIUsage(usage: CompletionUsage): Usage {
     const promptDetailTokens =
         (usage.prompt_tokens_details?.cached_tokens || 0) +
         (usage.prompt_tokens_details?.audio_tokens || 0);
@@ -24,5 +24,5 @@ export function transformOpenAIUsage(usage: CompletionUsage): TokenUsage {
 
 export type ModelUsage = {
     model: ModelId;
-    usage: TokenUsage;
+    usage: Usage;
 };

--- a/enter.pollinations.ai/test/track-image.test.ts
+++ b/enter.pollinations.ai/test/track-image.test.ts
@@ -1,4 +1,4 @@
-import type { ModelId, TokenUsage } from "@shared/registry/registry.ts";
+import type { ModelId, Usage } from "@shared/registry/registry.ts";
 import { calculateCost } from "@shared/registry/registry.ts";
 import { expect, test } from "vitest";
 
@@ -15,10 +15,10 @@ test("Image models should calculate costs proportionally to token count", () => 
     ];
 
     for (const model of models) {
-        const usage1: TokenUsage = {
+        const usage1: Usage = {
             completionImageTokens: 1,
         };
-        const usage10: TokenUsage = {
+        const usage10: Usage = {
             completionImageTokens: 10,
         };
 
@@ -35,7 +35,7 @@ test("Image models should calculate costs proportionally to token count", () => 
 });
 
 test("Models with API costs should have non-zero operational costs", () => {
-    const usage: TokenUsage = {
+    const usage: Usage = {
         completionImageTokens: 1,
     };
 
@@ -56,7 +56,7 @@ test("Cost should be non-negative for all models", () => {
         "turbo",
         "seedream",
     ];
-    const usage: TokenUsage = {
+    const usage: Usage = {
         completionImageTokens: 1,
     };
 
@@ -69,7 +69,7 @@ test("Cost should be non-negative for all models", () => {
 });
 
 test("gptimage-large should calculate costs for image output tokens", () => {
-    const usage: TokenUsage = {
+    const usage: Usage = {
         completionImageTokens: 1000,
     };
     const cost = calculateCost("gptimage-large", usage);
@@ -79,7 +79,7 @@ test("gptimage-large should calculate costs for image output tokens", () => {
 });
 
 test("gptimage-large should calculate costs for text input tokens", () => {
-    const usage: TokenUsage = {
+    const usage: Usage = {
         promptTextTokens: 1000,
     };
     const cost = calculateCost("gptimage-large", usage);
@@ -89,7 +89,7 @@ test("gptimage-large should calculate costs for text input tokens", () => {
 });
 
 test("gptimage-large should calculate costs for image input tokens", () => {
-    const usage: TokenUsage = {
+    const usage: Usage = {
         promptImageTokens: 1000,
     };
     const cost = calculateCost("gptimage-large", usage);
@@ -99,7 +99,7 @@ test("gptimage-large should calculate costs for image input tokens", () => {
 });
 
 test("gptimage-large combined input + output costs", () => {
-    const usage: TokenUsage = {
+    const usage: Usage = {
         promptTextTokens: 500,
         promptImageTokens: 3000, // Typical resized input ~3K tokens
         completionImageTokens: 1000,

--- a/image.pollinations.ai/src/utils/trackingHeaders.ts
+++ b/image.pollinations.ai/src/utils/trackingHeaders.ts
@@ -5,12 +5,12 @@
 
 import debug from "debug";
 import type { IMAGE_SERVICES } from "../../../shared/registry/image.ts";
-import type { TokenUsage } from "../../../shared/registry/registry.ts";
+import type { Usage } from "../../../shared/registry/registry.ts";
 import {
     buildUsageHeaders,
-    createImageTokenUsage,
+    createImageUsage,
     createVideoSecondsUsage,
-    createVideoTokenUsage,
+    createVideoTokensUsage,
 } from "../../../shared/registry/usage-headers.ts";
 
 const log = debug("pollinations:tracking-headers");
@@ -66,11 +66,11 @@ export function buildTrackingHeaders(
     const videoSeconds = trackingData?.usage?.completionVideoSeconds;
     const imageTokens = trackingData?.usage?.completionImageTokens;
 
-    let usage: TokenUsage;
+    let usage: Usage;
     if (videoTokens && videoTokens > 0) {
         // Seedance video model - use video tokens (from API response)
         log(`Using video tokens: ${videoTokens}`);
-        usage = createVideoTokenUsage(videoTokens);
+        usage = createVideoTokensUsage(videoTokens);
     } else if (videoSeconds && videoSeconds > 0) {
         // Veo video model - use video seconds
         log(`Using video seconds: ${videoSeconds}`);
@@ -79,7 +79,7 @@ export function buildTrackingHeaders(
         // Image model - use image tokens (default to 1 for unit-based)
         const tokens = imageTokens || 1;
         log(`Using image tokens: ${tokens}`);
-        usage = createImageTokenUsage(tokens);
+        usage = createImageUsage(tokens);
     }
 
     const headers = buildUsageHeaders(modelUsed, usage);

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -1,7 +1,7 @@
-import type { TokenUsage, UsageType } from "./registry.js";
+import type { Usage, UsageType } from "./registry.js";
 
 /**
- * Mapping from TokenUsage field names to HTTP header names
+ * Mapping from Usage field names to HTTP header names
  */
 export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
     promptTextTokens: "x-usage-prompt-text-tokens",
@@ -17,9 +17,9 @@ export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
 };
 
 /**
- * Convert OpenAI usage format to TokenUsage format
+ * Convert OpenAI usage format to Usage format
  */
-export function openaiUsageToTokenUsage(openaiUsage: {
+export function openaiUsageToUsage(openaiUsage: {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
@@ -33,7 +33,7 @@ export function openaiUsageToTokenUsage(openaiUsage: {
         accepted_prediction_tokens?: number;
         rejected_prediction_tokens?: number;
     } | null;
-}): TokenUsage {
+}): Usage {
     const promptDetailTokens =
         (openaiUsage.prompt_tokens_details?.cached_tokens || 0) +
         (openaiUsage.prompt_tokens_details?.audio_tokens || 0);
@@ -64,12 +64,12 @@ export function openaiUsageToTokenUsage(openaiUsage: {
 }
 
 /**
- * Build usage tracking headers from TokenUsage object
- * Returns headers with x-usage-* prefix for all non-zero token types
+ * Build usage tracking headers from Usage object
+ * Returns headers with x-usage-* prefix for all non-zero usage types
  */
 export function buildUsageHeaders(
     modelUsed: string,
-    usage: TokenUsage,
+    usage: Usage,
 ): Record<string, string> {
     const headers: Record<string, string> = {
         "x-model-used": modelUsed,
@@ -94,12 +94,12 @@ export function buildUsageHeaders(
 }
 
 /**
- * Parse usage headers back to TokenUsage object
+ * Parse usage headers back to Usage object
  */
 export function parseUsageHeaders(
     headers: Headers | Record<string, string>,
-): TokenUsage {
-    const usage: TokenUsage = {};
+): Usage {
+    const usage: Usage = {};
 
     const getHeader = (name: string) =>
         headers instanceof Headers ? headers.get(name) : headers[name];
@@ -116,28 +116,22 @@ export function parseUsageHeaders(
 }
 
 /**
- * Helper for image services: create TokenUsage with only image tokens
+ * Helper for image services: create Usage with only image tokens
  */
-export function createImageTokenUsage(
-    completionImageTokens: number,
-): TokenUsage {
+export function createImageUsage(completionImageTokens: number): Usage {
     return { completionImageTokens };
 }
 
 /**
- * Helper for video services: create TokenUsage with video seconds (Veo)
+ * Helper for video services: create Usage with video seconds (Veo)
  */
-export function createVideoSecondsUsage(
-    completionVideoSeconds: number,
-): TokenUsage {
+export function createVideoSecondsUsage(completionVideoSeconds: number): Usage {
     return { completionVideoSeconds };
 }
 
 /**
- * Helper for video services: create TokenUsage with video tokens (Seedance)
+ * Helper for video services: create Usage with video tokens (Seedance)
  */
-export function createVideoTokenUsage(
-    completionVideoTokens: number,
-): TokenUsage {
+export function createVideoTokensUsage(completionVideoTokens: number): Usage {
     return { completionVideoTokens };
 }

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -9,7 +9,7 @@ import { getIp } from "../shared/extractFromRequest.js";
 import { getServiceDefinition } from "../shared/registry/registry.js";
 import {
     buildUsageHeaders,
-    openaiUsageToTokenUsage,
+    openaiUsageToUsage,
 } from "../shared/registry/usage-headers.js";
 import { availableModels } from "./availableModels.js";
 import { generateTextPortkey } from "./generateTextPortkey.js";
@@ -358,8 +358,8 @@ export function sendOpenAIResponse(res, completion) {
 
     // Add usage headers if available (GitHub issue #4638)
     if (completion.usage && completion.model) {
-        const tokenUsage = openaiUsageToTokenUsage(completion.usage);
-        const usageHeaders = buildUsageHeaders(completion.model, tokenUsage);
+        const usage = openaiUsageToUsage(completion.usage);
+        const usageHeaders = buildUsageHeaders(completion.model, usage);
 
         for (const [key, value] of Object.entries(usageHeaders)) {
             res.setHeader(key, value);
@@ -386,8 +386,8 @@ export function sendContentResponse(res, completion) {
         completion.usage &&
         completion.model
     ) {
-        const tokenUsage = openaiUsageToTokenUsage(completion.usage);
-        const usageHeaders = buildUsageHeaders(completion.model, tokenUsage);
+        const usage = openaiUsageToUsage(completion.usage);
+        const usageHeaders = buildUsageHeaders(completion.model, usage);
 
         for (const [key, value] of Object.entries(usageHeaders)) {
             res.setHeader(key, value);


### PR DESCRIPTION
## Summary

- Rename `TokenUsage` → `Usage` (better name since it includes non-token metrics like `completionVideoSeconds`)
- Remove `DollarConvertedUsage` (was identical to `TokenUsage`)
- Remove `UsageConversionDefinition` (inlined into `CostDefinition`)
- Rename functions: `openaiUsageToUsage`, `createImageUsage`, `createVideoTokensUsage`

## What's preserved

- `UsageCost` and `UsagePrice` remain separate types (for future flexibility when cost ≠ price)
- `calculateCost()` and `calculatePrice()` remain separate functions
- `CostDefinition` and `PriceDefinition` remain separate

## Files changed (8)

- `shared/registry/registry.ts` - Type definitions
- `shared/registry/usage-headers.ts` - Helper functions
- `enter.pollinations.ai/src/usage.ts`
- `enter.pollinations.ai/src/db/schema/event.ts`
- `enter.pollinations.ai/src/middleware/track.ts`
- `enter.pollinations.ai/test/track-image.test.ts`
- `image.pollinations.ai/src/utils/trackingHeaders.ts`
- `text.pollinations.ai/server.js`

## Testing

- ✅ All tests pass