### PR TITLE
fix: reduce klein-large concurrency to prevent OOM errors

### DIFF
--- a/image.pollinations.ai/image_gen_flux_klein/flux_klein_9b.py
+++ b/image.pollinations.ai/image_gen_flux_klein/flux_klein_9b.py
@@ -90,8 +90,8 @@ class EditRequest(BaseModel):
     image=flux_klein_image,
     scaledown_window=5 * MINUTES,
     timeout=10 * MINUTES,
-    max_containers=2,
-    concurrency_limit=2,
+    max_containers=4,  # Increased to compensate for lower concurrency
+    concurrency_limit=1,  # Reduced from 2 - 9B model uses ~44GB VRAM, can't handle concurrent requests
     volumes={
         "/cache": modal.Volume.from_name("hf-hub-cache", create_if_missing=True),
         "/root/.nv": modal.Volume.from_name("nv-cache", create_if_missing=True),


### PR DESCRIPTION
## Problem
The klein-large (9B) model was showing **12.5% success rate** with 35.4s average response time due to CUDA OOM errors.

## Root Cause
The 9B model uses ~44GB VRAM on L40S (48GB GPU), leaving no room for concurrent requests. With `concurrency_limit=2`, two requests on the same container caused OOM crashes:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB. 
GPU 0 has a total capacity of 44.39 GiB of which 9.38 MiB is free.
```

## Fix
- Reduce `concurrency_limit` from 2 to 1 (one request per container)
- Increase `max_containers` from 2 to 4 (maintain throughput)

## Results
After deployment, the 5-minute window shows:
- ✅ **100% success rate** (2/2 requests)
- ✅ **0 errors** (was 18 5xx errors)
- ✅ **3.0s avg latency** (was 35.4s including retries)

## Already Deployed
The Modal app has been redeployed with these changes.