### PR TITLE
Send Discord announcement as single message with text + image

### DIFF
--- a/social/scripts/discord_post_merged_pr.py
+++ b/social/scripts/discord_post_merged_pr.py
@@ -318,10 +318,12 @@ def format_review_for_discord(message_content: str, pr_info: Dict) -> str:
 def post_to_discord(webhook_url: str, message_content: str, image_bytes: Optional[bytes] = None):
     """Post message + optional image to Discord webhook as single message"""
     if image_bytes:
-        # Send as multipart with both content and file
-        files = {"file": ("image.jpg", image_bytes, "image/jpeg")}
-        data = {"content": message_content}
-        response = requests.post(webhook_url, files=files, data=data)
+        # Send as multipart with both payload_json and file
+        files = {
+            "payload_json": (None, json.dumps({"content": message_content}), "application/json"),
+            "files[0]": ("image.jpg", image_bytes, "image/jpeg")
+        }
+        response = requests.post(webhook_url, files=files)
     else:
         # Send as JSON
         response = requests.post(webhook_url, json={"content": message_content})


### PR DESCRIPTION
## Changes

- Sends text and image in **one Discord message** (plain message, not embed)
- Uses correct multipart/form-data format with `payload_json` and `files[0]`
- Simpler than chunking or separate messages
- Truncates to 2000 char limit if needed

## Format

```python
files = {
    "payload_json": (None, json.dumps({"content": text}), "application/json"),
    "files[0]": ("image.jpg", image_bytes, "image/jpeg")
}
```

Per Discord API docs, this is the correct way to send text + file together.

Co-authored-by: fisventurous <fisventurous@users.noreply.github.com>