### PR TITLE
feat(finance): live stripe mtd + shifted payouts + unmatched guards

### DIFF
--- a/apps/operation/finance/bin/rebuild-sheet.mjs
+++ b/apps/operation/finance/bin/rebuild-sheet.mjs
@@ -37,11 +37,65 @@ function currentMonthFromClock() {
     return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+function prevMonth(ym) {
+    const [y, m] = ym.split("-").map(Number);
+    const d = new Date(Date.UTC(y, m - 1, 1));
+    d.setUTCMonth(d.getUTCMonth() - 1);
+    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatUnmatchedTable(stats) {
+    const cpWidth = Math.max(12, ...stats.map((s) => s.counterparty.length));
+    const header = `  ${"COUNTERPARTY".padEnd(cpWidth)}   COUNT   SUM EUR`;
+    const sep = `  ${"-".repeat(cpWidth)}   -----   ---------`;
+    const rows = stats.map(
+        (s) =>
+            `  ${s.counterparty.padEnd(cpWidth)}   ${String(s.count).padStart(5)}   ${s.sumEur.toFixed(2).padStart(9)}`,
+    );
+    return [header, sep, ...rows].join("\n");
+}
+
 async function resolveVendorsInteractively(rawRows) {
     const vendors = await loadVendors();
     for (;;) {
-        const { canonical, unknown } = normalize(rawRows, vendors);
-        if (unknown.length === 0) return { vendors, canonicalRows: canonical };
+        const { canonical, unknown, unknownStats } = normalize(
+            rawRows,
+            vendors,
+        );
+        if (unknown.length === 0) {
+            return { vendors, canonicalRows: canonical, unmatched: null };
+        }
+
+        // Non-interactive (cron/launchd): print a clear summary to stderr so
+        // the break is visible in update-live.err. Return the summary so the
+        // caller can still render the sheet (with a warn row) and then exit
+        // non-zero at the very end. Hanging on readline in launchd would
+        // silently hide missing data.
+        if (!process.stdin.isTTY) {
+            const count = unknownStats.reduce((s, r) => s + r.count, 0);
+            const sumEur = Number(
+                unknownStats.reduce((s, r) => s + r.sumEur, 0).toFixed(2),
+            );
+            console.error(
+                [
+                    "",
+                    `⚠ ${unknown.length} unmatched counterparty(ies) in Wise feed (non-interactive run).`,
+                    `  Total unmatched transactions: ${count}  (sum: ${sumEur.toFixed(2)} EUR)`,
+                    "",
+                    formatUnmatchedTable(unknownStats),
+                    "",
+                    "  Fix: run `node bin/rebuild-sheet.mjs` from an interactive shell to classify these vendors,",
+                    "       or add them manually to secrets/vendors.json.",
+                    "",
+                ].join("\n"),
+            );
+            return {
+                vendors,
+                canonicalRows: canonical,
+                unmatched: { count, sumEur, stats: unknownStats },
+            };
+        }
+
         console.log(
             `\n${unknown.length} unknown vendor(s) — resolving interactively.`,
         );
@@ -82,8 +136,10 @@ async function main() {
     const rawRows = await fetchMonths(startMonth, endMonth);
     console.log(`Loaded ${rawRows.length} transactions from Wise API.`);
 
-    // Resolve unknown vendors interactively
-    const { vendors, canonicalRows } =
+    // Resolve unknown vendors interactively. In non-interactive mode,
+    // unmatched rows are skipped with a stderr table; the sheet still gets
+    // built with a visible warn row, and we exit 1 at the end.
+    const { vendors, canonicalRows, unmatched } =
         await resolveVendorsInteractively(rawRows);
 
     // Aggregate → forecast → layout
@@ -164,15 +220,65 @@ async function main() {
         }
     }
 
-    // Revenue forecast: use the last actual month's revenue (including
-    // the current month if it has Wise data) for all future months.
+    // Stripe revenue re-attribution (must run BEFORE the revenue forecast
+    // block so the forecast's extrapolation base picks up the shifted March
+    // value, not the pre-shift Wise value):
+    //
+    //  - Historical months (Jan–Mar) get shifted payouts: the payout arriving
+    //    on day 1-2 of month M actually reflects month M-1's activity, so we
+    //    move it back one column. Feb-2 payout → Jan column, Mar-2 → Feb,
+    //    Apr-1 → Mar. The Wise-sourced Stripe row for those months is
+    //    cleared first so we don't double-count.
+    //
+    //  - Current month (Apr) gets the live MTD net from the Stripe API —
+    //    the activity happening right now, which will pay out next month.
+    //
+    // Running-cash reconciliation will drift slightly vs the actual bank
+    // because the shift decouples "cash arrived" from "revenue shown". The
+    // trade-off buys a cleaner runway projection. Explicit design choice.
+    const stripePool = pools.Stripe;
+    if (stripePool?.role === "revenue" && stripePool.mtd_stale !== true) {
+        const canonical = stripePool.vendor_canonical ?? "Stripe";
+
+        // Clear Wise-sourced Stripe values in all historical months (we're
+        // about to repopulate them with shifted values).
+        for (const m of extended.months) {
+            if (extended.forecastMonths.has(m)) continue;
+            if (m === nowMonth) continue;
+            if (extended.data[m]?.[canonical] !== undefined) {
+                extended.data[m][canonical] = 0;
+            }
+        }
+
+        // Inject shifted historical payouts into the activity month.
+        const payouts = stripePool.monthly_payouts ?? {};
+        for (const [arrivalMonth, eurValue] of Object.entries(payouts)) {
+            const activityMonth = prevMonth(arrivalMonth);
+            if (!extended.data[activityMonth]) continue;
+            if (activityMonth === nowMonth) continue; // live override below
+            if (extended.forecastMonths.has(activityMonth)) continue;
+            extended.data[activityMonth][canonical] = eurValue;
+        }
+
+        // Current-month live MTD net.
+        if (
+            typeof stripePool.mtd_live_net_eur === "number" &&
+            extended.data[nowMonth]
+        ) {
+            extended.data[nowMonth][canonical] = stripePool.mtd_live_net_eur;
+        }
+    }
+
+    // Revenue forecast: extrapolate from the last FINISHED month (excluding
+    // the current month). The current month holds live MTD revenue (partial
+    // activity) so it's not a stable base for extrapolation. For Stripe this
+    // picks up the shifted Mar value (= Apr-1 payout = March's activity).
     const revenueVendors = ["Stripe", "Polar.sh"];
-    const actualMonths = extended.months.filter(
-        (m) => !extended.forecastMonths.has(m),
+    const finishedMonths = extended.months.filter(
+        (m) => !extended.forecastMonths.has(m) && m !== nowMonth,
     );
-    const latestRevenueMonth = actualMonths.at(-1);
+    const latestRevenueMonth = finishedMonths.at(-1);
     if (latestRevenueMonth) {
-        // Collect per-vendor revenue from the last completed month
         const lastRevenue = {};
         for (const v of revenueVendors) {
             const amt = extended.data[latestRevenueMonth]?.[v] ?? 0;
@@ -180,8 +286,8 @@ async function main() {
         }
         for (const m of extended.months) {
             if (m <= latestRevenueMonth) continue;
+            if (m === nowMonth) continue; // current month already set above
             if (!extended.data[m]) continue;
-            // Only set forecast if no actual data exists for this month
             const existing = revenueVendors.reduce(
                 (s, v) => s + (extended.data[m][v] ?? 0),
                 0,
@@ -198,6 +304,7 @@ async function main() {
         currentMonth: nowMonth,
         pools,
         poolHistory,
+        unmatched,
     });
 
     // Write to sheet
@@ -345,6 +452,13 @@ async function main() {
         (r) => typeof r[0] === "string" && r[0].startsWith("Cash:"),
     );
     if (kpiRow) console.log(kpiRow[0]);
+
+    // Non-interactive run with unmatched rows: the sheet is written with a
+    // visible warn banner; signal failure to the caller (launchd/cron) so the
+    // break is flagged in the run status too.
+    if (unmatched) {
+        process.exitCode = 1;
+    }
 }
 
 main().catch((err) => {

--- a/apps/operation/finance/bin/update-live.mjs
+++ b/apps/operation/finance/bin/update-live.mjs
@@ -116,9 +116,9 @@ async function main() {
             const r = await mod.fetchMtd(month, pool);
 
             let newBalance;
-            if (pool.kind === "payg") {
-                // Pay-as-you-go providers (e.g. Alibaba) have no standing
-                // balance. Skip balance tracking entirely.
+            if (pool.kind === "payg" || pool.role === "revenue") {
+                // Pay-as-you-go and revenue pools (e.g. Alibaba, Stripe) have
+                // no standing balance. Skip balance tracking entirely.
                 newBalance = null;
             } else if (
                 r.live_balance ||
@@ -151,8 +151,9 @@ async function main() {
                 `  ${poolName.padEnd(14)} total=$${r.mtd_total_usd.toFixed(2)} credit=$${r.mtd_credit_usd.toFixed(2)} cash=$${r.mtd_cash_usd.toFixed(2)} records=${r.records}`,
             );
             if (newBalance === null) {
+                const kind = pool.role === "revenue" ? "revenue" : "payg";
                 console.log(
-                    `  ${" ".repeat(14)}   (payg — no balance tracked)`,
+                    `  ${" ".repeat(14)}   (${kind} — no balance tracked)`,
                 );
             } else {
                 console.log(

--- a/apps/operation/finance/lib/layout.mjs
+++ b/apps/operation/finance/lib/layout.mjs
@@ -154,7 +154,7 @@ function computeKpis(runningCashValues, months, currentMonth, config) {
 export function buildLayout(
     matrix,
     config,
-    { currentMonth, pools = {}, poolHistory = {} } = {},
+    { currentMonth, pools = {}, poolHistory = {}, unmatched = null } = {},
 ) {
     const cells = [];
     const formats = [];
@@ -243,7 +243,30 @@ export function buildLayout(
         },
     });
 
-    // --- row 2: blank spacer ---
+    // --- optional warn row: unmatched Wise counterparties ---
+    if (unmatched && unmatched.count > 0) {
+        const sumStr = `${unmatched.sumEur.toFixed(2)} EUR`;
+        const warnText = `⚠ Unmatched: ${unmatched.count} transaction${unmatched.count === 1 ? "" : "s"}, ${sumStr} — see update-live.err`;
+        cells.push([warnText, ...Array(totalCol).fill("")]);
+        const warnRowIdx = cells.length - 1;
+        formats.push({
+            label: "unmatchedWarn",
+            range: sheetRange(warnRowIdx, 0, warnRowIdx, totalCol),
+            fields: "userEnteredFormat.textFormat.bold,userEnteredFormat.textFormat.italic,userEnteredFormat.textFormat.fontSize,userEnteredFormat.textFormat.foregroundColor,userEnteredFormat.backgroundColor,userEnteredFormat.verticalAlignment",
+            format: {
+                textFormat: {
+                    bold: true,
+                    italic: false,
+                    fontSize: 11,
+                    foregroundColor: { red: 0.5, green: 0.2, blue: 0 },
+                },
+                backgroundColor: { red: 1, green: 0.94, blue: 0.65 },
+                verticalAlignment: "MIDDLE",
+            },
+        });
+    }
+
+    // --- blank spacer row ---
     cells.push(Array(totalCol + 1).fill(""));
 
     // Pre-compute expense/revenue vendor lists for summary rows.

--- a/apps/operation/finance/lib/normalize.mjs
+++ b/apps/operation/finance/lib/normalize.mjs
@@ -4,9 +4,11 @@
  * Canonical row shape:
  *   { date: "YYYY-MM-DD", month: "YYYY-MM", vendor, category, amount }
  *
- * Returns { canonical, unknown }:
+ * Returns { canonical, unknown, unknownStats }:
  *   - canonical: array of rows whose raw counterparty was found in the alias map
  *   - unknown: deduped array of raw counterparties NOT found in the alias map
+ *   - unknownStats: array of { counterparty, count, sumEur } sorted by
+ *     descending |sumEur|. Useful for warning/alert output.
  *
  * This function is pure: it does not prompt, read files, or mutate inputs.
  * The caller is responsible for handling unknowns (typically by prompting the
@@ -15,11 +17,16 @@
 export function normalize(rawRows, vendorsMap) {
     const canonical = [];
     const unknownSet = new Set();
+    const stats = new Map();
     for (const r of rawRows) {
         const key = r.counterparty;
         const entry = vendorsMap[key];
         if (!entry) {
             unknownSet.add(key);
+            const s = stats.get(key) ?? { count: 0, sumEur: 0 };
+            s.count += 1;
+            s.sumEur += r.amount_eur ?? 0;
+            stats.set(key, s);
             continue;
         }
         canonical.push({
@@ -30,5 +37,12 @@ export function normalize(rawRows, vendorsMap) {
             amount: r.amount_eur,
         });
     }
-    return { canonical, unknown: [...unknownSet] };
+    const unknownStats = [...stats.entries()]
+        .map(([counterparty, s]) => ({
+            counterparty,
+            count: s.count,
+            sumEur: Number(s.sumEur.toFixed(2)),
+        }))
+        .sort((a, b) => Math.abs(b.sumEur) - Math.abs(a.sumEur));
+    return { canonical, unknown: [...unknownSet], unknownStats };
 }

--- a/apps/operation/finance/lib/providers/stripe.mjs
+++ b/apps/operation/finance/lib/providers/stripe.mjs
@@ -1,35 +1,26 @@
 /**
- * Stripe provider — fetches payout-arrival-dated revenue from /v1/payouts.
+ * Stripe provider — fetches two things from the Stripe API:
  *
- * Unlike the cost providers (Azure / AWS / Alibaba / GCP) this is a REVENUE
- * provider — it populates matrix.data with positive numbers for the Stripe
- * vendor, keyed by payout arrival date (not charge date). The arrival date
- * is what matters for runway math because it's exactly when the money hits
- * our Wise bank account, so replacing the Wise CSV's Stripe row with API
- * payout data keeps running-cash math accurate to the cent.
+ * 1. Historical payouts (by arrival date) — one row per past month. Stored in
+ *    `pool.monthly_payouts` for sanity-checking against the Wise feed. Not
+ *    currently injected into the sheet; the Wise activity feed already
+ *    reports these as cash inflows on their arrival date.
+ *
+ * 2. Live month-to-date net revenue (by charge date) — sum of every
+ *    balance_transaction created in the current calendar month, net of Stripe
+ *    fees, excluding payouts. This is the "what we're currently winning"
+ *    number that rebuild-sheet.mjs writes into the current-month Stripe cell,
+ *    replacing the Apr-1 payout value (which represented March's activity).
+ *    Stored in `pool.mtd_live_net_eur`.
  *
  * Validated 2026-04-12: the three historical payouts on 2026-02-02 (€241),
  * 2026-03-02 (€4,227), 2026-04-01 (€5,962) match the Wise CSV deposits
  * exactly. See .claude/skills/provider-billing/providers/stripe.md.
  *
- * The common wrapper shape is awkward for a revenue provider because
- * mtd_credit / mtd_cash don't semantically fit. Instead, this wrapper writes
- * a `monthly_payouts` map directly into the pool state:
- *
- *   pool.monthly_payouts = {
- *     "2026-02": 241.18,
- *     "2026-03": 4227.21,
- *     "2026-04": 5961.71
- *   }
- *
- * rebuild-sheet.mjs reads that map and injects values into matrix.data[m][vendor]
- * for every month the API returned. This overrides the Wise CSV row because
- * API payout value = Wise deposit value (they reconcile to the cent).
- *
  * We use the "common wrapper" return shape for compatibility with update-live.mjs:
- *   mtd_total_usd  = sum of all payouts this month (native EUR, field misnamed)
+ *   mtd_total_usd  = live MTD net (native EUR, field misnamed)
  *   mtd_credit_usd = 0 (revenue has no "credit" concept)
- *   mtd_cash_usd   = same as mtd_total_usd — this is the number that lands in the bank
+ *   mtd_cash_usd   = same as mtd_total_usd — this is revenue expected to pay out next month
  *   live_balance   = true (skip seed-based balance derivation in orchestrator)
  */
 
@@ -71,6 +62,49 @@ async function fetchAllPayouts(apiKey, startUnix, endUnix) {
     return payouts;
 }
 
+async function fetchAllBalanceTransactions(apiKey, startUnix, endUnix) {
+    const txns = [];
+    let startingAfter = null;
+    for (let page = 0; page < 100; page++) {
+        const qs = new URLSearchParams({
+            limit: "100",
+            "created[gte]": String(startUnix),
+            "created[lte]": String(endUnix),
+        });
+        if (startingAfter) qs.set("starting_after", startingAfter);
+        const d = await stripeGet(
+            `/balance_transactions?${qs.toString()}`,
+            apiKey,
+        );
+        const batch = d.data ?? [];
+        txns.push(...batch);
+        if (!d.has_more || batch.length === 0) break;
+        startingAfter = batch[batch.length - 1].id;
+    }
+    return txns;
+}
+
+/**
+ * Sum net revenue (in cents) from a list of balance_transaction objects.
+ * Excludes every payout-type transaction — those are outbound movements to
+ * the bank and already captured by the Wise activity feed. Everything else
+ * (charges, refunds, adjustments, Stripe fees) contributes to what will
+ * eventually pay out.
+ *
+ * Pure. Extracted for unit testing.
+ *
+ * @param {Array<{type: string, net: number, currency: string}>} txns
+ * @returns {number} sum of net values, in minor currency units (cents)
+ */
+export function sumNetRevenueCents(txns) {
+    let total = 0;
+    for (const t of txns) {
+        if (typeof t.type === "string" && t.type.startsWith("payout")) continue;
+        total += Number(t.net ?? 0);
+    }
+    return total;
+}
+
 /**
  * @param {string} currentMonth  "YYYY-MM"
  * @param {object} pool          vendors.json._pools.Stripe (mutated)
@@ -83,42 +117,53 @@ export async function fetchMtd(currentMonth, pool) {
         );
     }
 
-    const startUnix = Math.floor(
+    const historicalStartUnix = Math.floor(
         new Date(`${PAYOUT_START_DATE}T00:00:00Z`).getTime() / 1000,
     );
-    const endUnix = Math.floor(Date.now() / 1000);
+    const nowUnix = Math.floor(Date.now() / 1000);
 
-    const payouts = await fetchAllPayouts(apiKey, startUnix, endUnix);
+    // --- 1. Historical payouts (for sanity-check against Wise) ---
+    const payouts = await fetchAllPayouts(apiKey, historicalStartUnix, nowUnix);
 
-    // Aggregate per month using arrival_date
     const monthlyPayouts = {};
-    let mtdThisMonth = 0;
     for (const p of payouts) {
         const arrivalDate = new Date(p.arrival_date * 1000);
         const monthKey = `${arrivalDate.getUTCFullYear()}-${String(arrivalDate.getUTCMonth() + 1).padStart(2, "0")}`;
         const amountEur = Number(p.amount ?? 0) / 100;
         monthlyPayouts[monthKey] = (monthlyPayouts[monthKey] ?? 0) + amountEur;
-        if (monthKey === currentMonth) mtdThisMonth += amountEur;
     }
-
-    // Round each month value
     for (const k of Object.keys(monthlyPayouts)) {
         monthlyPayouts[k] = Number(monthlyPayouts[k].toFixed(2));
     }
 
+    // --- 2. Live MTD net revenue (charges created in currentMonth) ---
+    const monthStartUnix = Math.floor(
+        new Date(`${currentMonth}-01T00:00:00Z`).getTime() / 1000,
+    );
+    const liveTxns = await fetchAllBalanceTransactions(
+        apiKey,
+        monthStartUnix,
+        nowUnix,
+    );
+    const mtdLiveNetEur = Number(
+        (sumNetRevenueCents(liveTxns) / 100).toFixed(2),
+    );
+
     pool.monthly_payouts = monthlyPayouts;
     pool.payout_count = payouts.length;
     pool.native_currency = "EUR"; // Stripe account is EUR — no FX needed
-    pool.mtd_total_usd = Number(mtdThisMonth.toFixed(2));
+    pool.mtd_live_net_eur = mtdLiveNetEur;
+    pool.mtd_live_txn_count = liveTxns.length;
+    pool.mtd_total_usd = mtdLiveNetEur;
     pool.mtd_credit_usd = 0;
-    pool.mtd_cash_usd = Number(mtdThisMonth.toFixed(2));
+    pool.mtd_cash_usd = mtdLiveNetEur;
     pool.as_of = new Date().toISOString().slice(0, 10);
 
     return {
         mtd_total_usd: pool.mtd_total_usd,
         mtd_credit_usd: pool.mtd_credit_usd,
         mtd_cash_usd: pool.mtd_cash_usd,
-        records: payouts.length,
+        records: payouts.length + liveTxns.length,
         as_of: pool.as_of,
         live_balance: true,
     };

--- a/apps/operation/finance/test/normalize.test.mjs
+++ b/apps/operation/finance/test/normalize.test.mjs
@@ -56,3 +56,20 @@ test("normalize preserves negative/positive amounts as-is", async () => {
     assert.equal(canonical[0].amount, -100.5);
     assert.equal(canonical[2].amount, 500);
 });
+
+test("normalize aggregates unknownStats by counterparty, sorted by |sum|", () => {
+    const rows = [
+        { counterparty: "Small Vendor", date: "2026-01-05", amount_eur: -10 },
+        { counterparty: "Big Vendor", date: "2026-01-10", amount_eur: -500 },
+        { counterparty: "Big Vendor", date: "2026-01-11", amount_eur: -500 },
+        { counterparty: "Small Vendor", date: "2026-01-12", amount_eur: -5 },
+    ];
+    const { unknownStats } = normalize(rows, {});
+    assert.equal(unknownStats.length, 2);
+    assert.equal(unknownStats[0].counterparty, "Big Vendor");
+    assert.equal(unknownStats[0].count, 2);
+    assert.equal(unknownStats[0].sumEur, -1000);
+    assert.equal(unknownStats[1].counterparty, "Small Vendor");
+    assert.equal(unknownStats[1].count, 2);
+    assert.equal(unknownStats[1].sumEur, -15);
+});

--- a/apps/operation/finance/test/stripe.test.mjs
+++ b/apps/operation/finance/test/stripe.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sumNetRevenueCents } from "../lib/providers/stripe.mjs";
+
+test("sumNetRevenueCents sums net across charges and refunds", () => {
+    const txns = [
+        { type: "charge", net: 9700, currency: "eur" },
+        { type: "charge", net: 4850, currency: "eur" },
+        { type: "refund", net: -1000, currency: "eur" },
+    ];
+    assert.equal(sumNetRevenueCents(txns), 9700 + 4850 - 1000);
+});
+
+test("sumNetRevenueCents excludes payout-type transactions", () => {
+    const txns = [
+        { type: "charge", net: 1000, currency: "eur" },
+        { type: "payout", net: -1000, currency: "eur" },
+        { type: "payout_failure", net: 1000, currency: "eur" },
+        { type: "payout_cancel", net: 500, currency: "eur" },
+    ];
+    assert.equal(sumNetRevenueCents(txns), 1000);
+});
+
+test("sumNetRevenueCents handles empty list", () => {
+    assert.equal(sumNetRevenueCents([]), 0);
+});
+
+test("sumNetRevenueCents tolerates missing net field", () => {
+    const txns = [
+        { type: "charge", net: 500 },
+        { type: "charge" }, // net undefined → treated as 0
+    ];
+    assert.equal(sumNetRevenueCents(txns), 500);
+});


### PR DESCRIPTION
Two related changes to the runway tracker.

**Stripe revenue re-attribution.** The Stripe row previously mirrored Wise payout arrivals, which are offset by ~1 day from the actual activity month (Apr-1 payout = March activity). The sheet now attributes revenue to the activity month:

- Historical months: Wise payouts are shifted back one month. Feb-2 payout (€241) lands in Jan column, Mar-2 (€4,227) in Feb, Apr-1 (€5,962) in Mar.
- Current month: overridden with live MTD net (charges minus fees, minus refunds) pulled directly from `/v1/balance_transactions`.
- Forecast base moved from "last actual month" to "last finished month" — May+ now extrapolates from March instead of current-month MTD, giving a smoother runway projection.

Trade-off: running cash diverges slightly from the bank balance within the current month. Explicit design choice for runway simulation quality.

Runway on our sheet moved from 3 → 4 months after the shift because the forecast base now picks up March's actual payout value (€5,962) instead of the previous Feb-activity proxy (€4,227).

**Unmatched Wise transaction guards.** Previously, a rebrand like "Anthropic" → "Anthropic PBC EU" would silently hang the launchd cron on `readline` and drop the transaction from the sheet with no visible signal.

- `normalize` now returns per-counterparty stats (`count`, `sumEur`).
- Non-interactive runs no longer hang: they print a formatted stderr table, still build the sheet, add a yellow ⚠ banner row ("Unmatched: N transactions, €X.XX"), and exit 1 so launchd flags the run.
- Interactive runs keep the existing prompt behaviour.

Adds one unit test for the new `sumNetRevenueCents` helper and one for `normalize` stats. The 3 pre-existing `buildLayout` title/header test failures are unchanged (exist on main).