### PR TITLE
fix(social): rename buffer_publish → buffer_stage, add retries + PR preview

### DIFF
--- a/.github/workflows/NEWS_Buffer_stage_posts.yml
+++ b/.github/workflows/NEWS_Buffer_stage_posts.yml
@@ -1,4 +1,4 @@
-name: Buffer Publish Post
+name: Buffer Stage Post
 
 on:
   pull_request:
@@ -38,11 +38,11 @@ jobs:
       - name: Install dependencies
         run: pip install requests pyyaml
 
-      - name: Publish to Buffer
+      - name: Stage on Buffer
         env:
           BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           POST_FILE_PATH: ${{ github.event.inputs.post_file || '' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: python social/scripts/buffer_publish_post.py
+        run: python social/scripts/buffer_stage_post.py

--- a/social/README-instagram.md
+++ b/social/README-instagram.md
@@ -27,7 +27,7 @@ flowchart TD
     B --> C["Scan recent PRs"]:::process
     C --> D["AI generates caption + 3-5 images"]:::ai
     D --> E["Creates PR with post JSON"]:::pr
-    E -->|PR merged| F["buffer_publish_post.py"]:::script
+    E -->|PR merged| F["buffer_stage_post.py"]:::script
     F --> G["Delivers same day at 15:00 UTC"]:::output
 
     classDef trigger fill:#f59e0b,stroke:#fff,stroke-width:2px,color:#000
@@ -45,7 +45,7 @@ flowchart TD
 | Script | Purpose |
 |--------|---------|
 | `scripts/instagram_generate_post.py` | Fetches PRs, generates post JSON with carousel images |
-| `scripts/buffer_publish_post.py` | Publishes to Buffer with scheduled delivery |
+| `scripts/buffer_stage_post.py` | Stages on Buffer for scheduled delivery |
 
 ## Prompts
 

--- a/social/README-linkedin.md
+++ b/social/README-linkedin.md
@@ -28,7 +28,7 @@ flowchart TD
     C --> D["AI writes professional post"]:::ai
     D --> E["AI generates infographic"]:::ai
     E --> F["Creates PR with JSON + image"]:::pr
-    F -->|PR merged| G["buffer_publish_post.py"]:::script
+    F -->|PR merged| G["buffer_stage_post.py"]:::script
     G --> H["Delivers same day at 14:00 UTC"]:::output
 
     classDef trigger fill:#f59e0b,stroke:#fff,stroke-width:2px,color:#000
@@ -46,7 +46,7 @@ flowchart TD
 | Script | Purpose |
 |--------|---------|
 | `scripts/linkedin_generate_post.py` | Fetches PRs, generates post JSON + image |
-| `scripts/buffer_publish_post.py` | Publishes to Buffer with scheduled delivery |
+| `scripts/buffer_stage_post.py` | Stages on Buffer for scheduled delivery |
 
 ## Prompts
 

--- a/social/README-twitter.md
+++ b/social/README-twitter.md
@@ -28,7 +28,7 @@ flowchart TD
     C --> D["AI writes casual tweet"]:::ai
     D --> E["AI generates dynamic image"]:::ai
     E --> F["Creates PR with JSON + image"]:::pr
-    F -->|PR merged| G["buffer_publish_post.py"]:::script
+    F -->|PR merged| G["buffer_stage_post.py"]:::script
     G --> H["Delivers same day at 17:00 UTC"]:::output
 
     classDef trigger fill:#f59e0b,stroke:#fff,stroke-width:2px,color:#000
@@ -46,7 +46,7 @@ flowchart TD
 | Script | Purpose |
 |--------|---------|
 | `scripts/twitter_generate_post.py` | Fetches PRs, generates tweet JSON + image |
-| `scripts/buffer_publish_post.py` | Publishes to Buffer with scheduled delivery |
+| `scripts/buffer_stage_post.py` | Stages on Buffer for scheduled delivery |
 
 ## Prompts
 

--- a/social/README.md
+++ b/social/README.md
@@ -98,7 +98,7 @@ social/
 │
 ├── scripts/                  # Python automation scripts
 │   ├── common.py             # Shared utilities (prompt loading, API calls)
-│   ├── buffer_publish_post.py
+│   ├── buffer_stage_post.py
 │   ├── buffer_utils.py
 │   ├── discord_post_merged_pr.py
 │   ├── discord_post_weekly_news.py

--- a/social/buffer-schedule.yml
+++ b/social/buffer-schedule.yml
@@ -1,6 +1,6 @@
 # Social Media Posting Schedule
 # All times in UTC
-# Used by buffer_publish_post.py to schedule posts via Buffer's customScheduled mode
+# Used by buffer_stage_post.py to schedule posts via Buffer's customScheduled mode
 #
 # Each post is generated once, reviewed via PR, and delivered once at the preferred time.
 # Generation frequency = delivery frequency. Lookback window matches the gap between generations.
@@ -23,5 +23,5 @@ instagram:
 # How it works:
 # 1. Cron generates post → creates PR for review
 # 2. PR merged → Buffer publish workflow triggers
-# 3. buffer_publish_post.py reads this schedule, picks next valid day at preferred time
+# 3. buffer_stage_post.py reads this schedule, picks next valid day at preferred time
 # 4. Buffer delivers the post at that scheduled time

--- a/social/scripts/instagram_generate_post.py
+++ b/social/scripts/instagram_generate_post.py
@@ -322,20 +322,26 @@ def create_post_pr(strategy: Dict, images: List[bytes], image_urls: List[str], p
     print(f"Created branch: {branch_name}")
 
     # Commit images to branch and build image data with stable URLs
-    image_data = []
+    image_data = []      # For JSON — uses main URLs (for Buffer after merge)
+    preview_urls = []    # For PR body — uses branch URLs (for human review before merge)
     for i, img_info in enumerate(strategy.get('images', [])):
         if i < len(images) and images[i] and i < len(image_urls) and image_urls[i]:
             # Commit image to branch for a stable URL
             image_path = f"social/news/transformed/instagram/posts/{today}-image-{i+1}.jpg"
             raw_url = commit_image_to_branch(images[i], image_path, branch_name, github_token, owner, repo)
-            if not raw_url:
+            if raw_url:
+                json_url = raw_url  # main URL for Buffer
+                branch_url = raw_url.replace("/main/", f"/{branch_name}/")
+            else:
                 print(f"Warning: Image {i+1} using generation URL as fallback — Buffer may fail to fetch it")
-            url = raw_url if raw_url else image_urls[i]
+                json_url = image_urls[i]
+                branch_url = image_urls[i]
             image_data.append({
-                "url": url,
+                "url": json_url,
                 "prompt": img_info.get('prompt', ''),
                 "description": img_info.get('description', '')
             })
+            preview_urls.append(branch_url)
 
     # Create the JSON post data
     post_data = {
@@ -386,13 +392,14 @@ def create_post_pr(strategy: Dict, images: List[bytes], image_urls: List[str], p
     # Create PR
     pr_title = f"Instagram Post - {today}"
 
-    # Build image preview for PR body
+    # Build image preview for PR body (uses branch URLs so reviewers can see images)
     image_preview = ""
     for i, img in enumerate(image_data):
         image_preview += f"\n### Image {i + 1}\n"
         image_preview += f"**Prompt:** {img['prompt'][:100]}...\n"
         image_preview += f"**Description:** {img['description']}\n"
-        image_preview += f"![Preview]({img['url']})\n"
+        preview_url = preview_urls[i] if i < len(preview_urls) else img['url']
+        image_preview += f"![Preview]({preview_url})\n"
 
     hashtags_str = " ".join(post_data['hashtags'])
 

--- a/social/scripts/linkedin_generate_post.py
+++ b/social/scripts/linkedin_generate_post.py
@@ -116,11 +116,13 @@ def create_post_pr(post_data: Dict, image_bytes: Optional[bytes], image_url: Opt
     print(f"Created branch: {branch_name}")
 
     # Commit image to branch and get stable URL
+    preview_url = image_url  # fallback: same as JSON
     if image_bytes:
         image_path = f"social/news/transformed/linkedin/posts/{today}-image.jpg"
         raw_url = commit_image_to_branch(image_bytes, image_path, branch_name, github_token, owner, repo)
         if raw_url:
-            image_url = raw_url
+            image_url = raw_url  # main URL for JSON/Buffer
+            preview_url = raw_url.replace("/main/", f"/{branch_name}/")  # branch URL for PR
         else:
             print("Warning: Using generation URL as fallback — Buffer may fail to fetch it")
 
@@ -184,7 +186,7 @@ def create_post_pr(post_data: Dict, image_bytes: Optional[bytes], image_url: Opt
     # Create PR
     pr_title = f"LinkedIn Post - {today}"
 
-    # Image preview in PR body
+    # Image preview in PR body (uses branch URL so reviewers can see it)
     image_preview = ""
     if image_url:
         image_preview = f"""
@@ -192,7 +194,7 @@ def create_post_pr(post_data: Dict, image_bytes: Optional[bytes], image_url: Opt
 **Prompt:** {post_data.get('image_prompt', 'N/A')[:200]}...
 **Text in image:** {post_data.get('image_text', 'N/A')}
 
-![Preview]({image_url})
+![Preview]({preview_url})
 """
 
     pr_body = f"""## LinkedIn Post for {today}

--- a/social/scripts/twitter_generate_post.py
+++ b/social/scripts/twitter_generate_post.py
@@ -122,11 +122,13 @@ def create_post_pr(post_data: Dict, image_bytes: Optional[bytes], image_url: Opt
     print(f"Created branch: {branch_name}")
 
     # Commit image to branch and get stable URL
+    preview_url = image_url  # fallback: same as JSON
     if image_bytes:
         image_path = f"social/news/transformed/twitter/posts/{today}-image.jpg"
         raw_url = commit_image_to_branch(image_bytes, image_path, branch_name, github_token, owner, repo)
         if raw_url:
-            image_url = raw_url
+            image_url = raw_url  # main URL for JSON/Buffer
+            preview_url = raw_url.replace("/main/", f"/{branch_name}/")  # branch URL for PR
         else:
             print("Warning: Using generation URL as fallback — Buffer may fail to fetch it")
 
@@ -193,14 +195,14 @@ def create_post_pr(post_data: Dict, image_bytes: Optional[bytes], image_url: Opt
     # Create PR
     pr_title = f"Twitter Post - {today}"
 
-    # Image preview in PR body
+    # Image preview in PR body (uses branch URL so reviewers can see it)
     image_preview = ""
     if image_url:
         image_preview = f"""
 ### Image
 **Prompt:** {post_data.get('image_prompt', 'N/A')[:200]}...
 
-![Preview]({image_url})
+![Preview]({preview_url})
 """
 
     pr_body = f"""## Twitter Post for {today}


### PR DESCRIPTION
## Summary
- Rename `buffer_publish_post.py` → `buffer_stage_post.py` (Buffer stages/schedules, not publishes directly)
- Add `verify_image_urls()` with 6 retries × 10s backoff before sending to Buffer — fixes CDN propagation race condition where Buffer fetches images before `raw.githubusercontent.com` has them
- PR body now uses branch URLs for `![Preview]()` so reviewers can see images before merge; JSON keeps `main` URLs for Buffer
- Update all workflow, README, and schedule references

## Test plan
- [ ] Merge this PR
- [ ] Trigger Instagram generation → verify PR body shows images
- [ ] Merge generated post PR → verify Buffer stage succeeds with retries
- [ ] Verify no remaining `buffer_publish` references: `grep -r "buffer_publish" social/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)