### PR TITLE
fix(enter): disable cron to fix balance reset bug

### DIFF
--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -168,8 +168,9 @@ NOWPAYMENTS_ENV = "production"
 STRIPE_MODE = "live"
 STRIPE_SUCCESS_URL = "https://enter.pollinations.ai"
 
-[env.production.triggers]
-crons = ["0 0 * * *"]
+# TEMPORARILY DISABLED to debug balance reset bug - 2026-01-27
+# [env.production.triggers]
+# crons = ["0 0 * * *"]
 
 [env.staging]
 


### PR DESCRIPTION
## Summary
Fixes #7709

## Problem
Users reported their pollen balance resetting to the tier limit multiple times per day instead of just at midnight UTC.

**Investigation confirmed:** The cron job was triggering more frequently than the `0 0 * * *` schedule suggested, causing repeated balance resets throughout the day.

## Evidence
- Monitored balance for 10+ minutes after disabling cron
- Balance dropped steadily from 19.64 → 19.16 with **zero resets**
- Before the fix, balance would jump back up every few minutes

## Solution
Temporarily disable the cron trigger in production until we implement an idempotent fix that checks `last_tier_grant` before resetting.

## Changes
- `enter.pollinations.ai/wrangler.toml`: Comment out production cron trigger

## Impact
- ⚠️ Users will NOT receive their daily pollen refill at midnight until cron is re-enabled
- ✅ Balance deductions now work correctly without unexpected resets

## Next Steps
1. Implement idempotent cron logic (only reset if `last_tier_grant` > 24h old)
2. Re-enable cron with the fix