### PR TITLE
feat: separate Discord webhooks for weekly vs realtime

### DIFF
--- a/.github/workflows/NEWS_pr_gist.yml
+++ b/.github/workflows/NEWS_pr_gist.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_REALTIME_WEBHOOK_URL: ${{ secrets.DISCORD_REALTIME_WEBHOOK_URL }}
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}
           REPO_FULL_NAME: ${{ github.repository }}
         run: python social/scripts/publish_realtime.py

--- a/.github/workflows/NEWS_publish.yml
+++ b/.github/workflows/NEWS_publish.yml
@@ -81,7 +81,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PUBLISH_MODE: direct
           WEEK_END_DATE: ${{ github.event.inputs.target_date || '' }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEEKLY_WEBHOOK_URL: ${{ secrets.DISCORD_WEEKLY_WEBHOOK_URL }}
           REDDIT_VPS_HOST: ${{ secrets.REDDIT_VPS_HOST }}
           REDDIT_VPS_USER: ${{ secrets.REDDIT_VPS_USER }}
           REDDIT_VPS_SSH_KEY: ${{ secrets.REDDIT_VPS_SSH_KEY }}

--- a/social/scripts/publish_realtime.py
+++ b/social/scripts/publish_realtime.py
@@ -92,7 +92,7 @@ def main():
     # Environment
     github_token = get_env("GITHUB_TOKEN")
     pollinations_token = get_env("POLLINATIONS_TOKEN")
-    discord_webhook = get_env("DISCORD_WEBHOOK_URL")
+    discord_webhook = get_env("DISCORD_REALTIME_WEBHOOK_URL")
     pr_number = get_env("PR_NUMBER")
     repo_full_name = get_env("REPO_FULL_NAME")
 

--- a/social/scripts/publish_weekly.py
+++ b/social/scripts/publish_weekly.py
@@ -198,7 +198,7 @@ def main():
             print("  Reddit VPS credentials not configured — skipping")
 
         # Discord
-        discord_webhook = get_env("DISCORD_WEBHOOK_URL", required=False)
+        discord_webhook = get_env("DISCORD_WEEKLY_WEBHOOK_URL", required=False)
         if discord_webhook:
             discord_path = os.path.join(weekly_dir, "discord.json")
             discord_data = read_news_file(discord_path, github_token, owner, repo)


### PR DESCRIPTION
## Summary
- `DISCORD_WEEKLY_WEBHOOK_URL` for weekly digest posts (different channel)
- `DISCORD_REALTIME_WEBHOOK_URL` for per-PR posts
- Secrets already set in repo settings

## Test plan
- [ ] Merge and trigger a PR to verify realtime Discord post goes to correct channel
- [ ] Next weekly run posts to the new weekly channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)