### PR TITLE
feat: pipeline foundation — schema + shared utils

### DIFF
--- a/enter.pollinations.ai/drizzle/0017_add_score_and_trust_score.sql
+++ b/enter.pollinations.ai/drizzle/0017_add_score_and_trust_score.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `user` ADD `trust_score` integer;--> statement-breakpoint
+ALTER TABLE `user` ADD `score` real;--> statement-breakpoint
+ALTER TABLE `user` ADD `score_checked_at` integer;--> statement-breakpoint
+UPDATE `user` SET `trust_score` = 100 WHERE `tier` IN ('spore', 'seed', 'flower', 'nectar', 'router') AND `trust_score` IS NULL;--> statement-breakpoint
+UPDATE `user` SET `trust_score` = 0 WHERE `tier` = 'microbe' AND `trust_score` IS NULL;

--- a/enter.pollinations.ai/drizzle/0018_add_user_github_id_index.sql
+++ b/enter.pollinations.ai/drizzle/0018_add_user_github_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_user_github_id` ON `user` (`github_id`);

--- a/enter.pollinations.ai/drizzle/meta/0017_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1272 @@
+{
+  "id": "79dd1906-4312-4150-bd71-f8d9ee17d07c",
+  "prevId": "7fe61c51-1789-4a50-9def-589b3317c07e",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'microbe'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crypto_balance": {
+          "name": "crypto_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trust_score": {
+          "name": "trust_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score_checked_at": {
+          "name": "score_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event": {
+      "name": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_status": {
+          "name": "event_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_processing_id": {
+          "name": "event_processing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "polar_delivery_attempts": {
+          "name": "polar_delivery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "polar_delivered_at": {
+          "name": "polar_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tinybird_delivery_attempts": {
+          "name": "tinybird_delivery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tinybird_delivered_at": {
+          "name": "tinybird_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_tier": {
+          "name": "user_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_github_id": {
+          "name": "user_github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_github_username": {
+          "name": "user_github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_name": {
+          "name": "api_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_type": {
+          "name": "api_key_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_meter_id": {
+          "name": "selected_meter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_meter_slug": {
+          "name": "selected_meter_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "balances": {
+          "name": "balances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referrer_url": {
+          "name": "referrer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referrer_domain": {
+          "name": "referrer_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_requested": {
+          "name": "model_requested",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_model_requested": {
+          "name": "resolved_model_requested",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider_used": {
+          "name": "model_provider_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_billed_usage": {
+          "name": "is_billed_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_price_prompt_text": {
+          "name": "token_price_prompt_text",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_prompt_cached": {
+          "name": "token_price_prompt_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_prompt_audio": {
+          "name": "token_price_prompt_audio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_prompt_image": {
+          "name": "token_price_prompt_image",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_text": {
+          "name": "token_price_completion_text",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_reasoning": {
+          "name": "token_price_completion_reasoning",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_audio": {
+          "name": "token_price_completion_audio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_image": {
+          "name": "token_price_completion_image",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_video_seconds": {
+          "name": "token_price_completion_video_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_video_tokens": {
+          "name": "token_price_completion_video_tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_text": {
+          "name": "token_count_prompt_text",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_audio": {
+          "name": "token_count_prompt_audio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_cached": {
+          "name": "token_count_prompt_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_image": {
+          "name": "token_count_prompt_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_text": {
+          "name": "token_count_completion_text",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_reasoning": {
+          "name": "token_count_completion_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_audio": {
+          "name": "token_count_completion_audio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_image": {
+          "name": "token_count_completion_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_video_seconds": {
+          "name": "token_count_completion_video_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_video_tokens": {
+          "name": "token_count_completion_video_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_price": {
+          "name": "estimated_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_hate_severity": {
+          "name": "moderation_prompt_hate_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_self_harm_severity": {
+          "name": "moderation_prompt_self_harm_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_sexual_severity": {
+          "name": "moderation_prompt_sexual_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_violence_severity": {
+          "name": "moderation_prompt_violence_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_jailbreak_detected": {
+          "name": "moderation_prompt_jailbreak_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_hate_severity": {
+          "name": "moderation_completion_hate_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_self_harm_severity": {
+          "name": "moderation_completion_self_harm_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_sexual_severity": {
+          "name": "moderation_completion_sexual_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_violence_severity": {
+          "name": "moderation_completion_violence_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_protected_material_code_detected": {
+          "name": "moderation_completion_protected_material_code_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_protected_material_text_detected": {
+          "name": "moderation_completion_protected_material_text_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_type": {
+          "name": "cache_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_semantic_similarity": {
+          "name": "cache_semantic_similarity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_semantic_threshold": {
+          "name": "cache_semantic_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_response_code": {
+          "name": "error_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_source": {
+          "name": "error_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_event_processing_id": {
+          "name": "idx_event_processing_id",
+          "columns": [
+            "event_processing_id"
+          ],
+          "isUnique": false
+        },
+        "idx_event_status_created": {
+          "name": "idx_event_status_created",
+          "columns": [
+            "event_status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_event_user_created": {
+          "name": "idx_event_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/0018_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1279 @@
+{
+  "id": "45c40834-8998-4c91-9183-f2cd4d19ac3d",
+  "prevId": "7fe61c51-1789-4a50-9def-589b3317c07e",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'microbe'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crypto_balance": {
+          "name": "crypto_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trust_score": {
+          "name": "trust_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score_checked_at": {
+          "name": "score_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event": {
+      "name": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_status": {
+          "name": "event_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_processing_id": {
+          "name": "event_processing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "polar_delivery_attempts": {
+          "name": "polar_delivery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "polar_delivered_at": {
+          "name": "polar_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tinybird_delivery_attempts": {
+          "name": "tinybird_delivery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tinybird_delivered_at": {
+          "name": "tinybird_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_tier": {
+          "name": "user_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_github_id": {
+          "name": "user_github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_github_username": {
+          "name": "user_github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_name": {
+          "name": "api_key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_type": {
+          "name": "api_key_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_meter_id": {
+          "name": "selected_meter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_meter_slug": {
+          "name": "selected_meter_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "balances": {
+          "name": "balances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referrer_url": {
+          "name": "referrer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referrer_domain": {
+          "name": "referrer_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_requested": {
+          "name": "model_requested",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_model_requested": {
+          "name": "resolved_model_requested",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_provider_used": {
+          "name": "model_provider_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_billed_usage": {
+          "name": "is_billed_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_price_prompt_text": {
+          "name": "token_price_prompt_text",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_prompt_cached": {
+          "name": "token_price_prompt_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_prompt_audio": {
+          "name": "token_price_prompt_audio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_prompt_image": {
+          "name": "token_price_prompt_image",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_text": {
+          "name": "token_price_completion_text",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_reasoning": {
+          "name": "token_price_completion_reasoning",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_audio": {
+          "name": "token_price_completion_audio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_image": {
+          "name": "token_price_completion_image",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_video_seconds": {
+          "name": "token_price_completion_video_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_price_completion_video_tokens": {
+          "name": "token_price_completion_video_tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_text": {
+          "name": "token_count_prompt_text",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_audio": {
+          "name": "token_count_prompt_audio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_cached": {
+          "name": "token_count_prompt_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_prompt_image": {
+          "name": "token_count_prompt_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_text": {
+          "name": "token_count_completion_text",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_reasoning": {
+          "name": "token_count_completion_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_audio": {
+          "name": "token_count_completion_audio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_image": {
+          "name": "token_count_completion_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_video_seconds": {
+          "name": "token_count_completion_video_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count_completion_video_tokens": {
+          "name": "token_count_completion_video_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_price": {
+          "name": "estimated_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_hate_severity": {
+          "name": "moderation_prompt_hate_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_self_harm_severity": {
+          "name": "moderation_prompt_self_harm_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_sexual_severity": {
+          "name": "moderation_prompt_sexual_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_violence_severity": {
+          "name": "moderation_prompt_violence_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_prompt_jailbreak_detected": {
+          "name": "moderation_prompt_jailbreak_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_hate_severity": {
+          "name": "moderation_completion_hate_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_self_harm_severity": {
+          "name": "moderation_completion_self_harm_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_sexual_severity": {
+          "name": "moderation_completion_sexual_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_violence_severity": {
+          "name": "moderation_completion_violence_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_protected_material_code_detected": {
+          "name": "moderation_completion_protected_material_code_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "moderation_completion_protected_material_text_detected": {
+          "name": "moderation_completion_protected_material_text_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_type": {
+          "name": "cache_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_semantic_similarity": {
+          "name": "cache_semantic_similarity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_semantic_threshold": {
+          "name": "cache_semantic_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_response_code": {
+          "name": "error_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_source": {
+          "name": "error_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_event_processing_id": {
+          "name": "idx_event_processing_id",
+          "columns": [
+            "event_processing_id"
+          ],
+          "isUnique": false
+        },
+        "idx_event_status_created": {
+          "name": "idx_event_status_created",
+          "columns": [
+            "event_status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_event_user_created": {
+          "name": "idx_event_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -120,6 +120,20 @@
       "when": 1769255535655,
       "tag": "0016_migrate-temporary-keytype-to-secret",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1769255535656,
+      "tag": "0017_add_score_and_trust_score",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1773848123928,
+      "tag": "0018_add_user_github_id_index",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/observability/datasources/d1_user.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_user.datasource
@@ -23,6 +23,9 @@ SCHEMA >
     `pack_balance` Nullable(Float64) `json:$.pack_balance`,
     `crypto_balance` Nullable(Float64) `json:$.crypto_balance`,
     `last_tier_grant` Nullable(Int64) `json:$.last_tier_grant`,
+    `trust_score` Nullable(Int32) `json:$.trust_score`,
+    `score` Nullable(Float64) `json:$.score`,
+    `score_checked_at` Nullable(Int64) `json:$.score_checked_at`,
     `synced_at` DateTime `json:$.synced_at`
 
 ENGINE "MergeTree"

--- a/enter.pollinations.ai/scripts/run-python.ts
+++ b/enter.pollinations.ai/scripts/run-python.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env npx tsx
+
+import { spawnSync } from "node:child_process";
+import { getPythonBin, getPythonEnv } from "./user-pipeline/shared/python.ts";
+
+const [script, ...args] = process.argv.slice(2);
+if (!script) {
+    console.error("❌ Missing Python script path");
+    process.exit(1);
+}
+
+const pythonBin = getPythonBin();
+const result = spawnSync(pythonBin, [script, ...args], {
+    stdio: "inherit",
+    env: getPythonEnv(),
+});
+
+if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/d1.py
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/d1.py
@@ -1,0 +1,55 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ensure_safe_env(env: str) -> str:
+    if env != "staging":
+        print(
+            f"❌ Unsupported env: {env}. This branch is locked to staging and cannot write to production.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return env
+
+
+def run_d1_query(query: str, env: str = "staging") -> list[dict] | None:
+    """Run a D1 query and return results."""
+    env = ensure_safe_env(env)
+    cmd = [
+        "npx",
+        "wrangler",
+        "d1",
+        "execute",
+        "DB",
+        "--remote",
+        "--env",
+        env,
+        "--command",
+        query,
+        "--json",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).resolve().parents[3],
+            timeout=120,
+        )
+
+        if result.returncode != 0:
+            print(f"❌ D1 query failed: {result.stderr}", file=sys.stderr)
+            return None
+
+        data = json.loads(result.stdout)
+        return data[0].get("results", [])
+
+    except subprocess.TimeoutExpired:
+        print("❌ D1 query timed out", file=sys.stderr)
+        return None
+    except (json.JSONDecodeError, KeyError, IndexError) as error:
+        print(f"❌ Failed to parse D1 response: {error}", file=sys.stderr)
+        return None

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/d1.ts
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/d1.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+
+type Environment = "staging" | "production";
+type D1Row = Record<string, string | number | null>;
+
+interface D1JsonResponse {
+    results?: D1Row[];
+}
+
+function buildWranglerArgs(env: Environment, sql: string): string[] {
+    return [
+        "wrangler",
+        "d1",
+        "execute",
+        "DB",
+        "--remote",
+        "--env",
+        env,
+        "--command",
+        sql,
+        "--json",
+    ];
+}
+
+export function queryD1(env: Environment, sql: string): D1Row[] {
+    const output = execFileSync("npx", buildWranglerArgs(env, sql), {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        maxBuffer: 100 * 1024 * 1024,
+        cwd: process.cwd(),
+    });
+
+    const data = JSON.parse(output) as D1JsonResponse[];
+    return data[0]?.results || [];
+}
+
+export function executeD1(env: Environment, sql: string): boolean {
+    try {
+        execFileSync("npx", buildWranglerArgs(env, sql), {
+            encoding: "utf-8",
+            stdio: ["pipe", "pipe", "pipe"],
+            maxBuffer: 20 * 1024 * 1024,
+            cwd: process.cwd(),
+        });
+        return true;
+    } catch (error) {
+        console.error(
+            "❌ D1 mutation failed:",
+            error instanceof Error ? error.message : String(error),
+        );
+        return false;
+    }
+}

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/email-cohort.ts
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/email-cohort.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+
+export function escapeSqlString(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+export function loadEmailCohort(filePath?: string): string[] | null {
+    if (!filePath) return null;
+
+    let content: string;
+    try {
+        content = readFileSync(filePath, "utf-8");
+    } catch (error) {
+        throw new Error(
+            `Failed to read --emails-file ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+
+    const emails = Array.from(
+        new Set(
+            content
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0 && !line.startsWith("#")),
+        ),
+    );
+
+    if (emails.length === 0) {
+        throw new Error(
+            `--emails-file ${filePath} did not contain any emails.`,
+        );
+    }
+
+    return emails;
+}
+
+export function buildEmailFilter(
+    column: string,
+    emails: string[] | null,
+): string {
+    if (!emails || emails.length === 0) return "";
+    const values = emails
+        .map((email) => `'${escapeSqlString(email)}'`)
+        .join(", ");
+    return ` AND ${column} IN (${values})`;
+}

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/github-identity.ts
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/github-identity.ts
@@ -1,0 +1,58 @@
+import { executeD1 } from "./d1.ts";
+import { escapeSqlString } from "./email-cohort.ts";
+
+type Environment = "staging" | "production";
+
+export const PIPELINE_DB_BATCH_SIZE = 200;
+export const GITHUB_ACCOUNT_DELETED_REASON = "github_account_deleted";
+export const GITHUB_USERNAME_RE = /^[A-Za-z0-9-]+$/;
+
+export function banUsersByEmails(env: Environment, emails: string[]): number {
+    const uniqueEmails = Array.from(new Set(emails));
+    let banned = 0;
+
+    for (let i = 0; i < uniqueEmails.length; i += PIPELINE_DB_BATCH_SIZE) {
+        const batch = uniqueEmails.slice(i, i + PIPELINE_DB_BATCH_SIZE);
+        if (batch.length === 0) continue;
+
+        const emailList = batch
+            .map((email) => `'${escapeSqlString(email)}'`)
+            .join(", ");
+        const ok = executeD1(
+            env,
+            `UPDATE user SET banned = 1, ban_reason = '${GITHUB_ACCOUNT_DELETED_REASON}' WHERE email IN (${emailList})`,
+        );
+        if (ok) banned += batch.length;
+    }
+
+    return banned;
+}
+
+export function banUsersByGithubIds(
+    env: Environment,
+    githubIds: number[],
+): number {
+    const uniqueIds = Array.from(
+        new Set(
+            githubIds.filter(
+                (githubId): githubId is number =>
+                    Number.isInteger(githubId) && githubId > 0,
+            ),
+        ),
+    );
+    let banned = 0;
+
+    for (let i = 0; i < uniqueIds.length; i += PIPELINE_DB_BATCH_SIZE) {
+        const batch = uniqueIds.slice(i, i + PIPELINE_DB_BATCH_SIZE);
+        if (batch.length === 0) continue;
+
+        const idList = batch.join(", ");
+        const ok = executeD1(
+            env,
+            `UPDATE user SET banned = 1, ban_reason = '${GITHUB_ACCOUNT_DELETED_REASON}' WHERE github_id IN (${idList})`,
+        );
+        if (ok) banned += batch.length;
+    }
+
+    return banned;
+}

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/github_account_state.py
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/github_account_state.py
@@ -1,0 +1,69 @@
+import re
+
+from d1 import run_d1_query
+
+GITHUB_USERNAME_RE = re.compile(r"^[A-Za-z0-9-]+$")
+GITHUB_ACCOUNT_DELETED_REASON = "github_account_deleted"
+D1_BATCH_SIZE = 500
+
+
+def extract_deleted_github_ids(results: list[dict]) -> list[int]:
+    github_ids: list[int] = []
+    for result in results:
+        github_id = result.get("github_id")
+        if isinstance(github_id, bool):
+            continue
+        if isinstance(github_id, int) and github_id > 0:
+            if result.get("status") == GITHUB_ACCOUNT_DELETED_REASON:
+                github_ids.append(github_id)
+    return github_ids
+
+
+def ban_github_ids(github_ids: list[int], env: str = "staging") -> int:
+    unique_github_ids = list(
+        dict.fromkeys(
+            github_id
+            for github_id in github_ids
+            if isinstance(github_id, int) and not isinstance(github_id, bool) and github_id > 0
+        )
+    )
+    if not unique_github_ids:
+        return 0
+
+    banned = 0
+    for i in range(0, len(unique_github_ids), D1_BATCH_SIZE):
+        batch = unique_github_ids[i : i + D1_BATCH_SIZE]
+        id_list = ", ".join(str(github_id) for github_id in batch)
+        update_query = f"""
+            UPDATE user
+            SET banned = 1, ban_reason = '{GITHUB_ACCOUNT_DELETED_REASON}'
+            WHERE github_id IN ({id_list})
+        """
+        result = run_d1_query(update_query, env)
+        if result is not None:
+            banned += len(batch)
+
+    return banned
+
+
+def ban_users_by_emails(emails: list[str], env: str = "staging") -> int:
+    unique_emails = [
+        email for email in dict.fromkeys(emails) if isinstance(email, str) and email
+    ]
+    if not unique_emails:
+        return 0
+
+    banned = 0
+    for i in range(0, len(unique_emails), D1_BATCH_SIZE):
+        batch = unique_emails[i : i + D1_BATCH_SIZE]
+        email_list = ", ".join("'" + email.replace("'", "''") + "'" for email in batch)
+        update_query = f"""
+            UPDATE user
+            SET banned = 1, ban_reason = '{GITHUB_ACCOUNT_DELETED_REASON}'
+            WHERE email IN ({email_list})
+        """
+        result = run_d1_query(update_query, env)
+        if result is not None:
+            banned += len(batch)
+
+    return banned

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/github_account_validation.py
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/github_account_validation.py
@@ -1,0 +1,439 @@
+"""GitHub account validation — existence checks and identity resolution.
+
+Extracted from github_score.py so that trust scoring can validate accounts
+without pulling in the full scoring engine and its github_risk dependency.
+"""
+
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+from tqdm import tqdm
+
+GITHUB_GRAPHQL = "https://api.github.com/graphql"
+GITHUB_REST_USER = "https://api.github.com/user/{}"
+BATCH_SIZE = 50
+ACCOUNT_LOOKUP_MAX_WORKERS = 3
+MAX_BATCHES = None  # Set to a number to limit batches for testing
+GITHUB_USERNAME_RE = re.compile(r"^[A-Za-z0-9-]+$")
+_AUTH_MODE = None
+_APP_TOKEN = None
+_APP_TOKEN_EXPIRES_AT = 0
+_APP_TOKEN_LOCK = threading.Lock()
+
+
+def _base64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode()
+
+
+def _generate_app_jwt(app_id: str, key_path: str) -> str:
+    now = int(time.time())
+    header = _base64url_encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = _base64url_encode(
+        json.dumps(
+            {
+                "iat": now - 60,
+                "exp": now + 10 * 60,
+                "iss": app_id,
+            }
+        ).encode()
+    )
+    signing_input = f"{header}.{payload}".encode()
+    signature = subprocess.run(
+        ["openssl", "dgst", "-binary", "-sha256", "-sign", key_path],
+        input=signing_input,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return f"{header}.{payload}.{_base64url_encode(signature)}"
+
+
+def _fetch_app_token(app_id: str, key_path: str) -> tuple[str, int]:
+    jwt = _generate_app_jwt(app_id, key_path)
+
+    installations_request = urllib.request.Request(
+        "https://api.github.com/app/installations",
+        headers={
+            "Authorization": f"Bearer {jwt}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "pollinations-github-validator",
+        },
+    )
+    with urllib.request.urlopen(installations_request, timeout=30) as response:
+        installations = json.loads(response.read())
+
+    if not installations:
+        raise RuntimeError("No GitHub App installations found")
+
+    installation_id = installations[0]["id"]
+    token_request = urllib.request.Request(
+        f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+        data=b"{}",
+        headers={
+            "Authorization": f"Bearer {jwt}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "pollinations-github-validator",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(token_request, timeout=30) as response:
+        token_data = json.loads(response.read())
+
+    expires_at = int(
+        datetime.fromisoformat(token_data["expires_at"].replace("Z", "+00:00")).timestamp()
+    )
+    return token_data["token"], expires_at - 5 * 60
+
+
+def get_github_token() -> str:
+    global _AUTH_MODE, _APP_TOKEN, _APP_TOKEN_EXPIRES_AT
+
+    app_id = os.environ.get("GITHUB_APP_ID")
+    key_path = os.environ.get("GITHUB_APP_PRIVATE_KEY_PATH")
+    if app_id or key_path:
+        if not app_id or not key_path:
+            raise RuntimeError(
+                "Set both GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY_PATH for GitHub App auth"
+            )
+        if not os.path.exists(key_path):
+            raise RuntimeError(f"GitHub App private key not found: {key_path}")
+
+        with _APP_TOKEN_LOCK:
+            if _APP_TOKEN and time.time() < _APP_TOKEN_EXPIRES_AT:
+                return _APP_TOKEN
+
+            _APP_TOKEN, _APP_TOKEN_EXPIRES_AT = _fetch_app_token(app_id, key_path)
+            if _AUTH_MODE != "app":
+                print(
+                    f"🔑 Using GitHub App auth via {os.path.basename(key_path)}",
+                    file=sys.stderr,
+                )
+                _AUTH_MODE = "app"
+            return _APP_TOKEN
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "Set GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY_PATH or GITHUB_TOKEN"
+        )
+    if _AUTH_MODE != "pat":
+        print("🔑 Using GITHUB_TOKEN auth", file=sys.stderr)
+        _AUTH_MODE = "pat"
+    return token
+
+
+def _parse_github_id(value) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        if value.is_integer() and value > 0:
+            return int(value)
+        return None
+    if isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _normalize_record(record: dict) -> dict:
+    username = record.get("github_username")
+    if not isinstance(username, str) or not username.strip():
+        username = record.get("username")
+    if not isinstance(username, str) or not username.strip():
+        username = None
+
+    return {
+        "github_id": _parse_github_id(record.get("github_id")),
+        "github_username": username.strip() if isinstance(username, str) else None,
+    }
+
+
+def build_account_status_query(usernames: list[str]) -> str:
+    """Build a minimal GraphQL query to check account existence."""
+    fragments = []
+    for i, username in enumerate(usernames):
+        safe_username = username.replace("\\", "\\\\").replace('"', '\\"')
+        fragments.append(
+            f'''
+    u{i}: user(login: "{safe_username}") {{
+        login
+    }}'''
+        )
+    return f"query {{ {''.join(fragments)} }}"
+
+
+def run_graphql_query(query: str, retries: int = 3) -> tuple[dict, int | None]:
+    request = urllib.request.Request(
+        GITHUB_GRAPHQL,
+        data=json.dumps({"query": query}).encode(),
+        headers={
+            "Authorization": f"Bearer {get_github_token()}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    rate_remaining = None
+    data = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                data = json.loads(response.read())
+                rate_remaining_header = response.headers.get("X-RateLimit-Remaining")
+                if rate_remaining_header:
+                    rate_remaining = int(rate_remaining_header)
+            break
+        except urllib.error.HTTPError as error:
+            if attempt < retries - 1 and error.code in (502, 503, 504):
+                time.sleep(5 * (attempt + 1))
+                continue
+            if attempt < retries - 1 and error.code in (403, 429):
+                retry_after = error.headers.get("Retry-After")
+                reset_at = error.headers.get("X-RateLimit-Reset")
+                if retry_after:
+                    wait = int(retry_after) + 1
+                elif reset_at:
+                    wait = max(int(reset_at) - int(time.time()), 0) + 1
+                else:
+                    wait = 60
+                print(f"   ⏳ Rate limited (HTTP {error.code}), waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            raise
+
+    if data is None:
+        raise RuntimeError("GitHub GraphQL request failed without a response")
+
+    return data, rate_remaining
+
+
+def run_rest_request(url: str, retries: int = 3) -> tuple[dict | None, int | None, int]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {get_github_token()}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "pollinations-github-validator",
+        },
+    )
+
+    rate_remaining = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                data = json.loads(response.read())
+                rate_remaining_header = response.headers.get("X-RateLimit-Remaining")
+                if rate_remaining_header:
+                    rate_remaining = int(rate_remaining_header)
+                return data, rate_remaining, response.status
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                return None, rate_remaining, 404
+            if attempt < retries - 1 and error.code in (502, 503, 504):
+                time.sleep(5 * (attempt + 1))
+                continue
+            if attempt < retries - 1 and error.code in (403, 429):
+                retry_after = error.headers.get("Retry-After")
+                reset_at = error.headers.get("X-RateLimit-Reset")
+                if retry_after:
+                    wait = int(retry_after) + 1
+                elif reset_at:
+                    wait = max(int(reset_at) - int(time.time()), 0) + 1
+                else:
+                    wait = 60
+                print(f"   ⏳ Rate limited (HTTP {error.code}), waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            return None, rate_remaining, error.code
+
+    raise RuntimeError("GitHub REST request failed without a response")
+
+
+def fetch_account_batch(
+    usernames: list[str], retries: int = 3
+) -> tuple[list[dict], int | None]:
+    """Fetch account existence for a batch of usernames."""
+    data, rate_remaining = run_graphql_query(
+        build_account_status_query(usernames),
+        retries,
+    )
+
+    results = []
+    for i, username in enumerate(usernames):
+        user_data = data.get("data", {}).get(f"u{i}")
+        results.append(
+            {
+                "username": username,
+                "status": "ok" if user_data else "github_account_deleted",
+            }
+        )
+    return results, rate_remaining
+
+
+def fetch_account_by_id(
+    github_id: int, retries: int = 3
+) -> tuple[dict | None, int | None, int]:
+    return run_rest_request(GITHUB_REST_USER.format(github_id), retries)
+
+
+def _validate_account_usernames(usernames: list[str]) -> list[dict]:
+    """Validate GitHub account existence in concurrent batches."""
+    if not usernames:
+        return []
+
+    get_github_token()
+
+    invalid_results = [
+        {
+            "username": username,
+            "status": "github_account_deleted",
+        }
+        for username in usernames
+        if not GITHUB_USERNAME_RE.match(username)
+    ]
+    valid_usernames = [
+        username for username in usernames if GITHUB_USERNAME_RE.match(username)
+    ]
+
+    if not valid_usernames:
+        return invalid_results
+
+    batches = [
+        valid_usernames[i : i + BATCH_SIZE]
+        for i in range(0, len(valid_usernames), BATCH_SIZE)
+    ]
+    if MAX_BATCHES:
+        batches = batches[:MAX_BATCHES]
+
+    results = invalid_results.copy()
+    progress_bar = tqdm(
+        total=len(batches),
+        desc="Checking accounts",
+        unit="batch",
+        bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{remaining}] {postfix}",
+    )
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            executor.submit(fetch_account_batch, batch): i
+            for i, batch in enumerate(batches)
+        }
+
+        for future in as_completed(futures):
+            batch_results, rate_remaining = future.result()
+            results.extend(batch_results)
+            progress_bar.set_postfix(
+                quota=rate_remaining if rate_remaining is not None else "?"
+            )
+            progress_bar.update(1)
+
+            if rate_remaining is not None and rate_remaining <= 100:
+                time.sleep(1 if rate_remaining > 50 else 2)
+            elif rate_remaining is None:
+                time.sleep(2)
+
+    progress_bar.close()
+    return results
+
+
+def validate_account_records(records: list[dict]) -> list[dict]:
+    if not records:
+        return []
+
+    get_github_token()
+
+    normalized = [_normalize_record(record) for record in records]
+    results: list[dict | None] = [None] * len(normalized)
+    username_only: list[tuple[int, str]] = []
+    id_jobs: list[tuple[int, int, str | None]] = []
+
+    for index, record in enumerate(normalized):
+        github_id = record["github_id"]
+        github_username = record["github_username"]
+
+        if github_id is not None:
+            id_jobs.append((index, github_id, github_username))
+            continue
+
+        if isinstance(github_username, str) and GITHUB_USERNAME_RE.match(github_username):
+            username_only.append((index, github_username))
+            continue
+
+        results[index] = {
+            "github_id": github_id,
+            "username": github_username,
+            "status": "github_account_deleted",
+        }
+
+    if id_jobs:
+        progress_bar = tqdm(
+            total=len(id_jobs),
+            desc="Resolving IDs",
+            unit="user",
+            bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{remaining}] {postfix}",
+        )
+        with ThreadPoolExecutor(max_workers=ACCOUNT_LOOKUP_MAX_WORKERS) as executor:
+            futures = {
+                executor.submit(fetch_account_by_id, github_id): (index, github_id)
+                for index, github_id, _github_username in id_jobs
+            }
+            for future in as_completed(futures):
+                index, github_id = futures[future]
+                data, rate_remaining, status = future.result()
+                if status == 200 and isinstance(data, dict):
+                    login = data.get("login")
+                    results[index] = {
+                        "github_id": github_id,
+                        "username": login if isinstance(login, str) else None,
+                        "status": "ok" if isinstance(login, str) else "github_account_deleted",
+                    }
+                else:
+                    results[index] = {
+                        "github_id": github_id,
+                        "username": normalized[index]["github_username"],
+                        "status": "github_account_deleted",
+                    }
+
+                progress_bar.set_postfix(
+                    quota=rate_remaining if rate_remaining is not None else "?"
+                )
+                progress_bar.update(1)
+
+                if rate_remaining is not None and rate_remaining <= 100:
+                    time.sleep(1 if rate_remaining > 50 else 2)
+                elif rate_remaining is None:
+                    time.sleep(1)
+
+        progress_bar.close()
+
+    if username_only:
+        usernames = [username for _index, username in username_only]
+        fallback_results = _validate_account_usernames(usernames)
+        by_username = {
+            result["username"]: result
+            for result in fallback_results
+            if isinstance(result.get("username"), str)
+        }
+        for index, username in username_only:
+            result = by_username.get(
+                username,
+                {"username": username, "status": "github_account_deleted"},
+            )
+            results[index] = {
+                "github_id": None,
+                "username": result.get("username"),
+                "status": result.get("status", "github_account_deleted"),
+            }
+
+    return [result for result in results if result is not None]

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/python.ts
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/python.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+
+const PYTHON_CANDIDATES = ["python3.11", "python3"] as const;
+
+export function getPythonBin(): string {
+    const configured = process.env.PYTHON_BIN?.trim();
+    if (configured) return configured;
+
+    for (const candidate of PYTHON_CANDIDATES) {
+        try {
+            execFileSync(candidate, ["-c", "import sys"], {
+                stdio: "ignore",
+            });
+            return candidate;
+        } catch {
+            // Try the next candidate.
+        }
+    }
+
+    console.error(
+        "❌ No usable Python interpreter found. Set PYTHON_BIN explicitly.",
+    );
+    process.exit(1);
+}
+
+export function getPythonEnv(): NodeJS.ProcessEnv {
+    const pythonBin = getPythonBin();
+    return {
+        ...process.env,
+        PYTHON_BIN: process.env.PYTHON_BIN?.trim() || pythonBin,
+    };
+}
+
+export function runInlinePython(source: string): string {
+    const pythonBin = getPythonBin();
+    return execFileSync(pythonBin, ["-c", source], {
+        encoding: "utf-8",
+        maxBuffer: 100 * 1024 * 1024,
+        env: getPythonEnv(),
+    });
+}

--- a/enter.pollinations.ai/scripts/user-pipeline/shared/python_runtime.py
+++ b/enter.pollinations.ai/scripts/user-pipeline/shared/python_runtime.py
@@ -1,0 +1,18 @@
+import os
+import shutil
+import sys
+
+
+def ensure_python_bin() -> None:
+    configured = os.environ.get("PYTHON_BIN")
+    if not configured:
+        return
+
+    resolved = shutil.which(configured) or configured
+    current = os.path.realpath(sys.executable)
+    target = os.path.realpath(resolved)
+    if current == target:
+        return
+
+    # Re-exec under the requested interpreter before the rest of the script runs.
+    os.execv(target, [target, *sys.argv])

--- a/enter.pollinations.ai/src/db/schema/better-auth.ts
+++ b/enter.pollinations.ai/src/db/schema/better-auth.ts
@@ -34,8 +34,12 @@ export const user = sqliteTable("user", {
   packBalance: real("pack_balance"),
   cryptoBalance: real("crypto_balance"),
   lastTierGrant: integer("last_tier_grant"),
+  trustScore: integer("trust_score"),
+  score: real("score"),
+  scoreCheckedAt: integer("score_checked_at"),
 }, (table) => [
   index("idx_user_email").on(table.email),
+  index("idx_user_github_id").on(table.githubId),
 ]);
 
 export const session = sqliteTable("session", {

--- a/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
+++ b/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
@@ -28,7 +28,8 @@ const TABLES: TableConfig[] = [
         datasource: "d1_user",
         query: `SELECT id, name, email, email_verified, image, created_at, updated_at,
                        role, banned, ban_reason, ban_expires, github_id, github_username,
-                       tier, tier_balance, pack_balance, crypto_balance, last_tier_grant
+                       tier, tier_balance, pack_balance, crypto_balance, last_tier_grant,
+                       trust_score, score, score_checked_at
                 FROM user`,
     },
     {


### PR DESCRIPTION
## Summary
- Add D1 migrations for `score`, `trust_score`, `score_checked_at` columns and `github_id` index
- Add shared pipeline utilities: D1 helpers, email cohort, GitHub identity, Python runner
- Extract `github_account_validation.py` from `github_score.py` for independent account validation
- Add new columns to Tinybird datasource and sync query

No behavior change — existing scripts and workflows continue to work.

Split from #9163. Co-authored-by: @ElliotEtag

## Merge order
```
main → PR1 (this) → PR2 (trust gate) ─┐
                  → PR3 (scoring)     ─┴→ PR4 (microbe onboarding)
```

## Test plan
- [ ] `npm run test` in enter.pollinations.ai passes
- [ ] D1 migration applies cleanly
- [ ] Old workflows still work (no deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)