### PR TITLE
fix: detect empty upstream responses and add fetch timeout

### DIFF
--- a/text.pollinations.ai/genericOpenAIClient.ts
+++ b/text.pollinations.ai/genericOpenAIClient.ts
@@ -18,6 +18,8 @@ import { cleanNullAndUndefined } from "./utils/objectCleaners.js";
 const log = debug("pollinations:genericopenai");
 const errorLog = debug("pollinations:error");
 
+const FETCH_TIMEOUT_MS = 30_000;
+
 function createApiError(
     response: { status: number; statusText: string },
     details: unknown,
@@ -103,6 +105,7 @@ export async function genericOpenAIClient(
             method: "POST",
             headers,
             body: JSON.stringify(requestBody),
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         });
 
         if (!response.ok) {
@@ -158,7 +161,24 @@ export async function genericOpenAIClient(
             `[${requestId}] Completed in ${Date.now() - startTime}ms, model: ${data.model || modelName}`,
         );
 
-        const originalChoice = data.choices?.[0] ?? {};
+        if (
+            !data.choices ||
+            data.choices.length === 0 ||
+            !data.choices[0].message
+        ) {
+            errorLog(
+                `[${requestId}] Empty or invalid response from upstream: choices=%j`,
+                data.choices,
+            );
+            const error = new Error(
+                `Empty response from upstream model ${modelName}`,
+            ) as ServiceError;
+            error.status = 502;
+            error.model = modelName;
+            throw error;
+        }
+
+        const originalChoice = data.choices[0];
         const formattedChoice = (
             formatResponse
                 ? formatResponse(
@@ -178,6 +198,18 @@ export async function genericOpenAIClient(
         };
     } catch (thrown: unknown) {
         const error = thrown as ServiceError;
+        if (error.name === "TimeoutError" || error.name === "AbortError") {
+            const timeoutErr = new Error(
+                `Request to ${modelName} timed out after ${FETCH_TIMEOUT_MS}ms`,
+            ) as ServiceError;
+            timeoutErr.status = 504;
+            timeoutErr.model = modelName;
+            errorLog(`[${requestId}] Timeout:`, {
+                model: modelName,
+                timeout: FETCH_TIMEOUT_MS,
+            });
+            throw timeoutErr;
+        }
         errorLog(`[${requestId}] Error:`, {
             error: error.message,
             status: error.status,

--- a/text.pollinations.ai/server.ts
+++ b/text.pollinations.ai/server.ts
@@ -251,7 +251,12 @@ function sendContentResponse(c: Context, completion: ChatCompletion): Response {
         return c.json(message);
     }
 
-    return c.text("");
+    errorLog("Empty message content from model:", JSON.stringify(completion));
+    const error: ServiceError = new Error(
+        "Empty response from model",
+    ) as ServiceError;
+    error.status = 502;
+    throw error;
 }
 
 function sendErrorResponse(


### PR DESCRIPTION
## Summary
- Detect empty/invalid responses from upstream providers (empty `choices` array, missing `message`) and throw 502 instead of silently returning 200 OK
- Add 30s fetch timeout via `AbortSignal.timeout()` to prevent requests from hanging indefinitely on slow upstream providers
- Replace silent empty-string fallback in `sendContentResponse` with 502 error

## Root Cause
When upstream providers (e.g., OVHcloud for Mistral) return empty `choices: []` or `choices: [{}]`, the code at `genericOpenAIClient.ts:161` silently converted this to `choices: [{}]` via `data.choices?.[0] ?? {}`. This propagated through the response pipeline as a valid 200 OK with no actual content. Additionally, no fetch timeout was configured, so slow upstream responses would hang indefinitely.

## Changes
- `genericOpenAIClient.ts`: Validate upstream response has non-empty choices with a message object; throw 502 on empty responses. Add 30s `AbortSignal.timeout()` to fetch, with proper 504 error on timeout.
- `server.ts`: Replace `return c.text("")` fallback with 502 error throw for empty message content.

## Test plan
- [ ] Verify Mistral model returns non-empty responses reliably
- [ ] Verify other models (openai, deepseek, gemini) still work correctly
- [ ] Verify timeout triggers 504 on slow responses instead of hanging
- [ ] Verify empty upstream responses return 502 error instead of empty 200

Fixes #8786

🤖 Generated with [Claude Code](https://claude.com/claude-code)