### PR TITLE
fix: add owner param for org-boss app token

### DIFF
--- a/.github/workflows/user-upgrade-spore-to-seed.yml
+++ b/.github/workflows/user-upgrade-spore-to-seed.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           app-id: ${{ secrets.ORG_BOSS_APP_ID }}
           private-key: ${{ secrets.ORG_BOSS_PRIVATE_KEY }}
+          owner: pollinations
 
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The org-boss GitHub App is installed at org level. The create-github-app-token action needs `owner: pollinations` to find the installation. Without it, it looks for a repo-level installation and gets a 404.