### PR TITLE
fix: bump diary tree cache key

### DIFF
--- a/pollinations.ai/src/hooks/useDiaryData.ts
+++ b/pollinations.ai/src/hooks/useDiaryData.ts
@@ -4,7 +4,7 @@ const RAW_BASE =
     "https://raw.githubusercontent.com/pollinations/pollinations/news/social/news";
 const TREE_API =
     "https://api.github.com/repos/pollinations/pollinations/git/trees/news?recursive=1";
-const TREE_CACHE_KEY = "diary_tree_v1";
+const TREE_CACHE_KEY = "diary_tree_v2";
 
 // --- Types ---
 


### PR DESCRIPTION
Weekly folders were renamed during migration (Saturday → Sunday dates). Users with stale localStorage cache see broken weekly entries and 404 images. Bumping cache key forces a fresh tree fetch.