### PR TITLE
Upgrade claude-large from Opus 4.5 to Opus 4.6 on Bedrock

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -316,8 +316,8 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "claude-large": {
-        aliases: ["claude-opus-4.5", "claude-opus"],
-        modelId: "claude-opus-4-5-20251101",
+        aliases: ["claude-opus-4.6", "claude-opus"],
+        modelId: "claude-opus-4-6-20260205",
         provider: "google",
         paidOnly: true,
         cost: [
@@ -327,7 +327,7 @@ export const TEXT_SERVICES = {
                 completionTextTokens: perMillion(25.0),
             },
         ],
-        description: "Anthropic Claude Opus 4.5 - Most Intelligent Model",
+        description: "Anthropic Claude Opus 4.6 - Most Intelligent Model",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -79,7 +79,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "claude-large",
-        config: portkeyConfig["claude-opus-4-5-fallback"],
+        config: portkeyConfig["claude-opus-4-6-fallback"],
         transform: createSystemPromptTransform(BASE_PROMPTS.conversational),
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -96,6 +96,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createBedrockNativeConfig({
             model: "global.anthropic.claude-opus-4-5-20251101-v1:0",
         }),
+    "global.anthropic.claude-opus-4-6-v1": () =>
+        createBedrockNativeConfig({
+            model: "global.anthropic.claude-opus-4-6-v1",
+        }),
 
     // ============================================================================
     // Google Vertex AI - Claude models (alternative to Bedrock)
@@ -147,7 +151,7 @@ export const portkeyConfig: PortkeyConfigMap = {
             },
         ],
     }),
-    "claude-opus-4-5-fallback": () => ({
+    "claude-opus-4-6-fallback": () => ({
         strategy: { mode: "fallback" },
         defaultOptions: { max_tokens: 16384 },
         targets: [
@@ -158,10 +162,10 @@ export const portkeyConfig: PortkeyConfigMap = {
                 aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
                 aws_region: process.env.AWS_REGION || "us-east-1",
                 override_params: {
-                    model: "global.anthropic.claude-opus-4-5-20251101-v1:0",
+                    model: "global.anthropic.claude-opus-4-6-v1",
                 },
             },
-            // Fallback: Google Vertex AI
+            // Fallback: Google Vertex AI (still Opus 4.5 until Vertex gets 4.6)
             {
                 provider: "vertex-ai",
                 authKey: googleCloudAuth.getAccessToken,


### PR DESCRIPTION
Upgrades `claude-large` model to Claude Opus 4.6, now available on AWS Bedrock (Feb 5, 2026).

**Changes:**
- Registry: updated aliases, modelId, description to Opus 4.6
- Added `global.anthropic.claude-opus-4-6-v1` Bedrock native config
- Renamed fallback config from `claude-opus-4-5-fallback` → `claude-opus-4-6-fallback`
- Vertex AI fallback stays at Opus 4.5 until Vertex gets 4.6

**Pricing:** Unchanged at $5/$25 per MTok (same as Opus 4.5)

**Tested:** Locally with enter token — confirmed Bedrock returns `global.anthropic.claude-opus-4-6-v1`