### PR TITLE
fix: Correct audio model icon on pricing page

### DIFF
--- a/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
@@ -210,8 +210,8 @@ export const ModelRow: FC<ModelRowProps> = ({
                     />
                     <PriceBadge
                         prices={[model.perSecondPrice]}
-                        emoji="🎬"
-                        subEmojis={["🎬"]}
+                        emoji={model.type === "audio" ? "🔊" : "🎬"}
+                        subEmojis={model.type === "audio" ? ["🔊"] : ["🎬"]}
                         perSecond
                         color={priceColor}
                     />


### PR DESCRIPTION
- Fixes Speech-to-Text (STT) models displaying video icon
- Changes `emoji` and `subEmojis` for `perSecondPrice` based on `model.type`