### PR TITLE
feat: pre-request balance check against estimated model cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,6 +409,16 @@ curl 'https://gen.pollinations.ai/audio/{text}?voice=nova&key=YOUR_API_KEY' -o s
 4. **Explain Changes**: High-level summary at each step
 5. **Capture Lessons**: When corrected, update this AGENTS.md with the pattern to prevent recurrence
 
+## Compact Instructions
+
+When compacting conversation context, preserve:
+- Full list of modified files with paths and line numbers
+- All code snippets, diffs, and implementation details
+- Test output, error messages, and command results
+- Complete task plan, progress, and pending items
+- User preferences and corrections from this session
+- Key architectural decisions and their rationale
+
 ## Core Principles
 
 - **Simplicity First**: Make every change as simple as possible. Impact minimal code.

--- a/enter.pollinations.ai/src/middleware/balance.ts
+++ b/enter.pollinations.ai/src/middleware/balance.ts
@@ -18,6 +18,28 @@ export type UserBalance = {
     cryptoBalance: number;
 };
 
+/**
+ * Get the total available balance across relevant buckets.
+ * For paid-only models: crypto + pack only.
+ * For regular models: tier + crypto + pack (only positive buckets).
+ */
+export function getAvailableBalance(
+    balances: UserBalance,
+    isPaidOnly = false,
+): number {
+    if (isPaidOnly) {
+        return (
+            Math.max(0, balances.cryptoBalance) +
+            Math.max(0, balances.packBalance)
+        );
+    }
+    return (
+        Math.max(0, balances.tierBalance) +
+        Math.max(0, balances.cryptoBalance) +
+        Math.max(0, balances.packBalance)
+    );
+}
+
 export type BalanceVariables = {
     balance: {
         requirePositiveBalance: (

--- a/enter.pollinations.ai/src/routes/images.ts
+++ b/enter.pollinations.ai/src/routes/images.ts
@@ -6,14 +6,14 @@
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { getDefaultErrorMessage, UpstreamError } from "@/error.ts";
-import type { AuthVariables } from "@/middleware/auth.ts";
-import type { BalanceVariables } from "@/middleware/balance.ts";
-import type { ModelVariables } from "@/middleware/model.ts";
 import {
     type CreateImageEditRequest,
     CreateImageEditRequestSchema,
     type CreateImageRequest,
 } from "@/schemas/openai.ts";
+
+// biome-ignore lint/suspicious/noExplicitAny: internal callback bridging typed proxy.ts and untyped Context.var
+type CheckBalanceFn = (vars: any, env: any) => Promise<void>;
 
 // --- Helpers ---
 
@@ -47,18 +47,11 @@ function imageResponse(
 }
 
 /** Auth + balance checks shared by both handlers. */
-async function requireAuthAndBalance(
-    c: Context,
-    checkBalance: (
-        vars: AuthVariables & BalanceVariables & ModelVariables,
-    ) => Promise<void>,
-) {
+async function requireAuthAndBalance(c: Context, checkBalance: CheckBalanceFn) {
     await c.var.auth.requireAuthorization();
     c.var.auth.requireModelAccess();
     c.var.auth.requireKeyBudget();
-    await checkBalance(
-        c.var as unknown as AuthVariables & BalanceVariables & ModelVariables,
-    );
+    await checkBalance(c.var, c.env);
 }
 
 /** Build image service URL with core params (kept in URL for caching/logging). */
@@ -212,9 +205,7 @@ async function parseEditInput(c: Context): Promise<{
 // --- Exported handlers ---
 
 export function handleImageGeneration(
-    checkBalance: (
-        vars: AuthVariables & BalanceVariables & ModelVariables,
-    ) => Promise<void>,
+    checkBalance: CheckBalanceFn,
     proxyHeaders: (c: Context) => Record<string, string>,
 ) {
     return async (c: Context) => {
@@ -264,9 +255,7 @@ export function handleImageGeneration(
 }
 
 export function handleImageEdit(
-    checkBalance: (
-        vars: AuthVariables & BalanceVariables & ModelVariables,
-    ) => Promise<void>,
+    checkBalance: CheckBalanceFn,
     proxyHeaders: (c: Context) => Record<string, string>,
 ) {
     return async (c: Context) => {

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -2,8 +2,13 @@ import { type Context, Hono } from "hono";
 import { proxy } from "hono/proxy";
 import { resolver as baseResolver, describeRoute } from "hono-openapi";
 import { type AuthVariables, auth } from "@/middleware/auth.ts";
-import { type BalanceVariables, balance } from "@/middleware/balance.ts";
+import {
+    type BalanceVariables,
+    balance,
+    getAvailableBalance,
+} from "@/middleware/balance.ts";
 import { imageCache } from "@/middleware/image-cache.ts";
+import type { LoggerVariables } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import { resolveModel } from "@/middleware/model.ts";
 import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
@@ -47,6 +52,7 @@ import {
 } from "@/schemas/openai.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
 import { errorResponseDescriptions } from "@/utils/api-docs.ts";
+import { getEstimatedPrice, getModelStats } from "@/utils/model-stats.ts";
 import { generateMusic, generateSpeech, generateSunoMusic } from "./audio.ts";
 
 // Build dynamic model lists from registry for use in API descriptions
@@ -76,7 +82,7 @@ const imageVideoHandlers = factory.createHandlers(
         await c.var.auth.requireAuthorization();
         c.var.auth.requireModelAccess();
         c.var.auth.requireKeyBudget();
-        await checkBalance(c.var);
+        await checkBalance(c.var, c.env);
 
         // Get prompt from validated param (using :prompt{[\\s\\S]+} regex pattern)
         const promptParam = c.req.param("prompt") || "";
@@ -130,7 +136,7 @@ const chatCompletionHandlers = factory.createHandlers(
         // Use resolved model from middleware for the backend request
         const requestBody = await c.req.json();
         requestBody.model = c.var.model.resolved;
-        await checkBalance(c.var);
+        await checkBalance(c.var, c.env);
 
         const textServiceUrl =
             c.env.TEXT_SERVICE_URL || "https://text.pollinations.ai";
@@ -508,7 +514,7 @@ export const proxyRoutes = new Hono<Env>()
             await c.var.auth.requireAuthorization();
             c.var.auth.requireModelAccess();
             c.var.auth.requireKeyBudget();
-            await checkBalance(c.var);
+            await checkBalance(c.var, c.env);
 
             // Use resolved model from middleware
             const model = c.var.model.resolved;
@@ -729,7 +735,7 @@ export const proxyRoutes = new Hono<Env>()
         async (c) => {
             const log = c.get("log").getChild("generate");
             await c.var.auth.requireAuthorization();
-            await checkBalance(c.var);
+            await checkBalance(c.var, c.env);
 
             const text = decodeURIComponent(c.req.param("text"));
             const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
@@ -952,16 +958,33 @@ export function contentFilterResultsToHeaders(
     return headers;
 }
 
-async function checkBalance({
-    auth,
-    balance,
-    model,
-}: AuthVariables & BalanceVariables & ModelVariables): Promise<void> {
+async function checkBalance(
+    vars: AuthVariables & BalanceVariables & ModelVariables & LoggerVariables,
+    env: CloudflareBindings,
+): Promise<void> {
+    const { auth, balance, model, log } = vars;
     if (!auth.user?.id) return;
 
     const serviceDefinition = getServiceDefinition(model.resolved);
     const isPaidOnly = serviceDefinition.paidOnly ?? false;
 
+    // Pre-check: reject if balance < estimated cost for this model
+    // getModelStats is cached in KV for 1hr, so this is cheap
+    const stats = await getModelStats(env.KV, log);
+    const estimatedCost = getEstimatedPrice(stats, model.resolved);
+
+    if (estimatedCost > 0) {
+        const userBalance = await balance.getBalance(auth.user.id);
+        const available = getAvailableBalance(userBalance, isPaidOnly);
+
+        if (available < estimatedCost) {
+            throw new HTTPException(402, {
+                message: `Insufficient balance. This model costs ~${estimatedCost.toFixed(4)} pollen per request, but your available balance is ${available.toFixed(4)}.`,
+            });
+        }
+    }
+
+    // Existing check: sets balanceCheckResult for downstream cost deduction
     if (isPaidOnly) {
         await balance.requirePaidBalance(
             auth.user.id,

--- a/enter.pollinations.ai/test/balance-check.test.ts
+++ b/enter.pollinations.ai/test/balance-check.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getAvailableBalance } from "@/middleware/balance.ts";
+
+describe("getAvailableBalance", () => {
+    it("sums all positive buckets for regular models", () => {
+        expect(
+            getAvailableBalance({
+                tierBalance: 0.1,
+                packBalance: 0.2,
+                cryptoBalance: 0.3,
+            }),
+        ).toBeCloseTo(0.6);
+    });
+
+    it("excludes tier for paid-only models", () => {
+        expect(
+            getAvailableBalance(
+                { tierBalance: 10, packBalance: 0.5, cryptoBalance: 0 },
+                true,
+            ),
+        ).toBeCloseTo(0.5);
+    });
+
+    it("ignores negative buckets", () => {
+        expect(
+            getAvailableBalance({
+                tierBalance: -1,
+                packBalance: 0.3,
+                cryptoBalance: -0.5,
+            }),
+        ).toBeCloseTo(0.3);
+    });
+
+    it("returns 0 when all buckets are negative or zero", () => {
+        expect(
+            getAvailableBalance({
+                tierBalance: -1,
+                packBalance: 0,
+                cryptoBalance: -2,
+            }),
+        ).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Rejects requests before proxying when available balance < estimated model cost
- Uses 7-day rolling average cost from Tinybird (cached 1hr in KV, no perf impact)
- Falls through to existing `> 0` check when no stats exist for a model
- Adds `getAvailableBalance()` helper that sums only positive buckets, respects paid-only models
- Prevents overspend for low-cap tiers (spore: 0.24, seed: 3.6 pollen cap)

## Test plan
- [x] Unit tests for `getAvailableBalance` (4 cases: regular, paid-only, negative buckets, all-zero)
- [ ] Manual: low-balance spore user hitting expensive model → clean 402
- [ ] Verify unknown model (no stats) falls through to existing check

🤖 Generated with [Claude Code](https://claude.com/claude-code)