### PR TITLE
[FEAT]: Resolve 1x1 video resolution mode for grok-video-pro 

### DIFF
--- a/enter.pollinations.ai/src/routes/images.ts
+++ b/enter.pollinations.ai/src/routes/images.ts
@@ -26,6 +26,7 @@ const PASSTHROUGH_PARAMS = [
     "transparent",
     "negative_prompt",
     "guidance_scale",
+    "mode",
 ] as const;
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {

--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -110,8 +110,15 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
     }),
     aspectRatio: z.string().optional().meta({
         description:
-            "Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by width/height.",
+            "Video aspect ratio (`16:9`, `9:16`, or `1:1`). Only applies to video models. `1:1` currently supported by `grok-video-pro` only. If not set, determined by width/height.",
     }),
+    mode: z
+        .enum(["fun", "normal", "spicy"] as const)
+        .optional()
+        .meta({
+            description:
+                "Generation mode for `grok-video-pro`. `fun` = playful/creative, `normal` = balanced (default), `spicy` = more intense. Only applies to `grok-video-pro`.",
+        }),
     audio: z.coerce.boolean().optional().default(false).meta({
         description:
             "Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo`, set to `true` to enable audio.",

--- a/image.pollinations.ai/src/models/xaiVideoModel.ts
+++ b/image.pollinations.ai/src/models/xaiVideoModel.ts
@@ -88,6 +88,11 @@ export async function callXaiVideoAPI(
         requestBody.image = safeParams.image[0];
     }
 
+    // Pass mode parameter if provided (fun, normal, spicy)
+    if (safeParams.mode) {
+        requestBody.mode = safeParams.mode;
+    }
+
     logOps("Request body:", JSON.stringify(requestBody));
 
     const submitResponse = await fetch(XAI_VIDEO_API_URL, {

--- a/image.pollinations.ai/src/params.ts
+++ b/image.pollinations.ai/src/params.ts
@@ -83,7 +83,8 @@ export const ImageParamsSchema = z
         guidance_scale: z.coerce.number().optional().catch(undefined),
         // Video-specific parameters - pass through to backend, let provider validate
         duration: z.coerce.number().optional(),
-        aspectRatio: z.enum(["16:9", "9:16"]).optional(),
+        aspectRatio: z.enum(["16:9", "9:16", "1:1"]).optional(),
+        mode: z.enum(["fun", "normal", "spicy"]).optional(),
         audio: sanitizedBoolean.catch(true), // generateAudio defaults to true
     })
     .transform((data) => {

--- a/image.pollinations.ai/src/utils/videoResolution.ts
+++ b/image.pollinations.ai/src/utils/videoResolution.ts
@@ -17,12 +17,12 @@ const log = debug("pollinations:video:resolution");
 export interface VideoResolutionInput {
     width?: number;
     height?: number;
-    aspectRatio?: "16:9" | "9:16";
+    aspectRatio?: "16:9" | "9:16" | "1:1";
     defaultResolution?: "480P" | "720P" | "1080P";
 }
 
 export interface VideoResolutionOutput {
-    aspectRatio: "16:9" | "9:16";
+    aspectRatio: "16:9" | "9:16" | "1:1";
     resolution: "480P" | "720P" | "1080P";
 }
 
@@ -65,9 +65,10 @@ export function calculateVideoResolution(
         const totalPixels = input.width * input.height;
         const ratio = input.width / input.height;
 
-        // Determine aspect ratio (16:9 = 1.778, 9:16 = 0.5625)
-        // Threshold at 1.0 (square) - wider than square → 16:9, taller → 9:16
-        const aspectRatio = ratio > 1.0 ? "16:9" : "9:16";
+        // Determine aspect ratio (16:9 = 1.778, 1:1 = 1.0, 9:16 = 0.5625)
+        // Use thresholds: >1.2 → 16:9, 0.83-1.2 → 1:1, <0.83 → 9:16
+        const aspectRatio: "16:9" | "9:16" | "1:1" =
+            ratio > 1.2 ? "16:9" : ratio < 0.83 ? "9:16" : "1:1";
 
         // Determine resolution tier from pixel count
         let resolution = RESOLUTION_TIERS[0].label; // Default to lowest


### PR DESCRIPTION
## Changes Made:- 

- 1:1 aspect ratio support for grok-video-pro
- Mode parameter (fun/normal/spicy):
- Also fixed during conflict resolution:

> Original PR from #9181 9181