### PR TITLE
fix: pass upstream error details through to users

### DIFF
--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -161,15 +161,21 @@ const chatCompletionHandlers = factory.createHandlers(
             // Try to extract meaningful error message from upstream JSON
             let errorMessage =
                 responseText || getDefaultErrorMessage(response.status);
+            let upstreamDetails: unknown;
             try {
                 const parsed = JSON.parse(responseText);
                 const extracted =
                     parsed?.details?.error?.message ||
+                    parsed?.details?.message ||
                     parsed?.error?.message ||
                     parsed?.message ||
                     (typeof parsed?.error === "string" ? parsed.error : null);
                 if (extracted) {
                     errorMessage = extracted;
+                }
+                // Preserve full upstream details for transparency
+                if (parsed?.details) {
+                    upstreamDetails = parsed.details;
                 }
             } catch {
                 // Not JSON or parse failed - use raw text as-is
@@ -177,6 +183,7 @@ const chatCompletionHandlers = factory.createHandlers(
 
             throw new UpstreamError(remapUpstreamStatus(response.status), {
                 message: errorMessage,
+                cause: upstreamDetails,
                 requestUrl: targetUrl,
             });
         }

--- a/text.pollinations.ai/genericOpenAIClient.ts
+++ b/text.pollinations.ai/genericOpenAIClient.ts
@@ -23,9 +23,23 @@ function createApiError(
     details: unknown,
     modelName: string,
 ): ServiceError {
-    const error = new Error(
-        `${response.status} ${response.statusText}`,
-    ) as ServiceError;
+    // Extract the most specific error message from upstream response body
+    let message = `${response.status} ${response.statusText}`;
+    if (details && typeof details === "object") {
+        const d = details as Record<string, unknown>;
+        const upstreamMsg =
+            d.message || (d.error as Record<string, unknown>)?.message;
+        if (upstreamMsg && typeof upstreamMsg === "string") {
+            message = `${response.status}: ${upstreamMsg}`;
+        }
+    } else if (
+        typeof details === "string" &&
+        details.length > 0 &&
+        details.length < 500
+    ) {
+        message = `${response.status}: ${details}`;
+    }
+    const error = new Error(message) as ServiceError;
     error.status = response.status;
     error.details = details;
     error.model = modelName;
@@ -108,8 +122,13 @@ export async function genericOpenAIClient(
         if (!response.ok) {
             const errorText = await response.text();
             const errorDetails = parseJsonSafe(errorText) || errorText;
+            // Log response headers for debugging upstream gateway issues
+            const traceId =
+                response.headers.get("x-portkey-trace-id") ||
+                response.headers.get("x-request-id") ||
+                "none";
             errorLog(
-                `[${requestId}] API error (${response.status}):`,
+                `[${requestId}] API error (${response.status}): traceId=${traceId}`,
                 errorDetails,
             );
             throw createApiError(response, errorDetails, modelName);

--- a/text.pollinations.ai/server.ts
+++ b/text.pollinations.ai/server.ts
@@ -264,9 +264,21 @@ function sendErrorResponse(
     const errorType = ERROR_TYPES[responseStatus] || "Internal Server Error";
 
     const errorDetails = error.details || error.response?.data;
+    // Use the most specific error message available from upstream details
+    let message = error.message || "An error occurred";
+    if (errorDetails && typeof errorDetails === "object") {
+        const details = errorDetails as Record<string, unknown>;
+        const upstreamMessage =
+            details.message ||
+            (details.error as Record<string, unknown>)?.message;
+        if (upstreamMessage && typeof upstreamMessage === "string") {
+            message = upstreamMessage;
+        }
+    }
+
     const errorResponse: Record<string, unknown> = {
         error: errorType,
-        message: error.message || "An error occurred",
+        message,
         requestId: Math.random().toString(36).substring(7),
         requestParameters: requestData || {},
     };


### PR DESCRIPTION
## Summary
- Extract upstream error messages instead of returning generic "500 Internal Server Error"
- Add `parsed?.details?.message` to enter worker extraction chain (was missing)
- Log Portkey trace ID on errors for easier debugging
- Pass upstream details as `cause` in UpstreamError for full transparency

## Context
DeepSeek/Kimi on Azure netsimsim return Portkey's `{ status: 'failure', message: 'Something went wrong' }` — this was being swallowed at 3 layers and users only saw "Internal Server Error".

## Test plan
- [ ] Verify error responses include upstream message instead of generic text
- [ ] Check Tinybird `error_details` now captures meaningful messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)