### PR TITLE
update image pricing and GPU cost dashboard

### DIFF
--- a/apps/operation/economics/provisioning/dashboards/daily-spending.json
+++ b/apps/operation/economics/provisioning/dashboards/daily-spending.json
@@ -110,7 +110,7 @@
         "type": "grafana-clickhouse-datasource",
         "uid": "PAD1A0A25CD30D456"
       },
-      "description": "Average daily paid GPU cost (io.net).",
+      "description": "Fixed daily paid GPU cost (Vast.ai). Flux: 4 GPUs @ $1.65/h, Z-Image: 4 GPUs @ $1.65/h.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -168,7 +168,7 @@
           },
           "format": 1,
           "range": true,
-          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  round(SUM(total_price) / GREATEST(1, uniqExact(toDate(start_time))), 2) as gpu_daily_spend\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND model_provider_used = 'io.net'\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)",
+          "rawSql": "SELECT ($gpu_flux_daily + $gpu_zimage_daily) as gpu_daily_spend",
           "refId": "A"
         }
       ],
@@ -267,7 +267,7 @@
         "type": "grafana-clickhouse-datasource",
         "uid": "PAD1A0A25CD30D456"
       },
-      "description": "Average daily free GPU cost (modal GPU + OVH GPU models).",
+      "description": "Fixed daily free GPU cost (Modal Klein + Klein-Large).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -321,7 +321,7 @@
           },
           "format": 1,
           "range": true,
-          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  round(SUM(total_price) / GREATEST(1, uniqExact(toDate(start_time))), 2) as free_gpu_daily\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND (\n    (model_provider_used = 'modal' AND (model_used IN ('klein', 'klein-large', 'ltx-2') OR model_used LIKE 'flux_klein%'))\n    OR (model_provider_used = 'ovhcloud' AND model_used NOT IN ('Qwen3-Coder-30B-A3B-Instruct', 'Mistral-Small-3.2-24B-Instruct-2506', 'whisper'))\n  )\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)",
+          "rawSql": "SELECT ($gpu_klein_daily + $gpu_klein_large_daily) as free_gpu_daily",
           "refId": "A"
         }
       ],
@@ -534,7 +534,7 @@
           },
           "format": 1,
           "range": true,
-          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  round(SUM(total_price) / GREATEST(1, uniqExact(toDate(start_time))), 2) as spend\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND model_provider_used IN ('google', 'aws', 'alibaba', 'azure', 'bytedance', 'io.net')\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)",
+          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  round(SUM(total_price) / GREATEST(1, uniqExact(toDate(start_time))), 2) as spend\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND model_provider_used IN ('google', 'aws', 'alibaba', 'azure', 'bytedance')\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)",
           "refId": "B",
           "hide": true
         },
@@ -551,10 +551,21 @@
         },
         {
           "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "PAD1A0A25CD30D456"
+          },
+          "format": 1,
+          "range": true,
+          "rawSql": "SELECT ($gpu_flux_daily + $gpu_zimage_daily) as gpu",
+          "refId": "E",
+          "hide": true
+        },
+        {
+          "datasource": {
             "type": "__expr__",
             "uid": "__expr__"
           },
-          "expression": "$A - $B - $D",
+          "expression": "$A - $B - $D - $E",
           "refId": "C",
           "type": "math"
         }
@@ -678,7 +689,7 @@
         "type": "grafana-clickhouse-datasource",
         "uid": "PAD1A0A25CD30D456"
       },
-      "description": "Daily paid GPU cost by provider/model (io.net).",
+      "description": "Daily paid GPU cost by provider/model (io.net/vast.ai).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -764,7 +775,7 @@
           },
           "format": 0,
           "range": true,
-          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  toStartOfInterval(start_time, INTERVAL 1 DAY) as time,\n  concat(model_provider_used, ' / ', model_used) as series,\n  SUM(total_price) as cost\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND model_provider_used = 'io.net'\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)\nGROUP BY time, series\nORDER BY time, series",
+          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  toStartOfInterval(start_time, INTERVAL 1 DAY) as time,\n  concat(model_provider_used, ' / ', model_used) as series,\n  SUM(total_price) as cost\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND model_provider_used IN ('io.net', 'vast.ai')\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)\nGROUP BY time, series\nORDER BY time, series",
           "refId": "A"
         }
       ],
@@ -1783,6 +1794,78 @@
       },
       {
         "type": "constant",
+        "name": "gpu_flux_daily",
+        "label": "Flux GPU Cost ($/day) - 4x GPUs @ $1.65/h",
+        "query": "158.40",
+        "current": {
+          "text": "158.40",
+          "value": "158.40"
+        },
+        "hide": 2,
+        "options": [
+          {
+            "text": "158.40",
+            "value": "158.40",
+            "selected": true
+          }
+        ]
+      },
+      {
+        "type": "constant",
+        "name": "gpu_zimage_daily",
+        "label": "Z-Image GPU Cost ($/day) - 4x GPUs @ $1.65/h",
+        "query": "158.40",
+        "current": {
+          "text": "158.40",
+          "value": "158.40"
+        },
+        "hide": 2,
+        "options": [
+          {
+            "text": "158.40",
+            "value": "158.40",
+            "selected": true
+          }
+        ]
+      },
+      {
+        "type": "constant",
+        "name": "gpu_klein_daily",
+        "label": "Klein GPU Cost ($/day) - Modal L40S",
+        "query": "61.90",
+        "current": {
+          "text": "61.90",
+          "value": "61.90"
+        },
+        "hide": 2,
+        "options": [
+          {
+            "text": "61.90",
+            "value": "61.90",
+            "selected": true
+          }
+        ]
+      },
+      {
+        "type": "constant",
+        "name": "gpu_klein_large_daily",
+        "label": "Klein-Large GPU Cost ($/day) - Modal L40S",
+        "query": "46.61",
+        "current": {
+          "text": "46.61",
+          "value": "46.61"
+        },
+        "hide": 2,
+        "options": [
+          {
+            "text": "46.61",
+            "value": "46.61",
+            "selected": true
+          }
+        ]
+      },
+      {
+        "type": "constant",
         "name": "infra_cloudflare_daily",
         "label": "Cloudflare Gateway ($/day)",
         "query": "60",
@@ -1803,16 +1886,16 @@
         "type": "constant",
         "name": "infra_aws_daily",
         "label": "AWS AI Services ($/day)",
-        "query": "140",
+        "query": "35",
         "current": {
-          "text": "140",
-          "value": "140"
+          "text": "35",
+          "value": "35"
         },
         "hide": 2,
         "options": [
           {
-            "text": "140",
-            "value": "140",
+            "text": "35",
+            "value": "35",
             "selected": true
           }
         ]

--- a/apps/operation/economics/provisioning/dashboards/platform-load.json
+++ b/apps/operation/economics/provisioning/dashboards/platform-load.json
@@ -1245,6 +1245,21 @@
               {
                 "matcher": {
                   "id": "byName",
+                  "options": "vast.ai"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#00D4AA",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
                   "options": "modal"
                 },
                 "properties": [

--- a/apps/operation/economics/provisioning/dashboards/provider-costs.json
+++ b/apps/operation/economics/provisioning/dashboards/provider-costs.json
@@ -246,6 +246,21 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "vast.ai"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00D4AA",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "modal"
             },
             "properties": [
@@ -891,6 +906,21 @@
             "matcher": {
               "id": "byName",
               "options": "io.net"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00D4AA",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "vast.ai"
             },
             "properties": [
               {

--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -22,17 +22,11 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
-        date: "2026-03-03",
-        emoji: "🎵",
-        title: "Suno v5, Flux 2 Dev & Step 3.5 Flash",
+        date: "2026-03-05",
+        emoji: "🏷️",
+        title: "Image Pricing Update",
         description:
-            "AI music generation, next-gen image model and a new fast text model are now live!",
-    },
-    {
-        date: "2026-03-03",
-        emoji: "📋",
-        title: "GPT-5.2 & Seedance Video",
-        description: "These models have moved to the paid category.",
+            "Flux $0.001/img, Z-Image $0.002/img, Klein $0.01/img, Klein-Large $0.015/img. Pollen tier compatible.",
     },
 ];
 

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -168,12 +168,11 @@ export const IMAGE_SERVICES = {
     "flux": {
         aliases: [],
         modelId: "flux",
-        provider: "io.net",
+        provider: "vast.ai",
         cost: [
-            // Flux Schnell (nunchaku-quantized) on io.net RTX 4090 cluster
             {
                 date: COST_START_DATE,
-                completionImageTokens: 0.0002, // ~$0.0002 per image (GPU cost estimate)
+                completionImageTokens: 0.001,
             },
         ],
         description: "Flux Schnell - Fast high-quality image generation",
@@ -183,13 +182,11 @@ export const IMAGE_SERVICES = {
     "zimage": {
         aliases: ["z-image", "z-image-turbo"],
         modelId: "zimage",
-        provider: "io.net",
+        provider: "vast.ai",
         cost: [
-            // Z-Image-Turbo (6B params, 9 steps) with SPAN 2x upscaling
-            // IO.net cluster (10x RTX 4090), ~1s for 768x768, ~2s for 1536x1536
             {
                 date: COST_START_DATE,
-                completionImageTokens: 0.0002, // ~$0.0002 per image (GPU cost estimate)
+                completionImageTokens: 0.002,
             },
         ],
         description: "Z-Image Turbo - Fast 6B Flux with 2x upscaling",
@@ -275,11 +272,9 @@ export const IMAGE_SERVICES = {
         modelId: "klein",
         provider: "modal",
         cost: [
-            // Flux Klein on Modal L40S GPU
-            // L40S: $0.000542/sec × 15s avg (including cold starts) = $0.008/image
             {
                 date: new Date("2026-01-21").getTime(), // Launch date
-                completionImageTokens: 0.008, // ~$0.008 per image (L40S @ 15s avg)
+                completionImageTokens: 0.01,
             },
         ],
         description:
@@ -292,10 +287,9 @@ export const IMAGE_SERVICES = {
         modelId: "klein-large",
         provider: "modal",
         cost: [
-            // Flux Klein 9B on Modal L40S GPU (~$0.012/image with cold starts)
             {
                 date: new Date("2026-01-21").getTime(),
-                completionImageTokens: 0.012,
+                completionImageTokens: 0.015,
             },
         ],
         description:


### PR DESCRIPTION
- Update flux/zimage provider from io.net to vast.ai in registry
- Update per-image prices: flux $0.001, zimage $0.002
- Add fixed daily GPU cost variables to spending dashboard (vast.ai $158.40/day, modal klein $61.90/day, klein-large $46.61/day)
- Reduce AWS infra from $140 to $35/day
- Add vast.ai color overrides in provider-costs and platform-load dashboards
- Update enter news banner with pricing announcement