### PR TITLE
fix: update openai provider from azure to azure-2

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -28,7 +28,7 @@ export const TEXT_SERVICES = {
     "openai": {
         aliases: [],
         modelId: "gpt-5-mini",
-        provider: "azure",
+        provider: "azure-2",
         cost: [
             {
                 date: COST_START_DATE,


### PR DESCRIPTION
Updates the `openai` model (gpt-5-mini) provider from `azure` to `azure-2` to reflect the correct routing.