### PR TITLE
fix: make qwen-large and qwen-vision free tier

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -592,7 +592,6 @@ export const TEXT_SERVICES = {
         aliases: ["qwen3.5", "qwen3.5-plus"],
         modelId: "qwen3.5-plus",
         provider: "alibaba",
-        paidOnly: true,
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),
@@ -613,7 +612,6 @@ export const TEXT_SERVICES = {
         aliases: ["qwen3-vl", "qwen3-vl-plus", "qwen-vl"],
         modelId: "qwen3-vl-plus",
         provider: "alibaba",
-        paidOnly: true,
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),


### PR DESCRIPTION
- Remove `paidOnly` from qwen-large (qwen3.5-plus)
- Remove `paidOnly` from qwen-vision (qwen3-vl-plus)
- qwen-coder-large remains paid-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)