### PR TITLE
fix(ci): remove misrouted .npmrc files blocking npmjs.org publish

### DIFF
--- a/packages/mcp/.npmrc
+++ b/packages/mcp/.npmrc
@@ -1,1 +1,0 @@
-@pollinations_ai:registry=https://npm.pkg.github.com

--- a/packages/ompc/.npmrc
+++ b/packages/ompc/.npmrc
@@ -1,1 +1,0 @@
-@pollinations_ai:registry=https://npm.pkg.github.com

--- a/packages/sdk/.npmrc
+++ b/packages/sdk/.npmrc
@@ -1,1 +1,0 @@
-@pollinations_ai:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Changes Made:- 

- The three package-level .npmrc files (sdk, mcp, ompc) contained `@pollinations_ai:registry=https://npm.pkg.github.com`, which made `npm publish` try to auth against GitHub Packages during the `registry.npmjs.org` publish step in publish-packages.yml — causing ENEEDAUTH since that step only has secrets.NPM_REGISTRY_KEY.

- The GH Packages publish step writes its own .npmrc on the fly, so the static files are unnecessary and actively broken. polli-cli never had one and its publishes work fine — same model applies here.