### PR TITLE
feat: upgrade TTS from eleven_multilingual_v2 to eleven_v3

### DIFF
--- a/enter.pollinations.ai/src/routes/audio.ts
+++ b/enter.pollinations.ai/src/routes/audio.ts
@@ -23,7 +23,7 @@ import { validator } from "@/middleware/validator.ts";
 import { errorResponseDescriptions } from "@/utils/api-docs.ts";
 import type { Env } from "../env.ts";
 
-const DEFAULT_ELEVENLABS_MODEL = "eleven_multilingual_v2";
+const DEFAULT_ELEVENLABS_MODEL = "eleven_v3";
 
 const CreateSpeechRequestSchema = z
     .object({

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -62,18 +62,17 @@ function perThousandChars(dollarsPerThousand: number): number {
 export const AUDIO_SERVICES = {
     elevenlabs: {
         aliases: ["tts", "text-to-speech", "eleven", "tts-1", "tts-1-hd"],
-        modelId: "eleven_multilingual_v2",
+        modelId: "eleven_v3",
         provider: "elevenlabs",
         cost: [
             {
                 date: new Date("2026-02-07").getTime(),
-                // ElevenLabs pricing: ~$0.18 per 1000 characters (average across plans)
-                // Based on: 1 credit = 1 character, ~$0.15-0.22 per 1000 credits depending on plan
-                // We use completionAudioTokens to track character usage
+                // ElevenLabs pricing: 1 credit = 1 character, ~$0.18 per 1000 chars
                 completionAudioTokens: perThousandChars(0.18),
             },
         ],
-        description: "ElevenLabs Text-to-Speech - Natural & Expressive Voices",
+        description:
+            "ElevenLabs v3 TTS - Expressive voices with emotions & audio tags",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],


### PR DESCRIPTION
## Upgrade ElevenLabs TTS to v3

- **Model**: `eleven_multilingual_v2` → `eleven_v3`
- **Pricing**: unchanged (1 credit/char, ~$0.18/1K chars)
- **New capabilities**: emotions via audio tags (`[laughing]`, `[crying]`), 70+ languages, multi-speaker dialogue
- **Char limit**: 5,000 (was 10,000 on v2)

### Files changed
- `shared/registry/audio.ts` — modelId + description
- `enter.pollinations.ai/src/routes/audio.ts` — default model constant

### Tested locally
- ✅ GET `/audio/{text}` — 200, ~50KB
- ✅ POST `/v1/audio/speech` with audio tags — 200, ~87KB