### PR TITLE
fix: replace misleading KPI metric, add deployment docs

### DIFF
--- a/apps/operation/kpi/README.md
+++ b/apps/operation/kpi/README.md
@@ -55,9 +55,27 @@ npm run dev
 
 ## Deployment
 
+**Cloudflare account:** Myceli (`b6ec751c0862027ba269faf7029b2501` / Elliot@myceli.ai)
+
+This is NOT on the Pollinations account. You must be logged into the myceli Cloudflare account.
+
 ```bash
-npm run deploy  # Deploys to kpi.myceli.ai
+cd apps/operation/kpi
+
+# 1. Login to the myceli account (opens browser)
+npx wrangler login
+# Verify: npx wrangler whoami → should show "Elliot@myceli.ai's Account"
+
+# 2. Build frontend
+npm run build
+
+# 3. Deploy
+CLOUDFLARE_ACCOUNT_ID=b6ec751c0862027ba269faf7029b2501 npx wrangler deploy
 ```
+
+**Live URL:** https://kpi.myceli.ai
+
+**Worker name:** `myceli-kpi`
 
 ## Secrets Management
 

--- a/apps/operation/kpi/src/components/KPITrendTable.jsx
+++ b/apps/operation/kpi/src/components/KPITrendTable.jsx
@@ -165,13 +165,13 @@ export function KPITrendTable({ weeklyData, title }) {
                 "Formula: (Revenue / Total Tokens) × 1,000,000. Unit economics — how much revenue per million tokens consumed.",
         },
         {
-            key: "conversionRate",
-            name: "Activation→Purchase",
+            key: "purchaseRate",
+            name: "Purchase Rate",
             category: "Efficiency",
             format: "percent",
-            calc: (w) => (w.packPurchases / w.activations) * 100,
+            calc: (w) => (w.packPurchases / w.wau) * 100,
             tooltip:
-                "Formula: (Pack Purchases / Activated Users) × 100. Funnel conversion from activation to paying customer.",
+                "Formula: (Pack Purchases / WAU) × 100. What % of active users bought a pollen pack this week.",
         },
         {
             key: "availability",


### PR DESCRIPTION
## Summary
- Replace Activation→Purchase metric with Purchase Rate (packPurchases/WAU)
- Old formula divided unrelated populations (purchases vs activations from same week)
- New metric: % of active users who bought a pollen pack this week
- Add KPI deployment docs to README (myceli Cloudflare account)

## Test plan
- [x] Verified all KPI formulas against live API data
- [x] Deployed and confirmed on kpi.myceli.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)