### PR TITLE
fix: use zimage model for supporter logos

### DIFF
--- a/pollinations.ai/src/copy/constants.ts
+++ b/pollinations.ai/src/copy/constants.ts
@@ -15,5 +15,5 @@ export const COPY_CONSTANTS = {
     supporterLogoPrompt:
         "Brutalist logo design with bold geometric shapes, heavy lines, stark contrast, raw minimalist aesthetic, transparent background (no background), flat design style. Company:",
     supporterLogoSeed: 1,
-    supporterLogoModel: "nanobanana",
+    supporterLogoModel: "zimage",
 };

--- a/pollinations.ai/src/theme/guidelines/helpers/illustrator.ts
+++ b/pollinations.ai/src/theme/guidelines/helpers/illustrator.ts
@@ -33,6 +33,6 @@ export async function generateSupporterLogo(
         width,
         height,
         seed,
-        model: "nanobanana",
+        model: "zimage",
     });
 }


### PR DESCRIPTION
## Summary
The supporter logos on the community page were not displaying.

## Root Cause
The `nanobanana` model was returning 403 errors with the default publishable key.

## Fix
Changed the supporter logo model from `nanobanana` to `zimage` which works correctly with the default API key.

## Files Changed
- `pollinations.ai/src/copy/constants.ts`
- `pollinations.ai/src/theme/guidelines/helpers/illustrator.ts`