### PR TITLE
feat: add grok-imagine image model (alpha)

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -1155,7 +1155,10 @@ const generateImage = async (
     }
 
     // api.airforce image models
-    if (safeParams.model === "imagen-4") {
+    if (
+        safeParams.model === "imagen-4" ||
+        safeParams.model === "grok-imagine"
+    ) {
         return await callAirforceImageAPI(
             prompt,
             safeParams,

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -149,6 +149,13 @@ export const IMAGE_CONFIG = {
         defaultSideLength: 1024,
     },
 
+    // Grok Imagine - xAI image generation via api.airforce
+    "grok-imagine": {
+        type: "airforce",
+        enhance: false,
+        defaultSideLength: 1024,
+    },
+
     // Grok Imagine Video - xAI video generation via api.airforce
     "grok-video": {
         type: "airforce-video",

--- a/image.pollinations.ai/src/models/airforceModel.ts
+++ b/image.pollinations.ai/src/models/airforceModel.ts
@@ -196,7 +196,10 @@ function buildRequestBody(
         if (imageUrl) {
             requestBody.image = imageUrl;
         }
-    } else if (airforceModel === "imagen-4") {
+    } else if (
+        airforceModel === "imagen-4" ||
+        airforceModel === "grok-imagine"
+    ) {
         const size = closestSupportedSize(safeParams.width, safeParams.height);
         if (size) requestBody.size = size;
     } else if (safeParams.width && safeParams.height) {

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -282,6 +282,21 @@ export const IMAGE_SERVICES = {
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
+    "grok-imagine": {
+        aliases: [],
+        modelId: "grok-imagine",
+        provider: "airforce",
+        alpha: true,
+        cost: [
+            {
+                date: new Date("2026-02-16").getTime(),
+                completionImageTokens: 0.0025, // $0.0025 per image
+            },
+        ],
+        description: "Grok Imagine (api.airforce) - xAI image gen",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
     "grok-video": {
         aliases: ["grok-imagine-video"],
         modelId: "grok-video",


### PR DESCRIPTION
- Add grok-imagine (xAI) via api.airforce as alpha image model
- $0.0025/image, text-only input, 1024px default
- Map to supported sizes (1024x1024, 1024x1792, 1792x1024) like imagen-4
- Tested locally: all aspect ratios working, ~8-13s generation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)