### PR TITLE
feat: upgrade fireworks models (minimax 2.7, qwen vl)

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -654,18 +654,23 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "minimax": {
-        aliases: ["minimax-m2.5", "minimax-m2p5"],
-        modelId: "accounts/fireworks/models/minimax-m2p5",
+        aliases: [
+            "minimax-m2.7",
+            "minimax-m2p7",
+            "minimax-m2.5",
+            "minimax-m2p5",
+        ],
+        modelId: "accounts/fireworks/models/minimax-m2p7",
         provider: "fireworks",
         cost: [
             {
-                date: new Date("2026-04-12").getTime(),
+                date: new Date("2026-04-19").getTime(),
                 promptTextTokens: perMillion(0.3),
-                promptCachedTokens: perMillion(0.03),
+                promptCachedTokens: perMillion(0.06),
                 completionTextTokens: perMillion(1.2),
             },
         ],
-        description: "MiniMax M2.5 - Coding, Agentic & Multi-Language",
+        description: "MiniMax M2.7 - Coding, Agentic & Multi-Language",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -761,30 +766,30 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "qwen-vision": {
-        aliases: ["qwen3-vl", "qwen3-vl-plus", "qwen-vl"],
-        modelId: "qwen3-vl-plus",
-        provider: "alibaba",
+        aliases: [
+            "qwen3-vl",
+            "qwen3-vl-30b-a3b-thinking",
+            "qwen3-vl-thinking",
+            "qwen3-vl-plus",
+            "qwen-vl",
+        ],
+        modelId: "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking",
+        provider: "fireworks",
         cost: [
             {
-                date: new Date("2026-03-22").getTime(),
-                promptTextTokens: perMillion(0.2), // per 1M tokens
-                completionTextTokens: perMillion(1.6), // per 1M tokens
-            },
-        ],
-        price: [
-            {
-                date: new Date("2026-03-22").getTime(),
-                promptTextTokens: perMillion(0.3), // per 1M tokens
-                completionTextTokens: perMillion(2.4), // per 1M tokens
+                date: new Date("2026-04-19").getTime(),
+                promptTextTokens: perMillion(0.15),
+                promptCachedTokens: perMillion(0.08),
+                completionTextTokens: perMillion(0.6),
             },
         ],
         description:
-            "Qwen3 VL Plus - Vision-Language Understanding with Reasoning via DashScope",
+            "Qwen3 VL 30B A3B Thinking - Vision-Language Reasoning (Fireworks)",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
-        contextLength: 131072,
+        contextLength: 262144,
         isSpecialized: false,
     },
     "qwen-safety": {

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -46,7 +46,9 @@ const models: ModelDefinition[] = [
     },
     {
         name: "qwen-vision",
-        config: portkeyConfig["qwen3-vl-plus"],
+        config: portkeyConfig[
+            "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking"
+        ],
     },
     {
         name: "mistral",
@@ -179,7 +181,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "minimax",
-        config: portkeyConfig["accounts/fireworks/models/minimax-m2p5"],
+        config: portkeyConfig["accounts/fireworks/models/minimax-m2p7"],
     },
     {
         name: "mistral-large",

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -188,16 +188,20 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/glm-5p1",
         }),
-    "accounts/fireworks/models/minimax-m2p5": () =>
+    "accounts/fireworks/models/minimax-m2p7": () =>
         createFireworksModelConfig({
-            model: "accounts/fireworks/models/minimax-m2p5",
+            model: "accounts/fireworks/models/minimax-m2p7",
         }),
 
     // -- Alibaba DashScope (Qwen) ---------------------------------------------
     "qwen3-coder-next": () =>
         createDashScopeModelConfig({ model: "qwen3-coder-next" }),
-    "qwen3-vl-plus": () =>
-        createDashScopeModelConfig({ model: "qwen3-vl-plus" }),
+
+    // -- Fireworks AI (Qwen VL) -----------------------------------------------
+    "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking",
+        }),
 
     // -- OVHcloud (Qwen) ------------------------------------------------------
     "qwen3-coder-30b-a3b-instruct": () =>


### PR DESCRIPTION
Two Fireworks upgrades consolidating Qwen vision onto a single provider.

- **MiniMax**: `minimax-m2p5` → `minimax-m2p7`. Same $0.30 in / $1.20 out; cached input doubled to $0.06/M.
- **qwen-vision**: DashScope `qwen3-vl-plus` → Fireworks `qwen3-vl-30b-a3b-thinking`. $0.20→$0.15 in (-25%), $1.60→$0.60 out (-62%), context 131K→262K. Trade-off: 30B-A3B MoE is the open-weight mid-tier, not Alibaba's flagship Plus — slight quality ceiling reduction on hardest vision tasks, big cost/context win for typical traffic.
- Old aliases preserved: `minimax-m2.5`, `minimax-m2p5`, `qwen3-vl-plus` still resolve.

Not touched (no Fireworks equivalent): `qwen-coder-large` (DashScope), `qwen-coder` (OVH), `qwen-safety` (OVH).