### PR TITLE
fix: case-insensitive URL matching in BYOP app-lookup

### DIFF
--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -86,6 +86,8 @@ export const appLookupRoutes = new Hono<Env>().get(
                 where: sql`json_extract(${schema.apikey.metadata}, '$.keyType') = 'publishable' AND json_extract(${schema.apikey.metadata}, '$.appUrl') IS NOT NULL`,
             });
             // Find the best match: longest appUrl that is a prefix of redirectUrl
+            // Case-insensitive to handle mixed-case registrations
+            const redirectLower = redirectUrl.toLowerCase();
             let bestMatch: (typeof candidates)[number] | null = null;
             let bestLen = 0;
             for (const row of candidates) {
@@ -93,7 +95,7 @@ export const appLookupRoutes = new Hono<Env>().get(
                 const appUrl = meta.appUrl as string;
                 if (
                     appUrl &&
-                    redirectUrl.startsWith(appUrl) &&
+                    redirectLower.startsWith(appUrl.toLowerCase()) &&
                     appUrl.length > bestLen
                 ) {
                     bestMatch = row;


### PR DESCRIPTION
## Summary
- Followup to #9699
- Normalize URLs to lowercase before prefix matching in Strategy 2
- Prevents attribution loss when app devs register URLs with mixed case (e.g., `HTTPS://App.Example.com`)
- Found by codex CLI review of #9699

## Test plan
- [ ] Verify app-lookup matches regardless of URL casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)