### PR TITLE
fix: exclude 4xx from model monitor request counts and success rate

### DIFF
--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -375,8 +375,10 @@ function App() {
                 return dir * (a.name || "").localeCompare(b.name || "");
             case "requests":
             case "share": {
-                const aReqs = (a.stats?.total_requests || 0) - (a.stats?.total_4xx || 0);
-                const bReqs = (b.stats?.total_requests || 0) - (b.stats?.total_4xx || 0);
+                const aReqs =
+                    (a.stats?.total_requests || 0) - (a.stats?.total_4xx || 0);
+                const bReqs =
+                    (b.stats?.total_requests || 0) - (b.stats?.total_4xx || 0);
                 return dir * (aReqs - bReqs);
             }
             case "ok2xx":
@@ -674,7 +676,9 @@ function App() {
                                             <td className="px-3 py-2 text-right tabular-nums text-gray-600">
                                                 {total > 0 ? (
                                                     <>
-                                                        {(total - total4xx).toLocaleString()}
+                                                        {(
+                                                            total - total4xx
+                                                        ).toLocaleString()}
                                                         {total4xx > 0 && (
                                                             <span className="text-gray-400 text-xs ml-1">
                                                                 (


### PR DESCRIPTION
## Summary
- Reqs column now shows non-4xx count as the big number, raw total in parentheses
- Success % calculated as `2xx / (total - 4xx)` instead of `(total - 5xx) / total`
- 4xx are user errors (bad request, auth, billing) and shouldn't inflate request counts or dilute success rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)