### PR TITLE
fix: nunchaku CUDA hang prevention + Sana 1.6B Lambda infra docs

### DIFF
--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -168,27 +168,38 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 
 ---
 
-### 6. SDXL Turbo / Legacy Sana (Vast.ai UK, 1x RTX 4090)
+### 6. Sana Sprint 1.6B Workers (Lambda Labs)
 
-| Property | Value |
-|----------|-------|
-| **Instance** | 34086100 (Vast.ai, UK) |
-| **Direct** | `http://45.143.122.9:32174` |
-| **Via OVH tunnel** | `localhost:19876` (on OVH → port 8765) |
-| **SSH** | `ssh -i ~/.ssh/pollinations_services_2026 -p 16100 root@ssh7.vast.ai` |
-| **Model** | `stabilityai/sdxl-turbo` (registers as `sana` type) |
+Two workers registered as `sana` type with OVH legacy service via heartbeat (no SSH tunnels).
 
-**Health check (direct):**
+| Instance | GPU | Host | Port | SSH |
+|----------|-----|------|------|-----|
+| Lambda A10 | A10 (24GB) | `150.136.85.48` | `8765` | `ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48` |
+| Lambda A100 | A100 (40GB) | `150.136.209.134` | `8765` | `ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134` |
+
+**Health check:**
 ```bash
-curl -s --connect-timeout 5 --max-time 10 http://45.143.122.9:32174/health
+curl -s --connect-timeout 5 --max-time 10 http://150.136.85.48:8765/health
+curl -s --connect-timeout 5 --max-time 10 http://150.136.209.134:8765/health
 ```
-Expected: `{"status":"healthy","model":"stabilityai/sdxl-turbo"}`
+Expected: `{"status":"healthy","model":"Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers"}`
 
-**SSH tunnel check (OVH side):**
+**Sana registry check (OVH side):**
 ```bash
-ssh -i ~/.ssh/id_rsa_ovh -o ConnectTimeout=5 ubuntu@57.130.31.42 "ss -tlnp | grep 19876"
+ssh -i ~/.ssh/id_rsa_ovh -o ConnectTimeout=5 ubuntu@57.130.31.42 "curl -s http://localhost:16384/register"
 ```
-Expected: LISTEN on port 19876
+Expected: 2 workers with 0% error rate
+
+**Restart:**
+```bash
+ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48 "sudo systemctl restart sana"
+ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134 "sudo systemctl restart sana"
+```
+
+**Notes:**
+- A10 generates at ~0.60s/img, A100 at ~0.25s/img
+- Replaced SDXL Turbo on Vast.ai (instance 34086100, now STOPPED)
+- Server code: `image.pollinations.ai/sana/server.py` (MAX_DIM=768, MAX_PIXELS=512*512)
 
 ---
 
@@ -217,9 +228,9 @@ When invoked, run checks in this order:
 4. **LTX-2 e2e** - if healthy, test through gen.pollinations.ai (use test token from `.testingtokens`)
 5. **ACE-Step health** - curl health endpoint on port 8189
 6. **Klein health** - curl RunPod proxy health endpoint
-7. **Legacy image service** - check systemctl status
-8. **SDXL Turbo / legacy sana** - curl health on 45.143.122.9:32174
-9. **SSH tunnel** - check port 19876 on OVH
+7. **Legacy image service** - check systemctl status on OVH
+8. **Sana workers** - curl health on both Lambda instances (A10 + A100)
+9. **Sana registry** - check OVH legacy registry for 2 workers with 0% errors
 10. **Disk space** - check OVH disk usage
 
 For each:
@@ -248,7 +259,8 @@ Report a brief status table:
 | ACE-Step | OK | 0.1s | |
 | Klein 4B | OK | 0.3s | RunPod |
 | Legacy image | OK | - | active |
-| SDXL Turbo (sana) | OK | 0.3s | vast.ai UK 34086100 |
-| SSH tunnel | OK | - | LISTEN |
+| Sana (Lambda A10) | OK | 0.2s | 1.6B, ~0.60s/img |
+| Sana (Lambda A100) | OK | 0.2s | 1.6B, ~0.25s/img |
+| Sana registry | OK | - | 2 workers, 0% errors |
 | OVH disk | OK | - | 45% used |
 ```

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,6 +1,6 @@
 # GPU Instances
 
-Last updated: 2026-04-04
+Last updated: 2026-04-05
 
 ## Capacity Summary
 
@@ -15,7 +15,9 @@ Last updated: 2026-04-04
 | Z-Image (serverless) | 1-2 | ADA_32_PRO | RunPod | pay-per-use | Elliot |
 | Flux | 4 | 4x RTX 5090 | Vast.ai | $1.68 | running (not in registry) |
 | Z-Image + Sana | 4 | 4x RTX 5090 | Vast.ai | $1.66 | **STOPPED** |
-| SDXL Turbo (legacy sana) | 1 | 1x RTX 4090 | Vast.ai | $0.36 | **ACTIVE** — legacy image.pollinations.ai |
+| Sana Sprint 1.6B | 1 | A10 | Lambda Labs | — | **ACTIVE** — sana registry |
+| Sana Sprint 1.6B | 1 | A100 | Lambda Labs | — | **ACTIVE** — sana registry |
+| ~~SDXL Turbo (legacy sana)~~ | 1 | 1x RTX 4090 | Vast.ai | $0.36 | **STOPPED** — replaced by Lambda Labs |
 | Z-Image | 3 | 3x RTX 5090 | Vast.ai | $1.55 | running (not in registry) |
 | **Total active** | **~8** | | | **~$1.94/hr + serverless** |
 
@@ -66,14 +68,11 @@ vastai show instances --raw    # JSON with full details
 | 2 | zimage-gpu2 | 8767 | 40184 | Z-Image |
 | 3 | zimage-gpu3 | 8768 | 40151 | Z-Image |
 
-### Instance 34086100 — SDXL Turbo / legacy Sana (`45.143.122.9`)
+### Instance 34086100 — STOPPED (formerly SDXL Turbo / Sana)
 
-- **GPU**: 1x RTX 4090 (24GB) | **Cost**: $0.36/hr
-- **SSH**: `ssh -i ~/.ssh/pollinations_services_2026 -p 16100 root@ssh7.vast.ai`
-- **Service**: SDXL Turbo (registers as `sana` for legacy `image.pollinations.ai`)
-- **Port**: 8765 → public 32174 (`http://45.143.122.9:32174`)
-- **Health**: `curl -s http://45.143.122.9:32174/health` → `{"status":"healthy","model":"stabilityai/sdxl-turbo"}`
-- **OVH tunnel**: OVH (57.130.31.42) tunnels `localhost:19876` → this instance's port 8765
+- **Status**: **STOPPED** (2026-04-05) — replaced by Lambda Labs Sana Sprint 1.6B workers
+- **GPU**: 1x RTX 4090 (24GB) | **Cost**: $0.36/hr (when running)
+- **Restart**: `vastai start instance 34086100`
 
 ## Provider: RunPod
 
@@ -171,6 +170,24 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 - **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@192.222.51.105`
 - **LTX-2**: port 8765, health at `/health`
 - **ACE-Step**: port 8189, systemd `acestep.service`
+
+### Sana Sprint 1.6B (A10)
+
+- **Host**: `150.136.85.48`
+- **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48`
+- **Port**: 8765, health at `/health`
+- **Model**: `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers`
+- **Speed**: ~0.60s/img
+- **Registry**: Registers as `sana` type with OVH legacy service
+
+### Sana Sprint 1.6B (A100)
+
+- **Host**: `150.136.209.134`
+- **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134`
+- **Port**: 8765, health at `/health`
+- **Model**: `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers`
+- **Speed**: ~0.25s/img
+- **Registry**: Registers as `sana` type with OVH legacy service
 
 ## Provider: EC2 (AWS)
 

--- a/image.pollinations.ai/nunchaku/server.py
+++ b/image.pollinations.ai/nunchaku/server.py
@@ -37,6 +37,7 @@ class ImageRequest(BaseModel):
     safety_checker_adj: float = 0.5  # Controls sensitivity of NSFW detection
 
 pipe = None
+gpu_semaphore = asyncio.Semaphore(1)  # Serialize GPU inference to prevent CUDA hangs
 
 # Function to get public IP address
 def get_public_ip():
@@ -60,7 +61,7 @@ async def send_heartbeat():
                 port = int(public_port)
             else:
                 port = int(os.getenv("PORT", "8765"))
-            url = f"http://{public_ip}:{port}"
+            url = f"https://{public_ip}" if port == 443 else f"http://{public_ip}:{port}"
             service_type = os.getenv("SERVICE_TYPE", "flux")  # Get service type from environment variable
             # Use direct EC2 endpoint to bypass Cloudflare (some io.net IPs are blocked)
             register_url = os.getenv("REGISTER_URL", "http://54.147.14.220:16384/register")
@@ -153,7 +154,7 @@ def find_nearest_valid_dimensions(width: float, height: float) -> tuple[int, int
         raise ValueError(f"Dimensions too small: {width}x{height}. Minimum allowed is {MIN_DIMENSION}x{MIN_DIMENSION}")
     
     # Cap total pixels to prevent CUDA OOM with quantized models
-    MAX_PIXELS = 1024 * 1024  # 1,048,576 pixels
+    MAX_PIXELS = 900 * 900  # 810,000 pixels — reduced to prevent CUDA hangs on RTX 4090
     start_w = round(width)
     start_h = round(height)
     
@@ -229,24 +230,25 @@ async def generate(request: ImageRequest, _auth: bool = Depends(verify_backend_t
     print(f"Adjusted dimensions: {width}x{height}")
 
     try:
-        with torch.inference_mode():
-            output = pipe(
-                prompt=request.prompts[0],
-                generator=generator,
-                width=width,
-                height=height,
-                num_inference_steps=request.steps,
-            )
+        async with gpu_semaphore:
+            with torch.inference_mode():
+                output = pipe(
+                    prompt=request.prompts[0],
+                    generator=generator,
+                    width=width,
+                    height=height,
+                    num_inference_steps=request.steps,
+                )
 
-        # Check for NSFW content
-        image = output.images[0]
-        concepts, has_nsfw = check_safety([image], request.safety_checker_adj)
-        
-        # Convert image to base64
-        img_byte_arr = io.BytesIO()
-        image.save(img_byte_arr, format='JPEG', quality=95)
-        img_base64 = base64.b64encode(img_byte_arr.getvalue()).decode('utf-8')
-        
+            # Check for NSFW content
+            image = output.images[0]
+            concepts, has_nsfw = check_safety([image], request.safety_checker_adj)
+
+            # Convert image to base64
+            img_byte_arr = io.BytesIO()
+            image.save(img_byte_arr, format='JPEG', quality=95)
+            img_base64 = base64.b64encode(img_byte_arr.getvalue()).decode('utf-8')
+
         response_content = [{
             "image": img_base64,
             "has_nsfw_concept": has_nsfw[0],
@@ -266,8 +268,10 @@ async def generate(request: ImageRequest, _auth: bool = Depends(verify_backend_t
         # Exit with non-zero status to trigger systemd restart
         sys.exit(1)
     except Exception as e:
-        # Catch any other unexpected errors (like CUDA kernel assertions) and return 500
-        # instead of crashing the entire server
+        error_msg = str(e).lower()
+        if "out of memory" in error_msg or "cuda error" in error_msg:
+            logger.error(f"CUDA error detected: {str(e)} - Exiting to trigger restart")
+            sys.exit(1)
         logger.error(f"Unexpected error during generation: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Generation failed: {str(e)}")
 


### PR DESCRIPTION
## Summary
- Fix nunchaku server CUDA hangs: asyncio.Semaphore(1), MAX_PIXELS 900x900, CUDA OOM detection, HTTPS URL fix
- Update monitoring skill: Sana Sprint 1.6B on Lambda (A10 + A100) replaces SDXL Turbo on Vast.ai
- Update GPU inventory: add Lambda Sana workers, mark Vast.ai 34086100 as STOPPED

Supersedes #9961

## Test plan
- [x] Deployed and verified stable on RunPod 4x RTX 4090 for 4+ hours
- [x] All monitoring checks passing
- [x] Sana registry shows 2 Lambda workers, 0% errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)