### PR TITLE
news: paid models update announcement

### DIFF
--- a/social/news/transformed/highlights.md
+++ b/social/news/transformed/highlights.md
@@ -1,3 +1,4 @@
+- **2026-02-05** – **💎 Paid Models Update** `claude`, `grok`, `kontext`, `seedream`, and `seedance-pro` are moving to paid-only.
 - **2026-02-02** – **🚀 Kimi K2.5** Upgraded model with vision support and improved reasoning capabilities.
 - **2026-02-02** – **🧠 Web Research** Claude can now use `perplexity` and `gemini-search` tools for real-time answers.
 - **2026-02-02** – **💎 Premium Access** High-end models `veo`, `claude-large`, and `seedream-pro` are now available for credit holders.


### PR DESCRIPTION
## Summary
- `claude`, `grok`, `kontext`, `seedream`, `seedance-pro` moving to paid-only
- `gemini-fast` stays free
- Migrates Mistral from Scaleway to OVHcloud (cheaper pricing)
- Adds highlights announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)