### PR TITLE
feat: logo cycles themes + tokenize tooltip backgrounds

### DIFF
--- a/pollinations.ai/src/ui/components/UserMenu.tsx
+++ b/pollinations.ai/src/ui/components/UserMenu.tsx
@@ -69,7 +69,7 @@ export function UserMenu() {
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 top-full mt-2 w-64 bg-surface-base border-r-4 border-b-4 border-border-brand rounded-button p-4 z-50 shadow-shadow-brand-lg">
+                <div className="absolute right-0 top-full mt-2 w-64 bg-[rgb(var(--surface-base))] backdrop-blur-md border-r-4 border-b-4 border-border-brand rounded-button p-4 z-50 shadow-shadow-brand-lg">
                     {/* Profile */}
                     {profile && (
                         <div className="mb-3">

--- a/pollinations.ai/src/ui/components/play/ModelSelector.tsx
+++ b/pollinations.ai/src/ui/components/play/ModelSelector.tsx
@@ -126,9 +126,9 @@ export const ModelSelector = memo(function ModelSelector({
                                 )}
                             </Button>
                             {!isAllowed && (
-                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                                     {copy.gatedModelTooltip}
-                                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-charcoal" />
+                                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-card" />
                                 </div>
                             )}
                         </div>

--- a/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
+++ b/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
@@ -409,7 +409,7 @@ export function PlayGenerator({
                                                 ),
                                             )
                                         }
-                                        className="absolute -top-1 -right-1 w-5 h-5 bg-charcoal border border-border-main rounded-full flex items-center justify-center text-text-body-main hover:bg-button-secondary-bg transition-colors"
+                                        className="absolute -top-1 -right-1 w-5 h-5 bg-surface-card border border-border-main rounded-full flex items-center justify-center text-text-body-main hover:bg-button-secondary-bg transition-colors"
                                     >
                                         ×
                                     </button>
@@ -483,9 +483,9 @@ export function PlayGenerator({
                                 >
                                     {copy.seedLabel}
                                 </Label>
-                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover/seed:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover/seed:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                                     {copy.seedTooltip}
-                                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-charcoal" />
+                                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-card" />
                                 </div>
                             </div>
                             <input
@@ -510,9 +510,9 @@ export function PlayGenerator({
                                 >
                                     {copy.enhanceLabel}
                                 </Label>
-                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover/enhance:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover/enhance:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                                     {copy.enhanceTooltip}
-                                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-charcoal" />
+                                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-card" />
                                 </div>
                             </div>
                             <label className="relative flex items-center justify-center p-3 bg-input-background hover:bg-input-background transition-colors cursor-pointer select-none group rounded-input">
@@ -615,9 +615,9 @@ export function PlayGenerator({
                     )}
                 </Button>
                 {!prompt && !isLoading && (
-                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover/generate:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover/generate:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                         {copy.enterPromptFirst}
-                        <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-charcoal" />
+                        <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-card" />
                     </div>
                 )}
             </div>

--- a/pollinations.ai/src/ui/components/theme/AIPromptInput.tsx
+++ b/pollinations.ai/src/ui/components/theme/AIPromptInput.tsx
@@ -184,9 +184,9 @@ export const ${capitalizedName}BackgroundHtml = ${
                         {copy.themeLoginPrompt}
                     </span>
                 </button>
-                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-input shadow-lg border border-border-main opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                     {copy.themeLoginTooltip}
-                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-charcoal" />
+                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-surface-card" />
                 </div>
             </div>
         );

--- a/pollinations.ai/src/ui/pages/AppsPage.tsx
+++ b/pollinations.ai/src/ui/pages/AppsPage.tsx
@@ -137,9 +137,9 @@ function AppCard({ app, copy }: { app: App; copy: typeof APPS_PAGE }) {
                                     <Badge variant="pollen">
                                         {copy.pollenBadge}
                                     </Badge>
-                                    <div className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-tag shadow-lg border border-border-main opacity-0 group-hover/byop:opacity-100 transition-opacity pointer-events-none w-max max-w-[280px] text-center z-50">
+                                    <div className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-tag shadow-lg border border-border-main opacity-0 group-hover/byop:opacity-100 transition-opacity pointer-events-none w-max max-w-[280px] text-center z-50">
                                         {copy.pollenTooltip}
-                                        <div className="absolute top-full left-4 border-4 border-transparent border-t-charcoal" />
+                                        <div className="absolute top-full left-4 border-4 border-transparent border-t-surface-card" />
                                     </div>
                                 </span>
                             )}
@@ -148,9 +148,9 @@ function AppCard({ app, copy }: { app: App; copy: typeof APPS_PAGE }) {
                                     <Badge variant="buzz">
                                         {copy.buzzBadge}
                                     </Badge>
-                                    <div className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-tag shadow-lg border border-border-main opacity-0 group-hover/buzz:opacity-100 transition-opacity pointer-events-none w-max max-w-[280px] text-center z-50">
+                                    <div className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-tag shadow-lg border border-border-main opacity-0 group-hover/buzz:opacity-100 transition-opacity pointer-events-none w-max max-w-[280px] text-center z-50">
                                         {copy.buzzTooltip}
-                                        <div className="absolute top-full left-4 border-4 border-transparent border-t-charcoal" />
+                                        <div className="absolute top-full left-4 border-4 border-transparent border-t-surface-card" />
                                     </div>
                                 </span>
                             )}
@@ -159,9 +159,9 @@ function AppCard({ app, copy }: { app: App; copy: typeof APPS_PAGE }) {
                                     <Badge variant="fresh">
                                         {copy.newBadge}
                                     </Badge>
-                                    <div className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-charcoal text-text-body-main text-xs rounded-tag shadow-lg border border-border-main opacity-0 group-hover/new:opacity-100 transition-opacity pointer-events-none w-max max-w-[280px] text-center z-50">
+                                    <div className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-surface-card text-text-body-main text-xs rounded-tag shadow-lg border border-border-main opacity-0 group-hover/new:opacity-100 transition-opacity pointer-events-none w-max max-w-[280px] text-center z-50">
                                         {copy.newTooltip}
-                                        <div className="absolute top-full left-4 border-4 border-transparent border-t-charcoal" />
+                                        <div className="absolute top-full left-4 border-4 border-transparent border-t-surface-card" />
                                     </div>
                                 </span>
                             )}


### PR DESCRIPTION
## Summary
- Logo click cycles through theme presets (with 1s throttle) instead of navigating home
- Theme creator (AIPromptInput) hidden by default — revealed as Easter egg after logo click, with close button to dismiss
- Desktop header collapsed from 2-row grid to single row (nav + social icons + UserMenu)
- Tooltip backgrounds tokenized: `bg-charcoal` → `bg-surface-card` across all 9 tooltip instances
- UserMenu dropdown uses full-opacity surface color + backdrop blur to fix transparency issues

## Test plan
- [ ] Click logo — should cycle through presets (colors + background change)
- [ ] Rapid-click logo — should throttle to max 1/second
- [ ] AIPromptInput hidden on page load, appears after first logo click
- [ ] Close (×) button on AIPromptInput hides it
- [ ] "Change theme" tooltip appears on logo hover (to the right)
- [ ] UserMenu dropdown opens and is fully opaque/readable
- [ ] Nav tabs, social icons, login all still work
- [ ] Tooltips on Play page follow active theme colors
- [ ] Test across default, dreams, pixelart presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)