### PR TITLE
fix: support image-to-video in grok-video-pro

### DIFF
--- a/image.pollinations.ai/src/models/xaiVideoModel.ts
+++ b/image.pollinations.ai/src/models/xaiVideoModel.ts
@@ -84,6 +84,10 @@ export async function callXaiVideoAPI(
     const aspectRatio = closestAspectRatio(safeParams.width, safeParams.height);
     if (aspectRatio) requestBody.aspect_ratio = aspectRatio;
 
+    if (safeParams.image?.length) {
+        requestBody.image_url = safeParams.image[0];
+    }
+
     logOps("Request body:", JSON.stringify(requestBody));
 
     const submitResponse = await fetch(XAI_VIDEO_API_URL, {

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -346,7 +346,7 @@ export const IMAGE_SERVICES = {
         ],
         description:
             "Grok Video Pro - xAI official video generation (720p, 1-15s)",
-        inputModalities: ["text"],
+        inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },
     "klein": {


### PR DESCRIPTION
## Summary
- Fix grok-video-pro to accept image input for image-to-video generation
- Update registry inputModalities from text-only to text+image
- Pass image_url to xAI API when image is provided

Fixes #9536

🤖 Generated with [Claude Code](https://claude.com/claude-code)