### PR TITLE
feat: route gemini-2.5-flash-lite to Vertex global endpoint

### DIFF
--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -167,7 +167,7 @@ export const portkeyConfig: PortkeyConfigMap = {
     ),
     "gemini-2.5-flash-lite": createVertexGeminiConfig(
         "gemini-2.5-flash-lite",
-        "us-central1",
+        "global",
     ),
     "gemini-3.1-flash-lite-preview": createVertexGeminiConfig(
         "gemini-3.1-flash-lite-preview",


### PR DESCRIPTION
## Summary
- Switch `gemini-2.5-flash-lite` region from `us-central1` to `global` to pool quota across regions
- Matches config already used by `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`

## Why
We were hitting 429 rate limits on `us-central1`. Previous attempt (#10047, reverted in #10048) tried moving to a separate GCP project but that account had even lower quota.

## Test results
Sustained load probe against local dev server:

| Config | Test | Result |
|---|---|---|
| `us-central1` (main) | 50 concurrent burst | 50/50 ok, ~36 rps |
| netsim GCP account | 10 concurrent burst | 9/10 (1× 429), collapses at 20+ |
| **`global` (this PR)** | **5 rps × 5 min = 1500 reqs** | **1500/1500 ok**, p50 282ms, p95 950ms, p99 1.2s |

Target load is 1k requests / 5 min (3.33 rps average). This handles 1.5× that with zero throttling.

## Test plan
- [x] Local smoke test — returns 200 via `global`
- [x] Sustained load probe — 1500/1500 ok at 5 rps × 5 min
- [ ] Watch production error rate after merge

polly please review