### PR TITLE
revert: switch DeepSeek and Kimi back to Fireworks

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -248,8 +248,8 @@ export const TEXT_SERVICES = {
     },
     "deepseek": {
         aliases: ["deepseek-v3", "deepseek-reasoning"],
-        modelId: "DeepSeek-V3.2",
-        provider: "azure",
+        modelId: "accounts/fireworks/models/deepseek-v3p2",
+        provider: "fireworks",
         cost: [
             {
                 date: COST_START_DATE,
@@ -509,8 +509,8 @@ export const TEXT_SERVICES = {
     },
     "kimi": {
         aliases: ["kimi-k2.5", "kimi-k2p5", "kimi-reasoning", "kimi-large"],
-        modelId: "Kimi-K2.5",
-        provider: "azure",
+        modelId: "accounts/fireworks/models/kimi-k2p5",
+        provider: "fireworks",
         cost: [
             {
                 date: new Date("2026-01-28").getTime(),

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -54,7 +54,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "deepseek",
-        config: portkeyConfig["DeepSeek-V3.2"],
+        config: portkeyConfig["accounts/fireworks/models/deepseek-v3p2"],
     },
     {
         name: "grok",
@@ -147,7 +147,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "kimi",
-        config: portkeyConfig["Kimi-K2.5"],
+        config: portkeyConfig["accounts/fireworks/models/kimi-k2p5"],
     },
     {
         name: "gemini-large",

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -189,7 +189,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createOVHcloudMistralConfig({ model: "Qwen3Guard-Gen-8B" }),
 
     // -- Fireworks AI ---------------------------------------------------------
-    "Kimi-K2.5": () => createAzureNetsimsimConfig({ model: "Kimi-K2.5" }),
+    "accounts/fireworks/models/kimi-k2p5": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/kimi-k2p5",
+        }),
     "accounts/fireworks/models/glm-5": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/glm-5",
@@ -198,8 +201,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/minimax-m2p5",
         }),
-    "DeepSeek-V3.2": () =>
-        createAzureNetsimsimConfig({ model: "DeepSeek-V3.2" }),
+    "accounts/fireworks/models/deepseek-v3p2": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/deepseek-v3p2",
+        }),
 
     // -- Community Models -----------------------------------------------------
     "polly": () =>


### PR DESCRIPTION
## Summary
- Revert DeepSeek and Kimi from Azure netsimsim back to Fireworks
- Azure route has ~75% failure rate (Portkey returns generic 500s)
- Fireworks was stable at 99.7% success rate

## Changed
- `availableModels.ts`: point back to Fireworks model IDs
- `modelConfigs.ts`: restore Fireworks config entries
- `shared/registry/text.ts`: restore Fireworks provider + model IDs

Kontext (image) stays on Azure netsimsim — only text models reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)