### PR TITLE
fix(sirius): responsive Lottie backgrounds for pollinations.ai

### DIFF
--- a/apps/sirius-cybernetics-elevator-challenge/src/styles/globals.css
+++ b/apps/sirius-cybernetics-elevator-challenge/src/styles/globals.css
@@ -95,3 +95,27 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+/* Responsive Lottie backgrounds - Fixes #9440 */
+body.iframe-mode .floor-lottie-container,
+body.iframe-mode .floor-lottie-container > div {
+  width: 200px !important;
+  height: 200px !important;
+}
+
+body.standalone-mode .floor-lottie-container,
+body.standalone-mode .floor-lottie-container > div {
+  width: 15vw !important;
+  height: 15vh !important;
+  max-width: 300px !important;
+  max-height: 300px !important;
+  min-width: 100px !important;
+  min-height: 100px !important;
+}
+
+@media (max-width: 768px) {
+  body.standalone-mode .floor-lottie-container {
+    width: 25vw !important;
+    height: 25vh !important;
+  }
+}


### PR DESCRIPTION
## Problem
Lottie animations at https://sirius-cybernetics-elevator-challenge.pollinations.ai/ were not resizing with browser window. PNG backgrounds worked, but Lottie stayed fixed.

## Solution
Added responsive CSS for `.floor-lottie-container`:

| Mode | Size |
|------|------|
| itch.io (iframe) | Fixed 200×200px |
| pollinations.ai (standalone) | 15vw×15vh scaling |
| Mobile (<768px) | 25vw×25vh |

## Files Changed
- `apps/sirius-cybernetics-elevator-challenge/src/styles/globals.css` (+24 lines)

## Testing
- [x] Resize browser at https://sirius-cybernetics-elevator-challenge.pollinations.ai/
- [ ] Lottie should scale with window (like PNG does)

Fixes #9440

@Circuit-Overtime ready for review!