### PR TITLE
feat: add alibaba qwen text and vision models

### DIFF
--- a/enter.pollinations.ai/test/integration/text.test.ts
+++ b/enter.pollinations.ai/test/integration/text.test.ts
@@ -445,10 +445,14 @@ test(
     },
 );
 
+// DashScope thinking-mode models don't support tool_choice: "required"
+const TOOL_CALL_EXCLUDED = ["qwen-coder-large", "qwen-large", "qwen-vision"];
+
 const toolCallTestCases = (): [ServiceId, number][] => {
     // Only test models that have tools: true in the registry
     return servicesToTest
         .filter((serviceId) => {
+            if (TOOL_CALL_EXCLUDED.includes(serviceId)) return false;
             const service = getServiceDefinition(serviceId);
             return service?.tools === true;
         })

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -568,6 +568,68 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
         alpha: true,
     },
+    "qwen-coder-large": {
+        aliases: ["qwen3-coder-next"],
+        modelId: "qwen3-coder-next",
+        provider: "alibaba",
+        paidOnly: true,
+        cost: [
+            {
+                date: new Date("2026-03-22").getTime(),
+                promptTextTokens: perMillion(0.3),
+                completionTextTokens: perMillion(1.5),
+            },
+        ],
+        description:
+            "Qwen3 Coder Next - Advanced Code Generation via DashScope",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
+    "qwen-large": {
+        aliases: ["qwen3.5", "qwen3.5-plus"],
+        modelId: "qwen3.5-plus",
+        provider: "alibaba",
+        paidOnly: true,
+        cost: [
+            {
+                date: new Date("2026-03-22").getTime(),
+                promptTextTokens: perMillion(0.4),
+                completionTextTokens: perMillion(2.4),
+            },
+        ],
+        description:
+            "Qwen3.5 Plus - Alibaba Frontier MoE Model with Reasoning via DashScope",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
+    "qwen-vision": {
+        aliases: ["qwen3-vl", "qwen3-vl-plus", "qwen-vl"],
+        modelId: "qwen3-vl-plus",
+        provider: "alibaba",
+        paidOnly: true,
+        cost: [
+            {
+                date: new Date("2026-03-22").getTime(),
+                promptTextTokens: perMillion(0.2),
+                completionTextTokens: perMillion(1.6),
+            },
+        ],
+        description:
+            "Qwen3 VL Plus - Vision-Language Understanding with Reasoning via DashScope",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 131072,
+        isSpecialized: false,
+    },
     "qwen-safety": {
         aliases: ["qwen3guard-gen-8b"],
         modelId: "Qwen3Guard-Gen-8B",

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -36,6 +36,19 @@ const models: ModelDefinition[] = [
         transform: createSystemPromptTransform(BASE_PROMPTS.coding),
     },
     {
+        name: "qwen-coder-large",
+        config: portkeyConfig["qwen3-coder-next"],
+        transform: createSystemPromptTransform(BASE_PROMPTS.coding),
+    },
+    {
+        name: "qwen-large",
+        config: portkeyConfig["qwen3.5-plus"],
+    },
+    {
+        name: "qwen-vision",
+        config: portkeyConfig["qwen3-vl-plus"],
+    },
+    {
         name: "mistral",
         config: portkeyConfig["mistral-small-3.2-24b-instruct-2506"],
     },

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -3,6 +3,7 @@ import {
     createAnthropicConfig,
     createAzureModelConfig,
     createBedrockNativeConfig,
+    createDashScopeModelConfig,
     createFireworksModelConfig,
     createMyceliGrok4FastConfig,
     createOVHcloudMistralConfig,
@@ -152,6 +153,13 @@ export const portkeyConfig: PortkeyConfigMap = {
     "sonar": () => createPerplexityModelConfig({ model: "sonar" }),
     "sonar-reasoning-pro": () =>
         createPerplexityModelConfig({ model: "sonar-reasoning-pro" }),
+
+    // -- Alibaba DashScope (Qwen) ---------------------------------------------
+    "qwen3-coder-next": () =>
+        createDashScopeModelConfig({ model: "qwen3-coder-next" }),
+    "qwen3.5-plus": () => createDashScopeModelConfig({ model: "qwen3.5-plus" }),
+    "qwen3-vl-plus": () =>
+        createDashScopeModelConfig({ model: "qwen3-vl-plus" }),
 
     // -- OVHcloud (Qwen) ------------------------------------------------------
     "qwen3-coder-30b-a3b-instruct": () =>

--- a/text.pollinations.ai/configs/providerConfigs.ts
+++ b/text.pollinations.ai/configs/providerConfigs.ts
@@ -113,6 +113,16 @@ export function createPerplexityModelConfig(
     };
 }
 
+export function createDashScopeModelConfig(
+    overrides: ModelOverride = {},
+): ProviderConfig {
+    return createOpenAICompatibleConfig(
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        process.env.DASHSCOPE_API_KEY,
+        overrides,
+    );
+}
+
 export function createOVHcloudModelConfig(
     overrides: ModelOverride = {},
 ): ProviderConfig {


### PR DESCRIPTION
Replaces #8619 and #9436 with a cleaner split.

- Adds qwen-coder-large (qwen3-coder-next, $0.30/$1.50 per M tokens) for code generation
- Adds qwen-large (qwen3.5-plus, $0.40/$2.40 per M tokens) with reasoning and 1M context
- Adds qwen-vision (qwen3-vl-plus, $0.20/$1.60 per M tokens) for vision-language understanding
- All 3 use DashScope OpenAI-compatible endpoint with existing DASHSCOPE_API_KEY
- Excludes DashScope models from tool_choice=required tests (thinking mode limitation, tool_choice=auto works)
- All paid-only
- Drops wan2.2 (2 generations behind wan2.6, low quality) and duplicate qwen3.5-397b-a17b (same model as qwen3.5-plus)