### PR TITLE
[codex] retire legacy tinybird public tokens

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/d1_user_public.pipe
+++ b/enter.pollinations.ai/observability/endpoints/d1_user_public.pipe
@@ -1,7 +1,6 @@
 DESCRIPTION >
     Restricted public view of D1 user table (no emails, no balances).
 
-TOKEN d1_user_public_read READ
 TOKEN tinybird_read_public READ
 
 NODE d1_user_public_node

--- a/enter.pollinations.ai/observability/endpoints/model_health.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health.pipe
@@ -1,4 +1,3 @@
-TOKEN model_health_read READ
 TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 

--- a/enter.pollinations.ai/observability/endpoints/model_health_24h.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health_24h.pipe
@@ -1,4 +1,3 @@
-TOKEN model_health_read READ
 TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 

--- a/enter.pollinations.ai/observability/endpoints/model_health_60m.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health_60m.pipe
@@ -1,4 +1,3 @@
-TOKEN model_health_read READ
 TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 

--- a/enter.pollinations.ai/observability/endpoints/model_health_7d.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health_7d.pipe
@@ -1,4 +1,3 @@
-TOKEN model_health_read READ
 TOKEN tinybird_read_public READ
 TOKEN tinybird_read READ
 

--- a/enter.pollinations.ai/observability/endpoints/public_model_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/public_model_stats.pipe
@@ -3,7 +3,6 @@ DESCRIPTION >
     Returns aggregated stats per model including request counts, average costs, and response times.
     Only includes models with at least 3 successful priced requests for reliable averages.
 
-TOKEN public_stats_read READ
 TOKEN tinybird_read_public READ
 
 NODE public_model_stats_node


### PR DESCRIPTION
## Summary
- removes legacy public Tinybird token directives from `public_model_stats`, `d1_user_public`, and `model_health*`
- leaves `tinybird_read_public` as the single public Tinybird token for those endpoints
- aligns the repo with the live Tinybird cleanup that is already deployed

## Why
- `public_stats_read`, `model_health_read`, and `d1_user_public_read` were the last leftover public Tinybird tokens
- all live public consumers were already moved to `tinybird_read_public`
- this follow-up prevents repo drift after the final Tinybird workspace cleanup

## Live rollout already completed
- Tinybird deployment `85` promoted successfully
- legacy public tokens removed from the Tinybird workspace
- verified `tinybird_read_public` still reads:
  - `public_model_stats`
  - `model_health_60m`
  - `d1_user_public`

## Validation
- `tb --cloud deployment create --check`
- verified legacy tokens were absent from `v0/tokens` after promotion
- verified public endpoint reads with `tinybird_read_public`
