### PR TITLE
fix: add audio models to API key permissions UI

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
@@ -1,3 +1,4 @@
+import { AUDIO_SERVICES } from "@shared/registry/audio.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { FC } from "react";
@@ -60,6 +61,13 @@ const videoModels = Object.entries(IMAGE_SERVICES)
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
 
+const audioModels = Object.keys(AUDIO_SERVICES)
+    .map((id) => ({
+        id,
+        label: getModelDisplayName(id),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
 /**
  * Unified permissions input for API keys.
  * Includes model restrictions and account permissions (profile, balance, usage).
@@ -88,7 +96,10 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
     // Model permissions logic
     const isUnrestricted = allowedModels === null;
     const totalModels =
-        textModels.length + imageModels.length + videoModels.length;
+        textModels.length +
+        imageModels.length +
+        videoModels.length +
+        audioModels.length;
     const selectedCount = isUnrestricted
         ? totalModels
         : (allowedModels ?? []).length;
@@ -276,6 +287,41 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
                                 </div>
                                 <div className="flex flex-col gap-1">
                                     {videoModels.map((model) => (
+                                        <ModelChip
+                                            key={model.id}
+                                            apiName={model.id}
+                                            officialName={model.label}
+                                            selected={isModelSelected(model.id)}
+                                            onClick={() =>
+                                                toggleModel(model.id)
+                                            }
+                                            disabled={disabled}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Audio models */}
+                            <div>
+                                <div className="flex items-center justify-between mb-1">
+                                    <span className="text-xs font-semibold text-gray-500 tracking-wide">
+                                        Audio
+                                    </span>
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            toggleCategory(audioModels)
+                                        }
+                                        disabled={disabled}
+                                        className="text-[10px] text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                                    >
+                                        {isCategoryAllSelected(audioModels)
+                                            ? "Deselect all"
+                                            : "Select all"}
+                                    </button>
+                                </div>
+                                <div className="flex flex-col gap-1">
+                                    {audioModels.map((model) => (
                                         <ModelChip
                                             key={model.id}
                                             apiName={model.id}

--- a/enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx
@@ -1,3 +1,4 @@
+import { AUDIO_SERVICES } from "@shared/registry/audio.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { FC } from "react";
@@ -31,6 +32,14 @@ const videoModels = Object.entries(IMAGE_SERVICES)
         (config.outputModalities as readonly string[]).includes("video"),
     )
     .map(([id]) => ({
+        id,
+        label: getModelDisplayName(id),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+// Audio models
+const audioModels = Object.keys(AUDIO_SERVICES)
+    .map((id) => ({
         id,
         label: getModelDisplayName(id),
     }))
@@ -86,7 +95,10 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
         (value ?? []).includes(modelId);
 
     const totalModels =
-        textModels.length + imageModels.length + videoModels.length;
+        textModels.length +
+        imageModels.length +
+        videoModels.length +
+        audioModels.length;
     const selectedCount = isUnrestricted ? totalModels : (value ?? []).length;
 
     return (
@@ -189,6 +201,25 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
                             </div>
                             <div className="flex flex-col gap-1">
                                 {videoModels.map((model) => (
+                                    <ModelChip
+                                        key={model.id}
+                                        apiName={model.id}
+                                        officialName={model.label}
+                                        selected={isModelSelected(model.id)}
+                                        onClick={() => toggleModel(model.id)}
+                                        disabled={disabled}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* Audio models */}
+                        <div>
+                            <div className="text-xs font-semibold text-gray-500 tracking-wide mb-1">
+                                Audio
+                            </div>
+                            <div className="flex flex-col gap-1">
+                                {audioModels.map((model) => (
                                     <ModelChip
                                         key={model.id}
                                         apiName={model.id}

--- a/enter.pollinations.ai/src/client/components/api-keys/model-utils.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/model-utils.ts
@@ -1,3 +1,4 @@
+import { AUDIO_SERVICES } from "@shared/registry/audio.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 
@@ -9,6 +10,10 @@ export const getModelDisplayName = (modelId: string): string => {
     const imageService = IMAGE_SERVICES[modelId as keyof typeof IMAGE_SERVICES];
     if (imageService) {
         return imageService.description?.split(" - ")[0] || modelId;
+    }
+    const audioService = AUDIO_SERVICES[modelId as keyof typeof AUDIO_SERVICES];
+    if (audioService) {
+        return audioService.description?.split(" - ")[0] || modelId;
     }
     return modelId;
 };


### PR DESCRIPTION
## Summary
- Add `AUDIO_SERVICES` import to model permissions selector and account permissions input
- Audio models (elevenlabs, elevenmusic, whisper) now appear as an "Audio" category alongside Text, Image, and Video
- Update `getModelDisplayName` to resolve audio model display names
- Fix `totalModels` count to include audio models

**Root cause:** The model permissions UI only imported `IMAGE_SERVICES` and `TEXT_SERVICES` from the shared registry — `AUDIO_SERVICES` was never included, so audio models could not be selected when restricting API keys to specific models.

## Test plan
- [ ] Open Enter dashboard, create a new API key
- [ ] Toggle "Limited to selected models" — verify Audio category appears with elevenlabs, elevenmusic, whisper
- [ ] Select audio models and create key — verify they persist in key permissions
- [ ] Verify "Select all" / "Deselect all" works for Audio category

🤖 Generated with [Claude Code](https://claude.com/claude-code)