### PR TITLE
feat(observability): error_event Tinybird stream for 5xx monitoring

### DIFF
--- a/enter.pollinations.ai/observability/datasources/error_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/error_event.datasource
@@ -1,0 +1,42 @@
+TOKEN tinybird_ingest APPEND
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+Server-side error events (5xx, upstream failures, uncaught exceptions) with full context.
+Short retention window for operational monitoring.
+
+SCHEMA >
+`timestamp`       DateTime               `json:$.timestamp`,
+`request_id`      String                 `json:$.requestId` DEFAULT '',
+`environment`     LowCardinality(String) `json:$.environment` DEFAULT 'undefined',
+
+-- Request
+`route_path`      String                 `json:$.routePath` DEFAULT '',
+`method`          LowCardinality(String) `json:$.method` DEFAULT '',
+`response_status` UInt32                 `json:$.responseStatus` DEFAULT 0,
+`duration_ms`     UInt32                 `json:$.durationMs` DEFAULT 0,
+
+-- Error
+`error_class`     LowCardinality(String) `json:$.errorClass` DEFAULT '',
+`error_code`      LowCardinality(String) `json:$.errorCode` DEFAULT '',
+`error_message`   String                 `json:$.errorMessage` DEFAULT '',
+`error_stack`     String                 `json:$.errorStack` DEFAULT '',
+`fingerprint`     String                 `json:$.fingerprint` DEFAULT '',
+
+-- Upstream (for UpstreamError / 502/503/504)
+`upstream_host`   LowCardinality(String) `json:$.upstreamHost` DEFAULT '',
+`upstream_status` UInt32                 `json:$.upstreamStatus` DEFAULT 0,
+`upstream_body`   String                 `json:$.upstreamBody` DEFAULT '',
+
+-- Context
+`model_requested` LowCardinality(String) `json:$.modelRequested` DEFAULT '',
+`event_type`      LowCardinality(String) `json:$.eventType` DEFAULT '',
+`user_id`         String                 `json:$.userId` DEFAULT '',
+`user_tier`       LowCardinality(String) `json:$.userTier` DEFAULT '',
+`api_key_id`      String                 `json:$.apiKeyId` DEFAULT '',
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMMDD(timestamp)"
+ENGINE_SORTING_KEY "timestamp, environment, error_class, fingerprint"
+ENGINE_PRIMARY_KEY "timestamp, environment"
+ENGINE_TTL "timestamp + toIntervalHour(3)"

--- a/enter.pollinations.ai/observability/endpoints/recent_errors.pipe
+++ b/enter.pollinations.ai/observability/endpoints/recent_errors.pipe
@@ -1,0 +1,35 @@
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+Recent server errors (5xx/upstream) for the last N hours. Agent-queryable rolling window.
+
+NODE recent_errors
+SQL >
+    SELECT
+        timestamp,
+        request_id,
+        environment,
+        route_path,
+        method,
+        response_status,
+        duration_ms,
+        error_class,
+        error_code,
+        error_message,
+        error_stack,
+        fingerprint,
+        upstream_host,
+        upstream_status,
+        upstream_body,
+        model_requested,
+        event_type,
+        user_id,
+        user_tier
+    FROM error_event
+    WHERE
+        timestamp >= now() - toIntervalHour({{Int32(hours, 3)}})
+        AND environment = {{String(environment, 'production')}}
+    ORDER BY timestamp DESC
+    LIMIT {{Int32(limit, 100)}}
+
+TYPE endpoint

--- a/enter.pollinations.ai/src/error.ts
+++ b/enter.pollinations.ai/src/error.ts
@@ -5,6 +5,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import { ValidationError } from "@/middleware/validator";
 import type { Env } from "./env.ts";
+import { buildErrorFingerprint, sendErrorEventToTinybird } from "./events.ts";
 
 type UpstreamErrorOptions = {
     res?: Response;
@@ -98,6 +99,47 @@ export const handleError: ErrorHandler<Env> = async (err, c) => {
         log.trace("HttpException: {message}", {
             message: err.message || getDefaultErrorMessage(err.status),
         });
+
+        if (status >= 500 && err instanceof UpstreamError) {
+            const routePath = c.req.routePath ?? c.req.path;
+            const topFrame = err.stack?.split("\n")[1]?.trim() ?? "";
+            const user = (c.var as any).auth?.user;
+            c.executionCtx.waitUntil(
+                sendErrorEventToTinybird(
+                    {
+                        timestamp,
+                        requestId: c.get("requestId") ?? "",
+                        environment: c.env.ENVIRONMENT,
+                        routePath,
+                        method: c.req.method,
+                        responseStatus: status,
+                        durationMs: 0,
+                        errorClass: "UpstreamError",
+                        errorCode: getErrorCode(status),
+                        errorMessage: err.message ?? "",
+                        errorStack: err.stack ?? "",
+                        fingerprint: buildErrorFingerprint(
+                            routePath,
+                            "UpstreamError",
+                            err.message ?? "",
+                            topFrame,
+                        ),
+                        upstreamHost: err.requestUrl?.hostname ?? "",
+                        upstreamStatus: status,
+                        upstreamBody: "",
+                        modelRequested: (c.var as any).modelRequested ?? "",
+                        eventType: (c.var as any).eventType ?? "",
+                        userId: user?.id ?? "",
+                        userTier: user?.tier ?? "",
+                        apiKeyId: (c.var as any).apiKeyId ?? "",
+                    },
+                    c.env.TINYBIRD_ERROR_INGEST_URL,
+                    c.env.TINYBIRD_INGEST_TOKEN,
+                    log,
+                ),
+            );
+        }
+
         return c.json(createErrorResponse(err, status, timestamp), status);
     }
 
@@ -128,6 +170,47 @@ export const handleError: ErrorHandler<Env> = async (err, c) => {
             cause: err.cause,
         },
     });
+
+    const topFrame = err.stack?.split("\n")[1]?.trim() ?? "";
+    const routePath = c.req.routePath ?? c.req.path;
+    c.executionCtx.waitUntil(
+        sendErrorEventToTinybird(
+            {
+                timestamp,
+                requestId: c.get("requestId") ?? "",
+                environment: c.env.ENVIRONMENT,
+                routePath,
+                method: c.req.method,
+                responseStatus: status,
+                durationMs: 0,
+                errorClass: err.name ?? "Error",
+                errorCode: getErrorCode(status),
+                errorMessage: err.message ?? "",
+                errorStack: err.stack ?? "",
+                fingerprint: buildErrorFingerprint(
+                    routePath,
+                    err.name ?? "Error",
+                    err.message ?? "",
+                    topFrame,
+                ),
+                upstreamHost:
+                    err instanceof UpstreamError
+                        ? (err.requestUrl?.hostname ?? "")
+                        : "",
+                upstreamStatus: 0,
+                upstreamBody: "",
+                modelRequested: (c.var as any).modelRequested ?? "",
+                eventType: (c.var as any).eventType ?? "",
+                userId: user?.id ?? "",
+                userTier: user?.tier ?? "",
+                apiKeyId: (c.var as any).apiKeyId ?? "",
+            },
+            c.env.TINYBIRD_ERROR_INGEST_URL,
+            c.env.TINYBIRD_INGEST_TOKEN,
+            log,
+        ),
+    );
+
     const response = createInternalErrorResponse(err, status, timestamp);
     return c.json(response, status);
 };

--- a/enter.pollinations.ai/src/events.ts
+++ b/enter.pollinations.ai/src/events.ts
@@ -102,6 +102,101 @@ export function flattenBalances(balances: Record<string, number> | null) {
     );
 }
 
+// Error event for Tinybird error_event datasource (server-side 5xx, upstream failures)
+export type ErrorEvent = {
+    timestamp: string;
+    requestId: string;
+    environment: string;
+    routePath: string;
+    method: string;
+    responseStatus: number;
+    durationMs: number;
+    errorClass: string;
+    errorCode: string;
+    errorMessage: string;
+    errorStack: string;
+    fingerprint: string;
+    upstreamHost: string;
+    upstreamStatus: number;
+    upstreamBody: string;
+    modelRequested: string;
+    eventType: string;
+    userId: string;
+    userTier: string;
+    apiKeyId: string;
+};
+
+export function buildErrorFingerprint(
+    routePath: string,
+    errorClass: string,
+    errorMessage: string,
+    topStackFrame: string,
+): string {
+    // Normalize message: strip dynamic parts (UUIDs, IDs, numbers)
+    const normalized = errorMessage
+        .replace(/[0-9a-f-]{8,}/gi, "*")
+        .slice(0, 100);
+    return `${routePath}|${errorClass}|${normalized}|${topStackFrame}`;
+}
+
+export async function sendErrorEventToTinybird(
+    event: ErrorEvent,
+    tinybirdErrorIngestUrl: string | undefined,
+    tinybirdIngestToken: string | undefined,
+    log: Logger,
+): Promise<void> {
+    if (!tinybirdErrorIngestUrl || !tinybirdIngestToken) return;
+
+    const body = JSON.stringify(removeUnset(event));
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await fetch(tinybirdErrorIngestUrl, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${tinybirdIngestToken}`,
+                    "Content-Type": "application/x-ndjson",
+                },
+                body,
+            });
+
+            if (response.ok) return;
+
+            const errorText = await response.text();
+            const isRetryable =
+                response.status >= 500 || response.status === 429;
+            if (!isRetryable || attempt === MAX_RETRIES) {
+                log.error(
+                    "Tinybird error_event ingest failed: status={status} error={error}",
+                    {
+                        status: response.status,
+                        error: errorText,
+                    },
+                );
+                return;
+            }
+            await retryWithBackoff(
+                attempt,
+                log,
+                "Tinybird error_event retry",
+                response.status,
+            );
+        } catch (err) {
+            if (attempt === MAX_RETRIES) {
+                log.error("Failed to send error_event to Tinybird: {error}", {
+                    error: err,
+                });
+                return;
+            }
+            await retryWithBackoff(
+                attempt,
+                log,
+                "Tinybird error_event network error",
+            );
+        }
+    }
+}
+
 // Tier event types for Tinybird tier_event datasource
 export type TierEventType = "tier_refill" | "tier_change" | "user_registration";
 

--- a/enter.pollinations.ai/worker-bindings.d.ts
+++ b/enter.pollinations.ai/worker-bindings.d.ts
@@ -21,6 +21,7 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
+        TINYBIRD_ERROR_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event";
         IMAGE_SERVICE_URL: "http://localhost:16384";
         TEXT_SERVICE_URL: "http://localhost:16385";
         NOWPAYMENTS_ENV: "sandbox";
@@ -65,6 +66,7 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
+        TINYBIRD_ERROR_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event";
         IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
         TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         POLLEN_REFILL_PER_HOUR: 1;
@@ -111,6 +113,7 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
+        TINYBIRD_ERROR_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event";
         IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
         TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         STRIPE_MODE: "sandbox";
@@ -154,6 +157,7 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event";
+        TINYBIRD_ERROR_INGEST_URL: "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event";
         IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
         TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         STRIPE_MODE: "sandbox";
@@ -198,6 +202,7 @@ declare namespace Cloudflare {
         TINYBIRD_CRYPTO_INGEST_URL: "http://localhost:7181/v0/events?name=crypto_event";
         TINYBIRD_TIER_INGEST_URL: "http://localhost:7181/v0/events?name=tier_event";
         TINYBIRD_STRIPE_INGEST_URL: "http://localhost:7181/v0/events?name=stripe_event";
+        TINYBIRD_ERROR_INGEST_URL: "http://localhost:7181/v0/events?name=error_event";
         IMAGE_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
         TEXT_SERVICE_URL: "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385";
         BETTER_AUTH_SECRET: string;
@@ -278,6 +283,9 @@ declare namespace Cloudflare {
         TINYBIRD_STRIPE_INGEST_URL:
             | "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
             | "http://localhost:7181/v0/events?name=stripe_event";
+        TINYBIRD_ERROR_INGEST_URL:
+            | "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event"
+            | "http://localhost:7181/v0/events?name=error_event";
         IMAGE_SERVICE_URL:
             | "http://localhost:16384"
             | "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384";
@@ -320,6 +328,7 @@ declare namespace NodeJS {
                 | "TINYBIRD_CRYPTO_INGEST_URL"
                 | "TINYBIRD_TIER_INGEST_URL"
                 | "TINYBIRD_STRIPE_INGEST_URL"
+                | "TINYBIRD_ERROR_INGEST_URL"
                 | "IMAGE_SERVICE_URL"
                 | "TEXT_SERVICE_URL"
                 | "NOWPAYMENTS_ENV"

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -54,6 +54,7 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
+TINYBIRD_ERROR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event"
 IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
 TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 # NOWPayments crypto payments (sandbox for dev)
@@ -102,6 +103,7 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
+TINYBIRD_ERROR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event"
 IMAGE_SERVICE_URL = "http://localhost:16384"
 TEXT_SERVICE_URL = "http://localhost:16385"
 # NOWPayments crypto payments (sandbox for local development)
@@ -171,6 +173,7 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
+TINYBIRD_ERROR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event"
 IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
 TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 POLLEN_REFILL_PER_HOUR = 1
@@ -236,6 +239,7 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
+TINYBIRD_ERROR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event"
 IMAGE_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16384"
 TEXT_SERVICE_URL = "http://ec2-54-147-14-220.compute-1.amazonaws.com:16385"
 # Stripe payments: sandbox mode for staging
@@ -291,6 +295,7 @@ TINYBIRD_POLAR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?
 TINYBIRD_CRYPTO_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=stripe_event"
+TINYBIRD_ERROR_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events?name=error_event"
 # TODO: Change back to staging endpoints once staging services are available
 # Staging URLs: IMAGE_SERVICE_URL = "http://ec2-44-222-254-250.compute-1.amazonaws.com:16384"
 #               TEXT_SERVICE_URL = "http://ec2-44-222-254-250.compute-1.amazonaws.com:16385"
@@ -348,6 +353,7 @@ TINYBIRD_POLAR_INGEST_URL = "http://localhost:7181/v0/events?name=polar_event"
 TINYBIRD_CRYPTO_INGEST_URL = "http://localhost:7181/v0/events?name=crypto_event"
 TINYBIRD_TIER_INGEST_URL = "http://localhost:7181/v0/events?name=tier_event"
 TINYBIRD_STRIPE_INGEST_URL = "http://localhost:7181/v0/events?name=stripe_event"
+TINYBIRD_ERROR_INGEST_URL = "http://localhost:7181/v0/events?name=error_event"
 TINYBIRD_INGEST_TOKEN = "test_tinybird_ingest_token"
 TINYBIRD_READ_TOKEN = "test_tinybird_read_token"
 TINYBIRD_SYNC_TOKEN = "test_tinybird_sync_token"


### PR DESCRIPTION
## Summary

- Adds `error_event` Tinybird datasource with 3h `ENGINE_TTL` — stores full stack, fingerprint, upstream context; auto-expires so it never pollutes the analytics tables
- Adds `recent_errors` pipe endpoint — agents query `?hours=3&environment=production` to get a clean rolling error window
- Emits one event per actionable failure: `InternalError` (500) and `UpstreamError` (502/503/504) via `waitUntil` (non-blocking)
- Fingerprint normalises dynamic parts (UUIDs, IDs) for dedup/clustering across repeated occurrences
- `TINYBIRD_ERROR_INGEST_URL` wired into all envs in `wrangler.toml` and `worker-bindings.d.ts`

## What's NOT logged
- 4xx (auth errors, rate limits, validation) — excluded by design, signal only
- Full request/response bodies — excluded for privacy

## Test plan
- [ ] Deploy Tinybird datasource: `tb --cloud deploy --check --wait` from `enter.pollinations.ai/observability`
- [ ] Trigger a 500 locally, confirm event appears in Tinybird
- [ ] Query `recent_errors` pipe with `?hours=1&environment=local`

polly please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)