### PR TITLE
fix: correct gptimage-large text input pricing

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -155,8 +155,8 @@ export const IMAGE_SERVICES = {
             // Official pricing: https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-openai%E2%80%99s-gpt-image-1-5-in-microsoft-foundry/4478139
             {
                 date: COST_START_DATE,
-                promptTextTokens: perMillion(8), // $8.00 per 1M input tokens (Azure)
-                promptCachedTokens: perMillion(2), // $2.00 per 1M cached input tokens (Azure)
+                promptTextTokens: perMillion(5), // $5.00 per 1M text input tokens (Azure)
+                promptCachedTokens: perMillion(1.25), // $1.25 per 1M cached text input tokens (Azure)
                 promptImageTokens: perMillion(8), // $8.00 per 1M image input tokens (Azure)
                 completionImageTokens: perMillion(32), // $32.00 per 1M output tokens (Azure)
             },


### PR DESCRIPTION
- Text input was using image input rate ($8/M → $5/M)
- Cached text input adjusted accordingly ($2/M → $1.25/M)
- Image input ($8/M) and output ($32/M) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)