### PR TITLE
fix: vision/multimodal messages returning [object Object]

### DIFF
--- a/text.pollinations.ai/textGenerationUtils.ts
+++ b/text.pollinations.ai/textGenerationUtils.ts
@@ -11,11 +11,11 @@ export function validateAndNormalizeMessages(messages: unknown): ChatMessage[] {
     return messages.map((raw: unknown) => {
         const msg = raw as ChatMessage;
         const hasToolContext = msg.tool_calls || msg.role === "tool";
-        let content: string | null;
+        let content: string | unknown[] | null;
         if (hasToolContext) {
-            content = msg.content != null ? String(msg.content) : null;
+            content = msg.content != null ? msg.content : null;
         } else {
-            content = msg.content ? String(msg.content) : "";
+            content = msg.content || "";
         }
 
         const normalizedMsg: ChatMessage = {


### PR DESCRIPTION
## Summary
- Fix `String()` coercion in `validateAndNormalizeMessages()` that turned multimodal content arrays into `"[object Object]"`
- Regression from TypeScript migration (d6f5ab8ec) — old JS code preserved arrays, new TS code wrapped in `String()`
- Tested locally: vision requests now return proper image descriptions

Fixes #8705