### PR TITLE
[codex] switch social images to gpt-image-2

### DIFF
--- a/social/README.md
+++ b/social/README.md
@@ -12,7 +12,7 @@ See [PIPELINE.md](PIPELINE.md) for the full design document (architecture, data 
 | **Weekly** | Buffer (scheduled) | Buffer (scheduled) | Buffer (scheduled) | VPS deploy | Webhook |
 | **Review** | Yes (daily PR) | Yes (weekly PR) | Yes (daily PR) | Yes (daily PR) | No (automatic) |
 | **Images** | 1 per post | 1 per post | up to 3 carousel | 1 per post | 1 per PR |
-| **Model** | `nanobanana-2` | `nanobanana-2` | `nanobanana-2` | `nanobanana-2` | `nanobanana-2` |
+| **Model** | `gpt-image-2` | `gpt-image-2` | `gpt-image-2` | `gpt-image-2` | `gpt-image-2` |
 
 ## Delivery Schedule
 

--- a/social/prompts/brand/visual.md
+++ b/social/prompts/brand/visual.md
@@ -82,7 +82,7 @@ The pollinations.ai bee MUST appear in every image, interacting with the scene.
 - Flat corporate vectors or sterile grids
 - Realistic photos
 
-## Image Model: nanobanana-2
+## Image Model: gpt-image-2
 
 - CONTEXTUAL UNDERSTANDING — it gets nuance
 - TEXT IN IMAGES — use simple pixel-style text sparingly

--- a/social/scripts/common.py
+++ b/social/scripts/common.py
@@ -22,7 +22,7 @@ POLLINATIONS_IMAGE_BASE = "https://gen.pollinations.ai/image"
 
 # Models - single source of truth for all social scripts
 MODEL = "gemini-large"  # Text generation model
-IMAGE_MODEL = "nanobanana-2"  # Image generation model
+IMAGE_MODEL = "gpt-image-2"  # Image generation model
 WEBSEARCH_MODEL = "perplexity-reasoning"  # Web search model (used by Instagram)
 
 # Limits and retry settings


### PR DESCRIPTION
- Updates the social news image generation default to `gpt-image-2`.
- Aligns `social/README.md` and the shared visual prompt model label with the new default.
- Leaves generated test images and endpoint investigation artifacts out of the PR.

Validation:
- `git diff --check -- social/scripts/common.py social/prompts/brand/visual.md social/README.md`
- `npx biome check --write social/README.md social/prompts/brand/visual.md` was attempted, but these Markdown paths are ignored by the repo Biome config.

Note:
- Endpoint investigation found `gpt-image-2` can return Azure 500s on longer social prompts; keeping this as draft for follow-up.