### PR TITLE
[PATCH]: GSOC HMR Page route change top scrollheight location

### DIFF
--- a/apps/gsoc/src/App.jsx
+++ b/apps/gsoc/src/App.jsx
@@ -1,6 +1,11 @@
 import { CssBaseline, createTheme, ThemeProvider } from "@mui/material";
-import { Route, BrowserRouter as Router, Routes, useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import {
+    Route,
+    BrowserRouter as Router,
+    Routes,
+    useLocation,
+} from "react-router-dom";
 import FloatingAssistant from "./components/FloatingAssistant";
 import Footer from "./components/Footer";
 import Navbar from "./components/Navbar";
@@ -52,7 +57,7 @@ const darkTheme = createTheme({
 function ScrollToTop() {
     const { pathname } = useLocation();
     useEffect(() => {
-        // Reset scroll to top whenever the pathname changes
+        void pathname;
         window.scrollTo({ top: 0, left: 0, behavior: "auto" });
     }, [pathname]);
     return null;

--- a/apps/gsoc/src/pages/Projects.jsx
+++ b/apps/gsoc/src/pages/Projects.jsx
@@ -170,8 +170,8 @@ const ProjectsPage = () => {
                             fontSize: "0.85rem",
                         }}
                     >
-                        <strong>Project sizes:</strong> Medium ≈
-                        175h • Large ≈ 350h
+                        <strong>Project sizes:</strong> Medium ≈ 175h • Large ≈
+                        350h
                     </Typography>
                 </Box>
 


### PR DESCRIPTION
## Changes made:- 

- added the use of `useLocation` from the `react-router-dom` so that every route loads from top 0
- removed the small project timeline since it doesn't exist in our proposed ideas