### PR TITLE
fix: int4 model path for RTX 4090, https heartbeat for z-image

### DIFF
--- a/image.pollinations.ai/nunchaku/server.py
+++ b/image.pollinations.ai/nunchaku/server.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 MODEL_ID = "black-forest-labs/FLUX.1-schnell"
 MODEL_CACHE = "model-cache"
-QUANT_MODEL_PATH = "mit-han-lab/svdq-fp4-flux.1-schnell"
+QUANT_MODEL_PATH = "mit-han-lab/svdq-int4-flux.1-schnell"
 
 class ImageRequest(BaseModel):
     prompts: List[str] = ["a photo of an astronaut riding a horse on mars"]

--- a/image.pollinations.ai/z-image/server.py
+++ b/image.pollinations.ai/z-image/server.py
@@ -51,7 +51,7 @@ async def send_heartbeat():
     if public_ip:
         try:
             port = int(os.getenv("PUBLIC_PORT", os.getenv("PORT", "10002")))
-            url = f"http://{public_ip}:{port}"
+            url = f"https://{public_ip}"
             service_type = os.getenv("SERVICE_TYPE", "zimage")
             # Use direct EC2 endpoint to bypass Cloudflare (some io.net IPs are blocked)
             register_url = os.getenv("REGISTER_URL", "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384/register")


### PR DESCRIPTION
- nunchaku: use svdq-int4 (not fp4) — RTX 4090 is Ada Lovelace, not Blackwell
- z-image: heartbeat registers with https:// instead of http://:443, which caused 400 errors from RunPod proxy