### PR TITLE
feat(gptimage-2): add gpt-image-2 via Azure eastus2

### DIFF
--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -199,11 +199,11 @@ function generateLLMDoc(): string {
     lines.push("- negative_prompt (string): Only flux, zimage");
     lines.push("- safe (boolean, default: false): Safety filter");
     lines.push(
-        '- quality (low|medium|high|hd, default: "medium"): gptimage, gptimage-large, gptimage-2',
+        '- quality (low|medium|high|hd, default: "medium"): gptimage, gptimage-large, gpt-image-2',
     );
     lines.push("- image (string): Reference image URL(s), | or , separated");
     lines.push(
-        "- transparent (boolean, default: false): gptimage, gptimage-large, gptimage-2",
+        "- transparent (boolean, default: false): gptimage, gptimage-large, gpt-image-2",
     );
     lines.push(
         "- reasoning (boolean, default: false): Enable thinking for improved text/layout. nanobanana, nanobanana-2, nanobanana-pro",

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -199,11 +199,11 @@ function generateLLMDoc(): string {
     lines.push("- negative_prompt (string): Only flux, zimage");
     lines.push("- safe (boolean, default: false): Safety filter");
     lines.push(
-        '- quality (low|medium|high|hd, default: "medium"): gptimage, gptimage-large',
+        '- quality (low|medium|high|hd, default: "medium"): gptimage, gptimage-large, gptimage-2',
     );
     lines.push("- image (string): Reference image URL(s), | or , separated");
     lines.push(
-        "- transparent (boolean, default: false): gptimage, gptimage-large",
+        "- transparent (boolean, default: false): gptimage, gptimage-large, gptimage-2",
     );
     lines.push(
         "- reasoning (boolean, default: false): Enable thinking for improved text/layout. nanobanana, nanobanana-2, nanobanana-pro",

--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -73,7 +73,7 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         .default("medium")
         .meta({
             description:
-                "Image quality level. Only supported by `gptimage` and `gptimage-large`.",
+                "Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gptimage-2`.",
         }),
     image: z
         .string()
@@ -104,7 +104,7 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:
-            "Generate image with transparent background. Only supported by `gptimage` and `gptimage-large`.",
+            "Generate image with transparent background. Only supported by `gptimage`, `gptimage-large`, and `gptimage-2`.",
     }),
 
     // Video-specific params

--- a/enter.pollinations.ai/src/schemas/image.ts
+++ b/enter.pollinations.ai/src/schemas/image.ts
@@ -73,7 +73,7 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         .default("medium")
         .meta({
             description:
-                "Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gptimage-2`.",
+                "Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`.",
         }),
     image: z
         .string()
@@ -104,7 +104,7 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:
-            "Generate image with transparent background. Only supported by `gptimage`, `gptimage-large`, and `gptimage-2`.",
+            "Generate image with transparent background. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`.",
     }),
 
     // Video-specific params

--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -345,6 +345,11 @@ const AZURE_GPTIMAGE_CONFIGS: Record<string, AzureGPTImageConfig> = {
             "https://myceli-prod-eastus2.cognitiveservices.azure.com/openai/deployments/gpt-image-1.5",
         modelName: "gpt-image-1.5",
     },
+    "gptimage-2": {
+        baseUrl:
+            "https://myceli-prod-eastus2.cognitiveservices.azure.com/openai/deployments/gpt-image-2",
+        modelName: "gpt-image-2",
+    },
 };
 
 /**
@@ -709,7 +714,8 @@ const generateImage = async (
 ): Promise<ImageGenerationResult> => {
     switch (safeParams.model) {
         case "gptimage":
-        case "gptimage-large": {
+        case "gptimage-large":
+        case "gptimage-2": {
             const gptConfig = AZURE_GPTIMAGE_CONFIGS[safeParams.model];
             logError(
                 `GPT Image (${gptConfig.modelName}) authentication check:`,

--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -345,7 +345,7 @@ const AZURE_GPTIMAGE_CONFIGS: Record<string, AzureGPTImageConfig> = {
             "https://myceli-prod-eastus2.cognitiveservices.azure.com/openai/deployments/gpt-image-1.5",
         modelName: "gpt-image-1.5",
     },
-    "gptimage-2": {
+    "gpt-image-2": {
         baseUrl:
             "https://myceli-prod-eastus2.cognitiveservices.azure.com/openai/deployments/gpt-image-2",
         modelName: "gpt-image-2",
@@ -715,7 +715,7 @@ const generateImage = async (
     switch (safeParams.model) {
         case "gptimage":
         case "gptimage-large":
-        case "gptimage-2": {
+        case "gpt-image-2": {
             const gptConfig = AZURE_GPTIMAGE_CONFIGS[safeParams.model];
             logError(
                 `GPT Image (${gptConfig.modelName}) authentication check:`,

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -89,6 +89,13 @@ export const IMAGE_CONFIG = {
         defaultSideLength: 1024,
     },
 
+    // Azure GPT Image 2 - next-gen image generation
+    "gptimage-2": {
+        type: "azure-gptimage-2",
+        enhance: false,
+        defaultSideLength: 1024,
+    },
+
     // Veo 3.1 Fast - Video generation via Vertex AI
     veo: {
         type: "vertex-ai-video",

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -90,8 +90,8 @@ export const IMAGE_CONFIG = {
     },
 
     // Azure GPT Image 2 - next-gen image generation
-    "gptimage-2": {
-        type: "azure-gptimage-2",
+    "gpt-image-2": {
+        type: "azure-gpt-image-2",
         enhance: false,
         defaultSideLength: 1024,
     },

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -178,9 +178,9 @@ export const IMAGE_SERVICES = {
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
     },
-    "gptimage-2": {
-        aliases: ["gpt-image-2"],
-        modelId: "gptimage-2",
+    "gpt-image-2": {
+        aliases: [],
+        modelId: "gpt-image-2",
         provider: "azure",
         cost: [
             {

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -178,6 +178,23 @@ export const IMAGE_SERVICES = {
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
     },
+    "gptimage-2": {
+        aliases: ["gpt-image-2"],
+        modelId: "gptimage-2",
+        provider: "azure",
+        cost: [
+            {
+                date: COST_START_DATE,
+                promptTextTokens: perMillion(5), // per 1M tokens
+                promptCachedTokens: perMillion(1.25), // per 1M tokens
+                promptImageTokens: perMillion(8), // per 1M tokens
+                completionImageTokens: perMillion(30), // per 1M tokens
+            },
+        ],
+        description: "GPT Image 2 - OpenAI's next-gen image generation model",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+    },
     "flux": {
         aliases: [],
         modelId: "flux",


### PR DESCRIPTION
Adds `gptimage-2` (OpenAI gpt-image-2, Azure version `2026-04-21`) routed through the existing `myceli-prod-eastus2` resource.

- Deployment already created on Azure (`GlobalStandard`, 60 RPM)
- Reuses existing `AZURE_GPTIMAGE_CONFIGS` dispatcher — zero new code paths
- Registry: no `paidOnly` (accessible with tier balance), no `price` override (cost = price, zero margin)
- Cost mirrors OpenAI's published pricing: text \$5 / cached \$1.25 / image input \$8 / image output \$30 per 1M tokens
- Docs/schema strings updated for `quality` and `transparent` parameters

Tested locally end-to-end against live Azure:
- `gptimage-2` → HTTP 200, 1024×1024 JPEG
- `gptimage` + `gptimage-large` regression → HTTP 200

Note: while testing, confirmed current prod `gptimage` 404s are because `production` branch is 24 commits behind `main` — PR #10398 (Sweden Central → eastus2 migration) landed on main 5h ago but hasn't been deployed yet.