### PR TITLE
feat(auth): stamp client_id on minted sk_ tokens

### DIFF
--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -32,6 +32,7 @@ SCHEMA >
 `api_key_created_via`   LowCardinality(String)  `json:$.apiKeyCreatedVia` DEFAULT 'undefined',
 `api_key_created_for_app` String                `json:$.apiKeyCreatedForApp` DEFAULT 'undefined',
 `api_key_created_for_user_id` String            `json:$.apiKeyCreatedForUserId` DEFAULT 'undefined',
+`api_key_client_id`     String                  `json:$.apiKeyClientId` DEFAULT 'undefined',
 
 -- Meter
 `selected_meter_id`     LowCardinality(String)  `json:$.selectedMeterId` DEFAULT 'undefined',

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -14,6 +14,7 @@ const SECONDS_PER_DAY = 24 * 60 * 60;
 
 type Attribution = {
     found: boolean;
+    clientId?: string;
     userId?: string;
     userName?: string;
     githubUsername?: string;
@@ -225,6 +226,7 @@ function AuthorizeComponent() {
                 createdVia: isDeviceMode ? "device-flow" : "redirect-auth",
                 ...(isDeviceMode && { deviceUserCode: user_code }),
                 ...(attribution?.found && {
+                    clientId: attribution.clientId,
                     createdForUserId: attribution.userId,
                     createdForApp: attribution.appName,
                 }),

--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -31,6 +31,7 @@ export type TinybirdEvent = {
     apiKeyCreatedVia?: string;
     apiKeyCreatedForApp?: string;
     apiKeyCreatedForUserId?: string;
+    apiKeyClientId?: string;
 
     // Meter
     selectedMeterId?: string;

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -134,6 +134,7 @@ export const track = (eventType: EventType) =>
             apiKeyCreatedForUserId: apiKeyMetadata?.createdForUserId as
                 | string
                 | undefined,
+            apiKeyClientId: apiKeyMetadata?.clientId as string | undefined,
         } satisfies UserData;
 
         let responseOverride = null;
@@ -409,6 +410,7 @@ type UserData = {
     apiKeyCreatedVia?: string;
     apiKeyCreatedForApp?: string;
     apiKeyCreatedForUserId?: string;
+    apiKeyClientId?: string;
 };
 
 type BalanceData = {

--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -19,6 +19,7 @@ async function resolveAttribution(
     });
     return {
         found: true as const,
+        clientId: keyRow.id,
         userId: keyRow.userId,
         userName: user?.name,
         githubUsername: user?.githubUsername || undefined,


### PR DESCRIPTION
## Summary
- `/api/app-lookup` returns `clientId` (the `pk_` apikey row id)
- `/authorize` writes `metadata.clientId` on minted `sk_`
- `track.ts` reads it into `apiKeyClientId`, emits to Tinybird
- `generation_event` datasource gains `api_key_client_id` column

Stable billing identity for app attribution (prereq for #10125 BYOP markup). Additive — old `sk_` keys without `clientId` keep working; the new Tinybird column defaults to `'undefined'` for old events.

## Test plan
- [ ] Deploy Tinybird datasource change: \`tb --cloud deploy --wait\` from observability/
- [ ] Mint a new \`sk_\` via /authorize and confirm \`metadata.clientId\` is set
- [ ] Make a request with the new key and confirm \`api_key_client_id\` lands in Tinybird
- [ ] Old \`sk_\` keys still work