### PR TITLE
fix: point highlights URLs to news branch

### DIFF
--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -2,9 +2,9 @@ import { type FC, useEffect, useState } from "react";
 import { Panel } from "../ui/panel.tsx";
 
 const HIGHLIGHTS_RAW_URL =
-    "https://raw.githubusercontent.com/pollinations/pollinations/main/social/news/highlights.md";
+    "https://raw.githubusercontent.com/pollinations/pollinations/news/social/news/highlights.md";
 const HIGHLIGHTS_GITHUB_URL =
-    "https://github.com/pollinations/pollinations/blob/main/social/news/highlights.md";
+    "https://github.com/pollinations/pollinations/blob/news/social/news/highlights.md";
 
 interface Highlight {
     date: string;

--- a/pollinations.ai/src/copy/constants.ts
+++ b/pollinations.ai/src/copy/constants.ts
@@ -4,7 +4,7 @@
 export const COPY_CONSTANTS = {
     // External data sources
     newsFilePath:
-        "https://raw.githubusercontent.com/pollinations/pollinations/main/social/news/highlights.md",
+        "https://raw.githubusercontent.com/pollinations/pollinations/news/social/news/highlights.md",
     appsFilePath: "/APPS.md",
 
     // API


### PR DESCRIPTION
## Summary
- highlights.md moved from `main` to `news` branch in #8290
- Both frontends were fetching from `main` → 404
- Update `raw.githubusercontent.com` URLs to use `news` branch

## Changes
- `pollinations.ai/src/copy/constants.ts`: `main` → `news`
- `enter.pollinations.ai/src/client/components/layout/news-banner.tsx`: `main` → `news` (both raw + blob URLs)

## Test plan
- [ ] Verify https://raw.githubusercontent.com/pollinations/pollinations/news/social/news/highlights.md returns content
- [ ] Check pollinations.ai news section loads highlights
- [ ] Check enter.pollinations.ai news banner loads highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)