### PR TITLE
[PATCH] Check existing version locks for the MCP package

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,13 +56,28 @@ jobs:
           npm ci
           npm run build
 
+      - name: Check if version already published
+        id: check
+        working-directory: packages/sdk
+        run: |
+          name=$(node -p "require('./package.json').name")
+          v=$(node -p "require('./package.json').version")
+          if npm view "$name@$v" version >/dev/null 2>&1; then
+            echo "Version $v already on npm — skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to NPM
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/sdk
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_KEY }}
 
       - name: Publish to GitHub Packages
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/sdk
         run: |
           # GitHub Packages requires scope matching the repo owner
@@ -97,13 +112,28 @@ jobs:
         working-directory: packages/mcp
         run: npm ci --ignore-scripts
 
+      - name: Check if version already published
+        id: check
+        working-directory: packages/mcp
+        run: |
+          name=$(node -p "require('./package.json').name")
+          v=$(node -p "require('./package.json').version")
+          if npm view "$name@$v" version >/dev/null 2>&1; then
+            echo "Version $v already on npm — skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to NPM
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/mcp
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_KEY }}
 
       - name: Publish to GitHub Packages
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/mcp
         run: |
           node -e "
@@ -137,13 +167,28 @@ jobs:
         working-directory: packages/ompc
         run: npm ci --ignore-scripts
 
+      - name: Check if version already published
+        id: check
+        working-directory: packages/ompc
+        run: |
+          name=$(node -p "require('./package.json').name")
+          v=$(node -p "require('./package.json').version")
+          if npm view "$name@$v" version >/dev/null 2>&1; then
+            echo "Version $v already on npm — skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to NPM
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/ompc
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_KEY }}
 
       - name: Publish to GitHub Packages
+        if: steps.check.outputs.skip != 'true'
         working-directory: packages/ompc
         run: |
           node -e "

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pollinations_ai/mcp",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Model Context Protocol (MCP) server for pollinations.ai - image, text, audio & video generation",
     "type": "module",
     "bin": {


### PR DESCRIPTION
## Changes Made:- 

- added the same Check if version already published step + if: steps.check.outputs.skip != 'true' guards on both publish steps (npm + GitHub Packages)
- The job will now skip publish cleanly when the version in package.json already exists. 