### PR TITLE
[codex] add usage period picker

### DIFF
--- a/enter.pollinations.ai/src/client/components/usage-analytics/constants.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/constants.ts
@@ -14,7 +14,3 @@ export const ALL_MODELS = [
         type: "image" as const,
     })),
 ];
-
-export const MS_PER_DAY = 86400000;
-export const MS_PER_WEEK = MS_PER_DAY * 7;
-export const MS_PER_30_DAYS = MS_PER_DAY * 30;

--- a/enter.pollinations.ai/src/client/components/usage-analytics/index.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/index.ts
@@ -1,6 +1,7 @@
 export { Chart } from "./chart";
 export { FilterButton } from "./filter-button";
 export { MultiSelect } from "./multi-select";
+export { currentUsagePeriod } from "./period-utils";
 export { Stat } from "./stat";
 export type {
     DailyUsageRecord,
@@ -8,7 +9,7 @@ export type {
     FilterState,
     Metric,
     ModelBreakdown,
-    TimeRange,
+    PeriodGranularity,
+    UsagePeriodSelection,
 } from "./types";
-export { TIME_RANGE_DAYS } from "./types";
 export { UsageGraph } from "./usage-graph";

--- a/enter.pollinations.ai/src/client/components/usage-analytics/period-picker.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/period-picker.tsx
@@ -1,0 +1,287 @@
+import type { FC } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/util.ts";
+import { FilterButton } from "./filter-button.tsx";
+import {
+    addUtcDays,
+    formatPeriodLabel,
+    isUsagePeriodSelectable,
+    periodFromDate,
+    periodToWindow,
+    startOfUtcDay,
+    usageMinDate,
+} from "./period-utils.ts";
+import type { PeriodGranularity, UsagePeriodSelection } from "./types.ts";
+
+type PeriodPickerProps = {
+    value: UsagePeriodSelection;
+    onChange: (value: UsagePeriodSelection) => void;
+};
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const MONTH_LABELS = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+];
+
+function addUtcMonths(date: Date, months: number): Date {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+    );
+}
+
+function monthGridDates(viewMonth: Date): Date[] {
+    const firstDay = new Date(
+        Date.UTC(viewMonth.getUTCFullYear(), viewMonth.getUTCMonth(), 1),
+    );
+    const firstWeekday = firstDay.getUTCDay() || 7;
+    const cursor = addUtcDays(firstDay, 1 - firstWeekday);
+    return Array.from({ length: 42 }, (_, index) => addUtcDays(cursor, index));
+}
+
+function sameUtcDay(left: Date, right: Date): boolean {
+    return left.toISOString().slice(0, 10) === right.toISOString().slice(0, 10);
+}
+
+function periodDate(value: UsagePeriodSelection): Date {
+    return periodToWindow(value).start;
+}
+
+export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
+    const [open, setOpen] = useState(false);
+    const [viewDate, setViewDate] = useState<Date>(() => periodDate(value));
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        setViewDate(periodDate(value));
+    }, [value]);
+
+    useEffect(() => {
+        const handleClick = (event: MouseEvent) => {
+            if (!ref.current?.contains(event.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handleClick);
+        return () => document.removeEventListener("mousedown", handleClick);
+    }, []);
+
+    const dates = useMemo(() => monthGridDates(viewDate), [viewDate]);
+    const selectedWindow = periodToWindow(value);
+    const today = startOfUtcDay();
+    const minDate = usageMinDate();
+    const previousViewDate =
+        value.granularity === "month"
+            ? addUtcMonths(viewDate, -12)
+            : addUtcMonths(viewDate, -1);
+    const nextViewDate =
+        value.granularity === "month"
+            ? addUtcMonths(viewDate, 12)
+            : addUtcMonths(viewDate, 1);
+    const previousDisabled =
+        value.granularity === "month"
+            ? previousViewDate.getUTCFullYear() < minDate.getUTCFullYear()
+            : addUtcMonths(previousViewDate, 1) <= minDate;
+    const nextDisabled =
+        value.granularity === "month"
+            ? nextViewDate.getUTCFullYear() > today.getUTCFullYear()
+            : nextViewDate > today;
+
+    const setGranularity = (granularity: PeriodGranularity) => {
+        onChange(periodFromDate(granularity, periodDate(value)));
+    };
+
+    const selectDate = (date: Date) => {
+        onChange(periodFromDate(value.granularity, date));
+        setOpen(false);
+    };
+
+    const viewLabel =
+        value.granularity === "month"
+            ? String(viewDate.getUTCFullYear())
+            : viewDate.toLocaleDateString("en-US", {
+                  timeZone: "UTC",
+                  month: "long",
+                  year: "numeric",
+              });
+
+    return (
+        <div ref={ref} className="relative flex flex-wrap items-center gap-2">
+            <div className="flex gap-1.5">
+                {(["day", "week", "month"] as PeriodGranularity[]).map(
+                    (granularity) => (
+                        <FilterButton
+                            key={granularity}
+                            active={value.granularity === granularity}
+                            onClick={() => setGranularity(granularity)}
+                        >
+                            {granularity[0].toUpperCase() +
+                                granularity.slice(1)}
+                        </FilterButton>
+                    ),
+                )}
+            </div>
+            <button
+                type="button"
+                onClick={() => setOpen((isOpen) => !isOpen)}
+                className={cn(
+                    "inline-flex min-w-[150px] items-center justify-between gap-2 rounded-full border px-4 py-1.5 text-left text-xs font-medium",
+                    "border-amber-950 bg-white text-amber-950 transition-all duration-200 ease-out hover:bg-amber-50",
+                    open && "bg-amber-50 shadow-sm",
+                )}
+            >
+                <span>{formatPeriodLabel(value)}</span>
+                <svg
+                    aria-hidden="true"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    className={cn(
+                        "shrink-0 transition-transform duration-200 ease-out",
+                        open && "rotate-180",
+                    )}
+                >
+                    <path
+                        d="M3 4.5 6 7.5l3-3"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.5"
+                    />
+                </svg>
+            </button>
+            {open && (
+                <div className="absolute left-0 top-full z-30 mt-2 w-[304px] rounded-xl border border-amber-950 bg-white p-3 shadow-lg transition-opacity duration-200 ease-out">
+                    <div className="mb-3 flex items-center justify-between">
+                        <button
+                            type="button"
+                            disabled={previousDisabled}
+                            onClick={() => setViewDate(previousViewDate)}
+                            className={cn(
+                                "rounded-full px-2 py-1 text-xs font-semibold text-amber-950 transition-colors hover:bg-amber-50",
+                                previousDisabled &&
+                                    "cursor-not-allowed opacity-30 hover:bg-transparent",
+                            )}
+                        >
+                            {"<"}
+                        </button>
+                        <div className="text-sm font-bold text-amber-950">
+                            {viewLabel}
+                        </div>
+                        <button
+                            type="button"
+                            disabled={nextDisabled}
+                            onClick={() => setViewDate(nextViewDate)}
+                            className={cn(
+                                "rounded-full px-2 py-1 text-xs font-semibold text-amber-950 transition-colors hover:bg-amber-50",
+                                nextDisabled &&
+                                    "cursor-not-allowed opacity-30 hover:bg-transparent",
+                            )}
+                        >
+                            {">"}
+                        </button>
+                    </div>
+
+                    {value.granularity === "month" ? (
+                        <div className="grid grid-cols-3 gap-1.5">
+                            {MONTH_LABELS.map((label, monthIndex) => {
+                                const date = new Date(
+                                    Date.UTC(
+                                        viewDate.getUTCFullYear(),
+                                        monthIndex,
+                                        1,
+                                    ),
+                                );
+                                const selectable = isUsagePeriodSelectable(
+                                    periodFromDate("month", date),
+                                );
+                                const selected =
+                                    date.getUTCFullYear() ===
+                                        selectedWindow.start.getUTCFullYear() &&
+                                    date.getUTCMonth() ===
+                                        selectedWindow.start.getUTCMonth();
+                                return (
+                                    <button
+                                        type="button"
+                                        key={label}
+                                        disabled={!selectable}
+                                        onClick={() => selectDate(date)}
+                                        className={cn(
+                                            "rounded-md px-3 py-2 text-xs font-medium transition-colors duration-150",
+                                            selected
+                                                ? "bg-amber-950 text-amber-100"
+                                                : "text-gray-700 hover:bg-amber-50",
+                                            !selectable &&
+                                                "cursor-not-allowed text-gray-300 hover:bg-transparent",
+                                        )}
+                                    >
+                                        {label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <>
+                            <div className="mb-1 grid grid-cols-7 gap-1 text-center text-[10px] font-bold uppercase text-gray-400">
+                                {WEEKDAY_LABELS.map((label) => (
+                                    <div key={label}>{label}</div>
+                                ))}
+                            </div>
+                            <div className="grid grid-cols-7 gap-1">
+                                {dates.map((date) => {
+                                    const inCurrentMonth =
+                                        date.getUTCMonth() ===
+                                        viewDate.getUTCMonth();
+                                    const selectable = isUsagePeriodSelectable(
+                                        periodFromDate(value.granularity, date),
+                                    );
+                                    const selected =
+                                        value.granularity === "day"
+                                            ? sameUtcDay(
+                                                  date,
+                                                  selectedWindow.start,
+                                              )
+                                            : date >= selectedWindow.start &&
+                                              date < selectedWindow.end;
+                                    return (
+                                        <button
+                                            type="button"
+                                            key={date.toISOString()}
+                                            disabled={!selectable}
+                                            onClick={() => selectDate(date)}
+                                            className={cn(
+                                                "aspect-square rounded-md text-xs font-medium transition-colors duration-150",
+                                                !inCurrentMonth &&
+                                                    "text-gray-300",
+                                                sameUtcDay(date, today) &&
+                                                    "ring-1 ring-amber-950/40",
+                                                selected
+                                                    ? "bg-amber-950 text-amber-100"
+                                                    : "text-gray-700 hover:bg-amber-50",
+                                                !selectable &&
+                                                    "cursor-not-allowed text-gray-300 hover:bg-transparent",
+                                            )}
+                                        >
+                                            {date.getUTCDate()}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/enter.pollinations.ai/src/client/components/usage-analytics/period-picker.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/period-picker.tsx
@@ -50,21 +50,37 @@ function monthGridDates(viewMonth: Date): Date[] {
 }
 
 function sameUtcDay(left: Date, right: Date): boolean {
-    return left.toISOString().slice(0, 10) === right.toISOString().slice(0, 10);
+    return left.getTime() === right.getTime();
 }
 
 function periodDate(value: UsagePeriodSelection): Date {
     return periodToWindow(value).start;
 }
 
+function viewBounds(
+    viewDate: Date,
+    granularity: PeriodGranularity,
+): { start: Date; end: Date } {
+    if (granularity === "month") {
+        const start = new Date(Date.UTC(viewDate.getUTCFullYear(), 0, 1));
+        return { start, end: addUtcMonths(start, 12) };
+    }
+
+    const start = new Date(
+        Date.UTC(viewDate.getUTCFullYear(), viewDate.getUTCMonth(), 1),
+    );
+    return { start, end: addUtcMonths(start, 1) };
+}
+
 export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
     const [open, setOpen] = useState(false);
     const [viewDate, setViewDate] = useState<Date>(() => periodDate(value));
     const ref = useRef<HTMLDivElement>(null);
+    const { granularity, period } = value;
 
     useEffect(() => {
-        setViewDate(periodDate(value));
-    }, [value]);
+        setViewDate(periodDate({ granularity, period }));
+    }, [granularity, period]);
 
     useEffect(() => {
         const handleClick = (event: MouseEvent) => {
@@ -75,6 +91,19 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
         document.addEventListener("mousedown", handleClick);
         return () => document.removeEventListener("mousedown", handleClick);
     }, []);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setOpen(false);
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [open]);
 
     const dates = useMemo(() => monthGridDates(viewDate), [viewDate]);
     const selectedWindow = periodToWindow(value);
@@ -88,14 +117,10 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
         value.granularity === "month"
             ? addUtcMonths(viewDate, 12)
             : addUtcMonths(viewDate, 1);
-    const previousDisabled =
-        value.granularity === "month"
-            ? previousViewDate.getUTCFullYear() < minDate.getUTCFullYear()
-            : addUtcMonths(previousViewDate, 1) <= minDate;
-    const nextDisabled =
-        value.granularity === "month"
-            ? nextViewDate.getUTCFullYear() > today.getUTCFullYear()
-            : nextViewDate > today;
+    const previousBounds = viewBounds(previousViewDate, value.granularity);
+    const nextBounds = viewBounds(nextViewDate, value.granularity);
+    const previousDisabled = previousBounds.end <= minDate;
+    const nextDisabled = nextBounds.start > today;
 
     const setGranularity = (granularity: PeriodGranularity) => {
         onChange(periodFromDate(granularity, periodDate(value)));
@@ -133,6 +158,9 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
             </div>
             <button
                 type="button"
+                aria-expanded={open}
+                aria-haspopup="dialog"
+                aria-label={`Select usage period, current ${formatPeriodLabel(value)}`}
                 onClick={() => setOpen((isOpen) => !isOpen)}
                 className={cn(
                     "inline-flex min-w-[150px] items-center justify-between gap-2 rounded-full border px-4 py-1.5 text-left text-xs font-medium",
@@ -162,10 +190,19 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                 </svg>
             </button>
             {open && (
-                <div className="absolute left-0 top-full z-30 mt-2 w-[304px] rounded-xl border border-amber-950 bg-white p-3 shadow-lg transition-opacity duration-200 ease-out">
+                <div
+                    role="dialog"
+                    aria-label="Usage period picker"
+                    className="absolute left-0 top-full z-30 mt-2 w-[304px] rounded-xl border border-amber-950 bg-white p-3 shadow-lg transition-opacity duration-200 ease-out"
+                >
                     <div className="mb-3 flex items-center justify-between">
                         <button
                             type="button"
+                            aria-label={
+                                value.granularity === "month"
+                                    ? "Previous year"
+                                    : "Previous month"
+                            }
                             disabled={previousDisabled}
                             onClick={() => setViewDate(previousViewDate)}
                             className={cn(
@@ -181,6 +218,11 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                         </div>
                         <button
                             type="button"
+                            aria-label={
+                                value.granularity === "month"
+                                    ? "Next year"
+                                    : "Next month"
+                            }
                             disabled={nextDisabled}
                             onClick={() => setViewDate(nextViewDate)}
                             className={cn(
@@ -206,6 +248,14 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                                 const selectable = isUsagePeriodSelectable(
                                     periodFromDate("month", date),
                                 );
+                                const ariaLabel = date.toLocaleDateString(
+                                    "en-US",
+                                    {
+                                        timeZone: "UTC",
+                                        month: "long",
+                                        year: "numeric",
+                                    },
+                                );
                                 const selected =
                                     date.getUTCFullYear() ===
                                         selectedWindow.start.getUTCFullYear() &&
@@ -215,6 +265,7 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                                     <button
                                         type="button"
                                         key={label}
+                                        aria-label={ariaLabel}
                                         disabled={!selectable}
                                         onClick={() => selectDate(date)}
                                         className={cn(
@@ -246,6 +297,19 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                                     const selectable = isUsagePeriodSelectable(
                                         periodFromDate(value.granularity, date),
                                     );
+                                    const ariaLabel =
+                                        value.granularity === "week"
+                                            ? `Select week ${formatPeriodLabel(periodFromDate("week", date))}`
+                                            : `Select ${date.toLocaleDateString(
+                                                  "en-US",
+                                                  {
+                                                      timeZone: "UTC",
+                                                      weekday: "long",
+                                                      month: "long",
+                                                      day: "numeric",
+                                                      year: "numeric",
+                                                  },
+                                              )}`;
                                     const selected =
                                         value.granularity === "day"
                                             ? sameUtcDay(
@@ -258,6 +322,7 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                                         <button
                                             type="button"
                                             key={date.toISOString()}
+                                            aria-label={ariaLabel}
                                             disabled={!selectable}
                                             onClick={() => selectDate(date)}
                                             className={cn(

--- a/enter.pollinations.ai/src/client/components/usage-analytics/period-utils.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/period-utils.ts
@@ -1,0 +1,159 @@
+import type { PeriodGranularity, UsagePeriodSelection } from "./types.ts";
+
+const MS_PER_DAY = 86400000;
+export const USAGE_MIN_DATE = "2026-01-01";
+
+export type UsagePeriodWindow = {
+    start: Date;
+    end: Date;
+};
+
+export function startOfUtcDay(date = new Date()): Date {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+}
+
+export function addUtcDays(date: Date, days: number): Date {
+    const next = new Date(date);
+    next.setUTCDate(next.getUTCDate() + days);
+    return next;
+}
+
+function startOfUtcMonth(date: Date): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function addUtcMonths(date: Date, months: number): Date {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+    );
+}
+
+function startOfUtcIsoWeek(date: Date): Date {
+    const day = date.getUTCDay() || 7;
+    return addUtcDays(startOfUtcDay(date), 1 - day);
+}
+
+function getUtcIsoWeekPeriod(date: Date): string {
+    const day = date.getUTCDay() || 7;
+    const thursday = addUtcDays(startOfUtcDay(date), 4 - day);
+    const isoYear = thursday.getUTCFullYear();
+    const yearStart = new Date(Date.UTC(isoYear, 0, 1));
+    const isoWeek = Math.ceil(
+        ((thursday.getTime() - yearStart.getTime()) / MS_PER_DAY + 1) / 7,
+    );
+    return `${isoYear}-W${String(isoWeek).padStart(2, "0")}`;
+}
+
+function formatUtcDatePeriod(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
+function formatUtcMonthPeriod(date: Date): string {
+    return date.toISOString().slice(0, 7);
+}
+
+export function periodFromDate(
+    granularity: PeriodGranularity,
+    date = new Date(),
+): UsagePeriodSelection {
+    if (granularity === "day") {
+        return {
+            granularity,
+            period: formatUtcDatePeriod(startOfUtcDay(date)),
+        };
+    }
+    if (granularity === "week") {
+        return { granularity, period: getUtcIsoWeekPeriod(date) };
+    }
+    return { granularity, period: formatUtcMonthPeriod(startOfUtcMonth(date)) };
+}
+
+export function currentUsagePeriod(): UsagePeriodSelection {
+    return periodFromDate("day");
+}
+
+export function usageMinDate(): Date {
+    return new Date(`${USAGE_MIN_DATE}T00:00:00.000Z`);
+}
+
+export function periodToWindow(
+    selection: UsagePeriodSelection,
+): UsagePeriodWindow {
+    if (selection.granularity === "day") {
+        const start = new Date(`${selection.period}T00:00:00.000Z`);
+        return { start, end: addUtcDays(start, 1) };
+    }
+
+    if (selection.granularity === "week") {
+        const [yearText, weekText] = selection.period.split("-W");
+        const isoYear = Number(yearText);
+        const isoWeek = Number(weekText);
+        const jan4 = new Date(Date.UTC(isoYear, 0, 4));
+        const start = addUtcDays(startOfUtcIsoWeek(jan4), (isoWeek - 1) * 7);
+        return { start, end: addUtcDays(start, 7) };
+    }
+
+    const [yearText, monthText] = selection.period.split("-");
+    const start = new Date(
+        Date.UTC(Number(yearText), Number(monthText) - 1, 1),
+    );
+    return { start, end: addUtcMonths(start, 1) };
+}
+
+export function formatPeriodLabel(selection: UsagePeriodSelection): string {
+    const { start, end } = periodToWindow(selection);
+
+    if (selection.granularity === "day") {
+        const today = startOfUtcDay();
+        const yesterday = addUtcDays(today, -1);
+        if (start.getTime() === today.getTime()) return "Today";
+        if (start.getTime() === yesterday.getTime()) return "Yesterday";
+        return start.toLocaleDateString("en-US", {
+            timeZone: "UTC",
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+        });
+    }
+
+    if (selection.granularity === "week") {
+        const weekEnd = addUtcDays(end, -1);
+        return `${start.toLocaleDateString("en-US", {
+            timeZone: "UTC",
+            month: "short",
+            day: "numeric",
+        })} - ${weekEnd.toLocaleDateString("en-US", {
+            timeZone: "UTC",
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+        })}`;
+    }
+
+    return start.toLocaleDateString("en-US", {
+        timeZone: "UTC",
+        month: "long",
+        year: "numeric",
+    });
+}
+
+export function getPeriodDates(selection: UsagePeriodSelection): string[] {
+    const { start, end } = periodToWindow(selection);
+    const dates: string[] = [];
+    const cursor = new Date(start);
+    while (cursor < end) {
+        dates.push(formatUtcDatePeriod(cursor));
+        cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+    return dates;
+}
+
+export function isUsagePeriodSelectable(
+    selection: UsagePeriodSelection,
+): boolean {
+    const { start, end } = periodToWindow(selection);
+    const today = startOfUtcDay();
+    return end > usageMinDate() && start <= today;
+}

--- a/enter.pollinations.ai/src/client/components/usage-analytics/types.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/types.ts
@@ -6,16 +6,17 @@ export type DailyUsageRecord = {
     cost_usd: number;
 };
 
-export type TimeRange = "7d" | "30d" | "all";
-export const TIME_RANGE_DAYS: Record<TimeRange, number> = {
-    "7d": 7,
-    "30d": 30,
-    all: 90,
+export type PeriodGranularity = "day" | "week" | "month";
+
+export type UsagePeriodSelection = {
+    granularity: PeriodGranularity;
+    period: string;
 };
+
 export type Metric = "requests" | "pollen";
 
 export type FilterState = {
-    timeRange: TimeRange;
+    period: UsagePeriodSelection;
     metric: Metric;
     selectedKeyIds: string[];
     selectedModels: string[];

--- a/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
@@ -7,7 +7,8 @@ import { Panel } from "../ui/panel.tsx";
 import { Chart } from "./chart";
 import { FilterButton } from "./filter-button";
 import { MultiSelect } from "./multi-select";
-import type { FilterState, Metric, TimeRange } from "./types";
+import { PeriodPicker } from "./period-picker.tsx";
+import type { FilterState, Metric, UsagePeriodSelection } from "./types";
 import { useUsageData } from "./use-usage-data";
 
 const TIER_PILL_CLASSES = {
@@ -22,18 +23,18 @@ const TIER_PILL_CLASSES = {
 
 type UsageGraphProps = {
     tier?: TierStatus;
-    timeRange: TimeRange;
-    onTimeRangeChange: (timeRange: TimeRange) => void;
+    period: UsagePeriodSelection;
+    onPeriodChange: (period: UsagePeriodSelection) => void;
     apiKeys: Array<{ id: string; name: string }>;
 };
 
 export const UsageGraph: FC<UsageGraphProps> = ({
     tier,
-    timeRange,
-    onTimeRangeChange,
+    period,
+    onPeriodChange,
     apiKeys,
 }) => {
-    const [filters, setFilters] = useState<Omit<FilterState, "timeRange">>({
+    const [filters, setFilters] = useState<Omit<FilterState, "period">>({
         metric: "pollen",
         selectedKeyIds: [],
         selectedModels: [],
@@ -55,7 +56,7 @@ export const UsageGraph: FC<UsageGraphProps> = ({
     const { loading, error, fetchUsage, usedModels, chartData, stats } =
         useUsageData({
             ...filters,
-            timeRange,
+            period,
         });
 
     const modelSelectOptions = usedModels.map((m) => ({
@@ -75,19 +76,6 @@ export const UsageGraph: FC<UsageGraphProps> = ({
     const showModelBreakdown =
         filters.selectedModels.length === 0 ||
         filters.selectedModels.length > 1;
-
-    // On mobile, if "all" (90 days) is selected, switch to 30d
-    useEffect(() => {
-        const handleResize = () => {
-            const isMobile = window.innerWidth < 640; // sm breakpoint
-            if (isMobile && timeRange === "all") {
-                onTimeRangeChange("30d");
-            }
-        };
-        handleResize(); // Check on mount
-        window.addEventListener("resize", handleResize);
-        return () => window.removeEventListener("resize", handleResize);
-    }, [onTimeRangeChange, timeRange]);
 
     return (
         <div className="flex flex-col gap-2">
@@ -121,33 +109,12 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                 )}
                 {!loading && !error && (
                     <>
-                        {/* Filters Row 1: Time Range + Metric */}
+                        {/* Filters Row 1: Period + Metric */}
                         <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-                            <div className="flex flex-wrap items-center gap-1.5">
-                                <span className="text-xs font-medium text-gray-500 mr-1">
-                                    Last
-                                </span>
-                                {(["7d", "30d", "all"] as TimeRange[]).map(
-                                    (t) => (
-                                        <FilterButton
-                                            key={t}
-                                            active={timeRange === t}
-                                            onClick={() => onTimeRangeChange(t)}
-                                            className={
-                                                t === "all"
-                                                    ? "hidden sm:inline-flex"
-                                                    : ""
-                                            }
-                                        >
-                                            {t === "7d"
-                                                ? "7 days"
-                                                : t === "30d"
-                                                  ? "30 days"
-                                                  : "90 days"}
-                                        </FilterButton>
-                                    ),
-                                )}
-                            </div>
+                            <PeriodPicker
+                                value={period}
+                                onChange={onPeriodChange}
+                            />
                             <div className="flex gap-1.5 items-center">
                                 <span className="text-xs font-medium text-gray-500 mr-1">
                                     Type

--- a/enter.pollinations.ai/src/client/components/usage-analytics/use-usage-data.ts
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/use-usage-data.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ALL_MODELS, MS_PER_30_DAYS, MS_PER_WEEK } from "./constants";
+import { ALL_MODELS } from "./constants";
+import { getPeriodDates } from "./period-utils.ts";
 import type {
     DailyUsageRecord,
     DataPoint,
     FilterState,
     ModelBreakdown,
 } from "./types";
-import { TIME_RANGE_DAYS } from "./types";
 
 type UsageDataResult = {
     dailyUsage: DailyUsageRecord[];
@@ -33,7 +33,8 @@ export function useUsageData(filters: FilterState): UsageDataResult {
         setLoading(true);
         setError(null);
         const params = new URLSearchParams({
-            days: TIME_RANGE_DAYS[filters.timeRange].toString(),
+            granularity: filters.period.granularity,
+            period: filters.period.period,
         });
         if (filters.selectedKeyIds.length > 0) {
             params.set("api_key_ids", filters.selectedKeyIds.join(","));
@@ -54,31 +55,19 @@ export function useUsageData(filters: FilterState): UsageDataResult {
                 setDailyUsage([]);
             })
             .finally(() => setLoading(false));
-    }, [filters.timeRange, filters.selectedKeyIds]);
+    }, [
+        filters.period.granularity,
+        filters.period.period,
+        filters.selectedKeyIds,
+    ]);
 
     useEffect(() => {
         fetchUsage();
     }, [fetchUsage]);
 
-    const cutoff = useMemo(() => {
-        const now = new Date();
-        return filters.timeRange === "7d"
-            ? new Date(now.getTime() - MS_PER_WEEK)
-            : filters.timeRange === "30d"
-              ? new Date(now.getTime() - MS_PER_30_DAYS)
-              : new Date(0);
-    }, [filters.timeRange]);
-
-    const timeFilteredData = useMemo(() => {
-        return dailyUsage.filter((r) => {
-            const recordDate = new Date(`${r.date}T00:00:00`);
-            return recordDate >= cutoff;
-        });
-    }, [dailyUsage, cutoff]);
-
     const usedModels = useMemo(() => {
         const modelIds = new Set<string>();
-        for (const r of timeFilteredData) {
+        for (const r of dailyUsage) {
             if (r.model) modelIds.add(r.model);
         }
 
@@ -88,12 +77,10 @@ export function useUsageData(filters: FilterState): UsageDataResult {
                 return { id, label: registered?.label || id };
             })
             .sort((a, b) => a.label.localeCompare(b.label));
-    }, [timeFilteredData]);
+    }, [dailyUsage]);
 
     const { chartData, stats, filteredData } = useMemo(() => {
         const filtered = dailyUsage.filter((r: DailyUsageRecord) => {
-            const recordDate = new Date(`${r.date}T00:00:00`);
-            if (recordDate < cutoff) return false;
             if (
                 filters.selectedModels.length > 0 &&
                 r.model &&
@@ -149,25 +136,10 @@ export function useUsageData(filters: FilterState): UsageDataResult {
             buckets.set(dateKey, cur);
         });
 
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        const startDate = new Date(
-            Math.max(
-                cutoff.getTime(),
-                today.getTime() - 90 * 24 * 60 * 60 * 1000,
-            ),
-        );
-        startDate.setHours(0, 0, 0, 0);
-
-        const allDates: string[] = [];
-        const currentDate = new Date(startDate);
-        while (currentDate <= today) {
-            allDates.push(currentDate.toISOString().split("T")[0]);
-            currentDate.setDate(currentDate.getDate() + 1);
-        }
+        const allDates = getPeriodDates(filters.period);
 
         const sorted = allDates.map((dateStr) => {
-            const date = new Date(`${dateStr}T00:00:00`);
+            const date = new Date(`${dateStr}T00:00:00.000Z`);
             const d = buckets.get(dateStr) || {
                 requests: 0,
                 pollen: 0,
@@ -198,10 +170,12 @@ export function useUsageData(filters: FilterState): UsageDataResult {
 
             return {
                 label: date.toLocaleDateString("en-US", {
+                    timeZone: "UTC",
                     month: "short",
                     day: "numeric",
                 }),
                 fullDate: date.toLocaleDateString("en-US", {
+                    timeZone: "UTC",
                     weekday: "short",
                     year: "numeric",
                     month: "short",
@@ -245,7 +219,7 @@ export function useUsageData(filters: FilterState): UsageDataResult {
             },
             filteredData: filtered,
         };
-    }, [dailyUsage, filters.selectedModels, filters.metric, cutoff]);
+    }, [dailyUsage, filters.selectedModels, filters.metric, filters.period]);
 
     return {
         dailyUsage,

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -16,9 +16,9 @@ import { NewsBanner } from "../components/layout/news-banner.tsx";
 import { User } from "../components/layout/user.tsx";
 import { Pricing } from "../components/pricing";
 import {
-    TIME_RANGE_DAYS,
-    type TimeRange,
+    currentUsagePeriod,
     UsageGraph,
+    type UsagePeriodSelection,
 } from "../components/usage-analytics";
 import { createKeyWithPermissions } from "../lib/create-api-key.ts";
 
@@ -78,8 +78,8 @@ function RouteComponent() {
 
     const [isSigningOut, setIsSigningOut] = useState(false);
     const [activeTab, setActiveTab] = useState<"balance" | "usage">("balance");
-    const [usageTimeRange, setUsageTimeRange] = useState<TimeRange>("7d");
-    const usageDays = TIME_RANGE_DAYS[usageTimeRange];
+    const [usagePeriod, setUsagePeriod] =
+        useState<UsagePeriodSelection>(currentUsagePeriod);
 
     const selectableKeys = useMemo(
         () =>
@@ -195,7 +195,8 @@ function RouteComponent() {
     function downloadDetailedUsage(): void {
         const params = new URLSearchParams({
             format: "csv",
-            days: usageDays.toString(),
+            granularity: usagePeriod.granularity,
+            period: usagePeriod.period,
             limit: DETAILED_USAGE_DOWNLOAD_LIMIT.toString(),
         });
         const anchor = document.createElement("a");
@@ -292,8 +293,8 @@ function RouteComponent() {
                     {activeTab === "usage" && (
                         <UsageGraph
                             tier={tierData?.active?.tier}
-                            timeRange={usageTimeRange}
-                            onTimeRangeChange={setUsageTimeRange}
+                            period={usagePeriod}
+                            onPeriodChange={setUsagePeriod}
                             apiKeys={selectableKeys}
                         />
                     )}

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -24,6 +24,9 @@ const USAGE_CHUNK_DAYS = 30;
 const MAX_USAGE_EXPORT_ROWS = 50_000;
 
 const SECONDS_PER_DAY = 86400;
+const USAGE_MIN_DATE = "2026-01-01";
+const PERIOD_GRANULARITIES = ["day", "week", "month"] as const;
+type PeriodGranularity = (typeof PERIOD_GRANULARITIES)[number];
 
 type UsageDebugBindings = CloudflareBindings & {
     USAGE_DEBUG_USER_ID?: string;
@@ -150,6 +153,11 @@ type UsageWindow = {
     until: string;
 };
 
+type UsagePeriod = {
+    granularity?: PeriodGranularity;
+    period?: string;
+};
+
 function buildUsageWindow(days: number): UsageWindow {
     const untilDate = startOfNextUtcDay();
     const sinceDate = addUtcDays(untilDate, -days);
@@ -159,12 +167,143 @@ function buildUsageWindow(days: number): UsageWindow {
     };
 }
 
+function startOfUtcDay(year: number, monthIndex: number, day: number): Date {
+    return new Date(Date.UTC(year, monthIndex, day, 0, 0, 0, 0));
+}
+
+function usageMinDate(): Date {
+    return new Date(`${USAGE_MIN_DATE}T00:00:00.000Z`);
+}
+
+function parseUtcDayPeriod(period: string): UsageWindow | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(period);
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const sinceDate = startOfUtcDay(year, month - 1, day);
+    if (
+        sinceDate.getUTCFullYear() !== year ||
+        sinceDate.getUTCMonth() !== month - 1 ||
+        sinceDate.getUTCDate() !== day
+    ) {
+        return null;
+    }
+    return {
+        since: formatTinybirdDateTime(sinceDate),
+        until: formatTinybirdDateTime(addUtcDays(sinceDate, 1)),
+    };
+}
+
+function parseUtcMonthPeriod(period: string): UsageWindow | null {
+    const match = /^(\d{4})-(\d{2})$/.exec(period);
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const sinceDate = startOfUtcDay(year, month - 1, 1);
+    if (
+        sinceDate.getUTCFullYear() !== year ||
+        sinceDate.getUTCMonth() !== month - 1
+    ) {
+        return null;
+    }
+    const untilDate = startOfUtcDay(year, month, 1);
+    return {
+        since: formatTinybirdDateTime(sinceDate),
+        until: formatTinybirdDateTime(untilDate),
+    };
+}
+
+function parseUtcWeekPeriod(period: string): UsageWindow | null {
+    const match = /^(\d{4})-W(\d{2})$/.exec(period);
+    if (!match) return null;
+    const isoYear = Number(match[1]);
+    const isoWeek = Number(match[2]);
+    if (isoWeek < 1 || isoWeek > 53) return null;
+
+    // ISO week 1 is the week containing Jan 4. Weeks start on Monday.
+    const jan4 = startOfUtcDay(isoYear, 0, 4);
+    const jan4Day = jan4.getUTCDay() || 7;
+    const weekOneMonday = addUtcDays(jan4, 1 - jan4Day);
+    const sinceDate = addUtcDays(weekOneMonday, (isoWeek - 1) * 7);
+
+    if (getUtcIsoWeekPeriod(sinceDate) !== period) return null;
+
+    return {
+        since: formatTinybirdDateTime(sinceDate),
+        until: formatTinybirdDateTime(addUtcDays(sinceDate, 7)),
+    };
+}
+
+function getUtcIsoWeekPeriod(date: Date): string {
+    const utcDate = startOfUtcDay(
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+    );
+    const day = utcDate.getUTCDay() || 7;
+    const thursday = addUtcDays(utcDate, 4 - day);
+    const isoYear = thursday.getUTCFullYear();
+    const yearStart = startOfUtcDay(isoYear, 0, 1);
+    const isoWeek = Math.ceil(
+        ((thursday.getTime() - yearStart.getTime()) / (SECONDS_PER_DAY * 1000) +
+            1) /
+            7,
+    );
+    return `${isoYear}-W${String(isoWeek).padStart(2, "0")}`;
+}
+
+function buildUsageWindowFromPeriod({
+    granularity,
+    period,
+}: UsagePeriod): UsageWindow | null {
+    if (!granularity || !period) return null;
+
+    if (granularity === "day") return parseUtcDayPeriod(period);
+    if (granularity === "week") return parseUtcWeekPeriod(period);
+    return parseUtcMonthPeriod(period);
+}
+
+function resolveUsageWindow(days: number, period: UsagePeriod): UsageWindow {
+    const hasPeriodParam = period.granularity || period.period;
+    const usageWindow = buildUsageWindowFromPeriod(period);
+    if (hasPeriodParam && !usageWindow) {
+        throw new HTTPException(400, {
+            message:
+                "Invalid usage period. Use granularity=day&period=YYYY-MM-DD, granularity=week&period=YYYY-WNN, or granularity=month&period=YYYY-MM.",
+        });
+    }
+    if (usageWindow) {
+        const sinceDate = new Date(`${usageWindow.since.replace(" ", "T")}Z`);
+        const untilDate = new Date(`${usageWindow.until.replace(" ", "T")}Z`);
+        const now = new Date();
+        const today = startOfUtcDay(
+            now.getUTCFullYear(),
+            now.getUTCMonth(),
+            now.getUTCDate(),
+        );
+        if (untilDate <= usageMinDate() || sinceDate > today) {
+            throw new HTTPException(400, {
+                message: `Usage period must overlap ${USAGE_MIN_DATE} through today.`,
+            });
+        }
+    }
+    return usageWindow || buildUsageWindow(days);
+}
+
+function usageWindowFilenamePart(days: number, period: UsagePeriod): string {
+    return period.granularity && period.period
+        ? `${period.granularity}-${period.period}`
+        : `${days}d`;
+}
+
 function buildUsageWindows(
     days: number,
+    period: UsagePeriod = {},
     chunkDays = USAGE_CHUNK_DAYS,
     newestFirst = false,
 ): UsageWindow[] {
-    const overallWindow = buildUsageWindow(days);
+    const overallWindow = resolveUsageWindow(days, period);
     const windows: UsageWindow[] = [];
     let cursor = new Date(`${overallWindow.since.replace(" ", "T")}Z`);
     const end = new Date(`${overallWindow.until.replace(" ", "T")}Z`);
@@ -229,6 +368,8 @@ const usageQuerySchema = z.object({
         .max(MAX_USAGE_DAYS)
         .optional()
         .default(DEFAULT_USAGE_DAYS),
+    granularity: z.enum(PERIOD_GRANULARITIES).optional(),
+    period: z.string().optional(),
 });
 
 // Query params schema for daily usage
@@ -241,6 +382,8 @@ const usageDailyQuerySchema = z.object({
         .max(MAX_USAGE_DAYS)
         .optional()
         .default(DEFAULT_DAILY_USAGE_DAYS),
+    granularity: z.enum(PERIOD_GRANULARITIES).optional(),
+    period: z.string().optional(),
     api_key_ids: z
         .string()
         .optional()
@@ -573,7 +716,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Usage History",
             description:
-                "Returns your request history with per-request details: model used, token counts, cost, and response time. Defaults to the last 30 days, supports up to 90 days via `days`, and supports JSON and CSV export. Each response is capped at 50,000 rows. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.",
+                "Returns your request history with per-request details: model used, token counts, cost, and response time. Defaults to the last 30 days, supports up to 90 days via `days`, or exact day/week/month periods via `granularity` and `period`. Supports JSON and CSV export. Each response is capped at 50,000 rows. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.",
             responses: {
                 200: {
                     description: "Usage records",
@@ -608,10 +751,18 @@ export const accountRoutes = new Hono<Env>()
                 });
             }
 
-            const { format, limit, before, days } = c.req.valid("query");
+            const { format, limit, before, days, granularity, period } =
+                c.req.valid("query");
             const { userId: usageUserId, overridden: usageUserOverridden } =
                 resolveUsageTargetUserId(c.env, user.id, apiKey);
-            const usageWindow = buildUsageWindow(days);
+            const usageWindow = resolveUsageWindow(days, {
+                granularity,
+                period,
+            });
+            const filenamePeriod = usageWindowFilenamePart(days, {
+                granularity,
+                period,
+            });
             const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
             const tinybirdToken = c.env.TINYBIRD_READ_TOKEN;
             const header =
@@ -657,7 +808,7 @@ export const accountRoutes = new Hono<Env>()
                     return new Response(csv, {
                         headers: {
                             "Content-Type": "text/csv",
-                            "Content-Disposition": `attachment; filename="pollinations-usage-latest-${usage.length}-rows-${days}d-${new Date().toISOString().split("T")[0]}.csv"`,
+                            "Content-Disposition": `attachment; filename="pollinations-usage-latest-${usage.length}-rows-${filenamePeriod}-${new Date().toISOString().split("T")[0]}.csv"`,
                         },
                     });
                 }
@@ -678,7 +829,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Daily Usage",
             description:
-                "Returns daily aggregated usage for the requested time window (max 90 days), grouped by date and model. Useful for dashboards and spending analysis. Supports JSON and CSV export. Results are cached for 1 hour. Requires `account:usage` permission when using API keys.",
+                "Returns daily aggregated usage for the requested time window, grouped by date and model. Use `days` for rolling windows or `granularity` and `period` for exact day/week/month periods. Useful for dashboards and spending analysis. Supports JSON and CSV export. Results are cached for 1 hour. Requires `account:usage` permission when using API keys.",
             responses: {
                 200: {
                     description: "Daily usage records aggregated by date/model",
@@ -715,6 +866,8 @@ export const accountRoutes = new Hono<Env>()
             const {
                 format,
                 days,
+                granularity,
+                period,
                 api_key_ids: apiKeyIds,
             } = c.req.valid("query");
             const { userId: usageUserId, overridden: usageUserOverridden } =
@@ -725,8 +878,14 @@ export const accountRoutes = new Hono<Env>()
             const cacheKeyPrefix = usageUserOverridden
                 ? `usage:daily:debug:${usageUserId}`
                 : `usage:daily:${usageUserId}`;
-            const cacheKey = `${cacheKeyPrefix}:${days}:${apiKeyIds.length > 0 ? `keys:${apiKeyIds.join(",")}` : "all"}`;
-            const windows = buildUsageWindows(days);
+            const periodCacheKey =
+                granularity && period ? `${granularity}:${period}` : `${days}d`;
+            const filenamePeriod = usageWindowFilenamePart(days, {
+                granularity,
+                period,
+            });
+            const cacheKey = `${cacheKeyPrefix}:${periodCacheKey}:${apiKeyIds.length > 0 ? `keys:${apiKeyIds.join(",")}` : "all"}`;
+            const windows = buildUsageWindows(days, { granularity, period });
 
             try {
                 let usage: DailyUsageRecord[] | null = null;
@@ -793,7 +952,7 @@ export const accountRoutes = new Hono<Env>()
                     return new Response(csv, {
                         headers: {
                             "Content-Type": "text/csv",
-                            "Content-Disposition": `attachment; filename="pollinations-usage-daily-${days}d-${new Date().toISOString().split("T")[0]}.csv"`,
+                            "Content-Disposition": `attachment; filename="pollinations-usage-daily-${filenamePeriod}-${new Date().toISOString().split("T")[0]}.csv"`,
                         },
                     });
                 }
@@ -1207,8 +1366,16 @@ export const accountRoutes = new Hono<Env>()
             }
             const user = c.var.auth.requireUser();
 
-            const { format, limit, before, days } = c.req.valid("query");
-            const usageWindow = buildUsageWindow(days);
+            const { format, limit, before, days, granularity, period } =
+                c.req.valid("query");
+            const usageWindow = resolveUsageWindow(days, {
+                granularity,
+                period,
+            });
+            const filenamePeriod = usageWindowFilenamePart(days, {
+                granularity,
+                period,
+            });
             const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
             const tinybirdToken = c.env.TINYBIRD_READ_TOKEN;
             const header =
@@ -1241,7 +1408,7 @@ export const accountRoutes = new Hono<Env>()
                     return new Response(csv, {
                         headers: {
                             "Content-Type": "text/csv",
-                            "Content-Disposition": `attachment; filename="pollinations-key-usage-${usage.length}-rows-${days}d-${new Date().toISOString().split("T")[0]}.csv"`,
+                            "Content-Disposition": `attachment; filename="pollinations-key-usage-${usage.length}-rows-${filenamePeriod}-${new Date().toISOString().split("T")[0]}.csv"`,
                         },
                     });
                 }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -153,18 +153,27 @@ type UsageWindow = {
     until: string;
 };
 
+type UsageWindowDates = {
+    sinceDate: Date;
+    untilDate: Date;
+};
+
 type UsagePeriod = {
     granularity?: PeriodGranularity;
     period?: string;
 };
 
-function buildUsageWindow(days: number): UsageWindow {
+function formatUsageWindow(window: UsageWindowDates): UsageWindow {
+    return {
+        since: formatTinybirdDateTime(window.sinceDate),
+        until: formatTinybirdDateTime(window.untilDate),
+    };
+}
+
+function buildUsageWindow(days: number): UsageWindowDates {
     const untilDate = startOfNextUtcDay();
     const sinceDate = addUtcDays(untilDate, -days);
-    return {
-        since: formatTinybirdDateTime(sinceDate),
-        until: formatTinybirdDateTime(untilDate),
-    };
+    return { sinceDate, untilDate };
 }
 
 function startOfUtcDay(year: number, monthIndex: number, day: number): Date {
@@ -175,7 +184,7 @@ function usageMinDate(): Date {
     return new Date(`${USAGE_MIN_DATE}T00:00:00.000Z`);
 }
 
-function parseUtcDayPeriod(period: string): UsageWindow | null {
+function parseUtcDayPeriod(period: string): UsageWindowDates | null {
     const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(period);
     if (!match) return null;
     const year = Number(match[1]);
@@ -189,13 +198,10 @@ function parseUtcDayPeriod(period: string): UsageWindow | null {
     ) {
         return null;
     }
-    return {
-        since: formatTinybirdDateTime(sinceDate),
-        until: formatTinybirdDateTime(addUtcDays(sinceDate, 1)),
-    };
+    return { sinceDate, untilDate: addUtcDays(sinceDate, 1) };
 }
 
-function parseUtcMonthPeriod(period: string): UsageWindow | null {
+function parseUtcMonthPeriod(period: string): UsageWindowDates | null {
     const match = /^(\d{4})-(\d{2})$/.exec(period);
     if (!match) return null;
     const year = Number(match[1]);
@@ -208,13 +214,10 @@ function parseUtcMonthPeriod(period: string): UsageWindow | null {
         return null;
     }
     const untilDate = startOfUtcDay(year, month, 1);
-    return {
-        since: formatTinybirdDateTime(sinceDate),
-        until: formatTinybirdDateTime(untilDate),
-    };
+    return { sinceDate, untilDate };
 }
 
-function parseUtcWeekPeriod(period: string): UsageWindow | null {
+function parseUtcWeekPeriod(period: string): UsageWindowDates | null {
     const match = /^(\d{4})-W(\d{2})$/.exec(period);
     if (!match) return null;
     const isoYear = Number(match[1]);
@@ -229,10 +232,7 @@ function parseUtcWeekPeriod(period: string): UsageWindow | null {
 
     if (getUtcIsoWeekPeriod(sinceDate) !== period) return null;
 
-    return {
-        since: formatTinybirdDateTime(sinceDate),
-        until: formatTinybirdDateTime(addUtcDays(sinceDate, 7)),
-    };
+    return { sinceDate, untilDate: addUtcDays(sinceDate, 7) };
 }
 
 function getUtcIsoWeekPeriod(date: Date): string {
@@ -256,15 +256,21 @@ function getUtcIsoWeekPeriod(date: Date): string {
 function buildUsageWindowFromPeriod({
     granularity,
     period,
-}: UsagePeriod): UsageWindow | null {
+}: UsagePeriod): UsageWindowDates | null {
     if (!granularity || !period) return null;
 
     if (granularity === "day") return parseUtcDayPeriod(period);
     if (granularity === "week") return parseUtcWeekPeriod(period);
-    return parseUtcMonthPeriod(period);
+    if (granularity === "month") return parseUtcMonthPeriod(period);
+
+    granularity satisfies never;
+    return null;
 }
 
-function resolveUsageWindow(days: number, period: UsagePeriod): UsageWindow {
+function resolveUsageWindow(
+    days: number,
+    period: UsagePeriod,
+): UsageWindowDates {
     const hasPeriodParam = period.granularity || period.period;
     const usageWindow = buildUsageWindowFromPeriod(period);
     if (hasPeriodParam && !usageWindow) {
@@ -274,15 +280,16 @@ function resolveUsageWindow(days: number, period: UsagePeriod): UsageWindow {
         });
     }
     if (usageWindow) {
-        const sinceDate = new Date(`${usageWindow.since.replace(" ", "T")}Z`);
-        const untilDate = new Date(`${usageWindow.until.replace(" ", "T")}Z`);
         const now = new Date();
         const today = startOfUtcDay(
             now.getUTCFullYear(),
             now.getUTCMonth(),
             now.getUTCDate(),
         );
-        if (untilDate <= usageMinDate() || sinceDate > today) {
+        if (
+            usageWindow.untilDate <= usageMinDate() ||
+            usageWindow.sinceDate > today
+        ) {
             throw new HTTPException(400, {
                 message: `Usage period must overlap ${USAGE_MIN_DATE} through today.`,
             });
@@ -305,16 +312,15 @@ function buildUsageWindows(
 ): UsageWindow[] {
     const overallWindow = resolveUsageWindow(days, period);
     const windows: UsageWindow[] = [];
-    let cursor = new Date(`${overallWindow.since.replace(" ", "T")}Z`);
-    const end = new Date(`${overallWindow.until.replace(" ", "T")}Z`);
+    let cursor = overallWindow.sinceDate;
+    const end = overallWindow.untilDate;
 
     while (cursor < end) {
         const next = addUtcDays(cursor, chunkDays);
         const boundedNext = next < end ? next : end;
-        windows.push({
-            since: formatTinybirdDateTime(cursor),
-            until: formatTinybirdDateTime(boundedNext),
-        });
+        windows.push(
+            formatUsageWindow({ sinceDate: cursor, untilDate: boundedNext }),
+        );
         cursor = boundedNext;
     }
 
@@ -755,10 +761,12 @@ export const accountRoutes = new Hono<Env>()
                 c.req.valid("query");
             const { userId: usageUserId, overridden: usageUserOverridden } =
                 resolveUsageTargetUserId(c.env, user.id, apiKey);
-            const usageWindow = resolveUsageWindow(days, {
-                granularity,
-                period,
-            });
+            const usageWindow = formatUsageWindow(
+                resolveUsageWindow(days, {
+                    granularity,
+                    period,
+                }),
+            );
             const filenamePeriod = usageWindowFilenamePart(days, {
                 granularity,
                 period,
@@ -1368,10 +1376,12 @@ export const accountRoutes = new Hono<Env>()
 
             const { format, limit, before, days, granularity, period } =
                 c.req.valid("query");
-            const usageWindow = resolveUsageWindow(days, {
-                granularity,
-                period,
-            });
+            const usageWindow = formatUsageWindow(
+                resolveUsageWindow(days, {
+                    granularity,
+                    period,
+                }),
+            );
             const filenamePeriod = usageWindowFilenamePart(days, {
                 granularity,
                 period,

--- a/enter.pollinations.ai/test/account-usage.test.ts
+++ b/enter.pollinations.ai/test/account-usage.test.ts
@@ -54,6 +54,61 @@ test("GET /api/account/usage/daily forwards api_key_ids filter to the pipe", asy
     expect(dailyCalls[0].query.until).toMatch(/^\d{4}-\d{2}-\d{2}/);
 });
 
+test("GET /api/account/usage/daily maps selected periods to exact windows", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    const day = await SELF.fetch(
+        "http://localhost:3000/api/account/usage/daily?granularity=day&period=2026-04-24",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(day.status).toBe(200);
+
+    const week = await SELF.fetch(
+        "http://localhost:3000/api/account/usage/daily?granularity=week&period=2026-W17",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(week.status).toBe(200);
+
+    const month = await SELF.fetch(
+        "http://localhost:3000/api/account/usage/daily?granularity=month&period=2026-04",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(month.status).toBe(200);
+
+    const dailyCalls = mocks.tinybird.state.pipeCalls.filter((call) =>
+        call.url.includes("user_usage_daily_filtered.json"),
+    );
+    expect(dailyCalls).toHaveLength(3);
+    expect(dailyCalls[0].query.since).toBe("2026-04-24 00:00:00");
+    expect(dailyCalls[0].query.until).toBe("2026-04-25 00:00:00");
+    expect(dailyCalls[1].query.since).toBe("2026-04-20 00:00:00");
+    expect(dailyCalls[1].query.until).toBe("2026-04-27 00:00:00");
+    expect(dailyCalls[2].query.since).toBe("2026-04-01 00:00:00");
+    expect(dailyCalls[2].query.until).toBe("2026-05-01 00:00:00");
+});
+
+test("GET /api/account/usage/daily rejects periods outside supported bounds", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    const beforeUsage = await SELF.fetch(
+        "http://localhost:3000/api/account/usage/daily?granularity=day&period=2025-12-31",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(beforeUsage.status).toBe(400);
+
+    const future = await SELF.fetch(
+        "http://localhost:3000/api/account/usage/daily?granularity=day&period=2026-05-01",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(future.status).toBe(400);
+});
+
 test("GET /api/account/usage?format=csv renders rows and sets filename from limit", async ({
     sessionToken,
     mocks,


### PR DESCRIPTION
- Replaces rolling usage range buttons with a Day/Week/Month calendar period picker.
- Adds backend support for exact `granularity` + `period` usage windows while keeping existing `days` behavior.
- Clamps selectable periods to `2026-01-01` through today and rejects out-of-bounds exact period requests.
- Updates CSV downloads to use the selected period.

Validation:
- `npm run typecheck`
- `npm run test -- account-usage.test.ts`