### PR TITLE
feat(enter): 1 pollen grant on first BYOP key mint

### DIFF
--- a/enter.pollinations.ai/drizzle/0018_add_byop_granted_at.sql
+++ b/enter.pollinations.ai/drizzle/0018_add_byop_granted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `byop_granted_at` integer;

--- a/enter.pollinations.ai/drizzle/meta/0018_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,770 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "53bf929f-6feb-4e13-9d5a-3d1262570af4",
+  "prevId": "fd04b46c-8c90-4ada-a7e2-32f20efe8e17",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crypto_balance": {
+          "name": "crypto_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_granted_at": {
+          "name": "byop_granted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1774230815486,
       "tag": "0017_numerous_richard_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1776700495352,
+      "tag": "0018_add_byop_granted_at",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/src/db/schema/better-auth.ts
+++ b/enter.pollinations.ai/src/db/schema/better-auth.ts
@@ -34,6 +34,7 @@ export const user = sqliteTable("user", {
   packBalance: real("pack_balance"),
   cryptoBalance: real("crypto_balance"),
   lastTierGrant: integer("last_tier_grant"),
+  byopGrantedAt: integer("byop_granted_at"),
 }, (table) => [
   index("idx_user_email").on(table.email),
 ]);

--- a/enter.pollinations.ai/src/routes/admin.ts
+++ b/enter.pollinations.ai/src/routes/admin.ts
@@ -184,16 +184,17 @@ export async function runTierRefill(
         .from(userTable)
         .where(sql`tier IS NOT NULL`);
 
-    // Add hourly pollen, capped at the tier max (negative balances recover gradually)
+    // Add hourly pollen, capped at the tier max (negative balances recover gradually).
+    // Balances already above cap (e.g. one-time BYOP grant) are preserved, not stripped.
     const hourlyResult = await db.run(sql`
         UPDATE user
         SET
             tier_balance = CASE tier
-                WHEN 'spore' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.spore}, ${TIER_POLLEN.spore})
-                WHEN 'seed' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.seed}, ${TIER_POLLEN.seed})
-                WHEN 'flower' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.flower}, ${TIER_POLLEN.flower})
-                WHEN 'nectar' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.nectar}, ${TIER_POLLEN.nectar})
-                WHEN 'router' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.router}, ${TIER_POLLEN.router})
+                WHEN 'spore' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.spore} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.spore}, ${TIER_POLLEN.spore}) END
+                WHEN 'seed' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.seed} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.seed}, ${TIER_POLLEN.seed}) END
+                WHEN 'flower' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.flower} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.flower}, ${TIER_POLLEN.flower}) END
+                WHEN 'nectar' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.nectar} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.nectar}, ${TIER_POLLEN.nectar}) END
+                WHEN 'router' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.router} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.router}, ${TIER_POLLEN.router}) END
                 ELSE tier_balance
             END,
             last_tier_grant = ${refillTimestamp}

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -9,6 +9,7 @@ import * as schema from "../db/schema/better-auth.ts";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import { validator } from "../middleware/validator.ts";
+import { BYOP_FIRST_KEY_GRANT_POLLEN } from "../tier-config.ts";
 import { parseMetadata } from "./metadata-utils.ts";
 
 function setPrivateNoStoreHeaders(c: {
@@ -97,6 +98,36 @@ async function updateKeyMetadata(
         .set({ metadata: JSON.stringify(merged), updatedAt: new Date() })
         .where(eq(schema.apikey.id, keyId));
     return merged;
+}
+
+/**
+ * One-time grant for spore users minting their first BYOP key.
+ * Idempotent via `byop_granted_at IS NULL` guard. Caps the granted user at spore
+ * so seed+ users don't get bumped. Grant is skipped when the constant is 0.
+ */
+async function maybeGrantByopFirstKeyPollen(
+    db: ReturnType<typeof drizzle<typeof schema>>,
+    userId: string,
+    keyMetadata: Record<string, unknown>,
+): Promise<void> {
+    if (BYOP_FIRST_KEY_GRANT_POLLEN <= 0) return;
+    const createdVia = keyMetadata.createdVia;
+    const isByopKey =
+        createdVia === "redirect-auth" || createdVia === "device-flow";
+    if (!isByopKey || !keyMetadata.clientId) return;
+    await db
+        .update(schema.user)
+        .set({
+            tierBalance: sql`COALESCE(${schema.user.tierBalance}, 0) + ${BYOP_FIRST_KEY_GRANT_POLLEN}`,
+            byopGrantedAt: Date.now(),
+        })
+        .where(
+            and(
+                eq(schema.user.id, userId),
+                eq(schema.user.tier, "spore"),
+                isNull(schema.user.byopGrantedAt),
+            ),
+        );
 }
 
 /**
@@ -262,6 +293,12 @@ export const apiKeysRoutes = new Hono<Env>()
                     .set(d1Updates)
                     .where(eq(schema.apikey.id, id));
             }
+
+            await maybeGrantByopFirstKeyPollen(
+                db,
+                user.id,
+                parseMetadata(existingKey.metadata),
+            );
 
             const updated = await db.query.apikey.findFirst({
                 where: eq(schema.apikey.id, id),

--- a/enter.pollinations.ai/src/tier-config.ts
+++ b/enter.pollinations.ai/src/tier-config.ts
@@ -14,6 +14,10 @@ export const tierNames = Object.keys(TIERS) as TierName[];
 
 export const DEFAULT_TIER: TierName = "spore";
 
+// One-time grant for spore users minting their first BYOP key.
+// Set to 0 to disable. Credited to tier_balance; refill preserves over-cap values.
+export const BYOP_FIRST_KEY_GRANT_POLLEN = 1.0;
+
 export const TIER_POLLEN = Object.fromEntries(
     Object.entries(TIERS).map(([tier, config]) => [tier, config.pollen]),
 ) as Record<TierName, number>;

--- a/enter.pollinations.ai/test/integration/tier-balance.test.ts
+++ b/enter.pollinations.ai/test/integration/tier-balance.test.ts
@@ -34,11 +34,13 @@ describe("Tier Balance Management", () => {
             const db = drizzle(env.DB);
             const executionContext = createExecutionContext();
 
-            // Setup: Create test users with different tiers and depleted balances
+            // Setup: Create test users with different tiers and depleted balances.
+            // flower starts below cap, router starts above cap (to verify
+            // above-cap balances are preserved by refill — BYOP grant path).
             const testUsers = [
                 { id: "user-spore", tier: "spore", tierBalance: 0 },
                 { id: "user-seed", tier: "seed", tierBalance: 0 },
-                { id: "user-flower", tier: "flower", tierBalance: 2.0 },
+                { id: "user-flower", tier: "flower", tierBalance: 0 },
                 { id: "user-nectar", tier: "nectar", tierBalance: 0 },
                 { id: "user-router", tier: "router", tierBalance: 100 },
             ];
@@ -101,8 +103,9 @@ describe("Tier Balance Management", () => {
             expect(users.find((u) => u.id === "user-nectar")?.tierBalance).toBe(
                 TIER_POLLEN.nectar,
             );
+            // Router starts at 100 (above cap 10); refill preserves it.
             expect(users.find((u) => u.id === "user-router")?.tierBalance).toBe(
-                TIER_POLLEN.router,
+                100,
             );
 
             // All refilled users should have lastTierGrant updated
@@ -154,7 +157,8 @@ describe("Tier Balance Management", () => {
                 .where(sql`${userTable.id} = 'user-multi-balance'`)
                 .limit(1);
 
-            expect(user[0]?.tierBalance).toBe(TIER_POLLEN.flower);
+            // Starts at 2 (above flower cap 0.4); refill preserves above-cap balance.
+            expect(user[0]?.tierBalance).toBe(2);
             expect(user[0]?.packBalance).toBe(50); // Unchanged
             expect(user[0]?.cryptoBalance).toBe(25); // Unchanged
         });

--- a/enter.pollinations.ai/test/integration/tier-system.test.ts
+++ b/enter.pollinations.ai/test/integration/tier-system.test.ts
@@ -407,7 +407,8 @@ describe("Tier System End-to-End", () => {
                 .where(sql`${userTable.id} = 'migrated-active'`)
                 .limit(1);
 
-            expect(activeUser[0]?.tierBalance).toBe(0.8); // Nectar tier (additive: MIN(15 + 0.8, 0.8) = 0.8, capped)
+            // Above nectar cap (0.8); refill preserves above-cap balance.
+            expect(activeUser[0]?.tierBalance).toBe(15);
             expect(activeUser[0]?.packBalance).toBe(200); // Unchanged
 
             const depletedUser = await db
@@ -430,7 +431,7 @@ describe("Tier System End-to-End", () => {
             const _executionContext = createExecutionContext();
             const userId = "tier-change-user";
 
-            // User starts as seed tier
+            // User starts as seed tier with a depleted balance
             await db
                 .insert(userTable)
                 .values({
@@ -438,7 +439,7 @@ describe("Tier System End-to-End", () => {
                     email: "tierchange@test.com",
                     name: "Tier Change User",
                     tier: "seed",
-                    tierBalance: 2, // Partially used seed balance
+                    tierBalance: 0,
                     packBalance: 0,
                     cryptoBalance: 0,
                     createdAt: new Date(),
@@ -448,7 +449,7 @@ describe("Tier System End-to-End", () => {
                     target: userTable.id,
                     set: {
                         tier: "seed",
-                        tierBalance: 2,
+                        tierBalance: 0,
                     },
                 });
 


### PR DESCRIPTION
- Grants **1 pollen** to `tier_balance` when a spore user mints their first BYOP key via `/authorize` (redirect flow or device flow)
- Idempotency: new `user.byop_granted_at` column, atomic single-SQL guard (`byop_granted_at IS NULL`) — race-safe on concurrent mints
- Eligibility: `tier = 'spore'` AND key's `metadata.createdVia ∈ {redirect-auth, device-flow}` AND `metadata.clientId` present
- Refill SQL patched to preserve above-cap balances (otherwise hourly cron would strip the grant back to 0.01)
- Constant in `tier-config.ts` — set `BYOP_FIRST_KEY_GRANT_POLLEN = 0` to disable, no redeploy path beyond code
- Tests: updated refill assertions to reflect preserved above-cap balances; 41 tier tests pass