### PR TITLE
fix: correct xAI video API parameter from image_url to image

### DIFF
--- a/image.pollinations.ai/src/models/xaiVideoModel.ts
+++ b/image.pollinations.ai/src/models/xaiVideoModel.ts
@@ -85,7 +85,7 @@ export async function callXaiVideoAPI(
     if (aspectRatio) requestBody.aspect_ratio = aspectRatio;
 
     if (safeParams.image?.length) {
-        requestBody.image_url = safeParams.image[0];
+        requestBody.image = safeParams.image[0];
     }
 
     logOps("Request body:", JSON.stringify(requestBody));


### PR DESCRIPTION
## Summary
- xAI API docs specify `image` not `image_url` for image-to-video
- Follow-up fix to #9544

🤖 Generated with [Claude Code](https://claude.com/claude-code)