### PR TITLE
fix: restore wan airforce primary with DashScope fallback

### DIFF
--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -104,7 +104,7 @@ export const IMAGE_CONFIG = {
         defaultResolution: "720p",
     },
 
-    // Alibaba Wan 2.6 - Video generation with audio (DashScope only, airforce disabled)
+    // Alibaba Wan 2.6 - Video generation with audio
     wan: {
         type: "alibaba-dashscope-video",
         enhance: false,

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -216,21 +216,20 @@ export const IMAGE_SERVICES = {
     "wan": {
         aliases: ["wan2.6", "wan-i2v"],
         modelId: "wan",
-        provider: "alibaba",
-        paidOnly: true,
+        provider: "airforce",
+        alpha: true,
         cost: [
-            // Wan 2.6 - Alibaba DashScope international pricing (720P)
-            // T2V: $0.10/sec, I2V+audio: $0.05/sec, I2V no audio: $0.025/sec
-            // Using I2V+audio rate as base since T2V also generates audio
-            // Audio cost split out separately for tracking
+            // Wan 2.6 - Pricing derived from Alibaba DashScope rates
+            // Video: $0.0125/sec, Audio: $0.0125/sec, Total: $0.025/sec (with audio)
+            // Applies to both Airforce (primary) and DashScope (fallback)
             {
-                date: new Date("2026-02-20").getTime(),
-                completionVideoSeconds: 0.05, // $0.05 per second (video)
-                completionAudioSeconds: 0.05, // $0.05 per second (audio)
+                date: new Date("2026-02-13").getTime(),
+                completionVideoSeconds: 0.0125, // $0.0125 per second (video only)
+                completionAudioSeconds: 0.0125, // $0.0125 per second (audio)
             },
         ],
         description:
-            "Wan 2.6 - Alibaba text/image-to-video with audio (2-15s, up to 1080P) via DashScope",
+            "Wan 2.6 - Alibaba text/image-to-video with audio (2-15s, up to 1080P). Primary via api.airforce, fallback via DashScope",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },


### PR DESCRIPTION
## Summary
- Restore wan to use api.airforce as primary provider with DashScope fallback on 5xx/network errors
- Revert pricing to $0.0125/sec (video) + $0.0125/sec (audio) — 4x cheaper than DashScope-only
- Provider tag back to "airforce", alpha: true

## Test plan
- [ ] Verify wan video generation works via api.airforce
- [ ] Verify DashScope fallback triggers on airforce failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)