### PR TITLE
fix(workflows): exclude apps/myceli from generic app deploy workflows

### DIFF
--- a/.github/workflows/app-deploy-manual.yml
+++ b/.github/workflows/app-deploy-manual.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/*/**'
       - '!apps/scripts/**'
       - '!apps/*.md'
+      - '!apps/myceli/**'
   workflow_dispatch:
     inputs:
       app_name:

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'apps/**'
+      - '!apps/myceli/**'
     branches: [production]
   workflow_dispatch:
 


### PR DESCRIPTION
Myceli apps have their own dedicated deploy workflow (deploy-myceli-websites.yml). This prevents the generic app-deploy and app-deploy-manual workflows from trying to deploy myceli subdirectories (economics-dashboard, kpi-dashboard, etc.) which causes failures because they're not in apps.json.