### PR TITLE
fix(image): respect safe=false for gptimage edits

### DIFF
--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -716,23 +716,27 @@ const callAzureGPTImageWithEndpoint = async (
                     const buffer =
                         await resizeInputImageForGptImage(originalBuffer);
 
-                    // Only check safety after we've successfully fetched the image
-                    logCloudflare(
-                        `Checking safety of input image ${i + 1}/${imageUrls.length}`,
-                    );
-                    const imageSafetyResult = await analyzeImageSafety(buffer);
-
-                    if (!imageSafetyResult.safe) {
-                        const errorMessage = `Input image ${i + 1} contains unsafe content: ${imageSafetyResult.formattedViolations}`;
-                        const error = new Error(errorMessage);
-                        await logGptImageError(
-                            prompt,
-                            safeParams,
-                            userInfo,
-                            error,
-                            imageSafetyResult,
+                    // Keep the extra local image safety screen only for safe=true.
+                    // Provider-side Azure/OpenAI safety still applies in all modes.
+                    if (safeParams.safe) {
+                        logCloudflare(
+                            `Checking safety of input image ${i + 1}/${imageUrls.length}`,
                         );
-                        throw error;
+                        const imageSafetyResult =
+                            await analyzeImageSafety(buffer);
+
+                        if (!imageSafetyResult.safe) {
+                            const errorMessage = `Input image ${i + 1} contains unsafe content: ${imageSafetyResult.formattedViolations}`;
+                            const error = new Error(errorMessage);
+                            await logGptImageError(
+                                prompt,
+                                safeParams,
+                                userInfo,
+                                error,
+                                imageSafetyResult,
+                            );
+                            throw error;
+                        }
                     }
 
                     // Determine file extension and MIME type from Content-Type header
@@ -954,17 +958,21 @@ const generateImage = async (
                 requestId,
                 30,
                 "Processing",
-                "Checking prompt safety...",
+                safeParams.safe
+                    ? "Checking prompt safety..."
+                    : "Preparing request...",
             );
 
             try {
-                await requireSafePrompt(
-                    prompt,
-                    safeParams,
-                    userInfo,
-                    progress,
-                    requestId,
-                );
+                if (safeParams.safe) {
+                    await requireSafePrompt(
+                        prompt,
+                        safeParams,
+                        userInfo,
+                        progress,
+                        requestId,
+                    );
+                }
 
                 progress.updateBar(
                     requestId,


### PR DESCRIPTION
makes `gptimage` and `gptimage-large` respect `safe=false` like `nanobanana` already does - #8949

\- skip local Azure prompt safety pre-check for `gptimage` and `gptimage-large` when `safe=false`
\- skip local Azure input image safety pre-check in GPT image edit mode when `safe=false`
\- keep provider-side Azure/OpenAI safety enforcement unchanged
\- update the progress label so `safe=false` requests no longer claim they are running the local prompt safety check

ref: #9319