### PR TITLE
fix: preserve aspect ratio in klein-9b dimension clamping

### DIFF
--- a/image.pollinations.ai/image_gen_flux_klein/flux_klein_9b.py
+++ b/image.pollinations.ai/image_gen_flux_klein/flux_klein_9b.py
@@ -76,16 +76,11 @@ MODEL_ID = "black-forest-labs/FLUX.2-klein-9B"
 MINUTES = 60
 
 # Maximum resolution to prevent OOM - 9B model is memory-hungry
-MAX_DIMENSION = 1024
 MAX_TOTAL_PIXELS = 1024 * 1024  # 1 megapixel max
 
 def clamp_dimensions(width: int, height: int) -> tuple[int, int]:
-    """Clamp dimensions to prevent OOM errors on 9B model."""
-    # First clamp individual dimensions
-    width = min(width, MAX_DIMENSION)
-    height = min(height, MAX_DIMENSION)
-    
-    # Then check total pixels
+    """Scale down dimensions while maintaining aspect ratio to prevent OOM errors."""
+    # Scale down proportionally if total pixels exceed max
     total_pixels = width * height
     if total_pixels > MAX_TOTAL_PIXELS:
         scale = (MAX_TOTAL_PIXELS / total_pixels) ** 0.5


### PR DESCRIPTION
Fixes klein-9b only generating 1:1 images.

**Problem:** The dimension clamping was limiting each dimension individually to 1024, forcing non-square images to become square.

**Fix:** Now only scales based on total pixel count (1 megapixel max), preserving aspect ratio.

Example: 1920x1080 → 1360x768 (maintains 16:9 ratio)

---
*Description condensed by Claude for readability*