### PR TITLE
fix: restore apps page by fetching APPS.md from GitHub

### DIFF
--- a/pollinations.ai/src/copy/constants.ts
+++ b/pollinations.ai/src/copy/constants.ts
@@ -5,7 +5,8 @@ export const COPY_CONSTANTS = {
     // External data sources
     newsFilePath:
         "https://raw.githubusercontent.com/pollinations/pollinations/news/social/news/highlights.md",
-    appsFilePath: "/APPS.md",
+    appsFilePath:
+        "https://raw.githubusercontent.com/pollinations/pollinations/production/apps/APPS.md",
 
     // API
     apiBaseUrl: "gen.pollinations.ai",


### PR DESCRIPTION
## Summary
- Fix empty apps page — merge commit `e1e5db63c` accidentally reverted `appsFilePath` to local `/APPS.md`
- The `prebuild` copy scripts were already removed in the same PR, so the local path 404s
- Restores fetch from `production` branch raw GitHub URL (as originally intended in PR #8284)

Fixes the "No apps found in this category yet" on https://pollinations.ai/apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)