### PR TITLE
fix(social): use main branch in Buffer image URLs

### DIFF
--- a/social/scripts/common.py
+++ b/social/scripts/common.py
@@ -486,7 +486,7 @@ def commit_image_to_branch(
     )
 
     if resp.status_code in [200, 201]:
-        raw_url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{file_path}"
+        raw_url = f"https://raw.githubusercontent.com/{owner}/{repo}/main/{file_path}"
         print(f"  Committed image to {file_path}")
         return raw_url
 


### PR DESCRIPTION
## Summary
- Fix Buffer "Failed to fetch image dimensions: Not Found" error
- `commit_image_to_branch` returned URLs pointing to the feature branch, which gets deleted after PR merge
- Buffer fetches images after merge, so the URL must point to `main` where the file lives post-merge

## Test plan
- [ ] Merge this PR
- [ ] Trigger Instagram generation workflow
- [ ] Merge the generated post PR
- [ ] Verify Buffer publish succeeds (no "Not Found" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)