### PR TITLE
fix: move Portkey gateway to custom domain to fix 524 timeouts

### DIFF
--- a/text.pollinations.ai/scripts/deploy-portkey.sh
+++ b/text.pollinations.ai/scripts/deploy-portkey.sh
@@ -9,7 +9,7 @@ set -e
 # Includes: code_execution, url_context, google_search tools for Gemini
 # PR: https://github.com/Portkey-AI/gateway/pull/1458
 PORTKEY_REPO="https://github.com/pollinations/gateway.git"
-PORTKEY_COMMIT="${PORTKEY_COMMIT:-0750ef464e3f39a860b94b4786354a81f451c97a}"  # v1.15.1 + video_url + code_execution + url_context + gemini token fix
+PORTKEY_COMMIT="${PORTKEY_COMMIT:-d2a366a0d63aeb3ba8a221064e291121737d4e33}"  # v1.15.1 + video_url + code_execution + url_context + gemini token fix + custom domain portkey.pollinations.ai
 CLONE_DIR="/tmp/portkey-gateway-$$"
 ENVIRONMENT="${PORTKEY_ENV:-production}"
 

--- a/text.pollinations.ai/secrets/env.json
+++ b/text.pollinations.ai/secrets/env.json
@@ -23,7 +23,7 @@
 	"PLN_ENTER_TOKEN": "ENC[AES256_GCM,data:droEvj242AbqU5BwU98c+1nQXaLSBlQwWM/ScudfjfdxAThvQxFpxg==,iv:HkK1WltFgvcalGDFdr6Z684NgIiEaEDWsBvifIx4Hgs=,tag:ocxHHEcLuzXZBjiWX858XA==,type:str]",
 	"PLN_FEED_PASSWORD": "ENC[AES256_GCM,data:BD1K2lSgIVzd4O1t,iv:Z+hhGLsR37x+MMqpQ/09DZHe+s3KlQcUKJTyK40m1pM=,tag:N0We8IW3gOWQzZBu0cJjgw==,type:str]",
 	"PLN_APPS_KEY": "ENC[AES256_GCM,data:xNT1ThbUJojEnLXj11Nxtg==,iv:+3c7/wpqJTNY9yk6HrtRRucRNkmTXrV02GYAd5Iz6fk=,tag:/rRMhSqkhONfvTpmskDrXw==,type:str]",
-	"PORTKEY_GATEWAY_URL": "ENC[AES256_GCM,data:mPy9aFHCl9nYz1Mh5/69fonnH6Eb5HqpG0rTMjvNjFoXNOSe8Vs=,iv:wOcVX+i+brARvFu9no9REGh5JMs6qELmOJ98vj3TCic=,tag:g/2P25aNTWle1ffWrQMt4Q==,type:str]",
+	"PORTKEY_GATEWAY_URL": "ENC[AES256_GCM,data:qmegowDopNQYGeCYwYryRu7ESDLI35gq4gDgf4D27w==,iv:IXH3G0RSTwmysYVLnVc0Ox6E/bBJ95i+QFh4J337sek=,tag:Uzja2AQkv6N3Yrb1dVcjdA==,type:str]",
 	"OVHCLOUD_API_KEY": "ENC[AES256_GCM,data:5YaNiZahLyEVk4ZwtADsMQkBvRr9ySMSF0w9qqxMGPxM6xnZxbjIXG4/LplvOJBn9n2VGa/D9ekUzusMt7ONVfl8MeIqnYlCK/N4LjZGTYfQThe7kH2OJtvv1UCSA6Z1tamGEVYyG4NDvqq8h2wQYzDO+2/JQ1QPn4taUsIc590iMit3vhZynIV0g5yhSfBF6yW2yCyHMI56B72wh0uRjO2as2Z5uBxwmHRjrbuOvNb/H0CdEr4nqp0ht6Us/g03+PUWJ31N7OLLanZPmF9pRn0HO22rTRhR4mEAdSBkEzR8gG6HmnonSd5KdsOWX5MmN/MipHVrmpXhObNbA58o5E8FybaCq8tEk1Fi5/klf8aK3Tv/oB1u1G9s,iv:dEReeQn1Mkf092ArQvQmaI8R/LV3+GLv6HS8/+wqSXE=,tag:Tyx0Kb/JAk0dOzYAvW7lKQ==,type:str]",
 	"FIREWORKS_API_KEY": "ENC[AES256_GCM,data:Sr3AqT1BxLbRP+qHmo2x9dS/f+62S5hvsg==,iv:894d9wnJ2zDI6QMIl8NakH5Tp5HmC9sKkICfRgjPQvw=,tag:/03AKXPk6cmM3PYAqjEDyw==,type:str]",
 	"AZURE_PF_GPT5MINI_ENDPOINT": "ENC[AES256_GCM,data:Ug9ggg2WMa0nqZ2Pf+hnSE+FZAybSfjWYmZioZm/hjfwEZY9thpxTQffeUfp8YM2wPaFhtIGGePPtGADKzxtCmKmDtZ82kPQwhuwCFul/4eEAOhL2LYrPRW17mjSIwwQDygS9gS6cfALiP7FROdIA/P0AdFmHUGVERwh5OCmqR+Ydw==,iv:qWiRxRkW6WtnPLZmDXcfgPAFKQ0blswVupElk/S2WkI=,tag:kJ5SkZYPzYBATo5UTAk3Hw==,type:str]",
@@ -36,8 +36,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpNmdHRitKTlBvL05zYWJX\nWnZWcE5EYUtTb0JqeW8yckFlbmVpWGhIQndFCm1QVG1XUFRoRlhnbGdXR1l1NlJZ\neFVLb1pxNUVMNzNQWFdzOFM5VVBmQTAKLS0tIDNxSDJvdVNDelZqZXJ4Sy9HbGRr\nUFB6MGFmK2s2UFNtMFNTd0ZsS0l3d2cKKsvTz1k/NUC+ZUOFy2zecyDuy7gEvocn\nyvQAxnHvTqrvAbaO4I+TbkP6SpV++66OgCSE2CjZduJOQx41C/Smyw==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-02-04T10:50:46Z",
-		"mac": "ENC[AES256_GCM,data:W/jWdWu7WwW+ZjKWk6+jn06mSqgFDayq1SMLOO6mNH4aH9Qh393CfMgSewNJBbYBT+YeQIujmgAIBHdro1sXWDdsfyv+0SCuGNBB7oMMFkWO/abg5uOCp/kQVZpufLjQOqfrmsFkLDwDaD5v7bVsmzziaic9jV/glO6QrJhybtA=,iv:NY4+FRt0Y/Jj2WFPgw/A87QIT/yV8pXehyM6W41wO34=,tag:bZaWWhpEtxkVLNxhI+tZpg==,type:str]",
+		"lastmodified": "2026-02-07T14:11:18Z",
+		"mac": "ENC[AES256_GCM,data:HPvrgEna91VY9OXpeUvRKiIf4tZ7wfEs+ovtJyeYi3KmlpXmGxkQYS7EZmz336+jZxR9ChxCYAOCC/oPkD73F+5cfuuc9HFgWsneFZYuEsyH10EP2UNYwwepXuOp6VniKEJI7pru7CWVsDhjpW5e1HM+8CWPfq5ypMyEBaBniYc=,iv:J+LbVjqo33sn4qHoFytEPfPioUbRRUP7FotkbErc+HQ=,tag:6cLzalJMFkAFUvyrlU0v9w==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
## Problem

The Portkey gateway Worker (`rubeus`) runs on a `workers.dev` domain, which has an unconfigurable ~100-120s `proxy_read_timeout`. This causes **Cloudflare 524 errors** for any LLM request that takes longer than ~100s (reasoning models with high effort, large context sizes, slow providers).

Users see 524 errors at ~130s and lose credits without getting a response.

## Root Cause

```
Client → Cloudflare → enter.pollinations.ai → text.pollinations.ai (EC2) → Portkey (workers.dev) → Provider
                                                                            ↑ ~100s timeout here
```

The `workers.dev` domain has a hard ~100s proxy timeout that cannot be configured. With Portkey's built-in retry logic, this manifests as 524 errors at ~250s.

## Fix

Deploy the Portkey gateway as a **new worker** (`rubeus-pollinations`) on a **custom domain** `portkey.pollinations.ai`. Since `pollinations.ai` is an Enterprise zone with `proxy_read_timeout=600s`, this eliminates the timeout bottleneck.

### Changes
- **`deploy-portkey.sh`**: Updated commit hash to `d2a366a` (fork with custom domain config in `wrangler.toml`)
- **`secrets/env.json`**: Updated `PORTKEY_GATEWAY_URL` from `https://rubeus.thomash-efd.workers.dev` → `https://portkey.pollinations.ai`

### Already deployed
- `rubeus-pollinations` worker is live on `portkey.pollinations.ai` ✅
- Tested directly with Bedrock credentials ✅
- Tested through local text service (openai, mistral, gemini, deepseek, claude-fast all 200) ✅
- Original `rubeus` worker on `workers.dev` left untouched (no production disruption)

## Issues addressed

Fixes #6529 — gemini-fast fails with 524 error on larger context sizes
Relates to #7280 — openai xhigh unusable, 130s then 524
Relates to #7211 — 524 error on long-running models
Supersedes #7321 — previous attempt at fixing 524 timeout (heartbeat approach)

## Note on PR #7321

PR #7321 proposed injecting SSE keep-alive heartbeats to work around the timeout. This PR fixes the **root cause** at the infrastructure level instead, making the heartbeat workaround unnecessary for the Portkey gateway path. PR #7321 can be closed once this is merged.