### PR TITLE
feat(play): remove anonymous publishable key, gate generation on login

### DIFF
--- a/pollinations.ai/src/api.config.ts
+++ b/pollinations.ai/src/api.config.ts
@@ -1,15 +1,11 @@
 // ==============================================
 // API CONFIGURATION
 // ==============================================
-// Direct calls to gen.pollinations.ai with publishable key.
-// No proxy needed - publishable keys are safe to expose on frontend.
+// Direct calls to gen.pollinations.ai. Users must log in and use their own
+// API key (sk_ / pk_ issued via enter.pollinations.ai) to generate.
 
-export const DEFAULT_API_KEY = "pk_iOJLArs0DLNG7EGm"; // Anonymous API access (rate-limited)
 export const APP_KEY = "pk_5F0qxjbCjlgBODHa"; // BYOP app key for authorization flow
 export const API_BASE = "https://gen.pollinations.ai";
-
-// Re-export for backward compatibility (use getApiKey() from useAuth for dynamic key)
-export const API_KEY = DEFAULT_API_KEY;
 
 export const API = {
     TEXT_GENERATION: `${API_BASE}/v1/chat/completions`,

--- a/pollinations.ai/src/copy/content/play.ts
+++ b/pollinations.ai/src/copy/content/play.ts
@@ -55,6 +55,7 @@ export const PLAY_PAGE = {
     generateTextButton: "Generate Text",
     generateAudioButton: "Generate Audio",
     generateVideoButton: "Generate Video",
+    loginToGenerateButton: "Log in to generate",
 
     // Tooltips
     seedTooltip: "Same seed + same prompt = same image",
@@ -106,16 +107,16 @@ export const PLAY_PAGE = {
     authTitle: "Authentication",
     authIntro:
         "API keys authenticate your requests. Create multiple keys for different apps and track usage separately.",
-    publishableLabel: "Publishable",
-    publishableFeature1: "🧪 Client-side demos & prototypes",
-    publishableFeature2: "⏱️ Rate limited: 1 pollen per IP per hour",
-    publishableBetaWarning:
-        "Beta — Turnstile protection coming soon. Not recommended for production yet.",
     secretLabel: "Secret",
     secretFeature1: "🔒 Server-side only",
     secretFeature2: "🚀 No rate limits",
     secretWarning:
         "Never expose in client-side code, git repos, or public URLs",
+    appKeyLabel: "App Key",
+    appKeyFeature1: "🌼 Identifies your app in the BYOP consent screen",
+    appKeyFeature2: "📈 Traffic attribution",
+    appKeyNote:
+        "For developers building apps where users bring their own Pollen. Create one at enter.pollinations.ai.",
     byopLabel: "Bring Your Own Pollen",
     byopDescription: "Building an app? Let users bring their own Pollen.",
     getKeyButton: "Get Your Key",

--- a/pollinations.ai/src/hooks/useAuth.tsx
+++ b/pollinations.ai/src/hooks/useAuth.tsx
@@ -7,7 +7,7 @@ import {
     useMemo,
     useState,
 } from "react";
-import { APP_KEY, DEFAULT_API_KEY } from "../api.config";
+import { APP_KEY } from "../api.config";
 import { fetchWithRetry } from "../utils/fetchWithRetry";
 
 const STORAGE_KEY = "pollinations_api_key";
@@ -29,7 +29,7 @@ interface UserBalance {
 // - AuthActions: login + logout (stable refs, never changes)
 
 interface AuthStateValue {
-    apiKey: string;
+    apiKey: string | null;
     isLoggedIn: boolean;
 }
 
@@ -169,7 +169,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const stateValue = useMemo<AuthStateValue>(
         () => ({
-            apiKey: userApiKey || DEFAULT_API_KEY,
+            apiKey: userApiKey,
             isLoggedIn: !!userApiKey,
         }),
         [userApiKey],

--- a/pollinations.ai/src/hooks/useModelList.ts
+++ b/pollinations.ai/src/hooks/useModelList.ts
@@ -106,7 +106,14 @@ function hasAudioOutput(m: RawModel): boolean {
     return typeof m !== "string" && !!m.output_modalities?.includes("audio");
 }
 
-async function fetchAllowedModels(apiKey: string): Promise<AllowedModelsData> {
+const EMPTY_ALLOWED: AllowedModelsData = { image: [], text: [], audio: [] };
+
+async function fetchAllowedModels(
+    apiKey: string | null,
+): Promise<AllowedModelsData> {
+    // Logged-out users have no allowed models — everything shows grayed out.
+    if (!apiKey) return EMPTY_ALLOWED;
+
     const authHeaders = { Authorization: `Bearer ${apiKey}` };
 
     const [allowedImageList, allowedTextList, allowedAudioList] =
@@ -145,9 +152,9 @@ async function fetchAllowedModels(apiKey: string): Promise<AllowedModelsData> {
  * Custom hook to fetch and manage available models from the API
  * Full model list comes from the shared registry (instant).
  * Only fetches API to determine which models are allowed for the current key.
- * @param apiKey - API key to use for authentication (from useAuth hook)
+ * @param apiKey - API key from useAuth (null when logged out → all models grayed out)
  */
-export function useModelList(apiKey: string): UseModelListReturn {
+export function useModelList(apiKey: string | null): UseModelListReturn {
     const [error, setError] = useState<Error | null>(null);
 
     const fetcher = useCallback(

--- a/pollinations.ai/src/services/pollinationsAPI.ts
+++ b/pollinations.ai/src/services/pollinationsAPI.ts
@@ -1,5 +1,9 @@
-import { API, API_KEY, DEFAULTS } from "../api.config";
+import { API, DEFAULTS } from "../api.config";
 import { fetchWithRetry } from "../utils/fetchWithRetry";
+
+function authHeaders(apiKey?: string): HeadersInit {
+    return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
 
 /**
  * Fetch text from Pollinations text generation API
@@ -9,13 +13,13 @@ export async function generateText(
     prompt: string,
     seed?: number | number[],
     model = DEFAULTS.TEXT_MODEL,
-    apiKey = API_KEY,
+    apiKey?: string,
 ): Promise<string> {
     const response = await fetchWithRetry(API.TEXT_GENERATION, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${apiKey}`,
+            ...authHeaders(apiKey),
         },
         body: JSON.stringify({
             messages: [{ role: "user", content: prompt }],
@@ -48,7 +52,7 @@ export async function generateImage(
         height = DEFAULTS.IMAGE_HEIGHT,
         seed = DEFAULTS.SEED,
         model = DEFAULTS.IMAGE_MODEL,
-        apiKey = API_KEY,
+        apiKey,
     } = options;
 
     const baseUrl = `${API.IMAGE_GENERATION}/${encodeURIComponent(prompt)}`;
@@ -60,7 +64,7 @@ export async function generateImage(
     const url = `${baseUrl}?${params.toString()}`;
 
     const response = await fetchWithRetry(url, {
-        headers: { Authorization: `Bearer ${apiKey}` },
+        headers: authHeaders(apiKey),
     });
 
     const blob = await response.blob();

--- a/pollinations.ai/src/ui/components/BuildDiary.tsx
+++ b/pollinations.ai/src/ui/components/BuildDiary.tsx
@@ -204,7 +204,7 @@ export function BuildDiary() {
     const { prettified: prettifiedSummary } = usePrettify(
         summaryItem,
         "text",
-        apiKey,
+        apiKey ?? undefined,
         "name",
     );
 

--- a/pollinations.ai/src/ui/components/ImageGenerator.tsx
+++ b/pollinations.ai/src/ui/components/ImageGenerator.tsx
@@ -36,7 +36,13 @@ export function ImageGenerator({
         setLoading(true);
         setError(null);
 
-        generateImage(prompt, { width, height, seed, model, apiKey })
+        generateImage(prompt, {
+            width,
+            height,
+            seed,
+            model,
+            apiKey: apiKey ?? undefined,
+        })
             .then((url) => {
                 objectUrl = url;
                 setImageUrl(url);

--- a/pollinations.ai/src/ui/components/UserMenu.tsx
+++ b/pollinations.ai/src/ui/components/UserMenu.tsx
@@ -104,7 +104,7 @@ export function UserMenu() {
                             {copy.apiKeyLabel}
                         </span>
                         <span className="font-mono text-base text-muted">
-                            {apiKey.slice(0, 4)}••••••••
+                            {apiKey ? `${apiKey.slice(0, 4)}••••••••` : "—"}
                         </span>
                     </div>
 

--- a/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
+++ b/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
@@ -16,7 +16,8 @@ interface PlayGeneratorProps {
     imageModels: Model[];
     textModels: Model[];
     audioModels: Model[];
-    apiKey: string;
+    apiKey: string | null;
+    onLoginRequired: () => void;
 }
 
 /** Renders a color-coded GET API URL: base/{type}/{prompt}?params&key=YOUR_API_KEY */
@@ -92,6 +93,7 @@ export function PlayGenerator({
     textModels,
     audioModels,
     apiKey,
+    onLoginRequired,
 }: PlayGeneratorProps) {
     const { copy } = usePageCopy(PLAY_PAGE, PLAY_PAGE_NO_TRANSLATE);
 
@@ -241,6 +243,10 @@ export function PlayGenerator({
 
     const handleGenerate = async () => {
         if (isLoading) return;
+        if (!apiKey) {
+            onLoginRequired();
+            return;
+        }
         setIsLoading(true);
         setError(null);
         setResult(null);
@@ -637,8 +643,8 @@ export function PlayGenerator({
             <div className="relative group/generate inline-block mb-6">
                 <Button
                     type="button"
-                    onClick={handleGenerate}
-                    disabled={!prompt && !isLoading}
+                    onClick={apiKey ? handleGenerate : onLoginRequired}
+                    disabled={!!apiKey && !prompt && !isLoading}
                     variant="generate"
                     size={null}
                     className={
@@ -665,6 +671,8 @@ export function PlayGenerator({
                             </span>
                             {copy.generatingText}
                         </span>
+                    ) : !apiKey ? (
+                        copy.loginToGenerateButton
                     ) : isVideoModel ? (
                         copy.generateVideoButton
                     ) : isAudioModel ? (
@@ -675,7 +683,7 @@ export function PlayGenerator({
                         copy.generateTextButton
                     )}
                 </Button>
-                {!prompt && !isLoading && (
+                {apiKey && !prompt && !isLoading && (
                     <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-white text-dark text-xs rounded-input shadow-lg border border-border opacity-0 group-hover/generate:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
                         {copy.enterPromptFirst}
                         <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-input-background" />
@@ -866,48 +874,6 @@ export function PlayGenerator({
 
             {/* Key type cards */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
-                <div className="bg-secondary-light p-4 rounded-sub-card">
-                    <div className="flex items-center gap-2 mb-2">
-                        <span className="font-mono text-lg font-black text-dark">
-                            pk_
-                        </span>
-                        <Label as="span" spacing="none" display="inline">
-                            {copy.publishableLabel}
-                        </Label>
-                    </div>
-                    <ul className="list-none p-0 m-0 space-y-1">
-                        <li>
-                            <Body
-                                as="span"
-                                size="xs"
-                                spacing="none"
-                                className="text-dark font-bold"
-                            >
-                                {copy.publishableFeature1}
-                            </Body>
-                        </li>
-                        <li>
-                            <Body
-                                as="span"
-                                size="xs"
-                                spacing="none"
-                                className="text-dark font-bold"
-                            >
-                                {copy.publishableFeature2}
-                            </Body>
-                        </li>
-                    </ul>
-                    <div className="mt-3 px-2 py-1 bg-accent-strong/30 rounded-sm">
-                        <Body
-                            size="xs"
-                            spacing="none"
-                            className="text-dark font-bold"
-                        >
-                            {copy.publishableBetaWarning}
-                        </Body>
-                    </div>
-                </div>
-
                 <div className="bg-primary-light p-4 rounded-sub-card">
                     <div className="flex items-center gap-2 mb-2">
                         <span className="font-mono text-lg font-black text-dark">
@@ -946,6 +912,48 @@ export function PlayGenerator({
                             className="text-dark font-bold"
                         >
                             {copy.secretWarning}
+                        </Body>
+                    </div>
+                </div>
+
+                <div className="bg-secondary-light p-4 rounded-sub-card">
+                    <div className="flex items-center gap-2 mb-2">
+                        <span className="font-mono text-lg font-black text-dark">
+                            pk_
+                        </span>
+                        <Label as="span" spacing="none" display="inline">
+                            {copy.appKeyLabel}
+                        </Label>
+                    </div>
+                    <ul className="list-none p-0 m-0 space-y-1">
+                        <li>
+                            <Body
+                                as="span"
+                                size="xs"
+                                spacing="none"
+                                className="text-dark font-bold"
+                            >
+                                {copy.appKeyFeature1}
+                            </Body>
+                        </li>
+                        <li>
+                            <Body
+                                as="span"
+                                size="xs"
+                                spacing="none"
+                                className="text-dark font-bold"
+                            >
+                                {copy.appKeyFeature2}
+                            </Body>
+                        </li>
+                    </ul>
+                    <div className="mt-3 px-2 py-1 bg-accent-strong/30 rounded-sm">
+                        <Body
+                            size="xs"
+                            spacing="none"
+                            className="text-dark font-bold"
+                        >
+                            {copy.appKeyNote}
                         </Body>
                     </div>
                 </div>

--- a/pollinations.ai/src/ui/pages/AppsPage.tsx
+++ b/pollinations.ai/src/ui/pages/AppsPage.tsx
@@ -283,7 +283,7 @@ export default function AppsPage() {
     const { prettified } = usePrettify(
         filteredApps,
         "description",
-        apiKey,
+        apiKey ?? undefined,
         "name",
         "emoji",
     );

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -16,7 +16,7 @@ import { Body, Title } from "../components/ui/typography";
 function PlayPage() {
     const [selectedModel, setSelectedModel] = useState("flux");
     const [prompt, setPrompt] = useState("");
-    const { apiKey, isLoggedIn } = useAuth();
+    const { apiKey, isLoggedIn, login } = useAuth();
     const {
         imageModels,
         textModels,
@@ -128,7 +128,8 @@ function PlayPage() {
                         imageModels={imageModels}
                         textModels={textModels}
                         audioModels={audioModels}
-                        apiKey={apiKey || ""}
+                        apiKey={apiKey}
+                        onLoginRequired={login}
                     />
                 </div>
             </PageCard>


### PR DESCRIPTION
Removes the hardcoded anonymous publishable key (`pk_iOJLArs0DLNG7EGm`) from the frontend. Logged-out users now see the full model catalog but everything is grayed out, and the generate button becomes a login CTA. The only way to generate is to log in with a real account (BYOP).

Changes:
- `api.config.ts` — delete `DEFAULT_API_KEY` and the `API_KEY` re-export; keep `APP_KEY` (OAuth app id for the login redirect)
- `useAuth` — `apiKey` is now `string | null` with no silent fallback
- `useModelList` — skip the allowed-models fetch when no key; empty sets → everything renders grayed out via the existing `ModelSelector` gating
- Play page — generate button shows "Log in to generate" when logged out; clicking it triggers the OAuth flow instead of a doomed anonymous request
- Swap the old `pk_` publishable promo card for a `pk_` App Key card that documents BYOP attribution (name/author on consent screen, traffic attribution)
- `pollinationsAPI.ts` — `apiKey` optional; `Authorization` header only sent when present. Site-internal translation/prettify calls are anonymous and absorbed by the R2 cache on the gen backend
- Fix four callsites that passed `apiKey` into translation helpers to convert `null → undefined`