### PR TITLE
feat(enter): restore tier + nextResetAt on /account/profile

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -9,11 +9,23 @@ import {
     user as userTable,
 } from "@/db/schema/better-auth.ts";
 import type { ApiKeyType } from "@/db/schema/event.ts";
+import { getTierCadence, tierNames } from "@/tier-config.ts";
 import { sanitizeAuthorizeAccountPermissions } from "../client/lib/authorize-config.ts";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import { validator } from "../middleware/validator.ts";
 import { parseMetadata } from "./metadata-utils.ts";
+
+// Calculate next tier refill time (null for tiers with no refill).
+// Matches the `0 * * * *` cron in wrangler.toml — top of the next UTC hour.
+function getNextRefillAt(tier?: string | null): string | null {
+    const cadence = tier ? getTierCadence(tier) : "none";
+    if (cadence === "none") return null;
+    const next = new Date();
+    next.setUTCMinutes(0, 0, 0);
+    next.setUTCHours(next.getUTCHours() + 1);
+    return next.toISOString();
+}
 
 // Cache TTL in seconds
 const CACHE_TTL = 60 * 60; // 1 hour
@@ -524,6 +536,15 @@ const profileResponseSchema = z.object({
         .string()
         .nullable()
         .describe("Profile picture URL (e.g. GitHub avatar)"),
+    tier: z
+        .enum(["anonymous", ...tierNames])
+        .describe("User's current tier level"),
+    nextResetAt: z.iso
+        .datetime()
+        .nullable()
+        .describe(
+            "Next pollen refill timestamp (ISO 8601). `null` for tiers with no refill.",
+        ),
     name: z
         .string()
         .nullable()
@@ -603,7 +624,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Profile",
             description:
-                "Returns your account profile. GitHub username and profile image are always returned. Name and email are returned only when the API key has the `account:profile` permission.",
+                "Returns your account profile. GitHub username, profile image, current tier, and next pollen refill timestamp are always returned. Name and email are returned only when the API key has the `account:profile` permission.",
             responses: {
                 200: {
                     description: "User profile",
@@ -628,6 +649,7 @@ export const accountRoutes = new Hono<Env>()
                 .select({
                     githubUsername: userTable.githubUsername,
                     image: userTable.image,
+                    tier: userTable.tier,
                     name: userTable.name,
                     email: userTable.email,
                 })
@@ -643,6 +665,8 @@ export const accountRoutes = new Hono<Env>()
             return c.json({
                 githubUsername: profile.githubUsername ?? null,
                 image: profile.image ?? null,
+                tier: profile.tier,
+                nextResetAt: getNextRefillAt(profile.tier),
                 ...(includeProfilePII && {
                     name: profile.name ?? null,
                     email: profile.email ?? null,

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -346,7 +346,7 @@ function generateLLMDoc(): string {
 
     lines.push("### GET /api/account/profile");
     lines.push(
-        "Returns user profile. `githubUsername` and `image` are always included. `name` and `email` are included only when the API key has the `account:profile` permission.",
+        "Returns user profile. `githubUsername`, `image`, `tier`, and `nextResetAt` are always included. `name` and `email` are included only when the API key has the `account:profile` permission. `nextResetAt` is `null` for tiers with no hourly refill.",
     );
     lines.push("");
 

--- a/enter.pollinations.ai/test/integration/account-profile.test.ts
+++ b/enter.pollinations.ai/test/integration/account-profile.test.ts
@@ -3,7 +3,7 @@ import { describe, expect } from "vitest";
 import { test } from "../fixtures.ts";
 
 describe("GET /api/account/profile", () => {
-    test("session auth returns githubUsername, image, name, email", async ({
+    test("session auth returns githubUsername, image, tier, nextResetAt, name, email", async ({
         sessionToken,
     }) => {
         const response = await SELF.fetch(
@@ -19,11 +19,13 @@ describe("GET /api/account/profile", () => {
         const data = (await response.json()) as Record<string, unknown>;
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
+        expect(data).toHaveProperty("tier");
+        expect(data).toHaveProperty("nextResetAt");
         expect(data).toHaveProperty("name");
         expect(data).toHaveProperty("email");
     });
 
-    test("api key without profile scope returns only githubUsername + image", async ({
+    test("api key without profile scope returns githubUsername, image, tier, nextResetAt (no name/email)", async ({
         apiKey,
     }) => {
         const response = await SELF.fetch(
@@ -35,6 +37,8 @@ describe("GET /api/account/profile", () => {
         const data = (await response.json()) as Record<string, unknown>;
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
+        expect(data).toHaveProperty("tier");
+        expect(data).toHaveProperty("nextResetAt");
         expect(data).not.toHaveProperty("name");
         expect(data).not.toHaveProperty("email");
     });
@@ -85,6 +89,8 @@ describe("GET /api/account/profile", () => {
         const data = (await response.json()) as Record<string, unknown>;
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
+        expect(data).toHaveProperty("tier");
+        expect(data).toHaveProperty("nextResetAt");
         expect(data).toHaveProperty("name");
         expect(data).toHaveProperty("email");
     });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -594,6 +594,10 @@ export interface AuthorizeOptions {
 export interface AccountProfile {
     githubUsername: string | null;
     image: string | null;
+    /** Current tier level (e.g. `"spore"`, `"seed"`, `"flower"`, `"nectar"`). */
+    tier: string;
+    /** ISO 8601 timestamp of the next pollen refill. `null` for tiers with no refill. */
+    nextResetAt: string | null;
     /** Only returned when the API key has the `profile` permission */
     name?: string | null;
     /** Only returned when the API key has the `profile` permission */


### PR DESCRIPTION
## Summary
- Always return `tier` and `nextResetAt` from `/account/profile` alongside `githubUsername` + `image` (no new scope needed — quota metadata, not PII)
- Restores the pre-#10255 `getNextRefillAt()` helper: top of next UTC hour, `null` for tiers with no refill (matches `0 * * * *` cron)
- Unblocks third-party apps (e.g. [opencode-pollinations-plugin](https://www.npmjs.com/package/opencode-pollinations-plugin), 20k+ downloads) that need tier info for quota display — there is currently no `sk_`-accessible surface exposing tier

#10255 also removed `name`/`email` (still scope-gated behind `account:profile`) and `createdAt` (not restored here — genuinely profile-only). Also note: the `user_tier` field defined in the OpenAI chat completion Zod schema is never populated — this PR is the alternative path instead of wiring that up.

## Test plan
- [x] `npx vitest run test/integration/account-profile.test.ts` — 3/3 pass (extended both scoped and unscoped cases to assert `tier` + `nextResetAt`)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean on touched files
- [ ] After deploy, run `npm run docs:generate` from `enter.pollinations.ai` to refresh `APIDOCS.md` from the live OpenAPI schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)