### PR TITLE
fix(enter): reflect CORS request headers so OpenAI SDKs work from browsers

### DIFF
--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -57,7 +57,7 @@ const app = new Hono<Env>()
         cors({
             origin: "*",
             allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-            allowHeaders: ["Content-Type", "Authorization"],
+            allowHeaders: [], // reflect Access-Control-Request-Headers (permissive; origin already "*")
             exposeHeaders: ["Content-Length", "Content-Disposition"],
             maxAge: 600,
         }),


### PR DESCRIPTION
## Summary

- **Problem:** `enter.pollinations.ai` hardcodes `allowHeaders: ["Content-Type", "Authorization"]`, which blocks CORS preflight for browser calls from the OpenAI SDK (sends `x-stainless-os`, `x-stainless-arch`, `x-stainless-lang`, etc. as telemetry)
- **Effect:** any BYOP web app using an OpenAI SDK against `gen.pollinations.ai/v1/chat/completions` fails with `Request header field x-stainless-os is not allowed by Access-Control-Allow-Headers in preflight response`
- **Fix:** set `allowHeaders: []` — Hono's `cors()` middleware then reflects the client's `Access-Control-Request-Headers`, which is the standard permissive pattern. No security change: `origin` is already `"*"` and all endpoints still require the `Authorization` bearer token

Tested manually: `curl -X OPTIONS` preflight with `x-stainless-os` in `Access-Control-Request-Headers` now succeeds against the updated middleware.

One-line change.

## Test plan

- [ ] Deploy and re-run preflight: `curl -sI -X OPTIONS https://gen.pollinations.ai/v1/chat/completions -H "Origin: https://example.com" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: authorization,content-type,x-stainless-os"` — should return `Access-Control-Allow-Headers: authorization,content-type,x-stainless-os`
- [ ] Confirm an OpenAI SDK browser call against `gen.pollinations.ai/v1/chat/completions` succeeds end-to-end