### PR TITLE
WIP: Durable Object request deduplication

### DIFF
--- a/enter.pollinations.ai/src/durable-objects/RequestDeduplicator.ts
+++ b/enter.pollinations.ai/src/durable-objects/RequestDeduplicator.ts
@@ -1,0 +1,57 @@
+import { DurableObject } from "cloudflare:workers";
+
+const STALE_MS = 120_000; // 2min — consider processing request stale
+
+/**
+ * RequestDeduplicator Durable Object
+ *
+ * Cross-isolate inflight request deduplication — tracks only "processing" state.
+ * Does NOT store responses. Concurrent duplicates wait until processing completes,
+ * then fall through to the cache layer which will have the response.
+ *
+ * Flow:
+ * 1. First request: checkRequest → {proceed: true}, origin runs, markDone()
+ * 2. Concurrent duplicate: checkRequest → {waiting: true}, polls, sees idle → falls through → cache HIT
+ * 3. Sequential request: checkRequest → {proceed: true} (no processing flag)
+ */
+export class RequestDeduplicator extends DurableObject {
+    private processing = false;
+    private timestamp = 0;
+
+    constructor(ctx: DurableObjectState, env: CloudflareBindings) {
+        super(ctx, env);
+
+        ctx.blockConcurrencyWhile(async () => {
+            const stored = await ctx.storage.get<{ timestamp: number }>(
+                "processing",
+            );
+            if (stored) {
+                this.processing = true;
+                this.timestamp = stored.timestamp;
+            }
+        });
+    }
+
+    async checkRequest(): Promise<{ proceed: true } | { waiting: true }> {
+        const now = Date.now();
+
+        if (this.processing) {
+            if (now - this.timestamp > STALE_MS) {
+                // Stale — let this request take over
+            } else {
+                return { waiting: true };
+            }
+        }
+
+        this.processing = true;
+        this.timestamp = now;
+        await this.ctx.storage.put("processing", { timestamp: now });
+        return { proceed: true };
+    }
+
+    async markDone(): Promise<void> {
+        this.processing = false;
+        this.timestamp = 0;
+        await this.ctx.storage.delete("processing");
+    }
+}

--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -71,8 +71,9 @@ app.onError(handleError);
 
 export type AppRoutes = typeof app;
 
-// Export Durable Object for pollen-based rate limiting
+// Export Durable Objects
 export { PollenRateLimiter } from "./durable-objects/PollenRateLimiter.ts";
+export { RequestDeduplicator } from "./durable-objects/RequestDeduplicator.ts";
 
 export default {
     fetch: app.fetch,

--- a/enter.pollinations.ai/src/middleware/requestDeduplication.ts
+++ b/enter.pollinations.ai/src/middleware/requestDeduplication.ts
@@ -1,54 +1,19 @@
+import type { Logger } from "@logtape/logtape";
 import { createMiddleware } from "hono/factory";
+import type { RequestDeduplicator } from "../durable-objects/RequestDeduplicator.ts";
 import type { Env } from "../env.ts";
 
 /**
- * Serialized response data that can be shared across request contexts
- * Cloudflare Workers cannot share Response objects between requests,
- * so we store the raw data and create new Response objects for each consumer
- */
-type SerializedResponse = {
-    body: ArrayBuffer;
-    status: number;
-    statusText: string;
-    headers: [string, string][];
-};
-
-/**
- * In-memory map of inflight requests
- * Key: URL hash, Value: Promise<SerializedResponse>
- */
-const inflightRequests = new Map<string, Promise<SerializedResponse>>();
-
-/**
- * Request deduplication middleware
+ * Request deduplication middleware (Durable Object-backed)
  *
- * Prevents duplicate concurrent requests by sharing response data.
- * When multiple identical requests arrive, only the first executes -
- * others wait for and share the same response data.
- *
- * How it works:
- * 1. Hash the request (method + URL + body) to create a unique key
- * 2. Check if a request for this key is already inflight
- * 3. If yes: wait for the existing promise, create new Response from data
- * 4. If no: execute the request, serialize response, store promise
- * 5. Auto-cleanup when request completes
- *
- * Key design: Uses method + URL + body (no user-specific data)
- * - GET: method + URL (with query params)
- * - POST: method + URL + request body (messages, model, etc.)
- * - Same request = same result for all users (deterministic endpoints)
- * - Maximizes deduplication efficiency
- *
- * Note: Stores serialized response data (not Response objects) because
- * Cloudflare Workers cannot share I/O objects between request contexts.
+ * Prevents duplicate concurrent requests across all isolates.
+ * The DO only tracks "processing" state — no response storage.
+ * Concurrent duplicates wait until processing completes, then fall through
+ * to the cache layer (image-cache / text-cache) which will have the response.
  */
 export const requestDeduplication = createMiddleware<Env>(async (c, next) => {
     const log = c.get("log");
 
-    // Deduplicate safe methods (GET, HEAD, OPTIONS, TRACE) and POST
-    // Safe methods: read-only, no side effects
-    // POST: deterministic for our AI generation endpoints
-    // Skip: PUT, DELETE, PATCH (not safe for deduplication)
     const method = c.req.method;
     const shouldDeduplicate = [
         "GET",
@@ -65,16 +30,29 @@ export const requestDeduplication = createMiddleware<Env>(async (c, next) => {
         return await next();
     }
 
-    // Skip deduplication for streaming requests
-    // Streaming responses cannot be buffered into ArrayBuffer without breaking SSE
+    // Skip for seed=-1 (random seed convention)
+    const seedParam = new URL(c.req.url).searchParams.get("seed");
+    if (seedParam === "-1") {
+        log.debug("[DEDUP] seed=-1, skipping deduplication");
+        return await next();
+    }
+
+    // Skip streaming and seed=-1 in POST body
     if (method === "POST") {
         try {
             const clonedReq = c.req.raw.clone();
-            const body = (await clonedReq.json()) as { stream?: boolean };
+            const body = (await clonedReq.json()) as {
+                stream?: boolean;
+                seed?: number;
+            };
             if (body?.stream === true) {
                 log.debug(
                     "[DEDUP] Skipping deduplication for streaming request",
                 );
+                return await next();
+            }
+            if (body?.seed === -1) {
+                log.debug("[DEDUP] seed=-1 in body, skipping deduplication");
                 return await next();
             }
         } catch {
@@ -82,103 +60,102 @@ export const requestDeduplication = createMiddleware<Env>(async (c, next) => {
         }
     }
 
-    // Create deduplication key from URL + method + body
-    const key = await createRequestKey(c);
-
-    log.debug("[DEDUP] Deduplicating request: {method} {url}", {
-        method,
-        url: c.req.url,
-        key: key.substring(0, 12) + "...",
-    });
-
-    // Check if request already inflight
-    const existingPromise = inflightRequests.get(key);
-    if (existingPromise) {
-        log.debug("[DEDUP] Waiting for inflight request");
-        const data = await existingPromise;
-        // Create new Response from serialized data with cache header
-        const headers = new Headers(data.headers);
-        headers.set("X-Cache", "HIT");
-        headers.set("X-Cache-Type", "DEDUP");
-        return new Response(data.body, {
-            status: data.status,
-            statusText: data.statusText,
-            headers,
-        });
+    // Skip if DO binding not available (e.g. local dev without DO support)
+    if (!c.env.REQUEST_DEDUPLICATOR) {
+        log.debug("[DEDUP] No DO binding, falling through");
+        return await next();
     }
 
-    // Start new request
-    log.debug("[DEDUP] Starting new request");
+    const key = await createRequestKey(c);
+    const stubId = c.env.REQUEST_DEDUPLICATOR.idFromName(key);
+    const stub = c.env.REQUEST_DEDUPLICATOR.get(
+        stubId,
+    ) as DurableObjectStub<RequestDeduplicator>;
 
-    // Create and store promise BEFORE executing
-    // Serialize response data so it can be shared across request contexts
-    const promise = (async (): Promise<SerializedResponse> => {
-        await next();
-        // Serialize the response for storage
-        const response = c.res;
-        const body = await response.clone().arrayBuffer();
-        return {
-            body,
-            status: response.status,
-            statusText: response.statusText,
-            headers: [...response.headers.entries()],
-        };
-    })();
-
-    inflightRequests.set(key, promise);
-
-    // Cleanup after completion
-    promise.finally(() => {
-        inflightRequests.delete(key);
-        log.debug("[DEDUP] Cleaned up request");
+    log.debug("[DEDUP] Checking request: {method} {url}", {
+        method,
+        url: c.req.url,
+        key: `${key.substring(0, 12)}...`,
     });
 
-    // Wait for serialization to complete, then return original response
-    await promise;
-    return c.res;
+    const result = await stub.checkRequest();
+
+    if ("waiting" in result) {
+        log.debug("[DEDUP] Waiting for inflight request to complete");
+        await waitForIdle(stub, log);
+        // Now fall through to next() — cache layer will serve the response
+        log.debug("[DEDUP] Inflight request done, proceeding to cache layer");
+    } else {
+        log.debug("[DEDUP] First request, proceeding");
+    }
+
+    // Execute the request (first request hits origin, waiters hit cache)
+    try {
+        await next();
+    } finally {
+        // Only the first request (proceed=true) marks done
+        if ("proceed" in result) {
+            try {
+                await stub.markDone();
+            } catch (err) {
+                log.debug("[DEDUP] Failed to mark done: {error}", {
+                    error: String(err),
+                });
+            }
+        }
+    }
 });
 
 /**
+ * Poll the DO until the processing request completes
+ */
+async function waitForIdle(
+    stub: DurableObjectStub<RequestDeduplicator>,
+    log: Logger,
+): Promise<void> {
+    const maxWait = 120_000;
+    const pollInterval = 500;
+    const start = Date.now();
+
+    while (Date.now() - start < maxWait) {
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+
+        const result = await stub.checkRequest();
+        if ("proceed" in result) {
+            // Processing finished (or stale), we got ownership — release it
+            // immediately since we'll just hit the cache layer
+            await stub.markDone();
+            return;
+        }
+        // Still waiting — continue polling
+    }
+
+    log.debug("[DEDUP] Poll timed out after {ms}ms", { ms: maxWait });
+}
+
+/**
  * Create a deduplication key from request URL, method, and body
- * Handles GET (URL only) and POST (URL + body) robustly
  */
 async function createRequestKey(c: {
     req: { method: string; url: string; raw: Request };
 }): Promise<string> {
-    const parts: string[] = [];
+    const parts: string[] = [c.req.method, c.req.url];
 
-    // Always include method and URL
-    parts.push(c.req.method);
-    parts.push(c.req.url);
-
-    // For POST, include body if present (GET uses URL params)
     if (c.req.method === "POST") {
         try {
-            // Clone the request to read body without consuming it
             const clonedReq = c.req.raw.clone();
             const body = await clonedReq.text();
             if (body) {
                 parts.push(body);
             }
-        } catch (error) {
-            // If body reading fails, just use URL (graceful degradation)
-            // This can happen with malformed requests or stream issues
-            console.debug(
-                "[DEDUP] Failed to read request body for key generation",
-                error,
-            );
+        } catch {
+            // Graceful degradation — just use URL
         }
     }
 
-    // Hash the combined parts
     const combined = parts.join("|");
-    const encoder = new TextEncoder();
-    const data = encoder.encode(combined);
+    const data = new TextEncoder().encode(combined);
     const hashBuffer = await crypto.subtle.digest("SHA-256", data);
     const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-
-    return `req:${hashHex}`;
+    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/enter.pollinations.ai/worker-bindings.d.ts
+++ b/enter.pollinations.ai/worker-bindings.d.ts
@@ -3,7 +3,7 @@
 declare namespace Cloudflare {
     interface GlobalProps {
         mainModule: typeof import("./src/index");
-        durableNamespaces: "PollenRateLimiter";
+        durableNamespaces: "PollenRateLimiter" | "RequestDeduplicator";
     }
     interface Env {
         KV: KVNamespace;
@@ -71,6 +71,7 @@ declare namespace Cloudflare {
         ELEVENLABS_API_KEY: string;
         OVHCLOUD_API_KEY: string;
         POLLEN_RATE_LIMITER: DurableObjectNamespace /* PollenRateLimiter from pollinations-enter */;
+        REQUEST_DEDUPLICATOR: DurableObjectNamespace /* RequestDeduplicator from pollinations-enter */;
         IMAGE_BUCKET: R2Bucket;
         TEXT_BUCKET: R2Bucket;
         DB: D1Database;

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -37,9 +37,18 @@ name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 script_name = "pollinations-enter"
 
+[[durable_objects.bindings]]
+name = "REQUEST_DEDUPLICATOR"
+class_name = "RequestDeduplicator"
+script_name = "pollinations-enter"
+
 [[migrations]]
 tag = "v2"
 new_classes = ["PollenRateLimiter"]
+
+[[migrations]]
+tag = "v3"
+new_classes = ["RequestDeduplicator"]
 
 [vars]
 ENVIRONMENT = "development"
@@ -143,9 +152,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.production.durable_objects.bindings]]
+name = "REQUEST_DEDUPLICATOR"
+class_name = "RequestDeduplicator"
+
 [[env.production.migrations]]
 tag = "v2"
 new_classes = ["PollenRateLimiter"]
+
+[[env.production.migrations]]
+tag = "v3"
+new_classes = ["RequestDeduplicator"]
 
 [env.production.vars]
 ENVIRONMENT = "production"
@@ -204,9 +221,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.staging.durable_objects.bindings]]
+name = "REQUEST_DEDUPLICATOR"
+class_name = "RequestDeduplicator"
+
 [[env.staging.migrations]]
 tag = "v2"
 new_classes = ["PollenRateLimiter"]
+
+[[env.staging.migrations]]
+tag = "v3"
+new_classes = ["RequestDeduplicator"]
 
 [env.staging.vars]
 ENVIRONMENT = "staging"
@@ -258,9 +283,17 @@ remote = true
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.dev.durable_objects.bindings]]
+name = "REQUEST_DEDUPLICATOR"
+class_name = "RequestDeduplicator"
+
 [[env.dev.migrations]]
 tag = "v2"
 new_classes = ["PollenRateLimiter"]
+
+[[env.dev.migrations]]
+tag = "v3"
+new_classes = ["RequestDeduplicator"]
 
 [env.dev.vars]
 ENVIRONMENT = "dev"
@@ -314,6 +347,10 @@ simple = { limit = 10000, period = 10 }
 [[env.test.durable_objects.bindings]]
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
+
+[[env.test.durable_objects.bindings]]
+name = "REQUEST_DEDUPLICATOR"
+class_name = "RequestDeduplicator"
 
 [env.test.vars]
 ENVIRONMENT = "test"


### PR DESCRIPTION
## Summary
- Replaces in-memory `Map` dedup with a Durable Object for cross-isolate inflight request deduplication
- DO tracks only "processing" state — concurrent duplicates wait, then fall through to cache layer
- Adds `seed=-1` and streaming bypass to dedup middleware
- Adds `REQUEST_DEDUPLICATOR` DO binding to all envs with v3 migration

## Still TODO
- **Fix test failures**: some image/text cache tests still fail because dedup + cache layer interaction needs tuning (sequential requests in tests hit DO before cache layer resets)
- **Verify `waitForIdle` polling**: the poller calls `checkRequest()` which claims ownership — need a separate `isProcessing()` RPC method that only reads state without claiming
- **Test isolated storage**: `storeResponse` in `waitUntil` caused isolated storage frame issues — now using `await` but needs verification
- **Run full test suite** and confirm no regressions vs pre-existing failures
- **Manual e2e test**: two concurrent identical video requests → only one hits origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)