### PR TITLE
feat: upgrade kimi to K2.5 via Fireworks AI

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -368,22 +368,24 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "kimi": {
-        aliases: ["kimi-k2", "kimi-reasoning", "kimi-k2-thinking"],
-        modelId: "moonshotai/kimi-k2-thinking-maas",
-        provider: "google",
+        aliases: ["kimi-k2.5", "kimi-k2p5", "kimi-reasoning", "kimi-large"],
+        modelId: "accounts/fireworks/models/kimi-k2p5",
+        provider: "fireworks",
         cost: [
             {
-                date: COST_START_DATE,
+                date: new Date("2026-01-28").getTime(),
                 promptTextTokens: perMillion(0.6),
-                completionTextTokens: perMillion(2.5),
+                promptCachedTokens: perMillion(0.1),
+                completionTextTokens: perMillion(3.0),
             },
         ],
         description:
-            "Moonshot Kimi K2 Thinking - Deep Reasoning & Tool Orchestration",
-        inputModalities: ["text"],
+            "Moonshot Kimi K2.5 - Flagship Agentic Model with Vision & Multi-Agent",
+        inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
+        contextWindow: 256000,
         isSpecialized: false,
     },
     "gemini-large": {

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -133,7 +133,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "kimi",
-        config: portkeyConfig["kimi-k2-thinking-maas"],
+        config: portkeyConfig["accounts/fireworks/models/kimi-k2p5"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -281,8 +281,12 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // ============================================================================
-    // Fireworks AI - glm-4.7, minimax-m2.1, deepseek-v3.2
+    // Fireworks AI - glm-4.7, minimax-m2.1, deepseek-v3.2, kimi-k2.5
     // ============================================================================
+    "accounts/fireworks/models/kimi-k2p5": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/kimi-k2p5",
+        }),
     "accounts/fireworks/models/glm-4p7": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/glm-4p7",


### PR DESCRIPTION
## Summary
Upgrades the `kimi` model from K2 Thinking to **Kimi K2.5** - Moonshot AI's flagship agentic model.

## Why K2.5?
- **Strictly better**: K2.5 = K2 + 15T additional training tokens
- **Vision support**: Now accepts images (K2 was text-only)
- **Agent Swarm**: Can orchestrate up to 100 sub-agents with 1,500 tool calls
- **SOTA benchmarks**: Beats K2 on HLE, AIME 2025, GPQA-Diamond, SWE-Bench

## Changes
| File | Change |
|------|--------|
| `shared/registry/text.ts` | Updated `kimi` service to use K2.5 model |
| `text.pollinations.ai/availableModels.ts` | Updated config to Fireworks K2.5 |
| `text.pollinations.ai/configs/modelConfigs.ts` | Added Fireworks config for kimi-k2p5 |

## Pricing
| | K2 (old) | K2.5 (new) |
|---|---|---|
| Input | $0.60/1M | $0.60/1M |
| Cached | - | $0.10/1M |
| Output | $2.50/1M | $3.00/1M |

Output is 20% more expensive but capabilities are significantly better.

## Aliases
`kimi`, `kimi-k2.5`, `kimi-k2p5`, `kimi-reasoning`, `kimi-large`