### PR TITLE
fix: pin better-auth to 1.4.17

### DIFF
--- a/enter.pollinations.ai/package-lock.json
+++ b/enter.pollinations.ai/package-lock.json
@@ -17,7 +17,7 @@
                 "@standard-community/standard-json": "^0.3.5",
                 "@standard-community/standard-openapi": "^0.2.9",
                 "@tanstack/react-router": "^1.139.3",
-                "better-auth": "^1.4.17",
+                "better-auth": "1.4.17",
                 "clsx": "^2.1.1",
                 "date-fns": "^4.1.0",
                 "drizzle-orm": "^0.44.7",

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -40,7 +40,7 @@
         "@standard-community/standard-json": "^0.3.5",
         "@standard-community/standard-openapi": "^0.2.9",
         "@tanstack/react-router": "^1.139.3",
-        "better-auth": "^1.4.17",
+        "better-auth": "1.4.17",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.44.7",


### PR DESCRIPTION
## Summary
- Pins `better-auth` from `^1.4.17` to exact `1.4.17`
- v1.5.x removed the `apiKey` plugin, breaking local dev server and tests
- Fixes `(0, apiKey) is not a function` error in auth middleware

## Test plan
- [x] Local dev server starts without auth errors
- [x] `api-key` plugin directory present in node_modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)