### PR TITLE
fix: align auto-polly with main polly setup

### DIFF
--- a/.github/scripts/project-manager.py
+++ b/.github/scripts/project-manager.py
@@ -518,9 +518,9 @@ def main():
     labels = normalize_labels(project_key, classification.get("labels", []))
     log_debug(f"Normalized labels: {labels}")
 
-    # Add "polly" label if AI determined issue is auto-fixable
+    # Add "polly" label if AI determined issue is auto-fixable (issues only, not PRs)
     # Safe because issue-polly-auto-fix.yml uses GitHub API to read issue body (not raw injection)
-    if classification.get("is_polly_fixable", False):
+    if classification.get("is_polly_fixable", False) and not IS_PULL_REQUEST:
         log_debug("AI determined issue is Polly-fixable, adding 'polly' label")
         labels.append("polly")
 

--- a/.github/workflows/issue-polly-auto-fix.yml
+++ b/.github/workflows/issue-polly-auto-fix.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     env:
       POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
@@ -61,15 +62,21 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup Router
+      - name: Setup
         if: steps.whitelist.outputs.authorized == 'true'
         id: setup
         run: |
+          # Add eyes reaction
+          gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/reactions -f content=eyes || true
+
+          # Get bot user ID and setup router config
           BOT_USER_ID=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
           echo "user-id=$BOT_USER_ID" >> "$GITHUB_OUTPUT"
           mkdir -p $HOME/.claude-code-router
           echo '{"LOG":true,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"'"${POLLINATIONS_TOKEN}"'","models":["claude-large","claude","kimi","perplexity-reasoning","openai-large","openai"]}],"Router":{"default":"pollinations,claude-large","background":"pollinations,claude","think":"pollinations,kimi","longContext":"pollinations,claude-large","longContextThreshold":60000,"webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
-          bunx @musistudio/claude-code-router@1.0.27 start &
+
+          # Start router with Bun
+          bunx @musistudio/claude-code-router start &
           until curl -s http://localhost:3456 >/dev/null; do sleep 0.5; done
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -78,6 +85,7 @@ jobs:
         if: steps.whitelist.outputs.authorized == 'true'
         with:
           fetch-depth: 0
+          repository: ${{ github.repository }}
           token: ${{ steps.token.outputs.token }}
 
       - uses: anthropics/claude-code-action@v1
@@ -92,12 +100,14 @@ jobs:
           anthropic_api_key: "ccr-pollinations"
           github_token: ${{ steps.token.outputs.token }}
           prompt: |
-            Fix this issue and create a PR:
-
             Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}
 
-            Read the issue body from the GitHub API to get the full details, then fix it.
+            Read the issue body from the GitHub API to get the full details.
 
-            Create a PR that fixes this issue and include "Fixes #${{ github.event.issue.number }}" in the PR description.
+            Decide the appropriate action:
+            1. If the issue requires code changes: fix the code, create a branch, commit, push, and open a PR with "Fixes #${{ github.event.issue.number }}" in the description.
+            2. If the issue is a question, discussion, or doesn't need code changes: just comment on the issue with a helpful response using `gh issue comment ${{ github.event.issue.number }}`.
+
+            Use your judgment — not every issue needs a PR.
           additional_permissions: |
             actions: read


### PR DESCRIPTION
- Unpin router version (was @1.0.27, now uses latest like main polly)
- Add id-token: write permission
- Add eyes reaction on issue trigger
- Add repository param to checkout
- Smart prompt: PR for code issues, comment for questions
- Human persona for both polly workflows (no AI/Claude mentions)