### PR TITLE
refactor: merge account:balance scope into account:usage

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
@@ -16,7 +16,7 @@ import {
 } from "./permission-ui.ts";
 
 type AccountPermissionOption = {
-    id: "profile" | "balance" | "usage" | "keys";
+    id: "profile" | "usage" | "keys";
     label: string;
     shortLabel?: string;
     tooltip: string;
@@ -42,14 +42,9 @@ export const ACCOUNT_PERMISSIONS: readonly AccountPermissionOption[] = [
         tooltip: "account name and email",
     },
     {
-        id: "balance",
-        label: "Balance",
-        tooltip: "full account balance",
-    },
-    {
         id: "usage",
         label: "Usage",
-        tooltip: "account usage",
+        tooltip: "account balance and usage",
     },
     {
         id: "keys",
@@ -110,7 +105,7 @@ const MODEL_CATEGORY_HOVER_CLASSES = {
 
 /**
  * Unified permissions input for API keys.
- * Includes model restrictions and account permissions (profile, balance, usage).
+ * Includes model restrictions and account permissions (profile, usage).
  */
 export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
     value,
@@ -217,7 +212,7 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
     return (
         <div>
             <div className="space-y-4">
-                {/* Other Permissions - Profile, Balance, Usage */}
+                {/* Other Permissions - Profile, Usage */}
                 {permissionOptions.map((permission) => {
                     const isChecked = value?.includes(permission.id) ?? false;
                     return (

--- a/enter.pollinations.ai/src/client/components/api-keys/types.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/types.ts
@@ -36,7 +36,7 @@ export type CreateApiKey = {
     pollenBudget?: number | null;
     /** Days until expiry. null = no expiry */
     expiryDays?: number | null;
-    /** Account permissions: ["balance", "usage"]. null = no permissions */
+    /** Account permissions: ["profile", "usage", "keys"]. null = no permissions */
     accountPermissions?: string[] | null;
     /** App URL for publishable keys (optional, for consent screen attribution) */
     appUrl?: string;

--- a/enter.pollinations.ai/src/client/lib/authorize-config.ts
+++ b/enter.pollinations.ai/src/client/lib/authorize-config.ts
@@ -29,16 +29,11 @@ export const DEFAULT_CONSENT_EXPIRY_DAYS = 7;
  * image (`/account/profile`) are all readable without any scope.
  *
  * - `profile`: read account name and email
- * - `balance`: read full account balance (key's own budget is free)
- * - `usage`: read account-wide usage (key's own usage is free)
+ * - `usage`: read full account balance + account-wide usage (key's own
+ *   balance and usage are free regardless)
  * - `keys`: create, list, and revoke API keys
  */
-export const CONSENT_PERMISSIONS = [
-    "profile",
-    "balance",
-    "usage",
-    "keys",
-] as const;
+export const CONSENT_PERMISSIONS = ["profile", "usage", "keys"] as const;
 
 export function sanitizeAuthorizeAccountPermissions(
     permissions: string[] | null | undefined,

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -524,25 +524,15 @@ function AuthorizeComponent() {
                                     </li>
                                 )}
                                 {keyPermissions.permissions.accountPermissions?.includes(
-                                    "balance",
-                                ) && (
-                                    <li className="flex items-start gap-2">
-                                        <span className="w-4 shrink-0 text-amber-800">
-                                            &#x1F4B0;
-                                        </span>
-                                        <span>
-                                            See your full account balance.
-                                        </span>
-                                    </li>
-                                )}
-                                {keyPermissions.permissions.accountPermissions?.includes(
                                     "usage",
                                 ) && (
                                     <li className="flex items-start gap-2">
                                         <span className="w-4 shrink-0 text-amber-800">
                                             &#x1F4CA;
                                         </span>
-                                        <span>See your account usage.</span>
+                                        <span>
+                                            See your account balance and usage.
+                                        </span>
                                     </li>
                                 )}
                                 {keyPermissions.permissions.accountPermissions?.includes(

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -9,8 +9,8 @@ import {
     user as userTable,
 } from "@/db/schema/better-auth.ts";
 import type { ApiKeyType } from "@/db/schema/event.ts";
+import { sanitizeAuthorizeAccountPermissions } from "../client/lib/authorize-config.ts";
 import type { Env } from "../env.ts";
-
 import { auth } from "../middleware/auth.ts";
 import { validator } from "../middleware/validator.ts";
 import { parseMetadata } from "./metadata-utils.ts";
@@ -902,10 +902,12 @@ export const accountRoutes = new Hono<Env>()
             const isPublishable = type === "publishable";
             const prefix = isPublishable ? "pk" : "sk";
 
-            // Strip "keys" from child account permissions to prevent escalation
-            const safeAccountPerms = accountPermissions
-                ? accountPermissions.filter((p) => p !== "keys")
-                : accountPermissions;
+            // Whitelist to known scopes (drops unknown / legacy names like "balance").
+            // Then strip "keys" to prevent escalation via the BYOP flow.
+            const safeAccountPerms =
+                sanitizeAuthorizeAccountPermissions(accountPermissions)?.filter(
+                    (p) => p !== "keys",
+                ) ?? null;
 
             // Build permissions object
             const permissions: Record<string, string[]> = {};

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -114,7 +114,7 @@ const CreateKeySchema = z.object({
         .nullable()
         .optional()
         .describe(
-            'Account permissions (e.g. ["balance", "usage"]). "keys" is auto-stripped.',
+            'Account permissions (e.g. ["usage"]). "keys" is auto-stripped.',
         ),
 });
 
@@ -507,7 +507,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Balance",
             description:
-                "Returns the pollen balance visible to the caller. API keys with a budget always see their remaining budget (no scope needed). Session auth or API keys with the `account:balance` scope see the full account balance.",
+                "Returns the pollen balance visible to the caller. API keys with a budget always see their remaining budget (no scope needed). Session auth or API keys with the `account:usage` scope see the full account balance.",
             responses: {
                 200: {
                     description: "Pollen balance",
@@ -520,7 +520,7 @@ export const accountRoutes = new Hono<Env>()
                 401: { description: "Unauthorized" },
                 403: {
                     description:
-                        "Permission denied - API key has no budget and is missing the `account:balance` scope",
+                        "Permission denied - API key has no budget and is missing the `account:usage` scope",
                 },
             },
         }),
@@ -534,11 +534,11 @@ export const accountRoutes = new Hono<Env>()
                 return c.json({ balance: apiKey.pollenBalance });
             }
 
-            // Beyond that, reading account balance requires the `balance` scope.
-            if (apiKey && !apiKey.permissions?.account?.includes("balance")) {
+            // Beyond that, reading account balance requires the `usage` scope.
+            if (apiKey && !apiKey.permissions?.account?.includes("usage")) {
                 throw new HTTPException(403, {
                     message:
-                        "API key does not have 'account:balance' scope and no budget of its own. Add `account:balance` to read account balance, or set a budget on the key.",
+                        "API key does not have 'account:usage' scope and no budget of its own. Add `account:usage` to read account balance, or set a budget on the key.",
                 });
             }
 

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -104,7 +104,7 @@ async function updateKeyMetadata(
  *
  * Permissions format: { models?: string[], account?: string[] }
  * - models: ["flux", "openai"] = restrict to specific models
- * - account: ["balance", "usage"] = allow access to account endpoints
+ * - account: ["profile", "usage", "keys"] = allow access to account endpoints
  */
 const UpdateApiKeySchema = z.object({
     name: z.string().optional().describe("Name for the API key"),
@@ -122,7 +122,9 @@ const UpdateApiKeySchema = z.object({
         .array(z.string())
         .nullable()
         .optional()
-        .describe('Account permissions: ["balance", "usage"]. null = none'),
+        .describe(
+            'Account permissions: ["profile", "usage", "keys"]. null = none',
+        ),
     expiresAt: z
         .string()
         .datetime()

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "hono-openapi";
 import { z } from "zod";
+import { sanitizeAuthorizeAccountPermissions } from "../client/lib/authorize-config.ts";
 import * as schema from "../db/schema/better-auth.ts";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
@@ -226,10 +227,17 @@ export const apiKeysRoutes = new Hono<Env>()
                 ? JSON.parse(existingKey.permissions as string)
                 : {};
 
+            // Whitelist to known scopes (drops unknown / legacy names like "balance").
+            // Dashboard-only endpoint, so "keys" is allowed here.
+            const sanitizedAccountPerms =
+                accountPermissions === undefined
+                    ? undefined
+                    : sanitizeAuthorizeAccountPermissions(accountPermissions);
+
             const updatedPermissions = buildUpdatedPermissions(
                 existingPermissions,
                 allowedModels,
-                accountPermissions,
+                sanitizedAccountPerms,
             );
 
             if (updatedPermissions) {

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -351,7 +351,9 @@ function generateLLMDoc(): string {
     lines.push(
         "Returns { balance } — remaining pollen (sum of tier + pack + crypto). If API key has a budget, returns key budget instead.",
     );
-    lines.push("Requires `account:balance` permission.");
+    lines.push(
+        "Requires `account:usage` permission when using an API key without a budget of its own.",
+    );
     lines.push("");
 
     lines.push("### GET /api/account/usage");
@@ -397,7 +399,7 @@ function generateLLMDoc(): string {
         "- pollenBudget (number, optional): Pollen budget cap. null = unlimited",
     );
     lines.push(
-        '- accountPermissions (string[], optional): e.g. ["balance","usage"]. "keys" is auto-stripped',
+        '- accountPermissions (string[], optional): e.g. ["profile","usage"]. "keys" is auto-stripped',
     );
     lines.push(
         "Returns full key value once: { id, key, name, type, prefix, start, expiresAt, permissions, pollenBudget }",
@@ -1102,7 +1104,6 @@ const RESPONSE_EXAMPLES: Record<string, unknown> = {
             "generate:text",
             "generate:image",
             "generate:audio",
-            "account:balance",
             "account:usage",
         ],
         pollenBudget: null,
@@ -1451,7 +1452,7 @@ export const createDocsRoutes = (apiRouter: Hono<Env>) => {
                                 "| `GET /account/usage/daily` | Daily aggregated usage for dashboards |",
                                 "| `GET /account/key` | API key validity, type, and permissions |",
                                 "",
-                                "When using API keys, specific permissions may be required (e.g., `account:balance`, `account:usage`).",
+                                "When using API keys, specific permissions may be required (e.g., `account:usage`, `account:profile`).",
                             ].join("\n"),
                         },
                         {

--- a/enter.pollinations.ai/test/authorize-config.test.ts
+++ b/enter.pollinations.ai/test/authorize-config.test.ts
@@ -60,7 +60,7 @@ describe("getAuthorizeInitialPermissions", () => {
         });
     });
 
-    it("keeps balance as an optional permission from the url", () => {
+    it("drops legacy balance scope after the merge with usage", () => {
         expect(
             getAuthorizeInitialPermissions({
                 permissions: ["balance", "usage"],
@@ -69,7 +69,7 @@ describe("getAuthorizeInitialPermissions", () => {
             allowedModels: undefined,
             pollenBudget: DEFAULT_CONSENT_BUDGET,
             expiryDays: DEFAULT_CONSENT_EXPIRY_DAYS,
-            accountPermissions: ["balance", "usage"],
+            accountPermissions: ["usage"],
         });
     });
 
@@ -102,12 +102,7 @@ describe("getAuthorizeInitialPermissions", () => {
 
 describe("sanitizeAuthorizeAccountPermissions", () => {
     it("allows only the consent permission set", () => {
-        expect(CONSENT_PERMISSIONS).toEqual([
-            "profile",
-            "balance",
-            "usage",
-            "keys",
-        ]);
+        expect(CONSENT_PERMISSIONS).toEqual(["profile", "usage", "keys"]);
         expect(
             sanitizeAuthorizeAccountPermissions([
                 "offline_access",

--- a/enter.pollinations.ai/test/integration/account-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/account-keys.test.ts
@@ -67,7 +67,7 @@ describe("Account Key Management API", () => {
                         name: "restricted-child",
                         allowedModels: ["flux", "openai"],
                         pollenBudget: 50,
-                        accountPermissions: ["balance", "usage"],
+                        accountPermissions: ["profile", "usage"],
                     }),
                 },
             );
@@ -76,7 +76,7 @@ describe("Account Key Management API", () => {
             const data = await response.json();
             expect(data.permissions).toEqual({
                 models: ["flux", "openai"],
-                account: ["balance", "usage"],
+                account: ["profile", "usage"],
             });
             expect(data.pollenBudget).toBe(50);
         });
@@ -94,7 +94,7 @@ describe("Account Key Management API", () => {
                     },
                     body: JSON.stringify({
                         name: "escalation-attempt",
-                        accountPermissions: ["balance", "keys", "usage"],
+                        accountPermissions: ["profile", "keys", "usage"],
                     }),
                 },
             );
@@ -102,7 +102,7 @@ describe("Account Key Management API", () => {
             expect(response.status).toBe(200);
             const data = await response.json();
             // "keys" should be stripped
-            expect(data.permissions.account).toEqual(["balance", "usage"]);
+            expect(data.permissions.account).toEqual(["profile", "usage"]);
             expect(data.permissions.account).not.toContain("keys");
         });
 

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -160,7 +160,7 @@ describe("API Key Management", () => {
                     },
                     body: JSON.stringify({
                         allowedModels: ["flux", "openai"],
-                        accountPermissions: ["balance", "usage"],
+                        accountPermissions: ["profile", "usage"],
                     }),
                 },
             );
@@ -182,7 +182,7 @@ describe("API Key Management", () => {
             const updatedKey = keys.data.find((k: any) => k.id === keyId);
             expect(updatedKey.permissions).toEqual({
                 models: ["flux", "openai"],
-                account: ["balance", "usage"],
+                account: ["profile", "usage"],
             });
         });
 
@@ -404,7 +404,7 @@ describe("API Key Management", () => {
                     },
                     body: JSON.stringify({
                         allowedModels: ["flux"],
-                        accountPermissions: ["balance"],
+                        accountPermissions: ["usage"],
                     }),
                 },
             );

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -565,7 +565,7 @@ export interface UploadResponse {
 // ============================================================================
 
 /** Account permission scopes */
-export type AccountPermission = "profile" | "balance" | "usage";
+export type AccountPermission = "profile" | "usage";
 
 /** Options for building a BYOP authorization URL */
 export interface AuthorizeOptions {
@@ -702,7 +702,7 @@ export interface AccountKey {
 }
 
 /** Key-scope permissions that can be granted on created keys. */
-export type KeyAccountPermission = "balance" | "usage" | "models" | string;
+export type KeyAccountPermission = "profile" | "usage" | "keys" | string;
 
 /** Options for POST /account/keys */
 export interface CreateKeyOptions {
@@ -717,9 +717,10 @@ export interface CreateKeyOptions {
     /** Pollen budget cap */
     pollenBudget?: number;
     /**
-     * Account permissions to grant (e.g. `["balance", "usage"]`).
-     * Without this, scoped keys cannot read account state.
-     * `"keys"` is auto-stripped server-side.
+     * Account permissions to grant (e.g. `["profile", "usage"]`).
+     * Without this, scoped keys cannot read account state beyond their
+     * own key metadata, budget, and per-key usage.
+     * `"keys"` is auto-stripped server-side on the BYOP flow.
      */
     accountPermissions?: KeyAccountPermission[];
 }


### PR DESCRIPTION
- Collapse `account:balance` + `account:usage` into a single `account:usage` scope
- `/account/balance` now gated by `account:usage` (key's own budget still readable with no scope)
- Consent + key-edit UI show one "Usage" row instead of two
- Silently drops legacy `"balance"` scope on new keys — no migration

Why: own-key balance and usage are both free, so the scope only gated account-wide aggregates. One scope is enough. Pre-launch — no external integrators affected.