### PR TITLE
fix: normalize finish_reason to OpenAI format

### DIFF
--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -31,7 +31,7 @@ function createVertexGeminiConfig(
         "vertex-project-id": process.env.GOOGLE_PROJECT_ID,
         "vertex-region": region,
         "vertex-model-id": modelId,
-        "strict-openai-compliance": "false",
+        "strict-openai-compliance": "true",
     });
 }
 

--- a/text.pollinations.ai/genericOpenAIClient.ts
+++ b/text.pollinations.ai/genericOpenAIClient.ts
@@ -170,6 +170,12 @@ export async function genericOpenAIClient(
                 : originalChoice
         ) as CompletionChoice;
 
+        // Some providers (e.g. Vertex AI) return "stop" even when tool_calls
+        // are present. OpenAI spec requires finish_reason "tool_calls" in that case.
+        if (formattedChoice.message?.tool_calls?.length) {
+            formattedChoice.finish_reason = "tool_calls";
+        }
+
         return {
             ...data,
             id: data.id || `genericopenai-${requestId}`,

--- a/text.pollinations.ai/portkeyUtils.ts
+++ b/text.pollinations.ai/portkeyUtils.ts
@@ -67,7 +67,7 @@ export async function generatePortkeyHeaders(
     }
 
     const headers: Record<string, string> = {
-        "x-portkey-strict-open-ai-compliance": "false",
+        "x-portkey-strict-open-ai-compliance": "true",
     };
 
     let apiKey: string | undefined;


### PR DESCRIPTION
## Summary
- Enable Portkey `strict-openai-compliance` — was `false`, causing raw provider finish_reason values to leak through (e.g. `STOP`, `end_turn`, `tool_use` instead of `stop`, `tool_calls`)
- Force `finish_reason: "tool_calls"` when `tool_calls` present (Vertex AI returns `stop` even for tool calls)

Tested locally: gemini-large, claude-large, kimi, deepseek all return correct OpenAI-format values now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)