### PR TITLE
fix(security): prevent credential/internal details leaking in error responses

### DIFF
--- a/enter.pollinations.ai/src/error.ts
+++ b/enter.pollinations.ai/src/error.ts
@@ -148,7 +148,6 @@ function createErrorResponse(
             code: getErrorCode(status),
             timestamp,
             ...(details && { details }),
-            ...(!!error.cause && { cause: error.cause }),
         },
         status,
     };

--- a/text.pollinations.ai/genericOpenAIClient.ts
+++ b/text.pollinations.ai/genericOpenAIClient.ts
@@ -96,7 +96,7 @@ export async function genericOpenAIClient(
             ...additionalHeaders,
         };
 
-        log(`[${requestId}] Headers:`, headers);
+        log(`[${requestId}] Headers:`, { ...headers, Authorization: headers.Authorization ? "[REDACTED]" : undefined });
 
         const response = await fetch(endpointUrl, {
             method: "POST",

--- a/text.pollinations.ai/server.ts
+++ b/text.pollinations.ai/server.ts
@@ -268,7 +268,9 @@ function sendErrorResponse(
         requestId: Math.random().toString(36).substring(7),
         requestParameters: requestData || {},
     };
-    if (errorDetails) errorResponse.details = errorDetails;
+    // Only include upstream error details for client errors (4xx), never for 5xx
+    // to avoid leaking internal credential context from upstream providers (e.g. Vertex AI)
+    if (errorDetails && responseStatus < 500) errorResponse.details = errorDetails;
 
     const authResult =
         (c as unknown as { authResult?: Record<string, unknown> }).authResult ||


### PR DESCRIPTION
## Summary

Three fixes preventing upstream provider error context (including Google/Vertex AI diagnostic data) from reaching API clients.

- **`enter/error.ts`**: Remove `cause` field from serialized HTTP error responses — cause is logged server-side but must not be forwarded to clients (could contain internal error objects from model registry or upstream providers)
- **`text/server.ts`**: Only include upstream `details` in 4xx responses, never 5xx — Vertex AI 5xx errors can contain project IDs, service account emails, or partial JWT claims from failed token exchanges
- **`text/genericOpenAIClient.ts`**: Redact `Authorization` header before debug-logging outgoing requests to avoid access tokens appearing in log output

## Test plan

- [ ] Trigger a 5xx from a text model — confirm `details` is absent from response body
- [ ] Trigger a 4xx (bad model name) — confirm `details` still present for client errors
- [ ] Confirm `cause` field no longer appears in any error response
- [ ] Check debug logs — Authorization should show `[REDACTED]`