### PR TITLE
feat: swap kimi to K2-thinking on Bedrock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,10 @@ agent-communication.md
 enter.pollinations.ai/src/tier-progression/spore-to-microbe-report-enriched.csv
 enter.pollinations.ai/src/tier-progression/spore-to-microbe-report-reviewed.csv
 enter.pollinations.ai/src/tier-progression/abuse-ledger.csv
+apps/operation/finance/secrets/vendors.json
+apps/operation/finance/secrets/update-live.err
+apps/operation/finance/secrets/pool-history.json
+apps/operation/finance/secrets/input/2026-03.csv
+apps/operation/finance/secrets/input/2026-02.csv
+apps/operation/finance/secrets/input/2026-01.csv
+apps/operation/finance/config.local.json

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -500,25 +500,29 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "kimi": {
-        aliases: ["kimi-k2.5", "kimi-k2p5", "kimi-reasoning", "kimi-large"],
-        modelId: "moonshotai.kimi-k2.5",
+        aliases: [
+            "kimi-k2-thinking",
+            "kimi-thinking",
+            "kimi-reasoning",
+            "kimi-large",
+        ],
+        modelId: "moonshot.kimi-k2-thinking",
         provider: "bedrock",
         cost: [
             {
-                date: new Date("2026-01-28").getTime(),
-                promptTextTokens: perMillion(0.6),
-                // Bedrock charges cached tokens at the same rate as regular input
-                promptCachedTokens: perMillion(0.6),
-                completionTextTokens: perMillion(3.0),
+                date: new Date("2026-04-12").getTime(),
+                promptTextTokens: perMillion(0.73),
+                promptCachedTokens: perMillion(0.73),
+                completionTextTokens: perMillion(3.03),
             },
         ],
         description:
-            "Moonshot Kimi K2.5 - Flagship Agentic Model with Vision & Multi-Agent",
-        inputModalities: ["text", "image"],
+            "Moonshot Kimi K2 Thinking - Reasoning model with extended thinking",
+        inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
-        contextLength: 256000,
+        contextLength: 128000,
         isSpecialized: false,
     },
     "gemini-large": {

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -143,7 +143,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "kimi",
-        config: portkeyConfig["moonshotai.kimi-k2.5"],
+        config: portkeyConfig["moonshot.kimi-k2-thinking"],
     },
     {
         name: "gemini-large",

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -93,9 +93,9 @@ export const portkeyConfig: PortkeyConfigMap = {
             "FW-DeepSeek-V3.2",
         ),
 
-    // -- AWS Bedrock (Kimi K2.5) — Azure FW-Kimi backend is unstable -----------
-    "moonshotai.kimi-k2.5": () =>
-        createBedrockNativeConfig({ model: "moonshotai.kimi-k2.5" }),
+    // -- AWS Bedrock (Kimi K2 Thinking) — Azure FW-Kimi backend is unstable ----
+    "moonshot.kimi-k2-thinking": () =>
+        createBedrockNativeConfig({ model: "moonshot.kimi-k2-thinking" }),
 
     // -- OVHcloud Mistral (cheaper than Azure, same model) ---------------------
     "mistral-small-3.2-24b-instruct-2506": () =>


### PR DESCRIPTION
- Swap kimi model from `moonshotai.kimi-k2.5` (non-thinking) to `moonshot.kimi-k2-thinking`
- Verified working on Bedrock: returns thinking blocks, handles 10 concurrent requests
- Update pricing to on-demand rates ($0.73 input / $3.03 output per M tokens)
- Fix context length to 128K and input modalities to text-only
- Gitignore finance secrets and local config files