### PR TITLE
fix: re-enable airforce models

### DIFF
--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -142,22 +142,22 @@ export const IMAGE_CONFIG = {
         defaultSideLength: 1024,
     },
 
-    // TEMPORARILY DISABLED - api.airforce outage (2026-02-20)
-    // "imagen-4": {
-    //     type: "airforce",
-    //     enhance: false,
-    //     defaultSideLength: 1024,
-    // },
+    // Imagen 4 - Google's latest image generation via api.airforce
+    "imagen-4": {
+        type: "airforce",
+        enhance: false,
+        defaultSideLength: 1024,
+    },
 
-    // TEMPORARILY DISABLED - api.airforce outage (2026-02-20)
-    // "grok-video": {
-    //     type: "airforce-video",
-    //     enhance: false,
-    //     isVideo: true,
-    //     defaultDuration: 5,
-    //     maxDuration: 10,
-    //     defaultResolution: "720p",
-    // },
+    // Grok Imagine Video - xAI video generation via api.airforce
+    "grok-video": {
+        type: "airforce-video",
+        enhance: false,
+        isVideo: true,
+        defaultDuration: 5,
+        maxDuration: 10,
+        defaultResolution: "720p",
+    },
 
     // LTX-2 - Fast video generation with audio on Modal
     "ltx-2": {

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -267,37 +267,36 @@ export const IMAGE_SERVICES = {
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
     },
-    // TEMPORARILY DISABLED - api.airforce outage (2026-02-20)
-    // "imagen-4": {
-    //     aliases: ["imagen"],
-    //     modelId: "imagen-4",
-    //     provider: "airforce",
-    //     alpha: true,
-    //     cost: [
-    //         {
-    //             date: new Date("2026-02-07").getTime(),
-    //             completionImageTokens: 0.0025, // $0.0025 per image
-    //         },
-    //     ],
-    //     description: "Imagen 4 (api.airforce) - Google's latest image gen",
-    //     inputModalities: ["text"],
-    //     outputModalities: ["image"],
-    // },
-    // "grok-video": {
-    //     aliases: ["grok-imagine-video"],
-    //     modelId: "grok-video",
-    //     provider: "airforce",
-    //     alpha: true,
-    //     cost: [
-    //         {
-    //             date: new Date("2026-02-07").getTime(),
-    //             completionVideoSeconds: 0.0025, // $0.0025 per second
-    //         },
-    //     ],
-    //     description: "Grok Video (api.airforce) - xAI video gen",
-    //     inputModalities: ["text", "image"],
-    //     outputModalities: ["video"],
-    // },
+    "imagen-4": {
+        aliases: ["imagen"],
+        modelId: "imagen-4",
+        provider: "airforce",
+        alpha: true,
+        cost: [
+            {
+                date: new Date("2026-02-07").getTime(),
+                completionImageTokens: 0.0025, // $0.0025 per image
+            },
+        ],
+        description: "Imagen 4 (api.airforce) - Google's latest image gen",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
+    "grok-video": {
+        aliases: ["grok-imagine-video"],
+        modelId: "grok-video",
+        provider: "airforce",
+        alpha: true,
+        cost: [
+            {
+                date: new Date("2026-02-07").getTime(),
+                completionVideoSeconds: 0.0025, // $0.0025 per second
+            },
+        ],
+        description: "Grok Video (api.airforce) - xAI video gen",
+        inputModalities: ["text", "image"],
+        outputModalities: ["video"],
+    },
     "ltx-2": {
         aliases: ["ltx2", "ltxvideo", "ltx-video"],
         modelId: "ltx-2",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -576,23 +576,22 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         isSpecialized: true,
     },
-    // TEMPORARILY DISABLED - api.airforce outage (2026-02-20)
-    // "qwen-character": {
-    //     aliases: [],
-    //     modelId: "qwen-character",
-    //     provider: "airforce",
-    //     cost: [
-    //         {
-    //             date: new Date("2026-02-09").getTime(),
-    //             promptTextTokens: perMillion(0.01), // $0.01/M via api.airforce
-    //             completionTextTokens: perMillion(0.01),
-    //         },
-    //     ],
-    //     description:
-    //         "Qwen Character (api.airforce) - roleplay & character chat",
-    //     inputModalities: ["text"],
-    //     outputModalities: ["text"],
-    //     isSpecialized: true,
-    //     alpha: true,
-    // },
+    "qwen-character": {
+        aliases: [],
+        modelId: "qwen-character",
+        provider: "airforce",
+        cost: [
+            {
+                date: new Date("2026-02-09").getTime(),
+                promptTextTokens: perMillion(0.01), // $0.01/M via api.airforce
+                completionTextTokens: perMillion(0.01),
+            },
+        ],
+        description:
+            "Qwen Character (api.airforce) - roleplay & character chat",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        isSpecialized: true,
+        alpha: true,
+    },
 } as const satisfies Record<string, ServiceDefinition<string>>;

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -286,11 +286,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // ============================================================================
-    // TEMPORARILY DISABLED - api.airforce outage (2026-02-20)
     // api.airforce - qwen-character (RP/character model)
     // ============================================================================
-    // "qwen-character": () =>
-    //     createAirforceModelConfig({
-    //         model: "qwen-character",
-    //     }),
+    "qwen-character": () =>
+        createAirforceModelConfig({
+            model: "qwen-character",
+        }),
 };


### PR DESCRIPTION
## Summary
- Re-enables imagen-4, grok-video, qwen-character (disabled in #8439 due to api.airforce outage)
- Uncomments registry entries, model configs, and Portkey configs
- Wan stays on DashScope direct for now (can be switched back in a follow-up)

Fixes #8455

## Test plan
- [ ] Verify imagen-4 image generation works via `gen.pollinations.ai`
- [ ] Verify grok-video video generation works
- [ ] Verify qwen-character text generation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)