### PR TITLE
feat: hardcode Sana + Z-Image servers for legacy image service

### DIFF
--- a/image.pollinations.ai/src/availableServers.ts
+++ b/image.pollinations.ai/src/availableServers.ts
@@ -327,3 +327,19 @@ export const fetchFromLeastBusyServer = async (
 // Wrapper for backward compatibility
 export const fetchFromLeastBusyFluxServer = (options: RequestInit) =>
     fetchFromLeastBusyServer("flux", options);
+
+// Hardcoded Sana server - bypasses registration flow
+const SANA_URL = process.env.SANA_URL || "http://localhost:19876";
+registerServer(SANA_URL, "sana");
+setInterval(() => registerServer(SANA_URL, "sana"), 30000);
+
+// Hardcoded Z-Image servers (GPUs 1-3 via SSH tunnel)
+for (const port of [19877, 19878, 19879]) {
+    const url = `http://localhost:${port}`;
+    registerServer(url, "zimage");
+}
+setInterval(() => {
+    for (const port of [19877, 19878, 19879]) {
+        registerServer(`http://localhost:${port}`, "zimage");
+    }
+}, 30000);


### PR DESCRIPTION
## Summary
- Hardcode Sana 0.6B (localhost:19876) and Z-Image (localhost:19877-19879) as backends for legacy `image.pollinations.ai`
- Bypasses heartbeat registration flow — servers connect via SSH tunnels from Scaleway to vast.ai Taiwan
- Already deployed and running on Scaleway

🤖 Generated with [Claude Code](https://claude.com/claude-code)