### PR TITLE
revert: remove Qwen3.5 — not available on Fireworks serverless

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -548,26 +548,6 @@ export const TEXT_SERVICES = {
         contextLength: 200000,
         isSpecialized: false,
     },
-    "qwen": {
-        aliases: ["qwen3.5", "qwen3p5", "qwen3p5-397b-a17b"],
-        modelId: "accounts/fireworks/models/qwen3p5-397b-a17b",
-        provider: "fireworks",
-        cost: [
-            {
-                date: new Date("2026-03-17").getTime(),
-                promptTextTokens: perMillion(0.6),
-                promptCachedTokens: perMillion(0.3),
-                completionTextTokens: perMillion(3.6),
-            },
-        ],
-        description: "Qwen3.5 397B A17B - Large MoE with Vision & Reasoning",
-        inputModalities: ["text", "image"],
-        outputModalities: ["text"],
-        tools: true,
-        reasoning: true,
-        contextLength: 262144,
-        isSpecialized: false,
-    },
     "nomnom": {
         aliases: ["web-scrape", "web-research"],
         modelId: "nomnom",

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -154,10 +154,6 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["accounts/fireworks/models/minimax-m2p5"],
     },
     {
-        name: "qwen",
-        config: portkeyConfig["accounts/fireworks/models/qwen3p5-397b-a17b"],
-    },
-    {
         name: "nomnom",
         config: portkeyConfig["nomnom"],
     },

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -179,10 +179,6 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/deepseek-v3p2",
         }),
-    "accounts/fireworks/models/qwen3p5-397b-a17b": () =>
-        createFireworksModelConfig({
-            model: "accounts/fireworks/models/qwen3p5-397b-a17b",
-        }),
 
     // -- Community Models -----------------------------------------------------
     "nomnom": () =>


### PR DESCRIPTION
## Summary
- Reverts #9225 (feat: add Qwen3.5 397B model via Fireworks)
- Qwen3.5 397B is not available on Fireworks serverless, causing failures
- Removes model from registry, availableModels, and portkeyConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)