### PR TITLE
fix: remove 'Pollen tier compatible' from news banner

### DIFF
--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -26,7 +26,7 @@ const PINNED_NEWS: Highlight[] = [
         emoji: "🏷️",
         title: "Image Pricing Update",
         description:
-            "Flux $0.001/img, Z-Image $0.002/img, Klein $0.01/img, Klein-Large $0.015/img. Pollen tier compatible.",
+            "Flux $0.001/img, Z-Image $0.002/img, Klein $0.01/img, Klein-Large $0.015/img.",
     },
 ];
 


### PR DESCRIPTION
## Summary
- Removes the phrase "Pollen tier compatible." from the image pricing news banner in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)