### PR TITLE
[FEAT]: format first line of snippet as H2 heading in Discord announcement

### DIFF
--- a/social/scripts/publish_realtime.py
+++ b/social/scripts/publish_realtime.py
@@ -136,14 +136,10 @@ def main():
 
     if not snippet:
         snippet = summary
-
-    # Format first line of snippet as H2 heading
     lines = snippet.split('\n', 1)
     if lines:
         lines[0] = f"## {lines[0]}"
         snippet = '\n'.join(lines)
-
-    # Format message with PR metadata footer
     pr_url = gist["url"]
     author = gist["author"]
 


### PR DESCRIPTION
## Changes Made:- 

- Split the summary generated by the AI  by `'\n'` 
- Pick the first line [0] and then attach `##` to it to make it H2