### PR TITLE
feat: hide expired API keys from dashboard

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -28,7 +28,11 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
         }
     }
 
-    const sortedKeys = [...apiKeys].sort(
+    const now = Date.now();
+    const visibleKeys = apiKeys.filter(
+        (k) => !k.expiresAt || new Date(k.expiresAt).getTime() > now,
+    );
+    const sortedKeys = [...visibleKeys].sort(
         (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
@@ -56,7 +60,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                 </div>
                 <Panel color="blue">
                     <div className="flex flex-col gap-3">
-                        {!apiKeys.length && (
+                        {!visibleKeys.length && (
                             <div className="rounded-xl bg-white/80 p-6 text-center">
                                 <p className="text-2xl mb-2">🔑</p>
                                 <p className="font-semibold text-gray-900 text-lg mb-2">
@@ -72,7 +76,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                 </p>
                             </div>
                         )}
-                        {apiKeys.length > 0 && (
+                        {visibleKeys.length > 0 && (
                             <div className="rounded-xl bg-amber-50/80 p-4">
                                 <p className="font-semibold text-amber-900 mb-1">
                                     🪷 Let your users bring their own Pollen


### PR DESCRIPTION
## Summary
- Filter keys past `expiresAt` before rendering in the dashboard
- Empty-state reappears if a user's only remaining keys are expired

## Test plan
- [ ] Create a key with short expiry, wait past it — key disappears from list
- [ ] Keys with no `expiresAt` still show

🤖 Generated with [Claude Code](https://claude.com/claude-code)