### PR TITLE
fix(media): prevent stale 404 cache blocking re-upload after delete

### DIFF
--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -282,7 +282,10 @@ api.get(
             const object = await c.env.MEDIA_BUCKET.get(hash);
 
             if (!object) {
-                return c.json({ error: "Not found" }, 404);
+                return c.json(
+                    { error: "Not found" },
+                    { status: 404, headers: { "Cache-Control": "no-store" } },
+                );
             }
 
             const headers = new Headers();
@@ -330,7 +333,10 @@ api.on(
             const object = await c.env.MEDIA_BUCKET.head(hash);
 
             if (!object) {
-                return new Response(null, { status: 404 });
+                return new Response(null, {
+                    status: 404,
+                    headers: { "Cache-Control": "no-store" },
+                });
             }
 
             const headers = new Headers();
@@ -437,6 +443,14 @@ api.delete(
             }
 
             await c.env.MEDIA_BUCKET.delete(hash);
+
+            // Purge CDN cache so re-uploads of the same content are immediately accessible
+            try {
+                const cache = caches.default;
+                await cache.delete(new Request(`https://${DOMAIN}/${hash}`));
+            } catch (e) {
+                console.error("Cache purge failed (non-fatal):", e);
+            }
 
             console.log(
                 JSON.stringify({

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -149,4 +149,46 @@ describe("media.pollinations.ai", () => {
         const getRes = await fetch(`${BASE_URL}/${upload.id}`);
         expect(getRes.status).toBe(404);
     });
+
+    it("upload, delete, and re-upload same content", async () => {
+        const unique = new Uint8Array([
+            ...TINY_PNG,
+            ...crypto.getRandomValues(new Uint8Array(8)),
+        ]);
+
+        // Upload
+        const uploadRes = await fetch(`${BASE_URL}/upload`, {
+            method: "POST",
+            body: unique,
+            headers: authHeaders("image/png"),
+        });
+        expect(uploadRes.status).toBe(200);
+        const upload = (await uploadRes.json()) as UploadResponse;
+        expect(upload.duplicate).toBe(false);
+
+        // Delete
+        const deleteRes = await fetch(`${BASE_URL}/${upload.id}`, {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${requireApiKey()}` },
+        });
+        expect(deleteRes.status).toBe(200);
+
+        // Re-upload same content
+        const reuploadRes = await fetch(`${BASE_URL}/upload`, {
+            method: "POST",
+            body: unique,
+            headers: authHeaders("image/png"),
+        });
+        expect(reuploadRes.status).toBe(200);
+        const reupload = (await reuploadRes.json()) as UploadResponse;
+        expect(reupload.id).toBe(upload.id);
+        expect(reupload.duplicate).toBe(false);
+
+        // Verify retrieval works after re-upload
+        const getRes2 = await fetch(`${BASE_URL}/${upload.id}`);
+        expect(getRes2.status).toBe(200);
+        expect(getRes2.headers.get("content-type")).toBe("image/png");
+        const body = new Uint8Array(await getRes2.arrayBuffer());
+        expect(body.length).toBe(unique.length);
+    });
 });


### PR DESCRIPTION
fixes the "ghost state" bug where deleting a file via DELETE /media/{hash} leaves the hash blocked, re-uploads succeed in R2 but GET still returns cached 404s

this is a cloudflare edge caching issue, not a database problem. the immutable cache-control header on successful responses also applies to 404s, causing stale 404s to persist after deletion

changes
\- add `Cache-Control: no-store` to 404 responses in GET and HEAD handlers
\- purge CDN cache entry on DELETE via `caches.default.delete()`
\- add regression test for upload → delete → re-upload → retrieve flow

Closes #8879