### PR TITLE
feat: migrate Sana Sprint 1.6B to GH200

### DIFF
--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monitor-services
-description: "Health check and auto-restart all Pollinations GPU services (Flux/Z-Image on RunPod, LTX-2 on GH200, Klein on RunPod, legacy image on OVH, Sana on Vast.ai). Use with /loop for recurring checks."
+description: "Health check and auto-restart all Pollinations GPU services (Flux/Z-Image on RunPod, LTX-2 on GH200, Klein on RunPod, legacy image on OVH, Sana on Oracle Cloud). Use with /loop for recurring checks."
 ---
 
 # Monitor Services
@@ -168,19 +168,17 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 
 ---
 
-### 6. Sana Sprint 1.6B Workers (Lambda Labs)
+### 6. Sana Sprint 1.6B Worker (GH200 - same host as LTX-2)
 
-Two workers registered as `sana` type with OVH legacy service via heartbeat (no SSH tunnels).
+One worker registered as `sana` type with OVH legacy service via heartbeat.
 
 | Instance | GPU | Host | Port | SSH |
 |----------|-----|------|------|-----|
-| Lambda A10 | A10 (24GB) | `150.136.85.48` | `8765` | `ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48` |
-| Lambda A100 | A100 (40GB) | `150.136.209.134` | `8765` | `ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134` |
+| Lambda GH200 | GH200 (96GB) | `192.222.51.105` | `8766` | `ssh -i ~/.ssh/thomashkey ubuntu@192.222.51.105` |
 
 **Health check:**
 ```bash
-curl -s --connect-timeout 5 --max-time 10 http://150.136.85.48:8765/health
-curl -s --connect-timeout 5 --max-time 10 http://150.136.209.134:8765/health
+curl -s --connect-timeout 5 --max-time 10 http://192.222.51.105:8766/health
 ```
 Expected: `{"status":"healthy","model":"Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers"}`
 
@@ -188,18 +186,19 @@ Expected: `{"status":"healthy","model":"Efficient-Large-Model/Sana_Sprint_1.6B_1
 ```bash
 ssh -i ~/.ssh/id_rsa_ovh -o ConnectTimeout=5 ubuntu@57.130.31.42 "curl -s http://localhost:16384/register"
 ```
-Expected: 2 workers with 0% error rate
+Expected: 1 worker with 0% error rate
 
 **Restart:**
 ```bash
-ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48 "sudo systemctl restart sana"
-ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134 "sudo systemctl restart sana"
+ssh -i ~/.ssh/thomashkey ubuntu@192.222.51.105 "sudo systemctl restart sana"
 ```
 
 **Notes:**
-- A10 generates at ~0.60s/img, A100 at ~0.25s/img
-- Replaced SDXL Turbo on Vast.ai (instance 34086100, now STOPPED)
+- GH200 generates at ~0.165s/img
+- Runs alongside LTX-2 (port 8765) and ACE-Step (port 8189) on the same host
+- Oracle A10/A100 instances decommissioned on 2026-04-12
 - Server code: `image.pollinations.ai/sana/server.py` (MAX_DIM=768, MAX_PIXELS=512*512)
+- Systemd service: `sana.service`
 
 ---
 
@@ -229,8 +228,8 @@ When invoked, run checks in this order:
 5. **ACE-Step health** - curl health endpoint on port 8189
 6. **Klein health** - curl RunPod proxy health endpoint
 7. **Legacy image service** - check systemctl status on OVH
-8. **Sana workers** - curl health on both Lambda instances (A10 + A100)
-9. **Sana registry** - check OVH legacy registry for 2 workers with 0% errors
+8. **Sana worker** - curl health on GH200 port 8766
+9. **Sana registry** - check OVH legacy registry for 1 worker with 0% errors
 10. **Disk space** - check OVH disk usage
 
 For each:
@@ -259,8 +258,7 @@ Report a brief status table:
 | ACE-Step | OK | 0.1s | |
 | Klein 4B | OK | 0.3s | RunPod |
 | Legacy image | OK | - | active |
-| Sana (Lambda A10) | OK | 0.2s | 1.6B, ~0.60s/img |
-| Sana (Lambda A100) | OK | 0.2s | 1.6B, ~0.25s/img |
-| Sana registry | OK | - | 2 workers, 0% errors |
+| Sana (GH200) | OK | 0.2s | 1.6B, ~0.165s/img |
+| Sana registry | OK | - | 1 worker, 0% errors |
 | OVH disk | OK | - | 45% used |
 ```

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -14,8 +14,9 @@ Last updated: 2026-04-05
 | Z-Image (serverless) | 1-2 | ADA_32_PRO | RunPod | pay-per-use | Elliot |
 | Flux | 4 | 4x RTX 5090 | Vast.ai | $1.68 | running (not in registry) |
 | Z-Image + Sana | 4 | 4x RTX 5090 | Vast.ai | $1.66 | **STOPPED** |
-| Sana Sprint 1.6B | 1 | A10 | Lambda Labs | — | **ACTIVE** — sana registry |
-| Sana Sprint 1.6B | 1 | A100 | Lambda Labs | — | **ACTIVE** — sana registry |
+| Sana Sprint 1.6B | 1 | GH200 | Lambda Labs | — | **ACTIVE** — sana registry (port 8766) |
+| ~~Sana Sprint 1.6B~~ | ~~1~~ | ~~A10~~ | ~~Oracle Cloud~~ | — | **STOPPED** (2026-04-12) |
+| ~~Sana Sprint 1.6B~~ | ~~1~~ | ~~A100~~ | ~~Oracle Cloud~~ | — | **STOPPED** (2026-04-12) |
 | ~~SDXL Turbo (legacy sana)~~ | 1 | 1x RTX 4090 | Vast.ai | $0.36 | **STOPPED** — replaced by Lambda Labs |
 | Z-Image | 3 | 3x RTX 5090 | Vast.ai | $1.55 | running (not in registry) |
 | **Total active** | **~8** | | | **~$1.94/hr + serverless** |
@@ -161,23 +162,34 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 - **LTX-2**: port 8765, health at `/health`
 - **ACE-Step**: port 8189, systemd `acestep.service`
 
-### Sana Sprint 1.6B (A10)
+### Sana Sprint 1.6B (GH200 - colocated with LTX-2 + ACE-Step)
 
+- **Host**: `192.222.51.105`
+- **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@192.222.51.105`
+- **Port**: 8766, health at `/health`
+- **Model**: `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers`
+- **Speed**: ~0.165s/img
+- **Registry**: Registers as `sana` type with OVH legacy service
+- **Systemd**: `sana.service`
+- **Code**: `/home/ubuntu/sana/server.py`
+
+### Sana Sprint 1.6B (A10) — STOPPED
+
+- **Status**: **STOPPED** (2026-04-12) — instance turned off
 - **Host**: `150.136.85.48`
 - **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@150.136.85.48`
 - **Port**: 8765, health at `/health`
 - **Model**: `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers`
 - **Speed**: ~0.60s/img
-- **Registry**: Registers as `sana` type with OVH legacy service
 
-### Sana Sprint 1.6B (A100)
+### Sana Sprint 1.6B (A100) — STOPPED
 
+- **Status**: **STOPPED** (2026-04-12) — replaced by Sana on GH200
 - **Host**: `150.136.209.134`
 - **SSH**: `ssh -i ~/.ssh/thomashkey ubuntu@150.136.209.134`
 - **Port**: 8765, health at `/health`
 - **Model**: `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers`
 - **Speed**: ~0.25s/img
-- **Registry**: Registers as `sana` type with OVH legacy service
 
 ## Provider: EC2 (AWS)
 

--- a/image.pollinations.ai/sana/server.py
+++ b/image.pollinations.ai/sana/server.py
@@ -1,4 +1,4 @@
-import os, sys, io, base64, logging, torch, time, threading, warnings, math
+import os, sys, io, base64, logging, torch, time, threading, warnings, asyncio, aiohttp
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -13,10 +13,11 @@ logger = logging.getLogger(__name__)
 for noisy in ["httpx", "httpcore", "urllib3", "diffusers", "transformers", "huggingface_hub"]:
     logging.getLogger(noisy).setLevel(logging.WARNING)
 
-MODEL_ID = "Efficient-Large-Model/Sana_Sprint_0.6B_1024px_diffusers"
+MODEL_ID = os.getenv("SANA_MODEL", "Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers")
 MODEL_CACHE = "model_cache"
-NUM_INFERENCE_STEPS = 2
-MAX_DIM = 512
+NUM_INFERENCE_STEPS = int(os.getenv("NUM_INFERENCE_STEPS", "2"))
+MAX_DIM = int(os.getenv("MAX_DIM", "768"))
+MAX_PIXELS = int(os.getenv("MAX_PIXELS", str(512 * 512)))
 
 generate_lock = threading.Lock()
 
@@ -32,9 +33,55 @@ def clamp_dims(w, h):
     w, h = min(w, MAX_DIM), min(h, MAX_DIM)
     w = max(32, (w // 32) * 32)
     h = max(32, (h // 32) * 32)
+    # Clamp total pixels
+    if w * h > MAX_PIXELS:
+        scale = (MAX_PIXELS / (w * h)) ** 0.5
+        w = max(32, int(w * scale) // 32 * 32)
+        h = max(32, int(h * scale) // 32 * 32)
     return w, h
 
 pipe = None
+
+# --- Heartbeat registration ---
+
+def get_public_ip():
+    import requests
+    try:
+        return requests.get("https://api.ipify.org", timeout=5).text
+    except:
+        return None
+
+async def send_heartbeat():
+    public_ip = os.getenv("PUBLIC_IP")
+    if not public_ip:
+        public_ip = await asyncio.get_event_loop().run_in_executor(None, get_public_ip)
+    if not public_ip:
+        return
+    port = int(os.getenv("PORT", "8765"))
+    url = f"http://{public_ip}:{port}"
+    register_url = os.getenv("REGISTER_URL", "http://57.130.31.42:16384/register")
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(register_url, json={"url": url, "type": "sana"}) as resp:
+                if resp.status == 200:
+                    logger.info("Heartbeat sent: %s", url)
+                else:
+                    logger.error("Heartbeat failed: %s", resp.status)
+    except Exception as e:
+        logger.error("Heartbeat error: %s", e)
+
+async def periodic_heartbeat():
+    while True:
+        try:
+            await send_heartbeat()
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Heartbeat loop error: %s", e)
+            await asyncio.sleep(5)
+
+# --- App lifecycle ---
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -44,9 +91,28 @@ async def lifespan(app: FastAPI):
     t0 = time.time()
     pipe = SanaSprintPipeline.from_pretrained(MODEL_ID, torch_dtype=torch.bfloat16, cache_dir=MODEL_CACHE).to("cuda")
     logger.info("Model loaded in %.1fs", time.time() - t0)
-    yield
 
-app = FastAPI(title="SANA-Sprint Legacy", lifespan=lifespan)
+    # Start heartbeat
+    heartbeat_task = None
+    try:
+        await send_heartbeat()
+        heartbeat_task = asyncio.create_task(periodic_heartbeat())
+        app.state.heartbeat_task = heartbeat_task
+        logger.info("Heartbeat started")
+    except Exception as e:
+        logger.error("Heartbeat init error: %s", e)
+
+    try:
+        yield
+    finally:
+        if heartbeat_task:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                pass
+
+app = FastAPI(title="SANA-Sprint", lifespan=lifespan)
 
 @app.post("/generate")
 def generate(request: ImageRequest):
@@ -80,4 +146,4 @@ async def health():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "10003")))
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8765")))


### PR DESCRIPTION
## Summary
- Deploys Sana Sprint 1.6B on GH200 (port 8766), colocated with LTX-2 + ACE-Step
- Adds heartbeat registration to sana `server.py` (posts to OVH registry every 30s)
- Upgrades default model from 0.6B to 1.6B with env-configurable settings
- Decommissions Oracle Cloud A10/A100 instances
- GH200 generates at ~0.165s/img (faster than A100's ~0.25s)

## Test plan
- [x] Sana deployed and serving production traffic on GH200
- [x] OVH registry shows 1 sana worker (GH200 only) after A100 removal
- [x] Health endpoint responds correctly
- [x] Heartbeat registration working (auto-registers with OVH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)