### PR TITLE
fix: sync tier explanation with commit scoring changes

### DIFF
--- a/enter.pollinations.ai/src/client/components/balance/tier-explanation.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/tier-explanation.tsx
@@ -31,10 +31,10 @@ const SeedTooltipContent = () => (
                 </tr>
                 <tr className="border-b border-gray-100">
                     <td className="py-1 pr-2 text-gray-600 leading-tight">
-                        Public commits (last 90 days)
+                        Public commits (last year)
                     </td>
                     <td className="py-1 text-right text-gray-800 whitespace-nowrap">
-                        0.1pt each (max 2)
+                        0.1pt each (max 3)
                     </td>
                 </tr>
                 <tr className="border-b border-gray-100">


### PR DESCRIPTION
## Summary
- Updates commit window label from "last 90 days" to "last year"
- Updates commit max points from 2 to 3

Follows up on #9501 which changed backend scoring. Flagged by polly review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)