### PR TITLE
docs: update vast.ai and Sana server docs

### DIFF
--- a/image.pollinations.ai/VASTAI_INSTANCES.md
+++ b/image.pollinations.ai/VASTAI_INSTANCES.md
@@ -1,6 +1,6 @@
 # Vast.ai GPU Instances - Flux & Z-Image Deployment
 
-Last updated: 2026-02-05
+Last updated: 2026-03-08
 
 ## Overview
 
@@ -12,7 +12,7 @@ Vast.ai instances running RTX 5090 GPUs for image generation:
 
 | Instance ID | Public IP | SSH Host | SSH Port | GPUs | GPU Type | Location | Services |
 |-------------|-----------|----------|----------|------|----------|----------|----------|
-| 30937024 | 211.72.13.202 | ssh3.vast.ai | 17024 | 4 | RTX 5090 | Taiwan | Flux (GPU 0), Z-Image (GPU 1,2,3) |
+| 30937024 | 211.72.13.202 | ssh3.vast.ai | 17024 | 4 | RTX 5090 | Taiwan | Sana 0.6B (GPU 0), Z-Image (GPU 1,2,3) |
 | 30826995 | 76.69.188.175 | ssh2.vast.ai | 26994 | 4 | RTX 5090 | Quebec, CA | Flux (GPU 0,1,2,3) |
 | 30939919 | 108.255.76.60 | ssh1.vast.ai | 19918 | 2 | RTX 5090 | North Carolina, US | Flux (GPU 0,1) |
 | 30994805 | 108.255.76.60 | ssh7.vast.ai | 34804 | 1 | RTX 5090 | North Carolina, US | Z-Image |
@@ -22,7 +22,7 @@ Vast.ai instances running RTX 5090 GPUs for image generation:
 **Instance 30937024 (Taiwan)**
 | Internal Port | External Port | Service |
 |---------------|---------------|---------|
-| 8765 | 47190 | Flux (GPU 0) |
+| 8765 | 47190 | Sana 0.6B (GPU 0) |
 | 8766 | 47162 | Z-Image (GPU 1) |
 | 8767 | 47174 | Z-Image (GPU 2) |
 | 8768 | 47158 | Z-Image (GPU 3) |
@@ -451,11 +451,11 @@ screen -dmS zimage-gpu3 bash -c 'cd /workspace/zimage && source venv/bin/activat
 - Check that `x-backend-token` header matches `PLN_IMAGE_BACKEND_TOKEN`
 - Verify the token in `enter.pollinations.ai/.testingtokens`
 
-## Capacity Summary (2026-02-05)
+## Capacity Summary (2026-03-08)
 
 | Instance | GPU | Service | VRAM | Port | Location |
 |----------|-----|---------|------|------|----------|
-| 30937024 | 0 | Flux | ~27 GB | 47190 | Taiwan |
+| 30937024 | 0 | Sana 0.6B | ~7 GB | 47190 | Taiwan |
 | 30937024 | 1 | Z-Image | ~26 GB | 47162 | Taiwan |
 | 30937024 | 2 | Z-Image | ~25 GB | 47174 | Taiwan |
 | 30937024 | 3 | Z-Image | ~26 GB | 47158 | Taiwan |
@@ -466,7 +466,50 @@ screen -dmS zimage-gpu3 bash -c 'cd /workspace/zimage && source venv/bin/activat
 | 30939919 | 0 | Flux | ~21 GB | 63218 | N. Carolina |
 | 30939919 | 1 | Flux | ~21 GB | 63511 | N. Carolina |
 | 30994805 | 0 | Z-Image | ~25 GB | 53559 | N. Carolina |
-| **Total** | **11** | **7 Flux + 4 Z-Image** | | |
+| **Total** | **11** | **6 Flux + 4 Z-Image + 1 Sana** | | |
+
+## Legacy image.pollinations.ai (Sana on Taiwan Instance)
+
+GPU 0 on Instance 30937024 (Taiwan) runs **Sana Sprint 0.6B** for the legacy `image.pollinations.ai` endpoint. This is separate from the `gen.pollinations.ai` gateway.
+
+**Architecture:**
+```
+image.pollinations.ai → Cloudflare tunnel → Scaleway (57.130.31.42:16384)
+  → SSH tunnel (localhost:19876) → vast.ai Taiwan (8765) → Sana 0.6B
+```
+
+**Scaleway gateway** (57.130.31.42):
+- Runs the full legacy image service from `master` branch (`image.pollinations.ai/src/index.ts`)
+- Provides rate limiting (90s per IP, 1 concurrent per IP), error images, queue management
+- Remaps all model requests (flux, z-image) to `sana`
+- SSH tunnel to vast.ai for Sana backend
+- Cloudflare tunnel: `image-origin.pollinations.ai` → localhost:16384
+
+**Sana config** (on vast.ai Taiwan GPU 0):
+- Model: `Sana_Sprint_0.6B_1024px_diffusers`
+- Max resolution: 512x512 (clamped, not rejected)
+- Inference steps: 2
+- Generation time: ~0.2-0.5s per image
+
+**Management:**
+```bash
+# Scaleway (legacy service)
+ssh -i ~/.ssh/id_rsa_ovh ubuntu@57.130.31.42
+sudo systemctl status image-pollinations.service
+sudo journalctl -u image-pollinations -f
+
+# Vast.ai (Sana)
+ssh -i ~/.ssh/pollinations_services_2026 -p 17024 root@ssh3.vast.ai
+screen -r sana-gpu0
+tail -f /tmp/sana.log
+
+# SSH tunnel (on Scaleway) - must be running for legacy service to work
+# Restart if needed:
+nohup ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=30 \
+  -i ~/.ssh/pollinations_services_2026 -p 17024 \
+  -L 19876:localhost:8765 -N root@ssh3.vast.ai \
+  > /tmp/tunnel-sana.log 2>&1 &
+```
 
 ## Notes
 

--- a/image.pollinations.ai/sana/SERVERS.md
+++ b/image.pollinations.ai/sana/SERVERS.md
@@ -1,30 +1,39 @@
 # SANA Sprint Servers
 
-| Host | SSH Alias | IP | GPUs | Ports | Provider |
-|------|-----------|-----|------|-------|----------|
-| sana-1 | `sana-1` | 51.158.101.128 | 2x L4 (24GB) | 10002, 10003 | Scaleway PAR1 |
-| sana-2 | `sana-2` | 51.159.129.211 | 2x L4 (24GB) | 10002, 10003 | Scaleway PAR2 |
-| comfystream | `comfystream` | 3.239.212.66 | 1x L40S (46GB) | 10002 | AWS |
+Last updated: 2026-03-08
 
-## Deployment
+## Current Deployment
 
-```bash
-# Deploy to a server with 2 GPUs
-./deploy.sh sana-1 2
+Sana Sprint 0.6B runs on the Taiwan vast.ai instance (GPU 0), serving the legacy `image.pollinations.ai` endpoint.
 
-# Deploy to a server with 1 GPU
-./deploy.sh comfystream 1
+| Host | Instance | IP | GPU | Port (int/ext) | Model |
+|------|----------|-----|-----|----------------|-------|
+| vast.ai Taiwan | 30937024 | 211.72.13.202 | GPU 0 (RTX 5090) | 8765 / 47190 | Sana Sprint 0.6B |
+
+- Max resolution: 512x512 (clamped)
+- Inference steps: 2
+- Generation time: ~0.2-0.5s
+
+Traffic reaches Sana via SSH tunnel from Scaleway (legacy gateway):
+```
+image.pollinations.ai → Cloudflare → Scaleway:16384 (legacy service)
+  → SSH tunnel (localhost:19876 → vast.ai:8765) → Sana 0.6B
 ```
 
-## Service Management
+## SSH Access
 
 ```bash
-# Check status
-ssh sana-1 "systemctl status sana-gpu0 sana-gpu1"
-
-# View logs
-ssh sana-1 "journalctl -u sana-gpu0 -f"
-
-# Restart
-ssh sana-1 "systemctl restart sana-gpu0 sana-gpu1"
+ssh -o StrictHostKeyChecking=no -i ~/.ssh/pollinations_services_2026 -p 17024 root@ssh3.vast.ai
+screen -r sana-gpu0
+tail -f /tmp/sana.log
 ```
+
+## Legacy Scaleway Sana Instances (Decommissioned)
+
+These Scaleway GPU instances previously ran Sana Sprint 1.6B but are no longer in use for Sana.
+
+| Host | SSH Alias | IP | GPUs | Provider |
+|------|-----------|-----|------|----------|
+| sana-1 | `sana-1` | 51.158.101.128 | 2x L4 (24GB) | Scaleway PAR1 |
+| sana-2 | `sana-2` | 51.159.129.211 | 2x L4 (24GB) | Scaleway PAR2 |
+| comfystream | `comfystream` | 3.239.212.66 | 1x L40S (46GB) | AWS |


### PR DESCRIPTION
## Summary
- Update Taiwan instance GPU 0 from Flux to Sana 0.6B in VASTAI_INSTANCES.md
- Document legacy image.pollinations.ai architecture (Scaleway → SSH tunnel → Sana)
- Update sana/SERVERS.md with current deployment, mark old Scaleway instances as decommissioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)