### PR TITLE
restore website title sizes and match play subtitle pattern

### DIFF
--- a/pollinations.ai/src/copy/content/play.ts
+++ b/pollinations.ai/src/copy/content/play.ts
@@ -15,7 +15,9 @@ export const PLAY_PAGE = {
     pageDescription: "playground for poking at models",
     // Page titles and navigation
     createTitle: "Create",
-    createDescription: "playground for poking at models.",
+    subtitlePrefix: "🎛️ A",
+    subtitleBold: "playground",
+    subtitleSuffix: " for poking at models. 🧪",
     pricingLinkText: "See pricing",
 
     // PlayGenerator UI labels

--- a/pollinations.ai/src/ui/components/ui/typography.tsx
+++ b/pollinations.ai/src/ui/components/ui/typography.tsx
@@ -15,7 +15,7 @@ import { cn } from "../../../utils";
 // - PlayPage: "Create" / "Watch" (spacing="none" for custom)
 // ============================================
 const titleVariants = cva(
-    "font-title text-xl md:text-2xl font-black text-dark leading-tight pt-1 pb-1",
+    "font-title text-4xl md:text-5xl font-black text-dark leading-tight pt-1 pb-1",
     {
         variants: {
             spacing: {
@@ -65,9 +65,9 @@ const headingVariants = cva("font-headline font-black text-dark uppercase", {
         variant: {
             // Section headings with border-left accent (H2 - major sections)
             section:
-                "text-base md:text-lg tracking-widest border-l-4 border-dark pl-4",
+                "text-2xl md:text-3xl tracking-widest border-l-4 border-dark pl-4",
             // Subsection headings (H3 - card titles, nested sections)
-            subsection: "text-sm md:text-base tracking-wider text-dark",
+            subsection: "text-lg md:text-xl tracking-wider text-dark",
         },
         spacing: {
             default: "mb-4", // Standard spacing

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -86,7 +86,11 @@ function PlayPage() {
                 </div>
 
                 <div className="mb-6">
-                    <Body className="mb-3">{pageCopy.createDescription}</Body>
+                    <Body className="mb-3">
+                        {pageCopy.subtitlePrefix}{" "}
+                        <strong>{pageCopy.subtitleBold}</strong>
+                        {pageCopy.subtitleSuffix}
+                    </Body>
                     <a
                         href={LINKS.enter}
                         target="_blank"


### PR DESCRIPTION
- Restore `Title` to `text-4xl md:text-5xl` and `Heading` `section`/`subsection` to pre-redesign sizes (shrunk in #8902, titles were ~50% smaller than before)
- Split Play page subtitle into `subtitlePrefix` / `subtitleBold` / `subtitleSuffix` so it renders the same way as Hello / Apps / Community
- Add leading/trailing emojis to Play subtitle to match the other pages