### PR TITLE
fix: skip redundant KV writes for API key verify tracking

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -15,6 +15,14 @@ import { user as userTable } from "./db/schema/better-auth.ts";
 import { sendTierEventToTinybird } from "./events.ts";
 import { DEFAULT_TIER, getTierPollen } from "./tier-config.ts";
 
+// Track which API keys have been written to KV in this isolate.
+// Better Auth writes tracking data (lastRequest, requestCount, updatedAt) to KV
+// on every verify call. At ~3-5M req/day this exceeds KV's write limits (429s).
+// First write per key (cache-warm on KV miss) goes through; subsequent writes
+// (verify tracking updates) are skipped. Session writes are unaffected.
+// Dashboard reads lastRequest from D1 (updated via deferUpdates).
+const kvWrittenKeys = new Set<string>();
+
 function addKeyPrefix(key: string) {
     return `auth:${key}`;
 }
@@ -102,12 +110,23 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
                 return await env.KV.get(addKeyPrefix(key));
             },
             set: async (key, value, ttl) => {
+                if (key.startsWith("api-key:")) {
+                    const prefixedKey = addKeyPrefix(key);
+                    if (kvWrittenKeys.has(prefixedKey)) return;
+                    await env.KV.put(prefixedKey, value, {
+                        expirationTtl: ttl,
+                    });
+                    kvWrittenKeys.add(prefixedKey);
+                    return;
+                }
                 await env.KV.put(addKeyPrefix(key), value, {
                     expirationTtl: ttl,
                 });
             },
             delete: async (key) => {
-                await env.KV.delete(addKeyPrefix(key));
+                const prefixedKey = addKeyPrefix(key);
+                kvWrittenKeys.delete(prefixedKey);
+                await env.KV.delete(prefixedKey);
             },
         },
         trustedOrigins: ["*"],


### PR DESCRIPTION
## Summary

- Better Auth writes 3 KV PUTs per `verifyApiKey` call (tracking `lastRequest`, `requestCount`, `updatedAt`) — purely for dashboard display
- At 3-5M req/day this exceeds KV write limits, flooding logs with `KV PUT failed: 429 Too Many Requests`
- Fix: only allow the first KV write per API key per isolate (cache-warm on miss), skip subsequent verify tracking writes
- Scoped to `api-key:` prefix — session writes are unaffected
- Dashboard reads `lastRequest` from D1 (already updated via `deferUpdates`)

## What changed

Single file: `enter.pollinations.ai/src/auth.ts`
- Module-level `Set` tracks which API keys have been written to KV
- `set()`: skip if key starts with `api-key:` and already written in this isolate
- `delete()`: clears the Set entry so next access re-warms the cache

## Test plan

- [ ] Deploy and monitor KV write volume in Cloudflare dashboard
- [ ] Verify API key auth works for both `sk_` and `pk_` keys
- [ ] Check `wrangler tail` for absence of KV 429 errors
- [ ] Verify key creation/deletion still works (admin routes)

Fixes #9125

🤖 Generated with [Claude Code](https://claude.com/claude-code)