### PR TITLE
feat(enter): 1 pollen welcome grant on every new signup

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -16,7 +16,11 @@ import {
     user as userTable,
 } from "./db/schema/better-auth.ts";
 import { sendTierEventToTinybird } from "./events.ts";
-import { DEFAULT_TIER, getTierPollen } from "./tier-config.ts";
+import {
+    DEFAULT_TIER,
+    getTierPollen,
+    SIGNUP_GRANT_POLLEN,
+} from "./tier-config.ts";
 
 export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
     const db = drizzle(env.DB);
@@ -272,7 +276,12 @@ function onAfterUserCreate(
     return async (user: GenericUser, _ctx: GenericEndpointContext | null) => {
         try {
             const db = drizzle(env.DB);
-            const tierBalance = getTierPollen(DEFAULT_TIER);
+            // Welcome grant when enabled — credited to tier_balance. Refill
+            // preserves above-cap balances so it isn't stripped next hour.
+            const tierBalance = Math.max(
+                getTierPollen(DEFAULT_TIER),
+                SIGNUP_GRANT_POLLEN,
+            );
             await db
                 .update(userTable)
                 .set({

--- a/enter.pollinations.ai/src/routes/admin.ts
+++ b/enter.pollinations.ai/src/routes/admin.ts
@@ -184,16 +184,17 @@ export async function runTierRefill(
         .from(userTable)
         .where(sql`tier IS NOT NULL`);
 
-    // Add hourly pollen, capped at the tier max (negative balances recover gradually)
+    // Add hourly pollen, capped at the tier max (negative balances recover gradually).
+    // Balances already above cap (e.g. one-time signup grant) are preserved, not stripped.
     const hourlyResult = await db.run(sql`
         UPDATE user
         SET
             tier_balance = CASE tier
-                WHEN 'spore' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.spore}, ${TIER_POLLEN.spore})
-                WHEN 'seed' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.seed}, ${TIER_POLLEN.seed})
-                WHEN 'flower' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.flower}, ${TIER_POLLEN.flower})
-                WHEN 'nectar' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.nectar}, ${TIER_POLLEN.nectar})
-                WHEN 'router' THEN MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.router}, ${TIER_POLLEN.router})
+                WHEN 'spore' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.spore} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.spore}, ${TIER_POLLEN.spore}) END
+                WHEN 'seed' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.seed} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.seed}, ${TIER_POLLEN.seed}) END
+                WHEN 'flower' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.flower} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.flower}, ${TIER_POLLEN.flower}) END
+                WHEN 'nectar' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.nectar} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.nectar}, ${TIER_POLLEN.nectar}) END
+                WHEN 'router' THEN CASE WHEN COALESCE(tier_balance, 0) >= ${TIER_POLLEN.router} THEN tier_balance ELSE MIN(COALESCE(tier_balance, 0) + ${TIER_POLLEN.router}, ${TIER_POLLEN.router}) END
                 ELSE tier_balance
             END,
             last_tier_grant = ${refillTimestamp}

--- a/enter.pollinations.ai/src/tier-config.ts
+++ b/enter.pollinations.ai/src/tier-config.ts
@@ -14,6 +14,11 @@ export const tierNames = Object.keys(TIERS) as TierName[];
 
 export const DEFAULT_TIER: TierName = "spore";
 
+// One-time welcome grant for every new signup.
+// Credited to tier_balance; refill preserves over-cap values.
+// Set to 0 to disable (falls back to the default tier's hourly pollen).
+export const SIGNUP_GRANT_POLLEN = 1.0;
+
 export const TIER_POLLEN = Object.fromEntries(
     Object.entries(TIERS).map(([tier, config]) => [tier, config.pollen]),
 ) as Record<TierName, number>;

--- a/enter.pollinations.ai/test/integration/tier-balance.test.ts
+++ b/enter.pollinations.ai/test/integration/tier-balance.test.ts
@@ -34,11 +34,13 @@ describe("Tier Balance Management", () => {
             const db = drizzle(env.DB);
             const executionContext = createExecutionContext();
 
-            // Setup: Create test users with different tiers and depleted balances
+            // Setup: Create test users with different tiers and depleted balances.
+            // Router starts above cap (to verify above-cap balances are preserved
+            // by refill — signup grant path).
             const testUsers = [
                 { id: "user-spore", tier: "spore", tierBalance: 0 },
                 { id: "user-seed", tier: "seed", tierBalance: 0 },
-                { id: "user-flower", tier: "flower", tierBalance: 2.0 },
+                { id: "user-flower", tier: "flower", tierBalance: 0 },
                 { id: "user-nectar", tier: "nectar", tierBalance: 0 },
                 { id: "user-router", tier: "router", tierBalance: 100 },
             ];
@@ -101,8 +103,9 @@ describe("Tier Balance Management", () => {
             expect(users.find((u) => u.id === "user-nectar")?.tierBalance).toBe(
                 TIER_POLLEN.nectar,
             );
+            // Router starts at 100 (above cap 10); refill preserves it.
             expect(users.find((u) => u.id === "user-router")?.tierBalance).toBe(
-                TIER_POLLEN.router,
+                100,
             );
 
             // All refilled users should have lastTierGrant updated
@@ -154,7 +157,8 @@ describe("Tier Balance Management", () => {
                 .where(sql`${userTable.id} = 'user-multi-balance'`)
                 .limit(1);
 
-            expect(user[0]?.tierBalance).toBe(TIER_POLLEN.flower);
+            // Starts at 2 (above flower cap 0.4); refill preserves above-cap balance.
+            expect(user[0]?.tierBalance).toBe(2);
             expect(user[0]?.packBalance).toBe(50); // Unchanged
             expect(user[0]?.cryptoBalance).toBe(25); // Unchanged
         });

--- a/enter.pollinations.ai/test/integration/tier-system.test.ts
+++ b/enter.pollinations.ai/test/integration/tier-system.test.ts
@@ -407,7 +407,8 @@ describe("Tier System End-to-End", () => {
                 .where(sql`${userTable.id} = 'migrated-active'`)
                 .limit(1);
 
-            expect(activeUser[0]?.tierBalance).toBe(0.8); // Nectar tier (additive: MIN(15 + 0.8, 0.8) = 0.8, capped)
+            // Above nectar cap (0.8); refill preserves above-cap balance.
+            expect(activeUser[0]?.tierBalance).toBe(15);
             expect(activeUser[0]?.packBalance).toBe(200); // Unchanged
 
             const depletedUser = await db
@@ -430,7 +431,7 @@ describe("Tier System End-to-End", () => {
             const _executionContext = createExecutionContext();
             const userId = "tier-change-user";
 
-            // User starts as seed tier
+            // User starts as seed tier with a depleted balance
             await db
                 .insert(userTable)
                 .values({
@@ -438,7 +439,7 @@ describe("Tier System End-to-End", () => {
                     email: "tierchange@test.com",
                     name: "Tier Change User",
                     tier: "seed",
-                    tierBalance: 2, // Partially used seed balance
+                    tierBalance: 0,
                     packBalance: 0,
                     cryptoBalance: 0,
                     createdAt: new Date(),
@@ -448,7 +449,7 @@ describe("Tier System End-to-End", () => {
                     target: userTable.id,
                     set: {
                         tier: "seed",
-                        tierBalance: 2,
+                        tierBalance: 0,
                     },
                 });
 


### PR DESCRIPTION
- Grants **1 pollen** to `tier_balance` for every new user in `auth.ts:onAfterUserCreate`
- No BYOP gate, no eligibility marker — one-shot by definition (hook runs once per user)
- Refill SQL patched to preserve above-cap balances (otherwise the hourly cron would strip it)
- Constant `SIGNUP_GRANT_POLLEN` in `tier-config.ts` — set to 0 to disable
- Tests updated to assert above-cap preservation; 41 tier tests pass

**Parallel proposal to #10363** (BYOP-scoped variant). Pick one, close the other.