### PR TITLE
feat: add spend policies to API keys

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -232,6 +232,9 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                     pollenBudget={
                                                         apiKey.pollenBalance
                                                     }
+                                                    spendPolicy={
+                                                        apiKey.spendPolicy
+                                                    }
                                                 />
                                                 <span className="flex items-center gap-1">
                                                     <span className="text-gray-400">

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -58,6 +58,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     const keyPermissions = useKeyPermissions({
         allowedModels: apiKey.permissions?.models ?? null,
         pollenBudget: apiKey.pollenBalance ?? null,
+        spendPolicy: apiKey.spendPolicy,
         accountPermissions: apiKey.permissions?.account ?? null,
         expiryDays,
     });

--- a/enter.pollinations.ai/src/client/components/api-keys/key-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/key-permissions.tsx
@@ -1,5 +1,9 @@
 import type { FC } from "react";
 import { useState } from "react";
+import {
+    DEFAULT_SPEND_POLICY,
+    type SpendPolicy,
+} from "@/utils/spend-policy.ts";
 import { AccountPermissionsInput } from "./account-permissions-input.tsx";
 import { ExpiryDaysInput } from "./expiry-days-input.tsx";
 import { PollenBudgetInput } from "./pollen-budget-input.tsx";
@@ -7,6 +11,7 @@ import { PollenBudgetInput } from "./pollen-budget-input.tsx";
 export interface KeyPermissions {
     allowedModels: string[] | null;
     pollenBudget: number | null;
+    spendPolicy: SpendPolicy;
     expiryDays: number | null;
     accountPermissions: string[] | null;
 }
@@ -23,6 +28,9 @@ export function useKeyPermissions(initial: Partial<KeyPermissions> = {}) {
     const [pollenBudget, setPollenBudget] = useState(
         initial.pollenBudget ?? null,
     );
+    const [spendPolicy, setSpendPolicy] = useState(
+        initial.spendPolicy ?? DEFAULT_SPEND_POLICY,
+    );
     const [expiryDays, setExpiryDays] = useState(initial.expiryDays ?? null);
     const [accountPermissions, setAccountPermissions] = useState(
         initial.accountPermissions !== undefined
@@ -34,11 +42,13 @@ export function useKeyPermissions(initial: Partial<KeyPermissions> = {}) {
         permissions: {
             allowedModels,
             pollenBudget,
+            spendPolicy,
             expiryDays,
             accountPermissions,
         },
         setAllowedModels,
         setPollenBudget,
+        setSpendPolicy,
         setExpiryDays,
         setAccountPermissions,
     };
@@ -48,6 +58,7 @@ interface KeyPermissionsInputsProps {
     value: ReturnType<typeof useKeyPermissions>;
     disabled?: boolean;
     inline?: boolean;
+    showSpendPolicy?: boolean;
 }
 
 /**
@@ -57,11 +68,13 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
     value,
     disabled = false,
     inline = false,
+    showSpendPolicy = true,
 }) => {
     const {
         permissions,
         setAllowedModels,
         setPollenBudget,
+        setSpendPolicy,
         setExpiryDays,
         setAccountPermissions,
     } = value;
@@ -71,12 +84,9 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
             <PollenBudgetInput
                 value={permissions.pollenBudget}
                 onChange={setPollenBudget}
-                disabled={disabled}
-                inline={inline}
-            />
-            <ExpiryDaysInput
-                value={permissions.expiryDays}
-                onChange={setExpiryDays}
+                spendPolicy={permissions.spendPolicy}
+                onSpendPolicyChange={setSpendPolicy}
+                showSpendPolicy={showSpendPolicy}
                 disabled={disabled}
                 inline={inline}
             />
@@ -86,6 +96,12 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
                 disabled={disabled}
                 allowedModels={permissions.allowedModels}
                 onModelsChange={setAllowedModels}
+            />
+            <ExpiryDaysInput
+                value={permissions.expiryDays}
+                onChange={setExpiryDays}
+                disabled={disabled}
+                inline={inline}
             />
         </div>
     );

--- a/enter.pollinations.ai/src/client/components/api-keys/limits-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/limits-badge.tsx
@@ -1,6 +1,7 @@
 import { type FormatDistanceToken, formatDistanceToNowStrict } from "date-fns";
 import type { FC } from "react";
 import { cn } from "@/util.ts";
+import { getSpendPolicyLabel, type SpendPolicy } from "@/utils/spend-policy.ts";
 
 const shortFormatDistance: Record<FormatDistanceToken, string> = {
     lessThanXSeconds: "{{count}}s",
@@ -29,7 +30,8 @@ export const shortLocale = {
 export const LimitsBadge: FC<{
     expiresAt: Date | null | undefined;
     pollenBudget: number | null | undefined;
-}> = ({ expiresAt, pollenBudget }) => {
+    spendPolicy: SpendPolicy;
+}> = ({ expiresAt, pollenBudget, spendPolicy }) => {
     const expiryStr = formatExpiry(expiresAt);
     const budgetStr = formatBudget(pollenBudget);
     const isExhausted = pollenBudget != null && pollenBudget <= 0;
@@ -49,6 +51,12 @@ export const LimitsBadge: FC<{
                     )}
                 >
                     {budgetStr}
+                </span>
+            </span>
+            <span>
+                <span className="text-gray-400">Spend: </span>
+                <span className="text-gray-500">
+                    {getSpendPolicyLabel(spendPolicy)}
                 </span>
             </span>
         </>

--- a/enter.pollinations.ai/src/client/components/api-keys/pollen-budget-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/pollen-budget-input.tsx
@@ -1,11 +1,20 @@
 import { Field } from "@ark-ui/react";
-import type { FC } from "react";
+import { type FC, useId } from "react";
+import { cn } from "@/util.ts";
+import {
+    getSpendPolicyLabel,
+    SPEND_POLICIES,
+    type SpendPolicy,
+} from "@/utils/spend-policy.ts";
 import { InfoTip } from "../ui/info-tip.tsx";
 import { Input } from "../ui/input.tsx";
 
 type PollenBudgetInputProps = {
     value: number | null;
     onChange: (value: number | null) => void;
+    spendPolicy: SpendPolicy;
+    onSpendPolicyChange: (value: SpendPolicy) => void;
+    showSpendPolicy?: boolean;
     disabled?: boolean;
     compact?: boolean;
     inline?: boolean;
@@ -19,40 +28,112 @@ type PollenBudgetInputProps = {
 export const PollenBudgetInput: FC<PollenBudgetInputProps> = ({
     value,
     onChange,
+    spendPolicy,
+    onSpendPolicyChange,
+    showSpendPolicy = true,
     disabled = false,
     compact = false,
     inline = false,
 }) => {
+    const spendPolicyId = useId();
+    const budgetInfoText = showSpendPolicy ? (
+        <div className="space-y-2">
+            <p>Set a spending limit for this key. Leave empty for unlimited.</p>
+            <ul className="list-disc space-y-1 pl-4">
+                <li>Auto: use free pollen first, then fall back to paid.</li>
+                <li>Free only: never spend paid pollen.</li>
+                <li>Paid only: skip free pollen and use pack or crypto.</li>
+            </ul>
+        </div>
+    ) : (
+        "Set a spending limit for this key. Leave empty for unlimited."
+    );
+
     return (
-        <Field.Root className={inline ? "flex items-center gap-3" : ""}>
+        <Field.Root className={inline ? "flex items-start gap-3" : ""}>
             {!compact && (
                 <Field.Label
-                    className={`flex items-center gap-1.5 text-sm font-semibold ${inline ? "mb-0 shrink-0" : "mb-2"}`}
+                    className={`flex items-center gap-1.5 text-sm font-semibold ${inline ? "mb-0 shrink-0 pt-2" : "mb-2"}`}
                 >
                     Budget
-                    <InfoTip
-                        text="Set a spending limit for this key. Leave empty for unlimited."
-                        label="Budget information"
-                    />
+                    <InfoTip text={budgetInfoText} label="Budget information" />
                 </Field.Label>
             )}
-            <div className="flex items-center gap-2">
-                <Input
-                    id="pollen-budget-input"
-                    name="pollen-budget"
-                    type="number"
-                    min={0}
-                    step={0.01}
-                    value={value ?? ""}
-                    onChange={(e) => {
-                        const val = e.target.value;
-                        onChange(val === "" ? null : Number(val));
-                    }}
-                    className={`w-32 ${compact ? "text-sm" : ""}`}
-                    placeholder="Unlimited"
-                    disabled={disabled}
-                />
-                <span className="text-sm text-gray-500">pollen</span>
+            <div
+                className={cn(
+                    "flex flex-wrap items-center gap-3",
+                    inline && "flex-1",
+                )}
+            >
+                <div className="flex items-center gap-2">
+                    <Input
+                        id="pollen-budget-input"
+                        name="pollen-budget"
+                        type="number"
+                        min={0}
+                        step={0.01}
+                        value={value ?? ""}
+                        onChange={(e) => {
+                            const val = e.target.value;
+                            onChange(val === "" ? null : Number(val));
+                        }}
+                        className={`w-32 ${compact ? "text-sm" : ""}`}
+                        placeholder="Unlimited"
+                        disabled={disabled}
+                    />
+                    <span className="text-sm text-gray-500">pollen</span>
+                </div>
+
+                {showSpendPolicy && (
+                    <div
+                        className="inline-flex max-w-full flex-wrap rounded-xl border border-gray-200 bg-transparent p-1"
+                        role="radiogroup"
+                        aria-label="Spend policy"
+                    >
+                        {SPEND_POLICIES.map((policy) => {
+                            const selected = spendPolicy === policy;
+                            const inputId = `${spendPolicyId}-${policy}`;
+
+                            return (
+                                <div
+                                    key={policy}
+                                    className={cn(
+                                        "flex items-center gap-1 rounded-lg px-1 transition-colors",
+                                        selected
+                                            ? "bg-rose-50 text-rose-900"
+                                            : "bg-transparent text-gray-700 hover:bg-gray-50",
+                                        disabled && "opacity-60",
+                                    )}
+                                >
+                                    <input
+                                        id={inputId}
+                                        type="radio"
+                                        name={spendPolicyId}
+                                        value={policy}
+                                        checked={selected}
+                                        onChange={() =>
+                                            onSpendPolicyChange(policy)
+                                        }
+                                        className="sr-only"
+                                        disabled={disabled}
+                                    />
+                                    <label
+                                        htmlFor={inputId}
+                                        className={cn(
+                                            "rounded-md px-2.5 py-2 text-center text-sm font-medium whitespace-nowrap transition-colors",
+                                            compact && "text-xs",
+                                            !disabled && "cursor-pointer",
+                                            disabled &&
+                                                "cursor-not-allowed opacity-60",
+                                        )}
+                                    >
+                                        {getSpendPolicyLabel(policy)}
+                                    </label>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
             </div>
         </Field.Root>
     );

--- a/enter.pollinations.ai/src/client/components/api-keys/types.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/types.ts
@@ -1,3 +1,5 @@
+import type { SpendPolicy } from "@/utils/spend-policy.ts";
+
 export interface ApiKey {
     id: string;
     name?: string | null;
@@ -9,12 +11,14 @@ export interface ApiKey {
     permissions: Record<string, string[]> | null;
     metadata: Record<string, unknown> | null;
     pollenBalance?: number | null;
+    spendPolicy: SpendPolicy;
 }
 
 export interface ApiKeyUpdateParams {
     name?: string;
     allowedModels?: string[] | null;
     pollenBudget?: number | null;
+    spendPolicy?: SpendPolicy;
     accountPermissions?: string[] | null;
     expiresAt?: Date | null;
 }
@@ -34,6 +38,8 @@ export type CreateApiKey = {
     allowedModels?: string[] | null;
     /** Pollen budget cap for this key. null = unlimited */
     pollenBudget?: number | null;
+    /** How this key chooses between free tier and paid pollen */
+    spendPolicy?: SpendPolicy;
     /** Days until expiry. null = no expiry */
     expiryDays?: number | null;
     /** Account permissions: ["balance", "usage"]. null = no permissions */

--- a/enter.pollinations.ai/src/client/components/ui/info-tip.tsx
+++ b/enter.pollinations.ai/src/client/components/ui/info-tip.tsx
@@ -1,7 +1,7 @@
-import { type FC, useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 
 type InfoTipProps = {
-    text: string;
+    text: ReactNode;
     label?: string;
 };
 
@@ -28,11 +28,11 @@ export const InfoTip: FC<InfoTipProps> = ({ text, label = "More info" }) => {
             <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full bg-pink-100 border border-pink-300 text-pink-500 hover:bg-pink-200 hover:border-pink-400 transition-colors text-[10px] font-bold cursor-pointer">
                 i
             </span>
-            <span
-                className={`${show ? "visible" : "invisible"} absolute right-0 sm:left-0 sm:right-auto top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs font-normal rounded-lg shadow-lg border border-pink-200 w-[200px] sm:w-[280px] z-50 pointer-events-none`}
+            <div
+                className={`${show ? "visible" : "invisible"} absolute right-0 sm:left-0 sm:right-auto top-full mt-1 px-3 py-2 bg-gradient-to-r from-pink-50 to-purple-50 text-left text-gray-800 text-xs font-normal rounded-lg shadow-lg border border-pink-200 w-[200px] sm:w-[280px] z-50 pointer-events-none`}
             >
                 {text}
-            </span>
+            </div>
         </button>
     );
 };

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -651,6 +651,7 @@ function AuthorizeComponent() {
                             <KeyPermissionsInputs
                                 value={keyPermissions}
                                 inline
+                                showSpendPolicy={false}
                             />
 
                             {!isDeviceMode && (

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -119,6 +119,7 @@ function RouteComponent() {
             metadata: {
                 description: formState.description,
                 keyType,
+                spendPolicy: formState.spendPolicy,
                 ...(isPublishable && { plaintextKey: "" }), // Placeholder, updated below
             },
         });
@@ -185,6 +186,7 @@ function RouteComponent() {
             id: apiKey.id,
             key: apiKey.key,
             name: apiKey.name,
+            spendPolicy: formState.spendPolicy,
         } as CreateApiKeyResponse;
     }
 
@@ -202,6 +204,7 @@ function RouteComponent() {
             name?: string;
             allowedModels?: string[] | null;
             pollenBudget?: number | null;
+            spendPolicy?: CreateApiKey["spendPolicy"];
             accountPermissions?: string[] | null;
             expiresAt?: Date | null;
         },

--- a/enter.pollinations.ai/src/middleware/auth.ts
+++ b/enter.pollinations.ai/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import type { Session, User } from "@/auth.ts";
 import * as schema from "@/db/schema/better-auth.ts";
+import { parseSpendPolicy, type SpendPolicy } from "@/utils/spend-policy.ts";
 import { createAuth } from "../auth.ts";
 import type { LoggerVariables } from "./logger.ts";
 import type { ModelVariables } from "./model.ts";
@@ -40,6 +41,7 @@ interface ApiKey {
     permissions?: Record<string, string[]>;
     metadata?: Record<string, unknown>;
     pollenBalance?: number | null;
+    spendPolicy: SpendPolicy;
     rawKey?: string;
 }
 
@@ -71,6 +73,19 @@ function assertNotBanned(user: {
             ? `Account banned: ${user.banReason}`
             : "Account banned",
     });
+}
+
+function parseApiKeyMetadata(
+    raw: string | null | undefined,
+): Record<string, unknown> {
+    if (!raw) return {};
+    try {
+        let parsed = JSON.parse(raw);
+        if (typeof parsed === "string") parsed = JSON.parse(parsed);
+        return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+        return {};
+    }
 }
 
 export const auth = (options: AuthOptions) =>
@@ -126,6 +141,7 @@ export const auth = (options: AuthOptions) =>
             const fullApiKey = apiKeyData
                 ? { ...apiKeyData, user: userData }
                 : null;
+            const metadata = parseApiKeyMetadata(fullApiKey?.metadata);
 
             // Check if key has expired
             if (fullApiKey?.expiresAt) {
@@ -150,8 +166,9 @@ export const auth = (options: AuthOptions) =>
                     id: keyResult.key.id,
                     name: keyResult.key.name || undefined,
                     permissions,
-                    metadata: keyResult.key.metadata || undefined,
+                    metadata,
                     pollenBalance: fullApiKey?.pollenBalance ?? null,
+                    spendPolicy: parseSpendPolicy(metadata.spendPolicy),
                     rawKey: rawApiKey,
                 },
                 rawApiKey,

--- a/enter.pollinations.ai/src/middleware/balance.ts
+++ b/enter.pollinations.ai/src/middleware/balance.ts
@@ -96,8 +96,13 @@ export type BalanceVariables = {
         requirePositiveBalance: (
             userId: string,
             message?: string,
+            balances?: UserBalance,
         ) => Promise<void>;
-        requirePaidBalance: (userId: string, message?: string) => Promise<void>;
+        requirePaidBalance: (
+            userId: string,
+            message?: string,
+            balances?: UserBalance,
+        ) => Promise<void>;
         getBalance: (userId: string) => Promise<UserBalance>;
         balanceCheckResult?: BalanceCheckResult;
     };
@@ -171,8 +176,13 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
         return { source: "pack", slug: "v1:meter:pack" };
     };
 
-    const requirePositiveBalance = async (userId: string, message?: string) => {
-        const balances = await fetchBalanceWithErrorHandling(userId);
+    const requirePositiveBalance = async (
+        userId: string,
+        message?: string,
+        prefetchedBalance?: UserBalance,
+    ) => {
+        const balances =
+            prefetchedBalance ?? (await fetchBalanceWithErrorHandling(userId));
         const spendPolicy =
             c.var.auth.apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
         const accessibleBalances = getAccessibleBalances(
@@ -223,8 +233,13 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
         });
     };
 
-    const requirePaidBalance = async (userId: string, message?: string) => {
-        const balances = await fetchBalanceWithErrorHandling(userId);
+    const requirePaidBalance = async (
+        userId: string,
+        message?: string,
+        prefetchedBalance?: UserBalance,
+    ) => {
+        const balances =
+            prefetchedBalance ?? (await fetchBalanceWithErrorHandling(userId));
         const spendPolicy =
             c.var.auth.apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
         const accessibleBalances = getAccessibleBalances(

--- a/enter.pollinations.ai/src/middleware/balance.ts
+++ b/enter.pollinations.ai/src/middleware/balance.ts
@@ -5,6 +5,10 @@ import { HTTPException } from "hono/http-exception";
 import { user as userTable } from "@/db/schema/better-auth.ts";
 import type { AuthVariables } from "@/middleware/auth.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
+import {
+    DEFAULT_SPEND_POLICY,
+    type SpendPolicy,
+} from "@/utils/spend-policy.ts";
 
 type BalanceCheckResult = {
     selectedMeterId: string;
@@ -18,25 +22,72 @@ export type UserBalance = {
     cryptoBalance: number;
 };
 
-/**
- * Get the total available balance across relevant buckets.
- * For paid-only models: crypto + pack only.
- * For regular models: tier + crypto + pack (only positive buckets).
- */
+export function getSpendPolicyError(
+    spendPolicy: SpendPolicy,
+    isPaidOnlyModel: boolean,
+    fallback: string,
+): string {
+    if (isPaidOnlyModel && spendPolicy === "tier_only") {
+        return "This API key is restricted to free pollen and cannot use paid-only models.";
+    }
+    if (spendPolicy === "tier_only") {
+        return "This API key is restricted to free pollen. Wait for your next refill or change the spend policy.";
+    }
+    if (spendPolicy === "paid_only") {
+        return "This API key is restricted to paid balance. Add pack or crypto pollen to continue.";
+    }
+    return fallback;
+}
+
+function getAccessibleBalances(
+    balances: UserBalance,
+    spendPolicy: SpendPolicy,
+    isPaidOnlyModel = false,
+): UserBalance {
+    if (isPaidOnlyModel) {
+        if (spendPolicy === "tier_only") {
+            return { tierBalance: 0, packBalance: 0, cryptoBalance: 0 };
+        }
+        return {
+            tierBalance: 0,
+            packBalance: balances.packBalance,
+            cryptoBalance: balances.cryptoBalance,
+        };
+    }
+
+    switch (spendPolicy) {
+        case "tier_only":
+            return {
+                tierBalance: balances.tierBalance,
+                packBalance: 0,
+                cryptoBalance: 0,
+            };
+        case "paid_only":
+            return {
+                tierBalance: 0,
+                packBalance: balances.packBalance,
+                cryptoBalance: balances.cryptoBalance,
+            };
+        default:
+            return balances;
+    }
+}
+
 export function getAvailableBalance(
     balances: UserBalance,
-    isPaidOnly = false,
+    spendPolicy = DEFAULT_SPEND_POLICY,
+    isPaidOnlyModel = false,
 ): number {
-    if (isPaidOnly) {
-        return (
-            Math.max(0, balances.cryptoBalance) +
-            Math.max(0, balances.packBalance)
-        );
-    }
+    const accessibleBalances = getAccessibleBalances(
+        balances,
+        spendPolicy,
+        isPaidOnlyModel,
+    );
+
     return (
-        Math.max(0, balances.tierBalance) +
-        Math.max(0, balances.cryptoBalance) +
-        Math.max(0, balances.packBalance)
+        Math.max(0, accessibleBalances.tierBalance) +
+        Math.max(0, accessibleBalances.cryptoBalance) +
+        Math.max(0, accessibleBalances.packBalance)
     );
 }
 
@@ -102,21 +153,19 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
     // Helper to determine selected balance source
     const determineBalanceSource = (
         balances: UserBalance,
-        isPaidOnly = false,
+        spendPolicy: SpendPolicy,
+        isPaidOnlyModel = false,
     ): { source: string; slug: string } => {
-        if (isPaidOnly) {
-            // For paid-only: crypto → pack
-            if (balances.cryptoBalance > 0) {
-                return { source: "crypto", slug: "v1:meter:crypto" };
-            }
-            return { source: "pack", slug: "v1:meter:pack" };
-        }
+        const accessibleBalances = getAccessibleBalances(
+            balances,
+            spendPolicy,
+            isPaidOnlyModel,
+        );
 
-        // Regular: tier → crypto → pack
-        if (balances.tierBalance > 0) {
+        if (accessibleBalances.tierBalance > 0) {
             return { source: "tier", slug: "v1:meter:tier" };
         }
-        if (balances.cryptoBalance > 0) {
+        if (accessibleBalances.cryptoBalance > 0) {
             return { source: "crypto", slug: "v1:meter:crypto" };
         }
         return { source: "pack", slug: "v1:meter:pack" };
@@ -124,31 +173,41 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
 
     const requirePositiveBalance = async (userId: string, message?: string) => {
         const balances = await fetchBalanceWithErrorHandling(userId);
-        // Check if any individual bucket is positive (don't sum — negative buckets shouldn't cancel out positive ones)
+        const spendPolicy =
+            c.var.auth.apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
+        const accessibleBalances = getAccessibleBalances(
+            balances,
+            spendPolicy,
+            false,
+        );
         const hasPositiveBalance =
-            balances.tierBalance > 0 ||
-            balances.cryptoBalance > 0 ||
-            balances.packBalance > 0;
+            accessibleBalances.tierBalance > 0 ||
+            accessibleBalances.cryptoBalance > 0 ||
+            accessibleBalances.packBalance > 0;
 
         log.debug(
-            "Local pollen balance for user {userId}: tier={tierBalance}, pack={packBalance}, crypto={cryptoBalance}",
+            "Local pollen balance for user {userId}: tier={tierBalance}, pack={packBalance}, crypto={cryptoBalance}, spendPolicy={spendPolicy}",
             {
                 userId,
                 tierBalance: balances.tierBalance,
                 packBalance: balances.packBalance,
                 cryptoBalance: balances.cryptoBalance,
+                spendPolicy,
             },
         );
 
         if (hasPositiveBalance) {
-            const { source, slug } = determineBalanceSource(balances);
+            const { source, slug } = determineBalanceSource(
+                balances,
+                spendPolicy,
+            );
             c.var.balance.balanceCheckResult = {
                 selectedMeterId: `local:${source}`,
                 selectedMeterSlug: slug,
                 balances: {
-                    "v1:meter:tier": balances.tierBalance,
-                    "v1:meter:crypto": balances.cryptoBalance,
-                    "v1:meter:pack": balances.packBalance,
+                    "v1:meter:tier": accessibleBalances.tierBalance,
+                    "v1:meter:crypto": accessibleBalances.cryptoBalance,
+                    "v1:meter:pack": accessibleBalances.packBalance,
                 },
             };
             return;
@@ -156,35 +215,51 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
 
         // no positive balance - 402 for all billing/payment issues
         throw new HTTPException(402, {
-            message: message || "Your pollen balance is too low.",
+            message: getSpendPolicyError(
+                spendPolicy,
+                false,
+                message || "Your pollen balance is too low.",
+            ),
         });
     };
 
     const requirePaidBalance = async (userId: string, message?: string) => {
         const balances = await fetchBalanceWithErrorHandling(userId);
+        const spendPolicy =
+            c.var.auth.apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
+        const accessibleBalances = getAccessibleBalances(
+            balances,
+            spendPolicy,
+            true,
+        );
 
-        // Check if any paid bucket is positive (don't sum — negative buckets shouldn't cancel out positive ones)
         const hasPositivePaidBalance =
-            balances.cryptoBalance > 0 || balances.packBalance > 0;
+            accessibleBalances.cryptoBalance > 0 ||
+            accessibleBalances.packBalance > 0;
 
         log.debug(
-            "Paid balance check for user {userId}: crypto={cryptoBalance}, pack={packBalance}",
+            "Paid balance check for user {userId}: crypto={cryptoBalance}, pack={packBalance}, spendPolicy={spendPolicy}",
             {
                 userId,
                 cryptoBalance: balances.cryptoBalance,
                 packBalance: balances.packBalance,
+                spendPolicy,
             },
         );
 
         if (hasPositivePaidBalance) {
-            const { source, slug } = determineBalanceSource(balances, true);
+            const { source, slug } = determineBalanceSource(
+                balances,
+                spendPolicy,
+                true,
+            );
             c.var.balance.balanceCheckResult = {
                 selectedMeterId: `local:${source}`,
                 selectedMeterSlug: slug,
                 balances: {
                     "v1:meter:tier": 0, // Tier not available for paid-only
-                    "v1:meter:crypto": balances.cryptoBalance,
-                    "v1:meter:pack": balances.packBalance,
+                    "v1:meter:crypto": accessibleBalances.cryptoBalance,
+                    "v1:meter:pack": accessibleBalances.packBalance,
                 },
             };
             return;
@@ -192,9 +267,12 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
 
         // No paid balance available
         throw new HTTPException(402, {
-            message:
+            message: getSpendPolicyError(
+                spendPolicy,
+                true,
                 message ||
-                "This model requires a paid balance. Tier balance cannot be used.",
+                    "This model requires a paid balance. Tier balance cannot be used.",
+            ),
         });
     };
 

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -222,6 +222,7 @@ export const track = (eventType: EventType) =>
                     userId: userTracking.userId,
                     apiKeyId: c.var.auth?.apiKey?.id,
                     apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
+                    spendPolicy: c.var.auth?.apiKey?.spendPolicy,
                     modelResolved: c.var.model?.resolved,
                 });
             })(),

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -9,7 +9,9 @@ import {
     user as userTable,
 } from "@/db/schema/better-auth.ts";
 import type { ApiKeyType } from "@/db/schema/event.ts";
+import { getAvailableBalance } from "@/middleware/balance.ts";
 import { getTierCadence, tierNames } from "@/tier-config.ts";
+import { DEFAULT_SPEND_POLICY, SPEND_POLICIES } from "@/utils/spend-policy.ts";
 
 // Calculate next tier refill time (null for tiers with no refill)
 function getNextRefillAt(tier?: string | null): string | null {
@@ -103,7 +105,7 @@ const balanceResponseSchema = z.object({
     balance: z
         .number()
         .describe(
-            "Remaining pollen balance (combines tier, pack, and crypto balances)",
+            "Remaining pollen balance available to this account or API key",
         ),
 });
 
@@ -253,6 +255,7 @@ export const accountRoutes = new Hono<Env>()
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
+            const spendPolicy = apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
 
             // Check permission for API key access
             if (apiKey && !apiKey.permissions?.account?.includes("balance")) {
@@ -286,10 +289,14 @@ export const accountRoutes = new Hono<Env>()
             // Clamp each bucket at 0 before summing — individual buckets can go negative
             // from overage but shouldn't reduce the visible total
             return c.json({
-                balance:
-                    Math.max(0, tierBalance) +
-                    Math.max(0, packBalance) +
-                    Math.max(0, cryptoBalance),
+                balance: getAvailableBalance(
+                    {
+                        tierBalance,
+                        packBalance,
+                        cryptoBalance,
+                    },
+                    spendPolicy,
+                ),
             });
         },
     )
@@ -640,6 +647,11 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Remaining pollen budget for this key, null = unlimited (uses user balance)",
                                         ),
+                                    spendPolicy: z
+                                        .enum(SPEND_POLICIES)
+                                        .describe(
+                                            "How this key chooses between free tier and paid pollen",
+                                        ),
                                     rateLimitEnabled: z
                                         .boolean()
                                         .describe(
@@ -720,6 +732,7 @@ export const accountRoutes = new Hono<Env>()
                 expiresIn,
                 permissions,
                 pollenBudget: apiKey.pollenBalance ?? null,
+                spendPolicy: apiKey.spendPolicy,
                 // Rate limiting applies to publishable keys only (see rate-limit-durable.ts)
                 rateLimitEnabled: keyType === "publishable",
             });

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -8,6 +8,7 @@ import * as schema from "../db/schema/better-auth.ts";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import { validator } from "../middleware/validator.ts";
+import { parseSpendPolicy, SPEND_POLICIES } from "../utils/spend-policy.ts";
 import { parseMetadata } from "./metadata-utils.ts";
 
 /**
@@ -111,6 +112,10 @@ const UpdateApiKeySchema = z.object({
         .nullable()
         .optional()
         .describe("Pollen budget cap for this key. null = unlimited"),
+    spendPolicy: z
+        .enum(SPEND_POLICIES)
+        .optional()
+        .describe("How this key spends free vs paid pollen"),
     accountPermissions: z
         .array(z.string())
         .nullable()
@@ -181,6 +186,9 @@ export const apiKeysRoutes = new Hono<Env>()
                         : null,
                     metadata: key.metadata ? parseMetadata(key.metadata) : null,
                     pollenBalance: key.pollenBalance,
+                    spendPolicy: parseSpendPolicy(
+                        parseMetadata(key.metadata).spendPolicy,
+                    ),
                 })),
             });
         },
@@ -205,6 +213,7 @@ export const apiKeysRoutes = new Hono<Env>()
                 name,
                 allowedModels,
                 pollenBudget,
+                spendPolicy,
                 accountPermissions,
                 expiresAt,
             } = c.req.valid("json");
@@ -237,6 +246,12 @@ export const apiKeysRoutes = new Hono<Env>()
             if (pollenBudget !== undefined)
                 d1Updates.pollenBalance = pollenBudget;
             if (expiresAt !== undefined) d1Updates.expiresAt = expiresAt;
+            if (spendPolicy !== undefined) {
+                d1Updates.metadata = JSON.stringify({
+                    ...parseMetadata(existingKey.metadata),
+                    spendPolicy,
+                });
+            }
 
             if (Object.keys(d1Updates).length > 0) {
                 await db
@@ -261,6 +276,9 @@ export const apiKeysRoutes = new Hono<Env>()
                 name: keyForCache?.name,
                 permissions: keyForCache?.permissions,
                 pollenBalance: keyForCache?.pollenBalance ?? null,
+                spendPolicy: parseSpendPolicy(
+                    parseMetadata(keyForCache?.metadata).spendPolicy,
+                ),
                 expiresAt: keyForCache?.expiresAt ?? null,
             });
         },

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -7,6 +7,7 @@ import {
     balance,
     getAvailableBalance,
     getSpendPolicyError,
+    type UserBalance,
 } from "@/middleware/balance.ts";
 import { imageCache } from "@/middleware/image-cache.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
@@ -959,6 +960,7 @@ async function checkBalance(
 
     const serviceDefinition = getServiceDefinition(model.resolved);
     const isPaidOnly = serviceDefinition.paidOnly ?? false;
+    let userBalance: UserBalance | undefined;
 
     // Pre-check: reject if balance < estimated cost for this model
     // getModelStats is cached in KV for 1hr, so this is cheap
@@ -978,7 +980,7 @@ async function checkBalance(
     }
 
     if (estimatedCost > 0) {
-        const userBalance = await balance.getBalance(auth.user.id);
+        userBalance = await balance.getBalance(auth.user.id);
         const spendPolicy = auth.apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
         const available = getAvailableBalance(
             userBalance,
@@ -1002,11 +1004,13 @@ async function checkBalance(
         await balance.requirePaidBalance(
             auth.user.id,
             "This model requires a paid balance. Tier balance cannot be used.",
+            userBalance,
         );
     } else {
         await balance.requirePositiveBalance(
             auth.user.id,
             "Insufficient pollen balance to use this model",
+            userBalance,
         );
     }
 }

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -6,6 +6,7 @@ import {
     type BalanceVariables,
     balance,
     getAvailableBalance,
+    getSpendPolicyError,
 } from "@/middleware/balance.ts";
 import { imageCache } from "@/middleware/image-cache.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
@@ -53,6 +54,7 @@ import {
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
 import { errorResponseDescriptions } from "@/utils/api-docs.ts";
 import { getEstimatedPrice, getModelStats } from "@/utils/model-stats.ts";
+import { DEFAULT_SPEND_POLICY } from "@/utils/spend-policy.ts";
 import { generateMusic, generateSpeech } from "./audio.ts";
 
 // Build dynamic model lists from registry for use in API descriptions
@@ -233,6 +235,7 @@ function filterModelsByPermissions<
 function hasPaidBalance(c: any): boolean | undefined {
     const user = c.var?.auth?.user;
     if (!user) return undefined;
+    if (c.var?.auth?.apiKey?.spendPolicy === "tier_only") return false;
     return (user.packBalance ?? 0) > 0 || (user.cryptoBalance ?? 0) > 0;
 }
 
@@ -976,11 +979,20 @@ async function checkBalance(
 
     if (estimatedCost > 0) {
         const userBalance = await balance.getBalance(auth.user.id);
-        const available = getAvailableBalance(userBalance, isPaidOnly);
+        const spendPolicy = auth.apiKey?.spendPolicy ?? DEFAULT_SPEND_POLICY;
+        const available = getAvailableBalance(
+            userBalance,
+            spendPolicy,
+            isPaidOnly,
+        );
 
         if (available < estimatedCost) {
             throw new HTTPException(402, {
-                message: `Insufficient balance. This model costs ~${estimatedCost.toFixed(4)} pollen per request, but your available balance is ${available.toFixed(4)}.`,
+                message: getSpendPolicyError(
+                    spendPolicy,
+                    isPaidOnly,
+                    `Insufficient balance. This model costs ~${estimatedCost.toFixed(4)} pollen per request, but your available balance is ${available.toFixed(4)}.`,
+                ),
             });
         }
     }

--- a/enter.pollinations.ai/src/utils/balance-deduction.ts
+++ b/enter.pollinations.ai/src/utils/balance-deduction.ts
@@ -1,6 +1,9 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { user as userTable } from "../db/schema/better-auth.ts";
+import {
+    apikey as apiKeyTable,
+    user as userTable,
+} from "../db/schema/better-auth.ts";
 
 /**
  * Atomically deducts pollen from user balance.
@@ -53,7 +56,6 @@ export async function atomicDeductUserBalance(
  */
 export async function atomicDeductApiKeyBalance(
     db: DrizzleD1Database,
-    apiKeyTable: any,
     apiKeyId: string,
     amount: number,
 ): Promise<void> {
@@ -64,6 +66,25 @@ export async function atomicDeductApiKeyBalance(
 		SET pollen_balance = pollen_balance - ${amount}
 		WHERE id = ${apiKeyId}
 		AND pollen_balance IS NOT NULL
+	`);
+}
+
+/**
+ * Atomically deducts pollen from tier balance only.
+ *
+ * Used by API keys that must never spill into paid balances.
+ */
+export async function atomicDeductTierBalance(
+    db: DrizzleD1Database,
+    userId: string,
+    amount: number,
+): Promise<void> {
+    if (amount <= 0) return;
+
+    await db.run(sql`
+		UPDATE ${userTable}
+		SET tier_balance = COALESCE(tier_balance, 0) - ${amount}
+		WHERE id = ${userId}
 	`);
 }
 

--- a/enter.pollinations.ai/src/utils/spend-policy.ts
+++ b/enter.pollinations.ai/src/utils/spend-policy.ts
@@ -1,0 +1,38 @@
+export const SPEND_POLICIES = ["auto", "tier_only", "paid_only"] as const;
+
+export type SpendPolicy = (typeof SPEND_POLICIES)[number];
+
+export const DEFAULT_SPEND_POLICY: SpendPolicy = "auto";
+
+export function isSpendPolicy(value: unknown): value is SpendPolicy {
+    return (
+        typeof value === "string" &&
+        (SPEND_POLICIES as readonly string[]).includes(value)
+    );
+}
+
+export function parseSpendPolicy(value: unknown): SpendPolicy {
+    return isSpendPolicy(value) ? value : DEFAULT_SPEND_POLICY;
+}
+
+export function getSpendPolicyLabel(policy: SpendPolicy): string {
+    switch (policy) {
+        case "tier_only":
+            return "Free only";
+        case "paid_only":
+            return "Paid only";
+        default:
+            return "Auto";
+    }
+}
+
+export function getSpendPolicyDescription(policy: SpendPolicy): string {
+    switch (policy) {
+        case "tier_only":
+            return "Never spend paid pollen. Requests stop when free pollen runs out.";
+        case "paid_only":
+            return "Skip free pollen and use pack or crypto balance only.";
+        default:
+            return "Use free pollen first, then fall back to paid balance.";
+    }
+}

--- a/enter.pollinations.ai/src/utils/track-helpers.ts
+++ b/enter.pollinations.ai/src/utils/track-helpers.ts
@@ -2,10 +2,14 @@ import { getLogger } from "@logtape/logtape";
 import type { ServiceId } from "@shared/registry/registry.ts";
 import { getServiceDefinition } from "@shared/registry/registry.ts";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { apikey as apikeyTable } from "@/db/schema/better-auth.ts";
+import {
+    DEFAULT_SPEND_POLICY,
+    type SpendPolicy,
+} from "@/utils/spend-policy.ts";
 import {
     atomicDeductApiKeyBalance,
     atomicDeductPaidBalance,
+    atomicDeductTierBalance,
     atomicDeductUserBalance,
     getUserBalances,
     identifyDeductionSource,
@@ -20,6 +24,7 @@ interface DeductionParams {
     userId?: string;
     apiKeyId?: string;
     apiKeyPollenBalance?: number | null;
+    spendPolicy?: SpendPolicy;
     modelResolved?: string;
 }
 
@@ -36,6 +41,7 @@ export async function handleBalanceDeduction(
         userId,
         apiKeyId,
         apiKeyPollenBalance,
+        spendPolicy,
         modelResolved,
     } = params;
 
@@ -48,7 +54,13 @@ export async function handleBalanceDeduction(
 
     // Handle user balance deduction
     if (userId) {
-        await deductUserBalance(db, userId, totalPrice, modelResolved);
+        await deductUserBalance(
+            db,
+            userId,
+            totalPrice,
+            modelResolved,
+            spendPolicy,
+        );
     }
 }
 
@@ -64,7 +76,7 @@ async function deductApiKeyBalance(
     amount: number,
 ): Promise<void> {
     try {
-        await atomicDeductApiKeyBalance(db, apikeyTable, apiKeyId, amount);
+        await atomicDeductApiKeyBalance(db, apiKeyId, amount);
         log.debug("Decremented {price} pollen from API key {keyId} budget", {
             price: amount,
             keyId: apiKeyId,
@@ -82,6 +94,7 @@ async function deductUserBalance(
     userId: string,
     amount: number,
     modelResolved?: string,
+    spendPolicy = DEFAULT_SPEND_POLICY,
 ): Promise<void> {
     try {
         const isPaidOnly = modelResolved
@@ -89,10 +102,19 @@ async function deductUserBalance(
               false)
             : false;
 
-        if (isPaidOnly) {
+        if (spendPolicy === "tier_only") {
+            await atomicDeductTierBalance(db, userId, amount);
+            log.debug(
+                "Decremented {price} pollen from user {userId} (tier-only key)",
+                { price: amount, userId },
+            );
+            return;
+        }
+
+        if (isPaidOnly || spendPolicy === "paid_only") {
             await atomicDeductPaidBalance(db, userId, amount);
             log.debug(
-                "Decremented {price} pollen from user {userId} (paid-only model, tier excluded)",
+                "Decremented {price} pollen from user {userId} (paid balances only)",
                 { price: amount, userId },
             );
             return;

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -45,6 +45,7 @@ test(
         expect(data).toHaveProperty("expiresIn");
         expect(data).toHaveProperty("permissions");
         expect(data).toHaveProperty("pollenBudget");
+        expect(data).toHaveProperty("spendPolicy");
         expect(data).toHaveProperty("rateLimitEnabled");
     },
 );

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -1,5 +1,7 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
 import { describe, expect } from "vitest";
+import { user as userTable } from "@/db/schema/better-auth.ts";
 import { test } from "../fixtures.ts";
 
 describe("API Key Management", () => {
@@ -36,6 +38,7 @@ describe("API Key Management", () => {
                 expect(key).toHaveProperty("start");
                 expect(key).toHaveProperty("createdAt");
                 expect(key).toHaveProperty("pollenBalance");
+                expect(key).toHaveProperty("spendPolicy");
             }
 
             // Find the restricted key and verify its permissions
@@ -210,6 +213,48 @@ describe("API Key Management", () => {
             const keys = await listResponse.json();
             const updatedKey = keys.data.find((k: any) => k.id === keyId);
             expect(updatedKey.pollenBalance).toBe(50);
+        });
+
+        test("should update spend policy", async ({ auth, sessionToken }) => {
+            const createResponse = await auth.apiKey.create({
+                name: "spend-policy-test",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+            const keyId = createResponse.data!.id;
+
+            const updateResponse = await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${keyId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        spendPolicy: "paid_only",
+                    }),
+                },
+            );
+
+            expect(updateResponse.status).toBe(200);
+            const result = await updateResponse.json();
+            expect(result.spendPolicy).toBe("paid_only");
+
+            const listResponse = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+            const keys = await listResponse.json();
+            const updatedKey = keys.data.find((k: any) => k.id === keyId);
+            expect(updatedKey.spendPolicy).toBe("paid_only");
         });
 
         test("should update expiry date", async ({ auth, sessionToken }) => {
@@ -601,6 +646,122 @@ describe("API Key Management", () => {
                 },
             );
             expect(response.status).toBe(402);
+        });
+
+        test("tier-only keys should not spill into paid balance", async ({
+            auth,
+            sessionToken,
+            mocks,
+        }) => {
+            await mocks.enable("polar", "tinybird", "vcr");
+            const db = drizzle(env.DB);
+            await db.update(userTable).set({
+                tierBalance: 0,
+                packBalance: 25,
+                cryptoBalance: 0,
+            });
+
+            const createResponse = await auth.apiKey.create({
+                name: "tier-only-test-key",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+
+            await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${createResponse.data!.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        spendPolicy: "tier_only",
+                    }),
+                },
+            );
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/generate/v1/chat/completions",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${createResponse.data!.key}`,
+                    },
+                    body: JSON.stringify({
+                        model: "openai-fast",
+                        messages: [{ role: "user", content: "Hello" }],
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(402);
+            const body = await response.json();
+            expect((body as any).error.message).toContain(
+                "restricted to free pollen",
+            );
+        });
+
+        test("paid-only keys should not use tier balance", async ({
+            auth,
+            sessionToken,
+            mocks,
+        }) => {
+            await mocks.enable("polar", "tinybird", "vcr");
+            const db = drizzle(env.DB);
+            await db.update(userTable).set({
+                tierBalance: 25,
+                packBalance: 0,
+                cryptoBalance: 0,
+            });
+
+            const createResponse = await auth.apiKey.create({
+                name: "paid-only-test-key",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+
+            await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${createResponse.data!.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        spendPolicy: "paid_only",
+                    }),
+                },
+            );
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/generate/v1/chat/completions",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${createResponse.data!.key}`,
+                    },
+                    body: JSON.stringify({
+                        model: "openai-fast",
+                        messages: [{ role: "user", content: "Hello" }],
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(402);
+            const body = await response.json();
+            expect((body as any).error.message).toContain(
+                "restricted to paid balance",
+            );
         });
     });
 });


### PR DESCRIPTION
- Adds `auto`, `tier_only`, and `paid_only` spend policies to API keys and enforces them in balance checks, model visibility, and deductions
- Exposes spend policy in API key/account responses and supports updating it through the dashboard
- Adds a compact budget + spend policy control, key list badge, and keeps the authorize flow on the default path
- Adds focused tests for spend policy updates and tier-only/paid-only enforcement

Fixes #9624