### PR TITLE
fix: strip thinking params for gemini-2.5-flash-lite

### DIFF
--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -104,7 +104,7 @@ const models: ModelDefinition[] = [
         transform: pipe(
             createSystemPromptTransform(BASE_PROMPTS.conversational),
             sanitizeToolSchemas(),
-            createGeminiThinkingTransform("v2.5"),
+            createGeminiThinkingTransform("none"),
         ),
     },
     {
@@ -113,7 +113,7 @@ const models: ModelDefinition[] = [
         transform: pipe(
             sanitizeToolSchemas(),
             createGeminiToolsTransform(["google_search"]),
-            createGeminiThinkingTransform("v2.5"),
+            createGeminiThinkingTransform("none"),
         ),
     },
     {

--- a/text.pollinations.ai/transforms/createGeminiThinkingTransform.ts
+++ b/text.pollinations.ai/transforms/createGeminiThinkingTransform.ts
@@ -7,8 +7,9 @@ const log = debug("pollinations:transforms:gemini-thinking");
  * - v2.5: Uses thinking.budget_tokens (0 to disable)
  * - v3-flash: Uses reasoning_effort ("none" for minimal thinking)
  * - v3-pro: Uses reasoning_effort ("low" for minimal thinking, can't fully disable)
+ * - none: Model doesn't support thinking (e.g. gemini-2.5-flash-lite) — strips thinking params
  */
-export type GeminiModelType = "v2.5" | "v3-flash" | "v3-pro";
+export type GeminiModelType = "v2.5" | "v3-flash" | "v3-pro" | "none";
 
 /**
  * Creates a transform that handles Gemini thinking mode configuration.
@@ -37,6 +38,15 @@ export function createGeminiThinkingTransform(
 
         // Only modify if thinking_budget is explicitly set
         if (thinkingBudget !== undefined) {
+            // Model doesn't support thinking — just strip the param
+            if (modelType === "none") {
+                log(
+                    "Model doesn't support thinking, stripping thinking_budget",
+                );
+                delete updatedOptions.thinking_budget;
+                return { messages, options: updatedOptions };
+            }
+
             const isDisabled = thinkingBudget === 0;
 
             log(


### PR DESCRIPTION
## Summary
- `gemini-2.5-flash-lite` doesn't support thinking config
- When users pass `thinking_budget: 0`, Portkey translates it to `thinking_config.include_thoughts` which Vertex AI rejects with 400: "include_thoughts is only enabled when thinking is enabled"
- Adds `"none"` model type to `createGeminiThinkingTransform` that strips thinking params without forwarding anything to the API
- Updates `gemini-fast` and `gemini-search` (both flash-lite) to use `"none"`

## Production evidence
```
vertex-ai error: Unable to submit request because Thinking_config.include_thoughts 
is only enabled when thinking is enabled.
```

## Test plan
- [ ] Deploy to text service
- [ ] Send request with `thinking_budget: 0` to `gemini-fast` — should succeed instead of 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)