### PR TITLE
fix: pass date to Buffer staging steps

### DIFF
--- a/.github/workflows/NEWS_summary.yml
+++ b/.github/workflows/NEWS_summary.yml
@@ -82,6 +82,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
           PUBLISH_MODE: buffer
+          TARGET_DATE: ${{ github.event.inputs.target_date || '' }}
         run: python social/scripts/publish_daily.py
 
       # ── Weekly: generate + stage to Buffer ─────────────────────────
@@ -101,4 +102,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
           PUBLISH_MODE: buffer
+          WEEK_START_DATE: ${{ github.event.inputs.target_date || '' }}
         run: python social/scripts/publish_weekly.py

--- a/social/scripts/publish_weekly.py
+++ b/social/scripts/publish_weekly.py
@@ -40,11 +40,17 @@ WEEKLY_REL_DIR = "social/news/weekly"
 # ── Helpers ──────────────────────────────────────────────────────────
 
 def get_week_end() -> str:
-    """Get the week_end date from env var or default to most recent Saturday UTC.
-    Matches generate_weekly.py which uses start + 6 days (Sun→Sat window)."""
+    """Get the week_end date from env var or compute from WEEK_START_DATE.
+    Matches generate_weekly.py which uses start + 6 days (Sun→Sat window).
+    Falls back to most recent Saturday UTC if neither override is set."""
     override = get_env("WEEK_END_DATE", required=False)
     if override:
         return override
+    # Match generate_weekly.py's logic: start + 6 days
+    week_start = get_env("WEEK_START_DATE", required=False)
+    if week_start:
+        start = datetime.strptime(week_start, "%Y-%m-%d").date()
+        return (start + timedelta(days=6)).strftime("%Y-%m-%d")
     today = datetime.now(timezone.utc).date()
     days_since_saturday = (today.weekday() - 5) % 7
     saturday = today - timedelta(days=days_since_saturday)


### PR DESCRIPTION
## Summary
- Fix weekly Buffer staging failing because `publish_weekly.py` computed a different date than `generate_weekly.py`
- Pass `WEEK_START_DATE` to weekly staging step and `TARGET_DATE` to daily staging step in `NEWS_summary.yml`
- Add `WEEK_START_DATE` support to `publish_weekly.py`'s `get_week_end()` so it matches generate's `start + 6` logic

## Root cause
When manually triggered with `target_date=2026-02-09`, generate stored content at `weekly/2026-02-15/` (start + 6), but staging computed `week_end=2026-02-14` (most recent Saturday) — wrong directory, no files found.

## Test plan
- [ ] Re-trigger `NEWS_summary.yml` with `mode=weekly` and `target_date=2026-02-09` after merge
- [ ] Verify Twitter, LinkedIn, Instagram appear in Buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)