### PR TITLE
feat: add paid models to OpenClaw config

### DIFF
--- a/apps/openclaw/index.html
+++ b/apps/openclaw/index.html
@@ -637,7 +637,9 @@
         "pollinations/deepseek": { "alias": "DeepSeek V3.2" },
         "pollinations/glm": { "alias": "GLM-4.7" },
         "pollinations/gemini-fast": { "alias": "Gemini Flash Lite" },
-        "pollinations/claude-fast": { "alias": "Claude Haiku 4.5" }
+        "pollinations/claude-fast": { "alias": "Claude Haiku 4.5" },
+        "pollinations/claude-large": { "alias": "Claude Opus 4.6 (paid)" },
+        "pollinations/gemini-large": { "alias": "Gemini 3 Pro (paid)" }
       }
     }
   },
@@ -654,7 +656,15 @@
           { "id": "deepseek", "name": "DeepSeek V3.2",
             "input": ["text"], "contextWindow": 128000, "maxTokens": 8192 },
           { "id": "glm", "name": "GLM-4.7",
-            "input": ["text"], "contextWindow": 128000, "maxTokens": 8192 }
+            "input": ["text"], "contextWindow": 128000, "maxTokens": 8192 },
+          { "id": "gemini-fast", "name": "Gemini Flash Lite",
+            "input": ["text","image"], "contextWindow": 128000, "maxTokens": 8192 },
+          { "id": "claude-fast", "name": "Claude Haiku 4.5",
+            "input": ["text","image"], "contextWindow": 200000, "maxTokens": 8192 },
+          { "id": "claude-large", "name": "Claude Opus 4.6 (Paid)",
+            "input": ["text","image"], "contextWindow": 200000, "maxTokens": 8192 },
+          { "id": "gemini-large", "name": "Gemini 3 Pro (Paid)", "reasoning": true,
+            "input": ["text","image","audio","video"], "contextWindow": 1000000, "maxTokens": 8192 }
         ]
       }
     }
@@ -757,7 +767,7 @@ function toggleManual() {
 
 function startAuthorize() {
     var redirectUrl = encodeURIComponent(window.location.origin + window.location.pathname);
-    var models = encodeURIComponent('kimi,deepseek,glm,gemini-fast,claude-fast');
+    var models = encodeURIComponent('kimi,deepseek,glm,gemini-fast,claude-fast,gemini-large,claude-large');
     window.location.href = 'https://enter.pollinations.ai/authorize?redirect_url=' + redirectUrl + '&models=' + models;
 }
 

--- a/apps/openclaw/setup-pollinations.sh
+++ b/apps/openclaw/setup-pollinations.sh
@@ -41,9 +41,8 @@ NEW_CONFIG=$(cat <<EOF
         "pollinations/glm": { "alias": "GLM-4.7 (Pollinations)" },
         "pollinations/gemini-fast": { "alias": "Gemini Flash Lite (Pollinations)" },
         "pollinations/claude-fast": { "alias": "Claude Haiku 4.5 (Pollinations)" },
-        "pollinations/claude": { "alias": "Claude Sonnet (Pollinations, paid)" },
-        "pollinations/gemini": { "alias": "Gemini 3 (Pollinations, paid)" },
-        "pollinations/grok": { "alias": "Grok 4 (Pollinations, paid)" }
+        "pollinations/claude-large": { "alias": "Claude Opus 4.6 (Pollinations, paid)" },
+        "pollinations/gemini-large": { "alias": "Gemini 3 Pro (Pollinations, paid)" }
       }
     }
   },
@@ -98,6 +97,24 @@ NEW_CONFIG=$(cat <<EOF
             "input": ["text", "image"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
             "contextWindow": 200000,
+            "maxTokens": 8192
+          },
+          {
+            "id": "claude-large",
+            "name": "Claude Opus 4.6 — Most Intelligent (Paid)",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 200000,
+            "maxTokens": 8192
+          },
+          {
+            "id": "gemini-large",
+            "name": "Gemini 3 Pro — Most Intelligent with 1M Context (Paid)",
+            "reasoning": true,
+            "input": ["text", "image", "audio", "video"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 1000000,
             "maxTokens": 8192
           }
         ]


### PR DESCRIPTION
- Add gemini-large and claude-large to default auth flow selection
- Add paid models (gemini-large, claude-large) to provider models array
- Add missing free models (gemini-fast, claude-fast) to manual JSON config
- Update agent aliases to use standardized naming

**Fixes:** Paid models (claude-large, gemini-large) were listed in agent aliases and model table UI but missing from the `models.providers.pollinations.models` array. If OpenClaw requires models to be declared in provider config, they wouldn't work.

**Changes:**
- [index.html:760](apps/openclaw/index.html#L760) - Added paid models to auth flow URL
- [index.html:632-642](apps/openclaw/index.html#L632-L642) - Updated agent aliases
- [index.html:651-666](apps/openclaw/index.html#L651-L666) - Added all models to provider config
- [setup-pollinations.sh:38-47](apps/openclaw/setup-pollinations.sh#L38-L47) - Updated agent aliases
- [setup-pollinations.sh:95-121](apps/openclaw/setup-pollinations.sh#L95-L121) - Added paid models to provider array

🤖 Generated with [Claude Code](https://claude.com/claude-code)