### PR TITLE
fix: increase API key rate limit to 10k req/s for high-volume games

### DIFF
--- a/enter.pollinations.ai/package-lock.json
+++ b/enter.pollinations.ai/package-lock.json
@@ -15,7 +15,7 @@
                 "@polar-sh/sdk": "^0.41.5",
                 "@scalar/hono-api-reference": "^0.9.32",
                 "@tanstack/react-router": "^1.139.3",
-                "better-auth": "^1.3.17",
+                "better-auth": "^1.4.17",
                 "clsx": "^2.1.1",
                 "date-fns": "^4.1.0",
                 "drizzle-orm": "^0.44.7",
@@ -415,7 +415,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -425,7 +425,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -459,7 +459,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
             "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.28.5"
@@ -731,7 +731,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
             "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -778,6 +778,54 @@
             },
             "bin": {
                 "cli": "dist/index.mjs"
+            }
+        },
+        "node_modules/@better-auth/cli/node_modules/better-auth": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.1.tgz",
+            "integrity": "sha512-HDVE69Nw6Y1FPTcmFEmPolfsjMfVB5U823Ij9yWBoM8MdHZ2lA3JVus4xQJ2oRE1riJTlcSLFcgJKWGD7V7hmw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@better-auth/core": "1.4.1",
+                "@better-auth/telemetry": "1.4.1",
+                "@better-auth/utils": "0.3.0",
+                "@better-fetch/fetch": "1.1.18",
+                "@noble/ciphers": "^2.0.0",
+                "@noble/hashes": "^2.0.0",
+                "@standard-schema/spec": "^1.0.0",
+                "better-call": "1.1.0",
+                "defu": "^6.1.4",
+                "jose": "^6.1.0",
+                "kysely": "^0.28.5",
+                "nanostores": "^1.0.1",
+                "zod": "^4.1.12"
+            },
+            "peerDependenciesMeta": {
+                "@lynx-js/react": {
+                    "optional": true
+                },
+                "@sveltejs/kit": {
+                    "optional": true
+                },
+                "next": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "solid-js": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@better-auth/cli/node_modules/drizzle-orm": {
@@ -906,6 +954,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.1.tgz",
             "integrity": "sha512-N4kyRdA472WGLoCjsJpUeYdZZvpoBDgP65hUeQQxTQYwBTqD9O17Tokax9CdNbkb4g34sTfxaJCfcncE3Hy4SA==",
+            "dev": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "zod": "^4.1.12"
@@ -923,6 +972,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.1.tgz",
             "integrity": "sha512-yNeazXYvMbyuCe1AA6tYWsJEKgcS7gF9PmmACmrPVhVBe1ncDhVfWMZ++YCmA2h8hjkR9755ZyofiYRPbj+kXQ==",
+            "dev": true,
             "dependencies": {
                 "@better-auth/utils": "0.3.0",
                 "@better-fetch/fetch": "1.1.18"
@@ -940,7 +990,8 @@
         "node_modules/@better-fetch/fetch": {
             "version": "1.1.18",
             "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.18.tgz",
-            "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="
+            "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==",
+            "dev": true
         },
         "node_modules/@chevrotain/cst-dts-gen": {
             "version": "10.5.0",
@@ -2251,7 +2302,7 @@
             "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
             "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
             "deprecated": "Merged into tsx: https://tsx.is",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "~0.18.20",
@@ -2636,7 +2687,7 @@
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
             "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -2675,7 +2726,7 @@
             "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
             "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
             "deprecated": "Merged into tsx: https://tsx.is",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@esbuild-kit/core-utils": "^3.3.2",
@@ -3682,7 +3733,7 @@
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -3836,14 +3887,14 @@
             "version": "5.22.0",
             "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
             "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines": {
             "version": "5.22.0",
             "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
             "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3857,14 +3908,14 @@
             "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
             "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
             "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/fetch-engine": {
             "version": "5.22.0",
             "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
             "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "5.22.0",
@@ -3876,7 +3927,7 @@
             "version": "5.22.0",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
             "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "5.22.0"
@@ -5615,7 +5666,7 @@
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
             "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/deep-eql": "*",
@@ -5635,7 +5686,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
             "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
@@ -5769,7 +5820,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
             "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/chai": "^5.2.2",
@@ -5786,7 +5837,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
             "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/spy": "3.2.4",
@@ -5813,7 +5864,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
             "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "tinyrainbow": "^2.0.0"
@@ -5826,7 +5877,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
             "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/utils": "3.2.4",
@@ -5841,7 +5892,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
             "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/pretty-format": "3.2.4",
@@ -5856,7 +5907,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
             "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "tinyspy": "^4.0.3"
@@ -5869,7 +5920,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
             "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vitest/pretty-format": "3.2.4",
@@ -5884,7 +5935,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.26.tgz",
             "integrity": "sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.5",
@@ -5898,7 +5949,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
             "integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -5911,14 +5962,14 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@vue/compiler-dom": {
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.26.tgz",
             "integrity": "sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-core": "3.5.26",
@@ -5929,7 +5980,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
             "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.28.5",
@@ -5947,14 +5998,14 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@vue/compiler-ssr": {
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.26.tgz",
             "integrity": "sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.26",
@@ -5965,7 +6016,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.26.tgz",
             "integrity": "sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/shared": "3.5.26"
@@ -5975,7 +6026,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.26.tgz",
             "integrity": "sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.26",
@@ -5986,7 +6037,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.26.tgz",
             "integrity": "sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "3.5.26",
@@ -5999,7 +6050,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.26.tgz",
             "integrity": "sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-ssr": "3.5.26",
@@ -6013,7 +6064,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.26.tgz",
             "integrity": "sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@vueless/storybook-dark-mode": {
@@ -7117,7 +7168,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -7191,33 +7242,83 @@
             }
         },
         "node_modules/better-auth": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.1.tgz",
-            "integrity": "sha512-HDVE69Nw6Y1FPTcmFEmPolfsjMfVB5U823Ij9yWBoM8MdHZ2lA3JVus4xQJ2oRE1riJTlcSLFcgJKWGD7V7hmw==",
+            "version": "1.4.17",
+            "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.17.tgz",
+            "integrity": "sha512-VmHGQyKsEahkEs37qguROKg/6ypYpNF13D7v/lkbO7w7Aivz0Bv2h+VyUkH4NzrGY0QBKXi1577mGhDCVwp0ew==",
             "license": "MIT",
             "dependencies": {
-                "@better-auth/core": "1.4.1",
-                "@better-auth/telemetry": "1.4.1",
+                "@better-auth/core": "1.4.17",
+                "@better-auth/telemetry": "1.4.17",
                 "@better-auth/utils": "0.3.0",
-                "@better-fetch/fetch": "1.1.18",
+                "@better-fetch/fetch": "1.1.21",
                 "@noble/ciphers": "^2.0.0",
                 "@noble/hashes": "^2.0.0",
-                "@standard-schema/spec": "^1.0.0",
-                "better-call": "1.1.0",
+                "better-call": "1.1.8",
                 "defu": "^6.1.4",
                 "jose": "^6.1.0",
                 "kysely": "^0.28.5",
                 "nanostores": "^1.0.1",
-                "zod": "^4.1.12"
+                "zod": "^4.3.5"
+            },
+            "peerDependencies": {
+                "@lynx-js/react": "*",
+                "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "@sveltejs/kit": "^2.0.0",
+                "@tanstack/react-start": "^1.0.0",
+                "@tanstack/solid-start": "^1.0.0",
+                "better-sqlite3": "^12.0.0",
+                "drizzle-kit": ">=0.31.4",
+                "drizzle-orm": ">=0.41.0",
+                "mongodb": "^6.0.0 || ^7.0.0",
+                "mysql2": "^3.0.0",
+                "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+                "pg": "^8.0.0",
+                "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0",
+                "solid-js": "^1.0.0",
+                "svelte": "^4.0.0 || ^5.0.0",
+                "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+                "vue": "^3.0.0"
             },
             "peerDependenciesMeta": {
                 "@lynx-js/react": {
                     "optional": true
                 },
+                "@prisma/client": {
+                    "optional": true
+                },
                 "@sveltejs/kit": {
                     "optional": true
                 },
+                "@tanstack/react-start": {
+                    "optional": true
+                },
+                "@tanstack/solid-start": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "drizzle-kit": {
+                    "optional": true
+                },
+                "drizzle-orm": {
+                    "optional": true
+                },
+                "mongodb": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
                 "next": {
+                    "optional": true
+                },
+                "pg": {
+                    "optional": true
+                },
+                "prisma": {
                     "optional": true
                 },
                 "react": {
@@ -7232,15 +7333,79 @@
                 "svelte": {
                     "optional": true
                 },
+                "vitest": {
+                    "optional": true
+                },
                 "vue": {
                     "optional": true
                 }
             }
         },
+        "node_modules/better-auth/node_modules/@better-auth/core": {
+            "version": "1.4.17",
+            "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.17.tgz",
+            "integrity": "sha512-WSaEQDdUO6B1CzAmissN6j0lx9fM9lcslEYzlApB5UzFaBeAOHNUONTdglSyUs6/idiZBoRvt0t/qMXCgIU8ug==",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "zod": "^4.3.5"
+            },
+            "peerDependencies": {
+                "@better-auth/utils": "0.3.0",
+                "@better-fetch/fetch": "1.1.21",
+                "better-call": "1.1.8",
+                "jose": "^6.1.0",
+                "kysely": "^0.28.5",
+                "nanostores": "^1.0.1"
+            }
+        },
+        "node_modules/better-auth/node_modules/@better-auth/telemetry": {
+            "version": "1.4.17",
+            "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.17.tgz",
+            "integrity": "sha512-R1BC4e/bNjQbXu7lG6ubpgmsPj7IMqky5DvMlzAtnAJWJhh99pMh/n6w5gOHa0cqDZgEAuj75IPTxv+q3YiInA==",
+            "dependencies": {
+                "@better-auth/utils": "0.3.0",
+                "@better-fetch/fetch": "1.1.21"
+            },
+            "peerDependencies": {
+                "@better-auth/core": "1.4.17"
+            }
+        },
+        "node_modules/better-auth/node_modules/@better-fetch/fetch": {
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+            "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+        },
+        "node_modules/better-auth/node_modules/better-call": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
+            "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
+            "license": "MIT",
+            "dependencies": {
+                "@better-auth/utils": "^0.3.0",
+                "@better-fetch/fetch": "^1.1.4",
+                "rou3": "^0.7.10",
+                "set-cookie-parser": "^2.7.1"
+            },
+            "peerDependencies": {
+                "zod": "^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/better-auth/node_modules/rou3": {
+            "version": "0.7.12",
+            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+            "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+            "license": "MIT"
+        },
         "node_modules/better-call": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.0.tgz",
             "integrity": "sha512-7CecYG+yN8J1uBJni/Mpjryp8bW/YySYsrGEWgFe048ORASjq17keGjbKI2kHEOSc6u8pi11UxzkJ7jIovQw6w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@better-auth/utils": "^0.3.0",
@@ -7392,7 +7557,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/bundle-name": {
@@ -7474,7 +7639,7 @@
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
             "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -7555,7 +7720,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
             "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "assertion-error": "^2.0.1",
@@ -7625,7 +7790,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
             "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 16"
@@ -7952,7 +8117,7 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
             "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -8109,7 +8274,7 @@
             "version": "0.31.7",
             "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.7.tgz",
             "integrity": "sha512-hOzRGSdyKIU4FcTSFYGKdXEjFsncVwHZ43gY3WU5Bz9j5Iadp6Rh6hxLSQ1IWXpKLBKt/d5y1cpSPcV+FcoQ1A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@drizzle-team/brocli": "^0.10.2",
@@ -8125,7 +8290,7 @@
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
             "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/drizzle-orm": {
@@ -8362,7 +8527,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
             "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -8381,7 +8546,7 @@
             "version": "0.25.12",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
             "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -8423,7 +8588,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
             "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4"
@@ -8481,7 +8646,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
@@ -8523,7 +8688,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
             "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.0.0"
@@ -8722,7 +8887,7 @@
             "version": "4.13.0",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
             "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -10002,7 +10167,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
             "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/lower-case": {
@@ -10056,7 +10221,7 @@
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -11299,14 +11464,14 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
             "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14.16"
@@ -11426,7 +11591,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -11475,7 +11640,7 @@
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
             "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -11518,7 +11683,7 @@
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -11666,7 +11831,7 @@
             "version": "5.22.0",
             "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
             "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -12286,7 +12451,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -12296,7 +12461,7 @@
             "version": "4.53.3",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
             "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.8"
@@ -12338,6 +12503,7 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.5.1.tgz",
             "integrity": "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/run-applescript": {
@@ -12536,7 +12702,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC"
         },
         "node_modules/simple-concat": {
@@ -12607,7 +12773,7 @@
             "version": "1.9.10",
             "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.10.tgz",
             "integrity": "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -12620,7 +12786,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
             "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -12631,7 +12797,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.3.3.tgz",
             "integrity": "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -12655,7 +12821,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -12665,7 +12831,7 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
@@ -12676,7 +12842,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -12706,7 +12872,7 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/standardwebhooks": {
@@ -12723,7 +12889,7 @@
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
             "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/stoppable": {
@@ -12870,7 +13036,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
             "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^9.0.1"
@@ -12883,7 +13049,7 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
             "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/stripe": {
@@ -13064,21 +13230,21 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
             "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/tinyexec": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
             "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
             "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -13095,7 +13261,7 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
@@ -13113,7 +13279,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -13126,7 +13292,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
             "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
@@ -13136,7 +13302,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
             "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
@@ -13146,7 +13312,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
             "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
@@ -13575,7 +13741,7 @@
             "version": "7.2.4",
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
             "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
@@ -13650,7 +13816,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
             "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
@@ -13693,7 +13859,7 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
@@ -13711,7 +13877,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -13724,7 +13890,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/chai": "^5.2.2",
@@ -13797,7 +13963,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -13810,7 +13976,7 @@
             "version": "3.5.26",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
             "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@vue/compiler-dom": "3.5.26",
@@ -13864,7 +14030,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
             "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "siginfo": "^2.0.0",

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -38,7 +38,7 @@
         "@polar-sh/sdk": "^0.41.5",
         "@scalar/hono-api-reference": "^0.9.32",
         "@tanstack/react-router": "^1.139.3",
-        "better-auth": "^1.3.17",
+        "better-auth": "^1.4.17",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.44.7",

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -64,7 +64,7 @@ export function createAuth(env: Cloudflare.Env) {
         rateLimit: {
             enabled: true,
             timeWindow: 1000, // 1 second
-            maxRequests: 5, // 5 requests
+            maxRequests: 10000, // Support high-volume games (10k req/s)
         },
     });
 
@@ -165,7 +165,7 @@ function polarPlugin(
 }
 
 function onBeforeUserCreate(polar: Polar) {
-    return async (user: Partial<User>, ctx?: GenericEndpointContext) => {
+    return async (user: Partial<User>, ctx: GenericEndpointContext | null) => {
         if (!ctx) return;
         try {
             if (!user.email) {
@@ -208,7 +208,7 @@ function onBeforeUserCreate(polar: Polar) {
 }
 
 function onAfterUserCreate(polar: Polar, defaultTierProductId?: string) {
-    return async (user: GenericUser, ctx?: GenericEndpointContext) => {
+    return async (user: GenericUser, ctx: GenericEndpointContext | null) => {
         if (!ctx) return;
         try {
             const { result } = await polar.customers.list({
@@ -245,7 +245,7 @@ function onAfterUserCreate(polar: Polar, defaultTierProductId?: string) {
 }
 
 function onUserUpdate(polar: Polar) {
-    return async (user: GenericUser, ctx?: GenericEndpointContext) => {
+    return async (user: GenericUser, ctx: GenericEndpointContext | null) => {
         if (!ctx) return;
         try {
             await polar.customers.updateExternal({


### PR DESCRIPTION
## Problem

Users (specifically wBrowsqq with a Roblox game) were experiencing intermittent `401 UNAUTHORIZED` errors when using `nova-fast` model, even with valid API keys.

## Root Cause

The `better-auth` API key plugin has a rate limit on key verification (was set to 5 req/s). When exceeded, it incorrectly returns `401 UNAUTHORIZED` instead of `429 TOO_MANY_REQUESTS`.

This is a known bug in better-auth, fixed in [PR #3213](https://github.com/better-auth/better-auth/pull/3213) (merged June 29, 2025), but we're on version `1.3.17` which doesn't include the fix.

## Solution

1. **Increase rate limit** from 5 to 10,000 requests/second to support high-volume games with many concurrent users
2. **Add proper 429 handling** in auth middleware to catch rate limit errors and re-throw as proper 429

## Changes

- `enter.pollinations.ai/src/auth.ts`: Increase `maxRequests` from 5 to 10,000
- `enter.pollinations.ai/src/middleware/auth.ts`: Add try/catch for rate limit errors

## Future

Consider upgrading `better-auth` to a version that includes the 401→429 fix once it's released in a stable version.