### PR TITLE
fix(enter): fix tier refill idempotency and add microbe tier

### DIFF
--- a/enter.pollinations.ai/src/routes/admin.ts
+++ b/enter.pollinations.ai/src/routes/admin.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@logtape/logtape";
 import { getLogger } from "@logtape/logtape";
 import { eq, sql } from "drizzle-orm";
-import type { D1Database } from "drizzle-orm/d1";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -17,20 +16,25 @@ import type { Env } from "../env.ts";
 
 const log = getLogger(["hono", "admin"]);
 
+// KV key for tracking bulk refill timestamp (separate from individual user refills)
+const BULK_REFILL_KV_KEY = "tier:bulk_refill:last_timestamp";
+
 // Helper functions for tier refill
 function getTodayStartMs(): number {
     const now = new Date();
     return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
 }
 
-async function getLastRefillTime(
-    db: ReturnType<typeof drizzle<D1Database>>,
-): Promise<number> {
-    const [result] = await db
-        .select({ lastGrant: sql<number>`MAX(last_tier_grant)` })
-        .from(userTable)
-        .where(sql`tier IS NOT NULL`);
-    return result?.lastGrant ?? 0;
+async function getLastBulkRefillTime(kv: KVNamespace): Promise<number> {
+    const value = await kv.get(BULK_REFILL_KV_KEY);
+    return value ? Number.parseInt(value, 10) : 0;
+}
+
+async function setLastBulkRefillTime(
+    kv: KVNamespace,
+    timestamp: number,
+): Promise<void> {
+    await kv.put(BULK_REFILL_KV_KEY, timestamp.toString());
 }
 
 function calculateTierBreakdown(
@@ -218,13 +222,15 @@ export const adminRoutes = new Hono<Env>()
     })
     .post("/trigger-refill", async (c) => {
         const db = drizzle(c.env.DB);
+        const kv = c.env.KV;
 
-        // Check idempotency: has refill already run today?
+        // Check idempotency: has BULK refill already run today?
+        // Uses KV to track bulk refill time separately from individual user refills
         const todayStartMs = getTodayStartMs();
-        const lastRefillMs = await getLastRefillTime(db);
+        const lastBulkRefillMs = await getLastBulkRefillTime(kv);
 
-        if (lastRefillMs >= todayStartMs) {
-            const lastRefillDate = new Date(lastRefillMs).toISOString();
+        if (lastBulkRefillMs >= todayStartMs) {
+            const lastRefillDate = new Date(lastBulkRefillMs).toISOString();
             log.info("TIER_REFILL_SKIPPED: already ran today at {lastRefill}", {
                 eventType: "tier_refill_skipped",
                 lastRefill: lastRefillDate,
@@ -252,6 +258,7 @@ export const adminRoutes = new Hono<Env>()
             UPDATE user
             SET
                 tier_balance = CASE tier
+                    WHEN 'microbe' THEN ${TIER_POLLEN.microbe}
                     WHEN 'spore' THEN ${TIER_POLLEN.spore}
                     WHEN 'seed' THEN ${TIER_POLLEN.seed}
                     WHEN 'flower' THEN ${TIER_POLLEN.flower}
@@ -264,7 +271,11 @@ export const adminRoutes = new Hono<Env>()
         `);
 
         const refillCount = result.meta.changes ?? 0;
-        const timestamp = new Date().toISOString();
+        const refillTimestamp = Date.now();
+        const timestamp = new Date(refillTimestamp).toISOString();
+
+        // Store bulk refill timestamp in KV for idempotency
+        await setLastBulkRefillTime(kv, refillTimestamp);
 
         // Calculate tier breakdown for response
         const tierBreakdown = calculateTierBreakdown(usersToRefill);


### PR DESCRIPTION
## Problem

The daily tier refill was **skipping most users**. Only ~607 out of ~23,000 users were getting refilled.

**Root cause:** The idempotency check used `MAX(last_tier_grant)` across all users to determine if the bulk refill had already run today. However, individual users also get their `lastTierGrant` updated on login (in `auth.ts`). This caused the bulk refill to skip whenever any single user had logged in that day.

**Timeline of the bug:**
1. Feb 1st 23:45 UTC - Last successful bulk refill (22,998 users)
2. Feb 2nd ~00:00 UTC - Some user logged in, got individual refill → MAX(last_tier_grant) became "today"
3. Feb 2nd 00:00 UTC - Cron ran → **skipped** because it thought refill already happened
4. Same pattern repeated on Feb 3rd

## Solution

1. **Use KV store for bulk refill tracking** - Store bulk refill timestamp in KV (`tier:bulk_refill:last_timestamp`) separately from individual user data
2. **Add microbe tier to bulk refill SQL** - The new microbe tier (0.1 pollen/day) was missing from the CASE statement

## Changes

- `enter.pollinations.ai/src/routes/admin.ts`:
  - New KV-based idempotency check (`getLastBulkRefillTime` / `setLastBulkRefillTime`)
  - Added `microbe` tier to bulk refill SQL CASE statement
  - Removed unused `D1Database` type import

## Testing

- Existing tests pass
- After merge and deploy, manually trigger the refill workflow to refill all users