### PR TITLE
fix(audio): stop parseMp4Duration on elevenmusic mp3 responses

### DIFF
--- a/enter.pollinations.ai/src/routes/audio.ts
+++ b/enter.pollinations.ai/src/routes/audio.ts
@@ -421,9 +421,8 @@ export async function generateMusic(opts: {
 
     // Buffer response and extract duration
     const audioBuffer = await response.arrayBuffer();
-    // Try MP4 header parsing first, fall back to MP3 byte-size estimate
-    const estimatedDuration =
-        parseMp4Duration(audioBuffer) ?? audioBuffer.byteLength / 16000;
+    // MP3 only — parseMp4Duration falsely matches random bytes in compressed audio
+    const estimatedDuration = audioBuffer.byteLength / 16000;
 
     const usageHeaders = buildUsageHeaders(
         "elevenmusic",

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -991,7 +991,19 @@ async function checkBalance(
     // Pre-check: reject if balance < estimated cost for this model
     // getModelStats is cached in KV for 1hr, so this is cheap
     const stats = await getModelStats(env.KV, log);
-    const estimatedCost = getEstimatedPrice(stats, model.resolved);
+    let estimatedCost = getEstimatedPrice(stats, model.resolved);
+
+    // Cap to guard against skewed Tinybird averages blocking users
+    if (estimatedCost > 5) {
+        log.warn(
+            "Estimated cost for {model} is suspiciously high ({cost}). Capping to 2.0",
+            {
+                model: model.resolved,
+                cost: estimatedCost,
+            },
+        );
+        estimatedCost = 2.0;
+    }
 
     if (estimatedCost > 0) {
         const userBalance = await balance.getBalance(auth.user.id);


### PR DESCRIPTION
fixes elevenmusic returning 402 with ~35880 pollen estimated cost

the root cause was `parseMp4Duration` being called on mp3 data. elevenmusic always returns mp3 (`Accept: audio/mpeg`), but the parser scans raw bytes for the mp4 `mvhd` atom. when random compressed bytes in an mp3 happen to match that 4-byte sequence, the parser reads adjacent garbage as timescale/duration, producing values like <7 million seconds

at $0.005/sec that's eh ~$38k per request!!, which got logged to tinybird and permanently skewed the `avg_cost_usd` stat. the proxy pre-check then compared this against the user's balance and blocked everyone with a 402

\- removed `parseMp4Duration` from `generateMusic` - mp3 uses byte-size estimate only
\- added a cap on `estimatedCost` in `checkBalance` so anomalous tinybird averages can't block users again

> [!NOTE]  
> tinybird caches the stats for about an hour, so the average will just self-correct as soon as real, sane requests start coming in. no need to go in and manually intervene within tinybird

Closes #9346
Closes #9363