### PR TITLE
fix: update OpenClaw setup script for v2026.3

### DIFF
--- a/apps/openclaw/README.md
+++ b/apps/openclaw/README.md
@@ -45,21 +45,23 @@ If you prefer not to run the script, edit `~/.openclaw/openclaw.json` directly. 
 
 ```json
 {
-  "providers": {
-    "pollinations": {
-      "baseUrl": "https://gen.pollinations.ai/v1",
-      "apiKey": "YOUR_API_KEY",
-      "api": "openai-completions",
-      "models": [
-        {
-          "id": "kimi",
-          "name": "Kimi K2.5",
-          "reasoning": true,
-          "input": ["text", "image"],
-          "contextWindow": 256000,
-          "maxTokens": 8192
-        }
-      ]
+  "models": {
+    "providers": {
+      "pollinations": {
+        "baseUrl": "https://gen.pollinations.ai/v1",
+        "apiKey": "YOUR_API_KEY",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "kimi",
+            "name": "Kimi K2.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 8192
+          }
+        ]
+      }
     }
   }
 }

--- a/apps/openclaw/setup-pollinations.sh
+++ b/apps/openclaw/setup-pollinations.sh
@@ -59,7 +59,7 @@ echo "Adding Pollinations models..."
 POLLINATIONS_PROVIDER=$(cat <<'EOF'
 {
   "baseUrl": "https://gen.pollinations.ai/v1",
-  "apiKey": "__KEY__",
+  "apiKey": "",
   "api": "openai-completions",
   "models": [
     {


### PR DESCRIPTION
## Summary

- Use `openclaw onboard` CLI instead of manually writing config JSON
- Fix credential storage: `models.providers` in openclaw.json, not deprecated `env` block
- Fix `contextLength` → `contextWindow` (correct field name since v2026.2)
- Replace 30-line deep-merge jq with simple provider patch (204 → 120 lines)
- Handle both fresh installs and existing setups
- Update README with correct paths (`models.json` location, current CLI commands)

## Test plan

- [x] Fresh install via `openclaw --profile polltest onboard`
- [x] Existing install (re-run with new key)
- [x] Preserves other providers (OpenRouter)
- [x] `openclaw models status` shows correct default + fallbacks
- [ ] End-to-end with real API key


🤖 Generated with [Claude Code](https://claude.com/claude-code)