### PR TITLE
fix: update veo 3.1 fast model id to GA version

### DIFF
--- a/image.pollinations.ai/src/models/veoVideoModel.ts
+++ b/image.pollinations.ai/src/models/veoVideoModel.ts
@@ -32,7 +32,7 @@ async function processImageForVeo(
 
 // Veo API constants
 const LOCATION = "us-central1"; // Veo is only available in us-central1
-const MODEL_ID = "veo-3.1-fast-generate-preview";
+const MODEL_ID = "veo-3.1-fast-generate-001";
 
 /**
  * Result of video generation


### PR DESCRIPTION
- Google retired the `-preview` alias when Veo 3.1 Fast went GA on 2025-11-17
- Every Veo call has been 404ing for ~2 weeks (937 requests, 0 success across Apr 5–Apr 15)
- Vertex error: \`Publisher Model veo-3.1-fast-generate-preview was not found\`
- Updates hardcoded ID in [image.pollinations.ai/src/models/veoVideoModel.ts:35](../blob/main/image.pollinations.ai/src/models/veoVideoModel.ts#L35) from \`veo-3.1-fast-generate-preview\` → \`veo-3.1-fast-generate-001\`
- Requires EC2 redeploy of image.pollinations.ai to take effect

polly please review