### PR TITLE
cleanup: retire legacy tinybird internal tokens

### DIFF
--- a/enter.pollinations.ai/observability/datasources/app_directory.datasource
+++ b/enter.pollinations.ai/observability/datasources/app_directory.datasource
@@ -1,5 +1,3 @@
-TOKEN app_directory_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/crypto_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/crypto_event.datasource
@@ -1,4 +1,3 @@
-TOKEN crypto_event_append APPEND
 TOKEN tinybird_ingest APPEND
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/d1_account.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_account.datasource
@@ -1,5 +1,3 @@
-TOKEN d1_account_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/d1_apikey.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_apikey.datasource
@@ -1,5 +1,3 @@
-TOKEN d1_apikey_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/d1_session.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_session.datasource
@@ -1,5 +1,3 @@
-TOKEN d1_session_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/d1_user.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_user.datasource
@@ -1,5 +1,3 @@
-TOKEN d1_user_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -1,5 +1,3 @@
-TOKEN generation_event_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_ingest APPEND
 TOKEN tinybird_read READ
 

--- a/enter.pollinations.ai/observability/datasources/polar_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/polar_event.datasource
@@ -1,4 +1,3 @@
-TOKEN polar_event_append APPEND
 TOKEN tinybird_ingest APPEND
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/scoring_snapshot.datasource
+++ b/enter.pollinations.ai/observability/datasources/scoring_snapshot.datasource
@@ -1,5 +1,4 @@
 TOKEN scoring_snapshot_append APPEND
-TOKEN grafana_generation_read READ
 TOKEN tinybird_read READ
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/datasources/stripe_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/stripe_event.datasource
@@ -1,5 +1,3 @@
-TOKEN stripe_event_append APPEND
-TOKEN stripe_event_read READ
 TOKEN tinybird_ingest APPEND
 TOKEN tinybird_read READ
 

--- a/enter.pollinations.ai/observability/datasources/tier_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/tier_event.datasource
@@ -1,4 +1,3 @@
-TOKEN tier_event_append APPEND
 TOKEN tinybird_ingest APPEND
 
 DESCRIPTION >

--- a/enter.pollinations.ai/observability/endpoints/app_byop_hostnames.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_byop_hostnames.pipe
@@ -3,8 +3,6 @@ DESCRIPTION >
     Priority: api_key_created_for_app (explicit app attribution) > api_key_name (hostname heuristic).
     Both signals kept so BYOP stats don't drop as app key adoption ramps up.
 
-TOKEN app_metrics READ
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE app_byop_hostnames_node

--- a/enter.pollinations.ai/observability/endpoints/app_byop_request_counts.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_byop_request_counts.pipe
@@ -3,8 +3,6 @@ DESCRIPTION >
     Priority: api_key_created_for_app (explicit) > api_key_name (hostname heuristic).
     Counts ALL requests through a BYOP app's API key, regardless of end user.
 
-TOKEN app_metrics READ
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE app_byop_request_counts_node

--- a/enter.pollinations.ai/observability/endpoints/app_request_counts.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_request_counts.pipe
@@ -2,8 +2,6 @@ DESCRIPTION >
     Get request counts per GitHub username in the last 24 hours.
     Used by the app metrics script to show activity levels per app author.
 
-TOKEN app_metrics READ
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE app_request_counts_node

--- a/enter.pollinations.ai/observability/endpoints/app_top_weekly.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_top_weekly.pipe
@@ -1,0 +1,74 @@
+DESCRIPTION >
+    Top registered community apps by verified app-attributed request count
+    over the last 7 days.
+    Source of truth is App Keys: publishable keys with a non-empty appUrl.
+    Current attribution only counts BYOP requests minted through redirect-auth
+    for that registered app.
+
+TOKEN tinybird_read READ
+
+NODE banned_users
+SQL >
+    SELECT github_username
+    FROM d1_user
+    WHERE synced_at = (SELECT max(synced_at) FROM d1_user)
+      AND banned = 1
+    GROUP BY github_username
+
+NODE registered_apps
+SQL >
+    SELECT
+        id AS app_key_id,
+        user_id AS owner_user_id,
+        name AS app_name,
+        JSONExtractString(metadata, 'appUrl') AS app_url
+    FROM d1_apikey
+    WHERE synced_at = (SELECT max(synced_at) FROM d1_apikey)
+      AND prefix = 'pk'
+      AND JSONExtractString(metadata, 'keyType') = 'publishable'
+      AND JSONExtractString(metadata, 'appUrl') != ''
+      AND positionCaseInsensitive(JSONExtractString(metadata, 'appUrl'), 'localhost') = 0
+      AND positionCaseInsensitive(JSONExtractString(metadata, 'appUrl'), '127.0.0.1') = 0
+      AND positionCaseInsensitive(JSONExtractString(metadata, 'appUrl'), 'pollinations.ai') = 0
+
+NODE byop_requests
+SQL >
+    SELECT
+        ra.app_url,
+        ra.app_name,
+        ra.owner_user_id,
+        ge.start_time
+    FROM generation_event ge
+    INNER JOIN registered_apps ra
+        ON ge.api_key_created_via = 'redirect-auth'
+       AND ge.api_key_created_for_app = ra.app_name
+       AND ge.api_key_created_for_user_id = ra.owner_user_id
+    WHERE ge.start_time > now() - INTERVAL 7 DAY
+      AND ge.environment = 'production'
+      AND ge.response_status >= 200 AND ge.response_status < 300
+      AND ge.total_price > 0
+      AND ge.user_github_username NOT IN (SELECT github_username FROM banned_users)
+
+NODE latest_users
+SQL >
+    SELECT
+        id AS user_id,
+        github_username
+    FROM d1_user
+    WHERE synced_at = (SELECT max(synced_at) FROM d1_user)
+
+NODE app_top_weekly_node
+SQL >
+    SELECT
+        requests.app_url,
+        any(requests.app_name) AS app_name,
+        any(users.github_username) AS owner,
+        count() AS request_count,
+        max(requests.start_time) AS last_seen
+    FROM byop_requests requests
+    LEFT JOIN latest_users users ON requests.owner_user_id = users.user_id
+    GROUP BY requests.app_url
+    ORDER BY request_count DESC, last_seen DESC
+    LIMIT 10
+
+TYPE endpoint

--- a/enter.pollinations.ai/observability/endpoints/daily_stripe_revenue.pipe
+++ b/enter.pollinations.ai/observability/endpoints/daily_stripe_revenue.pipe
@@ -1,7 +1,6 @@
 DESCRIPTION >
     Daily revenue from Stripe payments (checkout.session.completed events)
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE daily_stripe_revenue_node

--- a/enter.pollinations.ai/observability/endpoints/kpi_activations.pipe
+++ b/enter.pollinations.ai/observability/endpoints/kpi_activations.pipe
@@ -3,7 +3,6 @@ DESCRIPTION >
     of registration, grouped by registration week. Joins d1_user with
     generation_event to replace the previous hybrid D1+Tinybird+JS approach.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE registrations

--- a/enter.pollinations.ai/observability/endpoints/kpi_registrations.pipe
+++ b/enter.pollinations.ai/observability/endpoints/kpi_registrations.pipe
@@ -1,7 +1,6 @@
 DESCRIPTION >
     Weekly user registration counts from d1_user snapshot.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE registrations

--- a/enter.pollinations.ai/observability/endpoints/kpi_tier_distribution.pipe
+++ b/enter.pollinations.ai/observability/endpoints/kpi_tier_distribution.pipe
@@ -1,7 +1,6 @@
 DESCRIPTION >
     Tier distribution from d1_user snapshot.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE tier_distribution

--- a/enter.pollinations.ai/observability/endpoints/kpi_total_users.pipe
+++ b/enter.pollinations.ai/observability/endpoints/kpi_total_users.pipe
@@ -1,7 +1,6 @@
 DESCRIPTION >
     Total user count from d1_user snapshot.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE total_users

--- a/enter.pollinations.ai/observability/endpoints/user_usage.pipe
+++ b/enter.pollinations.ai/observability/endpoints/user_usage.pipe
@@ -2,7 +2,6 @@ DESCRIPTION >
     Get billed usage history for a specific user (last 30 days). Only returns billed requests.
     Use 'before' param with ISO timestamp for cursor pagination (e.g. before=2024-12-10T00:00:00).
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE user_usage_node

--- a/enter.pollinations.ai/observability/endpoints/user_usage_daily.pipe
+++ b/enter.pollinations.ai/observability/endpoints/user_usage_daily.pipe
@@ -2,7 +2,6 @@ DESCRIPTION >
     Get daily aggregated usage data for a user. Groups by date and model.
     Returns all historical data (no time limit). Use 'since' and 'until' for date range filtering.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE user_usage_daily_node

--- a/enter.pollinations.ai/observability/endpoints/weekly_active_users.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_active_users.pipe
@@ -3,7 +3,6 @@ DESCRIPTION >
     Returns data for the last N weeks.
     Supports start_date param for single-week queries to avoid Tinybird timeouts.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE weekly_active_users_node

--- a/enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe
@@ -3,7 +3,6 @@ DESCRIPTION >
     Only counts 5xx server errors as downtime (user errors like 4xx don't affect availability).
     Supports start_date param for single-week queries to avoid Tinybird timeouts.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE weekly_health_stats_node

--- a/enter.pollinations.ai/observability/endpoints/weekly_retention.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_retention.pipe
@@ -2,7 +2,6 @@ DESCRIPTION >
     Weekly cohort retention - tracks user retention week over week.
     Shows what percentage of users from each cohort returned in subsequent weeks.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE cohort_base

--- a/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
@@ -4,7 +4,6 @@ DESCRIPTION >
     Optimized: single-pass query with uniq() instead of uniqExact() for ~10x speed.
     Supports start_date param for single-week queries to avoid Tinybird timeouts.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE weekly_usage_stats_node

--- a/enter.pollinations.ai/observability/endpoints/weekly_user_segment.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_user_segment.pipe
@@ -5,7 +5,6 @@ DESCRIPTION >
     Two-node design: inner node evaluates the condition once per row,
     outer node pivots back to the original column schema.
 
-TOKEN model_usage READ
 TOKEN tinybird_read READ
 
 NODE grouped_by_byop


### PR DESCRIPTION
- Removes the last legacy internal Tinybird append/read token directives from observability\n- Restores app_top_weekly to repo state under tinybird_read so clean deploys do not try to delete the live pipe\n- Matches the live Tinybird cleanup already deployed in deployment #86\n- Intentionally keeps scoring_snapshot_append and human/admin tokens untouched