### PR TITLE
fix: expand POLLINATIONS_TOKEN env var in router config

### DIFF
--- a/.github/workflows/issue-polly-auto-fix.yml
+++ b/.github/workflows/issue-polly-auto-fix.yml
@@ -68,7 +68,7 @@ jobs:
           BOT_USER_ID=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
           echo "user-id=$BOT_USER_ID" >> "$GITHUB_OUTPUT"
           mkdir -p $HOME/.claude-code-router
-          echo '{"LOG":false,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"${POLLINATIONS_TOKEN}","models":["claude-large","claude","kimi-k2-thinking","perplexity-reasoning","openai-large","openai"]}],"Router":{"default":"pollinations,claude-large","background":"pollinations,claude","think":"pollinations,kimi-k2-thinking","longContext":"pollinations,claude-large","longContextThreshold":60000,"webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
+          echo '{"LOG":false,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"'"${POLLINATIONS_TOKEN}"'","models":["claude-large","claude","kimi-k2-thinking","perplexity-reasoning","openai-large","openai"]}],"Router":{"default":"pollinations,claude-large","background":"pollinations,claude","think":"pollinations,kimi-k2-thinking","longContext":"pollinations,claude-large","longContextThreshold":60000,"webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
           bunx @musistudio/claude-code-router@1.0.27 start &
           until curl -s http://localhost:3456 >/dev/null; do sleep 0.5; done
         env:


### PR DESCRIPTION
The entire JSON config was wrapped in single quotes, so ${POLLINATIONS_TOKEN} was written literally into the config file instead of being expanded to the actual secret value. The router then sent this literal string as the API key, causing auth failures and Claude Code exiting with code 1.

https://claude.ai/code/session_01DQmp7kRJHN6cgea5PcLdm8