### PR TITLE
feat: issue automation pipeline with Polly triage

### DIFF
--- a/.github/docs/TRIAGE.md
+++ b/.github/docs/TRIAGE.md
@@ -9,6 +9,36 @@
 - **pr-issue-assistant.yml** - AI assistant (Polly) via pollinations.ai, triggered by `polly` in issues/PRs. Whitelisted users only.
 - **issue-pr-review-changes.yml** - Claude Opus agent triggered by `@claude` in issues/PRs. Performs code reviews and answers questions.
 
+## Issue Automation Pipeline
+
+- **issue-automation.yml** - Automated triage on every new issue. Calls Polly API to detect duplicates, already-resolved issues, and minor auto-fixable problems.
+
+### Flow
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TD
+    A[Issue Opened] --> B{Bot or TIER?}
+    B -->|Yes| C[Skip]
+    B -->|No| D[Call Polly API]
+    D -->|3 retries| E{Parse JSON verdict}
+    E -->|Parse fail| C
+    E -->|Success| F{Check action + confidence}
+    F -->|duplicate >= 0.85| G[Comment + Close as not_planned]
+    F -->|resolved >= 0.85| H[Comment + Close as completed]
+    F -->|auto_fix >= 0.70| I[Comment + Add polly label]
+    F -->|skip / below threshold| C
+    I --> J[issue-polly-auto-fix.yml triggered]
+```
+
+### Model Routing (Auto-Fix)
+
+| Role | Model | Purpose |
+|------|-------|---------|
+| Default | GLM | Code generation and fixes |
+| Thinking | Kimi K2.5 | Reasoning and planning |
+| Web Search | Perplexity Reasoning | Web lookups |
+
 ## Project Management
 
 - **project-manager.yml** - AI-powered auto-kanban. Classifies issues/PRs and routes to Dev/Support/News/Tier projects with priority.

--- a/.github/workflows/issue-automation-backfill.yml
+++ b/.github/workflows/issue-automation-backfill.yml
@@ -1,0 +1,260 @@
+name: Issue Automation Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (log only, no actions)'
+        type: boolean
+        default: true
+      max_issues:
+        description: 'Max issues to process (0 = all)'
+        type: number
+        default: 50
+      delay_seconds:
+        description: 'Delay between API calls (seconds)'
+        type: number
+        default: 5
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: token
+        with:
+          app-id: ${{ secrets.POLLY_BOT_APP_ID }}
+          private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
+
+      - name: Backfill Triage
+        uses: actions/github-script@v7
+        env:
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_AUTOPOLLY_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MAX_ISSUES: ${{ inputs.max_issues }}
+          DELAY_SECONDS: ${{ inputs.delay_seconds }}
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            const maxIssues = parseInt(process.env.MAX_ISSUES) || 0;
+            const delaySec = parseInt(process.env.DELAY_SECONDS) || 5;
+
+            console.log(`=== Issue Automation Backfill ===`);
+            console.log(`Mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`);
+            console.log(`Max issues: ${maxIssues || 'all'}`);
+            console.log(`Delay: ${delaySec}s between calls`);
+            console.log('');
+
+            // --- Polly System Prompt ---
+            const systemPrompt = `You are an issue triage bot for pollinations/pollinations. Your ONLY output is a single raw JSON object. NO markdown. NO code fences. NO explanation. NO text before or after. JUST the JSON object starting with { and ending with }.
+
+            Workflow:
+            1. Use find_similar to check for duplicates
+            2. Use code_search to check if the problem is already fixed in code
+            3. Assess if it is a minor auto-fixable issue
+            4. Return your verdict as JSON
+
+            Schema: {"action":"duplicate|resolved|auto_fix|skip","confidence":0.0-1.0,"reason":"1-2 sentences","similar_issue":"#number or null","solution_reference":"file/commit/PR or null","comment":"friendly comment to post on the issue, or null if skip"}
+
+            Rules:
+            - "duplicate": Issue matches an existing open issue. High confidence only.
+            - "resolved": Problem is already fixed in the codebase (found via code_search). High confidence only.
+            - "auto_fix": Issue is minor and well-defined (typo, small bug, config change, doc update). Not urgent.
+            - "skip": Issue needs human attention (vague, complex, urgent, architectural).
+            - Always search before deciding. Never guess.
+            - For duplicates, reference the original issue number in the comment.
+            - For resolved issues, reference the specific file/commit/PR in the comment.`;
+
+            const fewShot = [
+              { role: 'user', content: 'Title: grok-video ignoring image input\nBody: When I pass an image to grok-video it completely ignores it and generates from text only.' },
+              { role: 'assistant', content: '{"action":"duplicate","confidence":0.95,"reason":"Exact duplicate of #8262 which reports the same grok-video image input being ignored.","similar_issue":"#8262","solution_reference":null,"comment":"This is a known issue! See #8262 for the ongoing discussion about grok-video ignoring image inputs. Closing as duplicate."}' },
+              { role: 'user', content: 'Title: Service is completely down, nothing works\nBody: All API endpoints returning 500 errors since 10 minutes ago.' },
+              { role: 'assistant', content: '{"action":"skip","confidence":0.99,"reason":"Critical outage report requiring immediate human investigation.","similar_issue":null,"solution_reference":null,"comment":null}' },
+              { role: 'user', content: 'Title: Fix broken link in README contributing section\nBody: The link to CONTRIBUTING.md in the main README.md points to /docs/CONTRIBUTING.md but the file is at /CONTRIBUTING.md in the repo root.' },
+              { role: 'assistant', content: '{"action":"auto_fix","confidence":0.90,"reason":"Simple broken link fix in README.md. Well-defined, minor change.","similar_issue":null,"solution_reference":"README.md","comment":"Looks like a quick link fix! Polly will take care of this."}' },
+            ];
+
+            // --- JSON extractor ---
+            function extractJSON(content) {
+              if (!content?.trim()) return null;
+              content = content.trim();
+
+              try {
+                const parsed = JSON.parse(content);
+                if (parsed?.action) return parsed;
+              } catch {}
+
+              const fenced = content.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
+              if (fenced) {
+                try {
+                  const parsed = JSON.parse(fenced[1]);
+                  if (parsed?.action) return parsed;
+                } catch {}
+              }
+
+              const braceMatch = content.match(/\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/);
+              if (braceMatch) {
+                try {
+                  const parsed = JSON.parse(braceMatch[0]);
+                  if (parsed?.action) return parsed;
+                } catch {}
+              }
+
+              return null;
+            }
+
+            // --- Call Polly for a single issue ---
+            const SEEDS = [42, 777, 1337];
+            async function triageIssue(issue) {
+              const issueContent = `Title: ${issue.title}\nBody: ${(issue.body || '').slice(0, 3000)}`;
+
+              for (let attempt = 0; attempt < 3; attempt++) {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), 120000);
+                try {
+                  const response = await fetch('https://gen.pollinations.ai/v1/chat/completions', {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Authorization': `Bearer ${process.env.POLLINATIONS_TOKEN}`,
+                    },
+                    body: JSON.stringify({
+                      model: 'polly',
+                      seed: SEEDS[attempt],
+                      messages: [
+                        { role: 'system', content: systemPrompt },
+                        ...fewShot,
+                        { role: 'user', content: issueContent },
+                      ],
+                      max_tokens: 500,
+                      response_format: { type: 'json_object' },
+                    }),
+                    signal: controller.signal,
+                  });
+
+                  if (response.ok) {
+                    const data = await response.json();
+                    const content = data.choices?.[0]?.message?.content;
+                    const verdict = extractJSON(content);
+                    if (verdict) return verdict;
+                  }
+                } catch (err) {
+                  console.log(`  Attempt ${attempt + 1} error: ${err.message}`);
+                } finally {
+                  clearTimeout(timeout);
+                }
+
+                if (attempt < 2) {
+                  await new Promise(r => setTimeout(r, 2000 * (attempt + 1)));
+                }
+              }
+              return null;
+            }
+
+            // --- Fetch all open issues (paginated) ---
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            let allIssues = [];
+            let page = 1;
+
+            while (true) {
+              const { data: batch } = await github.rest.issues.listForRepo({
+                owner, repo, state: 'open', per_page: 100, page,
+                sort: 'created', direction: 'asc',
+              });
+
+              // Filter out PRs (GitHub API returns PRs in issues endpoint)
+              const issues = batch.filter(i => !i.pull_request);
+              allIssues.push(...issues);
+
+              if (batch.length < 100) break;
+              page++;
+            }
+
+            console.log(`Found ${allIssues.length} open issues`);
+
+            // Filter out bots and TIER-labeled
+            const eligible = allIssues.filter(issue => {
+              const login = issue.user?.login || '';
+              if (login.endsWith('[bot]') || login.includes('dependabot') || login.includes('renovate')) return false;
+              if (issue.labels?.some(l => l.name.startsWith('TIER-'))) return false;
+              // Skip issues that already have the polly label
+              if (issue.labels?.some(l => l.name === 'polly')) return false;
+              return true;
+            });
+
+            const toProcess = maxIssues > 0 ? eligible.slice(0, maxIssues) : eligible;
+            console.log(`Eligible: ${eligible.length}, Processing: ${toProcess.length}`);
+            console.log('');
+
+            // --- Process each issue ---
+            const stats = { duplicate: 0, resolved: 0, auto_fix: 0, skip: 0, error: 0 };
+            const validActions = ['duplicate', 'resolved', 'auto_fix', 'skip'];
+            const thresholds = { duplicate: 0.85, resolved: 0.85, auto_fix: 0.70 };
+
+            for (let i = 0; i < toProcess.length; i++) {
+              const issue = toProcess[i];
+              console.log(`[${i + 1}/${toProcess.length}] #${issue.number}: ${issue.title.slice(0, 80)}`);
+
+              const verdict = await triageIssue(issue);
+
+              if (!verdict || !validActions.includes(verdict.action)) {
+                console.log(`  -> error (no valid verdict)`);
+                stats.error++;
+                if (i < toProcess.length - 1) await new Promise(r => setTimeout(r, delaySec * 1000));
+                continue;
+              }
+
+              const minConf = thresholds[verdict.action];
+              if (minConf && verdict.confidence < minConf) {
+                console.log(`  -> skip (${verdict.action} confidence ${verdict.confidence} < ${minConf})`);
+                stats.skip++;
+                if (i < toProcess.length - 1) await new Promise(r => setTimeout(r, delaySec * 1000));
+                continue;
+              }
+
+              console.log(`  -> ${verdict.action} (confidence: ${verdict.confidence}) ${verdict.reason || ''}`);
+              stats[verdict.action]++;
+
+              if (dryRun) {
+                if (i < toProcess.length - 1) await new Promise(r => setTimeout(r, delaySec * 1000));
+                continue;
+              }
+
+              // Execute action
+              const issue_number = issue.number;
+              try {
+                if (verdict.action === 'duplicate' && verdict.comment) {
+                  await github.rest.issues.createComment({ owner, repo, issue_number, body: verdict.comment });
+                  await github.rest.issues.update({ owner, repo, issue_number, state: 'closed', state_reason: 'not_planned' });
+                } else if (verdict.action === 'resolved' && verdict.comment) {
+                  await github.rest.issues.createComment({ owner, repo, issue_number, body: verdict.comment });
+                  await github.rest.issues.update({ owner, repo, issue_number, state: 'closed', state_reason: 'completed' });
+                } else if (verdict.action === 'auto_fix') {
+                  if (verdict.comment) {
+                    await github.rest.issues.createComment({ owner, repo, issue_number, body: verdict.comment });
+                  }
+                  await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['polly'] });
+                }
+              } catch (err) {
+                console.log(`  Action failed: ${err.message}`);
+              }
+
+              // Delay between issues
+              if (i < toProcess.length - 1) {
+                await new Promise(r => setTimeout(r, delaySec * 1000));
+              }
+            }
+
+            // --- Summary ---
+            console.log('');
+            console.log('=== Summary ===');
+            console.log(`${dryRun ? '(DRY RUN) ' : ''}Processed: ${toProcess.length}`);
+            console.log(`  duplicate: ${stats.duplicate}`);
+            console.log(`  resolved: ${stats.resolved}`);
+            console.log(`  auto_fix: ${stats.auto_fix}`);
+            console.log(`  skip: ${stats.skip}`);
+            console.log(`  error: ${stats.error}`);

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -109,10 +109,9 @@ jobs:
             let verdict = null;
 
             for (let attempt = 0; attempt < 3; attempt++) {
+              const controller = new AbortController();
+              const timeout = setTimeout(() => controller.abort(), 120000);
               try {
-                const controller = new AbortController();
-                const timeout = setTimeout(() => controller.abort(), 120000);
-
                 const response = await fetch('https://gen.pollinations.ai/v1/chat/completions', {
                   method: 'POST',
                   headers: {
@@ -133,8 +132,6 @@ jobs:
                   signal: controller.signal,
                 });
 
-                clearTimeout(timeout);
-
                 if (response.ok) {
                   const data = await response.json();
                   const content = data.choices?.[0]?.message?.content;
@@ -146,6 +143,8 @@ jobs:
                 }
               } catch (err) {
                 console.log(`Attempt ${attempt + 1} error: ${err.message}`);
+              } finally {
+                clearTimeout(timeout);
               }
 
               if (attempt < 2) {
@@ -159,6 +158,13 @@ jobs:
             }
 
             console.log(`Verdict: ${JSON.stringify(verdict)}`);
+
+            // --- Validate action ---
+            const validActions = ['duplicate', 'resolved', 'auto_fix', 'skip'];
+            if (!validActions.includes(verdict.action)) {
+              console.log(`Invalid action "${verdict.action}". Skipping.`);
+              return;
+            }
 
             // --- Confidence thresholds ---
             const thresholds = { duplicate: 0.85, resolved: 0.85, auto_fix: 0.70 };

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -1,0 +1,192 @@
+name: Issue Automation
+
+on:
+  issues:
+    types: [opened]
+
+concurrency:
+  group: issue-automation-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    # Skip bots and TIER issues
+    if: |
+      !endsWith(github.event.issue.user.login, '[bot]') &&
+      !contains(github.event.issue.user.login, 'dependabot') &&
+      !contains(github.event.issue.user.login, 'renovate')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: token
+        with:
+          app-id: ${{ secrets.POLLY_BOT_APP_ID }}
+          private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
+
+      - name: Triage Issue
+        uses: actions/github-script@v7
+        env:
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_AUTOPOLLY_KEY }}
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          script: |
+            const issue = context.payload.issue;
+
+            // Skip TIER-labeled issues
+            const hasTierLabel = issue.labels?.some(l => l.name.startsWith('TIER-'));
+            if (hasTierLabel) {
+              console.log('Skipping: TIER-labeled issue');
+              return;
+            }
+
+            // --- Polly System Prompt ---
+            const systemPrompt = `You are an issue triage bot for pollinations/pollinations. Your ONLY output is a single raw JSON object. NO markdown. NO code fences. NO explanation. NO text before or after. JUST the JSON object starting with { and ending with }.
+
+            Workflow:
+            1. Use find_similar to check for duplicates
+            2. Use code_search to check if the problem is already fixed in code
+            3. Assess if it is a minor auto-fixable issue
+            4. Return your verdict as JSON
+
+            Schema: {"action":"duplicate|resolved|auto_fix|skip","confidence":0.0-1.0,"reason":"1-2 sentences","similar_issue":"#number or null","solution_reference":"file/commit/PR or null","comment":"friendly comment to post on the issue, or null if skip"}
+
+            Rules:
+            - "duplicate": Issue matches an existing open issue. High confidence only.
+            - "resolved": Problem is already fixed in the codebase (found via code_search). High confidence only.
+            - "auto_fix": Issue is minor and well-defined (typo, small bug, config change, doc update). Not urgent.
+            - "skip": Issue needs human attention (vague, complex, urgent, architectural).
+            - Always search before deciding. Never guess.
+            - For duplicates, reference the original issue number in the comment.
+            - For resolved issues, reference the specific file/commit/PR in the comment.`;
+
+            // --- Few-shot examples ---
+            const fewShot = [
+              { role: 'user', content: 'Title: grok-video ignoring image input\nBody: When I pass an image to grok-video it completely ignores it and generates from text only.' },
+              { role: 'assistant', content: '{"action":"duplicate","confidence":0.95,"reason":"Exact duplicate of #8262 which reports the same grok-video image input being ignored.","similar_issue":"#8262","solution_reference":null,"comment":"This is a known issue! See #8262 for the ongoing discussion about grok-video ignoring image inputs. Closing as duplicate."}' },
+              { role: 'user', content: 'Title: Service is completely down, nothing works\nBody: All API endpoints returning 500 errors since 10 minutes ago.' },
+              { role: 'assistant', content: '{"action":"skip","confidence":0.99,"reason":"Critical outage report requiring immediate human investigation.","similar_issue":null,"solution_reference":null,"comment":null}' },
+              { role: 'user', content: 'Title: Fix broken link in README contributing section\nBody: The link to CONTRIBUTING.md in the main README.md points to /docs/CONTRIBUTING.md but the file is at /CONTRIBUTING.md in the repo root.' },
+              { role: 'assistant', content: '{"action":"auto_fix","confidence":0.90,"reason":"Simple broken link fix in README.md. Well-defined, minor change.","similar_issue":null,"solution_reference":"README.md","comment":"Looks like a quick link fix! Polly will take care of this."}' },
+            ];
+
+            // --- JSON extractor ---
+            function extractJSON(content) {
+              if (!content?.trim()) return null;
+              content = content.trim();
+
+              // Try 1: direct parse
+              try {
+                const parsed = JSON.parse(content);
+                if (parsed?.action) return parsed;
+              } catch {}
+
+              // Try 2: strip markdown code fences
+              const fenced = content.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/);
+              if (fenced) {
+                try {
+                  const parsed = JSON.parse(fenced[1]);
+                  if (parsed?.action) return parsed;
+                } catch {}
+              }
+
+              // Try 3: find JSON object in prose
+              const braceMatch = content.match(/\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/);
+              if (braceMatch) {
+                try {
+                  const parsed = JSON.parse(braceMatch[0]);
+                  if (parsed?.action) return parsed;
+                } catch {}
+              }
+
+              return null;
+            }
+
+            // --- Call Polly with retries ---
+            const SEEDS = [42, 777, 1337];
+            const issueContent = `Title: ${issue.title}\nBody: ${(issue.body || '').slice(0, 3000)}`;
+            let verdict = null;
+
+            for (let attempt = 0; attempt < 3; attempt++) {
+              try {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), 120000);
+
+                const response = await fetch('https://gen.pollinations.ai/v1/chat/completions', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${process.env.POLLINATIONS_TOKEN}`,
+                  },
+                  body: JSON.stringify({
+                    model: 'polly',
+                    seed: SEEDS[attempt],
+                    messages: [
+                      { role: 'system', content: systemPrompt },
+                      ...fewShot,
+                      { role: 'user', content: issueContent },
+                    ],
+                    max_tokens: 500,
+                    response_format: { type: 'json_object' },
+                  }),
+                  signal: controller.signal,
+                });
+
+                clearTimeout(timeout);
+
+                if (response.ok) {
+                  const data = await response.json();
+                  const content = data.choices?.[0]?.message?.content;
+                  console.log(`Attempt ${attempt + 1} raw response: ${content}`);
+                  verdict = extractJSON(content);
+                  if (verdict) break;
+                } else {
+                  console.log(`Attempt ${attempt + 1} HTTP ${response.status}`);
+                }
+              } catch (err) {
+                console.log(`Attempt ${attempt + 1} error: ${err.message}`);
+              }
+
+              if (attempt < 2) {
+                await new Promise(r => setTimeout(r, 2000 * (attempt + 1)));
+              }
+            }
+
+            if (!verdict) {
+              console.log('All retries failed or no valid JSON. Skipping.');
+              return;
+            }
+
+            console.log(`Verdict: ${JSON.stringify(verdict)}`);
+
+            // --- Confidence thresholds ---
+            const thresholds = { duplicate: 0.85, resolved: 0.85, auto_fix: 0.70 };
+            const minConfidence = thresholds[verdict.action];
+            if (minConfidence && verdict.confidence < minConfidence) {
+              console.log(`Confidence ${verdict.confidence} below threshold ${minConfidence} for ${verdict.action}. Skipping.`);
+              return;
+            }
+
+            // --- Execute action ---
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+
+            if (verdict.action === 'duplicate' && verdict.comment) {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: verdict.comment });
+              await github.rest.issues.update({ owner, repo, issue_number, state: 'closed', state_reason: 'not_planned' });
+              console.log(`Closed #${issue_number} as duplicate`);
+            } else if (verdict.action === 'resolved' && verdict.comment) {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: verdict.comment });
+              await github.rest.issues.update({ owner, repo, issue_number, state: 'closed', state_reason: 'completed' });
+              console.log(`Closed #${issue_number} as resolved`);
+            } else if (verdict.action === 'auto_fix') {
+              if (verdict.comment) {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body: verdict.comment });
+              }
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['polly'] });
+              console.log(`Added polly label to #${issue_number} for auto-fix`);
+            } else {
+              console.log(`Action: skip for #${issue_number}`);
+            }

--- a/.github/workflows/issue-polly-auto-fix.yml
+++ b/.github/workflows/issue-polly-auto-fix.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       actions: read
     env:
-      POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
+      POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_AUTOPOLLY_KEY }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: token
@@ -73,7 +73,7 @@ jobs:
           BOT_USER_ID=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
           echo "user-id=$BOT_USER_ID" >> "$GITHUB_OUTPUT"
           mkdir -p $HOME/.claude-code-router
-          echo '{"LOG":false,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"'"${POLLINATIONS_TOKEN}"'","models":["claude-large","perplexity-reasoning"]}],"Router":{"default":"pollinations,glm","webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
+          echo '{"LOG":false,"NON_INTERACTIVE_MODE":true,"API_TIMEOUT_MS":600000,"Providers":[{"name":"pollinations","api_base_url":"https://gen.pollinations.ai/v1/chat/completions","api_key":"'"${POLLINATIONS_TOKEN}"'","models":["claude-large","perplexity-reasoning","glm","kimi"]}],"Router":{"default":"pollinations,glm","thinking":"pollinations,kimi","webSearch":"pollinations,perplexity-reasoning"}}' > $HOME/.claude-code-router/config.json
 
           # Start router with Bun
           bunx @musistudio/claude-code-router start &


### PR DESCRIPTION
## Summary

- Adds `issue-automation.yml` — auto-triages every new issue via Polly API (duplicate detection, resolved check, minor auto-fix trigger)
- Updates `issue-polly-auto-fix.yml` router to GLM (default), Kimi K2.5 (thinking), Perplexity Reasoning (web)
- Both workflows now use `PLN_GITHUB_AUTOPOLLY_KEY` secret

## How it works

1. Issue opened → call Polly with structured prompt + few-shot examples
2. Polly uses `find_similar` + `code_search` tools, returns JSON verdict
3. Workflow acts on verdict:
   - **duplicate** (>= 0.85 confidence): comment + close
   - **resolved** (>= 0.85): comment + close
   - **auto_fix** (>= 0.70): comment + add `polly` label → triggers auto-fix
   - **skip**: do nothing, project-manager handles it
4. 3 retries with random seeds, robust JSON extraction (handles fences/prose)
5. Skips bots, TIER-labeled issues

## Test plan

- [ ] Verify `PLN_GITHUB_AUTOPOLLY_KEY` secret exists in repo settings
- [ ] Open a test issue with a known duplicate title → should auto-close
- [ ] Open a test issue with a minor fix request → should add `polly` label
- [ ] Open a vague issue → should skip (no action)
- [ ] Verify project-manager still runs independently