### PR TITLE
fix: update EC2 hostname after instance restart

### DIFF
--- a/.claude/skills/enter-services/SKILL.md
+++ b/.claude/skills/enter-services/SKILL.md
@@ -19,7 +19,7 @@ Must run from the `pollinations` repo root.
 
 | Environment | Gateway (Cloudflare Worker) | Text/Image Services (EC2) |
 |-------------|----------------------------|---------------------------|
-| **Production** | `enter.pollinations.ai` | `3.80.56.235` (ports 16384/16385) |
+| **Production** | `enter.pollinations.ai` | `54.147.14.220` (ports 16384/16385) |
 | **Staging** | `staging.enter.pollinations.ai` | `44.222.254.250` (ports 16384/16385) |
 
 ---
@@ -30,7 +30,7 @@ Add to `~/.ssh/config`:
 ```
 # Production instance
 Host enter-services
-  HostName 3.80.56.235
+  HostName 54.147.14.220
   User ubuntu
   IdentityFile ~/.ssh/enter-services-shared-key
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,8 @@ curl "http://localhost:3000/api/generate/v1/chat/completions" -H "Authorization:
 To test enter.pollinations.ai with local text/image services, edit `enter.pollinations.ai/wrangler.toml`:
 ```toml
 # Default (remote EC2):
-IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
-TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
+TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 
 # For local testing (env.local):
 IMAGE_SERVICE_URL = "http://localhost:16384"

--- a/enter.pollinations.ai/test/mocks/text-service.ts
+++ b/enter.pollinations.ai/test/mocks/text-service.ts
@@ -65,7 +65,7 @@ export function createMockTextService(): MockAPI<TextServiceState> {
     return {
         state,
         handlerMap: {
-            "ec2-3-80-56-235.compute-1.amazonaws.com:16385":
+            "ec2-54-147-14-220.compute-1.amazonaws.com:16385":
                 createHonoMockHandler(app),
         },
         reset: () => {

--- a/enter.pollinations.ai/worker-bindings.d.ts
+++ b/enter.pollinations.ai/worker-bindings.d.ts
@@ -65,8 +65,8 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
-        IMAGE_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384";
-        TEXT_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385";
+        IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
+        TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         POLLEN_REFILL_PER_HOUR: 1;
         NOWPAYMENTS_ENV: "production";
         STRIPE_MODE: "live";
@@ -113,8 +113,8 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
-        IMAGE_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384";
-        TEXT_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385";
+        IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
+        TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         STRIPE_MODE: "sandbox";
         STRIPE_SUCCESS_URL: "https://staging.enter.pollinations.ai";
         BETTER_AUTH_SECRET: string;
@@ -158,8 +158,8 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
-        IMAGE_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384";
-        TEXT_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385";
+        IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
+        TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         STRIPE_MODE: "sandbox";
         STRIPE_SUCCESS_URL: "https://dev.enter.pollinations.ai";
         BETTER_AUTH_SECRET: string;
@@ -204,8 +204,8 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "http://localhost:7181/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "http://localhost:7181/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "http://localhost:7181/v0/events?name=stripe_event";
-        IMAGE_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384";
-        TEXT_SERVICE_URL: "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385";
+        IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
+        TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         BETTER_AUTH_SECRET: string;
         POLAR_ACCESS_TOKEN: string;
         POLAR_WEBHOOK_SECRET: string;
@@ -290,10 +290,10 @@ declare namespace Cloudflare {
             | "http://localhost:7181/v0/events?name=stripe_event";
         IMAGE_SERVICE_URL:
             | "http://localhost:16384"
-            | "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384";
+            | "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
         TEXT_SERVICE_URL:
             | "http://localhost:16385"
-            | "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385";
+            | "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         STRIPE_MODE?: "sandbox" | "live";
         STRIPE_SUCCESS_URL?:
             | "http://localhost:3000"

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -53,8 +53,8 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
-IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
-TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
+TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 # NOWPayments crypto payments (sandbox for dev)
 NOWPAYMENTS_ENV = "sandbox"
 # Stripe payments (sandbox for dev)
@@ -163,8 +163,8 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
-IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
-TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
+TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 POLLEN_REFILL_PER_HOUR = 1
 # NOWPayments crypto payments (production)
 NOWPAYMENTS_ENV = "production"
@@ -227,8 +227,8 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
-IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
-TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
+TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 # Stripe payments: sandbox mode for staging
 STRIPE_MODE = "sandbox"
 STRIPE_SUCCESS_URL = "https://staging.enter.pollinations.ai"
@@ -285,8 +285,8 @@ TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events
 # Staging URLs: IMAGE_SERVICE_URL = "http://ec2-44-222-254-250.compute-1.amazonaws.com:16384"
 #               TEXT_SERVICE_URL = "http://ec2-44-222-254-250.compute-1.amazonaws.com:16385"
 # Currently using prod services for simplicity
-IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
-TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
+TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 # Stripe payments (sandbox for dev)
 STRIPE_MODE = "sandbox"
 STRIPE_SUCCESS_URL = "https://dev.enter.pollinations.ai"
@@ -341,5 +341,5 @@ TINYBIRD_GENERATION_INGEST_TOKEN = "test_tinybird_generation_ingest_token"
 TINYBIRD_TIER_INGEST_TOKEN = "test_tinybird_tier_ingest_token"
 TINYBIRD_POLAR_INGEST_TOKEN = "test_tinybird_polar_ingest_token"
 TINYBIRD_READ_TOKEN = "test_tinybird_read_token"
-IMAGE_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384"
-TEXT_SERVICE_URL = "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385"
+IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
+TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"

--- a/image.pollinations.ai/IONET_DEPLOYMENT_SUMMARY.md
+++ b/image.pollinations.ai/IONET_DEPLOYMENT_SUMMARY.md
@@ -15,7 +15,7 @@
 
 ### 1. Cloudflare Blocking Issue
 **Problem**: Some io.net outbound IPs were blocked by Cloudflare WAF
-**Solution**: Updated all services to use direct EC2 endpoint `http://3.80.56.235:16384/register`
+**Solution**: Updated all services to use direct EC2 endpoint `http://54.147.14.220:16384/register`
 
 ### 2. Flux Public IP Detection
 **Problem**: Containers auto-detected wrong internal IP (209.137.137.19 instead of 3.21.229.114)

--- a/image.pollinations.ai/IONET_INSTANCES.md
+++ b/image.pollinations.ai/IONET_INSTANCES.md
@@ -115,12 +115,12 @@ ssh -i ~/.ssh/pollinations_services_2026 -p 18960 root@ssh3.vast.ai
 ## Heartbeat Registration
 
 All GPU workers send heartbeats to the EC2 gateway:
-- **URL**: `http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register`
+- **URL**: `http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register`
 - **Payload**: `{"url": "http://IP:PORT", "type": "flux|zimage"}`
 
 To check currently registered servers:
 ```bash
-curl -s http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register
+curl -s http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register
 ```
 
 ## Service Management

--- a/image.pollinations.ai/VASTAI_INSTANCES.md
+++ b/image.pollinations.ai/VASTAI_INSTANCES.md
@@ -265,7 +265,7 @@ curl http://<PUBLIC_IP>:<MAPPED_FLUX_PORT>/docs
 ## Heartbeat Registration
 
 Servers send heartbeats to the EC2 image service:
-- **URL**: `http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register`
+- **URL**: `http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register`
 - **Payload**: `{"url": "http://PUBLIC_IP:PUBLIC_PORT", "type": "flux"}`
 - **Interval**: Every 30 seconds
 

--- a/image.pollinations.ai/nunchaku/Dockerfile.updated
+++ b/image.pollinations.ai/nunchaku/Dockerfile.updated
@@ -6,6 +6,6 @@ COPY server.py /app/server.py
 
 # Environment variables can be set at runtime, but we'll set sensible defaults
 ENV SERVICE_TYPE=flux
-ENV REGISTER_URL=http://3.80.56.235:16384/register
+ENV REGISTER_URL=http://54.147.14.220:16384/register
 
 # The entrypoint and CMD are inherited from the base image

--- a/image.pollinations.ai/nunchaku/server.py
+++ b/image.pollinations.ai/nunchaku/server.py
@@ -63,7 +63,7 @@ async def send_heartbeat():
             url = f"http://{public_ip}:{port}"
             service_type = os.getenv("SERVICE_TYPE", "flux")  # Get service type from environment variable
             # Use direct EC2 endpoint to bypass Cloudflare (some io.net IPs are blocked)
-            register_url = os.getenv("REGISTER_URL", "http://3.80.56.235:16384/register")
+            register_url = os.getenv("REGISTER_URL", "http://54.147.14.220:16384/register")
             async with aiohttp.ClientSession() as session:
                 async with session.post(register_url, json={'url': url, 'type': service_type}) as response:
                     if response.status == 200:

--- a/image.pollinations.ai/serverConfigAndScripts/check_instances.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/check_instances.sh
@@ -28,7 +28,7 @@ log "----------------------------------------"
 log "Fetching registered servers from EC2 image service..."
 
 # Use direct EC2 endpoint (requires SSH tunnel or internal access)
-REGISTER_URL="${REGISTER_URL:-http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register}"
+REGISTER_URL="${REGISTER_URL:-http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register}"
 registered_response=$(curl -s "$REGISTER_URL")
 if [ $? -ne 0 ]; then
     log "ERROR: Failed to fetch data from $REGISTER_URL"

--- a/image.pollinations.ai/serverConfigAndScripts/run_with_heartbeat.sh
+++ b/image.pollinations.ai/serverConfigAndScripts/run_with_heartbeat.sh
@@ -3,7 +3,7 @@
 # Default values
 HEARTBEAT_INTERVAL=30
 # Use direct EC2 endpoint to bypass Cloudflare (some io.net IPs are blocked)
-POLLINATIONS_URL="${REGISTER_URL:-http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register}"
+POLLINATIONS_URL="${REGISTER_URL:-http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register}"
 
 # Function to get public IP
 get_public_ip() {

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/run.sh
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/run.sh
@@ -6,7 +6,7 @@ set -e
 export CUDA_VISIBLE_DEVICES=0
 export PORT=8765
 export SERVICE_TYPE=ltx2
-export REGISTER_URL="${REGISTER_URL:-http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register}"
+export REGISTER_URL="${REGISTER_URL:-http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register}"
 export PLN_IMAGE_BACKEND_TOKEN="${PLN_IMAGE_BACKEND_TOKEN:?Set PLN_IMAGE_BACKEND_TOKEN env var}"
 export COMFYUI_ROOT="${COMFYUI_ROOT:-/home/ubuntu/comfy/ComfyUI}"
 export COMFYUI_LOG="${COMFYUI_LOG:-/home/ubuntu/comfy/comfyui.log}"

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server.py
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server.py
@@ -27,7 +27,7 @@ FRAME_COUNT_NODE = "177:113"
 SEED_NODES = ["177:118", "177:123"]
 
 # Heartbeat config
-REGISTER_URL = os.environ.get("REGISTER_URL", "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register")
+REGISTER_URL = os.environ.get("REGISTER_URL", "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register")
 PUBLIC_IP = os.environ.get("PUBLIC_IP", "")
 PUBLIC_PORT = os.environ.get("PUBLIC_PORT", "")
 SERVICE_TYPE = os.environ.get("SERVICE_TYPE", "ltx2")

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
@@ -23,7 +23,7 @@ WIDTH_HEIGHT_NODE = "177:131"
 FRAME_COUNT_NODE = "177:113"
 SEED_NODES = ["177:118", "177:123"]
 
-REGISTER_URL = os.environ.get("REGISTER_URL", "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register")
+REGISTER_URL = os.environ.get("REGISTER_URL", "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register")
 PUBLIC_IP = os.environ.get("PUBLIC_IP", "")
 PUBLIC_PORT = os.environ.get("PUBLIC_PORT", "")
 SERVICE_TYPE = os.environ.get("SERVICE_TYPE", "ltx2")

--- a/image.pollinations.ai/z-image/server.py
+++ b/image.pollinations.ai/z-image/server.py
@@ -54,7 +54,7 @@ async def send_heartbeat():
             url = f"http://{public_ip}:{port}"
             service_type = os.getenv("SERVICE_TYPE", "zimage")
             # Use direct EC2 endpoint to bypass Cloudflare (some io.net IPs are blocked)
-            register_url = os.getenv("REGISTER_URL", "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/register")
+            register_url = os.getenv("REGISTER_URL", "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register")
             async with aiohttp.ClientSession() as session:
                 async with session.post(
                     register_url,


### PR DESCRIPTION
## Summary
- Updates EC2 hostname from `ec2-3-80-56-235` to `ec2-54-147-14-220` after force-stop/restart
- Updates wrangler.toml, worker bindings, server scripts, and docs (16 files)
- Services verified running on new instance (image :16384, text :16385, discord bots)

## Test plan
- [ ] CI deploys updated wrangler.toml to Cloudflare Workers
- [ ] Image and text generation work via gen.pollinations.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)