### PR TITLE
Add IP logging to EC2 services for security investigation

### DIFF
--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -5,6 +5,7 @@ import { parse } from "node:url";
 import debug from "debug";
 import urldecode from "urldecode";
 import { extractToken, getIp } from "../../shared/extractFromRequest.js";
+import { logIp } from "../../shared/ipLogger.js";
 import { countFluxJobs, handleRegisterEndpoint } from "./availableServers.js";
 // IMAGE_CONFIG imported but used elsewhere
 // import { IMAGE_CONFIG } from "./models.js";
@@ -537,6 +538,11 @@ const server = http.createServer((req, res) => {
 
     const parsedUrl = parse(req.url, true);
     const pathname = parsedUrl.pathname;
+
+    // IP logging for security investigation
+    const ip = getIp(req);
+    const model = (parsedUrl.query?.model as string) || "unknown";
+    logIp(ip, "image", `path=${pathname} model=${model}`);
 
     // Handle deprecated /models endpoint BEFORE auth check
     if (pathname === "/models") {

--- a/shared/ipLogger.js
+++ b/shared/ipLogger.js
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+
+// IP logging for security investigation
+// Logs requester IPs to console and file for easy grep
+
+const LOG_FILE = process.env.IP_LOG_FILE || "/tmp/pollinations-ip-requests.log";
+
+/**
+ * Log an IP address with timestamp and optional context
+ * @param {string} ip - The IP address
+ * @param {string} service - Service name (text/image)
+ * @param {string} [context] - Optional context (endpoint, model, etc.)
+ */
+export function logIp(ip, service, context = "") {
+    const timestamp = new Date().toISOString();
+    const logLine = `[${timestamp}] [${service}] IP=${ip} ${context}`.trim();
+
+    // Console log for grep
+    console.log(`[IP-LOG] ${logLine}`);
+
+    // File log for persistence
+    try {
+        fs.appendFileSync(LOG_FILE, logLine + "\n");
+    } catch (err) {
+        console.error(`[IP-LOG] Failed to write to ${LOG_FILE}:`, err.message);
+    }
+}
+
+/**
+ * Get the log file path
+ */
+export function getLogFilePath() {
+    return LOG_FILE;
+}

--- a/text.pollinations.ai/server.js
+++ b/text.pollinations.ai/server.js
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 import express from "express";
 // Import shared utilities
 import { getIp } from "../shared/extractFromRequest.js";
+import { logIp } from "../shared/ipLogger.js";
 import { getServiceDefinition } from "../shared/registry/registry.js";
 import {
     buildUsageHeaders,
@@ -31,6 +32,14 @@ const authLog = debug("pollinations:auth");
 // Remove the custom JSON parsing middleware and use the standard bodyParser
 app.use(bodyParser.json({ limit: "20mb" }));
 app.use(cors());
+
+// IP logging middleware - log all incoming request IPs for security investigation
+app.use((req, _res, next) => {
+    const ip = getIp(req);
+    const model = req.body?.model || req.query?.model || "unknown";
+    logIp(ip, "text", `path=${req.path} model=${model}`);
+    next();
+});
 
 // Middleware to verify PLN_ENTER_TOKEN (after CORS for consistency)
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
Adds IP logging to both text and image services deployed on EC2 to investigate potential enter token leak.

## Changes
- **`shared/ipLogger.js`** - New shared utility for IP logging
  - Logs to console with `[IP-LOG]` prefix for easy grep
  - Logs to file at `/tmp/pollinations-ip-requests.log`
  - Configurable via `IP_LOG_FILE` env var

- **`text.pollinations.ai/server.js`** - Added IP logging middleware
- **`image.pollinations.ai/src/index.ts`** - Added IP logging in request handler

## Log Format
```
[IP-LOG] [2026-01-28T00:15:00.000Z] [text] IP=1.2.3.4 path=/v1/chat/completions model=openai
[IP-LOG] [2026-01-28T00:15:01.000Z] [image] IP=5.6.7.8 path=/prompt/test model=flux
```

## Usage After Deployment
```bash
# Grep console logs
grep "[IP-LOG]" /path/to/service.log

# View/watch file log
tail -f /tmp/pollinations-ip-requests.log

# Find specific IP
grep "IP=1.2.3.4" /tmp/pollinations-ip-requests.log
```

## Note
This is a temporary security measure to identify unauthorized access patterns. Can be removed once investigation is complete.