### PR TITLE
feat: remove SKIP logic from social news pipeline

### DIFF
--- a/social/prompts/format.md
+++ b/social/prompts/format.md
@@ -92,8 +92,6 @@ Output Format (JSON only):
 
 Return ONLY the JSON object. No markdown fences, no explanation.
 
-If nothing noteworthy shipped, return exactly `SKIP` instead of JSON.
-
 ## Discord
 
 - Greet <@&1424461167883194418> naturally and wittily
@@ -101,8 +99,6 @@ If nothing noteworthy shipped, return exactly `SKIP` instead of JSON.
 - Group changes into logical emoji sections (new features, improvements, community wins)
 - Total length: 200-400 words — punchy but complete
 - Include a pixel art image prompt following the visual style guide
-- If nothing major shipped, return SKIP
-
 Output Format (JSON only):
 {
     "message": "The Discord message text with emoji sections, bold formatting, greetings.",
@@ -111,8 +107,6 @@ Output Format (JSON only):
 }
 
 Return ONLY the JSON object. No markdown fences, no explanation.
-
-If nothing noteworthy shipped, return exactly `SKIP` instead of JSON.
 
 ## Realtime
 

--- a/social/prompts/highlights.md
+++ b/social/prompts/highlights.md
@@ -62,7 +62,7 @@ Add links naturally in the description using markdown format: [text](url)
 {links}
 
 ## CRITICAL
-- Output exactly `SKIP` if nothing qualifies
+- Always generate highlights — every merged PR is worth posting
 - Use your judgment - if something feels exciting and user-facing, include it
 - Typical weeks: 3-4 highlights. Slow weeks: 0-2. Big release weeks: up to 10
 - Trust your instincts on what users would find exciting
@@ -79,4 +79,4 @@ Typical week: 3-4 highlights. Some weeks: 0. Be very selective.
 CHANGELOG:
 {news_content}
 
-Output markdown bullets only, or SKIP if nothing qualifies.
+Output markdown bullets only.

--- a/social/prompts/tone/discord.md
+++ b/social/prompts/tone/discord.md
@@ -36,8 +36,6 @@ Think: enthusiastic community mod who actually knows the tech. Witty, celebrator
 - Only include MAJOR changes that matter to users
 - Skip styling/UI cosmetics, internal tooling, infrastructure
 - Focus on changes that impact users of services powered by pollinations.ai
-- If nothing major shipped, return `SKIP`
-
 TONE: Conversational, witty, celebratory. Highlight the cool stuff.
 
 ## Discord-Specific Image Adaptation

--- a/social/scripts/generate_weekly.py
+++ b/social/scripts/generate_weekly.py
@@ -176,9 +176,6 @@ def generate_discord_post(digest: Dict, token: str, week_end: str) -> Optional[D
         return None
 
     text = response.strip()
-    if text.upper().strip() == "SKIP":
-        return None
-
     result = parse_json_response(text)
     if result:
         result["date"] = week_end

--- a/social/scripts/publish_realtime.py
+++ b/social/scripts/publish_realtime.py
@@ -134,9 +134,6 @@ def main():
 
     if not snippet:
         snippet = summary
-    elif snippet.strip().upper() == "SKIP":
-        print("  AI returned SKIP — nothing noteworthy to post")
-        return
 
     # Format message with PR metadata footer
     pr_url = gist["url"]

--- a/social/scripts/update_highlights.py
+++ b/social/scripts/update_highlights.py
@@ -126,8 +126,8 @@ def generate_highlights_and_readme(pollinations_token: str, date_str: str) -> tu
         return None, None
 
     new_highlights = parse_response(ai_response)
-    if new_highlights.upper().strip() == "SKIP" or not new_highlights.strip():
-        print("  Highlights: skipped (AI returned SKIP or empty)")
+    if not new_highlights.strip():
+        print("  Highlights: empty response from AI")
         return None, None
 
     print(f"  Highlights: generated new entries")


### PR DESCRIPTION
## Summary
- Removes all SKIP sentinel logic from prompts and scripts
- Every merged PR is worth posting — no more skipping
- Fixes Discord posting literal "SKIP" text when AI deemed a PR "not noteworthy"

**Files changed:**
- `social/prompts/format.md` — removed 3 SKIP instructions (Reddit, Discord weekly)
- `social/prompts/highlights.md` — replaced SKIP with "always generate highlights"
- `social/prompts/tone/discord.md` — removed SKIP from content filtering
- `social/scripts/generate_weekly.py` — removed SKIP check in discord generation
- `social/scripts/update_highlights.py` — simplified to empty-only check

## Test plan
- [ ] Trigger a PR merge and verify Discord realtime post goes through without SKIP
- [ ] Run weekly generation and confirm all platforms generate content

🤖 Generated with [Claude Code](https://claude.com/claude-code)