### PR TITLE
fix: app deploy detection skips root-level files in apps/

### DIFF
--- a/.github/workflows/app-deploy-automatic.yml
+++ b/.github/workflows/app-deploy-automatic.yml
@@ -33,8 +33,8 @@ jobs:
             APP_NAME="${{ github.event.inputs.app_name }}"
           else
             git fetch origin main --depth=2
-            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep '^apps/' | head -1 || \
-                      git diff --name-only origin/main~1 HEAD | grep '^apps/' | head -1)
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep '^apps/[^/]*/' | head -1 || \
+                      git diff --name-only origin/main~1 HEAD | grep '^apps/[^/]*/' | head -1)
             APP_NAME=$(echo "$CHANGED" | sed 's|^apps/\([^/]*\)/.*|\1|')
           fi
           

--- a/apps/slidepainter/.env.example
+++ b/apps/slidepainter/.env.example
@@ -1,4 +1,0 @@
-# Pollinations API Token (get from https://enter.pollinations.ai)
-# Publishable Key (pk_) or Secret Key (sk_) both work
-# pk_ keys are safe for client-side code
-VITE_POLLINATIONS_AI_TOKEN=your_pollinations_api_token_here


### PR DESCRIPTION
## Summary
- Fix deploy workflow skipping when `apps/apps.json` changes alongside an app
- `grep '^apps/'` matched `apps/apps.json` before app subdirectory files → deploy skipped
- Changed to `grep '^apps/[^/]*/'` so only files inside app subdirectories are considered
- Removes unused `.env.example` from slidepainter

🤖 Generated with [Claude Code](https://claude.com/claude-code)