### PR TITLE
fix: add `to` prop to ButtonProps for React Router Link compatibility

### DIFF
--- a/pollinations.ai/src/ui/components/ui/button.tsx
+++ b/pollinations.ai/src/ui/components/ui/button.tsx
@@ -56,6 +56,7 @@ export interface ButtonProps
         VariantProps<typeof buttonVariants> {
     as?: React.ElementType;
     href?: string;
+    to?: string;
     target?: string;
     rel?: string;
 }


### PR DESCRIPTION
## Summary
- Fixes broken production deploy caused by TypeScript build error
- Adds `to?: string` to `ButtonProps` so `<Button as={Link} to="/path">` compiles correctly
- No runtime behavior change — `to` was already being passed through via `...props`

## Test plan
- [x] `npm run build` passes with no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)