### PR TITLE
Clarify App Key usage in BYOP docs and API reference

### DIFF
--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -1,80 +1,91 @@
-# Bring Your Own Pollen (BYOP)
+# 🌼 Bring Your Own Pollen (BYOP)
 
-your users pay for their own AI usage. you pay $0.
+Your users pay for their own AI usage. You pay $0.
 
-## how it works
+## 🔄 How It Works
 
-1. user taps "Connect with Pollinations"
-2. signs in, gets a temp API key
-3. their pollen, your app
+1. User taps "Connect with Pollinations"
+2. Signs in, gets a temp API key
+3. Their pollen, your app
 
-why this is good:
-- **$0 costs** — 1 user or 1000, same price: free
-- **no key management** — the auth flow handles it
-- **self-regulating** — everyone pays for what they use
-- **frontend only** — no backend needed
+Why this is good:
 
-![Authorize Screen](https://raw.githubusercontent.com/pollinations/pollinations/main/enter.pollinations.ai/public/authorize-screen.png)
+- 💸 **$0 costs** — 1 user or 1000, same price: free
+- 🔑 **No key management** — the auth flow handles it
+- ⚖️ **Self-regulating** — everyone pays for what they use
+- 🖥️ **Frontend only** — no backend needed
 
-## setup
+## 🗝️ App Key
 
-### 1. register your app (optional but recommended)
+An **App Key** is a publishable key (`pk_...`) you create on [enter.pollinations.ai](https://enter.pollinations.ai) specifically for BYOP. It's optional but strongly recommended:
 
-go to [enter.pollinations.ai](https://enter.pollinations.ai), create a publishable key:
-- set **App URL** to your app's URL (e.g. `https://myapp.com`)
-- enable **BYOP** toggle
-- the key name shows up as your app name on the consent screen
+| Without App Key | With App Key |
+|----------------|-------------|
+| Consent screen shows generic hostname | Consent screen shows **your app name + your GitHub** |
+| No traffic attribution | Traffic your app drives is **tracked to your account** |
+| No tier benefit | Real usage → **automatic tier upgrades** → higher pollen grants |
 
-this also lets us see how much traffic your app drives — apps that bring real usage get bumped to higher tiers.
+To create one, go to [enter.pollinations.ai](https://enter.pollinations.ai) → **Create New App Key**:
 
-### 2. build the auth link
+![Create New App Key](https://media.pollinations.ai/aa8ca9fe3110aff7)
 
-with `app_key` (consent screen shows your app name + your github):
+Set the **Name** (shows on the consent screen) and **App URL** (your app's domain). The key you get back is your `app_key`.
+
+When users authorize, this is what they see:
+
+![Authorize Screen](https://media.pollinations.ai/b030a47e32df2b2b)
+
+## ⚙️ Setup
+
+### 1. Build the Auth Link
+
+With `app_key` (consent screen shows your app name + your GitHub):
 ```
 https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com&app_key=pk_yourkey
 ```
 
-without (still works, just shows the hostname):
+Without (still works, just shows the hostname):
 ```
 https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com
 ```
 
-with restrictions:
+With restrictions:
 ```
 https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com&app_key=pk_yourkey&models=flux,openai&expiry=7&budget=10
 ```
 
-| param | what it does | example |
+| Param | What it does | Example |
 |-------|-------------|---------|
-| `app_key` | your publishable key — shows app name + author | `pk_abc123` |
-| `models` | restrict to specific models | `flux,openai,gptimage` |
-| `budget` | pollen cap | `10` |
-| `expiry` | key lifetime in days (default: 30) | `7` |
-| `permissions` | account access | `profile,balance,usage` |
+| `app_key` | Your publishable key — shows app name + author on consent screen, tracks traffic for tier upgrades | `pk_abc123` |
+| `redirect_url` | Where users return after authorizing — receives the temp API key in the URL fragment | `https://myapp.com` |
+| `models` | Restrict to specific models | `flux,openai,gptimage` |
+| `budget` | Pollen cap | `10` |
+| `expiry` | Key lifetime in days (default: 30) | `7` |
+| `permissions` | Account access | `profile,balance,usage` |
 
-### 3. handle the redirect
+### 2. Handle the Redirect
 
-user comes back with a key in the URL fragment:
+User comes back with a key in the URL fragment:
 ```
 https://myapp.com#api_key=sk_abc123xyz
 ```
 
-fragment, not query param — never hits server logs.
+Fragment, not query param — never hits server logs. 🔒
 
-## code
+## 💻 Code
 
 ```javascript
-// send user to auth
+// Send user to auth
 const params = new URLSearchParams({
   redirect_url: location.href,
   app_key: 'pk_yourkey', // optional — shows app name + author
 });
 window.location.href = `https://enter.pollinations.ai/authorize?${params}`;
 
-// grab key from URL after redirect
+// Grab key from URL after redirect
 const apiKey = new URLSearchParams(location.hash.slice(1)).get('api_key');
 
-// use their pollen
+// Use their pollen
 fetch('https://gen.pollinations.ai/v1/chat/completions', {
   method: 'POST',
   headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
@@ -82,7 +93,7 @@ fetch('https://gen.pollinations.ai/v1/chat/completions', {
 });
 ```
 
-keys expire in 30 days. users can revoke anytime from the dashboard.
+🕐 Keys expire in 30 days. Users can revoke anytime from the dashboard.
 
 ---
 

--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -85,6 +85,8 @@ BYOP lets your app's users **pay for their own AI generations** with their Polle
 
 🔄 Every user on the platform gets free Pollen refilled hourly. With BYOP, they spend that Pollen in *your* app — the **Pollinations flywheel**: build an app for free → integrate BYOP → your users arrive with Pollen → they fuel the app → you grow → bigger grants → build bigger.
 
+🔑 **App Key:** Create an **App Key** (`pk_...`) on [enter.pollinations.ai](https://enter.pollinations.ai) to get the most out of BYOP. With an App Key, the consent screen shows your **app name + GitHub** instead of a generic hostname, and the traffic your app drives is **tracked to your account** — helping you qualify for automatic tier upgrades and higher Pollen grants.
+
 📖 **[Full BYOP guide →](https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md)**
 
 ## 🎨 What can I create with Pollen?

--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -2,9 +2,11 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { describeRoute } from "hono-openapi";
+import { z } from "zod";
 import { createAuth } from "../auth.ts";
 import * as schema from "../db/schema/better-auth.ts";
 import type { Env } from "../env.ts";
+import { validator } from "../middleware/validator.ts";
 import { parseMetadata } from "./metadata-utils.ts";
 
 async function resolveAttribution(
@@ -29,17 +31,35 @@ async function resolveAttribution(
  * Public endpoint to resolve an app_key or redirect_url to attribution info.
  * No auth required — used during the /authorize flow.
  */
+const AppLookupQuerySchema = z.object({
+    app_key: z
+        .string()
+        .startsWith("pk_")
+        .optional()
+        .describe(
+            "Your publishable App Key (pk_...). When provided, the consent screen shows your app name and GitHub username instead of a generic hostname. Create one at enter.pollinations.ai → Create New App Key.",
+        ),
+    redirect_url: z
+        .string()
+        .url()
+        .optional()
+        .describe(
+            "The URL users return to after authorizing. If no app_key is provided, the system tries to match this URL against registered app URLs.",
+        ),
+});
+
 export const appLookupRoutes = new Hono<Env>().get(
     "/",
     describeRoute({
         tags: ["Account"],
         description:
-            "Look up app attribution by app_key or redirect_url. No auth required.",
+            "Look up app attribution by app_key or redirect_url. No auth required. Used during the /authorize BYOP flow to resolve the app name and author shown on the consent screen.",
         hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
     }),
+    validator("query", AppLookupQuerySchema),
     async (c) => {
-        const appKey = c.req.query("app_key");
-        const redirectUrl = c.req.query("redirect_url");
+        const { app_key: appKey, redirect_url: redirectUrl } =
+            c.req.valid("query");
         const db = drizzle(c.env.DB, { schema });
 
         // Strategy 1: Explicit app_key — verify via better-auth


### PR DESCRIPTION
- Adds dedicated App Key section to BYOP guide with comparison table (with vs without) and screenshots hosted on media.pollinations.ai
- Fixes broken authorize-screen image (was .png 404, now .webp on media.pollinations.ai)
- Adds App Key explanation to POLLEN_FAQ.md
- Adds Zod validation + OpenAPI descriptions to app-lookup route so app_key/redirect_url params are documented in the auto-generated API reference
- Cleans up markdown: proper capitalization, emojis on section headers