### PR TITLE
fix: align Azure GPT Image pricing

### DIFF
--- a/enter.pollinations.ai/test/track-image.test.ts
+++ b/enter.pollinations.ai/test/track-image.test.ts
@@ -87,9 +87,9 @@ test("gptimage-large should calculate costs for text input tokens", () => {
         promptTextTokens: 1000,
     };
     const cost = calculateCost("gptimage-large", usage);
-    // $8 per 1M tokens = $0.008 per 1K tokens
-    expect(cost.promptTextTokens).toBeCloseTo(0.008, 4);
-    expect(cost.totalCost).toBeCloseTo(0.008, 4);
+    // $5 per 1M tokens = $0.005 per 1K tokens
+    expect(cost.promptTextTokens).toBeCloseTo(0.005, 4);
+    expect(cost.totalCost).toBeCloseTo(0.005, 4);
 });
 
 test("gptimage-large should calculate costs for image input tokens", () => {
@@ -102,16 +102,28 @@ test("gptimage-large should calculate costs for image input tokens", () => {
     expect(cost.totalCost).toBeCloseTo(0.008, 4);
 });
 
-test("gptimage-large combined input + output costs", () => {
+test("gptimage-large should calculate costs for text output tokens", () => {
+    const usage: Usage = {
+        completionTextTokens: 1000,
+    };
+    const cost = calculateCost("gptimage-large", usage);
+    // $10 per 1M tokens = $0.01 per 1K tokens
+    expect(cost.completionTextTokens).toBeCloseTo(0.01, 4);
+    expect(cost.totalCost).toBeCloseTo(0.01, 4);
+});
+
+test("gptimage-large combined text/image input + output costs", () => {
     const usage: Usage = {
         promptTextTokens: 500,
         promptImageTokens: 3000, // Typical resized input ~3K tokens
+        completionTextTokens: 200,
         completionImageTokens: 1000,
     };
     const cost = calculateCost("gptimage-large", usage);
-    // Input: 500*$8/1M + 3000*$8/1M = $0.028
+    // Input: 500*$5/1M + 3000*$8/1M = $0.0265
+    // Text output: 200*$10/1M = $0.002
     // Output: 1000*$32/1M = $0.032
-    expect(cost.totalCost).toBeCloseTo(0.06, 4);
+    expect(cost.totalCost).toBeCloseTo(0.0605, 4);
 });
 
 test("nanobanana models calculate reasoning token costs", () => {

--- a/image.pollinations.ai/src/createAndReturnImages.ts
+++ b/image.pollinations.ai/src/createAndReturnImages.ts
@@ -61,6 +61,24 @@ type ScaledDimensions = {
     scalingFactor: number;
 };
 
+type AzureGPTImageTokenDetails = {
+    cached_tokens?: number;
+    image_tokens?: number;
+    text_tokens?: number;
+};
+
+type AzureGPTImageUsage = {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    prompt_tokens_details?: AzureGPTImageTokenDetails;
+    completion_tokens_details?: AzureGPTImageTokenDetails;
+    input_tokens?: number;
+    output_tokens?: number;
+    input_tokens_details?: AzureGPTImageTokenDetails;
+    output_tokens_details?: AzureGPTImageTokenDetails;
+};
+
 export type ImageGenerationResult = {
     buffer: Buffer;
     isMature: boolean;
@@ -79,6 +97,59 @@ export type AuthResult = {
     username: string | null;
     debugInfo: object;
 };
+
+function safeTokenCount(value: unknown): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function mapAzureGPTImageUsage(
+    usage: AzureGPTImageUsage | undefined,
+    separateCompletionTextTokens: boolean,
+) {
+    const promptTokens =
+        safeTokenCount(usage?.prompt_tokens) ||
+        safeTokenCount(usage?.input_tokens);
+    const completionTokens =
+        safeTokenCount(usage?.completion_tokens) ||
+        safeTokenCount(usage?.output_tokens) ||
+        safeTokenCount(usage?.total_tokens);
+
+    const promptDetails =
+        usage?.prompt_tokens_details || usage?.input_tokens_details;
+    const completionDetails =
+        usage?.completion_tokens_details || usage?.output_tokens_details;
+
+    const promptCachedTokens = safeTokenCount(promptDetails?.cached_tokens);
+    const promptImageTokens = safeTokenCount(promptDetails?.image_tokens);
+    const promptTextTokens =
+        safeTokenCount(promptDetails?.text_tokens) ||
+        Math.max(promptTokens - promptCachedTokens - promptImageTokens, 0);
+
+    const completionTextTokens = separateCompletionTextTokens
+        ? safeTokenCount(completionDetails?.text_tokens)
+        : 0;
+    const completionImageTokens =
+        safeTokenCount(completionDetails?.image_tokens) ||
+        Math.max(completionTokens - completionTextTokens, 0) ||
+        1;
+
+    const totalTokenCount =
+        safeTokenCount(usage?.total_tokens) ||
+        promptTextTokens +
+            promptCachedTokens +
+            promptImageTokens +
+            completionTextTokens +
+            completionImageTokens;
+
+    return {
+        promptTextTokens,
+        promptCachedTokens,
+        promptImageTokens,
+        completionTextTokens,
+        completionImageTokens,
+        totalTokenCount,
+    };
+}
 
 /**
  * Calculates scaled dimensions while maintaining aspect ratio
@@ -596,18 +667,14 @@ const callAzureGPTImageWithEndpoint = async (
     // Convert base64 to buffer
     const imageBuffer = Buffer.from(data.data[0].b64_json, "base64");
 
-    // Extract token usage from Azure OpenAI response
-    // Azure returns usage in format: { prompt_tokens, completion_tokens, total_tokens }
-    // Log full usage breakdown for debugging high token counts
-    logCloudflare(
-        `GPT Image full usage: prompt_tokens=${data.usage?.prompt_tokens}, completion_tokens=${data.usage?.completion_tokens}, total_tokens=${data.usage?.total_tokens}`,
+    const usage = mapAzureGPTImageUsage(
+        data.usage,
+        config.modelName === "gpt-image-1.5",
     );
 
-    const outputTokens =
-        data.usage?.completion_tokens || data.usage?.total_tokens || 1;
-
+    logCloudflare("GPT Image full usage:", data.usage);
     logCloudflare(
-        `GPT Image token usage: ${outputTokens} completion tokens (used for billing)`,
+        `GPT Image billable usage: promptText=${usage.promptTextTokens}, promptCached=${usage.promptCachedTokens}, promptImage=${usage.promptImageTokens}, completionText=${usage.completionTextTokens}, completionImage=${usage.completionImageTokens}`,
     );
 
     // Azure doesn't provide content safety information directly, so we'll set defaults
@@ -618,10 +685,7 @@ const callAzureGPTImageWithEndpoint = async (
         isChild: false, // Default assumption
         trackingData: {
             actualModel: safeParams.model,
-            usage: {
-                completionImageTokens: outputTokens,
-                totalTokenCount: outputTokens,
-            },
+            usage,
         },
     };
 };

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -191,6 +191,7 @@ export const IMAGE_SERVICES = {
                 promptTextTokens: perMillion(5), // per 1M tokens
                 promptCachedTokens: perMillion(1.25), // per 1M tokens
                 promptImageTokens: perMillion(8), // per 1M tokens
+                completionTextTokens: perMillion(10), // per 1M tokens
                 completionImageTokens: perMillion(32), // per 1M tokens
             },
         ],


### PR DESCRIPTION
- Adds Azure GPT Image 1.5 text output cost at the Global meter rate.
- Splits Azure GPT Image usage details into text/image prompt and completion buckets when available.
- Updates focused billing tests for GPT Image 1.5 text input/output and combined costs.

Validation:
- `npx biome check --write shared/registry/image.ts image.pollinations.ai/src/createAndReturnImages.ts enter.pollinations.ai/test/track-image.test.ts`
- `npx vitest run test/track-image.test.ts`