### PR TITLE
fix: add missing secrets for nova and qwen models

### DIFF
--- a/image.pollinations.ai/secrets/env.json
+++ b/image.pollinations.ai/secrets/env.json
@@ -26,6 +26,9 @@
 	"PRUNA_API_KEY": "ENC[AES256_GCM,data:3UvttlL6IjTuOK8UUjSi/NSXHAviV/Y/BjdmlpsytClrzjAe,iv:HzFSyOfhRqg79SQqhTwadqbS0Ego4Ii6SDiLE7hSZ3k=,tag:D3a8WpJEibGuAm8HDqgtDw==,type:str]",
 	"NOVA_REEL_S3_BUCKET": "ENC[AES256_GCM,data:DCIq17dGm7quYPKMHxheqvccAnIwfw==,iv:C7UOJQeWWRFUTejWbCKcwONF+MBIxoM+q+Of2VaSiSw=,tag:OSrq0d8HYmd5Y1IAY/TnKw==,type:str]",
 	"XAI_API_KEY": "ENC[AES256_GCM,data:pQ20kAl7NaDpWOsjivGSUmVmxW6HC3U2lccqNem1VcpVuSLlRe/5hzxB7yy3eZBVVRFT92kAxD9yl7vq+ovJPccPeT9e0BQme6JAaCLDIhfZv/4K,iv:YrHFspjzyWDzJrbEakmkrIyQAFufLOBWj0HGBUeA4AU=,tag:UQrs/j98/FYNmjXVTC8NHg==,type:str]",
+	"AWS_ACCESS_KEY_ID": "ENC[AES256_GCM,data:wWhwI/6+uC7eEi/JIKMFKStGpXs=,iv:lXSTNScB8vTPI/V409QsrgYfXL07I6LMsS8et56B6jc=,tag:NqNZcbBCUrv3X7H7t2xtkQ==,type:str]",
+	"AWS_SECRET_ACCESS_KEY": "ENC[AES256_GCM,data:670sKI+wR/xS40XXsVYxyuAdzp4NxCS9q3G+RRwvxAqMCHzWYKasdQ==,iv:Op3sXLeI/kYaRQhLuqDY2MlcIZfe52s2HTDNir8GdPM=,tag:8OabTqQlw2KfBtFAhTXrZA==,type:str]",
+	"AWS_REGION": "ENC[AES256_GCM,data:uYbKxMYBEgIo,iv:y6nyq22mEKHAUjTmbV9XktyHxCEU2TRK91m58uDbE6A=,tag:OVIbvDrHwZPYnBPg78w7AA==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -33,8 +36,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjS3RhWjhiZkdESks3RzlU\nMmtWd3B6T3Fuc09NWWh4VENYQ3BqUWpJSEQwClhOaVl6N2hZbzFQMWhIdHdyeTUv\nWmJGb3NKeDl3WVYra2grcVM3UHhFTzAKLS0tIE5RcGc2bTNwdE9GS1ZqY1VWRlZ6\nQ0p0eVkxdXpVeEF1ZThqeE9xV2swS2cK3NPhg7jXAi6/28RO3r2LIRP5DwAxsp7w\ngoAJwJ/b392PSfOrRkP4U3ExtutZ0BKtMfOmO4Elx3GzyCLXbFplqw==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-03-23T01:25:00Z",
-		"mac": "ENC[AES256_GCM,data:M4EYrhUOOFg1V34PD1z53db7yqZc3oxyBN//mXpwHpWnu0C08mX1cFdgjqL/UHKBYYv1H4fmZv/tsosvqLlE6Zv+7lC4v0AOBDEcCv1tyPMG35ZMb6307Yx3A5655+Nl0l2H0sNmZ5CtR8Pzm1ZoP3l8ESeXwrB0BtskTF0xb4E=,iv:R4fpWK7nyIyYXrYmfz+1c4tRqRn7DwTicyWiD1qwMao=,tag:5QOWJ+Fpv65zsdlu4JUVtQ==,type:str]",
+		"lastmodified": "2026-03-23T03:07:39Z",
+		"mac": "ENC[AES256_GCM,data:Efj7p/XyBWMie20zNQRqJnLgKwFGkqpVlW7noxpDOAV5YzB5aNoD0+bm3sFx0iU97bTW5A9hS4piWmdelSbGlsdB5FYEgLIkaRcrBiD5/ThdOD/wSj42d0pSYT1+Ep2OMsIjy6zS+sgtyReE9jlnYGPlcrE4QjNM1b9SJ5hzj40=,iv:PhtpMXTvRSTlJUEQ3LL2CP24T1jOUI5zDU4qMZFpLmY=,tag:f4AjSz0oT9HJQEP84sfVtA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/text.pollinations.ai/secrets/env.json
+++ b/text.pollinations.ai/secrets/env.json
@@ -33,6 +33,7 @@
 	"ANTHROPIC_API_KEY": "ENC[AES256_GCM,data:WVyjG1qvxnT8IzhmBUjavRahqqvZSqMgsdv7pr9jdca2VKB14ExJ3yHu+c5OcvOsY+HsFFMkYaKz9NvuGV8nz3z8Ti1QajciaU3p5kkAlEYYpfTyNT90oXM3XNhIuuqvqDUsOR0NRR1mnfVa,iv:erTvsv4WFyZOTHIt/xH6loLMKL7bprIgIVvSzKbSnnc=,tag:DqB1jo4VhHQh8x3NTD00lw==,type:str]",
 	"SERAPHYN_API_KEY": "ENC[AES256_GCM,data:FSJUopevOdaS9wf1SSoYYxn/AuhCo1bj9s6SqD+cDJqGDIY=,iv:A9wR80Etm5GxHvor4G9v5PPMm0wv1WcK6cWyovwQIsw=,tag:z496l/75zO8rMoU4f4VV1Q==,type:str]",
 	"AZURE_MYCELI_XAI_API_KEY": "ENC[AES256_GCM,data:LJRfIdxB1SS/+uPjmTvUmxtWMwiT9SEBE9esvo6xf3+9xpyISDgBcbkywA/INTwiL+4ZnhVQfx+tlmvDpZZMIZbfhedCwj1lwcI03ZV7VvfOT2fl,iv:wTvgaRtZv6xM41gsC3RVyjHlaGB/+TaClpOO0kWvHz8=,tag:8UaiObvrcobz3Pl2MpKetg==,type:str]",
+	"DASHSCOPE_API_KEY": "ENC[AES256_GCM,data:uBu+tmnelZbZD/3lh70LbtQeNmm7mGoGIAg+m+LLGL3WsE0=,iv:zLybkLTOOEg7AZnM8wkyKwkT6GsM+kcK9zkoEfED/r4=,tag:vN2L5bz/NAGFPQUsT9AFog==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -40,8 +41,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2dVNjY1M5eVhXZ1lvNXFI\nTlVBeGZjMXpoODh6emhvOGJ1dFpEdHpGcWpNClBzclZJSTBFQ1U0NjdFL0hEc0pX\nM2ttMEZzTGhSeWI5T3FFSHI2MXBVRTQKLS0tIDYzNEZDUnA1cXBieXJIRG9XYnZW\nNlcwUDF4bDlhMkJuQWc0aXpUdEREaEkKaJ1ZnDLLRh5YnV2vdG/ro61PxEag4CMj\nes4vEJF3eEMtvci61w62urNC/C3TXuyZULUJogyJ1yp0OYtAt6H7cA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-03-22T20:54:28Z",
-		"mac": "ENC[AES256_GCM,data:qmLFdeWHMQY6ncSypvjtISWSzBKT6BY5UYcyyYhMq7ErvICVsQ9S+yhH4tqdZc5nUuogWqp2wmSCVlaWj25yEJwyWFfZ/ZRszExlvQ2dVl8iUMpqOEJBqxUA8nNKVnjNYj6QEAvpxvnMj2LzyCr/ef7J73lxq4/xLxiwcExtngM=,iv:cfVuTSC0fng1MvVzGYUL6G6n4X1c5mN/VG8xu+W2idk=,tag:GQYgZNunCr1AnJpnvtzzRA==,type:str]",
+		"lastmodified": "2026-03-23T03:07:32Z",
+		"mac": "ENC[AES256_GCM,data:f3DC1kAADx1wicVr0vNGn/7aKOfS6+1bt5sqlPw9L49L1jwgz93qkv4/yvqJ2Q8XQCyH+SsEgRgKTvi37tq3oAtGmlGmGD4dBBH+QGcdtZOvc+vPI96EePhFkjT+QN16+n9We7SvyXMouwS5nTfUyGzFLKN3Y86dH3s/6PdLQCQ=,iv:nb1oa13crMmCGK2KfeW6kPOyMxKxoGIIqcVGLVNHEMw=,tag:LYYjn31BRCNpEGKvH6NGXg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
## Summary
- Add DASHSCOPE_API_KEY to text service sops (qwen text models returning 401)
- Add AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION to image service sops (nova-canvas/nova-reel returning 500)
- Keys copied from the service that already had them using `sops set`

## Test plan
- [ ] Merge to production and redeploy
- [ ] Test qwen-large, qwen-vision, qwen-coder-large on gen.pollinations.ai
- [ ] Test nova-canvas, nova-reel on gen.pollinations.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)