### PR TITLE
fix: deploy to production branch instead of main

### DIFF
--- a/apps/_scripts/deploy.sh
+++ b/apps/_scripts/deploy.sh
@@ -71,7 +71,7 @@ echo ""
 echo "🚀 Deploying to Cloudflare Pages..."
 npx wrangler pages deploy "$APP_PATH/$OUTPUT_DIR" \
     --project-name="$PROJECT_NAME" \
-    --branch=main \
+    --branch=production \
     --commit-dirty=true
 
 echo ""


### PR DESCRIPTION
## Summary
- `deploy-app.js` creates projects with `production_branch: "production"` but `deploy.sh` was deploying with `--branch=main`
- This mismatch caused all apps to deploy to Preview environment instead of Production
- Custom domains (`*.pollinations.ai`) only serve Production, so all deployed apps showed "Nothing is here yet"
- Fix: change `--branch=main` → `--branch=production` in deploy.sh

**Affects all apps** deployed through the unified pipeline (slidepainter, gsoc, chat, etc.)

After merging, existing apps need a redeploy to move from Preview → Production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)