### PR TITLE
[codex] consolidate tinybird public tokens

### DIFF
--- a/apps/model-monitor/src/hooks/useModelMonitor.js
+++ b/apps/model-monitor/src/hooks/useModelMonitor.js
@@ -7,7 +7,7 @@ import { TEXT_SERVICES } from "../../../../shared/registry/text.ts";
 // Note: This is a READ-ONLY public token, safe to expose in client code
 const TINYBIRD_HOST = "https://api.europe-west2.gcp.tinybird.co";
 const TINYBIRD_TOKEN =
-    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICJmZTRjODM1Ni1iOTYwLTQ0ZTYtODE1Mi1kY2UwYjc0YzExNjQiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.Wc49vYoVYI_xd4JSsH_Fe8mJk7Oc9hx0IIldwc1a44g";
+    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
 
 // Model list endpoints
 const MODEL_ENDPOINTS = {

--- a/enter.pollinations.ai/observability/endpoints/model_health.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health.pipe
@@ -1,4 +1,5 @@
 TOKEN model_health_read READ
+TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/endpoints/model_health_24h.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health_24h.pipe
@@ -1,4 +1,5 @@
 TOKEN model_health_read READ
+TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/endpoints/model_health_60m.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health_60m.pipe
@@ -1,4 +1,5 @@
 TOKEN model_health_read READ
+TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/endpoints/model_health_7d.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health_7d.pipe
@@ -1,4 +1,5 @@
 TOKEN model_health_read READ
+TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/src/utils/model-stats.ts
+++ b/enter.pollinations.ai/src/utils/model-stats.ts
@@ -2,7 +2,7 @@ import type { Logger } from "@logtape/logtape";
 import { cached } from "@/cache";
 
 const TINYBIRD_MODEL_STATS_URL =
-    "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json?token=p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICJiYzdkOTY4YS0wZmM1LTRmY2MtYWViNi0zZDQ0MWIwMGFlZjQiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.fhyEk0_6wt5a2RnM5tu4n_6nUfFdgN_YBMxg8VPv-Dw&limit=200";
+    "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json?token=p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8&limit=200";
 const CACHE_KEY = "model-stats";
 const CACHE_TTL = 3600; // 1 hour
 


### PR DESCRIPTION
## Summary
- switches `enter` public model stats to the consolidated `tinybird_read_public` token
- switches `model-monitor` health queries to the consolidated `tinybird_read_public` token
- grants `tinybird_read_public` additive access to the `model_health*` pipes so the cutover is non-destructive

## Why
- `public_stats_read` and `model_health_read` are still hardcoded in live consumers, so the Tinybird public-token cleanup is not complete yet
- this moves the remaining public consumers onto the consolidated public token before we retire the old Tinybird workspace tokens

## Impact
- no GitHub or Cloudflare secret changes
- no schema or pipe SQL changes
- after this merges and production `enter` deploys, the old Tinybird public tokens can be removed safely

## Validation
- `npx biome check --write apps/model-monitor/src/hooks/useModelMonitor.js enter.pollinations.ai/src/utils/model-stats.ts`
- `cd enter.pollinations.ai && npm run typecheck`
- `cd apps/model-monitor && npm run build`
- `tb --cloud deployment create --check` for the additive `tinybird_read_public` scope change
