### PR TITLE
chore: drop stale balance scope references after #10360

### DIFF
--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -1098,14 +1098,13 @@ const RESPONSE_EXAMPLES: Record<string, unknown> = {
     "get /account/key": {
         valid: true,
         type: "secret",
-        prefix: "sk_",
+        name: "my-bot",
         expiresAt: null,
-        permissions: [
-            "generate:text",
-            "generate:image",
-            "generate:audio",
-            "account:usage",
-        ],
+        expiresIn: null,
+        permissions: {
+            models: null,
+            account: ["usage"],
+        },
         pollenBudget: null,
         rateLimitEnabled: false,
     },

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -132,10 +132,10 @@ polli usage --daily      # daily cost summary
 ```bash
 polli keys list                                                    # list all keys on the account
 polli keys info                                                    # details about the CURRENTLY AUTHENTICATED key only (takes no id)
-polli keys create --name "my-bot" --type secret --budget 1000 --permissions balance usage   # scoped key
+polli keys create --name "my-bot" --type secret --budget 1000 --permissions profile usage   # scoped key
 polli keys revoke <id>                                             # id comes from `keys list --json`
 ```
-`--permissions <perms...>` scopes what the new key can do on the account (e.g. `balance usage` lets it call `polli --key <new> usage`). **Without `--permissions`, new scoped keys can generate media but cannot read account state** — `polli --key <new> usage` will 403. `"keys"` is auto-stripped from the list so a scoped key can never mint further keys. To inspect a specific key other than the current one, use `polli keys list --json | jq '.[] | select(.id == "<id>")'`. `keys info` is intentionally scoped to the caller's own key.
+`--permissions <perms...>` scopes what the new key can do on the account (e.g. `profile usage` lets it call `polli --key <new> usage`). **Without `--permissions`, new scoped keys can generate media but cannot read account state** — `polli --key <new> usage` will 403. `"keys"` is auto-stripped from the list so a scoped key can never mint further keys. To inspect a specific key other than the current one, use `polli keys list --json | jq '.[] | select(.id == "<id>")'`. `keys info` is intentionally scoped to the caller's own key.
 
 ### Read API docs
 ```bash

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -117,7 +117,7 @@ const login = new Command("login")
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
                 client_id: "pk_NgBAArhUeGvSRFba",
-                scope: "generate keys balance usage",
+                scope: "generate keys usage",
             }),
         }).catch((err) => {
             printError(

--- a/packages/polli-cli/src/commands/keys.ts
+++ b/packages/polli-cli/src/commands/keys.ts
@@ -166,7 +166,7 @@ const create = new Command("create")
     .option("--budget <pollen>", "Pollen budget cap")
     .option(
         "--permissions <perms...>",
-        'Account permissions (e.g. balance usage). "keys" is auto-stripped.',
+        'Account permissions (e.g. profile usage). "keys" is auto-stripped.',
     )
     .action(async (opts) => {
         const key = requireKey();

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations_ai/sdk",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Official SDK for pollinations.ai - Generate images, videos, audio, and text with ease",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -43,7 +43,7 @@ import { PollinationsError } from "./types.js";
 const DEFAULT_BASE_URL = "https://gen.pollinations.ai";
 const AUTH_BASE_URL = "https://enter.pollinations.ai";
 const DEVICE_FLOW_CLIENT_ID = "pk_NgBAArhUeGvSRFba";
-const DEVICE_FLOW_DEFAULT_SCOPE = "generate keys balance usage";
+const DEVICE_FLOW_DEFAULT_SCOPE = "generate keys usage";
 const DEFAULT_MAX_RETRIES = 3;
 const MAX_INT32 = 2147483647;
 // Default timeouts in milliseconds

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -805,7 +805,7 @@ export interface DeviceTokenResponse {
 export interface AuthorizeDeviceOptions extends RequestOptions {
     /** OAuth client ID. Defaults to the public polli CLI client. */
     clientId?: string;
-    /** Space-separated scope string (default: "generate keys balance usage") */
+    /** Space-separated scope string (default: "generate keys usage") */
     scope?: string;
 }
 


### PR DESCRIPTION
- polli auth login now requests scope \`generate keys usage\` so the consent screen pre-checks Usage (server was silently dropping \`balance\`)
- SDK \`DEVICE_FLOW_DEFAULT_SCOPE\` + \`AuthorizeDeviceOptions.scope\` docstring updated to match
- polli keys \`--permissions\` help text + \`SKILL.md\` example switched from \`balance usage\` to \`profile usage\`
- OpenAPI \`RESPONSE_EXAMPLES["get /account/key"]\` now returns the real \`{ models, account }\` shape instead of a stale flat string array with a nonexistent \`prefix\` field

Follow-up to #10360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)