### PR TITLE
fix: improve mobile modal and model layouts

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -8,7 +8,6 @@ import {
     uniqueNamesGenerator,
 } from "unique-names-generator";
 import { cn } from "@/util.ts";
-import { useScrollLock } from "../../hooks/use-scroll-lock.ts";
 import { Button } from "../button.tsx";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
@@ -64,8 +63,6 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
     const [isOpen, setIsOpen] = useState(false);
     const [copied, setCopied] = useState(false);
     const [error, setError] = useState<string | null>(null);
-
-    useScrollLock(isOpen);
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
@@ -159,7 +156,7 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                 </Button>
             </Dialog.Trigger>
             <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
-            <Dialog.Positioner className="fixed inset-0 flex items-start justify-center p-4 overflow-y-auto z-[100]">
+            <Dialog.Positioner className="fixed inset-0 z-[100] flex h-dvh touch-pan-y items-start justify-center overflow-y-auto overscroll-contain p-4 [-webkit-overflow-scrolling:touch]">
                 <Dialog.Content
                     className={cn(
                         "border-4 rounded-lg shadow-lg max-w-2xl w-full my-auto",

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -3,7 +3,6 @@ import { Field } from "@ark-ui/react/field";
 import type { FC } from "react";
 import { useState } from "react";
 import { cn } from "@/util.ts";
-import { useScrollLock } from "../../hooks/use-scroll-lock.ts";
 import { Button } from "../button.tsx";
 import { Badge } from "../ui/badge.tsx";
 import { Card } from "../ui/card.tsx";
@@ -34,8 +33,6 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     const initialAppUrl = (apiKey.metadata?.appUrl as string) || "";
     const isAppKey = isPublishable && !!initialAppUrl;
     const [appUrl, setAppUrl] = useState(initialAppUrl);
-
-    useScrollLock();
 
     async function handleCopyKey(): Promise<void> {
         if (!plaintextKey) return;
@@ -113,7 +110,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     return (
         <Dialog.Root open onOpenChange={({ open }) => !open && onClose()}>
             <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
-            <Dialog.Positioner className="fixed inset-0 flex items-start justify-center p-4 overflow-y-auto z-[100]">
+            <Dialog.Positioner className="fixed inset-0 z-[100] flex h-dvh touch-pan-y items-start justify-center overflow-y-auto overscroll-contain p-4 [-webkit-overflow-scrolling:touch]">
                 <Dialog.Content
                     className={cn(
                         "border-green-950 border-4 rounded-lg shadow-lg max-w-xl w-full my-auto",

--- a/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
@@ -365,6 +365,16 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
                                     </span>
                                 )}
                             </button>
+                            {expanded &&
+                                (modalityIcons.length > 0 ||
+                                    capabilityIcons.length > 0) && (
+                                    <div className="mt-2">
+                                        <MobileMetadataBadges
+                                            modalityIcons={modalityIcons}
+                                            capabilityIcons={capabilityIcons}
+                                        />
+                                    </div>
+                                )}
                         </div>
                     </div>
                     <span
@@ -380,26 +390,18 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
             {/* Expanded: capabilities + full pricing */}
             {expanded && (
                 <div className="px-4 pb-4 pt-0">
-                    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-4">
-                        <div className="pl-6">
-                            <MobileMetadataBadges
-                                modalityIcons={modalityIcons}
-                                capabilityIcons={capabilityIcons}
-                            />
-                        </div>
-                        <div className="flex w-56 max-w-full flex-col gap-2 justify-self-end">
-                            <MobilePriceGroup
-                                label="In"
-                                model={model}
-                                direction="input"
-                            />
+                    <div className="flex min-w-0 flex-col gap-2 pl-6">
+                        <MobilePriceGroup
+                            label="In"
+                            model={model}
+                            direction="input"
+                        />
 
-                            <MobilePriceGroup
-                                label="Out"
-                                model={model}
-                                direction="output"
-                            />
-                        </div>
+                        <MobilePriceGroup
+                            label="Out"
+                            model={model}
+                            direction="output"
+                        />
                     </div>
                 </div>
             )}
@@ -527,7 +529,7 @@ const MobileMetadataBadges: FC<MobileMetadataBadgesProps> = ({
     }
 
     return (
-        <div className="flex min-w-0 flex-col items-start gap-1.5 overflow-hidden">
+        <div className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-hidden">
             {modalityIcons.length > 0 && (
                 <Badge
                     color="gray"


### PR DESCRIPTION
- Moves mobile model Modalities and Capabilities badges below the API model name on one line.
- Makes expanded mobile model In/Out pricing full width instead of sharing a two-column row.
- Removes duplicate API-key dialog scroll locking and makes create/edit dialogs touch-scrollable on mobile Safari.

Validation:
- `npx biome check --write enter.pollinations.ai/src/client/components/pricing/model-table.tsx`
- `npx biome check --write enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx`
- `npm run typecheck`