### PR TITLE
fix: prevent prettification from hallucinating app names

### DIFF
--- a/.github/scripts/app-description-prompt.txt
+++ b/.github/scripts/app-description-prompt.txt
@@ -8,3 +8,5 @@ Rules:
 - Focus on what the app does, not how great it is
 - Must not contain pipe characters (|) or newlines
 - Do not start with "A" or "An" — start with the action or capability
+- NEVER change, rename, or replace the app name — preserve it exactly as given
+- Preserve all proper nouns, tool names, model names, and URLs exactly

--- a/pollinations.ai/src/copy/translation/prettify.ts
+++ b/pollinations.ai/src/copy/translation/prettify.ts
@@ -9,11 +9,18 @@ import { memoizeAsync } from "../../utils";
 interface CopyItem {
     id: string;
     text: string;
+    name?: string;
 }
 
 const PRETTIFY_PROMPT = `Rewrite each app description in zine-style for a creative AI showcase. Output ONLY numbered entries — no intro, no commentary.
 
 Each entry starts with its number (e.g. "1.") on the first line, then continues with markdown on the following lines until the next number.
+
+CRITICAL — preserve facts:
+- NEVER change, rename, or replace app names or project names — keep them exactly as given
+- NEVER invent new names, nicknames, or aliases for the app
+- Preserve all proper nouns, tool names, model names, and URLs exactly
+- Only restyle the description — do not alter what the app is or does
 
 Style guide:
 - One emoji at the start — no emoji spam
@@ -36,7 +43,12 @@ async function prettifyDescriptions(
     items: CopyItem[],
     apiKey?: string,
 ): Promise<CopyItem[]> {
-    const lines = items.map((item, i) => `${i + 1}. ${item.text}`).join("\n");
+    const lines = items
+        .map((item, i) => {
+            const prefix = item.name ? `[${item.name}] ` : "";
+            return `${i + 1}. ${prefix}${item.text}`;
+        })
+        .join("\n");
     const prompt = `${PRETTIFY_PROMPT}\n\n${lines}`;
 
     console.log(`✨ [PRETTIFY] Processing ${items.length} descriptions`);

--- a/pollinations.ai/src/hooks/usePrettify.ts
+++ b/pollinations.ai/src/hooks/usePrettify.ts
@@ -13,6 +13,7 @@ export function usePrettify<T, K extends keyof T>(
     items: T[],
     field: K,
     apiKey?: string,
+    nameField?: keyof T,
 ): { prettified: T[]; isPrettifying: boolean } {
     const [prettified, setPrettified] = useState<T[]>(items);
     const [isPrettifying, setIsPrettifying] = useState(false);
@@ -34,6 +35,7 @@ export function usePrettify<T, K extends keyof T>(
         const copyItems = items.map((item, i) => ({
             id: `item-${i}`,
             text: String(item[field] ?? ""),
+            name: nameField ? String(item[nameField] ?? "") : undefined,
         }));
 
         prettifyCopy(copyItems, apiKey)

--- a/pollinations.ai/src/ui/pages/AppsPage.tsx
+++ b/pollinations.ai/src/ui/pages/AppsPage.tsx
@@ -260,7 +260,12 @@ export default function AppsPage() {
         return allApps.filter(f.match).sort(sortApps);
     }, [allApps, filter]);
 
-    const { prettified } = usePrettify(filteredApps, "description", apiKey);
+    const { prettified } = usePrettify(
+        filteredApps,
+        "description",
+        apiKey,
+        "name",
+    );
 
     const { translated: displayApps } = useTranslate(prettified, "description");
 


### PR DESCRIPTION
## Summary
- Adds name-preservation guardrails to both frontend (`prettify.ts`) and backend (`app-description-prompt.txt`) prettification prompts
- Passes app name as `[AppName]` context prefix so the LLM knows what it's rewriting
- Adds `nameField` param to `usePrettify` hook to pipe names through the pipeline
- Fixes hallucination where e.g. "AlphaLLM" was rewritten as "Chaos Commander"

## Test plan
- [ ] Visit `/apps` page, verify app names display correctly (not hallucinated)
- [ ] Check console for `[PRETTIFY]` logs confirming descriptions process without errors
- [ ] Verify AlphaLLM and other apps retain their original names in prettified output

🤖 Generated with [Claude Code](https://claude.com/claude-code)