### PR TITLE
add API key rotation to developer dashboard

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -113,13 +113,13 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                             <div className="flex gap-1 shrink-0 ml-2 items-center">
                                                 <button
                                                     type="button"
-                                                    className="w-6 h-6 flex items-center justify-center rounded bg-blue-50 hover:bg-blue-100 text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
+                                                    className="w-6 h-6 flex items-center justify-center rounded bg-blue-50 hover:bg-blue-100 text-blue-400 hover:text-blue-600 transition-colors cursor-pointer text-sm"
                                                     onClick={() =>
                                                         setEditingKey(apiKey)
                                                     }
                                                     title="Edit key"
                                                 >
-                                                    ✏
+                                                    ✎
                                                 </button>
                                                 <button
                                                     type="button"

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -10,6 +10,7 @@ import { EditApiKeyDialog } from "./edit-api-key-dialog.tsx";
 import { KeyDisplay } from "./key-display.tsx";
 import { LimitsBadge, shortLocale } from "./limits-badge.tsx";
 import { ModelsBadge } from "./models-badge.tsx";
+import { RotateKeyDialog } from "./rotate-key-dialog.tsx";
 import type { ApiKey, ApiKeyManagerProps } from "./types.ts";
 
 export const ApiKeyList: FC<ApiKeyManagerProps> = ({
@@ -17,9 +18,11 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     onCreate,
     onUpdate,
     onDelete,
+    onRotate,
 }) => {
     const [deleteId, setDeleteId] = useState<string | null>(null);
     const [editingKey, setEditingKey] = useState<ApiKey | null>(null);
+    const [rotatingKey, setRotatingKey] = useState<ApiKey | null>(null);
 
     async function handleDelete(): Promise<void> {
         if (deleteId) {
@@ -108,6 +111,16 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                 </span>
                                             )}
                                             <div className="flex gap-1 shrink-0 ml-2 items-center">
+                                                <button
+                                                    type="button"
+                                                    className="w-6 h-6 flex items-center justify-center rounded bg-orange-50 hover:bg-orange-100 text-orange-400 hover:text-orange-600 transition-colors cursor-pointer"
+                                                    onClick={() =>
+                                                        setRotatingKey(apiKey)
+                                                    }
+                                                    title="Rotate key"
+                                                >
+                                                    ↻
+                                                </button>
                                                 <button
                                                     type="button"
                                                     className="w-6 h-6 flex items-center justify-center rounded bg-blue-50 hover:bg-blue-100 text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
@@ -243,6 +256,11 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                     onClose={() => setEditingKey(null)}
                 />
             )}
+            <RotateKeyDialog
+                apiKey={rotatingKey}
+                onRotate={onRotate}
+                onClose={() => setRotatingKey(null)}
+            />
         </>
     );
 };

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -119,7 +119,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                     }
                                                     title="Edit key"
                                                 >
-                                                    ✎
+                                                    ✏
                                                 </button>
                                                 <button
                                                     type="button"

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -113,16 +113,6 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                             <div className="flex gap-1 shrink-0 ml-2 items-center">
                                                 <button
                                                     type="button"
-                                                    className="w-6 h-6 flex items-center justify-center rounded bg-orange-50 hover:bg-orange-100 text-orange-400 hover:text-orange-600 transition-colors cursor-pointer"
-                                                    onClick={() =>
-                                                        setRotatingKey(apiKey)
-                                                    }
-                                                    title="Rotate key"
-                                                >
-                                                    ↻
-                                                </button>
-                                                <button
-                                                    type="button"
                                                     className="w-6 h-6 flex items-center justify-center rounded bg-blue-50 hover:bg-blue-100 text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
                                                     onClick={() =>
                                                         setEditingKey(apiKey)
@@ -130,6 +120,16 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                     title="Edit key"
                                                 >
                                                     ✎
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className="w-6 h-6 flex items-center justify-center rounded bg-orange-50 hover:bg-orange-100 text-orange-400 hover:text-orange-600 transition-colors cursor-pointer"
+                                                    onClick={() =>
+                                                        setRotatingKey(apiKey)
+                                                    }
+                                                    title="Rotate key"
+                                                >
+                                                    ↻
                                                 </button>
                                                 <button
                                                     type="button"

--- a/enter.pollinations.ai/src/client/components/api-keys/rotate-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/rotate-key-dialog.tsx
@@ -8,7 +8,7 @@ import type { ApiKey } from "./types.ts";
 
 interface RotateKeyDialogProps {
     apiKey: ApiKey | null;
-    onRotate: (id: string) => Promise<{ key: string }>;
+    onRotate: (id: string) => Promise<{ key: string; warning?: string }>;
     onClose: () => void;
 }
 
@@ -21,6 +21,7 @@ export const RotateKeyDialog: FC<RotateKeyDialogProps> = ({
     const [newKey, setNewKey] = useState<string | null>(null);
     const [copied, setCopied] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [warning, setWarning] = useState<string | null>(null);
 
     const isOpen = !!apiKey;
     const isSecret = apiKey?.metadata?.keyType !== "publishable";
@@ -30,6 +31,7 @@ export const RotateKeyDialog: FC<RotateKeyDialogProps> = ({
         setNewKey(null);
         setCopied(false);
         setError(null);
+        setWarning(null);
         setIsRotating(false);
         onClose();
     }
@@ -41,6 +43,9 @@ export const RotateKeyDialog: FC<RotateKeyDialogProps> = ({
         try {
             const result = await onRotate(apiKey.id);
             setNewKey(result.key);
+            if (result.warning) {
+                setWarning(result.warning);
+            }
         } catch (err) {
             setError(
                 err instanceof Error ? err.message : "Failed to rotate key",
@@ -114,6 +119,11 @@ export const RotateKeyDialog: FC<RotateKeyDialogProps> = ({
                     </div>
 
                     <div className="px-6 py-2 space-y-4">
+                        {warning && (
+                            <p className="text-sm text-amber-700 bg-amber-50 px-3 py-2 rounded-lg">
+                                ⚠️ {warning}
+                            </p>
+                        )}
                         {error && (
                             <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">
                                 {error}

--- a/enter.pollinations.ai/src/client/components/api-keys/rotate-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/rotate-key-dialog.tsx
@@ -1,0 +1,174 @@
+import { Dialog } from "@ark-ui/react/dialog";
+import type { FC } from "react";
+import { useState } from "react";
+import { cn } from "@/util.ts";
+import { useScrollLock } from "../../hooks/use-scroll-lock.ts";
+import { Button } from "../button.tsx";
+import type { ApiKey } from "./types.ts";
+
+interface RotateKeyDialogProps {
+    apiKey: ApiKey | null;
+    onRotate: (id: string) => Promise<{ key: string }>;
+    onClose: () => void;
+}
+
+export const RotateKeyDialog: FC<RotateKeyDialogProps> = ({
+    apiKey,
+    onRotate,
+    onClose,
+}) => {
+    const [isRotating, setIsRotating] = useState(false);
+    const [newKey, setNewKey] = useState<string | null>(null);
+    const [copied, setCopied] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const isOpen = !!apiKey;
+    const isSecret = apiKey?.metadata?.keyType !== "publishable";
+    useScrollLock(isOpen);
+
+    function handleClose() {
+        setNewKey(null);
+        setCopied(false);
+        setError(null);
+        setIsRotating(false);
+        onClose();
+    }
+
+    async function handleRotate() {
+        if (!apiKey) return;
+        setIsRotating(true);
+        setError(null);
+        try {
+            const result = await onRotate(apiKey.id);
+            setNewKey(result.key);
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : "Failed to rotate key",
+            );
+        } finally {
+            setIsRotating(false);
+        }
+    }
+
+    async function handleCopyAndClose() {
+        if (!newKey) return;
+        try {
+            await navigator.clipboard.writeText(newKey);
+            setCopied(true);
+            setTimeout(handleClose, 500);
+        } catch {
+            setError(
+                "Could not copy to clipboard. Please select and copy the key manually.",
+            );
+        }
+    }
+
+    function getButtonText(): string {
+        if (copied) return "Copied! Closing...";
+        if (newKey) return "Copy and Close";
+        if (isRotating) return "Rotating...";
+        return "Rotate";
+    }
+
+    return (
+        <Dialog.Root
+            open={isOpen}
+            onOpenChange={({ open }) => !open && handleClose()}
+        >
+            <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
+            <Dialog.Positioner className="fixed inset-0 flex items-center justify-center p-4 z-[100]">
+                <Dialog.Content
+                    className={cn(
+                        "border-4 rounded-lg shadow-lg max-w-lg w-full flex flex-col",
+                        "bg-green-100 border-green-950",
+                    )}
+                >
+                    <div className="p-6 pb-4">
+                        <Dialog.Title className="text-lg font-semibold">
+                            Rotate API Key
+                        </Dialog.Title>
+                        {newKey ? (
+                            <div className="text-sm mt-1 space-y-1">
+                                <p className="text-gray-500">
+                                    ✅ Your new key has been generated.
+                                </p>
+                                {isSecret && (
+                                    <p className="text-amber-700 font-medium">
+                                        ⚠️ Copy it now — you won't be able to see
+                                        it again!
+                                    </p>
+                                )}
+                            </div>
+                        ) : (
+                            <div className="text-sm mt-1 space-y-1">
+                                <p className="text-gray-500">
+                                    🔄 This will generate a new key and
+                                    invalidate the current one.
+                                </p>
+                                <p className="text-red-600 font-medium">
+                                    ⚠️ Any applications using the old key will
+                                    stop working.
+                                </p>
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="px-6 py-2 space-y-4">
+                        {error && (
+                            <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">
+                                {error}
+                            </p>
+                        )}
+
+                        {newKey ? (
+                            <div className="flex items-center gap-3">
+                                <span className="text-sm font-semibold shrink-0">
+                                    Your API Key
+                                </span>
+                                <input
+                                    type="text"
+                                    value={newKey}
+                                    readOnly
+                                    className="flex-1 px-3 py-2 border rounded-lg border-green-300 bg-green-200 font-mono text-xs"
+                                />
+                            </div>
+                        ) : (
+                            apiKey && (
+                                <div className="flex items-center gap-3">
+                                    <span className="text-sm font-semibold shrink-0">
+                                        Key
+                                    </span>
+                                    <span className="font-mono text-xs text-gray-500">
+                                        {apiKey.name} ({apiKey.start}...)
+                                    </span>
+                                </div>
+                            )
+                        )}
+                    </div>
+
+                    <div className="flex gap-2 justify-end p-6 pt-4">
+                        {!newKey && (
+                            <Button
+                                type="button"
+                                weight="outline"
+                                onClick={handleClose}
+                                disabled={isRotating}
+                            >
+                                Cancel
+                            </Button>
+                        )}
+                        <Button
+                            type="button"
+                            color={newKey ? "green" : "red"}
+                            weight="strong"
+                            onClick={newKey ? handleCopyAndClose : handleRotate}
+                            disabled={isRotating}
+                        >
+                            {getButtonText()}
+                        </Button>
+                    </div>
+                </Dialog.Content>
+            </Dialog.Positioner>
+        </Dialog.Root>
+    );
+};

--- a/enter.pollinations.ai/src/client/components/api-keys/types.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/types.ts
@@ -24,6 +24,7 @@ export interface ApiKeyManagerProps {
     onCreate: (formData: CreateApiKey) => Promise<CreateApiKeyResponse>;
     onUpdate: (id: string, updates: ApiKeyUpdateParams) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
+    onRotate: (id: string) => Promise<{ key: string }>;
 }
 
 export type CreateApiKey = {

--- a/enter.pollinations.ai/src/client/components/api-keys/types.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/types.ts
@@ -24,7 +24,7 @@ export interface ApiKeyManagerProps {
     onCreate: (formData: CreateApiKey) => Promise<CreateApiKeyResponse>;
     onUpdate: (id: string, updates: ApiKeyUpdateParams) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
-    onRotate: (id: string) => Promise<{ key: string }>;
+    onRotate: (id: string) => Promise<{ key: string; warning?: string }>;
 }
 
 export type CreateApiKey = {

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -196,6 +196,24 @@ function RouteComponent() {
         router.invalidate();
     }
 
+    async function handleRotateApiKey(id: string): Promise<{ key: string }> {
+        const response = await fetch(`/api/api-keys/${id}/rotate`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+        });
+        if (!response.ok) {
+            const err = await response.json().catch(() => null);
+            throw new Error(
+                (err as { message?: string })?.message ||
+                    "Failed to rotate key",
+            );
+        }
+        const data = await response.json();
+        router.invalidate();
+        return data as { key: string };
+    }
+
     async function handleUpdateApiKey(
         id: string,
         updates: {
@@ -485,6 +503,7 @@ function RouteComponent() {
                     onCreate={handleCreateApiKey}
                     onUpdate={handleUpdateApiKey}
                     onDelete={handleDeleteApiKey}
+                    onRotate={handleRotateApiKey}
                 />
                 <Pricing packBalance={packBalance} />
                 <FAQ />

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -196,7 +196,9 @@ function RouteComponent() {
         router.invalidate();
     }
 
-    async function handleRotateApiKey(id: string): Promise<{ key: string }> {
+    async function handleRotateApiKey(
+        id: string,
+    ): Promise<{ key: string; warning?: string }> {
         const response = await fetch(`/api/api-keys/${id}/rotate`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -211,7 +213,7 @@ function RouteComponent() {
         }
         const data = await response.json();
         router.invalidate();
-        return data as { key: string };
+        return data as { key: string; warning?: string };
     }
 
     async function handleUpdateApiKey(

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -212,9 +212,8 @@ export const apiKeysRoutes = new Hono<Env>()
             const db = drizzle(c.env.DB, { schema });
             const existingKey = await requireOwnedKey(db, id, user.id);
 
-            const existingPermissions = existingKey.permissions
-                ? JSON.parse(existingKey.permissions as string)
-                : {};
+            const existingPermissions =
+                parsePermissions(existingKey.permissions as string) ?? {};
 
             const updatedPermissions = buildUpdatedPermissions(
                 existingPermissions,

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -333,9 +333,8 @@ export const apiKeysRoutes = new Hono<Env>()
             const existingMeta = existingKey.metadata
                 ? parseMetadata(existingKey.metadata)
                 : {};
-            const existingPermissions = existingKey.permissions
-                ? JSON.parse(existingKey.permissions as string)
-                : {};
+            const existingPermissions =
+                parsePermissions(existingKey.permissions as string) ?? {};
 
             const keyType =
                 (existingMeta.keyType as string) ||
@@ -365,9 +364,10 @@ export const apiKeysRoutes = new Hono<Env>()
             }
             await updateKeyMetadata(db, newKeyId, metadataPatch, null);
 
-            // Step 3: Copy permissions, budget, expiry, and preserve createdAt
+            // Step 3: Copy permissions, budget, expiry, prefix, and preserve createdAt
             const d1Updates: Record<string, unknown> = {
                 createdAt: existingKey.createdAt,
+                prefix,
             };
             if (existingKey.pollenBalance !== null) {
                 d1Updates.pollenBalance = existingKey.pollenBalance;

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -308,4 +308,125 @@ export const apiKeysRoutes = new Hono<Env>()
 
             return c.json({ id, metadata });
         },
+    )
+    /**
+     * Rotate an API key: creates a new key with the same settings, then deletes the old one.
+     * Returns the new plaintext key (shown once, like creation).
+     */
+    .post(
+        "/:id/rotate",
+        describeRoute({
+            tags: ["👤 Account"],
+            description:
+                "Rotate an API key. Creates a new key with identical settings, deletes the old one.",
+            hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
+        }),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const authClient = c.var.auth.client;
+            const { id } = c.req.param();
+
+            const db = drizzle(c.env.DB, { schema });
+            const existingKey = await requireOwnedKey(db, id, user.id);
+
+            // Parse existing metadata and permissions
+            const existingMeta = existingKey.metadata
+                ? parseMetadata(existingKey.metadata)
+                : {};
+            const existingPermissions = existingKey.permissions
+                ? JSON.parse(existingKey.permissions as string)
+                : {};
+
+            const keyType =
+                (existingMeta.keyType as string) ||
+                (existingKey.prefix === "pk" ? "publishable" : "secret");
+            const isPublishable = keyType === "publishable";
+            const prefix = isPublishable ? "pk" : "sk";
+
+            // Step 1: Create new key
+            const createResult = await authClient.api.createApiKey({
+                body: { name: existingKey.name || "rotated-key", prefix },
+                headers: c.req.raw.headers,
+            });
+
+            if (!createResult?.key) {
+                throw new HTTPException(500, {
+                    message: "Failed to create replacement key",
+                });
+            }
+
+            const newKeyId = createResult.id;
+            const newPlaintextKey = createResult.key;
+
+            // Step 2: Copy over metadata
+            const metadataPatch: Record<string, unknown> = { ...existingMeta };
+            if (isPublishable) {
+                metadataPatch.plaintextKey = newPlaintextKey;
+            }
+            await updateKeyMetadata(db, newKeyId, metadataPatch, null);
+
+            // Step 3: Copy permissions, budget, expiry, and preserve createdAt
+            const d1Updates: Record<string, unknown> = {
+                createdAt: existingKey.createdAt,
+            };
+            if (existingKey.pollenBalance !== null) {
+                d1Updates.pollenBalance = existingKey.pollenBalance;
+            }
+            if (existingKey.expiresAt) {
+                d1Updates.expiresAt = existingKey.expiresAt;
+            }
+            await db
+                .update(schema.apikey)
+                .set(d1Updates)
+                .where(eq(schema.apikey.id, newKeyId));
+
+            if (Object.keys(existingPermissions).length > 0) {
+                await authClient.api.updateApiKey({
+                    body: {
+                        keyId: newKeyId,
+                        userId: user.id,
+                        permissions: existingPermissions,
+                    },
+                });
+            }
+
+            // Step 4: Invalidate KV cache for both old and new keys
+            // New key was modified directly in D1 after creation, so its cache is stale
+            const newKeyRow = await db.query.apikey.findFirst({
+                where: eq(schema.apikey.id, newKeyId),
+            });
+            await c.env.KV.delete(`auth:api-key:${newKeyId}`);
+            if (newKeyRow?.key) {
+                await c.env.KV.delete(`auth:api-key:${newKeyRow.key}`);
+            }
+
+            // Step 5: Delete old key (non-fatal — user still gets the new key)
+            let oldKeyDeleted = true;
+            try {
+                await authClient.api.deleteApiKey({
+                    body: { keyId: id },
+                    headers: c.req.raw.headers,
+                });
+            } catch {
+                oldKeyDeleted = false;
+            }
+
+            // Invalidate KV cache for old key
+            await c.env.KV.delete(`auth:api-key:${id}`);
+            if (existingKey.key) {
+                await c.env.KV.delete(`auth:api-key:${existingKey.key}`);
+            }
+
+            return c.json({
+                id: newKeyId,
+                key: newPlaintextKey,
+                name: existingKey.name,
+                ...(oldKeyDeleted
+                    ? {}
+                    : {
+                          warning:
+                              "Old key could not be deleted. Please delete it manually.",
+                      }),
+            });
+        },
     );


### PR DESCRIPTION
- Adds `POST /api/api-keys/:id/rotate` endpoint that creates a new key with identical settings (permissions, budget, expiry, metadata), preserves the original `createdAt`, then deletes the old key
- Adds rotate button (↻) in the key list row alongside edit/delete
- Opens a confirmation modal → spinner → new key display with copy-and-close (same design pattern as key creation)
- Create-first-then-delete order avoids any window where the user has zero working keys
- If old key deletion fails, user still receives the new key with a warning to manually clean up
- KV cache invalidated for both old and new keys after rotation
- Conditional messaging: secret keys warn "you won't see it again", publishable keys don't
- Clipboard failure keeps dialog open instead of silently closing