### PR TITLE
[WIP] Add Claude Code web search config with Perplexity MCP

### DIFF
--- a/.claude/WEB_SEARCH_SETUP.md
+++ b/.claude/WEB_SEARCH_SETUP.md
@@ -1,0 +1,95 @@
+# Web Search Setup for Claude Code
+
+This project is configured with web search capabilities via MCP servers and skills.
+
+## Quick Start
+
+### Get the Perplexity API Key
+
+The key is in `text.pollinations.ai/secrets/env.json`. Extract it with:
+
+```bash
+cd text.pollinations.ai && sops -d secrets/env.json | jq -r '.PERPLEXITY_API_KEY'
+```
+
+### Set the Environment Variable
+
+Add to your `~/.zshrc`:
+
+```bash
+export PERPLEXITY_API_KEY="pplx-xxx..."  # paste key here
+```
+
+Then: `source ~/.zshrc` and restart Claude Code.
+
+## What's Configured
+
+### MCP Server: Perplexity (`.mcp.json`)
+
+The project includes a `.mcp.json` that configures the Perplexity MCP server. It uses `${PERPLEXITY_API_KEY}` environment variable expansion, so the actual key is never committed.
+
+**Available tools:**
+- `perplexity_search` - Direct web search with ranked results
+- `perplexity_ask` - Conversational AI with real-time web search
+- `perplexity_research` - Deep research with citations
+- `perplexity_reason` - Advanced reasoning and problem-solving
+
+### Skill: web-research (`.claude/skills/web-research/`)
+
+A skill that provides structured research workflows:
+- Multi-source research strategy
+- Parallel subagent spawning
+- Citation and verification guidelines
+
+### Subagent: web-researcher (`.claude/agents/web-researcher.md`)
+
+A specialized subagent for research tasks that can be invoked with:
+```
+Use the web-researcher subagent to research [topic]
+```
+
+## Usage Examples
+
+### Quick search
+```
+Search the web for latest Claude Code best practices
+```
+
+### Deep research
+```
+Research how to implement semantic caching with Cloudflare Vectorize
+```
+
+### Using the subagent
+```
+Use the web-researcher subagent to investigate Bedrock web search support
+```
+
+## Troubleshooting
+
+### "PERPLEXITY_API_KEY not set"
+
+Make sure the environment variable is set in your shell:
+```bash
+echo $PERPLEXITY_API_KEY
+```
+
+### MCP server not loading
+
+Check MCP status:
+```
+/mcp
+```
+
+Restart Claude Code after setting environment variables.
+
+### Bedrock users
+
+Note: Anthropic's built-in `WebSearch` tool is **not available on Bedrock**. The Perplexity MCP server is the recommended alternative for web search capabilities.
+
+## Getting a Perplexity API Key
+
+1. Go to https://www.perplexity.ai/account/api/group
+2. Create an API group if you don't have one
+3. Generate a new API key
+4. Set it as `PERPLEXITY_API_KEY` environment variable

--- a/.claude/agents/web-researcher.md
+++ b/.claude/agents/web-researcher.md
@@ -1,0 +1,61 @@
+---
+name: web-researcher
+description: Research topics using web search, Perplexity, and multiple sources. Spawns parallel searches and synthesizes findings.
+model: claude-sonnet-4-5-20250514
+allowed-tools:
+  - WebSearch
+  - WebFetch
+  - Read
+  - Grep
+  - Glob
+  - mcp__perplexity__perplexity_search
+  - mcp__perplexity__perplexity_ask
+  - mcp__perplexity__perplexity_research
+---
+
+# Web Researcher Subagent
+
+You are a specialized research agent. Your job is to find accurate, up-to-date information from multiple sources.
+
+## Research Process
+
+1. **Understand the Query**: Parse what information is needed
+2. **Search Multiple Sources**: Use available tools to gather information
+3. **Verify & Cross-Reference**: Check multiple sources for accuracy
+4. **Synthesize**: Combine findings into a clear summary with citations
+
+## Tool Priority
+
+1. **perplexity_research** - For deep, comprehensive research with citations
+2. **perplexity_ask** - For quick questions with web context
+3. **perplexity_search** - For finding specific URLs/sources
+4. **WebSearch** - Anthropic's built-in search (fallback)
+5. **WebFetch** - To read specific URLs you've found
+
+## Output Format
+
+Always structure your findings as:
+
+```markdown
+## Summary
+[Brief answer to the research question]
+
+## Key Findings
+- [Finding 1] - [Source URL]
+- [Finding 2] - [Source URL]
+
+## Details
+[Expanded information organized by topic]
+
+## Sources
+1. [Title](URL) - Brief description
+2. [Title](URL) - Brief description
+```
+
+## Guidelines
+
+- Always cite sources with URLs
+- Note publication dates when available
+- Flag conflicting information between sources
+- Prefer official documentation over blog posts
+- Be explicit about uncertainty

--- a/.claude/skills/web-research/SKILL.md
+++ b/.claude/skills/web-research/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: web-research
+description: Research a topic using web search, parallel subagents, and multiple sources. Use when asked to research, investigate, find information, or verify facts.
+allowed-tools: Task, WebSearch, WebFetch, Grep, Glob, Read, mcp__perplexity__perplexity_search, mcp__perplexity__perplexity_ask, mcp__perplexity__perplexity_research
+---
+
+# Web Research Skill
+
+When researching a topic, use this multi-source approach for comprehensive results.
+
+## Available Tools
+
+### Built-in Tools
+- **WebSearch**: Find URLs for a topic (Anthropic's search, may not work on Bedrock)
+- **WebFetch**: Fetch and analyze content from a specific URL
+
+### MCP Tools (if configured)
+- **perplexity_search**: Direct web search with ranked results
+- **perplexity_ask**: Conversational AI with real-time web search (sonar-pro)
+- **perplexity_research**: Deep research with citations (sonar-deep-research)
+
+## Research Strategy
+
+### Step 1: Quick Search
+Use `perplexity_ask` or `WebSearch` for initial exploration:
+- Get overview of the topic
+- Identify key sources and URLs
+- Note important terminology
+
+### Step 2: Deep Dive (if needed)
+For complex topics, use `perplexity_research` or spawn parallel subagents:
+
+```
+Use Task tool to spawn these subagents in parallel:
+
+1. **Documentation Agent** (subagent_type: general-purpose)
+   - Search official documentation
+   - Find GitHub repos/issues
+   - Look for best practices
+
+2. **Community Agent** (subagent_type: general-purpose)
+   - Search Stack Overflow, Reddit discussions
+   - Find real-world experiences
+   - Note common pitfalls
+
+3. **Codebase Explorer** (subagent_type: Explore)
+   - Search existing patterns in this codebase
+   - Find related implementations
+```
+
+### Step 3: Synthesize
+After gathering information:
+- Cross-reference multiple sources
+- Verify information is current (check dates)
+- Prioritize official docs over blog posts
+- Note version-specific considerations
+
+## Guidelines
+
+- **Cite sources**: Always include URLs for claims
+- **Verify recency**: Check publication dates, prefer recent info
+- **Cross-reference**: Don't rely on single source for important facts
+- **Be skeptical**: Note when sources conflict
+- **Respect rate limits**: Don't spam search APIs
+
+## Example Usage
+
+```
+Research the latest best practices for Claude Code web search integration
+```
+
+```
+Find how other projects implement semantic caching with Cloudflare Vectorize
+```
+
+```
+Investigate why Bedrock doesn't support Anthropic's web_search tool
+```

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ debugsession_*/
 *.swp
 *.swo
 *~
+
+# Claude Code local config (may contain API keys)
+~/.claude.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "perplexity": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@perplexity-ai/mcp-server"],
+      "env": {
+        "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## WIP: Claude Code Web Search Configuration

Adds web search capabilities for Claude Code using Perplexity MCP server.

### Added
- `.mcp.json` - Perplexity MCP server config (uses `${PERPLEXITY_API_KEY}` env var)
- `.claude/skills/web-research/SKILL.md` - Web research skill
- `.claude/agents/web-researcher.md` - Research subagent
- `.claude/WEB_SEARCH_SETUP.md` - Setup docs

### Setup
```bash
# Get key from encrypted secrets
cd text.pollinations.ai && sops -d secrets/env.json | jq -r '.PERPLEXITY_API_KEY'

# Add to ~/.zshrc
export PERPLEXITY_API_KEY="pplx-xxx..."
```

### Why Perplexity MCP?
Anthropic's built-in `web_search` tool is **not available on Bedrock**. Perplexity MCP provides equivalent functionality.