### PR TITLE
fix: remove double URL-encoding in Instagram I2I image generation

### DIFF
--- a/social/scripts/instagram_generate_post.py
+++ b/social/scripts/instagram_generate_post.py
@@ -344,12 +344,12 @@ def generate_image(prompt: str, token: str, index: int, reference_url: str = Non
             "key": token
         }
 
-        # Add reference image for I2I (must be fully URL-encoded)
+        # Add reference image for I2I
         if reference_url:
             # Strip key= param from reference URL if present (auth goes on outer URL only)
             clean_ref = re.sub(r'[&?]key=[^&]*', '', reference_url)
-            # Encode the full URL so nested params don't break outer URL parsing
-            params["image"] = quote(clean_ref, safe='')
+            # Don't pre-encode - requests library handles URL encoding of params
+            params["image"] = clean_ref
 
         if attempt == 0:
             print(f"  Using seed: {seed}")


### PR DESCRIPTION
## Problem

The Instagram post generation workflow (`NEWS_Instagram_generate_posts.yml`) has been failing since the enter.pollinations.ai refactor. Carousel images using image-to-image (I2I) references were getting **400 Bad Request** errors:

```
"Invalid image URL. Put image= param last in your URL, or URL-encode it."
```

## Root Cause

The `image` parameter was being pre-encoded with `quote()` before passing to `requests.get()`, which then encoded it **again**. This double-encoding corrupted the URL (e.g., `%20` → `%2520`).

## Fix

Removed the redundant `quote()` call. The `requests` library handles URL encoding of params automatically.

## Testing

Verified locally with a real I2I API call:
```
Testing I2I request with fix...
Status: 200
Content-Type: image/jpeg
SUCCESS: Got image (14,774 bytes)
```

## Related

- Failed run: https://github.com/pollinations/pollinations/actions/runs/21404518220