### PR TITLE
docs: add Flux/Z-Image RunPod + SDXL Turbo to GPU docs and monitoring

### DIFF
--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monitor-services
-description: "Health check and auto-restart all Pollinations GPU services (LTX-2 on GH200, Klein on RunPod, legacy image on OVH, Sana on Vast.ai). Use with /loop for recurring checks."
+description: "Health check and auto-restart all Pollinations GPU services (Flux/Z-Image on RunPod, LTX-2 on GH200, Klein on RunPod, legacy image on OVH, Sana on Vast.ai). Use with /loop for recurring checks."
 ---
 
 # Monitor Services
@@ -126,21 +126,63 @@ Wait ~30s for model load, then re-check health.
 
 ---
 
-### 5. Sana Image Model (Vast.ai via OVH tunnel)
+### 5. Flux + Z-Image Workers (RunPod 4x RTX 4090)
 
 | Property | Value |
 |----------|-------|
-| **Direct** | `211.72.13.202:47190` |
-| **Via OVH tunnel** | `localhost:19876` (on OVH) |
+| **Pod** | `hsl3ksl31lvrcc` |
+| **Provider** | RunPod (4x RTX 4090, community cloud) |
+| **SSH** | `ssh -i ~/.ssh/thomashkey -p 28895 root@38.65.239.17` |
+
+**Workers:**
+
+| GPU | Port | Proxy URL | Service |
+|-----|------|-----------|---------|
+| 0 | 8765 | `https://hsl3ksl31lvrcc-8765.proxy.runpod.net` | Flux (INT4) |
+| 1 | 8766 | `https://hsl3ksl31lvrcc-8766.proxy.runpod.net` | Flux (INT4) |
+| 2 | 8767 | `https://hsl3ksl31lvrcc-8767.proxy.runpod.net` | Z-Image |
+| 3 | 8768 | `https://hsl3ksl31lvrcc-8768.proxy.runpod.net` | Z-Image |
+
+**Health check (per worker):**
+```bash
+curl -s --connect-timeout 5 --max-time 15 https://hsl3ksl31lvrcc-8765.proxy.runpod.net/generate \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"prompt":"test","width":512,"height":512}' -o /dev/null -w "HTTP %{http_code}"
+```
+Expected: HTTP 200
+
+**Registry check (all image workers at once):**
+```bash
+curl -s --connect-timeout 5 --max-time 10 http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register
+```
+Expected: 4 workers with 0% error rate, all `hsl3ksl31lvrcc-*.proxy.runpod.net`
+
+**Restart a worker:**
+```bash
+ssh -i ~/.ssh/thomashkey -p 28895 root@38.65.239.17
+screen -S flux-gpu0 -X quit
+screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nunchaku/venv/bin/activate && \
+  CUDA_VISIBLE_DEVICES=0 PORT=8765 PUBLIC_IP=hsl3ksl31lvrcc-8765.proxy.runpod.net PUBLIC_PORT=443 \
+  SERVICE_TYPE=flux python /opt/pollinations/image.pollinations.ai/nunchaku/server.py 2>&1 | tee /tmp/flux-gpu0.log'
+```
+
+---
+
+### 6. SDXL Turbo / Legacy Sana (Vast.ai UK, 1x RTX 4090)
+
+| Property | Value |
+|----------|-------|
+| **Instance** | 34086100 (Vast.ai, UK) |
+| **Direct** | `http://45.143.122.9:32174` |
+| **Via OVH tunnel** | `localhost:19876` (on OVH → port 8765) |
+| **SSH** | `ssh -i ~/.ssh/pollinations_services_2026 -p 16100 root@ssh7.vast.ai` |
+| **Model** | `stabilityai/sdxl-turbo` (registers as `sana` type) |
 
 **Health check (direct):**
 ```bash
-curl -s --connect-timeout 5 --max-time 30 -X POST http://211.72.13.202:47190/generate \
-  -H "Content-Type: application/json" \
-  -d '{"prompt":"test","width":512,"height":512}' \
-  -o /dev/null -w "HTTP %{http_code}"
+curl -s --connect-timeout 5 --max-time 10 http://45.143.122.9:32174/health
 ```
-Expected: HTTP 200
+Expected: `{"status":"healthy","model":"stabilityai/sdxl-turbo"}`
 
 **SSH tunnel check (OVH side):**
 ```bash
@@ -150,7 +192,7 @@ Expected: LISTEN on port 19876
 
 ---
 
-### 5. OVH Disk Space
+### 7. OVH Disk Space
 
 **Check:**
 ```bash
@@ -169,14 +211,16 @@ ssh -i ~/.ssh/id_rsa_ovh ubuntu@57.130.31.42 "sudo truncate -s 0 /var/log/syslog
 
 When invoked, run checks in this order:
 
-1. **LTX-2 health** - curl health endpoint
-2. **LTX-2 e2e** - if healthy, test through gen.pollinations.ai (use test token from `.testingtokens`)
-3. **ACE-Step health** - curl health endpoint on port 8189
-4. **Klein health** - curl RunPod proxy health endpoint
-5. **Legacy image service** - check systemctl status
-6. **Sana direct** - curl generate endpoint
-7. **SSH tunnel** - check port 19876 on OVH
-8. **Disk space** - check OVH disk usage
+1. **EC2 image registry** - curl register endpoint, check worker count and error rates
+2. **Flux/Z-Image RunPod** - verify 4 workers registered with 0% error rate
+3. **LTX-2 health** - curl health endpoint
+4. **LTX-2 e2e** - if healthy, test through gen.pollinations.ai (use test token from `.testingtokens`)
+5. **ACE-Step health** - curl health endpoint on port 8189
+6. **Klein health** - curl RunPod proxy health endpoint
+7. **Legacy image service** - check systemctl status
+8. **SDXL Turbo / legacy sana** - curl health on 45.143.122.9:32174
+9. **SSH tunnel** - check port 19876 on OVH
+10. **Disk space** - check OVH disk usage
 
 For each:
 - If healthy: report OK with latency
@@ -194,12 +238,17 @@ Report a brief status table:
 ```
 | Service | Status | Latency | Notes |
 |---------|--------|---------|-------|
+| EC2 registry | OK | 0.1s | 4 workers, 0% errors |
+| Flux RunPod (gpu0) | OK | 2.9s | hsl3ksl31lvrcc-8765 |
+| Flux RunPod (gpu1) | OK | 2.9s | hsl3ksl31lvrcc-8766 |
+| Z-Image RunPod (gpu2) | OK | 1.5s | hsl3ksl31lvrcc-8767 |
+| Z-Image RunPod (gpu3) | OK | 1.5s | hsl3ksl31lvrcc-8768 |
 | LTX-2 health | OK | 0.2s | |
 | LTX-2 e2e | OK | 11.3s | 682KB |
 | ACE-Step | OK | 0.1s | |
 | Klein 4B | OK | 0.3s | RunPod |
 | Legacy image | OK | - | active |
-| Sana | OK | 2.1s | |
+| SDXL Turbo (sana) | OK | 0.3s | vast.ai UK 34086100 |
 | SSH tunnel | OK | - | LISTEN |
 | OVH disk | OK | - | 45% used |
 ```

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -4,18 +4,20 @@ Last updated: 2026-04-04
 
 ## Capacity Summary
 
-| Model | Workers | GPUs | Provider | Cost/hr |
-|-------|---------|------|----------|---------|
-| Flux | 4 | 4x RTX 5090 | Vast.ai | $1.68 |
-| Z-Image | 6 | 6x RTX 5090 | Vast.ai | $3.21 |
-| Sana | 1 | 1x RTX 5090 | Vast.ai | (shared) |
-| Klein 4B | 1 | 1x RTX 3090 | RunPod | $0.22 |
-| Flux (serverless) | 1 | ADA_24 | RunPod | pay-per-use |
-| Z-Image (serverless) | 1-2 | ADA_32_PRO | RunPod | pay-per-use |
-| gpu-worker | 4 | 4x RTX 4090 | RunPod | $1.36 |
-| LTX-2 Video | 0-1 | H200 | Modal | auto-scaling |
-| LTX-2 + ACE-Step | 1 | GH200 | Lambda Labs | — |
-| **Total** | **~18** | | | **~$6.47/hr + serverless** |
+| Model | Workers | GPUs | Provider | Cost/hr | Status |
+|-------|---------|------|----------|---------|--------|
+| Flux (INT4) | 2 | 2x RTX 4090 | RunPod | (shared) | **ACTIVE — production** |
+| Z-Image | 2 | 2x RTX 4090 | RunPod | (shared) | **ACTIVE — production** |
+| Klein 4B | 1 | 1x RTX 3090 | RunPod | $0.22 | **ACTIVE** |
+| LTX-2 Video | 0-1 | H200 | Modal | auto-scaling | **ACTIVE** |
+| LTX-2 + ACE-Step | 1 | GH200 | Lambda Labs | — | **ACTIVE** |
+| Flux (serverless) | 1 | ADA_24 | RunPod | pay-per-use | Elliot |
+| Z-Image (serverless) | 1-2 | ADA_32_PRO | RunPod | pay-per-use | Elliot |
+| Flux | 4 | 4x RTX 5090 | Vast.ai | $1.68 | running (not in registry) |
+| Z-Image + Sana | 4 | 4x RTX 5090 | Vast.ai | $1.66 | **STOPPED** |
+| SDXL Turbo (legacy sana) | 1 | 1x RTX 4090 | Vast.ai | $0.36 | **ACTIVE** — legacy image.pollinations.ai |
+| Z-Image | 3 | 3x RTX 5090 | Vast.ai | $1.55 | running (not in registry) |
+| **Total active** | **~8** | | | **~$1.94/hr + serverless** |
 
 ## Provider: Vast.ai
 
@@ -38,10 +40,12 @@ vastai show instances --raw    # JSON with full details
 | 2 | flux-gpu2 | 8767 | 21050 | http://76.69.188.175:21050 |
 | 3 | flux-gpu3 | 8768 | 21059 | http://76.69.188.175:21059 |
 
-### Instance 30937024 — Z-Image + Sana (`211.72.13.202`)
+### Instance 30937024 — Z-Image + Sana (`211.72.13.202`) — STOPPED
 
-- **GPUs**: 4x RTX 5090 (32GB each) | **Cost**: $1.66/hr
+- **Status**: **STOPPED** (2026-04-04) — replaced by RunPod pod hsl3ksl31lvrcc
+- **GPUs**: 4x RTX 5090 (32GB each) | **Cost**: $1.66/hr (when running)
 - **SSH**: `ssh -i ~/.ssh/pollinations_services_2026 -p 17024 root@ssh3.vast.ai`
+- **Restart**: `vastai start instance 30937024`
 
 | GPU | Screen Session | Internal Port | Public Port | Service |
 |-----|---------------|---------------|-------------|---------|
@@ -61,6 +65,15 @@ vastai show instances --raw    # JSON with full details
 | 1 | zimage-gpu1 | 8766 | 40160 | Z-Image |
 | 2 | zimage-gpu2 | 8767 | 40184 | Z-Image |
 | 3 | zimage-gpu3 | 8768 | 40151 | Z-Image |
+
+### Instance 34086100 — SDXL Turbo / legacy Sana (`45.143.122.9`)
+
+- **GPU**: 1x RTX 4090 (24GB) | **Cost**: $0.36/hr
+- **SSH**: `ssh -i ~/.ssh/pollinations_services_2026 -p 16100 root@ssh7.vast.ai`
+- **Service**: SDXL Turbo (registers as `sana` for legacy `image.pollinations.ai`)
+- **Port**: 8765 → public 32174 (`http://45.143.122.9:32174`)
+- **Health**: `curl -s http://45.143.122.9:32174/health` → `{"status":"healthy","model":"stabilityai/sdxl-turbo"}`
+- **OVH tunnel**: OVH (57.130.31.42) tunnels `localhost:19876` → this instance's port 8765
 
 ## Provider: RunPod
 
@@ -88,13 +101,53 @@ runpodctl pod get <id>         # pod details
 curl -s https://pi90tfk3sa9t12-8000.proxy.runpod.net/health
 ```
 
-### Pod hsl3ksl31lvrcc — gpu-worker (Elliot)
+### Pod hsl3ksl31lvrcc — Flux + Z-Image (4x RTX 4090)
 
-- **GPU**: 4x RTX 4090 | **Cost**: $1.36/hr
-- **SSH**: `ssh root@38.65.239.17 -p 28895`
-- **Ports**: 8765-8768 (one per GPU)
+- **GPU**: 4x RTX 4090 (24GB each) | **Cost**: $1.36/hr (community cloud)
+- **SSH**: `ssh -i ~/.ssh/thomashkey -p 28895 root@38.65.239.17`
+- **Image**: `runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404`
+- **Storage**: 100GB container disk + 50GB persistent volume
+- **Repo**: `/opt/pollinations` (symlinked from `/workspace/pollinations`)
 
-### Serverless Endpoints
+| GPU | Screen Session | Port | Proxy URL | Service |
+|-----|---------------|------|-----------|---------|
+| 0 | flux-gpu0 | 8765 | `https://hsl3ksl31lvrcc-8765.proxy.runpod.net` | Flux (INT4, nunchaku) |
+| 1 | flux-gpu1 | 8766 | `https://hsl3ksl31lvrcc-8766.proxy.runpod.net` | Flux (INT4, nunchaku) |
+| 2 | zimage-gpu2 | 8767 | `https://hsl3ksl31lvrcc-8767.proxy.runpod.net` | Z-Image (Turbo + SPAN 2x) |
+| 3 | zimage-gpu3 | 8768 | `https://hsl3ksl31lvrcc-8768.proxy.runpod.net` | Z-Image (Turbo + SPAN 2x) |
+
+**Venvs** (separate per service):
+- Flux: `/opt/pollinations/image.pollinations.ai/nunchaku/venv` (torch 2.9.1+cu128)
+- Z-Image: `/opt/pollinations/image.pollinations.ai/z-image/venv`
+
+**Health check:**
+```bash
+curl -s https://hsl3ksl31lvrcc-8765.proxy.runpod.net/generate -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"test","width":512,"height":512}' -o /dev/null -w "HTTP %{http_code}"
+```
+
+**Registry check (all workers):**
+```bash
+curl -s http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register | python3 -m json.tool
+```
+
+**Restart a worker:**
+```bash
+ssh -i ~/.ssh/thomashkey -p 28895 root@38.65.239.17
+screen -S flux-gpu0 -X quit
+screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nunchaku/venv/bin/activate && \
+  CUDA_VISIBLE_DEVICES=0 PORT=8765 PUBLIC_IP=hsl3ksl31lvrcc-8765.proxy.runpod.net PUBLIC_PORT=443 \
+  SERVICE_TYPE=flux python /opt/pollinations/image.pollinations.ai/nunchaku/server.py 2>&1 | tee /tmp/flux-gpu0.log'
+```
+
+**Key notes:**
+- Uses INT4 quantization (not FP4) — RTX 4090 is Ada Lovelace, not Blackwell
+- Heartbeats register with `https://` proxy URLs (patched `server.py` line 63)
+- Replaced Vast.ai Taiwan instance for production Flux/Z-Image traffic
+- ~2.9s per Flux image, ~1.5s per Z-Image at 512x512
+
+### Serverless Endpoints (Elliot)
 
 | Endpoint | ID | Image | GPU | Workers |
 |----------|----|-------|-----|---------|


### PR DESCRIPTION
## Summary
- Add RunPod pod hsl3ksl31lvrcc (4x RTX 4090) details: proxy URLs, venvs, screen sessions, restart commands
- Mark Vast.ai Taiwan instance (30937024) as STOPPED — replaced by RunPod
- Add UK Vast.ai instance 34086100 running SDXL Turbo (legacy sana endpoint)
- Add Flux/Z-Image workers + EC2 registry check to monitor-services skill
- Update capacity summary to reflect current active infrastructure

## Test plan
- [ ] Run `/monitor-services` to verify new health checks work
- [ ] Verify `curl -s http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register` shows 4 RunPod workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)