### PR TITLE
fix: grok aspect ratio conversion

### DIFF
--- a/image.pollinations.ai/src/models/airforceModel.ts
+++ b/image.pollinations.ai/src/models/airforceModel.ts
@@ -159,6 +159,17 @@ function buildRequestBody(
             defaultResolution: "720P",
         });
 
+        // grok-imagine-video at airforce does not support 16:9 or 9:16, so we need to convert to 3:2 or 2:3 which is closest to these values
+        if (airforceModel === "grok-imagine-video") {
+            const airforceAspectRatio =
+                aspectRatio === "16:9"
+                    ? "3:2"
+                    : aspectRatio === "9:16"
+                      ? "2:3"
+                      : aspectRatio;
+            requestBody.aspect_ratio = airforceAspectRatio;
+        }
+
         // Map resolution to size parameter (grok-video uses WxH format)
         const sizeMap: Record<string, Record<string, string>> = {
             "16:9": {


### PR DESCRIPTION
grok-imagine-video at airforce does not support 16:9 or 9:16, so we need to convert to 3:2 or 2:3 which is closest to these values