### PR TITLE
fix: update claude-airforce pricing to ~1/3 of official Sonnet 4.6

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -646,8 +646,8 @@ export const TEXT_SERVICES = {
         cost: [
             {
                 date: new Date("2026-03-09").getTime(),
-                promptTextTokens: perMillion(0.01), // via api.airforce
-                completionTextTokens: perMillion(0.01),
+                promptTextTokens: perMillion(1.0), // ~1/3 of official Sonnet 4.6 pricing
+                completionTextTokens: perMillion(5.0),
             },
         ],
         description:


### PR DESCRIPTION
## Summary
- Update claude-airforce (Sonnet 4.6 via api.airforce) pricing from $0.01/$0.01 to $1.00/$5.00 per 1M tokens
- This is ~1/3 of official Anthropic Sonnet 4.6 pricing ($3.00/$15.00)

🤖 Generated with [Claude Code](https://claude.com/claude-code)