### PR TITLE
fix: grok aspect ratio conversion

### DIFF
--- a/image.pollinations.ai/src/models/airforceModel.ts
+++ b/image.pollinations.ai/src/models/airforceModel.ts
@@ -167,7 +167,7 @@ function buildRequestBody(
                     : aspectRatio === "9:16"
                       ? "2:3"
                       : aspectRatio;
-            requestBody.aspect_ratio = airforceAspectRatio;
+            requestBody.aspectRatio = airforceAspectRatio;
         }
 
         // Map resolution to size parameter (grok-video uses WxH format)


### PR DESCRIPTION
grok-imagine-video at airforce does not support 16:9 or 9:16, so we need to convert to 3:2 or 2:3 which is closest to these values