### PR TITLE
add gross margin, app submissions, and 6h cache to KPI dashboard

### DIFF
--- a/apps/operation/kpi/src/App.jsx
+++ b/apps/operation/kpi/src/App.jsx
@@ -16,6 +16,7 @@ import { getWeeklyRevenue } from "./api/polar";
 import {
     getWeeklyActivations,
     getWeeklyActiveUsers,
+    getWeeklyAppSubmissions,
     getWeeklyChurn,
     getWeeklyHealthStats,
     getWeeklyRetention,
@@ -52,6 +53,7 @@ export default function App() {
         "Retention",
         "User segments",
         "Activations",
+        "App submissions",
     ];
 
     useEffect(() => {
@@ -99,6 +101,9 @@ export default function App() {
                 );
                 const tinybirdActivations = await step("Activations", () =>
                     getWeeklyActivations(12),
+                );
+                const appSubmissions = await step("App submissions", () =>
+                    getWeeklyAppSubmissions(),
                 );
 
                 // Check for missing data
@@ -157,6 +162,7 @@ export default function App() {
                             tokensPerUser: row.tokens_per_user,
                             textRequests: row.text_requests,
                             imageRequests: row.image_requests,
+                            costUsd: row.cost_usd,
                         });
                     }
                 }
@@ -233,6 +239,19 @@ export default function App() {
                         if (existing) {
                             existing.activations = row.activations;
                         }
+                    }
+                }
+
+                // GitHub: App submissions and approvals
+                if (appSubmissions) {
+                    for (const row of appSubmissions) {
+                        const existing = weekMap.get(row.week) || {
+                            week: row.week,
+                        };
+                        weekMap.set(row.week, {
+                            ...existing,
+                            appSubmissions: row.submitted,
+                        });
                     }
                 }
 

--- a/apps/operation/kpi/src/api/tinybird.js
+++ b/apps/operation/kpi/src/api/tinybird.js
@@ -48,3 +48,10 @@ export async function getWeeklyChurn(weeksBack = 12) {
     const data = await res.json();
     return data.data || [];
 }
+
+export async function getWeeklyAppSubmissions() {
+    const res = await fetch("/api/kpi/app-submissions");
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.data || [];
+}

--- a/apps/operation/kpi/src/components/KPITrendTable.jsx
+++ b/apps/operation/kpi/src/components/KPITrendTable.jsx
@@ -156,6 +156,18 @@ export function KPITrendTable({ weeklyData, title }) {
                 "Average Revenue Per Active user. Formula: Weekly Revenue / WAU. Measures monetization efficiency.",
         },
         {
+            key: "grossMargin",
+            name: "Gross Margin",
+            category: "Efficiency",
+            format: "percent",
+            calc: (w) =>
+                w.revenue > 0
+                    ? ((w.revenue - (w.costUsd || 0)) / w.revenue) * 100
+                    : null,
+            tooltip:
+                "Formula: (Revenue - COGS) / Revenue × 100. Higher is better. COGS = compute costs from generation_event.total_cost (GPU, tokens, providers).",
+        },
+        {
             key: "revenuePerMTokens",
             name: "Rev/1M Tokens",
             category: "Efficiency",
@@ -212,6 +224,14 @@ export function KPITrendTable({ weeklyData, title }) {
             format: "number",
             tooltip:
                 "Count of users active 4 weeks ago but inactive in the last 2 weeks.",
+        },
+        {
+            key: "appSubmissions",
+            name: "App Submissions",
+            category: "Community",
+            format: "number",
+            tooltip:
+                "New app submissions via GitHub issues (TIER-APP label). Counts issues created this week.",
         },
     ];
 

--- a/apps/operation/kpi/src/worker/index.ts
+++ b/apps/operation/kpi/src/worker/index.ts
@@ -18,6 +18,9 @@ type Env = {
     POLAR_ACCESS_TOKEN: string;
     POLAR_API: string;
     GITHUB_TOKEN?: string;
+    GITHUB_APP_ID?: string;
+    GITHUB_APP_PRIVATE_KEY?: string;
+    GITHUB_APP_INSTALLATION_ID?: string;
     GITHUB_REPO: string;
     DASHBOARD_PASSWORD?: string;
     __STATIC_CONTENT: KVNamespace;
@@ -25,7 +28,7 @@ type Env = {
 
 // Helper to fetch from Tinybird with caching, retry, and error logging
 // Uses Cloudflare Cache API to avoid hammering Tinybird on concurrent page loads
-const TINYBIRD_CACHE_TTL = 300; // 5 minutes — weekly data barely changes
+const TINYBIRD_CACHE_TTL = 21600; // 6 hours — weekly data barely changes
 
 async function fetchTinybird(
     env: Env,
@@ -482,13 +485,158 @@ app.get("/api/kpi/user-segments", async (c) => {
     return c.json({ data: result.data });
 });
 
+// GitHub App JWT auth for higher rate limits (15k/hr vs 5k/hr)
+// Falls back to GITHUB_TOKEN (PAT) if app credentials aren't configured
+async function getGitHubToken(env: Env): Promise<string | null> {
+    // Try GitHub App auth first
+    if (
+        env.GITHUB_APP_ID &&
+        env.GITHUB_APP_PRIVATE_KEY &&
+        env.GITHUB_APP_INSTALLATION_ID
+    ) {
+        try {
+            const now = Math.floor(Date.now() / 1000);
+            const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+                .replace(/=/g, "")
+                .replace(/\+/g, "-")
+                .replace(/\//g, "_");
+            const payload = btoa(
+                JSON.stringify({
+                    iat: now - 30,
+                    exp: now + 600,
+                    iss: env.GITHUB_APP_ID,
+                }),
+            )
+                .replace(/=/g, "")
+                .replace(/\+/g, "-")
+                .replace(/\//g, "_");
+
+            // Import RSA private key for signing
+            const pemBody = env.GITHUB_APP_PRIVATE_KEY.replace(
+                /-----BEGIN RSA PRIVATE KEY-----/,
+                "",
+            )
+                .replace(/-----END RSA PRIVATE KEY-----/, "")
+                .replace(/\s/g, "");
+            const binaryKey = Uint8Array.from(atob(pemBody), (c) =>
+                c.charCodeAt(0),
+            );
+            const cryptoKey = await crypto.subtle.importKey(
+                "pkcs8",
+                binaryKey,
+                { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+                false,
+                ["sign"],
+            );
+
+            const sigData = new TextEncoder().encode(`${header}.${payload}`);
+            const signature = await crypto.subtle.sign(
+                "RSASSA-PKCS1-v1_5",
+                cryptoKey,
+                sigData,
+            );
+            const sig = btoa(String.fromCharCode(...new Uint8Array(signature)))
+                .replace(/=/g, "")
+                .replace(/\+/g, "-")
+                .replace(/\//g, "_");
+
+            const jwtToken = `${header}.${payload}.${sig}`;
+
+            // Exchange JWT for installation token
+            const res = await fetch(
+                `https://api.github.com/app/installations/${env.GITHUB_APP_INSTALLATION_ID}/access_tokens`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${jwtToken}`,
+                        Accept: "application/vnd.github+json",
+                        "User-Agent": "KPI-Dashboard",
+                    },
+                },
+            );
+
+            if (res.ok) {
+                const data = (await res.json()) as { token: string };
+                return data.token;
+            }
+            console.error(`[GitHub App] Token exchange failed: ${res.status}`);
+        } catch (e) {
+            console.error(
+                `[GitHub App] Auth failed, falling back to PAT: ${e}`,
+            );
+        }
+    }
+
+    return env.GITHUB_TOKEN || null;
+}
+
+// GitHub: App submissions — weekly counts from issue labels
+app.get("/api/kpi/app-submissions", async (c) => {
+    const token = await getGitHubToken(c.env);
+    const headers: Record<string, string> = {
+        "User-Agent": "KPI-Dashboard",
+        Accept: "application/vnd.github+json",
+    };
+    if (token) headers.Authorization = `token ${token}`;
+
+    // Fetch all TIER-APP issues (submissions) and TIER-APP-COMPLETE issues (approved)
+    // GitHub Search API lets us get created/closed dates with labels in one call
+    const repo = c.env.GITHUB_REPO;
+    const since = DATA_START_DATE;
+
+    // TIER-APP label gets replaced as issues progress, so search each label separately
+    // GitHub Search API treats comma-separated labels as AND, not OR
+    const labels = [
+        "TIER-APP",
+        "TIER-APP-REVIEW",
+        "TIER-APP-APPROVED",
+        "TIER-APP-COMPLETE",
+        "TIER-APP-REJECTED",
+        "TIER-APP-INCOMPLETE",
+    ];
+    const seenIssues = new Set<number>();
+    const weeklySubmissions: Record<string, number> = {};
+
+    for (const label of labels) {
+        const query = `repo:${repo}+is:issue+label:${label}+created:>=${since}`;
+        let page = 1;
+        let totalCount = 0;
+        do {
+            const res = await fetch(
+                `https://api.github.com/search/issues?q=${query}&per_page=100&sort=created&order=asc&page=${page}`,
+                { headers },
+            );
+            if (!res.ok) break;
+            const data = (await res.json()) as {
+                total_count: number;
+                items: Array<{ number: number; created_at: string }>;
+            };
+            totalCount = data.total_count;
+            for (const issue of data.items) {
+                if (seenIssues.has(issue.number)) continue;
+                seenIssues.add(issue.number);
+                const week = getWeekStart(new Date(issue.created_at));
+                weeklySubmissions[week] = (weeklySubmissions[week] || 0) + 1;
+            }
+            page++;
+        } while ((page - 1) * 100 < totalCount && page <= 5);
+    }
+
+    const result = Object.entries(weeklySubmissions)
+        .map(([week, submitted]) => ({ week, submitted }))
+        .sort((a, b) => a.week.localeCompare(b.week));
+
+    return c.json({ data: result });
+});
+
 // GitHub: Stars
 app.get("/api/kpi/github", async (c) => {
+    const token = await getGitHubToken(c.env);
     const headers: Record<string, string> = {
         "User-Agent": "KPI-Dashboard",
     };
-    if (c.env.GITHUB_TOKEN) {
-        headers.Authorization = `token ${c.env.GITHUB_TOKEN}`;
+    if (token) {
+        headers.Authorization = `token ${token}`;
     }
 
     const res = await fetch(


### PR DESCRIPTION
- add gross margin % row (revenue - costs / revenue) using TinyBird cost_usd
- add app submissions tracking via GitHub Search API across all TIER-APP label states
- add GitHub App JWT auth with PAT fallback for higher rate limits
- increase TinyBird cache TTL from 5min to 6h (weekly data doesn't need frequent refresh)
- fix GitHub label search: query each label separately since comma-separated = AND not OR