### PR TITLE
fix: unify BYOP detection across KPI dashboard and Grafana

### DIFF
--- a/apps/operation/economics/provisioning/dashboards/byop.json
+++ b/apps/operation/economics/provisioning/dashboards/byop.json
@@ -13,7 +13,7 @@
             "type": "dashboard"
         }]
     },
-    "description": "BYOP (Bring Your Own Pollen) — apps where multiple users each bring their own API key. Filters to key names shared by 2+ distinct users.",
+    "description": "BYOP (Bring Your Own Pollen) — apps using secret API keys with hostname-like names (api_key_type='secret' AND api_key_name LIKE '%.%').",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 1,
@@ -33,7 +33,7 @@
                 "type": "grafana-clickhouse-datasource",
                 "uid": "PAD1A0A25CD30D456"
             },
-            "description": "Total pollen consumed through BYOP apps (key names shared by 2+ users).",
+            "description": "Total pollen consumed through BYOP apps (secret keys with hostname names).",
             "fieldConfig": {
                 "defaults": {
                     "color": { "fixedColor": "green", "mode": "fixed" },
@@ -62,7 +62,7 @@
             "targets": [{
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 0,
-                "rawSql": "SELECT sum(total_pollen) as total_pollen FROM (SELECT api_key_name, sum(total_price) as total_pollen FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND length(api_key_name) > 0 AND api_key_name != 'undefined' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58')) GROUP BY api_key_name HAVING countDistinct(user_github_id) >= 2)",
+                "rawSql": "SELECT sum(total_price) as total_pollen FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND api_key_type = 'secret' AND api_key_name LIKE '%.%' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))",
                 "refId": "A"
             }],
             "title": "Total BYOP Pollen",
@@ -102,7 +102,7 @@
             "targets": [{
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 0,
-                "rawSql": "SELECT sum(tier_pollen) as tier_pollen FROM (SELECT api_key_name, sumIf(total_price, selected_meter_slug IN ('v1:meter:tier', 'local:tier')) as tier_pollen FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND length(api_key_name) > 0 AND api_key_name != 'undefined' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58')) GROUP BY api_key_name HAVING countDistinct(user_github_id) >= 2)",
+                "rawSql": "SELECT sumIf(total_price, selected_meter_slug IN ('v1:meter:tier', 'local:tier')) as tier_pollen FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND api_key_type = 'secret' AND api_key_name LIKE '%.%' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))",
                 "refId": "A"
             }],
             "title": "Tier ρ (Free)",
@@ -142,7 +142,7 @@
             "targets": [{
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 0,
-                "rawSql": "SELECT sum(pack_pollen) as pack_pollen FROM (SELECT api_key_name, sumIf(total_price, selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_pollen FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND length(api_key_name) > 0 AND api_key_name != 'undefined' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58')) GROUP BY api_key_name HAVING countDistinct(user_github_id) >= 2)",
+                "rawSql": "SELECT sumIf(total_price, selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_pollen FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND api_key_type = 'secret' AND api_key_name LIKE '%.%' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))",
                 "refId": "A"
             }],
             "title": "Pack ρ (Paid)",
@@ -182,7 +182,7 @@
             "targets": [{
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 0,
-                "rawSql": "SELECT sum(user_count) as unique_users FROM (SELECT api_key_name, countDistinct(user_github_id) as user_count FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND length(api_key_name) > 0 AND api_key_name != 'undefined' AND user_github_id != '' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58')) GROUP BY api_key_name HAVING user_count >= 2)",
+                "rawSql": "SELECT countDistinct(user_github_id) as unique_users FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND api_key_type = 'secret' AND api_key_name LIKE '%.%' AND user_github_id != '' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))",
                 "refId": "A"
             }],
             "title": "BYOP Users",
@@ -193,7 +193,7 @@
                 "type": "grafana-clickhouse-datasource",
                 "uid": "PAD1A0A25CD30D456"
             },
-            "description": "Number of distinct BYOP apps (key names shared by 2+ users).",
+            "description": "Number of distinct BYOP apps (secret keys with hostname names).",
             "fieldConfig": {
                 "defaults": {
                     "color": { "fixedColor": "purple", "mode": "fixed" },
@@ -222,7 +222,7 @@
             "targets": [{
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 0,
-                "rawSql": "SELECT count() as byop_apps FROM (SELECT api_key_name FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND length(api_key_name) > 0 AND api_key_name != 'undefined' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58')) GROUP BY api_key_name HAVING countDistinct(user_github_id) >= 2)",
+                "rawSql": "SELECT countDistinct(api_key_name) as byop_apps FROM generation_event WHERE $__timeFilter(start_time) AND environment = 'production' AND response_status >= 200 AND response_status < 300 AND total_price > 0 AND api_key_type = 'secret' AND api_key_name LIKE '%.%' AND user_github_id != '241978997' AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))",
                 "refId": "A"
             }],
             "title": "BYOP Apps",
@@ -241,7 +241,7 @@
                 "type": "grafana-clickhouse-datasource",
                 "uid": "PAD1A0A25CD30D456"
             },
-            "description": "Apps (key names) used by multiple users — the core BYOP pattern. Ranked by total pollen consumed. Shows top spender (owner) and average pollen per user.",
+            "description": "BYOP apps (secret keys with hostname names). Ranked by total pollen consumed. Shows top spender (owner) and average pollen per user.",
             "fieldConfig": {
                 "defaults": {
                     "color": { "mode": "thresholds" },
@@ -348,7 +348,7 @@
             "targets": [{
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 1,
-                "rawSql": "SELECT\n  app,\n  if(pack_pollen + tier_pollen > 0, (pack_pollen - tier_pollen) / (pack_pollen + tier_pollen), 0) as pack_ratio,\n  avg_per_user, owner, users, tier_pollen, pack_pollen, total_pollen, requests\nFROM (\n  SELECT\n    app,\n    argMax(user, user_total) as owner,\n    count() as users,\n    sum(user_total) / count() as avg_per_user,\n    sum(tier_pollen) as tier_pollen,\n    sum(pack_pollen) as pack_pollen,\n    sum(user_total) as total_pollen,\n    sum(requests) as requests\n  FROM (\n    SELECT\n      api_key_name as app,\n      if(user_github_username != '' AND user_github_username != 'undefined', user_github_username, user_github_id) as user,\n      sumIf(total_price, selected_meter_slug IN ('v1:meter:tier', 'local:tier')) as tier_pollen,\n      sumIf(total_price, selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_pollen,\n      sum(total_price) as user_total,\n      count() as requests\n    FROM generation_event\n    WHERE $__timeFilter(start_time)\n      AND environment = 'production'\n      AND response_status >= 200 AND response_status < 300\n      AND total_price > 0\n      AND length(api_key_name) > 0\n      AND api_key_name != 'undefined'\n      AND user_github_id != ''\n      AND user_github_id != '241978997'\n      AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))\n    GROUP BY app, user\n  )\n  GROUP BY app\n  HAVING count() >= 2\n  ORDER BY total_pollen DESC\n)",
+                "rawSql": "SELECT\n  app,\n  if(pack_pollen + tier_pollen > 0, (pack_pollen - tier_pollen) / (pack_pollen + tier_pollen), 0) as pack_ratio,\n  avg_per_user, owner, users, tier_pollen, pack_pollen, total_pollen, requests\nFROM (\n  SELECT\n    app,\n    argMax(user, user_total) as owner,\n    count() as users,\n    sum(user_total) / count() as avg_per_user,\n    sum(tier_pollen) as tier_pollen,\n    sum(pack_pollen) as pack_pollen,\n    sum(user_total) as total_pollen,\n    sum(requests) as requests\n  FROM (\n    SELECT\n      api_key_name as app,\n      if(user_github_username != '' AND user_github_username != 'undefined', user_github_username, user_github_id) as user,\n      sumIf(total_price, selected_meter_slug IN ('v1:meter:tier', 'local:tier')) as tier_pollen,\n      sumIf(total_price, selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_pollen,\n      sum(total_price) as user_total,\n      count() as requests\n    FROM generation_event\n    WHERE $__timeFilter(start_time)\n      AND environment = 'production'\n      AND response_status >= 200 AND response_status < 300\n      AND total_price > 0\n      AND api_key_type = 'secret'\n      AND api_key_name LIKE '%.%'\n      AND user_github_id != ''\n      AND user_github_id != '241978997'\n      AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))\n    GROUP BY app, user\n  )\n  GROUP BY app\n  ORDER BY total_pollen DESC\n)",
                 "refId": "A"
             }],
             "title": "BYOP App Ranking",
@@ -450,7 +450,7 @@
                 "datasource": { "type": "grafana-clickhouse-datasource", "uid": "PAD1A0A25CD30D456" },
                 "format": 0,
                 "range": true,
-                "rawSql": "SELECT\n  time,\n  sumIf(pack_pollen, user_count >= 2) as pack_pollen,\n  sumIf(tier_pollen, user_count >= 2) as tier_pollen,\n  if(pack_pollen + tier_pollen > 0, tier_pollen / (pack_pollen + tier_pollen), 0) as tier_pct\nFROM (\n  SELECT\n    toStartOfInterval(start_time, INTERVAL 1 DAY) as time,\n    api_key_name,\n    sumIf(total_price, selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_pollen,\n    sumIf(total_price, selected_meter_slug IN ('v1:meter:tier', 'local:tier')) as tier_pollen,\n    countDistinct(user_github_id) as user_count\n  FROM generation_event\n  WHERE $__timeFilter(start_time)\n    AND environment = 'production'\n    AND response_status >= 200 AND response_status < 300\n    AND total_price > 0\n    AND length(api_key_name) > 0\n    AND api_key_name != 'undefined'\n    AND user_github_id != '241978997'\n    AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))\n  GROUP BY time, api_key_name\n)\nGROUP BY time\nORDER BY time",
+                "rawSql": "SELECT\n  toStartOfInterval(start_time, INTERVAL 1 DAY) as time,\n  sumIf(total_price, selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_pollen,\n  sumIf(total_price, selected_meter_slug IN ('v1:meter:tier', 'local:tier')) as tier_pollen,\n  if(pack_pollen + tier_pollen > 0, tier_pollen / (pack_pollen + tier_pollen), 0) as tier_pct\nFROM generation_event\nWHERE $__timeFilter(start_time)\n  AND environment = 'production'\n  AND response_status >= 200 AND response_status < 300\n  AND total_price > 0\n  AND api_key_type = 'secret'\n  AND api_key_name LIKE '%.%'\n  AND user_github_id != '241978997'\n  AND (start_time < toDateTime('2025-12-30 16:59:45') OR start_time > toDateTime('2026-01-08 18:19:58'))\nGROUP BY time\nORDER BY time",
                 "refId": "A"
             }],
             "title": "Daily BYOP Consumption — Pack vs Tier",

--- a/apps/operation/kpi/src/App.jsx
+++ b/apps/operation/kpi/src/App.jsx
@@ -168,12 +168,12 @@ export default function App() {
                         };
                         weekMap.set(row.week, {
                             ...existing,
-                            developerUsers: row.developer_users,
-                            developerPollen: row.developer_pollen,
-                            enduserUsers: row.enduser_users,
-                            enduserPollen: row.enduser_pollen,
-                            enduserUserPct: row.enduser_user_pct,
-                            enduserPollenPct: row.enduser_pollen_pct,
+                            byopUsers: row.byop_users,
+                            byopPollen: row.byop_pollen,
+                            otherUsers: row.other_users,
+                            otherPollen: row.other_pollen,
+                            byopUserPct: row.byop_user_pct,
+                            byopPollenPct: row.byop_pollen_pct,
                         });
                     }
                 }

--- a/apps/operation/kpi/src/components/KPITrendTable.jsx
+++ b/apps/operation/kpi/src/components/KPITrendTable.jsx
@@ -182,20 +182,20 @@ export function KPITrendTable({ weeklyData, title }) {
                 "% of requests without server errors (5xx). User errors (4xx) don't count as downtime. Formula: (total - 5xx) / total × 100",
         },
         {
-            key: "enduserUserPct",
-            name: "End-user %",
+            key: "byopUserPct",
+            name: "BYOP User %",
             category: "Segments",
             format: "percent",
             tooltip:
-                "% of active users using temporary keys (end-users via BYOP). Developer = secret/publishable keys.",
+                "% of active users from BYOP apps (secret keys with hostname names, e.g. myapp.com). Matches website BYOP detection.",
         },
         {
-            key: "enduserPollenPct",
-            name: "End-user Pollen %",
+            key: "byopPollenPct",
+            name: "BYOP Pollen %",
             category: "Segments",
             format: "percent",
             tooltip:
-                "% of pollen consumed by end-users (temporary keys). Shows B2C vs B2B revenue split.",
+                "% of pollen consumed by BYOP apps. Shows how much usage comes from apps that bring their own pollen.",
         },
         {
             key: "churnRate",

--- a/apps/operation/kpi/src/worker/index.ts
+++ b/apps/operation/kpi/src/worker/index.ts
@@ -483,17 +483,17 @@ app.get("/api/kpi/user-segments", async (c) => {
     const data = (await res.json()) as {
         data: Array<{
             week: string;
-            developer_users: number;
-            developer_pollen: number;
-            developer_requests: number;
-            enduser_users: number;
-            enduser_pollen: number;
-            enduser_requests: number;
+            byop_users: number;
+            byop_pollen: number;
+            byop_requests: number;
+            other_users: number;
+            other_pollen: number;
+            other_requests: number;
             total_users: number;
             total_pollen: number;
             total_requests: number;
-            enduser_user_pct: number;
-            enduser_pollen_pct: number;
+            byop_user_pct: number;
+            byop_pollen_pct: number;
         }>;
     };
     return c.json({ data: data.data });

--- a/enter.pollinations.ai/observability/endpoints/weekly_user_segment.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_user_segment.pipe
@@ -1,5 +1,7 @@
 DESCRIPTION >
-    Weekly B2B (developer) vs B2C (end-user) usage metrics based on api_key_type
+    Weekly BYOP vs non-BYOP usage metrics.
+    BYOP = secret API keys with hostname-like names (contains a dot),
+    matching the detection logic used by app_byop_hostnames.pipe.
 
 TOKEN model_usage READ
 
@@ -8,21 +10,21 @@ SQL >
     %
     SELECT
         toStartOfWeek(start_time, 1) AS week,
-        -- Developer (B2B): secret or publishable keys
-        countIf(DISTINCT user_id, api_key_type IN ('secret', 'publishable')) AS developer_users,
-        sumIf(total_price, api_key_type IN ('secret', 'publishable')) AS developer_pollen,
-        countIf(api_key_type IN ('secret', 'publishable')) AS developer_requests,
-        -- End-user (B2C): temporary keys (BYOP)
-        countIf(DISTINCT user_id, api_key_type = 'temporary') AS enduser_users,
-        sumIf(total_price, api_key_type = 'temporary') AS enduser_pollen,
-        countIf(api_key_type = 'temporary') AS enduser_requests,
+        -- BYOP: secret keys with hostname-like names (e.g. myapp.com)
+        countIf(DISTINCT user_id, api_key_type = 'secret' AND api_key_name LIKE '%.%') AS byop_users,
+        sumIf(total_price, api_key_type = 'secret' AND api_key_name LIKE '%.%') AS byop_pollen,
+        countIf(api_key_type = 'secret' AND api_key_name LIKE '%.%') AS byop_requests,
+        -- Non-BYOP: everything else
+        countIf(DISTINCT user_id, NOT (api_key_type = 'secret' AND api_key_name LIKE '%.%')) AS other_users,
+        sumIf(total_price, NOT (api_key_type = 'secret' AND api_key_name LIKE '%.%')) AS other_pollen,
+        countIf(NOT (api_key_type = 'secret' AND api_key_name LIKE '%.%')) AS other_requests,
         -- Totals
-        developer_users + enduser_users AS total_users,
-        developer_pollen + enduser_pollen AS total_pollen,
-        developer_requests + enduser_requests AS total_requests,
+        byop_users + other_users AS total_users,
+        byop_pollen + other_pollen AS total_pollen,
+        byop_requests + other_requests AS total_requests,
         -- Percentages
-        if(total_users > 0, round(enduser_users / total_users * 100, 1), 0) AS enduser_user_pct,
-        if(total_pollen > 0, round(enduser_pollen / total_pollen * 100, 1), 0) AS enduser_pollen_pct
+        if(total_users > 0, round(byop_users / total_users * 100, 1), 0) AS byop_user_pct,
+        if(total_pollen > 0, round(byop_pollen / total_pollen * 100, 1), 0) AS byop_pollen_pct
     FROM generation_event
     WHERE
         environment = 'production'


### PR DESCRIPTION
## Summary
- Fix BYOP detection in KPI dashboard TinyBird pipe (`weekly_user_segment.pipe`) — was using `api_key_type='temporary'`, now uses `api_key_type='secret' AND api_key_name LIKE '%.%'` matching the website
- Fix Grafana BYOP dashboard — was using `HAVING countDistinct(user_github_id) >= 2`, now uses the same secret key + hostname filter
- Update KPI dashboard worker types, App.jsx field mappings, and KPITrendTable labels to match new column names (`byop_*` instead of `enduser_*`)
- TinyBird pipe already deployed and verified

## Test plan
- [x] TinyBird pipe deployed and returning correct data (verified via curl)
- [ ] Deploy KPI dashboard worker to verify frontend renders correctly
- [ ] Import updated Grafana dashboard JSON and verify panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)