### PR TITLE
fix: wan DashScope only, remove airforce path

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -216,20 +216,21 @@ export const IMAGE_SERVICES = {
     "wan": {
         aliases: ["wan2.6", "wan-i2v"],
         modelId: "wan",
-        provider: "airforce",
-        alpha: true,
+        provider: "alibaba",
+        paidOnly: true,
         cost: [
-            // Wan 2.6 - Pricing derived from Alibaba DashScope rates
-            // Video: $0.0125/sec, Audio: $0.0125/sec, Total: $0.025/sec (with audio)
-            // Applies to both Airforce (primary) and DashScope (fallback)
+            // Wan 2.6 - Alibaba DashScope international pricing (720P)
+            // T2V: $0.10/sec, I2V+audio: $0.05/sec, I2V no audio: $0.025/sec
+            // Using I2V+audio rate as base since T2V also generates audio
+            // Audio cost split out separately for tracking
             {
-                date: new Date("2026-02-13").getTime(),
-                completionVideoSeconds: 0.0125, // $0.0125 per second (video only)
-                completionAudioSeconds: 0.0125, // $0.0125 per second (audio)
+                date: new Date("2026-02-20").getTime(),
+                completionVideoSeconds: 0.05, // $0.05 per second (video)
+                completionAudioSeconds: 0.05, // $0.05 per second (audio)
             },
         ],
         description:
-            "Wan 2.6 - Alibaba text/image-to-video with audio (2-15s, up to 1080P). Primary via api.airforce, fallback via DashScope",
+            "Wan 2.6 - Alibaba text/image-to-video with audio (2-15s, up to 1080P) via DashScope",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },


### PR DESCRIPTION
## Summary
- Wan routes directly to DashScope, no airforce attempt
- Restores `provider: "alibaba"`, `paidOnly: true`, DashScope pricing ($0.05/sec)
- Airforce global 1 req/sec rate limit made it unusable — wan always fell back anyway

## Test plan
- [x] Verified locally wan always hit airforce 429 and fell back to DashScope
- [ ] Verify wan works via DashScope after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)