### PR TITLE
chore(polli): drop alpha, cut 0.1.0, harden publish CI

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -179,13 +179,27 @@ jobs:
           npm ci
           npm run build
 
-      - name: Publish to NPM (alpha)
+      - name: Check if version already published
+        id: check
         working-directory: packages/polli-cli
-        run: npm publish --access public --tag alpha
+        run: |
+          v=$(node -p "require('./package.json').version")
+          if npm view "@pollinations_ai/cli@$v" version >/dev/null 2>&1; then
+            echo "Version $v already on npm — skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to NPM
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/polli-cli
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_KEY }}
 
-      - name: Publish to GitHub Packages (alpha)
+      - name: Publish to GitHub Packages
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/polli-cli
         run: |
           node -e "
@@ -196,6 +210,6 @@ jobs:
           "
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
           echo "@pollinations:registry=https://npm.pkg.github.com" >> .npmrc
-          npm publish --access public --tag alpha
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

- npmjs.com page for \`@pollinations_ai/cli\` was stuck showing alpha.1's README. \`latest\` dist-tag was never moved past \`alpha.1\` because the workflow publishes with \`--tag alpha\`, which deliberately does not touch \`latest\`.
- #10282's publish failed silently (403, version already published) because the PR didn't bump the version — nobody noticed until #10284 bumped to alpha.2 and that one succeeded. But \`latest\` still pointed at alpha.1.

## Changes

- Bump 0.1.0-alpha.2 → 0.1.0. Publishing 0.1.0 auto-updates \`latest\` (semver: 0.1.0 > 0.1.0-alpha.2).
- Drop \`--tag alpha\` from both publish steps.
- Add skip-if-version-already-published guard — future PRs forgetting to bump the version no longer red-x the workflow.

## Verification

- \`node -e "require('semver').gt('0.1.0', '0.1.0-alpha.2')"\` → true. 0.1.0 will become \`latest\` on publish.
- \`npm view\` returns exit 1 (E404) on unpublished versions; the bash \`if\` catches that as "not yet published" correctly.