### PR TITLE
feat: add API key management endpoints (create, list, revoke)

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
@@ -31,6 +31,11 @@ const ACCOUNT_PERMISSIONS = [
         label: "Usage",
         tooltip: "Read usage history",
     },
+    {
+        id: "keys",
+        label: "Key Management",
+        tooltip: "Create, list, and revoke API keys via API",
+    },
 ] as const;
 
 const textModels = Object.keys(TEXT_SERVICES)

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -10,6 +10,7 @@ import {
 } from "@/db/schema/better-auth.ts";
 import type { ApiKeyType } from "@/db/schema/event.ts";
 import { getTierCadence, tierNames } from "@/tier-config.ts";
+import { invalidateApiKeyCache } from "../auth.ts";
 
 // Calculate next tier refill time (null for tiers with no refill)
 function getNextRefillAt(tier?: string | null): string | null {
@@ -25,9 +26,68 @@ function getNextRefillAt(tier?: string | null): string | null {
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import { validator } from "../middleware/validator.ts";
+import { parseMetadata } from "./metadata-utils.ts";
 
 // Cache TTL in seconds
 const CACHE_TTL = 60 * 60; // 1 hour
+
+const SECONDS_PER_DAY = 86400;
+
+/**
+ * Require that the caller has `account:keys` permission and is using a secret key.
+ * Session-authenticated users (no apiKey) are always allowed.
+ */
+function requireKeysPermission(apiKey?: {
+    permissions?: Record<string, string[]>;
+    metadata?: Record<string, unknown>;
+}): void {
+    if (!apiKey) return; // session auth — always allowed
+    const keyType = (apiKey.metadata?.keyType as string) || "secret";
+    if (keyType !== "secret") {
+        throw new HTTPException(403, {
+            message: "Only secret keys (sk_) can manage API keys",
+        });
+    }
+    if (!apiKey.permissions?.account?.includes("keys")) {
+        throw new HTTPException(403, {
+            message: "API key does not have 'account:keys' permission",
+        });
+    }
+}
+
+// Schema for creating an API key via the API
+const CreateKeySchema = z.object({
+    name: z.string().min(1).max(253).describe("Name for the API key"),
+    type: z
+        .enum(["secret", "publishable"])
+        .optional()
+        .default("secret")
+        .describe("Key type: secret (sk_) or publishable (pk_)"),
+    expiresIn: z
+        .number()
+        .int()
+        .positive()
+        .max(365 * SECONDS_PER_DAY)
+        .optional()
+        .describe("Expiry in seconds from now (max 365 days)"),
+    allowedModels: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("Model IDs this key can access. null = all models"),
+    pollenBudget: z
+        .number()
+        .nullable()
+        .optional()
+        .describe("Pollen budget cap. null = unlimited"),
+    accountPermissions: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+            'Account permissions (e.g. ["balance", "usage"]). "keys" is auto-stripped.',
+        ),
+});
 
 // CSV escape helper
 const escapeCSV = (val: string | number | boolean | null) => {
@@ -578,6 +638,226 @@ export const accountRoutes = new Hono<Env>()
                 log.error("Error fetching daily usage: {error}", { error });
                 return c.json({ error: "Failed to fetch usage data" }, 500);
             }
+        },
+    )
+    .get(
+        "/keys",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "List API Keys",
+            description:
+                "List all API keys for the current user. Requires `account:keys` permission when using API keys. Secret key values are never returned.",
+            responses: {
+                200: { description: "List of API keys" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+            },
+        }),
+        async (c) => {
+            await c.var.auth.requireAuthorization();
+            const user = c.var.auth.requireUser();
+            requireKeysPermission(c.var.auth.apiKey);
+
+            const db = drizzle(c.env.DB);
+            const keys = await db
+                .select({
+                    id: apikeyTable.id,
+                    name: apikeyTable.name,
+                    start: apikeyTable.start,
+                    prefix: apikeyTable.prefix,
+                    createdAt: apikeyTable.createdAt,
+                    expiresAt: apikeyTable.expiresAt,
+                    lastRequest: apikeyTable.lastRequest,
+                    permissions: apikeyTable.permissions,
+                    metadata: apikeyTable.metadata,
+                    pollenBalance: apikeyTable.pollenBalance,
+                    enabled: apikeyTable.enabled,
+                })
+                .from(apikeyTable)
+                .where(eq(apikeyTable.userId, user.id))
+                .all();
+
+            c.header("Cache-Control", "private, no-store, max-age=0");
+            return c.json({
+                data: keys.map((key) => ({
+                    id: key.id,
+                    name: key.name,
+                    start: key.start,
+                    prefix: key.prefix,
+                    createdAt: key.createdAt,
+                    expiresAt: key.expiresAt,
+                    lastRequest: key.lastRequest,
+                    permissions: key.permissions
+                        ? (() => {
+                              try {
+                                  return JSON.parse(key.permissions);
+                              } catch {
+                                  return null;
+                              }
+                          })()
+                        : null,
+                    metadata: parseMetadata(key.metadata),
+                    pollenBalance: key.pollenBalance,
+                    enabled: key.enabled,
+                })),
+            });
+        },
+    )
+    .post(
+        "/keys",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "Create API Key",
+            description:
+                "Create a new API key. Requires `account:keys` permission and a secret key (sk_). The full key value is returned only once in the response. The `keys` account permission is automatically stripped from child keys to prevent escalation.",
+            responses: {
+                200: { description: "Created API key with full secret" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied or publishable key" },
+            },
+        }),
+        validator("json", CreateKeySchema),
+        async (c) => {
+            await c.var.auth.requireAuthorization();
+            const user = c.var.auth.requireUser();
+            requireKeysPermission(c.var.auth.apiKey);
+
+            const {
+                name,
+                type,
+                expiresIn,
+                allowedModels,
+                pollenBudget,
+                accountPermissions,
+            } = c.req.valid("json");
+
+            const isPublishable = type === "publishable";
+            const prefix = isPublishable ? "pk" : "sk";
+
+            // Strip "keys" from child account permissions to prevent escalation
+            const safeAccountPerms = accountPermissions
+                ? accountPermissions.filter((p) => p !== "keys")
+                : accountPermissions;
+
+            // Build permissions object
+            const permissions: Record<string, string[]> = {};
+            if (allowedModels) permissions.models = allowedModels;
+            if (safeAccountPerms && safeAccountPerms.length > 0)
+                permissions.account = safeAccountPerms;
+
+            // Create key via better-auth server API (no session needed when passing userId)
+            const authClient = c.var.auth.client;
+            const created = await authClient.api.createApiKey({
+                body: {
+                    name,
+                    prefix,
+                    userId: user.id,
+                    ...(expiresIn != null && { expiresIn }),
+                    metadata: {
+                        keyType: type,
+                        createdVia: "api",
+                    },
+                    permissions:
+                        Object.keys(permissions).length > 0
+                            ? permissions
+                            : undefined,
+                },
+            });
+
+            if (!created?.id || !created?.key) {
+                throw new HTTPException(500, {
+                    message: "Failed to create API key",
+                });
+            }
+
+            const db = drizzle(c.env.DB);
+
+            // Set D1 custom fields (pollenBudget, publishable plaintext)
+            const d1Updates: Record<string, unknown> = {};
+            if (pollenBudget != null) d1Updates.pollenBalance = pollenBudget;
+            if (isPublishable) {
+                d1Updates.metadata = JSON.stringify({
+                    keyType: type,
+                    createdVia: "api",
+                    plaintextKey: created.key,
+                });
+            }
+
+            if (Object.keys(d1Updates).length > 0) {
+                await db
+                    .update(apikeyTable)
+                    .set(d1Updates)
+                    .where(eq(apikeyTable.id, created.id));
+            }
+
+            return c.json({
+                id: created.id,
+                key: created.key,
+                name: created.name,
+                type,
+                prefix,
+                start: created.start,
+                expiresAt: created.expiresAt,
+                permissions:
+                    Object.keys(permissions).length > 0 ? permissions : null,
+                pollenBudget: pollenBudget ?? null,
+            });
+        },
+    )
+    .delete(
+        "/keys/:id",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "Revoke API Key",
+            description:
+                "Delete/revoke an API key. Requires `account:keys` permission and a secret key (sk_). Cannot revoke the key used to authenticate the request.",
+            responses: {
+                200: { description: "Key revoked" },
+                400: { description: "Cannot revoke self" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+                404: { description: "Key not found" },
+            },
+        }),
+        async (c) => {
+            await c.var.auth.requireAuthorization();
+            const user = c.var.auth.requireUser();
+            const callerKey = c.var.auth.apiKey;
+            requireKeysPermission(callerKey);
+
+            const { id } = c.req.param();
+
+            // Prevent self-revocation
+            if (callerKey && callerKey.id === id) {
+                throw new HTTPException(400, {
+                    message:
+                        "Cannot revoke the API key used to authenticate this request",
+                });
+            }
+
+            const db = drizzle(c.env.DB);
+            const key = await db
+                .select()
+                .from(apikeyTable)
+                .where(
+                    and(
+                        eq(apikeyTable.id, id),
+                        eq(apikeyTable.userId, user.id),
+                    ),
+                )
+                .get();
+
+            if (!key) {
+                throw new HTTPException(404, { message: "API key not found" });
+            }
+
+            // Delete from DB and invalidate cache
+            await Promise.all([
+                db.delete(apikeyTable).where(eq(apikeyTable.id, id)),
+                invalidateApiKeyCache(c.env, key),
+            ]);
+
+            return c.json({ success: true });
         },
     )
     .get(

--- a/enter.pollinations.ai/test/integration/account-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/account-keys.test.ts
@@ -1,0 +1,380 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
+
+describe("Account Key Management API", () => {
+    describe("POST /api/account/keys (create)", () => {
+        test("should create a secret key via session auth", async ({
+            sessionToken,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "test-child-key",
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.id).toBeTruthy();
+            expect(data.key).toBeTruthy();
+            expect(data.key.startsWith("sk_")).toBe(true);
+            expect(data.name).toBe("test-child-key");
+            expect(data.type).toBe("secret");
+        });
+
+        test("should create a publishable key", async ({ sessionToken }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "test-pub-key",
+                        type: "publishable",
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.key.startsWith("pk_")).toBe(true);
+            expect(data.type).toBe("publishable");
+        });
+
+        test("should create key with permissions and budget", async ({
+            sessionToken,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "restricted-child",
+                        allowedModels: ["flux", "openai"],
+                        pollenBudget: 50,
+                        accountPermissions: ["balance", "usage"],
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.permissions).toEqual({
+                models: ["flux", "openai"],
+                account: ["balance", "usage"],
+            });
+            expect(data.pollenBudget).toBe(50);
+        });
+
+        test("should strip 'keys' from child account permissions", async ({
+            sessionToken,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "escalation-attempt",
+                        accountPermissions: ["balance", "keys", "usage"],
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            // "keys" should be stripped
+            expect(data.permissions.account).toEqual(["balance", "usage"]);
+            expect(data.permissions.account).not.toContain("keys");
+        });
+
+        test("should create key via API key with account:keys permission", async ({
+            auth,
+            sessionToken,
+        }) => {
+            // First create a key with account:keys permission via session
+            const createParent = await auth.apiKey.create({
+                name: "parent-key",
+                prefix: "sk",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+            if (!createParent.data)
+                throw new Error("Failed to create parent key");
+
+            // Set account:keys permission via the update endpoint
+            const updateResp = await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${createParent.data.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        accountPermissions: ["keys"],
+                    }),
+                },
+            );
+            expect(updateResp.status).toBe(200);
+
+            // Now use the parent key to create a child key
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${createParent.data.key}`,
+                    },
+                    body: JSON.stringify({
+                        name: "child-from-api",
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.key.startsWith("sk_")).toBe(true);
+            expect(data.name).toBe("child-from-api");
+        });
+
+        test("should reject API key without account:keys permission", async ({
+            apiKey,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${apiKey}`,
+                    },
+                    body: JSON.stringify({
+                        name: "should-fail",
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(403);
+        });
+
+        test("should reject publishable key even with keys permission", async ({
+            auth,
+            sessionToken,
+        }) => {
+            // Create a publishable key
+            const createPub = await auth.apiKey.create({
+                name: "pub-with-keys-perm",
+                prefix: "pk",
+                metadata: { keyType: "publishable" },
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+            if (!createPub.data) throw new Error("Failed to create pk key");
+
+            // Set account:keys permission
+            await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${createPub.data.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        accountPermissions: ["keys"],
+                    }),
+                },
+            );
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${createPub.data.key}`,
+                    },
+                    body: JSON.stringify({ name: "should-fail" }),
+                },
+            );
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe("GET /api/account/keys (list)", () => {
+        test("should list keys via session auth", async ({
+            sessionToken,
+            apiKey,
+        }) => {
+            expect(apiKey).toBeTruthy(); // ensure at least one key exists
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.data).toBeInstanceOf(Array);
+            expect(data.data.length).toBeGreaterThanOrEqual(1);
+
+            // Keys should not contain the full secret
+            for (const key of data.data) {
+                expect(key).toHaveProperty("id");
+                expect(key).toHaveProperty("name");
+                expect(key).toHaveProperty("start");
+                expect(key).not.toHaveProperty("key");
+            }
+        });
+
+        test("should reject API key without account:keys permission", async ({
+            apiKey,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe("DELETE /api/account/keys/:id (revoke)", () => {
+        test("should revoke a key via session auth", async ({
+            auth,
+            sessionToken,
+        }) => {
+            // Create a key to revoke
+            const createResp = await auth.apiKey.create({
+                name: "to-be-revoked",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+            if (!createResp.data) throw new Error("Failed to create key");
+            const keyId = createResp.data.id;
+
+            const response = await SELF.fetch(
+                `http://localhost:3000/api/account/keys/${keyId}`,
+                {
+                    method: "DELETE",
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.success).toBe(true);
+
+            // Verify the key no longer works
+            const verifyResp = await SELF.fetch(
+                "http://localhost:3000/api/account/key",
+                {
+                    headers: {
+                        Authorization: `Bearer ${createResp.data.key}`,
+                    },
+                },
+            );
+            expect(verifyResp.status).toBe(401);
+        });
+
+        test("should prevent self-revocation via API key", async ({
+            auth,
+            sessionToken,
+        }) => {
+            // Create a key with account:keys permission
+            const createResp = await auth.apiKey.create({
+                name: "self-revoke-test",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+            if (!createResp.data) throw new Error("Failed to create key");
+
+            // Grant account:keys permission
+            await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${createResp.data.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        accountPermissions: ["keys"],
+                    }),
+                },
+            );
+
+            // Try to revoke itself
+            const response = await SELF.fetch(
+                `http://localhost:3000/api/account/keys/${createResp.data.id}`,
+                {
+                    method: "DELETE",
+                    headers: {
+                        Authorization: `Bearer ${createResp.data.key}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(400);
+        });
+
+        test("should return 404 for non-existent key", async ({
+            sessionToken,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys/nonexistent-id",
+                {
+                    method: "DELETE",
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(404);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/account/keys` — create API keys programmatically (returns full secret once)
- Adds `GET /api/account/keys` — list all user's keys (masked, no secrets)
- Adds `DELETE /api/account/keys/:id` — revoke a key (cannot delete self)
- New `account:keys` permission gates all three endpoints (sk_ keys only)
- Auto-strips `keys` from child key permissions to prevent escalation
- Adds "Key Management" checkbox to dashboard + device flow authorize UI
- 10 integration tests covering create, list, delete, escalation prevention

## Security

- Only `sk_` (secret) keys can manage keys — publishable keys rejected with 403
- `account:keys` permission required — opt-in only
- Child keys **cannot** receive `account:keys` — no infinite chain
- Self-revocation prevented (400)
- Session auth (dashboard/device flow) always allowed — no permission check needed

## Endpoints

| Method | Path | Permission | Description |
|--------|------|-----------|-------------|
| `GET` | `/api/account/keys` | `account:keys` | List all keys |
| `POST` | `/api/account/keys` | `account:keys` | Create key |
| `DELETE` | `/api/account/keys/:id` | `account:keys` | Revoke key |

## Test plan

- [ ] Run `npx vitest run test/integration/account-keys.test.ts`
- [ ] Verify dashboard shows "Key Management" permission checkbox
- [ ] Verify device flow authorize page shows same checkbox
- [ ] Test CLI `polli keys create` against new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)