### PR TITLE
migrate claude models to aws bedrock + rename to version-based names

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -353,7 +353,7 @@ export const TEXT_SERVICES = {
     "midijourney": {
         aliases: [],
         modelId: "claude-haiku-4-5-20251001",
-        provider: "anthropic",
+        provider: "bedrock",
         cost: [
             {
                 date: COST_START_DATE,
@@ -371,7 +371,7 @@ export const TEXT_SERVICES = {
     "midijourney-large": {
         aliases: [],
         modelId: "claude-opus-4-6",
-        provider: "anthropic",
+        provider: "bedrock",
         paidOnly: true,
         cost: [
             {
@@ -387,10 +387,10 @@ export const TEXT_SERVICES = {
         tools: true,
         isSpecialized: true,
     },
-    "claude-fast": {
-        aliases: ["claude-haiku-4.5", "claude-haiku"],
+    "claude-haiku-4.5": {
+        aliases: ["claude-fast", "claude-haiku"],
         modelId: "claude-haiku-4-5-20251001",
-        provider: "anthropic",
+        provider: "bedrock",
         cost: [
             {
                 date: COST_START_DATE,
@@ -406,10 +406,10 @@ export const TEXT_SERVICES = {
         contextLength: 200000,
         isSpecialized: false,
     },
-    "claude": {
-        aliases: ["claude-sonnet-4.6", "claude-sonnet"],
+    "claude-sonnet-4.6": {
+        aliases: ["claude", "claude-sonnet"],
         modelId: "claude-sonnet-4-6",
-        provider: "anthropic",
+        provider: "bedrock",
         paidOnly: true,
         cost: [
             {
@@ -426,10 +426,10 @@ export const TEXT_SERVICES = {
         contextLength: 200000,
         isSpecialized: false,
     },
-    "claude-large": {
-        aliases: ["claude-opus-4.6", "claude-opus"],
+    "claude-opus-4.6": {
+        aliases: ["claude-large", "claude-opus"],
         modelId: "claude-opus-4-6",
-        provider: "anthropic",
+        provider: "bedrock",
         paidOnly: true,
         cost: [
             {
@@ -446,10 +446,10 @@ export const TEXT_SERVICES = {
         contextLength: 200000,
         isSpecialized: false,
     },
-    "claude-legacy": {
-        aliases: ["claude-opus-4.5", "claude-large-legacy"],
+    "claude-opus-4.5": {
+        aliases: ["claude-legacy", "claude-large-legacy"],
         modelId: "claude-opus-4-5-20251101",
-        provider: "anthropic",
+        provider: "bedrock",
         paidOnly: true,
         hidden: true,
         cost: [

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -77,19 +77,19 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["gpt-audio-2025-12-15"],
     },
     {
-        name: "claude-fast",
+        name: "claude-haiku-4.5",
         config: portkeyConfig["claude-haiku-4-5"],
     },
     {
-        name: "claude",
+        name: "claude-sonnet-4.6",
         config: portkeyConfig["claude-sonnet-4-6"],
     },
     {
-        name: "claude-large",
+        name: "claude-opus-4.6",
         config: portkeyConfig["claude-opus-4-6"],
     },
     {
-        name: "claude-legacy",
+        name: "claude-opus-4.5",
         config: portkeyConfig["claude-opus-4-5"],
     },
     {

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -1,6 +1,5 @@
 import googleCloudAuth from "../auth/googleCloudAuth.js";
 import {
-    createAnthropicConfig,
     createAzureModelConfig,
     createAzureXaiModelConfig,
     createBedrockNativeConfig,
@@ -102,25 +101,25 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "Mistral-Small-3.2-24B-Instruct-2506",
         }),
 
-    // -- Claude Direct Anthropic API ------------------------------------------
+    // -- Claude via AWS Bedrock -----------------------------------------------
     "claude-sonnet-4-6": () =>
-        createAnthropicConfig({
-            model: "claude-sonnet-4-6",
+        createBedrockNativeConfig({
+            model: "us.anthropic.claude-sonnet-4-6",
             defaultOptions: { max_tokens: 64000 },
         }),
     "claude-opus-4-6": () =>
-        createAnthropicConfig({
-            model: "claude-opus-4-6",
+        createBedrockNativeConfig({
+            model: "us.anthropic.claude-opus-4-6-v1",
             defaultOptions: { max_tokens: 128000 },
         }),
     "claude-opus-4-5": () =>
-        createAnthropicConfig({
-            model: "claude-opus-4-5-20251101",
+        createBedrockNativeConfig({
+            model: "us.anthropic.claude-opus-4-5-20251101-v1:0",
             defaultOptions: { max_tokens: 64000 },
         }),
     "claude-haiku-4-5": () =>
-        createAnthropicConfig({
-            model: "claude-haiku-4-5-20251001",
+        createBedrockNativeConfig({
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             defaultOptions: { max_tokens: 64000 },
         }),
 


### PR DESCRIPTION
- Moves all Claude models (Haiku 4.5, Sonnet 4.6, Opus 4.6, Opus 4.5) from direct Anthropic API to AWS Bedrock
- Renames primary registry keys to version-based format (`claude-haiku-4.5`, `claude-sonnet-4.6`, `claude-opus-4.6`, `claude-opus-4.5`)
- Old names (`claude`, `claude-fast`, `claude-large`, `claude-legacy`) preserved as aliases for backward compatibility
- Uses existing AWS credentials (same as Nova models), no new secrets needed
- Pricing unchanged (Bedrock matches direct Anthropic pricing)
- All models and aliases tested locally against Bedrock, 32 unit tests pass