### PR TITLE
feat: hello page layout and copy improvements

### DIFF
--- a/pollinations.ai/src/copy/content/hello.ts
+++ b/pollinations.ai/src/copy/content/hello.ts
@@ -4,7 +4,7 @@ export const HELLO_PAGE = {
     // Section 1 — Hero
     heroTitle: "The open platform for AI builders.",
     heroBody:
-        "One API. 40+ models. Text, image, audio, video. Daily compute grants. You bring the idea — we handle the rest.",
+        "One API. 40+ models. Text, image, audio, video  — all on one Pollen balance. Daily compute grants. You bring the idea — we handle the rest.",
     heroStat1: "500+",
     heroStat1Label: "live apps",
     heroStat2: "3M",
@@ -27,11 +27,6 @@ export const HELLO_PAGE = {
     loopEarnEmoji: "💰",
     flywheelCenter: "Your Apps",
     comingSoonBadge: "coming soon",
-
-    // Section — For builders
-    buildersTitle: "For builders",
-    buildersBody:
-        "One API. Text, image, audio, video — all on one Pollen balance.",
 
     // Flywheel explanation (right column)
     flywheelTitle: "The flywheel",

--- a/pollinations.ai/src/ui/components/FlywheelRing.tsx
+++ b/pollinations.ai/src/ui/components/FlywheelRing.tsx
@@ -5,8 +5,8 @@ interface FlywheelRingProps {
     pageCopy: Record<string, unknown>;
 }
 
-const CX = 170;
-const CY = 170;
+const CX = 200;
+const CY = 200;
 
 function toRad(deg: number) {
     return ((deg - 90) * Math.PI) / 180;
@@ -18,8 +18,8 @@ function pt(r: number, deg: number) {
 }
 
 // Node positions
-const NODE_R = 127;
-const NODE_SIZE = 80;
+const NODE_R = 150;
+const NODE_SIZE = 90;
 const NODE_HALF = NODE_SIZE / 2;
 
 const NODES: readonly {
@@ -49,7 +49,7 @@ const NODE_POSITIONS = NODES.map((n) => {
 // Short straight arrows between consecutive nodes
 const ARROW_SIZE = 28;
 const ARROW_HALF = ARROW_SIZE / 2;
-const ARROW_R = 95; // radius where arrows sit (between center and nodes)
+const ARROW_R = 112; // radius where arrows sit (between center and nodes)
 
 const ARROWS = [
     { angle: 45 }, // build → ship
@@ -65,8 +65,8 @@ export function FlywheelRing({ pageCopy }: FlywheelRingProps) {
     const copy = pageCopy as Record<string, string>;
 
     return (
-        <div className="flex lg:justify-center">
-            <div className="relative w-[340px] h-[340px]">
+        <div className="flex justify-center">
+            <div className="relative w-[400px] h-[400px]">
                 {/* Short straight arrows between nodes */}
                 {ARROWS.map((arrow) => (
                     <div
@@ -99,7 +99,7 @@ export function FlywheelRing({ pageCopy }: FlywheelRingProps) {
 
                 {/* Center label */}
                 <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
-                    <span className="font-headline text-sm font-black text-text-highlight tracking-wider">
+                    <span className="font-headline text-base font-black text-text-highlight tracking-wider">
                         {copy.flywheelCenter}
                     </span>
                 </div>
@@ -117,11 +117,11 @@ export function FlywheelRing({ pageCopy }: FlywheelRingProps) {
                             justifyContent: "center",
                         }}
                     >
-                        <span className="text-[32px] leading-none">
+                        <span className="text-[40px] leading-none">
                             {copy[node.emojiKey]}
                         </span>
                         <span
-                            className={`font-headline text-[11px] font-black uppercase tracking-wider whitespace-nowrap px-2 py-0.5 rounded-full ${
+                            className={`font-headline text-xs font-black uppercase tracking-wider whitespace-nowrap px-2.5 py-1 rounded-full ${
                                 node.soon
                                     ? "bg-border-accent/15 text-text-accent border border-border-accent/50"
                                     : "bg-button-focus-ring/20 text-text-highlight border border-border-highlight shadow-shadow-highlight-sm"

--- a/pollinations.ai/src/ui/components/ui/page-container.tsx
+++ b/pollinations.ai/src/ui/components/ui/page-container.tsx
@@ -41,7 +41,7 @@ export const PageContainer = React.forwardRef<
             )}
             {...props}
         >
-            <div className="max-w-4xl mx-auto">{children}</div>
+            <div className="max-w-5xl mx-auto">{children}</div>
         </div>
     );
 });

--- a/pollinations.ai/src/ui/pages/HelloPage.tsx
+++ b/pollinations.ai/src/ui/pages/HelloPage.tsx
@@ -65,17 +65,12 @@ function HelloPage() {
 
                 <Divider />
 
-                {/* Section — For builders */}
+                {/* Section — Flywheel & Tiers */}
                 <div className="mb-12">
-                    <Heading variant="section" spacing="comfortable">
-                        {pageCopy.buildersTitle}
-                    </Heading>
-                    <Body spacing="comfortable">{pageCopy.buildersBody}</Body>
-
                     {/* Row 1: Flywheel (left) + explanation (right) */}
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center mb-10">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center mb-10">
                         <FlywheelRing pageCopy={pageCopy} />
-                        <div>
+                        <div className="max-w-xs md:ml-8">
                             <Body spacing="comfortable">
                                 {pageCopy.flywheelBody}
                             </Body>
@@ -86,14 +81,22 @@ function HelloPage() {
                     </div>
 
                     {/* Row 2: Explanation (left) + Tier cards (right) */}
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
                         {/* Tier explanation */}
-                        <div>
+                        <div className="max-w-sm md:ml-8">
                             <Body spacing="comfortable">
                                 {pageCopy.tierBody}
                             </Body>
-                            <div className="bg-border-accent/10 border-2 border-border-accent/30 border-r-4 border-b-4 p-4 mb-4">
-                                <span className="font-headline text-base font-black text-text-accent">
+                            <a
+                                href={LINKS.enterTiersFaq}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="font-headline text-base font-black text-text-highlight hover:underline mb-4 inline-block"
+                            >
+                                {pageCopy.tierHowLink}
+                            </a>
+                            <div className="bg-border-accent/10 border-2 border-border-accent/30 border-r-4 border-b-4 p-4 inline-block text-left">
+                                <span className="font-headline text-xl font-black text-yellow">
                                     {pageCopy.usersTitle}
                                 </span>
                                 <Body
@@ -115,7 +118,7 @@ function HelloPage() {
                         </div>
 
                         {/* Tier ladder: Nectar (top) → Flower → Seed (bottom) */}
-                        <div className="relative flex flex-col gap-4 pl-6 max-w-[300px] lg:mx-auto">
+                        <div className="relative flex flex-col gap-4 pl-6 max-w-[300px] md:ml-8">
                             {/* Gradient progression line */}
                             <div
                                 className="absolute left-0 top-2 bottom-2 w-[3px]"
@@ -182,14 +185,6 @@ function HelloPage() {
                             ))}
                         </div>
                     </div>
-                    <a
-                        href={LINKS.enterTiersFaq}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-headline text-base font-black text-text-highlight hover:underline mt-4 inline-block"
-                    >
-                        {pageCopy.tierHowLink}
-                    </a>
                 </div>
 
                 <Divider />
@@ -218,7 +213,7 @@ function HelloPage() {
                                         className="py-1"
                                     >
                                         <p className="font-body text-base text-text-body-secondary leading-relaxed">
-                                            <span className="shrink-0 bg-button-primary-bg text-text-on-color px-1.5 py-0.5 font-mono font-black text-xs rounded-tag mr-2">
+                                            <span className="shrink-0 text-yellow font-mono font-black text-xs mr-2">
                                                 {item.date}
                                             </span>
                                             <span className="mr-2">


### PR DESCRIPTION
- Merge "For builders" body text into hero section, remove redundant section
- Widen page container from max-w-4xl to max-w-5xl
- Lower responsive grid breakpoint from lg to md so 2-column stays longer
- Scale up flywheel diagram (340→400px) with bigger icons and labels
- Left-align content on mobile, constrain text columns with max-width
- Yellow date text in What's New, yellow BYOP title, move FAQ link inline