### PR TITLE
move deepseek to Azure FW deployment and kimi to Bedrock

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -252,14 +252,14 @@ export const TEXT_SERVICES = {
     },
     "deepseek": {
         aliases: ["deepseek-v3", "deepseek-v3.2", "deepseek-reasoning"],
-        modelId: "DeepSeek-V3.2",
+        modelId: "FW-DeepSeek-V3.2",
         provider: "azure",
         cost: [
             {
                 date: COST_START_DATE,
-                promptTextTokens: perMillion(0.58),
-                promptCachedTokens: perMillion(0.29),
-                completionTextTokens: perMillion(1.68),
+                promptTextTokens: perMillion(0.62),
+                promptCachedTokens: perMillion(0.31),
+                completionTextTokens: perMillion(1.85),
             },
         ],
         description: "DeepSeek V3.2 - Efficient Reasoning & Agentic AI",
@@ -501,13 +501,12 @@ export const TEXT_SERVICES = {
     },
     "kimi": {
         aliases: ["kimi-k2.5", "kimi-k2p5", "kimi-reasoning", "kimi-large"],
-        modelId: "Kimi-K2.5",
-        provider: "azure",
+        modelId: "moonshotai.kimi-k2.5",
+        provider: "bedrock",
         cost: [
             {
                 date: new Date("2026-01-28").getTime(),
                 promptTextTokens: perMillion(0.6),
-                promptCachedTokens: perMillion(0.1),
                 completionTextTokens: perMillion(3.0),
             },
         ],

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -507,6 +507,8 @@ export const TEXT_SERVICES = {
             {
                 date: new Date("2026-01-28").getTime(),
                 promptTextTokens: perMillion(0.6),
+                // Bedrock charges cached tokens at the same rate as regular input
+                promptCachedTokens: perMillion(0.6),
                 completionTextTokens: perMillion(3.0),
             },
         ],

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -54,7 +54,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "deepseek",
-        config: portkeyConfig["accounts/fireworks/models/deepseek-v3p2"],
+        config: portkeyConfig["FW-DeepSeek-V3.2"],
     },
     {
         name: "grok",
@@ -143,7 +143,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "kimi",
-        config: portkeyConfig["accounts/fireworks/models/kimi-k2p5"],
+        config: portkeyConfig["moonshotai.kimi-k2.5"],
     },
     {
         name: "gemini-large",

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -3,7 +3,6 @@ import {
     createAzureModelConfig,
     createBedrockNativeConfig,
     createDashScopeModelConfig,
-    createFireworksModelConfig,
     createOVHcloudMistralConfig,
     createOVHcloudModelConfig,
     createPerplexityModelConfig,
@@ -86,15 +85,17 @@ export const portkeyConfig: PortkeyConfigMap = {
             "grok-4-20-reasoning",
         ),
 
-    // -- Fireworks AI (DeepSeek, Kimi) — bypassing Portkey/Azure stability issues
-    "accounts/fireworks/models/deepseek-v3p2": () =>
-        createFireworksModelConfig({
-            model: "accounts/fireworks/models/deepseek-v3p2",
-        }),
-    "accounts/fireworks/models/kimi-k2p5": () =>
-        createFireworksModelConfig({
-            model: "accounts/fireworks/models/kimi-k2p5",
-        }),
+    // -- Azure (Myceli Prod — eastus, Fireworks-hosted DeepSeek) ---------------
+    "FW-DeepSeek-V3.2": () =>
+        createAzureModelConfig(
+            process.env.AZURE_MYCELI_PROD_API_KEY,
+            "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/deployments/FW-DeepSeek-V3.2/chat/completions?api-version=2024-12-01-preview",
+            "FW-DeepSeek-V3.2",
+        ),
+
+    // -- AWS Bedrock (Kimi K2.5) — Azure FW-Kimi backend is unstable -----------
+    "moonshotai.kimi-k2.5": () =>
+        createBedrockNativeConfig({ model: "moonshotai.kimi-k2.5" }),
 
     // -- OVHcloud Mistral (cheaper than Azure, same model) ---------------------
     "mistral-small-3.2-24b-instruct-2506": () =>


### PR DESCRIPTION
- deepseek: Fireworks direct → Azure FW-DeepSeek-V3.2 (DataZoneStandard, capacity 250)
- kimi: Fireworks direct → AWS Bedrock moonshotai.kimi-k2.5
- Azure FW-Kimi-K2.5 was tested but the backend is broken (consistent 30s+ timeouts in eastus and eastus2)
- Bedrock Kimi K2.5 works reliably; verified 20/20 success under 10 concurrent load for both models
- Deployments created via Azure CLI on myceli-prod-eastus resource