### PR TITLE
chore(polli): bump to 0.1.0-alpha.2

### DIFF
--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Previous publish for this version number already exists on npm; bumping to unblock republish of #10282 contents.