### PR TITLE
fix(enter): reject API keys with no user to prevent infinite pollen bug

### DIFF
--- a/enter.pollinations.ai/src/utils/track-helpers.ts
+++ b/enter.pollinations.ai/src/utils/track-helpers.ts
@@ -40,6 +40,16 @@ export async function handleBalanceDeduction({
     // Handle user balance deduction
     if (userId) {
         await deductUserBalance(db, userId, totalPrice);
+    } else {
+        // CRITICAL: Billable usage without userId means balance won't be deducted!
+        // This is a bug - log it so we can investigate
+        log.error(
+            "BILLING_SKIP: Billable request with no userId - balance NOT deducted! price={price} apiKeyId={apiKeyId}",
+            {
+                price: totalPrice,
+                apiKeyId: apiKeyId ?? "none",
+            },
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #7709

## Problem
Users reported an "Infinite Pollen Glitch" where balance decreases after usage but instantly resets to full tier limit.

**Root cause:** When an API key has a broken/missing user association in D1, the balance deduction in `track-helpers.ts` was silently skipped because `userId` was undefined.

## Solution
1. **Reject requests** with HTTP 402 when API key exists but has no associated user
2. **Add backup logging** in track-helpers.ts if billing is somehow still skipped

## Changes
- `enter.pollinations.ai/src/middleware/auth.ts`: Add check for missing user, throw 402
- `enter.pollinations.ai/src/utils/track-helpers.ts`: Add error logging as safety net

## Testing
- API keys with valid user: ✅ Works normally
- API keys with missing user: ✅ Returns 402 with helpful message