### PR TITLE
docs: drop legacy balance permission from examples

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -363,7 +363,7 @@ Create a new API key. Requires `account:keys` permission and a secret key (sk\_)
 
 - **`accountPermissions`**
 
-  `object` — Account permissions (e.g. \["balance", "usage"]). "keys" is auto-stripped.
+  `object` — Account permissions (e.g. \["profile", "usage"]). "keys" is auto-stripped.
 
 - **`allowedModels`**
 

--- a/apps/ai-dungeon-master/src/hooks/useAuth.ts
+++ b/apps/ai-dungeon-master/src/hooks/useAuth.ts
@@ -58,7 +58,7 @@ export function useAuth() {
 
     const login = useCallback(() => {
         const currentUrl = window.location.href.split("#")[0];
-        const authUrl = `${ENTER_URL}/authorize?redirect_url=${encodeURIComponent(currentUrl)}&app_key=${APP_KEY}&permissions=profile,balance`;
+        const authUrl = `${ENTER_URL}/authorize?redirect_url=${encodeURIComponent(currentUrl)}&app_key=${APP_KEY}&permissions=profile,usage`;
         window.location.href = authUrl;
     }, []);
 

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -37,7 +37,7 @@ export function getAuthorizeUrl() {
         redirect_url: redirect,
         budget: "5",
         models: "gptimage,nanobanana,claude-fast",
-        permissions: "profile,balance",
+        permissions: "profile,usage",
     })}`;
 }
 

--- a/apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts
@@ -56,7 +56,7 @@ const APP_KEY = "pk_vbqLj6cwn05D2v5B";
 
 function getAuthorizeUrl(): string {
     const redirect = window.location.href.split("#")[0];
-    return `${ENTER_URL}/authorize?${new URLSearchParams({ redirect_url: redirect, app_key: APP_KEY, permissions: "profile,balance" })}`;
+    return `${ENTER_URL}/authorize?${new URLSearchParams({ redirect_url: redirect, app_key: APP_KEY, permissions: "profile,usage" })}`;
 }
 
 export function useBYOP() {

--- a/apps/slidepainter/src/hooks/useAuth.ts
+++ b/apps/slidepainter/src/hooks/useAuth.ts
@@ -148,7 +148,7 @@ export function useAuth(): UseAuthReturn {
 
     const login = useCallback(() => {
         const currentUrl = window.location.href.split("#")[0];
-        const authUrl = `${ENTER_URL}/authorize?redirect_url=${encodeURIComponent(currentUrl)}&permissions=profile,balance`;
+        const authUrl = `${ENTER_URL}/authorize?redirect_url=${encodeURIComponent(currentUrl)}&permissions=profile,usage`;
         window.location.href = authUrl;
     }, []);
 

--- a/enter.pollinations.ai/AGENTS.md
+++ b/enter.pollinations.ai/AGENTS.md
@@ -598,13 +598,12 @@ https://enter.pollinations.ai/authorize?redirect_url=YOUR_APP_URL&app_key=pk_you
 | `models` | Comma-separated allowed models | `flux,openai,gptimage` |
 | `budget` | Pollen budget limit | `10` |
 | `expiry` | Expiry in days (default: 30) | `7` |
-| `permissions` | Account permissions | `profile,balance,usage` |
+| `permissions` | Account permissions | `profile,usage` |
 
 ### Account Permissions
 
 - `profile`: Read user's name, email, GitHub username
-- `balance`: Read pollen balance
-- `usage`: Read usage history
+- `usage`: Read usage history and pollen balance
 
 ### App Registration
 
@@ -613,7 +612,7 @@ Register a `pk_` key at enter.pollinations.ai with **App URL** + **BYOP** toggle
 ### Example
 
 ```
-https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com/callback&app_key=pk_abc123&permissions=profile,balance&expiry=7
+https://enter.pollinations.ai/authorize?redirect_url=https://myapp.com/callback&app_key=pk_abc123&permissions=profile,usage&expiry=7
 ```
 
 After authorization, the user is redirected back with an `sk_` key in the URL fragment:

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1676,7 +1676,7 @@ export class Pollinations {
      *   redirectUrl: 'https://myapp.com/callback',
      *   models: ['flux', 'openai'],
      *   budget: 10,
-     *   permissions: ['profile', 'balance'],
+     *   permissions: ['profile', 'usage'],
      * });
      * // Redirect user to this URL
      * ```
@@ -1989,7 +1989,7 @@ export class Pollinations {
      *   name: 'my-bot',
      *   type: 'secret',
      *   pollenBudget: 1000,
-     *   accountPermissions: ['balance', 'usage'],
+     *   accountPermissions: ['usage'],
      * });
      * console.log('Save this now — it will not be shown again:', created.key);
      * ```

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -645,7 +645,7 @@ export async function listKeys(): Promise<AccountKey[]> {
  * const created = await createKey({
  *   name: 'my-bot',
  *   type: 'secret',
- *   accountPermissions: ['balance', 'usage'],
+ *   accountPermissions: ['usage'],
  * });
  * console.log('Save this key — it will not be shown again:', created.key);
  * ```

--- a/pollinations.ai/src/hooks/useAuth.tsx
+++ b/pollinations.ai/src/hooks/useAuth.tsx
@@ -156,7 +156,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const login = useCallback(() => {
         const currentUrl = window.location.href.split("#")[0];
-        const authUrl = `${ENTER_URL}/authorize?redirect_url=${encodeURIComponent(currentUrl)}&app_key=${APP_KEY}&permissions=profile,balance`;
+        const authUrl = `${ENTER_URL}/authorize?redirect_url=${encodeURIComponent(currentUrl)}&app_key=${APP_KEY}&permissions=profile,usage`;
         window.location.href = authUrl;
     }, []);
 


### PR DESCRIPTION
Follow-up to #10391. The `balance` scope was merged into `usage` and is dropped by the sanitizer on the backend. This sweep updates the remaining stale examples so docs match current behavior.

- Update SDK JSDoc for `authorizeUrl` and `createKey` (client + helpers)
- Update BYOP `authorize` URLs in pollinations.ai + 4 community apps (ai-dungeon-master, slidepainter, sirius-cybernetics-elevator-challenge, catgpt)
- Update AGENTS.md parameter table, permission list, and example URL
- Update APIDOCS.md `accountPermissions` example

Test `drops legacy balance scope after the merge with usage` in `authorize-config.test.ts` intentionally left untouched — it asserts the legacy-drop behavior.