### PR TITLE
fix: handle GitHub 403/429 rate limits in spore-to-seed upgrade

### DIFF
--- a/.github/scripts/user_validate_github_profile.py
+++ b/.github/scripts/user_validate_github_profile.py
@@ -116,7 +116,19 @@ def fetch_batch(usernames: list[str], retries: int = 3) -> list[dict]:
             break
         except urllib.error.HTTPError as error:
             if attempt < retries - 1 and error.code in (502, 503, 504):
-                time.sleep(5 * (attempt + 1))  # Exponential backoff: 5s, 10s, 15s
+                time.sleep(5 * (attempt + 1))
+                continue
+            if attempt < retries - 1 and error.code in (403, 429):
+                retry_after = error.headers.get("Retry-After")
+                reset_at = error.headers.get("X-RateLimit-Reset")
+                if retry_after:
+                    wait = int(retry_after) + 1
+                elif reset_at:
+                    wait = max(int(reset_at) - int(time.time()), 0) + 1
+                else:
+                    wait = 60
+                print(f"   ⏳ Rate limited (HTTP {error.code}), waiting {wait}s...")
+                time.sleep(wait)
                 continue
             raise
 


### PR DESCRIPTION
## Summary
- Fixes [failed CI run](https://github.com/pollinations/pollinations/actions/runs/21694261050/job/62560991295) where `user_upgrade_spore_to_seed` crashed on HTTP 403 (GitHub rate limit)
- Adds 403/429 handling to `fetch_batch` retry logic — reads `Retry-After` and `X-RateLimit-Reset` headers to wait the exact reset duration
- Falls back to 60s wait if headers are missing

## Test plan
- [ ] Verify next scheduled run of `upgrade-spore-to-seed` completes without 403 crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)