### PR TITLE
feat(enter): add tier-only mode for api keys, fix cursor-pointer on 'select all'

### DIFF
--- a/enter.pollinations.ai/scripts/format-logs.ts
+++ b/enter.pollinations.ai/scripts/format-logs.ts
@@ -1,6 +1,6 @@
-import { LogLevel, getLogger } from "@logtape/logtape";
-import { ensureConfigured } from "../src/logger.ts";
 import { createInterface } from "node:readline/promises";
+import { getLogger, type LogLevel } from "@logtape/logtape";
+import { ensureConfigured } from "../src/logger.ts";
 
 async function main() {
     await ensureConfigured({ level: "trace", format: "text" });

--- a/enter.pollinations.ai/scripts/send-midi-note.js
+++ b/enter.pollinations.ai/scripts/send-midi-note.js
@@ -3,22 +3,22 @@
 // Usage: ./send-midi-note.js <note> [velocity] [duration_ms]
 // Example: ./send-midi-note.js 60 100 200
 
-import easymidi from 'easymidi';
+import easymidi from "easymidi";
 
 const note = parseInt(process.argv[2] || 60); // Default C4
 const velocity = parseInt(process.argv[3] || 100);
 const duration = parseInt(process.argv[4] || 100); // ms
 
 try {
-    const output = new easymidi.Output('IAC Driver Bus 1');
-    
-    output.send('noteon', { note, velocity, channel: 0 });
-    
+    const output = new easymidi.Output("IAC Driver Bus 1");
+
+    output.send("noteon", { note, velocity, channel: 0 });
+
     setTimeout(() => {
-        output.send('noteoff', { note, velocity: 0, channel: 0 });
+        output.send("noteoff", { note, velocity: 0, channel: 0 });
         output.close();
     }, duration);
 } catch (err) {
-    console.error('MIDI error:', err.message);
+    console.error("MIDI error:", err.message);
     process.exit(1);
 }

--- a/enter.pollinations.ai/src/cache.ts
+++ b/enter.pollinations.ai/src/cache.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@logtape/logtape";
+import type { Logger } from "@logtape/logtape";
 
 interface CacheOptions<TArgs extends any[]> {
     log: Logger;

--- a/enter.pollinations.ai/src/client/api.ts
+++ b/enter.pollinations.ai/src/client/api.ts
@@ -1,5 +1,5 @@
-import type { ApiRoutes } from "../index.ts";
 import { hc } from "hono/client";
+import type { ApiRoutes } from "../index.ts";
 
 export const apiClient = hc<ApiRoutes>("/api");
 export type ApiClient = typeof apiClient;

--- a/enter.pollinations.ai/src/client/auth.ts
+++ b/enter.pollinations.ai/src/client/auth.ts
@@ -1,9 +1,11 @@
-import { config } from "./config.ts";
-import { apiKeyClient } from "better-auth/client/plugins";
-import { createAuthClient } from "better-auth/react";
-import { createAuth } from "@/auth.ts";
-import { inferAdditionalFields } from "better-auth/client/plugins";
 import { redirect } from "@tanstack/react-router";
+import {
+    apiKeyClient,
+    inferAdditionalFields,
+} from "better-auth/client/plugins";
+import { createAuthClient } from "better-auth/react";
+import type { createAuth } from "@/auth.ts";
+import { config } from "./config.ts";
 
 export const authClient = createAuthClient({
     baseURL: config.baseUrl,

--- a/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
@@ -197,7 +197,7 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
                                             toggleCategory(textModels)
                                         }
                                         disabled={disabled}
-                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
                                     >
                                         {isCategoryAllSelected(textModels)
                                             ? "Deselect all"
@@ -232,7 +232,7 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
                                             toggleCategory(imageModels)
                                         }
                                         disabled={disabled}
-                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
                                     >
                                         {isCategoryAllSelected(imageModels)
                                             ? "Deselect all"
@@ -267,7 +267,7 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
                                             toggleCategory(videoModels)
                                         }
                                         disabled={disabled}
-                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
                                     >
                                         {isCategoryAllSelected(videoModels)
                                             ? "Deselect all"

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -63,6 +63,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
         pollenBudget: apiKey.pollenBalance ?? null,
         accountPermissions: apiKey.permissions?.account ?? null,
         expiryDays,
+        tierOnly: apiKey.tierOnly ?? false,
     });
 
     async function handleSave() {

--- a/enter.pollinations.ai/src/client/components/api-keys/key-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/key-permissions.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
+import { cn } from "@/util.ts";
 import { AccountPermissionsInput } from "./account-permissions-input.tsx";
 import { ExpiryDaysInput } from "./expiry-days-input.tsx";
 import { PollenBudgetInput } from "./pollen-budget-input.tsx";
@@ -9,6 +10,7 @@ export interface KeyPermissions {
     pollenBudget: number | null;
     expiryDays: number | null;
     accountPermissions: string[] | null;
+    tierOnly: boolean;
 }
 
 /**
@@ -27,6 +29,7 @@ export function useKeyPermissions(initial: Partial<KeyPermissions> = {}) {
     const [accountPermissions, setAccountPermissions] = useState(
         initial.accountPermissions ?? DEFAULT_ACCOUNT_PERMISSIONS,
     );
+    const [tierOnly, setTierOnly] = useState(initial.tierOnly ?? false);
 
     return {
         permissions: {
@@ -34,11 +37,13 @@ export function useKeyPermissions(initial: Partial<KeyPermissions> = {}) {
             pollenBudget,
             expiryDays,
             accountPermissions,
+            tierOnly,
         },
         setAllowedModels,
         setPollenBudget,
         setExpiryDays,
         setAccountPermissions,
+        setTierOnly,
     };
 }
 
@@ -62,6 +67,7 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
         setPollenBudget,
         setExpiryDays,
         setAccountPermissions,
+        setTierOnly,
     } = value;
 
     return (
@@ -78,6 +84,35 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
                 disabled={disabled}
                 inline={inline}
             />
+            {/* Tier-only toggle */}
+            <div>
+                <div className="text-sm font-semibold mb-2">Balance Mode</div>
+                <button
+                    type="button"
+                    onClick={() => setTierOnly(!permissions.tierOnly)}
+                    disabled={disabled}
+                    className={cn(
+                        "w-full flex items-center gap-3 px-3 py-2 rounded-lg border transition-all text-left cursor-pointer",
+                        permissions.tierOnly
+                            ? "border-amber-400 bg-amber-50"
+                            : "border-gray-200 hover:border-gray-300",
+                        disabled && "opacity-50 cursor-not-allowed",
+                    )}
+                >
+                    <div className="flex-1">
+                        <span className="text-sm font-medium">Tier Only</span>
+                        <span className="text-sm text-gray-500">
+                            {" "}
+                            – {permissions.tierOnly
+                                ? "Uses daily tier balance only (ignores paid)"
+                                : "Uses all available balances"}
+                        </span>
+                    </div>
+                    <span className="text-gray-400 text-lg leading-none">
+                        {permissions.tierOnly ? "✕" : "+"}
+                    </span>
+                </button>
+            </div>
             <AccountPermissionsInput
                 value={permissions.accountPermissions}
                 onChange={setAccountPermissions}

--- a/enter.pollinations.ai/src/client/components/api-keys/types.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/types.ts
@@ -9,6 +9,7 @@ export interface ApiKey {
     permissions: Record<string, string[]> | null;
     metadata: Record<string, unknown> | null;
     pollenBalance?: number | null;
+    tierOnly?: boolean;
 }
 
 export interface ApiKeyUpdateParams {
@@ -17,6 +18,7 @@ export interface ApiKeyUpdateParams {
     pollenBudget?: number | null;
     accountPermissions?: string[] | null;
     expiresAt?: Date | null;
+    tierOnly?: boolean;
 }
 
 export interface ApiKeyManagerProps {

--- a/enter.pollinations.ai/src/content-filter.ts
+++ b/enter.pollinations.ai/src/content-filter.ts
@@ -1,6 +1,6 @@
-import {
-    type ContentFilterResult,
-    type ContentFilterSeverity,
+import type {
+    ContentFilterResult,
+    ContentFilterSeverity,
 } from "@/schemas/openai.ts";
 
 const severityOrder: Record<ContentFilterSeverity, number> = {

--- a/enter.pollinations.ai/src/db/schema/better-auth.ts
+++ b/enter.pollinations.ai/src/db/schema/better-auth.ts
@@ -129,6 +129,7 @@ export const apikey = sqliteTable("apikey", {
   permissions: text("permissions"),
   metadata: text("metadata"),
   pollenBalance: real("pollen_balance"),
+  tierOnly: integer("tier_only", { mode: "boolean" }).default(false),
 }, (table) => [
   index("idx_apikey_key").on(table.key),
   index('idx_apikey_expires_at').on(table.expiresAt),

--- a/enter.pollinations.ai/src/durable-objects/PollenRateLimiter.ts
+++ b/enter.pollinations.ai/src/durable-objects/PollenRateLimiter.ts
@@ -30,7 +30,8 @@ export class PollenRateLimiter extends DurableObject {
         // Load state from storage - blockConcurrencyWhile ensures no requests
         // are delivered until initialization completes, preventing race conditions
         ctx.blockConcurrencyWhile(async () => {
-            this.nextAllowedTime = (await ctx.storage.get("nextAllowedTime")) ?? 0;
+            this.nextAllowedTime =
+                (await ctx.storage.get("nextAllowedTime")) ?? 0;
             this.log.debug("Loaded state: nextAllowedTime={nextAllowedTime}", {
                 nextAllowedTime: this.nextAllowedTime,
             });
@@ -74,10 +75,10 @@ export class PollenRateLimiter extends DurableObject {
         const waitTime = Math.ceil(cost / this.refillRate);
         this.nextAllowedTime = now + waitTime;
 
-        this.log.debug(
-            "Consumed {cost} pollen, next allowed in {waitMs}ms",
-            { cost, waitMs: waitTime },
-        );
+        this.log.debug("Consumed {cost} pollen, next allowed in {waitMs}ms", {
+            cost,
+            waitMs: waitTime,
+        });
 
         await this.ctx.storage.put("nextAllowedTime", this.nextAllowedTime);
     }

--- a/enter.pollinations.ai/src/env.ts
+++ b/enter.pollinations.ai/src/env.ts
@@ -1,5 +1,5 @@
-import { RequestIdVariables } from "hono/request-id";
-import { LoggerVariables } from "./middleware/logger.ts";
+import type { RequestIdVariables } from "hono/request-id";
+import type { LoggerVariables } from "./middleware/logger.ts";
 
 export type ErrorVariables = {
     error?: Error;

--- a/enter.pollinations.ai/src/logger.ts
+++ b/enter.pollinations.ai/src/logger.ts
@@ -1,14 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { inspect } from "node:util";
-import { applyColor } from "@/util";
 import {
     configure,
-    getConsoleSink,
+    type FormattedValues,
     getAnsiColorFormatter,
+    getConsoleSink,
     getJsonLinesFormatter,
-    FormattedValues,
-    LogLevel,
+    type LogLevel,
 } from "@logtape/logtape";
+import { applyColor } from "@/util";
 
 export type LogFormat = "json" | "text";
 

--- a/enter.pollinations.ai/src/middleware/alias.ts
+++ b/enter.pollinations.ai/src/middleware/alias.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from "hono/factory";
 import { routePath } from "hono/route";
-import { LoggerVariables } from "@/middleware/logger.ts";
+import type { LoggerVariables } from "@/middleware/logger.ts";
 
 type AliasEnv = {
     Bindings: CloudflareBindings;

--- a/enter.pollinations.ai/src/middleware/auth.ts
+++ b/enter.pollinations.ai/src/middleware/auth.ts
@@ -40,6 +40,7 @@ interface ApiKey {
     permissions?: Record<string, string[]>;
     metadata?: Record<string, unknown>;
     pollenBalance?: number | null;
+    tierOnly?: boolean;
     rawKey?: string;
 }
 
@@ -131,6 +132,7 @@ export const auth = (options: AuthOptions) =>
                     permissions,
                     metadata: keyResult.key.metadata || undefined,
                     pollenBalance: fullApiKey?.pollenBalance ?? null,
+                    tierOnly: fullApiKey?.tierOnly ?? false,
                     rawKey: rawApiKey,
                 },
                 rawApiKey,

--- a/enter.pollinations.ai/src/middleware/image-cache.ts
+++ b/enter.pollinations.ai/src/middleware/image-cache.ts
@@ -5,13 +5,13 @@
  */
 
 import { createMiddleware } from "hono/factory";
+import type { RequestIdVariables } from "hono/request-id";
+import type { LoggerVariables } from "@/middleware/logger.ts";
 import {
+    cacheResponse,
     generateCacheKey,
     setHttpMetadataHeaders,
-    cacheResponse,
 } from "@/utils/image-cache.ts";
-import type { LoggerVariables } from "@/middleware/logger.ts";
-import { RequestIdVariables } from "hono/request-id";
 
 type ImageCacheEnv = {
     Bindings: CloudflareBindings;

--- a/enter.pollinations.ai/src/middleware/logger.ts
+++ b/enter.pollinations.ai/src/middleware/logger.ts
@@ -1,4 +1,4 @@
-import { getLogger, Logger, withContext } from "@logtape/logtape";
+import { getLogger, type Logger, withContext } from "@logtape/logtape";
 import { createMiddleware } from "hono/factory";
 import { ensureConfigured } from "@/logger";
 

--- a/enter.pollinations.ai/src/middleware/model.ts
+++ b/enter.pollinations.ai/src/middleware/model.ts
@@ -1,9 +1,9 @@
-import { createMiddleware } from "hono/factory";
-import { HTTPException } from "hono/http-exception";
-import type { EventType } from "@shared/registry/types.ts";
+import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import { resolveServiceId, type ServiceId } from "@shared/registry/registry.ts";
 import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
-import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import type { EventType } from "@shared/registry/types.ts";
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
 
 export type ModelVariables = {
     model: {

--- a/enter.pollinations.ai/src/middleware/rate-limit-durable.ts
+++ b/enter.pollinations.ai/src/middleware/rate-limit-durable.ts
@@ -1,9 +1,9 @@
 import { createMiddleware } from "hono/factory";
-import type { AuthVariables } from "./auth.ts";
-import { PollenRateLimiter } from "@/durable-objects/PollenRateLimiter.ts";
+import type { PollenRateLimiter } from "@/durable-objects/PollenRateLimiter.ts";
+import type { Env } from "@/env.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { safeRound } from "@/util.ts";
-import { Env } from "@/env.ts";
+import type { AuthVariables } from "./auth.ts";
 
 export type FrontendKeyRateLimitVariables = {
     // will be undefined when using a secret api key

--- a/enter.pollinations.ai/src/middleware/text-cache.ts
+++ b/enter.pollinations.ai/src/middleware/text-cache.ts
@@ -5,13 +5,13 @@
  */
 
 import { createMiddleware } from "hono/factory";
+import type { RequestIdVariables } from "hono/request-id";
+import type { LoggerVariables } from "@/middleware/logger.ts";
 import {
+    createCaptureStream,
     generateCacheKey,
     getCachedResponse,
-    createCaptureStream,
 } from "@/utils/text-cache.ts";
-import type { LoggerVariables } from "@/middleware/logger.ts";
-import type { RequestIdVariables } from "hono/request-id";
 
 type TextCacheEnv = {
     Bindings: CloudflareBindings;

--- a/enter.pollinations.ai/src/middleware/validator.ts
+++ b/enter.pollinations.ai/src/middleware/validator.ts
@@ -1,7 +1,7 @@
 import type { ValidationTargets } from "hono";
 import { validator as zValidator } from "hono-openapi";
-import { z, ZodError } from "zod";
-import { $ZodIssue } from "zod/v4/core";
+import { ZodError, type z } from "zod";
+import type { $ZodIssue } from "zod/v4/core";
 
 const validationTargetMessages: { [key in keyof ValidationTargets]: string } = {
     query: "Query parameter validation failed",

--- a/enter.pollinations.ai/src/routes/model-stats.ts
+++ b/enter.pollinations.ai/src/routes/model-stats.ts
@@ -4,8 +4,8 @@
  * to avoid duplicate caching and Tinybird calls
  */
 
-import { Hono } from "hono";
 import { getLogger } from "@logtape/logtape";
+import { Hono } from "hono";
 import type { Env } from "../env.ts";
 import { getModelStats } from "../utils/model-stats.ts";
 

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -598,6 +598,12 @@ async function checkBalance({
 }: AuthVariables & BalanceVariables & ModelVariables): Promise<void> {
     if (!auth.user?.id) return;
 
+    // Check if API key has tierOnly restriction
+    if (auth.apiKey?.tierOnly) {
+        await balance.requireTierOnly(auth.user.id);
+        return;
+    }
+
     const serviceDefinition = getServiceDefinition(model.resolved);
     const isPaidOnly = serviceDefinition.paidOnly ?? false;
 

--- a/enter.pollinations.ai/src/schemas/openai.ts
+++ b/enter.pollinations.ai/src/schemas/openai.ts
@@ -2,8 +2,8 @@
 
 import { z } from "zod";
 import {
-    DEFAULT_TEXT_MODEL,
     AUDIO_VOICES,
+    DEFAULT_TEXT_MODEL,
     TEXT_SERVICES,
 } from "../../../shared/registry/text.ts";
 

--- a/enter.pollinations.ai/src/schemas/text.ts
+++ b/enter.pollinations.ai/src/schemas/text.ts
@@ -1,4 +1,4 @@
-import { TEXT_SERVICES, DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
+import { DEFAULT_TEXT_MODEL, TEXT_SERVICES } from "@shared/registry/text.ts";
 import { z } from "zod";
 
 const VALID_TEXT_MODELS = [

--- a/enter.pollinations.ai/src/util.ts
+++ b/enter.pollinations.ai/src/util.ts
@@ -112,10 +112,10 @@ export function safeRound(amount: number, precision: number = 6): number {
         return 0;
     }
     // Handle very small amounts (avoid floating point issues)
-    if (Math.abs(amount) < Math.pow(10, -(precision + 2))) {
+    if (Math.abs(amount) < 10 ** -(precision + 2)) {
         return 0;
     }
-    const factor = Math.pow(10, precision);
+    const factor = 10 ** precision;
     return Math.round(amount * factor) / factor;
 }
 
@@ -139,8 +139,8 @@ export function exponentialBackoffDelay(
 
     if (attempt === 0) return 0;
 
-    const base = Math.pow(maxDelay / minDelay, 1 / (maxAttempts - 1));
-    const delay = minDelay * Math.pow(base, attempt - 1);
+    const base = (maxDelay / minDelay) ** (1 / (maxAttempts - 1));
+    const delay = minDelay * base ** (attempt - 1);
 
     if (jitter > 0) {
         const jitterRange = delay * jitter;

--- a/enter.pollinations.ai/src/utils/api-docs.ts
+++ b/enter.pollinations.ai/src/utils/api-docs.ts
@@ -1,11 +1,11 @@
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { resolver } from "hono-openapi";
 import {
     createErrorResponseSchema,
     type ErrorStatusCode,
     getDefaultErrorMessage,
     KNOWN_ERROR_STATUS_CODES,
 } from "@/error.ts";
-import { resolver } from "hono-openapi";
-import { ContentfulStatusCode } from "hono/utils/http-status";
 
 function createErrorResponseDescription(status: ContentfulStatusCode) {
     return {

--- a/enter.pollinations.ai/src/utils/image-cache.ts
+++ b/enter.pollinations.ai/src/utils/image-cache.ts
@@ -4,9 +4,9 @@
  * Following the "thin proxy" design principle - keeping logic simple and minimal
  */
 
+import type { Logger } from "@logtape/logtape";
 import type { Context } from "hono";
 import { removeUnset } from "@/util.ts";
-import { Logger } from "@logtape/logtape";
 
 /**
  * Generate a consistent cache key from URL

--- a/enter.pollinations.ai/src/utils/model-stats.ts
+++ b/enter.pollinations.ai/src/utils/model-stats.ts
@@ -1,5 +1,5 @@
-import { cached } from "@/cache";
 import type { Logger } from "@logtape/logtape";
+import { cached } from "@/cache";
 
 const TINYBIRD_MODEL_STATS_URL =
     "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json?token=p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICJiYzdkOTY4YS0wZmM1LTRmY2MtYWViNi0zZDQ0MWIwMGFlZjQiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.fhyEk0_6wt5a2RnM5tu4n_6nUfFdgN_YBMxg8VPv-Dw";

--- a/enter.pollinations.ai/src/utils/text-cache.ts
+++ b/enter.pollinations.ai/src/utils/text-cache.ts
@@ -4,9 +4,9 @@
  * Following the "thin proxy" design principle - keeping logic simple and minimal
  */
 
-import type { Context } from "hono";
 import type { Logger } from "@logtape/logtape";
 import stableStringify from "fast-json-stable-stringify";
+import type { Context } from "hono";
 
 // Parameters to exclude from cache key (auth + cache control)
 const EXCLUDED_PARAMS = ["key", "no-cache"];

--- a/enter.pollinations.ai/test-redirect-auth.html
+++ b/enter.pollinations.ai/test-redirect-auth.html
@@ -108,7 +108,7 @@
 
         // Check for API key in URL fragment on page load
         // Key is passed in fragment (#api_key=...) to prevent leaking to server logs
-        window.onload = function() {
+        window.onload = () => {
             const hash = window.location.hash.substring(1); // Remove #
             const hashParams = new URLSearchParams(hash);
             const key = hashParams.get('api_key');

--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "vitest";
-import { resolveServiceId } from "@shared/registry/registry.js";
-import type { ServiceDefinition } from "@shared/registry/registry.js";
-import { TEXT_SERVICES } from "@shared/registry/text";
 import { IMAGE_SERVICES } from "@shared/registry/image";
+import type { ServiceDefinition } from "@shared/registry/registry.js";
+import { resolveServiceId } from "@shared/registry/registry.js";
+import { TEXT_SERVICES } from "@shared/registry/text";
+import { expect, test } from "vitest";
 
 function serviceAliasTestCases(
     services: Record<string, ServiceDefinition>,

--- a/enter.pollinations.ai/test/deduplication.test.ts
+++ b/enter.pollinations.ai/test/deduplication.test.ts
@@ -1,7 +1,7 @@
 import { SELF } from "cloudflare:test";
-import { test } from "./fixtures.ts";
-import { expect } from "vitest";
 import { getLogger } from "@logtape/logtape";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
 
 const textEndpoint = "http://localhost:3000/api/generate/v1/chat/completions";
 const log = getLogger(["test", "deduplication"]);

--- a/enter.pollinations.ai/test/events.test.ts
+++ b/enter.pollinations.ai/test/events.test.ts
@@ -1,8 +1,8 @@
 import { env } from "cloudflare:test";
-import { test } from "./fixtures.ts";
-import { sendToTinybird, flattenBalances } from "@/events.ts";
-import { exponentialBackoffDelay } from "@/util.ts";
 import { expect } from "vitest";
+import { flattenBalances, sendToTinybird } from "@/events.ts";
+import { exponentialBackoffDelay } from "@/util.ts";
+import { test } from "./fixtures.ts";
 
 test("sendToTinybird sends event to Tinybird API", async ({ log, mocks }) => {
     await mocks.enable("tinybird");

--- a/enter.pollinations.ai/test/integration/audio.test.ts
+++ b/enter.pollinations.ai/test/integration/audio.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
-import { test } from "../fixtures.ts";
 import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
 
 describe("GET /text/:prompt (audio)", () => {
     test(

--- a/enter.pollinations.ai/test/integration/public-endpoints.test.ts
+++ b/enter.pollinations.ai/test/integration/public-endpoints.test.ts
@@ -1,5 +1,5 @@
 import { SELF } from "cloudflare:test";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
 import { test as fixtureTest } from "../fixtures.ts";
 
 // Test public endpoints that should be accessible without authentication

--- a/enter.pollinations.ai/test/integration/text-cache.test.ts
+++ b/enter.pollinations.ai/test/integration/text-cache.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
-import { test } from "../fixtures.ts";
 import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
 
 type TextCacheHeaders = {
     cache: "HIT" | "MISS" | "BYPASS";

--- a/enter.pollinations.ai/test/mocks/fetch.ts
+++ b/enter.pollinations.ai/test/mocks/fetch.ts
@@ -1,6 +1,6 @@
+import { getLogger } from "@logtape/logtape";
 import type { Hono } from "hono";
 import { vi } from "vitest";
-import { getLogger } from "@logtape/logtape";
 
 const originalFetch = globalThis.fetch;
 const activeRequests = new Set<Promise<any>>();

--- a/enter.pollinations.ai/test/mocks/polar.ts
+++ b/enter.pollinations.ai/test/mocks/polar.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
+import type { PolarEvent } from "@/events.ts";
 import { createHonoMockHandler, type MockAPI } from "./fetch.ts";
-import { PolarEvent } from "@/events.ts";
 
 export type MockPolarState = {
     events: PolarEvent[];

--- a/enter.pollinations.ai/test/mocks/text-service.ts
+++ b/enter.pollinations.ai/test/mocks/text-service.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
+import { stream } from "hono/streaming";
 import type { MockAPI } from "./fetch.ts";
 import { createHonoMockHandler } from "./fetch.ts";
-import { stream } from "hono/streaming";
 
 export function createMockTextService(): MockAPI<Record<string, never>> {
     const app = new Hono().post("/openai", async (c) => {

--- a/enter.pollinations.ai/test/mocks/tinybird.ts
+++ b/enter.pollinations.ai/test/mocks/tinybird.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
+import type { SelectGenerationEvent } from "@/db/schema/event.ts";
 import { createHonoMockHandler, type MockAPI } from "./fetch.ts";
-import { SelectGenerationEvent } from "@/db/schema/event.ts";
 
 type TinybirdGenerationEvent = Omit<
     SelectGenerationEvent,

--- a/enter.pollinations.ai/test/mocks/vcr.ts
+++ b/enter.pollinations.ai/test/mocks/vcr.ts
@@ -1,9 +1,9 @@
-import crypto from "node:crypto";
-import { createHonoMockHandler, MockAPI } from "./fetch";
 import { env } from "cloudflare:test";
+import crypto from "node:crypto";
+import { getLogger } from "@logtape/logtape";
 import { Hono } from "hono";
 import { expect, inject } from "vitest";
-import { getLogger } from "@logtape/logtape";
+import { createHonoMockHandler, type MockAPI } from "./fetch";
 
 const log = getLogger(["test", "mock", "vcr"]);
 const snapshotServerUrl = inject("snapshotServerUrl");
@@ -337,7 +337,7 @@ function replayChunks(
             yield encoder.encode(chunk.data);
         }
     }
-    // @ts-ignore - ReadableStream.from is supported
+    // @ts-expect-error - ReadableStream.from is supported
     return ReadableStream.from(streamGenerator());
 }
 

--- a/enter.pollinations.ai/test/rate-limit.test.ts
+++ b/enter.pollinations.ai/test/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { SELF } from "cloudflare:test";
-import { test } from "./fixtures.ts";
-import { expect } from "vitest";
 import { getLogger } from "@logtape/logtape";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
 
 const endpoint = "http://localhost:3000/api/generate/v1/chat/completions";
 const log = getLogger(["test", "rate-limit"]);

--- a/enter.pollinations.ai/test/setup/snapshot-server.ts
+++ b/enter.pollinations.ai/test/setup/snapshot-server.ts
@@ -1,9 +1,9 @@
-import { serve } from "@hono/node-server";
-import { Hono } from "hono";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { TestProject } from "vitest/node";
+import { serve } from "@hono/node-server";
 import { getLogger } from "@logtape/logtape";
+import { Hono } from "hono";
+import type { TestProject } from "vitest/node";
 
 const SNAPSHOTS_DIR = path.join(process.cwd(), "test", "mocks", "snapshots");
 

--- a/enter.pollinations.ai/vitest.config.ts
+++ b/enter.pollinations.ai/vitest.config.ts
@@ -3,8 +3,8 @@ import {
     defineWorkersConfig,
     readD1Migrations,
 } from "@cloudflare/vitest-pool-workers/config";
-import viteConfig from "./vite.config";
 import { loadEnv } from "vite";
+import viteConfig from "./vite.config";
 
 export default defineWorkersConfig(async ({ mode }) => {
     const migrationsPath = path.join(__dirname, "drizzle");


### PR DESCRIPTION
adds tier-only mode for api keys + fixes cursor on select all buttons

thought this could be a nice way to test free-tier limits without touching paid pollen, when tier-only is enabled on a key, it only uses your daily tier balance and ignores any paid balance you have. I believe some users would benefit from this as well, so they can preserve their paid pollens. if this isn't needed or you're not interested in the tier switching thing, totally fine to skip it.

also fixed the missing cursor-pointer on those select all buttons in the model permissions section.

changes:
- add `tierOnly` column to apikey schema
- add balance mode toggle in key settings UI
- add `requireTierOnly()` balance check
- fix cursor-pointer on select all buttons