### PR TITLE
fix: wan falls back to DashScope on airforce 429 rate limits

### DIFF
--- a/image.pollinations.ai/src/models/wanVideoModel.ts
+++ b/image.pollinations.ai/src/models/wanVideoModel.ts
@@ -113,10 +113,12 @@ export async function callWanAPI(
         );
 
         // Don't fall back on client errors (4xx) — bad prompts/params will fail on DashScope too
+        // Exception: 429 rate limits should fall back since DashScope has its own quota
         if (
             error instanceof HttpError &&
             error.status >= 400 &&
-            error.status < 500
+            error.status < 500 &&
+            error.status !== 429
         ) {
             throw error;
         }


### PR DESCRIPTION
## Summary
- Allow 429 rate limit errors to trigger DashScope fallback for wan model
- airforce has a global 1 req/sec rate limit; DashScope has separate quota
- Other 4xx errors (400, 403) still throw immediately (bad params won't succeed on either provider)

Found during local testing — airforce rate limits are frequent enough that wan needs this fallback path.

## Test plan
- [x] Tested locally: airforce 429 → DashScope fallback → video returned successfully
- [x] Tested locally: airforce success path still works when not rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)