### PR TITLE
feat: paid-only for grok (xai), elevenmusic, wan-fast

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -293,7 +293,6 @@ export const IMAGE_SERVICES = {
         ],
         modelId: "qwen-image",
         provider: "alibaba",
-        paidOnly: true,
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -592,7 +592,6 @@ export const TEXT_SERVICES = {
         aliases: ["glm-5", "glm-4.7", "glm-4p7"],
         modelId: "accounts/fireworks/models/glm-5",
         provider: "fireworks",
-        paidOnly: true,
         cost: [
             {
                 date: new Date("2026-02-13").getTime(),
@@ -674,7 +673,6 @@ export const TEXT_SERVICES = {
         aliases: ["qwen3.5", "qwen3.5-plus"],
         modelId: "qwen3.5-plus",
         provider: "alibaba",
-        paidOnly: true,
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),


### PR DESCRIPTION
## Summary

- Adds `paidOnly: true` to `grok-imagine`, `elevenmusic`, `wan-fast`
- `grok-imagine-pro` and `grok-video-pro` were already paid-only
- Reverts `paidOnly` from `glm`, `qwen-large`, `qwen-image` (out of scope)
- Azure grok text models unchanged (already paid-only)

https://claude.ai/code/session_012eEpJGHfcUncWLx7UmQX4g