### PR TITLE
fix: keep api key dialog scroll inside modal

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -155,11 +155,11 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                     {triggerLabel}
                 </Button>
             </Dialog.Trigger>
-            <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
-            <Dialog.Positioner className="fixed inset-0 z-[100] flex h-dvh touch-pan-y items-start justify-center overflow-y-auto overscroll-contain p-4 [-webkit-overflow-scrolling:touch]">
+            <Dialog.Backdrop className="fixed inset-0 z-[100] bg-green-950/50" />
+            <Dialog.Positioner className="fixed inset-0 z-[110] flex h-dvh items-start justify-center overflow-hidden p-4">
                 <Dialog.Content
                     className={cn(
-                        "border-4 rounded-lg shadow-lg max-w-2xl w-full my-auto",
+                        "my-auto flex max-h-[calc(100dvh-2rem)] w-full max-w-2xl flex-col overflow-hidden rounded-lg border-4 shadow-lg",
                         "bg-white border-green-950",
                     )}
                 >
@@ -190,17 +190,17 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
 
                     <form
                         onSubmit={handleSubmit}
-                        className="flex flex-col flex-1 min-h-0 overflow-hidden"
+                        className="flex min-h-0 flex-1 flex-col"
                     >
-                        {error && (
-                            <div className="px-6 pt-2 pb-4 shrink-0">
-                                <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">
-                                    {error}
-                                </p>
-                            </div>
-                        )}
+                        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-6 pb-2 touch-pan-y [-webkit-overflow-scrolling:touch]">
+                            {error && (
+                                <div className="pb-2">
+                                    <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">
+                                        {error}
+                                    </p>
+                                </div>
+                            )}
 
-                        <div className="px-6 pb-2 space-y-4">
                             <hr className="border-gray-200" />
                             <Field.Root className="flex items-center gap-3">
                                 <Field.Label className="text-sm font-semibold shrink-0">

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -109,12 +109,12 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
 
     return (
         <Dialog.Root open onOpenChange={({ open }) => !open && onClose()}>
-            <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
-            <Dialog.Positioner className="fixed inset-0 z-[100] flex h-dvh touch-pan-y items-start justify-center overflow-y-auto overscroll-contain p-4 [-webkit-overflow-scrolling:touch]">
+            <Dialog.Backdrop className="fixed inset-0 z-[100] bg-green-950/50" />
+            <Dialog.Positioner className="fixed inset-0 z-[110] flex h-dvh items-start justify-center overflow-hidden p-4">
                 <Dialog.Content
                     className={cn(
-                        "border-green-950 border-4 rounded-lg shadow-lg max-w-xl w-full my-auto",
-                        "bg-green-100",
+                        "my-auto flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-lg border-4 shadow-lg",
+                        "bg-green-100 border-green-950",
                     )}
                 >
                     <div className="shrink-0 p-6 pb-4">
@@ -160,7 +160,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                         </div>
                     </div>
 
-                    <div className="p-6 py-4">
+                    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-6 py-4 touch-pan-y [-webkit-overflow-scrolling:touch]">
                         {error && (
                             <Card
                                 color="red"


### PR DESCRIPTION
- Bounds the create/edit API key dialog content to the mobile viewport.
- Moves vertical scrolling from the full-screen positioner into the modal body itself.
- Keeps the dialog header and footer fixed while the permissions/model list scrolls inside the card.

Root cause:
- On iOS, swipes over the expanded Models section could escape the dialog positioner and scroll the page behind the modal.

Validation:
- `npx biome check --write enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx`
- `npm run typecheck`