### PR TITLE
refactor: standardize GitHub secrets for pollinations.ai API keys

### DIFF
--- a/.github/workflows/NEWS_Discord_post_merged_pr.yml
+++ b/.github/workflows/NEWS_Discord_post_merged_pr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Review PR and Post to Discord
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO_FULL_NAME: ${{ github.repository }}

--- a/.github/workflows/NEWS_Discord_post_weekly_news.yml
+++ b/.github/workflows/NEWS_Discord_post_weekly_news.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Transform and Post to Discord
         env:
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           DISCORD_WEBHOOK_DIGEST: ${{ secrets.DISCORD_WEBHOOK_DIGEST }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: python social/scripts/discord_post_weekly_news.py

--- a/.github/workflows/NEWS_GitHub_create_highlights.yml
+++ b/.github/workflows/NEWS_GitHub_create_highlights.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create Highlights and PR
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_LABELS: NEWS
         run: python social/scripts/github_create_highlights.py

--- a/.github/workflows/NEWS_GitHub_create_weekly_news.yml
+++ b/.github/workflows/NEWS_GitHub_create_weekly_news.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate NEWS.md and Create PR
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_LABELS: NEWS
         run: python social/scripts/github_create_weekly_news.py

--- a/.github/workflows/NEWS_Instagram_generate_posts.yml
+++ b/.github/workflows/NEWS_Instagram_generate_posts.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate Instagram Post and Create PR
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SOURCE_REPO: ${{ inputs.source_repo || 'pollinations/pollinations' }}
           DAYS_BACK: ${{ inputs.days_back || '1' }}

--- a/.github/workflows/NEWS_LinkedIn_generate_posts.yml
+++ b/.github/workflows/NEWS_LinkedIn_generate_posts.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate LinkedIn Post and Create PR
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SOURCE_REPO: ${{ inputs.source_repo || 'pollinations/pollinations' }}
           DAYS_BACK: ${{ inputs.days_back || '7' }}

--- a/.github/workflows/NEWS_Twitter_generate_posts.yml
+++ b/.github/workflows/NEWS_Twitter_generate_posts.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate Twitter Post and Create PR
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
-          POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SOURCE_REPO: ${{ inputs.source_repo || 'pollinations/pollinations' }}
           DAYS_BACK: ${{ inputs.days_back || '1' }}

--- a/.github/workflows/app-review-submission.yml
+++ b/.github/workflows/app-review-submission.yml
@@ -174,7 +174,7 @@ jobs:
         run: python .github/scripts/app-review-agent.py
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
-          POLLINATIONS_API_KEY: ${{ secrets.CLAUDE_CODE_TOKEN }}
+          POLLINATIONS_API_KEY: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           ISSUE_AUTHOR: ${{ steps.issue.outputs.author }}
           VALIDATION_RESULT: ${{ steps.validate.outputs.result }}

--- a/.github/workflows/pr-issue-assistant.yml
+++ b/.github/workflows/pr-issue-assistant.yml
@@ -28,7 +28,7 @@ jobs:
       id-token: write
       actions: read
     env:
-      CLAUDE_CODE_TOKEN: ${{ secrets.CLAUDE_CODE_TOKEN }}
+      POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: token
@@ -97,7 +97,7 @@ jobs:
           BOT_USER_ID=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
           echo "user-id=$BOT_USER_ID" >> "$GITHUB_OUTPUT"
           mkdir -p $HOME/.claude-code-router
-          echo '{"LOG":false,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"${CLAUDE_CODE_TOKEN}","models":["claude-large","claude","kimi-k2-thinking","perplexity-reasoning","openai-large","openai"]}],"Router":{"default":"pollinations,claude-large","background":"pollinations,claude","think":"pollinations,kimi-k2-thinking","longContext":"pollinations,claude-large","longContextThreshold":60000,"webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
+          echo '{"LOG":false,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"${POLLINATIONS_TOKEN}","models":["claude-large","claude","kimi-k2-thinking","perplexity-reasoning","openai-large","openai"]}],"Router":{"default":"pollinations,claude-large","background":"pollinations,claude","think":"pollinations,kimi-k2-thinking","longContext":"pollinations,claude-large","longContextThreshold":60000,"webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
 
           # Start router with Bun
           bunx @musistudio/claude-code-router start &

--- a/.github/workflows/project-manager.yml
+++ b/.github/workflows/project-manager.yml
@@ -41,5 +41,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           GITHUB_EVENT: ${{ toJSON(github.event) }}
-          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_PROJECT_MANAGER_SK_KEY }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
         run: python .github/scripts/project-manager.py


### PR DESCRIPTION
## Summary

Standardizes GitHub secret names for pollinations.ai API keys across all workflows.

## Changes

**NEWS workflows (7 files):**
- Changed `secrets.POLLINATIONS_TOKEN` → `secrets.PLN_GITHUB_NEWS_KEY`

**Polly/automation workflows (3 files):**
- `pr-issue-assistant.yml`: `secrets.CLAUDE_CODE_TOKEN` → `secrets.PLN_GITHUB_POLLY_KEY`
- `project-manager.yml`: `secrets.PLN_GITHUB_PROJECT_MANAGER_SK_KEY` → `secrets.PLN_GITHUB_POLLY_KEY`
- `app-review-submission.yml`: `secrets.CLAUDE_CODE_TOKEN` → `secrets.PLN_GITHUB_POLLY_KEY`

**Consistency fix:**
- Renamed `CLAUDE_CODE_TOKEN` env var to `POLLINATIONS_TOKEN` in `pr-issue-assistant.yml`

## Required Actions

**Before merging**, add these new secrets to GitHub:
- `PLN_GITHUB_NEWS_KEY`
- `PLN_GITHUB_POLLY_KEY`

**After merging**, these old secrets can be deleted:
- `POLLINATIONS_TOKEN`
- `CLAUDE_CODE_TOKEN`
- `PLN_GITHUB_PROJECT_MANAGER_SK_KEY`