### PR TITLE
rename flux + zimage provider from vast.ai to runpod; reclassify runpod+lambda as free GPU

### DIFF
--- a/apps/operation/economics/provisioning/dashboards/daily-spending.json
+++ b/apps/operation/economics/provisioning/dashboards/daily-spending.json
@@ -689,7 +689,7 @@
         "type": "grafana-clickhouse-datasource",
         "uid": "PAD1A0A25CD30D456"
       },
-      "description": "Daily paid GPU cost by provider/model (io.net/vast.ai).",
+      "description": "Daily paid GPU cost by provider/model (legacy io.net/vast.ai).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -908,7 +908,7 @@
         "type": "grafana-clickhouse-datasource",
         "uid": "PAD1A0A25CD30D456"
       },
-      "description": "Daily free GPU cost by provider/model. Modal GPU models (klein, ltx-2) + OVH GPU models.",
+      "description": "Daily free GPU cost by provider/model. All RunPod and Lambda models (flux, zimage, klein, ltx-2, etc.), legacy Modal events for klein/ltx-2, and OVH GPU models.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -994,7 +994,7 @@
           },
           "format": 0,
           "range": true,
-          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  toStartOfInterval(start_time, INTERVAL 1 DAY) as time,\n  concat(model_provider_used, ' / ', model_used) as series,\n  SUM(total_price) as cost\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND (\n    (model_provider_used = 'modal' AND (model_used IN ('klein', 'klein-large', 'ltx-2') OR model_used LIKE 'flux_klein%'))\n    OR (model_provider_used = 'ovhcloud' AND model_used NOT IN ('Qwen3-Coder-30B-A3B-Instruct', 'Mistral-Small-3.2-24B-Instruct-2506', 'whisper'))\n  )\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)\nGROUP BY time, series\nORDER BY time, series",
+          "rawSql": "WITH banned_users AS (\n  SELECT github_username\n  FROM d1_user\n  WHERE banned = 1\n  GROUP BY github_username\n)\nSELECT\n  toStartOfInterval(start_time, INTERVAL 1 DAY) as time,\n  concat(model_provider_used, ' / ', model_used) as series,\n  SUM(total_price) as cost\nFROM generation_event\nWHERE start_time >= $__fromTime AND start_time < $__toTime\n  AND (\n    (model_provider_used IN ('runpod', 'lambda'))\n    OR (model_provider_used = 'modal' AND (model_used IN ('klein', 'klein-large', 'ltx-2') OR model_used LIKE 'flux_klein%'))\n    OR (model_provider_used = 'ovhcloud' AND model_used NOT IN ('Qwen3-Coder-30B-A3B-Instruct', 'Mistral-Small-3.2-24B-Instruct-2506', 'whisper'))\n  )\n  AND is_billed_usage = true\n  AND response_status >= 200 AND response_status < 300\n    AND user_github_username NOT IN (SELECT github_username FROM banned_users)\nGROUP BY time, series\nORDER BY time, series",
           "refId": "A"
         }
       ],

--- a/apps/operation/economics/provisioning/dashboards/platform-load.json
+++ b/apps/operation/economics/provisioning/dashboards/platform-load.json
@@ -1260,6 +1260,21 @@
               {
                 "matcher": {
                   "id": "byName",
+                  "options": "runpod"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#00D4AA",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
                   "options": "modal"
                 },
                 "properties": [

--- a/apps/operation/economics/provisioning/dashboards/provider-costs.json
+++ b/apps/operation/economics/provisioning/dashboards/provider-costs.json
@@ -261,6 +261,21 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "runpod"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00D4AA",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "modal"
             },
             "properties": [
@@ -921,6 +936,21 @@
             "matcher": {
               "id": "byName",
               "options": "vast.ai"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00D4AA",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "runpod"
             },
             "properties": [
               {

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -166,7 +166,7 @@ export const IMAGE_SERVICES = {
     "flux": {
         aliases: [],
         modelId: "flux",
-        provider: "vast.ai",
+        provider: "runpod",
         cost: [
             {
                 date: COST_START_DATE,
@@ -180,7 +180,7 @@ export const IMAGE_SERVICES = {
     "zimage": {
         aliases: ["z-image", "z-image-turbo"],
         modelId: "zimage",
-        provider: "vast.ai",
+        provider: "runpod",
         cost: [
             {
                 date: COST_START_DATE,


### PR DESCRIPTION
flux and zimage moved from vast.ai to runpod. runpod and lambda are **free GPU infrastructure** for pollinations (monthly rent, not per-request pricing), so all events on those providers now land in the "Free GPU" dashboard bucket — not "Paid GPU".

### registry change (shared/registry/image.ts)

- \`flux.provider\`: \`vast.ai\` → \`runpod\`
- \`zimage.provider\`: \`vast.ai\` → \`runpod\`

klein (already \`runpod\`) and ltx-2 (already \`lambda\`) unchanged in the registry. this value is read at enter.pollinations.ai/src/middleware/track.ts:239 and emitted as \`model_provider_used\` on every generation event.

### grafana color rules (historical continuity)

**provider-costs.json**, **platform-load.json**: add matching \`runpod\` color rules next to the existing \`vast.ai\` ones so both render in teal. historical data tagged \`vast.ai\` stays visible alongside new \`runpod\` events.

### grafana daily-spending.json SQL filters

**"Paid GPU" panel**: unchanged from main — \`AND model_provider_used IN ('io.net', 'vast.ai')\`. no runpod/lambda inclusion. after flux/zimage finish migrating, this panel will only show historical io.net/vast.ai data (which eventually ages out). description updated from \`"(io.net/vast.ai)"\` → \`"(legacy io.net/vast.ai)"\` to reflect that these are historical providers.

**"Free GPU" panel**: filter extended. previous:
\`\`\`
(modal AND klein/klein-large/ltx-2/flux_klein%) OR (ovhcloud GPU models)
\`\`\`
new:
\`\`\`
(runpod|lambda) OR
(modal AND klein/klein-large/ltx-2/flux_klein%) OR
(ovhcloud GPU models)
\`\`\`
the broad \`runpod|lambda\` clause catches flux, zimage, klein, ltx-2, and any future model on the same infra. the modal clause stays to keep historical klein/ltx-2 events visible.

description updated to: _"Daily free GPU cost by provider/model. All RunPod and Lambda models (flux, zimage, klein, ltx-2, etc.), legacy Modal events for klein/ltx-2, and OVH GPU models."_

**"Free Inference" queries** at lines 237 and 889 unchanged — they already filter on a closed list of non-GPU free providers and never included flux/zimage/klein/ltx-2.

### unaffected

- **pruna** and **sana** still run on vast.ai — their provider field is unchanged
- test vcr cassettes keyed on the provider string at test/mocks/vcr.ts:72 will regenerate automatically on next run with \`TEST_VCR_MODE=record\`

### known orphans (flagged, not in this PR)

- \`$gpu_klein_daily\` and \`$gpu_klein_large_daily\` constants at daily-spending.json:1833,1851 are labeled "Modal L40S" but klein runs on runpod now. values may be stale.
- the "Free GPU $/day" stat at line 324 only sums those two Klein constants — it doesn't account for flux/zimage/ltx-2 infra rent. existing gap, unrelated to the provider rename.

the cost-accounting calculation you shared (flux $0.000298/image at proportional split, zimage $0.000396/image at 50/50 split, klein $0.003341/image) shows a separate model-level cost analysis that could eventually replace the per-model constant lookups with a runtime computation from RunPod pod rent + successful generation counts. out of scope here.

### not in this PR (follow-ups)
- unused-secrets cleanup (TESTING_REFERRER, REFILL_TOKEN, MODAL_LTX2_*, AIRFORCE_API_KEY, AZURE_MYCELI_GPT_AUDIO_MINI_*, etc.)
- dead /feed system removal in image.pollinations.ai