### PR TITLE
fix: correct grok pricing and add nova-canvas editing

### DIFF
--- a/image.pollinations.ai/src/models/novaCanvasModel.ts
+++ b/image.pollinations.ai/src/models/novaCanvasModel.ts
@@ -2,6 +2,7 @@ import debug from "debug";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
+import { downloadImageAsBase64 } from "../utils/imageDownload.ts";
 
 const logOps = debug("pollinations:nova-canvas:ops");
 const logError = debug("pollinations:nova-canvas:error");
@@ -73,18 +74,27 @@ export async function callNovaCanvasAPI(
         safeParams.height || 1024,
     );
 
-    logOps("Calling Nova Canvas API:", {
+    // Check if image input is provided for editing mode
+    const rawImageUrl = safeParams.image
+        ? Array.isArray(safeParams.image)
+            ? safeParams.image[0]
+            : safeParams.image
+        : undefined;
+    const mode = rawImageUrl ? "IMAGE_VARIATION" : "TEXT_IMAGE";
+
+    logOps(`Calling Nova Canvas API (${mode}):`, {
         prompt: prompt.substring(0, 100),
         width,
         height,
         seed: safeParams.seed,
+        hasImage: !!rawImageUrl,
     });
 
     progress.updateBar(
         requestId,
         35,
         "Processing",
-        "Generating with Nova Canvas...",
+        `Generating with Nova Canvas (${mode === "IMAGE_VARIATION" ? "editing" : "text-to-image"})...`,
     );
 
     // Dynamic import to avoid requiring the SDK at module load time
@@ -100,19 +110,37 @@ export async function callNovaCanvasAPI(
         },
     });
 
-    const requestBody = {
-        taskType: "TEXT_IMAGE",
-        textToImageParams: {
-            text: prompt,
-        },
-        imageGenerationConfig: {
-            numberOfImages: 1,
-            height,
-            width,
-            cfgScale: 8.0,
-            ...(safeParams.seed != null ? { seed: safeParams.seed } : {}),
-        },
+    const imageGenerationConfig = {
+        numberOfImages: 1,
+        height,
+        width,
+        cfgScale: 8.0,
+        ...(safeParams.seed != null ? { seed: safeParams.seed } : {}),
     };
+
+    let requestBody: Record<string, unknown>;
+
+    if (rawImageUrl) {
+        // Image variation mode - download and convert to base64
+        const { base64 } = await downloadImageAsBase64(rawImageUrl);
+        requestBody = {
+            taskType: "IMAGE_VARIATION",
+            imageVariationParams: {
+                text: prompt,
+                images: [base64],
+                similarityStrength: 0.7,
+            },
+            imageGenerationConfig,
+        };
+    } else {
+        requestBody = {
+            taskType: "TEXT_IMAGE",
+            textToImageParams: {
+                text: prompt,
+            },
+            imageGenerationConfig,
+        };
+    }
 
     const command = new InvokeModelCommand({
         modelId: "amazon.nova-canvas-v1:0",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -341,7 +341,7 @@ export const IMAGE_SERVICES = {
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),
-                completionVideoSeconds: 0.07, // $0.07 per second at 720p
+                completionVideoSeconds: 0.05, // $0.05 per second at 720p
             },
         ],
         description:
@@ -436,8 +436,8 @@ export const IMAGE_SERVICES = {
                 completionImageTokens: 0.04, // $0.04 per image
             },
         ],
-        description: "Amazon Nova Canvas - Bedrock Image Generation",
-        inputModalities: ["text"],
+        description: "Amazon Nova Canvas - Bedrock Image Generation & Editing",
+        inputModalities: ["text", "image"],
         outputModalities: ["image"],
     },
     "nova-reel": {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -224,7 +224,7 @@ export const TEXT_SERVICES = {
             {
                 date: new Date("2026-03-22").getTime(),
                 promptTextTokens: perMillion(0.2),
-                promptCachedTokens: perMillion(0.2),
+                promptCachedTokens: perMillion(0.05), // $0.05 per 1M cached input tokens
                 completionTextTokens: perMillion(0.5),
             },
         ],
@@ -244,7 +244,7 @@ export const TEXT_SERVICES = {
             {
                 date: new Date("2026-03-22").getTime(),
                 promptTextTokens: perMillion(0.2),
-                promptCachedTokens: perMillion(0.2),
+                promptCachedTokens: perMillion(0.05), // $0.05 per 1M cached input tokens
                 completionTextTokens: perMillion(0.5),
             },
         ],
@@ -266,7 +266,7 @@ export const TEXT_SERVICES = {
             {
                 date: new Date("2026-03-22").getTime(),
                 promptTextTokens: perMillion(0.2),
-                promptCachedTokens: perMillion(0.2),
+                promptCachedTokens: perMillion(0.05), // $0.05 per 1M cached input tokens
                 completionTextTokens: perMillion(0.5),
             },
         ],


### PR DESCRIPTION
## Summary
- Fix grok cached input: $0.20 → $0.05/M tokens (matches xAI pricing)
- Fix grok-video-pro: $0.07 → $0.05/sec (matches xAI pricing)
- Add IMAGE_VARIATION to nova-canvas when image input provided
- Update nova-canvas registry to accept image input modality

## Test plan
- [ ] Verify grok text billing with cached tokens
- [ ] Verify grok-video-pro billing at $0.05/sec
- [ ] Test nova-canvas text-to-image (unchanged)
- [ ] Test nova-canvas with image input (new editing mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)