### PR TITLE
fix: remove file-based IP logging (grew to 22GB)

### DIFF
--- a/shared/ipLogger.js
+++ b/shared/ipLogger.js
@@ -1,9 +1,5 @@
-import fs from "node:fs";
-
 // IP logging for security investigation
-// Logs requester IPs to console and file for easy grep
-
-const LOG_FILE = process.env.IP_LOG_FILE || "/tmp/pollinations-ip-requests.log";
+// Logs requester IPs to console for easy grep
 
 /**
  * Log an IP address with timestamp and optional context
@@ -14,21 +10,5 @@ const LOG_FILE = process.env.IP_LOG_FILE || "/tmp/pollinations-ip-requests.log";
 export function logIp(ip, service, context = "") {
     const timestamp = new Date().toISOString();
     const logLine = `[${timestamp}] [${service}] IP=${ip} ${context}`.trim();
-
-    // Console log for grep
     console.log(`[IP-LOG] ${logLine}`);
-
-    // File log for persistence
-    try {
-        fs.appendFileSync(LOG_FILE, logLine + "\n");
-    } catch (err) {
-        console.error(`[IP-LOG] Failed to write to ${LOG_FILE}:`, err.message);
-    }
-}
-
-/**
- * Get the log file path
- */
-export function getLogFilePath() {
-    return LOG_FILE;
 }


### PR DESCRIPTION
## Summary
- Remove `fs.appendFileSync` to `/tmp/pollinations-ip-requests.log` that grew to 22GB on enter-services
- Remove unused `getLogFilePath` export and `fs` import
- Console `[IP-LOG]` output retained for grep-based investigation

## Test plan
- [ ] Verify text.pollinations.ai and image.pollinations.ai still start (they import `logIp`)
- [ ] Confirm `/tmp/pollinations-ip-requests.log` is no longer written to

polly please review