### PR TITLE
fix(auth): harden github username sync on login

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -8,10 +8,13 @@ import {
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
 import { admin, apiKey, openAPI } from "better-auth/plugins";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import * as betterAuthSchema from "./db/schema/better-auth.ts";
-import { user as userTable } from "./db/schema/better-auth.ts";
+import {
+    account as accountTable,
+    user as userTable,
+} from "./db/schema/better-auth.ts";
 import { sendTierEventToTinybird } from "./events.ts";
 import { DEFAULT_TIER, getTierPollen } from "./tier-config.ts";
 
@@ -205,6 +208,9 @@ function tierPlugin(
  * GitHub usernames are mutable — users can rename their account.
  * We fetch the current username from GitHub API using the immutable github_id
  * and update D1 if it changed. Non-blocking via waitUntil.
+ *
+ * When github_id is missing from the user table (legacy rows), we resolve it
+ * from the account table and backfill so subsequent logins skip the fallback.
  */
 function onAfterSessionCreate(
     env: Cloudflare.Env,
@@ -227,7 +233,30 @@ function onAfterSessionCreate(
                         .where(eq(userTable.id, session.userId))
                         .limit(1);
 
-                    if (!user?.githubId) return;
+                    let githubId = user?.githubId;
+
+                    // Fallback: resolve github_id from the account table
+                    if (!githubId) {
+                        const [acct] = await db
+                            .select({ accountId: accountTable.accountId })
+                            .from(accountTable)
+                            .where(
+                                and(
+                                    eq(accountTable.userId, session.userId),
+                                    eq(accountTable.providerId, "github"),
+                                ),
+                            )
+                            .limit(1);
+
+                        if (!acct?.accountId) return;
+                        githubId = Number(acct.accountId);
+
+                        // Backfill so subsequent logins skip this fallback
+                        await db
+                            .update(userTable)
+                            .set({ githubId })
+                            .where(eq(userTable.id, session.userId));
+                    }
 
                     const headers: Record<string, string> = {
                         Accept: "application/vnd.github+json",
@@ -238,23 +267,32 @@ function onAfterSessionCreate(
                         headers.Authorization = `Basic ${btoa(`${env.GITHUB_CLIENT_ID}:${env.GITHUB_CLIENT_SECRET}`)}`;
                     }
                     const res = await fetch(
-                        `https://api.github.com/user/${user.githubId}`,
+                        `https://api.github.com/user/${githubId}`,
                         { headers },
                     );
-                    if (!res.ok) return;
+                    if (!res.ok) {
+                        console.error(
+                            `[username-sync] GitHub API ${res.status} for user ${githubId}`,
+                        );
+                        return;
+                    }
 
                     const profile = (await res.json()) as { login: string };
                     if (
                         profile.login &&
-                        profile.login !== user.githubUsername
+                        profile.login !== user?.githubUsername
                     ) {
                         await db
                             .update(userTable)
                             .set({ githubUsername: profile.login })
                             .where(eq(userTable.id, session.userId));
                     }
-                } catch {
-                    // Silently ignore — username sync is best-effort
+                } catch (e) {
+                    console.error(
+                        "[username-sync] failed for session",
+                        session.userId,
+                        e,
+                    );
                 }
             })(),
         );


### PR DESCRIPTION
hardens the github username sync hook in `onAfterSessionCreate` so renamed usernames are reliably detected on login

the existing hook relied on `user.github_id` being populated, but silently bailed if it was null and aet all the errors. this adds a fallback and visibility

\- when `github_id` is null on the user row, resolve it from the `account` table (this now always stores the github numeric id)
\- backfill `github_id` on the user row so the fallback is only needed once
\- replace silent `catch {}` with `console.error` so failures show up in `wrangler tail`

closes #9255