### PR TITLE
fix: use hostname for ACE-Step music service

### DIFF
--- a/enter.pollinations.ai/secrets/dev.vars.json
+++ b/enter.pollinations.ai/secrets/dev.vars.json
@@ -18,7 +18,7 @@
 	"TINYBIRD_TIER_INGEST_TOKEN": "ENC[AES256_GCM,data:UXV/KgO2Knq/hpqFQp2YoNxK2tPLeQ4qdP5Qk1bOBSfcYa+nAvULzwM0HlzBPMqmMc6Oc23/IB7TmhmAFHctG/cVDu+5W0NIrqPBPNefzAzTG5RU8l+NEliGxm3yYy/v8YfVoxXZR0r+sQM1nEXi98xkkVCrDKf4UEbXI3PydWLUCzbU8s4QDwLwX6bFRvdjphvJ9GJ1yTIKYK/HkuaRYPSkoM45netT4ZurLkwpfcQIhWd+FpOndYiZ2ZzlWD5KpzQ4Mg0HB6Icd0kpHQ==,iv:WDcRUuvApbimYYvqBNPafCq/aSX7mxzhnO4UmSP3A5g=,tag:EHiuKnBlcVyoyaHayg0sjQ==,type:str]",
 	"TINYBIRD_GENERATION_INGEST_TOKEN": "ENC[AES256_GCM,data:L57nBCvKgpfuNNftnmsmjFxiKzkkyQrXcsrfd857dXdpU1QDUdWqLKBq4aItoazGDfSIFHii5wwFNW/i1SAMM1V2jsWqxl+p7R5i/mxgZbYgmMg1Ipp6M8PVSO6mGAkGMuZ6kQTUeSMQUs51wkQdPlbcUtFt3zKIKq4mi3wHoX08gEeJPhoVygmP1f361Ry+Wss+RNuMtFNfKsenur/iWNv4LNaFBh0awK5WSbNi2SQfJaIlifks3mtGJEK0HtB9vltPbt/3KZu+xbXJfg==,iv:KPpxhZYPQXKEbtKBa+7vejT9p3nmIBmL12HBGzPnzDI=,tag:y3YQPvXNezhQyZlrgKcbpw==,type:str]",
 	"SERAPHYN_API_KEY": "ENC[AES256_GCM,data:q+P/i1ensBd2HLgjyZJLA4OvwSMenLYISD4tDW+kkNmctV4=,iv:+rTNSSLIJgAHQuo+Z2zhfRwlwb9j9PvgJXoPNYi1iO0=,tag:QB/Necn5ZN2c+OhISf/y3w==,type:str]",
-	"MUSIC_SERVICE_URL": "ENC[AES256_GCM,data:6mrTJJQza11F/gIn7Hbg4PLwuhXWKag88l4=,iv:zvZ+8z3wb5sUNbCR9CGgXCk2ICp0x64gsONXGxY9F6M=,tag:VErT7rNBS/OadDclcNjlUg==,type:str]",
+	"MUSIC_SERVICE_URL": "ENC[AES256_GCM,data:aV0h2X3zbqi5hQtyvlesRj0hxnjgqytEhnw+NicYFIIs/cSL7asTNrg=,iv:MsgKO3q7dxsIEOQ4mazCPxy7OhG//1hG6iuIKlXPCCo=,tag:O3AzzWP1g9/ERneY1A4s9Q==,type:str]",
 	"MUSIC_SERVICE_TOKEN": "ENC[AES256_GCM,data:vA8MHcRke9LkPcj8pfA+6xJsx2QX41W5rFLt7H/9nYOBZrm2qcSAzbQi2A==,iv:2DQYd7wKKpRX0LGUdVtR18d9ONH9sI1ESOxkQv+aZbI=,tag:4xfGpyjBA09a1Ek2IsJg9A==,type:str]",
 	"sops": {
 		"age": [
@@ -27,8 +27,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhQTlYaEVoUFAyTnZrci9x\nRmZiV0xwcUpMWk1pbG1oRVNWTWhsTGluZkMwCmhyQ0lidFowMmNsT1phYXNOT1pO\neVJZSFZYZ2VqV05obXZzSGRlK2VBVkkKLS0tIFpRY201MXNRcll3M3dJVS9YNW44\nOHRCbGpuMnptWFZ1SjNwS3JsY09RQ00KKI3ha+RFfJkyNypw8sEji2oQ7u83qWC3\nMOT35Dvdce8B+bhn5tlr2D1upoMOfQr6KQr9DA7PgJuFTp53jIDhrQ==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-03T09:13:13Z",
-		"mac": "ENC[AES256_GCM,data:oAF5XTfDMsIeTRGME4A+tVnDa4rgBPb6ANXBchs4RBeGY230l5pEFOZhAGcYEhjICZm0Fx36R5wJcNpFei43v3hLuhkapKwtGp0TDPQfP/zEpIxRs2Ctr9dxOgH/GojT1jg5eA85tHQJsg8M54nye2TbKtOZbNmeOwfNAo7MKrc=,iv:e6XdBEB3GxFS8ed328zFuZvLYiAI15IZt21+60V6vEQ=,tag:L9lij3/bnt22FKR6fImwLw==,type:str]",
+		"lastmodified": "2026-04-03T10:22:24Z",
+		"mac": "ENC[AES256_GCM,data:rCES1rjIin+KTw9lruqS/s6IgiXS0xSAuUu7UP6Qfc3ma5lI5eNLVyX4+usxayjY7FPO44SXJxfC3PbTRCUN8ZCFpsqjF98aNNdbw9hIx+mwCkkY1SgJIvAaDMJ+wloBu2oht5DlsScJtGOmhu4d+APVHBm2BdOX+QR7ehM1F5s=,iv:dFo5gA95xtyY51iquF8Y2Of3yWlmnNNiuuMupD3hy68=,tag:vzKPUagEedNSzjMTUxrQRQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/enter.pollinations.ai/secrets/prod.vars.json
+++ b/enter.pollinations.ai/secrets/prod.vars.json
@@ -19,7 +19,7 @@
 	"TINYBIRD_READ_TOKEN": "ENC[AES256_GCM,data:XToEyY25lNi/nX6JkBZMx1+C8Jt/GtcoIEAPf5KIMIcJnG2p/bvcdz1AE9T4JmE6Hna95WO0a5uyzgqfhKBXwbhy9jsp6G+V9caRuK1Hb7Zw1d0hBQwBAOExW2NTmPOLAeSIYqzAVLcvFaeCiGZJfoX+owCOJJwxSDo9C56uN39nkScMWBFrImDEGw8nlrgw6X6jwPKQ8b/GhNL9TQkf2LKVgWn8TavXAqDyR6S+02su8DaKEtDl6+QzZSXRNjIgcu7uhKjXA6re2A5CwA==,iv:+ixOABiu6cFS/P2caJYNrgCWIguADZAarFHlWzHDV5s=,tag:ixwW8g6qzSEG0E2bXE5PXg==,type:str]",
 	"TINYBIRD_STRIPE_INGEST_TOKEN": "ENC[AES256_GCM,data:a8gfR+sLvDaTYRmurVleq8I/pKmc5hiHjfKT2PmkqXbuz4Wbtz6QplnA4Hu2eTvN4PUtMj3D2kaHetzdgswkWGQ/n9VMNhu4PhdOBBilkGbrbByTwcRzwFIpjQx7r5UYzv+IvocUGVf/QeTJXY1mxVmDWHb4zgRa1RyTDdmFnX6zafyfFoLICIsy4AWCta695+yHJifrW1/+16tuxQoW5rYPVC0exa97/vdwQUJpGVJcN4/OxKFq5YA8A1M1UGYFk7BUg77rS4yJ5AGchQ==,iv:g/cHLLhArhu4BjA0nRdz3FQeyaTIrZjJP/g2ylBvXko=,tag:DJo3xdlophqyJA5fzoM1gg==,type:str]",
 	"TINYBIRD_TIER_INGEST_TOKEN": "ENC[AES256_GCM,data:oJOs0XMhA9ricBz4kcKHYbfMveHiSnA8w34LTxRR3hI/Jt4DBQ8C0Ci/+iL1hRVvi4FkptxPZ8mdBYBrx05KsYZLfVLFp9lk8cjIREv9qC+OdYTP0a70Ni3weS1Jq6uCXjH2fikOVy3Xu2s7A/KZ5YWXUPlWqQinhmmelrv8w41JqiBsPSOCETkjUX82joDtmDn77wq9MNNh+mYfMmuHHc9V4oZDT/hR33Nm/+aCJjNGFjk+FKTNX4rBo9YYhdONqUurU9cSAyO4T6AXrA==,iv:++hznc5t6ZldV/80fFf9E1pHvl+OVzAEJQAcJt9duAA=,tag:34hC6iCQ8ta8VHdeiqa/7w==,type:str]",
-	"MUSIC_SERVICE_URL": "ENC[AES256_GCM,data:cev9rQlVLSJta8zmZvhMlrYISefAPrcPuPw=,iv:6PBpNUrXzEoPuo9f2+CQ5D8HB0nFjxWIWLg1HU1YwCo=,tag:p6w5IumZTJF5dhAlArn6Lg==,type:str]",
+	"MUSIC_SERVICE_URL": "ENC[AES256_GCM,data:qr5glBPwSKi/KOY6Z1SHD4EnidSuWdMjUKZZtrO1SuytDJlYzJhREQw=,iv:j0TlC5gpz9Q8PwwPt2Xxkx+R9QPit7WilkqWOEa9j4A=,tag:uKGPO3tWJ/WW4g7dFyGbZw==,type:str]",
 	"MUSIC_SERVICE_TOKEN": "ENC[AES256_GCM,data:UX9BNESfCipb5UFDPkbdazsNaJ9xEpvP/syH0zjwz4HEln+QFb8BW1IqBQ==,iv:LoL8IQ3BJj5S9adq7LHkQ04+Oq60ctQjQgnpjZ8VRtw=,tag:u8hlTPDsnWOAGENe8Rt/bg==,type:str]",
 	"sops": {
 		"age": [
@@ -28,8 +28,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsWk1qSzcvUUZtOFBLWDRz\nUEJmTFpNMW9uejlRTmF1dmlTTXo2SGNJd0NBCjd2Rlc1N1EreWlYOHlEZ3Y1OE4z\nZlRhZTc5MHlGRktsRjRCenp3YmZRa2cKLS0tIERYMmMrV1M0UGU0K0hGSGQzRC9Z\nUDhkbDdQTzlSaDNqazh5d2d5ak1jSk0KcWhLUsfMX8nJx+AbdGomZLskTj8dr+ZH\nkYjBWQ64KUrtEjwZaPsA9CtibeKBnrGvYeY9rMuldbxQP4lHqsm+ag==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-03T09:13:13Z",
-		"mac": "ENC[AES256_GCM,data:HCLb2SGowdC3t+a51SCf9Dnj1ong51tc1E4qYh7/sTN2MX1ijzFhEY5HGiCc5ytetDbEbfFxrkrbW6mYEq98cYyjXZ7eJ7piz5uelIYkHztSoEvcb///PMC71QomT9kaxBLAaq+fkULtPDiHItlIXklCCP6LI3emuo246hpYy6g=,iv:bDZhGJVSQw/UuJDDMKSulaWqXmuQtblEOUeD9pOcKTY=,tag:WYZ/moAaFgC99BIlbBbnQg==,type:str]",
+		"lastmodified": "2026-04-03T10:22:24Z",
+		"mac": "ENC[AES256_GCM,data:F4OkrPKpULX8byD/Jz2A+5hVI+oyTcBp8rg5Nbt+xmh+IwguD7Mvnqrv1H7JG7lmZchNVvcpU8RQYkBvef3DoNrzQO8r+zPdK2pVJuTG0/+R5dEeu+NgQ2VQsuIau4+zxQQ7BN1MQ7+zejOyeyi/4jEsTWE0QpY1RpAFiu90JOY=,iv:Ds9hgHcvKYOvU3uCvccWjg7Ft3pvkaDneMNQHDmcTKg=,tag:fSh4ACqUsXSmznsnFvx53g==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/enter.pollinations.ai/secrets/staging.vars.json
+++ b/enter.pollinations.ai/secrets/staging.vars.json
@@ -19,7 +19,7 @@
 	"ELEVENLABS_API_KEY": "ENC[AES256_GCM,data:li4S2siymxl9zOGQaRSY4oXzFomK/VI5kiCvqAL9hRZFkRdK9cwnLgzoLJ7V0hyrppJR,iv:H9pDLC60n3tDs3IT/VdslioIgBYglt7ex1ldbS1+JPE=,tag:ZYSRNNU6L5UHmFMO9JBizQ==,type:str]",
 	"AIRFORCE_API_KEY": "ENC[AES256_GCM,data:IUIpX4Lr6Drlf7v5fPAtrMAxduJNszLmlvxZ8TufmgVFHh37897v+bkDqcjzI0xskqrPPqGgfmHnD8FdnOveiD70IgInImA=,iv:SY4HTUKaPfp8s6kHpOmGmJTmWgWUiXlHax0a5iKGcmQ=,tag:/KUOlgJVVy0SXBmPlpmFVA==,type:str]",
 	"OVHCLOUD_API_KEY": "ENC[AES256_GCM,data:4GJ21q78x+mzz+Yb1hDj7x5zzwMrgcWqKpBt2UhaXMsyUSnJ2jLtrydsv/zPxoP9jPtULOg0IEXBaEqXhMg37gfRWtcUyEXOKOUG45S8glymHGskWk+OHHzrBPWkdz6pn8bHyIOlEXv++SNAU35ciDmulb+iOrc00BuIAoqIkGGfRuCNofXl3T2ybzbvzCS1f7eQcq6WJxGpCaXhaOWSTcPCgfiOCYPvGsFRd3dLPoEh0UhdvBvQj8EZn5brKSlLChstXz/Qyf2kzPiBmKujlEIJMcGsMaNrhxjjzD3V0/fQnNh8NauKL4ROoXxHI8mCRhJWTx4QYp8Gw6+wSKpVappxll+kfigsmRP/03DJcmv3KnYpD1fGj2QS,iv:JmtJvXGnek/eqx95DsRUlFnNn+CuWHHv75JNgDjMAdg=,tag:duGxb9BOdJ5RMAJWRSyizA==,type:str]",
-	"MUSIC_SERVICE_URL": "ENC[AES256_GCM,data:XXPDcxGMDX7GRxFRhF7MhIa6ZimZllfIZoE=,iv:zVEd+5fISsY0nfdwecpanAbRd+FjHaS0H36TfKSpzRQ=,tag:pu3kxShL+JWvUZwl9bPWXA==,type:str]",
+	"MUSIC_SERVICE_URL": "ENC[AES256_GCM,data:5Mk4t9kdRsTfe8ho4+36Uqvx3xmEFlWin/WbB2XTScYcRRwP1jmafyo=,iv:z+p6f3U7NVw7S1QMFk6DoA7acpRaJSREdQ0SNJcpAh0=,tag:SVAM3YUiQg2MQiOCbxICcg==,type:str]",
 	"MUSIC_SERVICE_TOKEN": "ENC[AES256_GCM,data:y3wpkbgdIxDB8UgurEd+kI02q4qVWZM2sMbrfqjZ29sEueGq3Ogdr2hDpQ==,iv:WQK1Tiz1NQDT/VW0XiGvhfXjxt3WNEJpsd63kvtDuB0=,tag:g02VL0zw9v1cP+jS6Uha4w==,type:str]",
 	"sops": {
 		"age": [
@@ -28,8 +28,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPVUdZNXNQdG9vVlhLb1Jr\ndVlBcTdmN004Qi9JbU5HL3Qrc3NHeGVweGhRCml3Rnd1bnQ0TXJ4Z2lpWHhSTGxC\nRXU0cXJ0aXQ4RWpPK2t4NkxtNGpqM00KLS0tIHBzM2l0clZIakdkb1dtNXRvdHpM\na3B5TU9tZFVuNmlYcmNzVXFzLzVEOXMK7wKyp3BPjMzhho9yMoNtJ1Dtzz89T+cu\nMuv8HHQM/cI/SvwxPxFipCcfoIyGoFm/A1VhLPFHJ6fu4W5b2jnf5g==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-03T09:13:13Z",
-		"mac": "ENC[AES256_GCM,data:EjkVBJxVjXKbBiUcj68P9oj8OzBmi9EtlxJ/6AKQ/oGtMLVPqWKL8pCzciln1QNlTG+9UhbBXRjW2VGhiTcmFen+gmPmQ3PNqeMmmITCdDB2Lr1AVvlH4jBXUz7iWLa3KbUnuRecofg6D+AH7a+WN6yDpzi374FKyu0ceXbl98g=,iv:3/RtE6uyVogtG8UY4tbEey2qQIyAXupoS12CBw+BFhU=,tag:Pzy3dxmXbSSE6l6f7D9eSQ==,type:str]",
+		"lastmodified": "2026-04-03T10:22:24Z",
+		"mac": "ENC[AES256_GCM,data:eO5snIot1kJrqi5Q11Xco8ZCCG1dHd3PM9A8jN3kobmyx/g3gAGFCHFK+xesh/57PpupLeLFkwn8TsnBbBCf2pMg/vfShb7mqkv9sxhx0hiPcURjf242S49X2TfyUmvRAPJudJwx7J0trP8O3FTq0S1sjsRH8GLvaPiOU7nJn70=,iv:T1YuGPv6duL7KXdbJaImxdQ2Xwq1xC/Oiz6UZWp+QYQ=,tag:jCIdV/kuGUmkl5YwNrk21w==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
## Summary
- Updates encrypted secrets (dev/staging/prod) to use `music-backend.pollinations.ai:8189` instead of bare IP `192.222.51.105:8189`
- CF Workers can't reach bare IPs (error 1003), hostname required
- DNS A record already configured, production secrets already pushed via `wrangler secret put`
- Supersedes #9878 (had merge conflicts)

## Test plan
- [x] Production already tested end-to-end (both GET /audio/:text and POST /v1/audio/speech return valid MP3s)
- [x] DNS record verified: `music-backend.pollinations.ai → 192.222.51.105`

🤖 Generated with [Claude Code](https://claude.com/claude-code)