### PR TITLE
fix(enter): reduce rate limit from 10k to 1k req/s

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -64,7 +64,7 @@ export function createAuth(env: Cloudflare.Env) {
         rateLimit: {
             enabled: true,
             timeWindow: 1000, // 1 second
-            maxRequests: 10000, // Support high-volume games (10k req/s)
+            maxRequests: 1000, // 1k req/s per API key
         },
     });
 


### PR DESCRIPTION
Reduce API key rate limit from 10,000 to 1,000 requests per second.

10k was excessive - 1k/sec is still plenty for high-volume use cases.

**Also updated all existing keys in production D1** to use the new 1k limit.