### PR TITLE
fix: add Nova Lite fallback for nova-fast + silence auth tracking errors

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -88,8 +88,10 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
                 ? {
                       handler: (promise: Promise<any>) => {
                           ctx.waitUntil(
-                              promise.catch((e) => {
-                                  console.error("Background task failed:", e);
+                              promise.catch(() => {
+                                  // Silently ignore - these are non-critical tracking updates
+                                  // (lastRequest, requestCount) that fail due to D1 contention
+                                  // under high concurrent load. Auth still works correctly.
                               }),
                           );
                       },

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -160,7 +160,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "nova-fast",
-        config: portkeyConfig["amazon.nova-micro-v1:0"],
+        config: portkeyConfig["nova-micro-fallback"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -186,6 +186,32 @@ export const portkeyConfig: PortkeyConfigMap = {
         createBedrockNativeConfig({
             model: "amazon.nova-micro-v1:0",
         }),
+    // Nova Micro with Nova Lite fallback for rate limiting
+    "nova-micro-fallback": () => ({
+        strategy: { mode: "fallback" },
+        targets: [
+            // Primary: Nova Micro (cheapest)
+            {
+                provider: "bedrock",
+                aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
+                aws_region: process.env.AWS_REGION || "us-east-1",
+                override_params: {
+                    model: "amazon.nova-micro-v1:0",
+                },
+            },
+            // Fallback: Nova Lite (multimodal, slightly more expensive but still cheap)
+            {
+                provider: "bedrock",
+                aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
+                aws_region: process.env.AWS_REGION || "us-east-1",
+                override_params: {
+                    model: "amazon.nova-lite-v1:0",
+                },
+            },
+        ],
+    }),
 
     // ============================================================================
     // Google Vertex AI - gemini, gemini-fast, gemini-large, gemini-search, kimi-k2-thinking


### PR DESCRIPTION
## Summary

Two fixes for production stability:

### 1. Nova Lite fallback for `nova-fast`

When Nova Micro hits rate limits (429 errors), Portkey will automatically fall back to Nova Lite.

**Pricing comparison:**
| Model | Input (per 1K tokens) | Output (per 1K tokens) |
|-------|----------------------|------------------------|
| Nova Micro | $0.000035 | $0.00014 |
| Nova Lite | $0.00006 | $0.00024 |

Nova Lite is ~2x the cost but still very cheap, and provides rate limit resilience.

### 2. Silence non-critical Better Auth tracking errors

The `deferUpdates` + `backgroundTasks` configuration is working, but the D1 database still experiences contention under high concurrent load. These errors are for non-critical tracking data (`lastRequest`, `requestCount`) - auth still works correctly.

Changed from logging errors to silently ignoring them since they don't affect functionality.

## Changes

- `text.pollinations.ai/configs/modelConfigs.ts`: Add `nova-micro-fallback` config
- `text.pollinations.ai/availableModels.ts`: Switch `nova-fast` to use fallback config
- `enter.pollinations.ai/src/auth.ts`: Silence background task errors

## Testing

- [ ] Deploy to text.pollinations.ai EC2
- [ ] Deploy to enter.pollinations.ai Cloudflare Workers
- [ ] Verify nova-fast works and falls back on rate limit