### PR TITLE
[codex] fix enter usage exports for power users

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -190,7 +190,7 @@ Returns your current pollen balance. If the API key has a budget limit, returns 
 - **Path:** `/account/usage`
 - **Tags:** 👤 Account
 
-Returns your request history with per-request details: model used, token counts, cost, and response time. Supports JSON and CSV export. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.
+Returns your request history with per-request details: model used, token counts, cost, and response time. Defaults to the last 30 days, supports up to 90 days via `days`, and supports JSON and CSV export. Each response is capped at 50,000 rows. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.
 
 #### Responses
 
@@ -300,7 +300,7 @@ Returns your request history with per-request details: model used, token counts,
 - **Path:** `/account/usage/daily`
 - **Tags:** 👤 Account
 
-Returns daily aggregated usage for the last 90 days, grouped by date and model. Useful for dashboards and spending analysis. Supports JSON and CSV export. Results are cached for 1 hour. Requires `account:usage` permission when using API keys.
+Returns daily aggregated usage for the requested time window (max 90 days), grouped by date and model. Useful for dashboards and spending analysis. Supports JSON and CSV export. Results are cached for 1 hour. Requires `account:usage` permission when using API keys.
 
 #### Responses
 

--- a/enter.pollinations.ai/.gitignore
+++ b/enter.pollinations.ai/.gitignore
@@ -4,6 +4,7 @@ dist/
 .wrangler/
 .dev.vars
 .dev.vars.local
+.dev.vars.override
 .dev.vars.prod
 .env
 *.log

--- a/enter.pollinations.ai/observability/endpoints/user_usage.pipe
+++ b/enter.pollinations.ai/observability/endpoints/user_usage.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
-    Get billed usage history for a specific user (last 30 days). Only returns billed requests.
-    Use 'before' param with ISO timestamp for cursor pagination (e.g. before=2024-12-10T00:00:00).
+    Get billed usage history for a specific user. Only returns billed requests.
+    Defaults to the last 30 days. Use 'since' and 'until' to override the date window.
+    Use 'before' and 'before_event_id' for stable cursor pagination.
 
 TOKEN tinybird_read READ
 
@@ -9,6 +10,7 @@ SQL >
     %
     SELECT
         start_time as timestamp,
+        event_id as cursor_event_id,
         event_type as type,
         model_used as model,
         api_key_name as api_key,
@@ -27,11 +29,26 @@ SQL >
     FROM generation_event
     WHERE user_id = {{String(user_id, '')}}
     AND total_price > 0
+    {% if defined(since) %}
+    AND start_time >= {{DateTime(since)}}
+    {% else %}
     AND start_time >= now() - INTERVAL 30 DAY
-    {% if defined(before) %}
+    {% end %}
+    {% if defined(until) %}
+    AND start_time < {{DateTime(until)}}
+    {% end %}
+    {% if defined(before) and defined(before_event_id) %}
+    AND (
+        start_time < {{DateTime(before)}}
+        OR (
+            start_time = {{DateTime(before)}}
+            AND event_id < {{String(before_event_id)}}
+        )
+    )
+    {% elif defined(before) %}
     AND start_time < {{DateTime(before)}}
     {% end %}
-    ORDER BY start_time DESC
+    ORDER BY start_time DESC, event_id DESC
     LIMIT {{Int32(limit, 100)}}
 
 TYPE endpoint

--- a/enter.pollinations.ai/observability/endpoints/user_usage_daily_by_api_key.pipe
+++ b/enter.pollinations.ai/observability/endpoints/user_usage_daily_by_api_key.pipe
@@ -1,0 +1,29 @@
+DESCRIPTION >
+    Get daily aggregated billed usage data for a user, grouped by date, model, meter source, and API key.
+    Use for exact API key filtering in the dashboard. Use 'since' and 'until' for date range filtering.
+
+TOKEN tinybird_read READ
+
+NODE user_usage_daily_by_api_key_node
+SQL >
+    %
+    SELECT
+        toDate(start_time) as date,
+        resolved_model_requested as model,
+        splitByChar(':', selected_meter_slug)[-1] as meter_source,
+        api_key_name,
+        count() as requests,
+        sum(total_price) as cost_usd
+    FROM generation_event
+    WHERE user_id = {{String(user_id, '')}}
+    AND total_price > 0
+    {% if defined(since) %}
+    AND start_time >= {{DateTime(since)}}
+    {% end %}
+    {% if defined(until) %}
+    AND start_time < {{DateTime(until)}}
+    {% end %}
+    GROUP BY date, model, meter_source, api_key_name
+    ORDER BY date DESC, requests DESC
+
+TYPE endpoint

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "typecheck": "tsc --noEmit",
         "decrypt-vars": "node scripts/decrypt-dev-vars.mjs",
-        "dev": "npm run decrypt-vars && vite dev",
+        "dev": "npm run decrypt-vars && CLOUDFLARE_ENV=local vite dev",
         "dev:production": "npm run decrypt-vars:production && CLOUDFLARE_ENV=production vite dev",
         "test": "npm run decrypt-vars && vitest run",
         "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/enter.pollinations.ai/scripts/decrypt-dev-vars.mjs
+++ b/enter.pollinations.ai/scripts/decrypt-dev-vars.mjs
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 
 const root = resolve(import.meta.dirname, "..");
 const outputPath = resolve(root, ".dev.vars");
-const overridePath = resolve(root, ".dev.vars.local");
+const overridePath = resolve(root, ".dev.vars.override");
 
 const parseEnv = (text) => {
     const vars = new Map();

--- a/enter.pollinations.ai/src/client/components/usage-analytics/index.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/index.ts
@@ -10,4 +10,5 @@ export type {
     ModelBreakdown,
     TimeRange,
 } from "./types";
+export { TIME_RANGE_DAYS } from "./types";
 export { UsageGraph } from "./usage-graph";

--- a/enter.pollinations.ai/src/client/components/usage-analytics/types.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/types.ts
@@ -8,6 +8,11 @@ export type DailyUsageRecord = {
 };
 
 export type TimeRange = "7d" | "30d" | "all";
+export const TIME_RANGE_DAYS: Record<TimeRange, number> = {
+    "7d": 7,
+    "30d": 30,
+    all: 90,
+};
 export type Metric = "requests" | "pollen";
 
 export type FilterState = {

--- a/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
@@ -20,9 +20,18 @@ const TIER_PILL_CLASSES = {
     violet: "bg-violet-200 text-violet-950",
 } as const;
 
-export const UsageGraph: FC<{ tier?: TierStatus }> = ({ tier }) => {
-    const [filters, setFilters] = useState<FilterState>({
-        timeRange: "7d",
+type UsageGraphProps = {
+    tier?: TierStatus;
+    timeRange: TimeRange;
+    onTimeRangeChange: (timeRange: TimeRange) => void;
+};
+
+export const UsageGraph: FC<UsageGraphProps> = ({
+    tier,
+    timeRange,
+    onTimeRangeChange,
+}) => {
+    const [filters, setFilters] = useState<Omit<FilterState, "timeRange">>({
         metric: "pollen",
         selectedKeys: [],
         selectedModels: [],
@@ -36,7 +45,10 @@ export const UsageGraph: FC<{ tier?: TierStatus }> = ({ tier }) => {
         usedKeys,
         chartData,
         stats,
-    } = useUsageData(filters);
+    } = useUsageData({
+        ...filters,
+        timeRange,
+    });
 
     const keySelectOptions = usedKeys.map((name) => ({
         value: name,
@@ -65,14 +77,14 @@ export const UsageGraph: FC<{ tier?: TierStatus }> = ({ tier }) => {
     useEffect(() => {
         const handleResize = () => {
             const isMobile = window.innerWidth < 640; // sm breakpoint
-            if (isMobile && filters.timeRange === "all") {
-                setFilters((f) => ({ ...f, timeRange: "30d" }));
+            if (isMobile && timeRange === "all") {
+                onTimeRangeChange("30d");
             }
         };
         handleResize(); // Check on mount
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
-    }, [filters.timeRange]);
+    }, [onTimeRangeChange, timeRange]);
 
     return (
         <div className="flex flex-col gap-2">
@@ -116,13 +128,8 @@ export const UsageGraph: FC<{ tier?: TierStatus }> = ({ tier }) => {
                                     (t) => (
                                         <FilterButton
                                             key={t}
-                                            active={filters.timeRange === t}
-                                            onClick={() =>
-                                                setFilters((f) => ({
-                                                    ...f,
-                                                    timeRange: t,
-                                                }))
-                                            }
+                                            active={timeRange === t}
+                                            onClick={() => onTimeRangeChange(t)}
                                             className={
                                                 t === "all"
                                                     ? "hidden sm:inline-flex"

--- a/enter.pollinations.ai/src/client/components/usage-analytics/use-usage-data.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/use-usage-data.ts
@@ -6,6 +6,7 @@ import type {
     FilterState,
     ModelBreakdown,
 } from "./types";
+import { TIME_RANGE_DAYS } from "./types";
 
 type UsageDataResult = {
     dailyUsage: DailyUsageRecord[];
@@ -31,8 +32,12 @@ export function useUsageData(filters: FilterState): UsageDataResult {
     const fetchUsage = useCallback(() => {
         setLoading(true);
         setError(null);
+        const params = new URLSearchParams({
+            days: TIME_RANGE_DAYS[filters.timeRange].toString(),
+            granularity: "api_key",
+        });
 
-        fetch("/api/account/usage/daily")
+        fetch(`/api/account/usage/daily?${params.toString()}`)
             .then((r) => {
                 if (!r.ok)
                     throw new Error(`Failed to fetch usage data: ${r.status}`);
@@ -47,7 +52,7 @@ export function useUsageData(filters: FilterState): UsageDataResult {
                 setDailyUsage([]);
             })
             .finally(() => setLoading(false));
-    }, []);
+    }, [filters.timeRange]);
 
     // Fetch on mount
     useEffect(() => {

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -15,9 +15,14 @@ import { Header } from "../components/layout/header.tsx";
 import { NewsBanner } from "../components/layout/news-banner.tsx";
 import { User } from "../components/layout/user.tsx";
 import { Pricing } from "../components/pricing";
-import { UsageGraph } from "../components/usage-analytics";
+import {
+    TIME_RANGE_DAYS,
+    type TimeRange,
+    UsageGraph,
+} from "../components/usage-analytics";
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
+const DETAILED_USAGE_DOWNLOAD_LIMIT = 50_000;
 
 export const Route = createFileRoute("/")({
     component: RouteComponent,
@@ -73,9 +78,10 @@ function RouteComponent() {
 
     const [isSigningOut, setIsSigningOut] = useState(false);
     const [activeTab, setActiveTab] = useState<"balance" | "usage">("balance");
+    const [usageTimeRange, setUsageTimeRange] = useState<TimeRange>("7d");
     const [downloadOpen, setDownloadOpen] = useState(false);
-    const [downloadingDetailed, setDownloadingDetailed] = useState(false);
     const downloadRef = useRef<HTMLDivElement>(null);
+    const usageDays = TIME_RANGE_DAYS[usageTimeRange];
 
     useEffect(() => {
         const handleClickOutside = (e: MouseEvent) => {
@@ -221,6 +227,15 @@ function RouteComponent() {
         router.invalidate();
     }
 
+    function triggerUsageDownload(path: string, params: URLSearchParams): void {
+        const anchor = document.createElement("a");
+        anchor.href = `${path}?${params.toString()}`;
+        anchor.rel = "noopener";
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+    }
+
     return (
         <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-20">
@@ -328,98 +343,40 @@ function RouteComponent() {
                                             <button
                                                 type="button"
                                                 onClick={async () => {
-                                                    try {
-                                                        const res = await fetch(
-                                                            "/api/account/usage/daily?format=csv",
-                                                        );
-                                                        if (!res.ok)
-                                                            throw new Error(
-                                                                "Failed to fetch",
-                                                            );
-                                                        const blob =
-                                                            await res.blob();
-                                                        const url =
-                                                            URL.createObjectURL(
-                                                                blob,
-                                                            );
-                                                        const a =
-                                                            document.createElement(
-                                                                "a",
-                                                            );
-                                                        a.href = url;
-                                                        a.download =
-                                                            "usage-daily.csv";
-                                                        a.click();
-                                                        URL.revokeObjectURL(
-                                                            url,
-                                                        );
-                                                    } catch (e) {
-                                                        console.error(
-                                                            "Download failed:",
-                                                            e,
-                                                        );
-                                                    } finally {
-                                                        setDownloadOpen(false);
-                                                    }
+                                                    triggerUsageDownload(
+                                                        "/api/account/usage/daily",
+                                                        new URLSearchParams({
+                                                            format: "csv",
+                                                            days: usageDays.toString(),
+                                                        }),
+                                                    );
+                                                    setDownloadOpen(false);
                                                 }}
                                                 className="w-full px-3 py-2 text-left text-sm text-amber-900 hover:bg-amber-50"
                                             >
                                                 Daily Summary
                                                 <span className="block text-xs text-amber-500">
-                                                    Aggregated by day
+                                                    Selected period
                                                 </span>
                                             </button>
                                             <button
                                                 type="button"
-                                                onClick={async () => {
-                                                    setDownloadingDetailed(
-                                                        true,
+                                                onClick={() => {
+                                                    triggerUsageDownload(
+                                                        "/api/account/usage",
+                                                        new URLSearchParams({
+                                                            format: "csv",
+                                                            days: usageDays.toString(),
+                                                            limit: DETAILED_USAGE_DOWNLOAD_LIMIT.toString(),
+                                                        }),
                                                     );
-                                                    try {
-                                                        const res = await fetch(
-                                                            "/api/account/usage?format=csv&limit=50000",
-                                                        );
-                                                        if (!res.ok)
-                                                            throw new Error(
-                                                                "Failed to fetch",
-                                                            );
-                                                        const blob =
-                                                            await res.blob();
-                                                        const url =
-                                                            URL.createObjectURL(
-                                                                blob,
-                                                            );
-                                                        const a =
-                                                            document.createElement(
-                                                                "a",
-                                                            );
-                                                        a.href = url;
-                                                        a.download =
-                                                            "usage-detailed.csv";
-                                                        a.click();
-                                                        URL.revokeObjectURL(
-                                                            url,
-                                                        );
-                                                    } catch (e) {
-                                                        console.error(
-                                                            "Download failed:",
-                                                            e,
-                                                        );
-                                                    } finally {
-                                                        setDownloadingDetailed(
-                                                            false,
-                                                        );
-                                                        setDownloadOpen(false);
-                                                    }
+                                                    setDownloadOpen(false);
                                                 }}
-                                                disabled={downloadingDetailed}
-                                                className="w-full px-3 py-2 text-left text-sm text-amber-900 hover:bg-amber-50 disabled:opacity-50"
+                                                className="w-full px-3 py-2 text-left text-sm text-amber-900 hover:bg-amber-50"
                                             >
-                                                {downloadingDetailed
-                                                    ? "Downloading..."
-                                                    : "Detailed Usage"}
+                                                Detailed Usage
                                                 <span className="block text-xs text-amber-500">
-                                                    Per-request data
+                                                    Latest 50k requests
                                                 </span>
                                             </button>
                                         </div>
@@ -437,7 +394,11 @@ function RouteComponent() {
                         />
                     )}
                     {activeTab === "usage" && (
-                        <UsageGraph tier={tierData?.active?.tier} />
+                        <UsageGraph
+                            tier={tierData?.active?.tier}
+                            timeRange={usageTimeRange}
+                            onTimeRangeChange={setUsageTimeRange}
+                        />
                     )}
                 </div>
                 {tierData && (

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -10,6 +10,7 @@ import {
 } from "@/db/schema/better-auth.ts";
 import type { ApiKeyType } from "@/db/schema/event.ts";
 import { getTierCadence, tierNames } from "@/tier-config.ts";
+import type { Env } from "../env.ts";
 
 // Calculate next tier refill time (null for tiers with no refill)
 function getNextRefillAt(tier?: string | null): string | null {
@@ -22,15 +23,56 @@ function getNextRefillAt(tier?: string | null): string | null {
     return nextHour.toISOString();
 }
 
-import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import { validator } from "../middleware/validator.ts";
 import { parseMetadata } from "./metadata-utils.ts";
 
 // Cache TTL in seconds
 const CACHE_TTL = 60 * 60; // 1 hour
+const DEFAULT_USAGE_DAYS = 30;
+const DEFAULT_DAILY_USAGE_DAYS = 90;
+const MAX_USAGE_DAYS = 90;
+const USAGE_CHUNK_DAYS = 30;
+const MAX_USAGE_EXPORT_ROWS = 50_000;
 
 const SECONDS_PER_DAY = 86400;
+
+type UsageDebugBindings = CloudflareBindings & {
+    USAGE_DEBUG_USER_ID?: string;
+};
+
+function resolveUsageTargetUserId(
+    env: CloudflareBindings,
+    currentUserId: string,
+    apiKey?: {
+        permissions?: Record<string, string[]>;
+        metadata?: Record<string, unknown>;
+    },
+): { userId: string; overridden: boolean } {
+    if (apiKey) {
+        return { userId: currentUserId, overridden: false };
+    }
+
+    const environment = String(env.ENVIRONMENT || "");
+    const allowDebugOverride =
+        environment === "local" ||
+        environment === "development" ||
+        environment === "dev";
+
+    if (!allowDebugOverride) {
+        return { userId: currentUserId, overridden: false };
+    }
+
+    const debugUserId = (env as UsageDebugBindings).USAGE_DEBUG_USER_ID?.trim();
+    if (!debugUserId) {
+        return { userId: currentUserId, overridden: false };
+    }
+
+    return {
+        userId: debugUserId,
+        overridden: debugUserId !== currentUserId,
+    };
+}
 
 /**
  * Require that the caller has `account:keys` permission and is using a secret key.
@@ -98,16 +140,120 @@ const escapeCSV = (val: string | number | boolean | null) => {
     return str;
 };
 
+function formatTinybirdDateTime(date: Date): string {
+    return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function startOfNextUtcDay(now = new Date()): Date {
+    const next = new Date(now);
+    next.setUTCHours(0, 0, 0, 0);
+    next.setUTCDate(next.getUTCDate() + 1);
+    return next;
+}
+
+function addUtcDays(date: Date, days: number): Date {
+    const next = new Date(date);
+    next.setUTCDate(next.getUTCDate() + days);
+    return next;
+}
+
+type UsageWindow = {
+    since: string;
+    until: string;
+};
+
+function buildUsageWindow(days: number): UsageWindow {
+    const untilDate = startOfNextUtcDay();
+    const sinceDate = addUtcDays(untilDate, -days);
+    return {
+        since: formatTinybirdDateTime(sinceDate),
+        until: formatTinybirdDateTime(untilDate),
+    };
+}
+
+function buildUsageWindows(
+    days: number,
+    chunkDays = USAGE_CHUNK_DAYS,
+    newestFirst = false,
+): UsageWindow[] {
+    const overallWindow = buildUsageWindow(days);
+    const windows: UsageWindow[] = [];
+    let cursor = new Date(`${overallWindow.since.replace(" ", "T")}Z`);
+    const end = new Date(`${overallWindow.until.replace(" ", "T")}Z`);
+
+    while (cursor < end) {
+        const next = addUtcDays(cursor, chunkDays);
+        const boundedNext = next < end ? next : end;
+        windows.push({
+            since: formatTinybirdDateTime(cursor),
+            until: formatTinybirdDateTime(boundedNext),
+        });
+        cursor = boundedNext;
+    }
+
+    return newestFirst ? windows.reverse() : windows;
+}
+
+async function fetchTinybirdRows<T>(
+    origin: string,
+    path: string,
+    token: string,
+    params: Record<string, string | undefined>,
+): Promise<T[]> {
+    const url = new URL(path, origin);
+    for (const [key, value] of Object.entries(params)) {
+        if (value) {
+            url.searchParams.set(key, value);
+        }
+    }
+
+    const response = await fetch(url.toString(), {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+            `Tinybird error: ${response.status} ${errorText || "(empty response)"}`,
+        );
+    }
+
+    const data = (await response.json()) as { data: T[] };
+    return data.data;
+}
+
 // Query params schema for usage
 const usageQuerySchema = z.object({
     format: z.enum(["json", "csv"]).optional().default("json"),
-    limit: z.coerce.number().min(1).max(50000).optional().default(100),
+    limit: z.coerce
+        .number()
+        .min(1)
+        .max(MAX_USAGE_EXPORT_ROWS)
+        .optional()
+        .default(100),
     before: z.string().optional(), // ISO timestamp cursor for pagination
+    days: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_USAGE_DAYS)
+        .optional()
+        .default(DEFAULT_USAGE_DAYS),
 });
 
 // Query params schema for daily usage
 const usageDailyQuerySchema = z.object({
     format: z.enum(["json", "csv"]).optional().default("json"),
+    days: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_USAGE_DAYS)
+        .optional()
+        .default(DEFAULT_DAILY_USAGE_DAYS),
+    granularity: z.enum(["summary", "api_key"]).optional().default("summary"),
 });
 
 type DailyUsageRecord = {
@@ -116,6 +262,34 @@ type DailyUsageRecord = {
     meter_source: string | null;
     requests: number;
     cost_usd: number;
+    api_key_names?: string[];
+};
+
+type KeyedDailyUsageRecord = Omit<DailyUsageRecord, "api_key_names"> & {
+    api_key_name: string | null;
+};
+
+type UsageRecord = {
+    timestamp: string;
+    type: string;
+    model: string | null;
+    api_key: string | null;
+    api_key_type: string | null;
+    meter_source: string | null;
+    input_text_tokens: number;
+    input_cached_tokens: number;
+    input_audio_tokens: number;
+    input_image_tokens: number;
+    output_text_tokens: number;
+    output_reasoning_tokens: number;
+    output_audio_tokens: number;
+    output_image_tokens: number;
+    cost_usd: number;
+    response_time_ms: number | null;
+};
+
+type UsageRecordWithCursor = UsageRecord & {
+    cursor_event_id: string;
 };
 
 // Response schema for daily usage OpenAPI documentation
@@ -128,6 +302,12 @@ const dailyUsageRecordSchema = z.object({
         .describe("Billing source ('tier', 'pack', 'crypto')"),
     requests: z.number().describe("Number of requests"),
     cost_usd: z.number().describe("Total cost in USD"),
+    api_key_names: z
+        .array(z.string())
+        .optional()
+        .describe(
+            "API key names included in this bucket. Present for dashboard usage data.",
+        ),
 });
 
 const dailyUsageResponseSchema = z.object({
@@ -136,6 +316,90 @@ const dailyUsageResponseSchema = z.object({
         .describe("Array of daily usage records"),
     count: z.number().describe("Number of records returned"),
 });
+
+function normalizeKeyedDailyUsage(
+    usage: KeyedDailyUsageRecord[],
+): DailyUsageRecord[] {
+    return usage.map((row) => ({
+        date: row.date,
+        model: row.model,
+        meter_source: row.meter_source,
+        requests: row.requests,
+        cost_usd: row.cost_usd,
+        api_key_names:
+            row.api_key_name && row.api_key_name !== "undefined"
+                ? [row.api_key_name]
+                : [],
+    }));
+}
+
+function sortDailyUsageRecords(
+    usage: DailyUsageRecord[],
+    granularity: "summary" | "api_key",
+): DailyUsageRecord[] {
+    return usage.toSorted((left, right) => {
+        if (left.date !== right.date) {
+            return right.date.localeCompare(left.date);
+        }
+        if (right.requests !== left.requests) {
+            return right.requests - left.requests;
+        }
+        if ((left.model || "") !== (right.model || "")) {
+            return (left.model || "").localeCompare(right.model || "");
+        }
+        if ((left.meter_source || "") !== (right.meter_source || "")) {
+            return (left.meter_source || "").localeCompare(
+                right.meter_source || "",
+            );
+        }
+        if (granularity === "api_key") {
+            return (left.api_key_names?.[0] || "").localeCompare(
+                right.api_key_names?.[0] || "",
+            );
+        }
+        return 0;
+    });
+}
+
+function usageRecordToCsvRow(row: UsageRecord): string {
+    return `${escapeCSV(row.timestamp)},${escapeCSV(row.type)},${escapeCSV(row.model)},${escapeCSV(row.api_key)},${escapeCSV(row.api_key_type)},${escapeCSV(row.meter_source)},${row.input_text_tokens},${row.input_cached_tokens},${row.input_audio_tokens},${row.input_image_tokens},${row.output_text_tokens},${row.output_reasoning_tokens},${row.output_audio_tokens},${row.output_image_tokens},${row.cost_usd},${escapeCSV(row.response_time_ms)}`;
+}
+
+function dailyUsageRecordToCsvRow(row: DailyUsageRecord): string {
+    return `${escapeCSV(row.date)},${escapeCSV(row.model)},${escapeCSV(row.meter_source)},${row.requests},${row.cost_usd}`;
+}
+
+async function fetchDetailedUsagePage(
+    origin: string,
+    token: string,
+    params: {
+        userId: string;
+        limit: number;
+        since: string;
+        until: string;
+        before?: string;
+        beforeEventId?: string;
+    },
+): Promise<UsageRecordWithCursor[]> {
+    return fetchTinybirdRows<UsageRecordWithCursor>(
+        origin,
+        "/v0/pipes/user_usage.json",
+        token,
+        {
+            user_id: params.userId,
+            limit: params.limit.toString(),
+            since: params.since,
+            until: params.until,
+            before: params.before,
+            before_event_id: params.beforeEventId,
+        },
+    );
+}
+
+function stripUsageCursor(row: UsageRecordWithCursor): UsageRecord {
+    const { cursor_event_id: _, ...usage } = row;
+    return usage;
+}
 
 // Response schemas for OpenAPI documentation
 const profileResponseSchema = z.object({
@@ -358,7 +622,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Usage History",
             description:
-                "Returns your request history with per-request details: model used, token counts, cost, and response time. Supports JSON and CSV export. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.",
+                "Returns your request history with per-request details: model used, token counts, cost, and response time. Defaults to the last 30 days, supports up to 90 days via `days`, and supports JSON and CSV export. Each response is capped at 50,000 rows. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.",
             responses: {
                 200: {
                     description: "Usage records",
@@ -393,87 +657,42 @@ export const accountRoutes = new Hono<Env>()
                 });
             }
 
-            const { format, limit, before } = c.req.valid("query");
+            const { format, limit, before, days } = c.req.valid("query");
+            const { userId: usageUserId, overridden: usageUserOverridden } =
+                resolveUsageTargetUserId(c.env, user.id, apiKey);
+            const usageWindow = buildUsageWindow(days);
+            const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
+            const tinybirdToken = c.env.TINYBIRD_READ_TOKEN;
+            const header =
+                "timestamp,type,model,api_key,api_key_type,meter_source,input_text_tokens,input_cached_tokens,input_audio_tokens,input_image_tokens,output_text_tokens,output_reasoning_tokens,output_audio_tokens,output_image_tokens,cost_usd,response_time_ms";
 
             log.debug(
-                "Fetching usage: userId={userId} format={format} limit={limit} before={before}",
+                "Fetching usage: requesterUserId={requesterUserId} targetUserId={targetUserId} override={override} format={format} limit={limit} before={before} days={days}",
                 {
-                    userId: user.id,
+                    requesterUserId: user.id,
+                    targetUserId: usageUserId,
+                    override: usageUserOverridden,
                     format,
                     limit,
                     before,
+                    days,
                 },
             );
 
-            // Build Tinybird API URL from ingest URL origin
-            const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
-            const tinybirdUrl = new URL(
-                "/v0/pipes/user_usage.json",
-                tinybirdOrigin,
-            );
-            tinybirdUrl.searchParams.set("user_id", user.id);
-            tinybirdUrl.searchParams.set("limit", limit.toString());
-            if (before) {
-                tinybirdUrl.searchParams.set("before", before);
-            }
-
-            log.debug("Querying Tinybird: {url}", {
-                url: tinybirdUrl.toString(),
-            });
-
             try {
-                const response = await fetch(tinybirdUrl.toString(), {
-                    headers: {
-                        Authorization: `Bearer ${c.env.TINYBIRD_READ_TOKEN}`,
-                    },
-                });
-
-                if (!response.ok) {
-                    const errorText = await response.text();
-                    log.error(
-                        "Tinybird error: url={url} status={status} error={error}",
+                const usage = (
+                    await fetchDetailedUsagePage(
+                        tinybirdOrigin,
+                        tinybirdToken,
                         {
-                            url: tinybirdUrl.toString(),
-                            status: response.status,
-                            error: errorText,
+                            userId: usageUserId,
+                            limit,
+                            since: usageWindow.since,
+                            until: usageWindow.until,
+                            before,
                         },
-                    );
-
-                    const status = response.status >= 500 ? 503 : 500;
-                    return c.json(
-                        {
-                            error: "Failed to fetch usage data",
-                            details:
-                                response.status === 401
-                                    ? "Unauthorized"
-                                    : "Service Unavailable",
-                        },
-                        status,
-                    );
-                }
-
-                const data = (await response.json()) as {
-                    data: Array<{
-                        timestamp: string;
-                        type: string;
-                        model: string | null;
-                        api_key: string | null;
-                        api_key_type: string | null;
-                        meter_source: string | null;
-                        input_text_tokens: number;
-                        input_cached_tokens: number;
-                        input_audio_tokens: number;
-                        input_image_tokens: number;
-                        output_text_tokens: number;
-                        output_reasoning_tokens: number;
-                        output_audio_tokens: number;
-                        output_image_tokens: number;
-                        cost_usd: number;
-                        response_time_ms: number | null;
-                    }>;
-                };
-
-                const usage = data.data;
+                    )
+                ).map(stripUsageCursor);
 
                 log.debug("Fetched {count} usage records", {
                     count: usage.length,
@@ -481,18 +700,13 @@ export const accountRoutes = new Hono<Env>()
 
                 // Return CSV if requested
                 if (format === "csv") {
-                    const header =
-                        "timestamp,type,model,api_key,api_key_type,meter_source,input_text_tokens,input_cached_tokens,input_audio_tokens,input_image_tokens,output_text_tokens,output_reasoning_tokens,output_audio_tokens,output_image_tokens,cost_usd,response_time_ms";
-                    const rows = usage.map(
-                        (row) =>
-                            `${escapeCSV(row.timestamp)},${escapeCSV(row.type)},${escapeCSV(row.model)},${escapeCSV(row.api_key)},${escapeCSV(row.api_key_type)},${escapeCSV(row.meter_source)},${row.input_text_tokens},${row.input_cached_tokens},${row.input_audio_tokens},${row.input_image_tokens},${row.output_text_tokens},${row.output_reasoning_tokens},${row.output_audio_tokens},${row.output_image_tokens},${row.cost_usd},${row.response_time_ms || ""}`,
-                    );
+                    const rows = usage.map(usageRecordToCsvRow);
                     const csv = [header, ...rows].join("\n");
 
                     return new Response(csv, {
                         headers: {
                             "Content-Type": "text/csv",
-                            "Content-Disposition": `attachment; filename="pollinations-usage-${new Date().toISOString().split("T")[0]}.csv"`,
+                            "Content-Disposition": `attachment; filename="pollinations-usage-latest-${usage.length}-rows-${days}d-${new Date().toISOString().split("T")[0]}.csv"`,
                         },
                     });
                 }
@@ -513,7 +727,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Daily Usage",
             description:
-                "Returns daily aggregated usage for the last 90 days, grouped by date and model. Useful for dashboards and spending analysis. Supports JSON and CSV export. Results are cached for 1 hour. Requires `account:usage` permission when using API keys.",
+                "Returns daily aggregated usage for the requested time window (max 90 days), grouped by date and model. Useful for dashboards and spending analysis. Supports JSON and CSV export. Results are cached for 1 hour. Requires `account:usage` permission when using API keys.",
             responses: {
                 200: {
                     description: "Daily usage records aggregated by date/model",
@@ -547,10 +761,17 @@ export const accountRoutes = new Hono<Env>()
                 });
             }
 
+            const { format, days, granularity } = c.req.valid("query");
+            const { userId: usageUserId, overridden: usageUserOverridden } =
+                resolveUsageTargetUserId(c.env, user.id, apiKey);
             const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
             const tinybirdToken = c.env.TINYBIRD_READ_TOKEN;
             const kv = c.env.KV;
-            const cacheKey = `usage:daily:${user.id}`;
+            const cacheKeyPrefix = usageUserOverridden
+                ? `usage:daily:debug:${usageUserId}`
+                : `usage:daily:${usageUserId}`;
+            const cacheKey = `${cacheKeyPrefix}:${granularity}:${days}`;
+            const windows = buildUsageWindows(days);
 
             try {
                 let usage: DailyUsageRecord[] | null = null;
@@ -567,32 +788,29 @@ export const accountRoutes = new Hono<Env>()
                 }
 
                 if (!usage) {
-                    const ninetyDaysAgo = new Date(
-                        Date.now() - 90 * 24 * 60 * 60 * 1000,
+                    const endpointPath =
+                        granularity === "api_key"
+                            ? "/v0/pipes/user_usage_daily_by_api_key.json"
+                            : "/v0/pipes/user_usage_daily.json";
+                    const chunkResults = await Promise.all(
+                        windows.map((window) =>
+                            fetchTinybirdRows<
+                                DailyUsageRecord | KeyedDailyUsageRecord
+                            >(tinybirdOrigin, endpointPath, tinybirdToken, {
+                                user_id: usageUserId,
+                                since: window.since,
+                                until: window.until,
+                            }),
+                        ),
                     );
-                    const since = `${ninetyDaysAgo.toISOString().split("T")[0]} 00:00:00`;
-
-                    const url = new URL(
-                        "/v0/pipes/user_usage_daily.json",
-                        tinybirdOrigin,
-                    );
-                    url.searchParams.set("user_id", user.id);
-                    url.searchParams.set("since", since);
-
-                    const response = await fetch(url.toString(), {
-                        headers: {
-                            Authorization: `Bearer ${tinybirdToken}`,
-                        },
-                    });
-
-                    if (!response.ok) {
-                        throw new Error(`Tinybird error: ${response.status}`);
-                    }
-
-                    const data = (await response.json()) as {
-                        data: DailyUsageRecord[];
-                    };
-                    usage = data.data;
+                    const rows = chunkResults.flat();
+                    usage =
+                        granularity === "api_key"
+                            ? normalizeKeyedDailyUsage(
+                                  rows as KeyedDailyUsageRecord[],
+                              )
+                            : (rows as DailyUsageRecord[]);
+                    usage = sortDailyUsageRecords(usage, granularity);
 
                     try {
                         await kv.put(cacheKey, JSON.stringify(usage), {
@@ -604,27 +822,34 @@ export const accountRoutes = new Hono<Env>()
                 }
 
                 log.debug(
-                    "Fetched daily usage: count={count} cached={cached}",
+                    "Fetched daily usage: requesterUserId={requesterUserId} targetUserId={targetUserId} override={override} days={days} granularity={granularity} count={count} cached={cached}",
                     {
+                        requesterUserId: user.id,
+                        targetUserId: usageUserId,
+                        override: usageUserOverridden,
+                        days,
+                        granularity,
                         count: usage.length,
                         cached,
                     },
                 );
 
-                const { format } = c.req.valid("query");
-
                 if (format === "csv") {
-                    const header = "date,model,meter_source,requests,cost_usd";
-                    const rows = usage.map(
-                        (row) =>
-                            `${escapeCSV(row.date)},${escapeCSV(row.model)},${escapeCSV(row.meter_source)},${row.requests},${row.cost_usd}`,
+                    const header =
+                        granularity === "api_key"
+                            ? "date,model,meter_source,api_key_names,requests,cost_usd"
+                            : "date,model,meter_source,requests,cost_usd";
+                    const rows = usage.map((row) =>
+                        granularity === "api_key"
+                            ? `${escapeCSV(row.date)},${escapeCSV(row.model)},${escapeCSV(row.meter_source)},${escapeCSV(row.api_key_names?.join("|") || "")},${row.requests},${row.cost_usd}`
+                            : dailyUsageRecordToCsvRow(row),
                     );
                     const csv = [header, ...rows].join("\n");
 
                     return new Response(csv, {
                         headers: {
                             "Content-Type": "text/csv",
-                            "Content-Disposition": `attachment; filename="pollinations-usage-daily-${new Date().toISOString().split("T")[0]}.csv"`,
+                            "Content-Disposition": `attachment; filename="pollinations-usage-daily-${days}d-${new Date().toISOString().split("T")[0]}.csv"`,
                         },
                     });
                 }

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -334,16 +334,18 @@ function generateLLMDoc(): string {
         "Per-request usage history: model, token counts, cost, response time.",
     );
     lines.push(
-        "Query params: format (json|csv, default json), limit (1-50000, default 100), before (ISO timestamp cursor)",
+        "Query params: format (json|csv, default json), days (1-90, default 30), limit (1-50000, default 100), before (ISO timestamp cursor). Each response is capped by limit; dashboard detailed CSV uses the latest 50,000 rows within the selected period.",
     );
     lines.push("Requires `account:usage` permission.");
     lines.push("");
 
     lines.push("### GET /api/account/usage/daily");
     lines.push(
-        "Daily aggregated usage (last 90 days) grouped by date and model: { date, model, meter_source, requests, cost_usd }.",
+        "Daily aggregated usage for the requested time window (max 90 days) grouped by date and model: { date, model, meter_source, requests, cost_usd }.",
     );
-    lines.push("Query params: format (json|csv, default json)");
+    lines.push(
+        "Query params: format (json|csv, default json), days (1-90, default 90)",
+    );
     lines.push("Requires `account:usage` permission. Cached 1 hour.");
     lines.push("");
 
@@ -892,8 +894,8 @@ models.forEach((m) => console.log(\`\${m.id}: \${m.description}\`));`,
 curl "https://gen.pollinations.ai/account/usage?limit=10" \\
   -H "Authorization: Bearer YOUR_API_KEY"
 
-# Export as CSV
-curl "https://gen.pollinations.ai/account/usage?format=csv&limit=100" \\
+# Export the latest 50,000 rows from the last 30 days as CSV
+curl "https://gen.pollinations.ai/account/usage?format=csv&days=30&limit=50000" \\
   -H "Authorization: Bearer YOUR_API_KEY" -o usage.csv`,
         },
         {
@@ -903,11 +905,11 @@ curl "https://gen.pollinations.ai/account/usage?format=csv&limit=100" \\
 
 response = requests.get(
     "https://gen.pollinations.ai/account/usage",
-    params={"limit": 10},
+    params={"limit": 10, "days": 30},
     headers={"Authorization": "Bearer YOUR_API_KEY"},
 )
-for record in response.json()["data"]:
-    print(f"{record['model']}: {record['cost']} pollen")`,
+for record in response.json()["usage"]:
+    print(f"{record['model']}: {record['cost_usd']} pollen")`,
         },
     ],
     "get /account/usage/daily": [

--- a/enter.pollinations.ai/test/account-usage.test.ts
+++ b/enter.pollinations.ai/test/account-usage.test.ts
@@ -1,0 +1,232 @@
+import { env, SELF } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { user as userTable } from "@/db/schema/better-auth.ts";
+import { test } from "./fixtures.ts";
+import type { MockTinybirdState } from "./mocks/tinybird.ts";
+
+type MockTinybirdEvent = MockTinybirdState["events"][number];
+
+async function getTestUserId(): Promise<string> {
+    const db = drizzle(env.DB);
+    const users = await db
+        .select({ id: userTable.id })
+        .from(userTable)
+        .limit(1);
+    const user = users[0];
+    if (!user) {
+        throw new Error("Test user not found");
+    }
+    return user.id;
+}
+
+function createUsageEvent(
+    userId: string,
+    options: {
+        id: string;
+        startTime: string;
+        apiKeyName: string;
+        model?: string;
+        meterSource?: string;
+        totalPrice?: number;
+    },
+): MockTinybirdEvent {
+    const model = options.model ?? "openai-fast";
+    const meterSource = options.meterSource ?? "tier";
+    const totalPrice = options.totalPrice ?? 1;
+
+    return {
+        id: options.id,
+        requestId: `request-${options.id}`,
+        requestPath: "/api/generate/v1/chat/completions",
+        startTime: options.startTime,
+        endTime: options.startTime,
+        responseTime: 123,
+        responseStatus: 200,
+        environment: "test",
+        eventType: "generate.text",
+        userId,
+        userTier: "seed",
+        userGithubId: "12345",
+        userGithubUsername: "test-user",
+        apiKeyId: `key-${options.apiKeyName}`,
+        apiKeyName: options.apiKeyName,
+        apiKeyType: "secret",
+        apiKeyCreatedVia: "dashboard",
+        apiKeyCreatedForApp: "",
+        apiKeyCreatedForUserId: userId,
+        selectedMeterId: meterSource,
+        selectedMeterSlug: `user:${meterSource}`,
+        balances: {},
+        referrerUrl: "https://example.com",
+        referrerDomain: "example.com",
+        modelRequested: model,
+        resolvedModelRequested: model,
+        modelUsed: model,
+        modelProviderUsed: "openai",
+        isBilledUsage: true,
+        tokenPricePromptText: 0,
+        tokenPricePromptCached: 0,
+        tokenPricePromptAudio: 0,
+        tokenPricePromptImage: 0,
+        tokenPriceCompletionText: 0,
+        tokenPriceCompletionReasoning: 0,
+        tokenPriceCompletionAudio: 0,
+        tokenPriceCompletionImage: 0,
+        tokenCountPromptText: 10,
+        tokenCountPromptAudio: 0,
+        tokenCountPromptCached: 0,
+        tokenCountPromptImage: 0,
+        tokenCountCompletionText: 20,
+        tokenCountCompletionReasoning: 0,
+        tokenCountCompletionAudio: 0,
+        tokenCountCompletionImage: 0,
+        totalCost: totalPrice,
+        totalPrice,
+        moderationPromptHateSeverity: "safe",
+        moderationPromptSelfHarmSeverity: "safe",
+        moderationPromptSexualSeverity: "safe",
+        moderationPromptViolenceSeverity: "safe",
+        moderationPromptJailbreakDetected: false,
+        moderationCompletionHateSeverity: "safe",
+        moderationCompletionSelfHarmSeverity: "safe",
+        moderationCompletionSexualSeverity: "safe",
+        moderationCompletionViolenceSeverity: "safe",
+        moderationCompletionProtectedMaterialCodeDetected: false,
+        moderationCompletionProtectedMaterialTextDetected: false,
+        cacheHit: false,
+        cacheType: "none",
+        cacheSemanticSimilarity: null,
+        cacheSemanticThreshold: null,
+        cacheKey: "",
+        errorResponseCode: "undefined",
+        errorSource: "undefined",
+        errorMessage: "",
+        errorStack: "",
+        errorDetails: "",
+        ipSubnet: "127.0.0.0/24",
+        ipHash: "hash",
+    } as MockTinybirdEvent;
+}
+
+test("GET /api/account/usage/daily uses exact API key granularity and respects days", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    const userId = await getTestUserId();
+
+    mocks.tinybird.state.events.push(
+        createUsageEvent(userId, {
+            id: "event-a1",
+            startTime: "2026-04-14T10:00:00.000Z",
+            apiKeyName: "alpha",
+            totalPrice: 2,
+        }),
+        createUsageEvent(userId, {
+            id: "event-a2",
+            startTime: "2026-04-14T11:00:00.000Z",
+            apiKeyName: "alpha",
+            totalPrice: 3,
+        }),
+        createUsageEvent(userId, {
+            id: "event-b1",
+            startTime: "2026-04-14T12:00:00.000Z",
+            apiKeyName: "beta",
+            totalPrice: 5,
+        }),
+        createUsageEvent(userId, {
+            id: "event-old",
+            startTime: "2025-12-01T12:00:00.000Z",
+            apiKeyName: "alpha",
+            totalPrice: 8,
+        }),
+    );
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/usage/daily?days=30&granularity=api_key",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+        usage: Array<{
+            date: string;
+            requests: number;
+            cost_usd: number;
+            api_key_names?: string[];
+        }>;
+    };
+
+    expect(data.usage).toHaveLength(2);
+    expect(data.usage).toEqual([
+        expect.objectContaining({
+            date: "2026-04-14",
+            requests: 2,
+            cost_usd: 5,
+            api_key_names: ["alpha"],
+        }),
+        expect.objectContaining({
+            date: "2026-04-14",
+            requests: 1,
+            cost_usd: 5,
+            api_key_names: ["beta"],
+        }),
+    ]);
+});
+
+test("GET /api/account/usage CSV export is capped to the latest 50k rows", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    const userId = await getTestUserId();
+
+    const sameTimestamp = "2026-04-14T12:10:00.000Z";
+    mocks.tinybird.state.events.push(
+        createUsageEvent(userId, {
+            id: "event-000000",
+            startTime: sameTimestamp,
+            apiKeyName: "truncated-oldest-row",
+            totalPrice: 1,
+        }),
+    );
+
+    for (let index = 1; index <= 50_000; index += 1) {
+        mocks.tinybird.state.events.push(
+            createUsageEvent(userId, {
+                id: `event-${String(index).padStart(6, "0")}`,
+                startTime: sameTimestamp,
+                apiKeyName: "alpha",
+                totalPrice: 1,
+            }),
+        );
+    }
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/usage?format=csv&days=30&limit=50000",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toContain(
+        "latest-50000-rows-30d",
+    );
+
+    const csv = await response.text();
+    const lines = csv.trim().split("\n");
+
+    expect(lines).toHaveLength(50_001);
+    expect(lines[0]).toContain("timestamp,type,model");
+    expect(lines[1]).toContain("2026-04-14 12:10:00");
+    expect(csv).not.toContain("truncated-oldest-row");
+    expect(csv).toContain("alpha");
+});

--- a/enter.pollinations.ai/test/mocks/tinybird.ts
+++ b/enter.pollinations.ai/test/mocks/tinybird.ts
@@ -22,35 +22,93 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
         events: [],
     };
 
-    const tinybirdAPI = new Hono().post("/v0/events", async (c) => {
-        const eventName = c.req.query("name");
-        const body = await c.req.text();
-        const rows = parseNdjson(body);
+    const tinybirdAPI = new Hono()
+        .post("/v0/events", async (c) => {
+            const eventName = c.req.query("name");
+            const body = await c.req.text();
+            const rows = parseNdjson(body);
 
-        // Only track generation_event in state (other event types are accepted silently)
-        if (eventName === "generation_event") {
-            const events: TinybirdGenerationEvent[] = rows;
-            // simulate failure if id starts with "simulate_error"
-            if (
-                events.find((event) =>
-                    event.id.includes("simulate_tinybird_error"),
-                )
-            ) {
-                throw new Error(
-                    "Failed to ingest mock tinybird events: simulated error",
-                );
+            // Only track generation_event in state (other event types are accepted silently)
+            if (eventName === "generation_event") {
+                const events: TinybirdGenerationEvent[] = rows;
+                // simulate failure if id starts with "simulate_error"
+                if (
+                    events.find((event) =>
+                        event.id.includes("simulate_tinybird_error"),
+                    )
+                ) {
+                    throw new Error(
+                        "Failed to ingest mock tinybird events: simulated error",
+                    );
+                }
+                state.events.push(...events);
             }
-            state.events.push(...events);
-        }
 
-        return c.json(
-            {
-                successful_rows: rows.length,
-                quarantined_rows: 0,
-            },
-            200,
-        );
-    });
+            return c.json(
+                {
+                    successful_rows: rows.length,
+                    quarantined_rows: 0,
+                },
+                200,
+            );
+        })
+        .get("/v0/pipes/user_usage.json", async (c) => {
+            const userId = c.req.query("user_id") || "";
+            const limit = Number(c.req.query("limit") || "100");
+            const before = c.req.query("before");
+            const beforeEventId = c.req.query("before_event_id");
+            const since = c.req.query("since");
+            const until = c.req.query("until");
+
+            const rows = state.events
+                .filter((event) => isBilledUsage(event, userId))
+                .filter((event) => isWithinRange(event, since, until))
+                .sort(compareEventsNewestFirst)
+                .filter((event) => isBeforeCursor(event, before, beforeEventId))
+                .slice(0, limit)
+                .map((event) => ({
+                    timestamp: formatTimestamp(event.startTime),
+                    cursor_event_id: event.id,
+                    type: event.eventType,
+                    model: event.modelUsed ?? null,
+                    api_key: event.apiKeyName ?? null,
+                    api_key_type: event.apiKeyType ?? null,
+                    meter_source: getMeterSource(event.selectedMeterSlug),
+                    input_text_tokens: event.tokenCountPromptText ?? 0,
+                    input_cached_tokens: event.tokenCountPromptCached ?? 0,
+                    input_audio_tokens: event.tokenCountPromptAudio ?? 0,
+                    input_image_tokens: event.tokenCountPromptImage ?? 0,
+                    output_text_tokens: event.tokenCountCompletionText ?? 0,
+                    output_reasoning_tokens:
+                        event.tokenCountCompletionReasoning ?? 0,
+                    output_audio_tokens: event.tokenCountCompletionAudio ?? 0,
+                    output_image_tokens: event.tokenCountCompletionImage ?? 0,
+                    cost_usd: Number(event.totalPrice ?? 0),
+                    response_time_ms: event.responseTime ?? null,
+                }));
+
+            return c.json({ data: rows }, 200);
+        })
+        .get("/v0/pipes/user_usage_daily.json", async (c) => {
+            const rows = aggregateDailyUsage(
+                state.events,
+                c.req.query("user_id") || "",
+                c.req.query("since"),
+                c.req.query("until"),
+                false,
+            );
+            return c.json({ data: rows }, 200);
+        })
+        .get("/v0/pipes/user_usage_daily_by_api_key.json", async (c) => {
+            const rows = aggregateDailyUsage(
+                state.events,
+                c.req.query("user_id") || "",
+                c.req.query("since"),
+                c.req.query("until"),
+                true,
+            );
+            return c.json({ data: rows }, 200);
+        });
 
     const handlerMap = {
         "localhost:7181": createHonoMockHandler(tinybirdAPI),
@@ -67,6 +125,151 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
     };
 }
 
-function parseNdjson(input: string): any[] {
-    return input.split("\n").map((line) => JSON.parse(line));
+function parseNdjson(input: string): unknown[] {
+    return input
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line));
+}
+
+function isBilledUsage(
+    event: TinybirdGenerationEvent,
+    userId: string,
+): boolean {
+    return event.userId === userId && Number(event.totalPrice ?? 0) > 0;
+}
+
+function parseDateTime(value?: string | Date | null): number {
+    if (!value) return Number.NaN;
+    if (value instanceof Date) return value.getTime();
+    return new Date(
+        value.includes("T") ? value : `${value.replace(" ", "T")}Z`,
+    ).getTime();
+}
+
+function isWithinRange(
+    event: TinybirdGenerationEvent,
+    since?: string | null,
+    until?: string | null,
+): boolean {
+    const eventTime = parseDateTime(event.startTime);
+    if (since && eventTime < parseDateTime(since)) {
+        return false;
+    }
+    if (until && eventTime >= parseDateTime(until)) {
+        return false;
+    }
+    return true;
+}
+
+function compareEventsNewestFirst(
+    left: TinybirdGenerationEvent,
+    right: TinybirdGenerationEvent,
+): number {
+    const timeDiff =
+        parseDateTime(right.startTime) - parseDateTime(left.startTime);
+    if (timeDiff !== 0) return timeDiff;
+    return right.id.localeCompare(left.id);
+}
+
+function isBeforeCursor(
+    event: TinybirdGenerationEvent,
+    before?: string | null,
+    beforeEventId?: string | null,
+): boolean {
+    if (!before) return true;
+
+    const eventTime = parseDateTime(event.startTime);
+    const beforeTime = parseDateTime(before);
+    if (eventTime < beforeTime) return true;
+    if (eventTime > beforeTime) return false;
+    if (!beforeEventId) return false;
+    return event.id < beforeEventId;
+}
+
+function formatTimestamp(value: string | Date): string {
+    return new Date(value).toISOString().slice(0, 19).replace("T", " ");
+}
+
+function getMeterSource(selectedMeterSlug?: string | null): string | null {
+    if (!selectedMeterSlug) return null;
+    const parts = selectedMeterSlug.split(":");
+    return parts.at(-1) || null;
+}
+
+function aggregateDailyUsage(
+    events: TinybirdGenerationEvent[],
+    userId: string,
+    since?: string | null,
+    until?: string | null,
+    byApiKey = false,
+) {
+    const buckets = new Map<
+        string,
+        {
+            date: string;
+            model: string | null;
+            meter_source: string | null;
+            requests: number;
+            cost_usd: number;
+            api_key_names: Set<string>;
+            api_key_name?: string | null;
+        }
+    >();
+
+    for (const event of events) {
+        if (
+            !isBilledUsage(event, userId) ||
+            !isWithinRange(event, since, until)
+        ) {
+            continue;
+        }
+
+        const date = new Date(event.startTime).toISOString().slice(0, 10);
+        const model = event.resolvedModelRequested ?? null;
+        const meterSource = getMeterSource(event.selectedMeterSlug);
+        const apiKeyName =
+            event.apiKeyName && event.apiKeyName !== "undefined"
+                ? event.apiKeyName
+                : null;
+        const key = byApiKey
+            ? [date, model ?? "", meterSource ?? "", apiKeyName ?? ""].join("|")
+            : [date, model ?? "", meterSource ?? ""].join("|");
+
+        const current = buckets.get(key) || {
+            date,
+            model,
+            meter_source: meterSource,
+            requests: 0,
+            cost_usd: 0,
+            api_key_names: new Set<string>(),
+            ...(byApiKey ? { api_key_name: apiKeyName } : {}),
+        };
+        current.requests += 1;
+        current.cost_usd += Number(event.totalPrice ?? 0);
+        if (apiKeyName) {
+            current.api_key_names.add(apiKeyName);
+        }
+        buckets.set(key, current);
+    }
+
+    return Array.from(buckets.values())
+        .map((value) => ({
+            date: value.date,
+            model: value.model,
+            meter_source: value.meter_source,
+            requests: value.requests,
+            cost_usd: value.cost_usd,
+            ...(byApiKey
+                ? { api_key_name: value.api_key_name ?? null }
+                : {
+                      api_key_names: Array.from(value.api_key_names).sort(),
+                  }),
+        }))
+        .sort((left, right) => {
+            if (left.date !== right.date) {
+                return right.date.localeCompare(left.date);
+            }
+            return right.requests - left.requests;
+        });
 }

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -78,12 +78,15 @@ id = "aa0d0aceb6bd45de93032270c7adf4ab"
 [[env.local.r2_buckets]]
 binding = "IMAGE_BUCKET"
 bucket_name = "pollinations-images"
-remote = true
 
 [[env.local.r2_buckets]]
 binding = "TEXT_BUCKET"
 bucket_name = "pollinations-text-enter"
-remote = true
+
+[[env.local.durable_objects.bindings]]
+name = "POLLEN_RATE_LIMITER"
+class_name = "PollenRateLimiter"
+script_name = "pollinations-enter"
 
 [env.local.vars]
 ENVIRONMENT = "local"
@@ -99,6 +102,8 @@ TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?n
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
 IMAGE_SERVICE_URL = "http://localhost:16384"
 TEXT_SERVICE_URL = "http://localhost:16385"
+# NOWPayments crypto payments (sandbox for local development)
+NOWPAYMENTS_ENV = "sandbox"
 # Stripe payments (sandbox for local development)
 STRIPE_MODE = "sandbox"
 STRIPE_SUCCESS_URL = "http://localhost:3000"

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -7,6 +7,7 @@ import type {
     ChatOptions,
     ChatResponse,
     ChatStreamChunk,
+    DailyUsageOptions,
     DailyUsageResponse,
     ImageEditOptions,
     ImageGenerateOptions,
@@ -1608,6 +1609,7 @@ export class Pollinations {
     async accountUsage(options: UsageOptions = {}): Promise<UsageResponse> {
         const params = new URLSearchParams();
         if (options.format) params.set("format", options.format);
+        if (options.days) params.set("days", String(options.days));
         if (options.limit) params.set("limit", String(options.limit));
         if (options.before) params.set("before", options.before);
 
@@ -1634,10 +1636,11 @@ export class Pollinations {
      * ```
      */
     async accountUsageDaily(
-        options: { format?: "json" | "csv" } = {},
+        options: DailyUsageOptions = {},
     ): Promise<DailyUsageResponse> {
         const params = new URLSearchParams();
         if (options.format) params.set("format", options.format);
+        if (options.days) params.set("days", String(options.days));
 
         const qs = params.toString();
         const url = `${this.baseUrl}/account/usage/daily${qs ? `?${qs}` : ""}`;

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -36,6 +36,7 @@ import type {
     AudioGenerateOptions,
     AuthorizeOptions,
     ChatOptions,
+    DailyUsageOptions,
     DailyUsageResponse,
     ImageEditOptions,
     ImageGenerateOptions,
@@ -546,9 +547,9 @@ export async function getUsage(options?: UsageOptions): Promise<UsageResponse> {
 /**
  * Get daily usage summary
  */
-export async function getDailyUsage(options?: {
-    format?: "json" | "csv";
-}): Promise<DailyUsageResponse> {
+export async function getDailyUsage(
+    options?: DailyUsageOptions,
+): Promise<DailyUsageResponse> {
     return getClient().accountUsageDaily(options);
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -627,10 +627,20 @@ export interface UsageResponse {
 export interface UsageOptions {
     /** Response format (default: 'json') */
     format?: "json" | "csv";
-    /** Max records to return, 1-50000 (default: 100) */
+    /** Number of days to include, max 90 (default: 30) */
+    days?: number;
+    /** Max records to return, 1-50000 (default: 100). CSV exports are capped at 50000. */
     limit?: number;
     /** ISO timestamp cursor for pagination */
     before?: string;
+}
+
+/** Options for fetching daily usage */
+export interface DailyUsageOptions {
+    /** Response format (default: 'json') */
+    format?: "json" | "csv";
+    /** Number of days to include, max 90 (default: 90) */
+    days?: number;
 }
 
 /** Daily usage summary */


### PR DESCRIPTION
## What changed
- fix the usage dashboard to fetch only the selected `7d / 30d / 90d` window instead of always asking Tinybird for the full 90-day daily payload
- add an exact per-key Tinybird daily pipe so the API key filter is no longer approximate
- keep `Daily Summary` as the full selected-period export, and make `Detailed Usage` an explicit latest `50k` rows export within the selected period
- align account route docs, API docs, SDK types, and local enter dev config used to reproduce the power-user path safely
- add usage route tests and extend the Tinybird mock coverage

## Why
- the daily usage query was timing out for heavy users
- the detailed export path was either truncating silently or producing impractically large files
- the graph and downloads did not consistently follow the selected time range

## Validation
- `npm run typecheck` in `enter.pollinations.ai`
- `CLOUDFLARE_ENV=local ./node_modules/.bin/vitest run test/account-usage.test.ts`
- validated the new Tinybird pipes live during development