### PR TITLE
fix: merge consecutive messages for perplexity models

### DIFF
--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -8,6 +8,7 @@ import { createMessageTransform } from "./transforms/createMessageTransform.js";
 import { createSystemPromptTransform } from "./transforms/createSystemPromptTransform.js";
 import { pipe } from "./transforms/pipe.js";
 import { removeToolsForJsonResponse } from "./transforms/removeToolsForJsonResponse.ts";
+import { mergeConsecutiveMessages } from "./transforms/mergeConsecutiveMessages.js";
 import { sanitizeToolSchemas } from "./transforms/sanitizeToolSchemas.js";
 import type { TransformFn } from "./types.js";
 
@@ -123,10 +124,12 @@ const models: ModelDefinition[] = [
     {
         name: "perplexity-fast",
         config: portkeyConfig["sonar"],
+        transform: mergeConsecutiveMessages,
     },
     {
         name: "perplexity-reasoning",
         config: portkeyConfig["sonar-reasoning-pro"],
+        transform: mergeConsecutiveMessages,
     },
     {
         name: "kimi",

--- a/text.pollinations.ai/transforms/mergeConsecutiveMessages.ts
+++ b/text.pollinations.ai/transforms/mergeConsecutiveMessages.ts
@@ -1,0 +1,49 @@
+import debug from "debug";
+import type {
+    ChatMessage,
+    TransformOptions,
+    TransformResult,
+} from "../types.js";
+
+const log = debug("pollinations:transforms:merge");
+
+/**
+ * Merges consecutive messages with the same role into a single message.
+ * Fixes "user/assistant messages should alternate" errors from providers like Perplexity.
+ */
+export function mergeConsecutiveMessages(
+    messages: ChatMessage[],
+    options: TransformOptions,
+): TransformResult {
+    if (!Array.isArray(messages) || messages.length <= 1) {
+        return { messages, options };
+    }
+
+    const merged: ChatMessage[] = [];
+    let mergeCount = 0;
+
+    for (const msg of messages) {
+        const prev = merged[merged.length - 1];
+
+        // Only merge if same role, both have string content, and not tool/function messages
+        if (
+            prev &&
+            prev.role === msg.role &&
+            typeof prev.content === "string" &&
+            typeof msg.content === "string" &&
+            !msg.tool_call_id &&
+            !msg.tool_calls
+        ) {
+            prev.content = `${prev.content}\n\n${msg.content}`;
+            mergeCount++;
+        } else {
+            merged.push({ ...msg });
+        }
+    }
+
+    if (mergeCount > 0) {
+        log(`Merged ${mergeCount} consecutive same-role messages`);
+    }
+
+    return { messages: merged, options };
+}


### PR DESCRIPTION
## Summary
- Add `mergeConsecutiveMessages` transform that joins consecutive same-role messages
- Apply to `perplexity-fast` and `perplexity-reasoning` which require strict alternation
- Fixes `user or tool message(s) should alternate with assistant message(s)` errors

## Test plan
- [ ] Send chat with multiple consecutive user messages to perplexity-fast
- [ ] Verify no BAD_REQUEST alternation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)