### PR TITLE
[FEAT]: Allow the users to choose b/w pk or sk during the BYOP key exchange

### DIFF
--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -53,17 +53,29 @@ https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com
 
 With restrictions:
 ```
-https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com&app_key=pk_yourkey&models=flux,openai&expiry=7&budget=10
+https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com&app_key=pk_yourkey&key_type=publishable&models=flux,openai&expiry=7&budget=10
 ```
 
 | Param | What it does | Example |
 |-------|-------------|---------|
 | `app_key` | Your publishable key — shows app name + author on consent screen, tracks traffic for tier upgrades | `pk_abc123` |
 | `redirect_url` | Where users return after authorizing — receives the temp API key in the URL fragment | `https://myapp.com` |
+| `key_type` | Key type to create: `secret` (sk_, full access) or `publishable` (pk_, rate-limited, safe for frontend). Default: `secret`. User can toggle on the consent screen. | `publishable` |
 | `models` | Restrict to specific models | `flux,openai,gptimage` |
 | `budget` | Pollen cap | `10` |
 | `expiry` | Key lifetime in days (default: 30) | `7` |
 | `permissions` | Account access | `profile,balance,usage` |
+
+### Key Types: `sk_` vs `pk_`
+
+| | Secret (`sk_`) | Publishable (`pk_`) |
+|---|---|---|
+| **Use case** | Server-side / backend | Client-side / frontend |
+| **Rate limiting** | None | 1 pollen/IP/hour |
+| **Key length** | 32 chars | 16 chars |
+| **Safe to embed in frontend?** | No | Yes |
+
+For web apps, use `?key_type=publishable` so users get a `pk_` key by default. They can still toggle to `sk_` on the consent screen if they prefer.
 
 ### 2. Handle the Redirect
 
@@ -81,6 +93,7 @@ Fragment, not query param — never hits server logs. 🔒
 const params = new URLSearchParams({
   redirect_url: location.href,
   app_key: 'pk_yourkey', // optional — shows app name + author
+  key_type: 'publishable', // optional — pre-selects pk_ key (user can toggle)
 });
 window.location.href = `https://enter.pollinations.ai/authorize?${params}`;
 

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -56,9 +56,17 @@ export const Route = createFileRoute("/authorize")({
             budget?: number | null;
             expiry?: number | null;
             permissions?: string[] | null;
+            key_type?: "publishable" | "secret";
         } = {
             redirect_url: (search.redirect_url as string) || "",
         };
+
+        if (
+            search.key_type === "publishable" ||
+            search.key_type === "secret"
+        ) {
+            result.key_type = search.key_type;
+        }
 
         if (search.user_code && typeof search.user_code === "string") {
             result.user_code = search.user_code;
@@ -98,6 +106,7 @@ function AuthorizeComponent() {
         budget,
         expiry,
         permissions: urlPermissions,
+        key_type: urlKeyType,
     } = Route.useSearch();
     const navigate = useNavigate();
 
@@ -106,6 +115,9 @@ function AuthorizeComponent() {
     const { data: session, isPending } = authClient.useSession();
     const user = session?.user;
 
+    const [keyType, setKeyType] = useState<"publishable" | "secret">(
+        urlKeyType ?? "secret",
+    );
     const [isAuthorizing, setIsAuthorizing] = useState(false);
     const [isSigningIn, setIsSigningIn] = useState(false);
     const [error, setError] = useState<string | null>(null);

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -61,10 +61,7 @@ export const Route = createFileRoute("/authorize")({
             redirect_url: (search.redirect_url as string) || "",
         };
 
-        if (
-            search.key_type === "publishable" ||
-            search.key_type === "secret"
-        ) {
+        if (search.key_type === "publishable" || search.key_type === "secret") {
             result.key_type = search.key_type;
         }
 

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -231,9 +231,9 @@ function AuthorizeComponent() {
             ...(expiryDays !== null && {
                 expiresIn: expiryDays * SECONDS_PER_DAY,
             }),
-            prefix: "sk",
+            prefix: keyType === "publishable" ? "pk" : "sk",
             metadata: {
-                keyType: "secret",
+                keyType,
                 createdVia: isDeviceMode ? "device-flow" : "redirect-auth",
                 ...(isDeviceMode && { deviceUserCode: user_code }),
                 ...(attribution?.found && {
@@ -658,6 +658,45 @@ function AuthorizeComponent() {
                                     </li>
                                 </ul>
                             )}
+
+                            <div>
+                                <p className="text-sm font-medium text-green-950 mb-2">
+                                    Key type
+                                </p>
+                                <div className="flex gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={() => setKeyType("secret")}
+                                        className={`flex-1 text-sm rounded-lg px-3 py-2 border-2 transition-colors ${
+                                            keyType === "secret"
+                                                ? "border-green-700 bg-green-200 text-green-950 font-medium"
+                                                : "border-green-300 bg-green-50 text-green-700 hover:border-green-400"
+                                        }`}
+                                    >
+                                        <span className="font-mono">sk_</span>{" "}
+                                        Secret
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            setKeyType("publishable")
+                                        }
+                                        className={`flex-1 text-sm rounded-lg px-3 py-2 border-2 transition-colors ${
+                                            keyType === "publishable"
+                                                ? "border-green-700 bg-green-200 text-green-950 font-medium"
+                                                : "border-green-300 bg-green-50 text-green-700 hover:border-green-400"
+                                        }`}
+                                    >
+                                        <span className="font-mono">pk_</span>{" "}
+                                        Publishable
+                                    </button>
+                                </div>
+                                <p className="text-xs text-green-700 mt-1">
+                                    {keyType === "secret"
+                                        ? "Full access — keep this key private."
+                                        : "Safe to embed in frontend code — limited permissions."}
+                                </p>
+                            </div>
 
                             <KeyPermissionsInputs
                                 value={keyPermissions}


### PR DESCRIPTION
## Changes Made:- 

- New query param `?key_type=publishable` where apps can pre-select the key type in the authorize URL. Accepts publishable or secret (default: secret).

- New keyType state, initialized from the URL param, user can toggle it during auth.

- Toggle UI  added two buttons (sk_ Secret / pk_ Publishable) placed above the KeyPermissionsInputs section, with a helper text explaining the difference:

Dynamic key creation — createKeyAndSetPermissions now uses the selected type:
prefix: keyType === "publishable" ? "pk" : "sk" (was hardcoded "sk")
metadata.keyType: keyType (was hardcoded "secret")

> Before: All BYOP keys were always sk_ with no choice.
After: Users see a toggle and can pick pk_ or sk_. Apps can pre-select via ?key_type=publishable in the authorize URL.