### PR TITLE
fix: restore docs regenerate workflow auth

### DIFF
--- a/.github/workflows/docs-regenerate-apidocs.yml
+++ b/.github/workflows/docs-regenerate-apidocs.yml
@@ -66,7 +66,7 @@ jobs:
           fi
 
       - name: Create PR with updated docs
-        if: ${{ steps.changes.outputs.changed == 'true' && (github.event_name == 'push' || inputs.create_pr || github.event.client_payload.create_pr) }}
+        if: ${{ steps.changes.outputs.changed == 'true' && (github.event_name == 'push' || inputs.create_pr || github.event.client_payload.create_pr == true || github.event.client_payload.create_pr == 'true') }}
         run: |
           BRANCH="docs/regenerate-apidocs-$(date +%s)"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
- Restores branch pushes via the repo GITHUB_TOKEN
- Uses the POLLY_BOT app token only for gh PR creation
- Re-adds the write permissions this workflow needs

Fixes the failing Regenerate API Docs workflow when APIDOCS.md changes.