### PR TITLE
fix: add missing ltx-2 routing in video handler

### DIFF
--- a/image.pollinations.ai/src/createAndReturnVideos.ts
+++ b/image.pollinations.ai/src/createAndReturnVideos.ts
@@ -4,6 +4,7 @@
  */
 
 import debug from "debug";
+import { callLtx2API } from "./models/ltx2VideoModel.ts";
 import { callNovaReelAPI } from "./models/novaReelModel.ts";
 import { callPrunaVideoAPI } from "./models/prunaModel.ts";
 import {
@@ -70,6 +71,9 @@ export async function createAndReturnVideo(
                 progress,
                 requestId,
             );
+            break;
+        case "ltx-2":
+            result = await callLtx2API(prompt, safeParams, progress, requestId);
             break;
         case "p-video":
             result = await callPrunaVideoAPI(


### PR DESCRIPTION
## Summary
- Adds missing `callLtx2API` import and `case "ltx-2"` switch in `createAndReturnVideos.ts`
- The squash merge of #9452 lost these changes due to conflicts with concurrent video model additions (wan-fast, nova-reel, grok-video-pro, xai)
- Without this fix, ltx-2 requests hit the `default` case and return "Video generation not supported"

## Test plan
- [x] `npm run test` passes
- [x] Biome check clean
- [ ] After merge + deploy: `curl https://gen.pollinations.ai/video/test?model=ltx-2` returns MP4

🤖 Generated with [Claude Code](https://claude.com/claude-code)