### PR TITLE
fix: rotate Azure gptimage endpoints to new April deployments

### DIFF
--- a/image.pollinations.ai/secrets/env.json
+++ b/image.pollinations.ai/secrets/env.json
@@ -18,10 +18,10 @@
 	"AIRFORCE_API_KEY": "ENC[AES256_GCM,data:5YDDotTPYfFLUI2qhBxSQRWI/kot+bSJAl0HC7JGJ5alcNCxLqx28r5nLT10neT3WsHEd4/0axU6HEG2nivlt5r0hjdsU+o=,iv:2AJkpOrrIMKQxZGjOs0bUkolE5qqFAwHBsyBsgSxB08=,tag:rnDzJpBFnmEu3vq0a7X6ow==,type:str]",
 	"MODAL_LTX2_TOKEN_ID": "ENC[AES256_GCM,data:yn42h8phdNsND69fy1aO41OCg5ob3Jh/lw==,iv:7onWFpKihj1pklZ3TletpGI0KsxK4lu28J2JjXFgalE=,tag:ENCy/c9sm/gcujt9BmQJJA==,type:str]",
 	"MODAL_LTX2_TOKEN_SECRET": "ENC[AES256_GCM,data:u50W0Q33NPaBmRh+HHsOc+O/8XPkuKH0cQ==,iv:p6gdijqCTmtOnyKBvZ6JYLjSRNdjuIsZYJxsqjZWYsc=,tag:vOXKor7dC1U0XlG5JPb2lg==,type:str]",
-	"AZURE_GPTIMAGE_1_MINI_ENDPOINT": "ENC[AES256_GCM,data:yrrO+VyUDlqxB7HNtzEkVdUKxd+VbZCvDFX9NfftDWSaHoDF6mxQkTrdB6iiZfsxKj45K4QMA+ut1Qm827kOZ8hO3lXiGmn/8UxF8Co6SQRcelRymLj4MuB9vZcTMt6c1npO6At3QGFhzao76k4h6d1yZJMtwpLfjpZgIsjzKq69neULsQePZG8=,iv:u46wbicnM1dCN3dqCs1m2jNjaByRT++8bB5TkZlSbbQ=,tag:VzDlDoeWWa/SCf30PwB4CQ==,type:str]",
-	"AZURE_GPTIMAGE_1_MINI_API_KEY": "ENC[AES256_GCM,data:bs8sighGEhTt9SMfxmoFjXI/Sh43zTUzuElWFpXyVE0p5We6+nJpqdLPbBSVwT/hIYQQgR5lHQwp6pAqSRAz+sgzHpYJ78xUjJbQxVMt32gryEmL,iv:Ug84AKVmhdfoE9XU+cj8NVcraND88CvohyeemqF9Pfo=,tag:Ib3cAmftSpWBfzRaEzvjPQ==,type:str]",
-	"AZURE_GPTIMAGE_15_ENDPOINT": "ENC[AES256_GCM,data:IIwFWLLAW5WPRga3sxlEtUVDvC0nq31KgtVUHTkK+AmmqO/Hk4fn+WGjacS/ZlC6vlzexxWw1z3mmthQ4YbM5eaq+qxvLfUGnGsQ+JWR/Tyx5SKZULR7/YPBK/VKRaLHt781ryeyLzXse9xoo+i6+0d4kAuO14IxChdM4BdBXn4nc4h1Lbs=,iv:cbXEaJkBG4Hp8y+bg9paMFoh2i1aYPXFH1sKwR9vegQ=,tag:enG3iAfvj8yOt8jc3BMJNQ==,type:str]",
-	"AZURE_GPTIMAGE_15_API_KEY": "ENC[AES256_GCM,data:LOncg8RthwaBuhblxVql4vSt0DSjZck47kOvoU+pc+168TjhoyfVLEOGufuA9vtvsGJnlVdsWKxY3eON8jlEAehvyTACCOXSTMnrAM9dg3UXFOFT,iv:3sMiNCvA+tYkcisToFnpt/fTDy7CZYkp3lSHnf90zAk=,tag:XEDil5n8gO2C+HqZRIfrIQ==,type:str]",
+	"AZURE_GPTIMAGE_1_MINI_ENDPOINT": "ENC[AES256_GCM,data:rvrrL81P91ThLIQc+DJNAKVxuJrMQKRhBXdzwgP/FBTovpkh7yUlGjSt6J004SQfFhKsQvYrKplhICO+xcrKGGW1Ba5V4vfB2IYlZN5Cvk46oj7kR2l/5V4cW6rg6KoqxMyqGoNCnaPgbKUKz3gIYnu6RBMAWi+iyLbaeUhL0pR7OdCoVhKfqNf2s3982FGoTC0=,iv:i5iNJiFLhwLT7UMyMyM7d9Hl1227qaLtelX08TlXM3U=,tag:ygwsxiIiSyv+Ks/sLg2huQ==,type:str]",
+	"AZURE_GPTIMAGE_1_MINI_API_KEY": "ENC[AES256_GCM,data:Hw+TcPsIV84To0cg1N3rws0eArPFScNJKcEyCb+c0WMBGEcu3eQGB9V6GSXIwtBVmoZ2q3/woRSYggR2qkGWZmBnEgUH5tnFFz/B5dJDkHiySk8m,iv:FB6ci1Dj8UsVve6za1mHvgfS5BKdAjotJ8ADA0RHYYA=,tag:a+gYEGqfqDPdaUVnvfeI3Q==,type:str]",
+	"AZURE_GPTIMAGE_15_ENDPOINT": "ENC[AES256_GCM,data:Uu0aoZ7ysNOKsnpoZ2Ma5jojwwl8MGl7ZKiK7p0R4zoF0OJ/7OV84xysuvhOTAGoIUYGMNtrRy0cMxOik+Ybb6cIRd1SENSoz/T1mFxL+hz95MoKQ10XPR1s7Ytv708S+C8ZWDh9FmZxEfvMzsv1EjxI2sUF9E8LSTqTFlYbliBqvnll7lIUlg==,iv:3y8ZsEpjVqSvZn1n0PWQXWrz2pohFBvNrLFU1nmWEXk=,tag:wGhT+zdr7cIclmfnv4m+MA==,type:str]",
+	"AZURE_GPTIMAGE_15_API_KEY": "ENC[AES256_GCM,data:4qkrAP2eUGzZ1hhiEzpYJwydXUpqrnM7DBCZJsLzLaI9byJ+zADLAwbz2L4FGDn49ecuEUZo9/QPScvIGU/1PilmyoFfkdzTpm8u8uJiO+3NOaFu,iv:eTFP2aFGPPOTlAyPFZSeu2WqN7olrAdvefbh21MYWK8=,tag:7Oner6P+BbvAX2CzqlTJuw==,type:str]",
 	"PRUNA_API_KEY": "ENC[AES256_GCM,data:3UvttlL6IjTuOK8UUjSi/NSXHAviV/Y/BjdmlpsytClrzjAe,iv:HzFSyOfhRqg79SQqhTwadqbS0Ego4Ii6SDiLE7hSZ3k=,tag:D3a8WpJEibGuAm8HDqgtDw==,type:str]",
 	"NOVA_REEL_S3_BUCKET": "ENC[AES256_GCM,data:DCIq17dGm7quYPKMHxheqvccAnIwfw==,iv:C7UOJQeWWRFUTejWbCKcwONF+MBIxoM+q+Of2VaSiSw=,tag:OSrq0d8HYmd5Y1IAY/TnKw==,type:str]",
 	"XAI_API_KEY": "ENC[AES256_GCM,data:pQ20kAl7NaDpWOsjivGSUmVmxW6HC3U2lccqNem1VcpVuSLlRe/5hzxB7yy3eZBVVRFT92kAxD9yl7vq+ovJPccPeT9e0BQme6JAaCLDIhfZv/4K,iv:YrHFspjzyWDzJrbEakmkrIyQAFufLOBWj0HGBUeA4AU=,tag:UQrs/j98/FYNmjXVTC8NHg==,type:str]",
@@ -36,8 +36,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjS3RhWjhiZkdESks3RzlU\nMmtWd3B6T3Fuc09NWWh4VENYQ3BqUWpJSEQwClhOaVl6N2hZbzFQMWhIdHdyeTUv\nWmJGb3NKeDl3WVYra2grcVM3UHhFTzAKLS0tIE5RcGc2bTNwdE9GS1ZqY1VWRlZ6\nQ0p0eVkxdXpVeEF1ZThqeE9xV2swS2cK3NPhg7jXAi6/28RO3r2LIRP5DwAxsp7w\ngoAJwJ/b392PSfOrRkP4U3ExtutZ0BKtMfOmO4Elx3GzyCLXbFplqw==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-04T10:59:07Z",
-		"mac": "ENC[AES256_GCM,data:CLLO1oawgw+4+M0pJJym4ZSwXK7IOz6rXopihVCriVuzJ+kuG1a3+TyY+kdCGCP7ZyXMN/gn1XgyfTo3Agq0/UQ5z9kFxIVTXrexQYAujtNq4Czggh0+KTaIRC8KaDnnrw5fMeKRi4s8hEfdZi0qXNykBAU8HucUzpdx89MHOUw=,iv:Gxdyk3YTMMLNSiCx95WrG0SQ4vk60oFYn4biMjDi/vU=,tag:sdcUMI/dqbE2moleNf4CAA==,type:str]",
+		"lastmodified": "2026-04-05T11:51:06Z",
+		"mac": "ENC[AES256_GCM,data:RMfvGAkco7mXO8rVn0a8Uz6Seu8KPvoN9qipd26+GvDBg13vuLwMV5zO4xcnUWV6kpATYfT0Jwj13aoYzqnVF5wExpiCOXefgELOKYoAnylpB7tUtCZdXTYeX+1WmNDlhseiQfnfwaAs85t1OxeGt/0XP8PiQdHk/GWc+uchVRw=,iv:CFM0rl+6o+Dd49mUp2MABG7OHrLbGzx3KL1UQjlkA8M=,tag:rvJ+23GqvTFsEOto9+lzSg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
## Summary
- Rotate gpt-image-1-mini to new `thomas-6746-april-westus-resourc` (westus3) deployment
- Rotate gpt-image-1.5 to new `myceli-new-april-resource` (eastus2) deployment
- Both endpoints tested and confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)