### PR TITLE
fix: update gateway commit for Gemini executable_code blocks + reasoning_effort fix

### DIFF
--- a/text.pollinations.ai/scripts/deploy-portkey.sh
+++ b/text.pollinations.ai/scripts/deploy-portkey.sh
@@ -9,7 +9,7 @@ set -e
 # Includes: code_execution, url_context, google_search tools for Gemini
 # PR: https://github.com/Portkey-AI/gateway/pull/1458
 PORTKEY_REPO="https://github.com/pollinations/gateway.git"
-PORTKEY_COMMIT="${PORTKEY_COMMIT:-d2a366a0d63aeb3ba8a221064e291121737d4e33}"  # v1.15.1 + video_url + code_execution + url_context + gemini token fix + custom domain portkey.pollinations.ai
+PORTKEY_COMMIT="${PORTKEY_COMMIT:-0cecfca42ef9e916fbe66213f4dcbb063664f54c}"  # v1.15.1 + video_url + code_execution + url_context + gemini token fix + custom domain + executable_code/code_execution_result content blocks + reasoning_effort thinking fix
 CLONE_DIR="/tmp/portkey-gateway-$$"
 ENVIRONMENT="${PORTKEY_ENV:-production}"
 


### PR DESCRIPTION
Updates the Portkey gateway deploy commit from `d2a366a0` to `0cecfca4` (merged PR pollinations/gateway#2 by @JustappleJust).

### Changes in new gateway commit:
- **`executable_code` / `code_execution_result` content blocks** — Maps Gemini's native code execution response types to/from OpenAI-compatible format
- **`reasoning_effort` thinking fix** — Fixes bug where thinking content wasn't shown when only `reasoning_effort` was set (without explicit `type: 'enabled'`)

### Files changed:
- `text.pollinations.ai/scripts/deploy-portkey.sh` — commit hash update only