### PR TITLE
fix: reduce workflow noise on PR merges

### DIFF
--- a/.github/workflows/app-review-submission.yml
+++ b/.github/workflows/app-review-submission.yml
@@ -7,6 +7,8 @@ on:
     types: [created]
   pull_request_target:
     types: [closed]
+    paths:
+      - 'apps/APPS.md'
   workflow_dispatch:
     inputs:
       issue_number:

--- a/.github/workflows/app-upgrade-tier.yml
+++ b/.github/workflows/app-upgrade-tier.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types: [closed]
     branches: [main]
+    paths:
+      - 'apps/APPS.md'
 
 concurrency:
   group: app-upgrade-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Add `paths: ['apps/APPS.md']` filter to `pull_request_target` trigger in:
  - `app-review-submission.yml`
  - `app-upgrade-tier.yml`
- These were triggering on every PR merge then immediately skipping
- Issue/comment/dispatch triggers unaffected — full app review pipeline still works

## Test plan
- [ ] Merge an unrelated PR — verify these workflows no longer appear
- [ ] Submit a test app issue — verify the review pipeline still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)