### PR TITLE
announce: hourly pollen refills (March 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We've launched **https://gen.pollinations.ai** — a single endpoint for all you
 
 ## 🆕 Latest News
 
+- **2026-03-09** – **⏱️ Hourly Pollen Refills** Starting March 11, tier pollen refills hourly. Spore: 0.01p/hr, Seed: 0.125p/hr, Flower: 0.4p/hr, Nectar: 0.8p/hr. Need more? Pollen packs at [enter.pollinations.ai](https://enter.pollinations.ai).
 - **2026-03-08** – **🎨 Fresh coat of pixels** The [main website](https://hello.pollinations.ai) has a new look. We replaced the old theming engine with a cohesive color palette and dynamic retro pixel art backgrounds. Much cozier.
 - **2026-03-06** – **📦 SDK Upgrades: Audio & BYOP** The hive has ears. You can now run Whisper Speech-to-Text, handle media uploads, and let users spend their own Pollen credits directly through the SDK.
 - **2026-03-06** – **🧠 Step-3.5-Flash Available** `step-3.5-flash` is now wired up and ready for chat completions via the [Unified API](https://gen.pollinations.ai).

--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -22,11 +22,11 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
-        date: "2026-03-05",
-        emoji: "🏷️",
-        title: "Image Pricing Update",
+        date: "2026-03-09",
+        emoji: "⏱️",
+        title: "Hourly Pollen Refills (March 11)",
         description:
-            "Flux $0.001/img, Z-Image $0.002/img, Klein $0.01/img, Klein-Large $0.015/img.",
+            "Spore: 0.01p/hr, Seed: 0.125p/hr, Flower: 0.4p/hr, Nectar: 0.8p/hr.",
     },
 ];
 


### PR DESCRIPTION
## Summary
- Adds README news entry for hourly pollen refills
- Updates pinned news banner on enter.pollinations.ai
- Discord announcement posted to #announcements

🤖 Generated with [Claude Code](https://claude.com/claude-code)