### PR TITLE
fix: show platform badge on app cards

### DIFF
--- a/pollinations.ai/src/ui/pages/AppsPage.tsx
+++ b/pollinations.ai/src/ui/pages/AppsPage.tsx
@@ -237,10 +237,7 @@ function AppCard({ app, copy }: { app: App; copy: typeof APPS_PAGE }) {
                         </a>
                     )}
                     {app.platform && PLATFORM_DISPLAY[app.platform] && (
-                        <Badge
-                            variant="muted"
-                            className="ml-auto bg-transparent border-transparent shadow-none px-0"
-                        >
+                        <Badge variant="muted" className="ml-auto">
                             {PLATFORM_DISPLAY[app.platform]}
                         </Badge>
                     )}


### PR DESCRIPTION
The platform badge (e.g. 🌐 Web, 📱 Android) was rendered with `bg-transparent border-transparent shadow-none px-0` — completely stripping the muted variant's background and border, making it invisible against the card.

Removes the aggressive class overrides so the badge uses its default muted styling (subtle background + border).