### PR TITLE
fix: prevent CUDA hangs in nunchaku server

### DIFF
--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monitor-services
-description: "Health check and auto-restart all Pollinations GPU services (Flux/Z-Image on RunPod, LTX-2 on GH200, Klein on RunPod, legacy image on OVH, Sana on Vast.ai). Use with /loop for recurring checks."
+description: "Health check and auto-restart all Pollinations GPU services (Flux/Z-Image on RunPod, LTX-2 on GH200, Klein on RunPod, legacy image on OVH, Sana Sprint 1.6B on Vast.ai + Lambda Labs A10/A100). Use with /loop for recurring checks."
 ---
 
 # Monitor Services
@@ -168,27 +168,69 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 
 ---
 
-### 6. SDXL Turbo / Legacy Sana (Vast.ai UK, 1x RTX 4090)
+### 6. Sana Sprint 1.6B Workers (3 instances)
+
+All register as `sana` type with OVH legacy service. Direct port access, no SSH tunnels.
+
+**6a. Vast.ai RTX 4090 (`45.143.122.9`)**
 
 | Property | Value |
 |----------|-------|
 | **Instance** | 34086100 (Vast.ai, UK) |
 | **Direct** | `http://45.143.122.9:32174` |
-| **Via OVH tunnel** | `localhost:19876` (on OVH → port 8765) |
-| **SSH** | `ssh -i ~/.ssh/pollinations_services_2026 -p 16100 root@ssh7.vast.ai` |
-| **Model** | `stabilityai/sdxl-turbo` (registers as `sana` type) |
+| **SSH** | `ssh -i ~/.ssh/id_ed25519 -p 16100 root@ssh7.vast.ai` |
+| **Model** | `Sana_Sprint_1.6B_1024px_diffusers` |
 
-**Health check (direct):**
+**Health check:**
 ```bash
 curl -s --connect-timeout 5 --max-time 10 http://45.143.122.9:32174/health
 ```
-Expected: `{"status":"healthy","model":"stabilityai/sdxl-turbo"}`
 
-**SSH tunnel check (OVH side):**
+**6b. Lambda Labs A10 (`150.136.85.48`)**
+
+| Property | Value |
+|----------|-------|
+| **Host** | `150.136.85.48` |
+| **Port** | `8765` |
+| **SSH** | `ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48` |
+| **Model** | `Sana_Sprint_1.6B_1024px_diffusers` |
+| **Speed** | ~0.60s/image at 512x512 |
+
+**Health check:**
 ```bash
-ssh -i ~/.ssh/id_rsa_ovh -o ConnectTimeout=5 ubuntu@57.130.31.42 "ss -tlnp | grep 19876"
+curl -s --connect-timeout 5 --max-time 10 http://150.136.85.48:8765/health
 ```
-Expected: LISTEN on port 19876
+
+**Restart:**
+```bash
+ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48 "bash /home/ubuntu/start_sana.sh"
+```
+
+**6c. Lambda Labs A100 (`150.136.209.134`)**
+
+| Property | Value |
+|----------|-------|
+| **Host** | `150.136.209.134` |
+| **Port** | `8765` |
+| **SSH** | `ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134` |
+| **Model** | `Sana_Sprint_1.6B_1024px_diffusers` |
+| **Speed** | ~0.25s/image at 512x512 |
+
+**Health check:**
+```bash
+curl -s --connect-timeout 5 --max-time 10 http://150.136.209.134:8765/health
+```
+
+**Restart:**
+```bash
+ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134 "bash /home/ubuntu/start_sana.sh"
+```
+
+**Legacy sana registry check (all sana workers):**
+```bash
+ssh -i ~/.ssh/id_rsa_ovh -o ConnectTimeout=5 ubuntu@57.130.31.42 "curl -s http://localhost:16384/register"
+```
+Expected: 3 sana workers with low error rates
 
 ---
 
@@ -217,9 +259,9 @@ When invoked, run checks in this order:
 4. **LTX-2 e2e** - if healthy, test through gen.pollinations.ai (use test token from `.testingtokens`)
 5. **ACE-Step health** - curl health endpoint on port 8189
 6. **Klein health** - curl RunPod proxy health endpoint
-7. **Legacy image service** - check systemctl status
-8. **SDXL Turbo / legacy sana** - curl health on 45.143.122.9:32174
-9. **SSH tunnel** - check port 19876 on OVH
+7. **Legacy image service** - check systemctl status on OVH
+8. **Sana workers** - curl health on all 3: Vast.ai (45.143.122.9:32174), A10 (150.136.85.48:8765), A100 (150.136.209.134:8765)
+9. **Legacy sana registry** - check OVH localhost:16384/register for 3 sana workers
 10. **Disk space** - check OVH disk usage
 
 For each:
@@ -248,7 +290,9 @@ Report a brief status table:
 | ACE-Step | OK | 0.1s | |
 | Klein 4B | OK | 0.3s | RunPod |
 | Legacy image | OK | - | active |
-| SDXL Turbo (sana) | OK | 0.3s | vast.ai UK 34086100 |
-| SSH tunnel | OK | - | LISTEN |
+| Sana (Vast.ai 4090) | OK | 0.3s | 45.143.122.9:32174 |
+| Sana (Lambda A10) | OK | 0.3s | 150.136.85.48:8765 |
+| Sana (Lambda A100) | OK | 0.3s | 150.136.209.134:8765 |
+| Sana registry | OK | - | 3 workers, low errors |
 | OVH disk | OK | - | 45% used |
 ```

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,6 +1,6 @@
 # GPU Instances
 
-Last updated: 2026-04-04
+Last updated: 2026-04-05
 
 ## Capacity Summary
 
@@ -15,9 +15,11 @@ Last updated: 2026-04-04
 | Z-Image (serverless) | 1-2 | ADA_32_PRO | RunPod | pay-per-use | Elliot |
 | Flux | 4 | 4x RTX 5090 | Vast.ai | $1.68 | running (not in registry) |
 | Z-Image + Sana | 4 | 4x RTX 5090 | Vast.ai | $1.66 | **STOPPED** |
-| SDXL Turbo (legacy sana) | 1 | 1x RTX 4090 | Vast.ai | $0.36 | **ACTIVE** — legacy image.pollinations.ai |
+| Sana Sprint 1.6B | 1 | 1x RTX 4090 | Vast.ai | $0.36 | **ACTIVE** — legacy image.pollinations.ai |
+| Sana Sprint 1.6B | 1 | 1x A10 | Lambda Labs | — | **ACTIVE** — legacy image.pollinations.ai |
+| Sana Sprint 1.6B | 1 | 1x A100 SXM4 | Lambda Labs | — | **ACTIVE** — legacy image.pollinations.ai |
 | Z-Image | 3 | 3x RTX 5090 | Vast.ai | $1.55 | running (not in registry) |
-| **Total active** | **~8** | | | **~$1.94/hr + serverless** |
+| **Total active** | **~10** | | | **~$1.94/hr + serverless + Lambda** |
 
 ## Provider: Vast.ai
 
@@ -66,14 +68,15 @@ vastai show instances --raw    # JSON with full details
 | 2 | zimage-gpu2 | 8767 | 40184 | Z-Image |
 | 3 | zimage-gpu3 | 8768 | 40151 | Z-Image |
 
-### Instance 34086100 — SDXL Turbo / legacy Sana (`45.143.122.9`)
+### Instance 34086100 — Sana Sprint 1.6B (`45.143.122.9`)
 
 - **GPU**: 1x RTX 4090 (24GB) | **Cost**: $0.36/hr
-- **SSH**: `ssh -i ~/.ssh/pollinations_services_2026 -p 16100 root@ssh7.vast.ai`
-- **Service**: SDXL Turbo (registers as `sana` for legacy `image.pollinations.ai`)
+- **SSH**: `ssh -i ~/.ssh/id_ed25519 -p 16100 root@ssh7.vast.ai`
+- **Service**: Sana Sprint 1.6B (registers as `sana` for legacy `image.pollinations.ai`)
 - **Port**: 8765 → public 32174 (`http://45.143.122.9:32174`)
-- **Health**: `curl -s http://45.143.122.9:32174/health` → `{"status":"healthy","model":"stabilityai/sdxl-turbo"}`
-- **OVH tunnel**: OVH (57.130.31.42) tunnels `localhost:19876` → this instance's port 8765
+- **Health**: `curl -s http://45.143.122.9:32174/health` → `{"status":"healthy","model":"Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers"}`
+- **Server code**: `sana_server.py` (same as `image.pollinations.ai/sana/server.py`)
+- **Note**: No SSH tunnel needed — direct port access only
 
 ## Provider: RunPod
 
@@ -165,12 +168,43 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 
 ## Provider: Lambda Labs
 
+API: `curl -u "secret_polli2_...:" https://cloud.lambda.ai/api/v1/instances`
+
 ### LTX-2.3 Video + ACE-Step Music (GH200)
 
 - **Host**: `192.222.51.105`
+- **GPU**: 1x GH200 (96GB)
 - **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@192.222.51.105`
 - **LTX-2**: port 8765, health at `/health`
 - **ACE-Step**: port 8189, systemd `acestep.service`
+
+### Sana Sprint 1.6B (A10)
+
+- **Host**: `150.136.85.48`
+- **GPU**: 1x A10 (24GB) | **Region**: us-east-1
+- **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48`
+- **Service**: Sana Sprint 1.6B (registers as `sana` with OVH legacy service)
+- **Port**: 8765 (direct access, no tunnel)
+- **Health**: `curl -s http://150.136.85.48:8765/health`
+- **Server code**: `/home/ubuntu/sana_server.py` (same as `image.pollinations.ai/sana/server.py`)
+- **Start script**: `/home/ubuntu/start_sana.sh`
+- **Logs**: `/home/ubuntu/sana.log`
+- **Performance**: ~0.60s/image at 512x512, 12.7GB VRAM (55%)
+- **Constraints**: MAX_DIM=768, MAX_PIXELS=262144 (512x512)
+
+### Sana Sprint 1.6B (A100)
+
+- **Host**: `150.136.209.134`
+- **GPU**: 1x A100 SXM4 (40GB) | **Region**: us-east-1
+- **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134`
+- **Service**: Sana Sprint 1.6B (registers as `sana` with OVH legacy service)
+- **Port**: 8765 (direct access, no tunnel)
+- **Health**: `curl -s http://150.136.209.134:8765/health`
+- **Server code**: `/home/ubuntu/sana_server.py` (same as `image.pollinations.ai/sana/server.py`)
+- **Start script**: `/home/ubuntu/start_sana.sh`
+- **Logs**: `/home/ubuntu/sana.log`
+- **Performance**: ~0.25s/image at 512x512
+- **Constraints**: MAX_DIM=768, MAX_PIXELS=262144 (512x512)
 
 ## Provider: EC2 (AWS)
 
@@ -193,7 +227,7 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 - **Host**: `57.130.31.42`
 - **SSH**: `ssh -i ~/.ssh/id_rsa_ovh ubuntu@57.130.31.42`
 - **Port**: 16384
-- **Sana tunnel**: localhost:19876 → vast.ai:47190
+- **Note**: Sana workers register directly via heartbeat, no SSH tunnel needed
 
 ## Heartbeat Registration
 

--- a/image.pollinations.ai/nunchaku/server.py
+++ b/image.pollinations.ai/nunchaku/server.py
@@ -37,6 +37,7 @@ class ImageRequest(BaseModel):
     safety_checker_adj: float = 0.5  # Controls sensitivity of NSFW detection
 
 pipe = None
+gpu_semaphore = asyncio.Semaphore(1)  # Serialize GPU inference to prevent CUDA hangs
 
 # Function to get public IP address
 def get_public_ip():
@@ -60,7 +61,7 @@ async def send_heartbeat():
                 port = int(public_port)
             else:
                 port = int(os.getenv("PORT", "8765"))
-            url = f"http://{public_ip}:{port}"
+            url = f"https://{public_ip}" if port == 443 else f"http://{public_ip}:{port}"
             service_type = os.getenv("SERVICE_TYPE", "flux")  # Get service type from environment variable
             # Use direct EC2 endpoint to bypass Cloudflare (some io.net IPs are blocked)
             register_url = os.getenv("REGISTER_URL", "http://54.147.14.220:16384/register")
@@ -153,7 +154,7 @@ def find_nearest_valid_dimensions(width: float, height: float) -> tuple[int, int
         raise ValueError(f"Dimensions too small: {width}x{height}. Minimum allowed is {MIN_DIMENSION}x{MIN_DIMENSION}")
     
     # Cap total pixels to prevent CUDA OOM with quantized models
-    MAX_PIXELS = 1024 * 1024  # 1,048,576 pixels
+    MAX_PIXELS = 900 * 900  # 810,000 pixels — reduced from 1024x1024 to prevent CUDA hangs on RTX 4090
     start_w = round(width)
     start_h = round(height)
     
@@ -229,24 +230,25 @@ async def generate(request: ImageRequest, _auth: bool = Depends(verify_backend_t
     print(f"Adjusted dimensions: {width}x{height}")
 
     try:
-        with torch.inference_mode():
-            output = pipe(
-                prompt=request.prompts[0],
-                generator=generator,
-                width=width,
-                height=height,
-                num_inference_steps=request.steps,
-            )
+        async with gpu_semaphore:
+            with torch.inference_mode():
+                output = pipe(
+                    prompt=request.prompts[0],
+                    generator=generator,
+                    width=width,
+                    height=height,
+                    num_inference_steps=request.steps,
+                )
 
-        # Check for NSFW content
-        image = output.images[0]
-        concepts, has_nsfw = check_safety([image], request.safety_checker_adj)
-        
-        # Convert image to base64
-        img_byte_arr = io.BytesIO()
-        image.save(img_byte_arr, format='JPEG', quality=95)
-        img_base64 = base64.b64encode(img_byte_arr.getvalue()).decode('utf-8')
-        
+            # Check for NSFW content
+            image = output.images[0]
+            concepts, has_nsfw = check_safety([image], request.safety_checker_adj)
+
+            # Convert image to base64
+            img_byte_arr = io.BytesIO()
+            image.save(img_byte_arr, format='JPEG', quality=95)
+            img_base64 = base64.b64encode(img_byte_arr.getvalue()).decode('utf-8')
+
         response_content = [{
             "image": img_base64,
             "has_nsfw_concept": has_nsfw[0],
@@ -256,18 +258,22 @@ async def generate(request: ImageRequest, _auth: bool = Depends(verify_backend_t
             "seed": seed,
             "prompt": request.prompts[0]
         }]
-        
+
         # Send heartbeat after successful generation
         await send_heartbeat()
         return JSONResponse(content=response_content)
     
     except torch.cuda.OutOfMemoryError as e:
-        logger.error(f"CUDA OOM Error: {str(e)} - Exiting to trigger systemd restart")
-        # Exit with non-zero status to trigger systemd restart
+        logger.error(f"CUDA OOM Error: {str(e)} - Exiting to trigger restart")
         sys.exit(1)
     except Exception as e:
-        # Catch any other unexpected errors (like CUDA kernel assertions) and return 500
-        # instead of crashing the entire server
+        error_msg = str(e).lower()
+        # Nunchaku throws C++ CUDA OOM as a generic Exception, not torch.cuda.OutOfMemoryError.
+        # After CUDA OOM the GPU state is corrupted and all subsequent requests fail,
+        # so we must exit to force a clean restart.
+        if "out of memory" in error_msg or "cuda error" in error_msg:
+            logger.error(f"CUDA error detected: {str(e)} - Exiting to trigger restart")
+            sys.exit(1)
         logger.error(f"Unexpected error during generation: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Generation failed: {str(e)}")
 

--- a/image.pollinations.ai/sana/server.py
+++ b/image.pollinations.ai/sana/server.py
@@ -1,8 +1,9 @@
-import os, sys, io, base64, logging, torch, time, threading, warnings, math
+import os, sys, io, base64, logging, torch, time, threading, warnings, math, asyncio
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from contextlib import asynccontextmanager
+import aiohttp
 
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["TQDM_DISABLE"] = "1"
@@ -13,10 +14,11 @@ logger = logging.getLogger(__name__)
 for noisy in ["httpx", "httpcore", "urllib3", "diffusers", "transformers", "huggingface_hub"]:
     logging.getLogger(noisy).setLevel(logging.WARNING)
 
-MODEL_ID = "Efficient-Large-Model/Sana_Sprint_0.6B_1024px_diffusers"
+MODEL_ID = "Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers"
 MODEL_CACHE = "model_cache"
 NUM_INFERENCE_STEPS = 2
-MAX_DIM = 512
+MAX_DIM = 768
+MAX_PIXELS = 512 * 512  # 262144
 
 generate_lock = threading.Lock()
 
@@ -32,9 +34,46 @@ def clamp_dims(w, h):
     w, h = min(w, MAX_DIM), min(h, MAX_DIM)
     w = max(32, (w // 32) * 32)
     h = max(32, (h // 32) * 32)
+    if w * h > MAX_PIXELS:
+        scale = (MAX_PIXELS / (w * h)) ** 0.5
+        w = max(32, (int(w * scale) // 32) * 32)
+        h = max(32, (int(h * scale) // 32) * 32)
     return w, h
 
 pipe = None
+
+async def send_heartbeat():
+    public_ip = os.getenv("PUBLIC_IP")
+    if not public_ip:
+        try:
+            import requests
+            public_ip = requests.get("https://api.ipify.org", timeout=5).text
+        except Exception:
+            return
+    port = int(os.getenv("PUBLIC_PORT", os.getenv("PORT", "8765")))
+    url = f"http://{public_ip}:{port}"
+    service_type = os.getenv("SERVICE_TYPE", "sana")
+    register_url = os.getenv("REGISTER_URL", "http://54.147.14.220:16384/register")
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(register_url, json={"url": url, "type": service_type}) as resp:
+                if resp.status == 200:
+                    logger.info("Heartbeat sent: %s type=%s", url, service_type)
+                else:
+                    logger.error("Heartbeat failed: %d", resp.status)
+    except Exception as e:
+        logger.error("Heartbeat error: %s", e)
+
+async def periodic_heartbeat():
+    while True:
+        try:
+            await send_heartbeat()
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Heartbeat loop error: %s", e)
+            await asyncio.sleep(5)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -44,7 +83,15 @@ async def lifespan(app: FastAPI):
     t0 = time.time()
     pipe = SanaSprintPipeline.from_pretrained(MODEL_ID, torch_dtype=torch.bfloat16, cache_dir=MODEL_CACHE).to("cuda")
     logger.info("Model loaded in %.1fs", time.time() - t0)
-    yield
+    heartbeat_task = asyncio.create_task(periodic_heartbeat())
+    try:
+        yield
+    finally:
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass
 
 app = FastAPI(title="SANA-Sprint Legacy", lifespan=lifespan)
 
@@ -80,4 +127,4 @@ async def health():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "10003")))
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8765")))


### PR DESCRIPTION
## Summary
- Add `asyncio.Semaphore(1)` to serialize GPU inference — prevents concurrent VRAM competition causing CUDA deadlocks
- Reduce MAX_PIXELS from 1024x1024 to 900x900 — 768x1280 requests were hanging RTX 4090s
- Detect CUDA OOM from nunchaku C++ layer (thrown as generic Exception, not `torch.cuda.OutOfMemoryError`) and `sys.exit(1)` for clean restart
- Fix HTTPS URL construction for RunPod proxy registration (port 443)
- Update sana server to Sana Sprint 1.6B, add Lambda Labs A10/A100 to monitoring

## Context
Flux gpu0 was crashing repeatedly (~every 30min) on 768x1280 generation requests. The nunchaku C++ layer either throws a generic CUDA OOM or deadlocks entirely. Already deployed to RunPod — this PR syncs the repo.

## Test plan
- [x] Deployed to RunPod 4x RTX 4090 pod, all 4 workers healthy
- [x] Monitoring loop confirms 0% error rates after deploy
- [ ] Watch gpu0 stability over next few hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

polly please review