### PR TITLE
refactor(enter): centralize upstream error capture, keep full bodies

### DIFF
--- a/enter.pollinations.ai/src/error.ts
+++ b/enter.pollinations.ai/src/error.ts
@@ -45,10 +45,11 @@ export async function ensureUpstreamOk(
 ): Promise<Response> {
     if (response.ok) return response;
     const responseBody = await response.text();
+    const rawMessage =
+        extractUpstreamMessage(responseBody) ||
+        getDefaultErrorMessage(response.status);
     throw new UpstreamError(remapUpstreamStatus(response.status), {
-        message:
-            extractUpstreamMessage(responseBody) ||
-            getDefaultErrorMessage(response.status),
+        message: truncateString(rawMessage, MAX_ERROR_MESSAGE_LENGTH) ?? "",
         requestUrl:
             typeof requestUrl === "string" ? new URL(requestUrl) : requestUrl,
         upstreamStatus: response.status,

--- a/enter.pollinations.ai/src/error.ts
+++ b/enter.pollinations.ai/src/error.ts
@@ -39,6 +39,20 @@ export class UpstreamError extends HTTPException {
     }
 }
 
+export async function ensureUpstreamOk(
+    response: Response,
+    requestUrl: URL,
+): Promise<Response> {
+    if (response.ok) return response;
+    const responseBody = await response.text();
+    throw new UpstreamError(remapUpstreamStatus(response.status), {
+        message: responseBody || getDefaultErrorMessage(response.status),
+        requestUrl,
+        upstreamStatus: response.status,
+        responseBody,
+    });
+}
+
 const GenericErrorDetailsSchema = z
     .object({
         name: z.string(),
@@ -124,9 +138,9 @@ type ServerErrorEnvelope = {
     apiKeyId?: string;
 };
 
-const MAX_ERROR_MESSAGE_LENGTH = 2000;
+const MAX_ERROR_MESSAGE_LENGTH = 4000;
 const MAX_STACK_LENGTH = 12000;
-const MAX_UPSTREAM_BODY_LENGTH = 4000;
+const MAX_UPSTREAM_BODY_LENGTH = 16000;
 
 export const handleError: ErrorHandler<Env> = async (err, c) => {
     const log = c.get("log");

--- a/enter.pollinations.ai/src/error.ts
+++ b/enter.pollinations.ai/src/error.ts
@@ -41,16 +41,34 @@ export class UpstreamError extends HTTPException {
 
 export async function ensureUpstreamOk(
     response: Response,
-    requestUrl: URL,
+    requestUrl: string | URL,
 ): Promise<Response> {
     if (response.ok) return response;
     const responseBody = await response.text();
     throw new UpstreamError(remapUpstreamStatus(response.status), {
-        message: responseBody || getDefaultErrorMessage(response.status),
-        requestUrl,
+        message:
+            extractUpstreamMessage(responseBody) ||
+            getDefaultErrorMessage(response.status),
+        requestUrl:
+            typeof requestUrl === "string" ? new URL(requestUrl) : requestUrl,
         upstreamStatus: response.status,
         responseBody,
     });
+}
+
+function extractUpstreamMessage(body: string): string {
+    try {
+        const parsed = JSON.parse(body);
+        const extracted =
+            parsed?.details?.error?.message ||
+            parsed?.error?.message ||
+            parsed?.message ||
+            (typeof parsed?.error === "string" ? parsed.error : null);
+        if (typeof extracted === "string" && extracted) return extracted;
+    } catch {
+        // Not JSON — fall through to raw body
+    }
+    return body;
 }
 
 const GenericErrorDetailsSchema = z
@@ -138,7 +156,7 @@ type ServerErrorEnvelope = {
     apiKeyId?: string;
 };
 
-const MAX_ERROR_MESSAGE_LENGTH = 4000;
+const MAX_ERROR_MESSAGE_LENGTH = 2000;
 const MAX_STACK_LENGTH = 12000;
 const MAX_UPSTREAM_BODY_LENGTH = 16000;
 
@@ -255,11 +273,13 @@ function createUpstreamErrorResponse(
 }
 
 /**
- * Remap upstream 429s to 502 so clients can distinguish between our own rate
- * limit (429) and a downstream provider quota issue (502 Bad Gateway).
+ * Remap upstream 4xx statuses that are our operational concern (auth, routing,
+ * quota, conflicts) to 502 Bad Gateway. Leaves input-content errors
+ * (400/413/422) as-is since those can reflect user input we failed to validate.
  */
 export function remapUpstreamStatus(status: number): ContentfulStatusCode {
-    if (status === 429) return 502;
+    const remapTo502 = new Set([401, 403, 404, 409, 415, 429]);
+    if (remapTo502.has(status)) return 502;
     return status as ContentfulStatusCode;
 }
 

--- a/enter.pollinations.ai/src/routes/audio.ts
+++ b/enter.pollinations.ai/src/routes/audio.ts
@@ -13,11 +13,7 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { describeRoute } from "hono-openapi";
 import { z } from "zod";
-import {
-    getDefaultErrorMessage,
-    remapUpstreamStatus,
-    UpstreamError,
-} from "@/error.ts";
+import { ensureUpstreamOk, UpstreamError } from "@/error.ts";
 import { auth } from "@/middleware/auth.ts";
 import { balance } from "@/middleware/balance.ts";
 import { resolveModel } from "@/middleware/model.ts";
@@ -155,7 +151,7 @@ export async function generateSpeech(opts: {
         elevenLabsBody.seed = opts.seed;
     }
 
-    const response = await fetch(elevenLabsUrl, {
+    const rawResponse = await fetch(elevenLabsUrl, {
         method: "POST",
         headers: {
             "xi-api-key": apiKey,
@@ -164,19 +160,10 @@ export async function generateSpeech(opts: {
         },
         body: JSON.stringify(elevenLabsBody),
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        log.warn("ElevenLabs error {status}: {body}", {
-            status: response.status,
-            body: errorText,
-        });
-        throw new UpstreamError(remapUpstreamStatus(response.status), {
-            message: errorText || getDefaultErrorMessage(response.status),
-            upstreamStatus: response.status,
-            responseBody: errorText,
-        });
-    }
+    const response = await ensureUpstreamOk(
+        rawResponse,
+        new URL(elevenLabsUrl),
+    );
 
     const contentType = response.headers.get("content-type") || "audio/mpeg";
 
@@ -244,29 +231,18 @@ export async function transcribeWithElevenLabs(opts: {
         formData.append("language_code", language);
     }
 
-    const response = await fetch(
-        "https://api.elevenlabs.io/v1/speech-to-text",
-        {
-            method: "POST",
-            headers: {
-                "xi-api-key": apiKey,
-            },
-            body: formData,
+    const elevenLabsUrl = "https://api.elevenlabs.io/v1/speech-to-text";
+    const rawResponse = await fetch(elevenLabsUrl, {
+        method: "POST",
+        headers: {
+            "xi-api-key": apiKey,
         },
+        body: formData,
+    });
+    const response = await ensureUpstreamOk(
+        rawResponse,
+        new URL(elevenLabsUrl),
     );
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        log.warn("ElevenLabs transcription error {status}: {body}", {
-            status: response.status,
-            body: errorText,
-        });
-        throw new UpstreamError(remapUpstreamStatus(response.status), {
-            message: errorText || getDefaultErrorMessage(response.status),
-            upstreamStatus: response.status,
-            responseBody: errorText,
-        });
-    }
 
     const elevenLabsData: ElevenLabsTranscriptionResponse =
         await response.json();
@@ -378,7 +354,7 @@ export async function generateMusic(opts: {
         elevenLabsBody.seed = opts.seed;
     }
 
-    const response = await fetch(elevenLabsUrl, {
+    const rawResponse = await fetch(elevenLabsUrl, {
         method: "POST",
         headers: {
             "xi-api-key": apiKey,
@@ -387,19 +363,10 @@ export async function generateMusic(opts: {
         },
         body: JSON.stringify(elevenLabsBody),
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        log.warn("ElevenLabs Music error {status}: {body}", {
-            status: response.status,
-            body: errorText,
-        });
-        throw new UpstreamError(remapUpstreamStatus(response.status), {
-            message: errorText || getDefaultErrorMessage(response.status),
-            upstreamStatus: response.status,
-            responseBody: errorText,
-        });
-    }
+    const response = await ensureUpstreamOk(
+        rawResponse,
+        new URL(elevenLabsUrl),
+    );
 
     const contentType = response.headers.get("content-type") || "audio/mpeg";
 
@@ -478,7 +445,7 @@ export async function generateQwenTts(opts: {
         parameters: instruct ? { instruct } : {},
     };
 
-    const response = await fetch(QWEN_TTS_ENDPOINT, {
+    const rawResponse = await fetch(QWEN_TTS_ENDPOINT, {
         method: "POST",
         headers: {
             Authorization: `Bearer ${apiKey}`,
@@ -486,19 +453,10 @@ export async function generateQwenTts(opts: {
         },
         body: JSON.stringify(body),
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        log.warn("Qwen TTS error {status}: {body}", {
-            status: response.status,
-            body: errorText,
-        });
-        throw new UpstreamError(remapUpstreamStatus(response.status), {
-            message: errorText || getDefaultErrorMessage(response.status),
-            upstreamStatus: response.status,
-            responseBody: errorText,
-        });
-    }
+    const response = await ensureUpstreamOk(
+        rawResponse,
+        new URL(QWEN_TTS_ENDPOINT),
+    );
 
     const data = (await response.json()) as {
         output?: { audio?: { url?: string } };
@@ -570,7 +528,8 @@ export async function generateAceStepMusic(opts: {
 
     const authHeaders = { Authorization: `Bearer ${serviceToken}` };
 
-    const submitResponse = await fetch(`${serviceUrl}/release_task`, {
+    const submitUrl = `${serviceUrl}/release_task`;
+    const rawSubmitResponse = await fetch(submitUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
@@ -582,19 +541,10 @@ export async function generateAceStepMusic(opts: {
             audio_format: "mp3",
         }),
     });
-
-    if (!submitResponse.ok) {
-        const errorText = await submitResponse.text();
-        log.warn("ACE-Step submit error {status}: {body}", {
-            status: submitResponse.status,
-            body: errorText,
-        });
-        throw new UpstreamError(submitResponse.status as ContentfulStatusCode, {
-            message: errorText || getDefaultErrorMessage(submitResponse.status),
-            upstreamStatus: submitResponse.status,
-            responseBody: errorText,
-        });
-    }
+    const submitResponse = await ensureUpstreamOk(
+        rawSubmitResponse,
+        new URL(submitUrl),
+    );
 
     const submitData = (await submitResponse.json()) as {
         data?: { task_id?: string };
@@ -962,30 +912,19 @@ export const audioRoutes = new Hono<Env>()
             whisperFormData.append("timestamp_granularities[]", "word");
 
             // Thin proxy to OVHcloud Whisper
-            const response = await fetch(
-                "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/audio/transcriptions",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${ovhApiKey}`,
-                    },
-                    body: whisperFormData,
+            const whisperUrl =
+                "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/audio/transcriptions";
+            const rawResponse = await fetch(whisperUrl, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${ovhApiKey}`,
                 },
+                body: whisperFormData,
+            });
+            const response = await ensureUpstreamOk(
+                rawResponse,
+                new URL(whisperUrl),
             );
-
-            if (!response.ok) {
-                const errorText = await response.text();
-                log.warn("Transcription error {status}: {body}", {
-                    status: response.status,
-                    body: errorText,
-                });
-                throw new UpstreamError(remapUpstreamStatus(response.status), {
-                    message:
-                        errorText || getDefaultErrorMessage(response.status),
-                    upstreamStatus: response.status,
-                    responseBody: errorText,
-                });
-            }
 
             // Read body to extract duration for usage billing
             const responseBody = await response.text();

--- a/enter.pollinations.ai/src/routes/audio.ts
+++ b/enter.pollinations.ai/src/routes/audio.ts
@@ -160,10 +160,7 @@ export async function generateSpeech(opts: {
         },
         body: JSON.stringify(elevenLabsBody),
     });
-    const response = await ensureUpstreamOk(
-        rawResponse,
-        new URL(elevenLabsUrl),
-    );
+    const response = await ensureUpstreamOk(rawResponse, elevenLabsUrl);
 
     const contentType = response.headers.get("content-type") || "audio/mpeg";
 
@@ -239,10 +236,7 @@ export async function transcribeWithElevenLabs(opts: {
         },
         body: formData,
     });
-    const response = await ensureUpstreamOk(
-        rawResponse,
-        new URL(elevenLabsUrl),
-    );
+    const response = await ensureUpstreamOk(rawResponse, elevenLabsUrl);
 
     const elevenLabsData: ElevenLabsTranscriptionResponse =
         await response.json();
@@ -363,10 +357,7 @@ export async function generateMusic(opts: {
         },
         body: JSON.stringify(elevenLabsBody),
     });
-    const response = await ensureUpstreamOk(
-        rawResponse,
-        new URL(elevenLabsUrl),
-    );
+    const response = await ensureUpstreamOk(rawResponse, elevenLabsUrl);
 
     const contentType = response.headers.get("content-type") || "audio/mpeg";
 
@@ -453,10 +444,7 @@ export async function generateQwenTts(opts: {
         },
         body: JSON.stringify(body),
     });
-    const response = await ensureUpstreamOk(
-        rawResponse,
-        new URL(QWEN_TTS_ENDPOINT),
-    );
+    const response = await ensureUpstreamOk(rawResponse, QWEN_TTS_ENDPOINT);
 
     const data = (await response.json()) as {
         output?: { audio?: { url?: string } };
@@ -469,17 +457,10 @@ export async function generateQwenTts(opts: {
         });
     }
 
-    const audioResponse = await fetch(audioUrl);
-    if (!audioResponse.ok) {
-        const errorText = await audioResponse.text();
-        throw new UpstreamError(502 as ContentfulStatusCode, {
-            message:
-                errorText ||
-                `Failed to fetch generated audio: ${audioResponse.status}`,
-            upstreamStatus: audioResponse.status,
-            responseBody: errorText,
-        });
-    }
+    const audioResponse = await ensureUpstreamOk(
+        await fetch(audioUrl),
+        audioUrl,
+    );
     const audioBuffer = await audioResponse.arrayBuffer();
 
     const serviceId = model.includes("instruct")
@@ -541,10 +522,7 @@ export async function generateAceStepMusic(opts: {
             audio_format: "mp3",
         }),
     });
-    const submitResponse = await ensureUpstreamOk(
-        rawSubmitResponse,
-        new URL(submitUrl),
-    );
+    const submitResponse = await ensureUpstreamOk(rawSubmitResponse, submitUrl);
 
     const submitData = (await submitResponse.json()) as {
         data?: { task_id?: string };
@@ -617,18 +595,11 @@ export async function generateAceStepMusic(opts: {
         });
     }
 
-    const audioResponse = await fetch(`${serviceUrl}${audioPath}`, {
-        headers: authHeaders,
-    });
-    if (!audioResponse.ok) {
-        const errorText = await audioResponse.text();
-        throw new UpstreamError(audioResponse.status as ContentfulStatusCode, {
-            message: errorText || "Failed to download generated audio",
-            upstreamStatus: audioResponse.status,
-            responseBody: errorText,
-        });
-    }
-
+    const audioUrl = `${serviceUrl}${audioPath}`;
+    const audioResponse = await ensureUpstreamOk(
+        await fetch(audioUrl, { headers: authHeaders }),
+        audioUrl,
+    );
     const audioBuffer = await audioResponse.arrayBuffer();
 
     // Use requested duration for billing (more accurate than byte-size heuristic)
@@ -921,10 +892,7 @@ export const audioRoutes = new Hono<Env>()
                 },
                 body: whisperFormData,
             });
-            const response = await ensureUpstreamOk(
-                rawResponse,
-                new URL(whisperUrl),
-            );
+            const response = await ensureUpstreamOk(rawResponse, whisperUrl);
 
             // Read body to extract duration for usage billing
             const responseBody = await response.text();

--- a/enter.pollinations.ai/src/routes/images.ts
+++ b/enter.pollinations.ai/src/routes/images.ts
@@ -5,7 +5,7 @@
  */
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { getDefaultErrorMessage, UpstreamError } from "@/error.ts";
+import { ensureUpstreamOk, UpstreamError } from "@/error.ts";
 import {
     type CreateImageEditRequest,
     CreateImageEditRequestSchema,
@@ -78,21 +78,14 @@ async function postToImageService(
     body: Record<string, unknown>,
     proxyHeaders: (c: Context) => Record<string, string>,
 ): Promise<Response> {
-    const response = await fetch(targetUrl.toString(), {
-        method: "POST",
-        headers: { ...proxyHeaders(c), "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-    });
-    if (!response.ok) {
-        const responseText = await response.text();
-        throw new UpstreamError(response.status as ContentfulStatusCode, {
-            message: responseText || getDefaultErrorMessage(response.status),
-            requestUrl: targetUrl,
-            upstreamStatus: response.status,
-            responseBody: responseText,
-        });
-    }
-    return response;
+    return ensureUpstreamOk(
+        await fetch(targetUrl.toString(), {
+            method: "POST",
+            headers: { ...proxyHeaders(c), "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        }),
+        targetUrl,
+    );
 }
 
 /** Resolve OpenAI params to Pollinations equivalents. */

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -28,11 +28,7 @@ import {
 import { createFactory } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
-import {
-    getDefaultErrorMessage,
-    remapUpstreamStatus,
-    UpstreamError,
-} from "@/error.ts";
+import { ensureUpstreamOk, UpstreamError } from "@/error.ts";
 import { validator } from "@/middleware/validator.ts";
 import { GenerateImageRequestQueryParamsSchema } from "@/schemas/image.ts";
 import {
@@ -105,22 +101,7 @@ const imageVideoHandlers = factory.createHandlers(
             body: c.req.raw.body,
         });
 
-        if (!response.ok) {
-            const responseText = await response.text();
-            log.warn("Image service error {status}: {body}", {
-                status: response.status,
-                body: responseText,
-            });
-            throw new UpstreamError(remapUpstreamStatus(response.status), {
-                message:
-                    responseText || getDefaultErrorMessage(response.status),
-                requestUrl: targetUrl,
-                upstreamStatus: response.status,
-                responseBody: responseText,
-            });
-        }
-
-        return response;
+        return ensureUpstreamOk(response, targetUrl);
     },
 );
 
@@ -130,7 +111,6 @@ const chatCompletionHandlers = factory.createHandlers(
     resolveModel("generate.text"),
     track("generate.text"),
     async (c) => {
-        const log = c.get("log").getChild("generate");
         await c.var.auth.requireAuthorization();
         c.var.auth.requireModelAccess();
         c.var.auth.requireKeyBudget();
@@ -143,43 +123,12 @@ const chatCompletionHandlers = factory.createHandlers(
         const textServiceUrl =
             c.env.TEXT_SERVICE_URL || "https://text.pollinations.ai";
         const targetUrl = proxyUrl(c, `${textServiceUrl}/openai`);
-        const response = await proxy(targetUrl, {
+        const rawResponse = await proxy(targetUrl, {
             method: c.req.method,
             headers: proxyHeaders(c),
             body: JSON.stringify(requestBody),
         });
-
-        if (!response.ok) {
-            const responseText = await response.text();
-            log.warn("Chat completions error {status}: {body}", {
-                status: response.status,
-                body: responseText,
-            });
-
-            // Try to extract meaningful error message from upstream JSON
-            let errorMessage =
-                responseText || getDefaultErrorMessage(response.status);
-            try {
-                const parsed = JSON.parse(responseText);
-                const extracted =
-                    parsed?.details?.error?.message ||
-                    parsed?.error?.message ||
-                    parsed?.message ||
-                    (typeof parsed?.error === "string" ? parsed.error : null);
-                if (extracted) {
-                    errorMessage = extracted;
-                }
-            } catch {
-                // Not JSON or parse failed - use raw text as-is
-            }
-
-            throw new UpstreamError(remapUpstreamStatus(response.status), {
-                message: errorMessage,
-                requestUrl: targetUrl,
-                upstreamStatus: response.status,
-                responseBody: responseText,
-            });
-        }
+        const response = await ensureUpstreamOk(rawResponse, targetUrl);
 
         // Validate streaming responses: if client requested stream but upstream
         // returned non-SSE, throw rather than forwarding broken data.
@@ -516,7 +465,6 @@ export const proxyRoutes = new Hono<Env>()
         resolveModel("generate.text"),
         track("generate.text"),
         async (c) => {
-            const log = c.get("log").getChild("generate");
             await c.var.auth.requireAuthorization();
             c.var.auth.requireModelAccess();
             c.var.auth.requireKeyBudget();
@@ -535,25 +483,11 @@ export const proxyRoutes = new Hono<Env>()
             // Add model param after proxyUrl() to ensure it's always present
             targetUrl.searchParams.set("model", model);
 
-            const response = await fetch(targetUrl, {
+            const rawResponse = await fetch(targetUrl, {
                 method: "GET",
                 headers: proxyHeaders(c),
             });
-
-            if (!response.ok) {
-                const responseText = await response.text();
-                log.warn("Text service error {status}: {body}", {
-                    status: response.status,
-                    body: responseText,
-                });
-                throw new UpstreamError(remapUpstreamStatus(response.status), {
-                    message:
-                        responseText || getDefaultErrorMessage(response.status),
-                    requestUrl: targetUrl,
-                    upstreamStatus: response.status,
-                    responseBody: responseText,
-                });
-            }
+            const response = await ensureUpstreamOk(rawResponse, targetUrl);
 
             // Backend returns plain text for text models and raw audio for audio models
             // No JSON parsing needed for GET endpoint - just pass through the response

--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -433,20 +433,12 @@ const checkCacheAndGenerate = async (
             "X-Error-Type": errorType,
         });
 
-        // Create a response object with error information.
-        // Intentionally excludes `prompt` from requestParameters to avoid
-        // echoing user content back in error bodies (flows through to clients
-        // and to Tinybird error_event via enter.pollinations.ai).
         const responseObj = {
             error: errorType,
             message: error.message,
             details: error.details,
             timingInfo: relativeTiming(timingInfo),
             requestId,
-            requestParameters: {
-                ...safeParams,
-                referrer,
-            },
             queueInfo: null,
         };
 

--- a/image.pollinations.ai/src/index.ts
+++ b/image.pollinations.ai/src/index.ts
@@ -433,7 +433,10 @@ const checkCacheAndGenerate = async (
             "X-Error-Type": errorType,
         });
 
-        // Create a response object with error information
+        // Create a response object with error information.
+        // Intentionally excludes `prompt` from requestParameters to avoid
+        // echoing user content back in error bodies (flows through to clients
+        // and to Tinybird error_event via enter.pollinations.ai).
         const responseObj = {
             error: errorType,
             message: error.message,
@@ -441,7 +444,6 @@ const checkCacheAndGenerate = async (
             timingInfo: relativeTiming(timingInfo),
             requestId,
             requestParameters: {
-                prompt: originalPrompt,
                 ...safeParams,
                 referrer,
             },

--- a/text.pollinations.ai/server.ts
+++ b/text.pollinations.ai/server.ts
@@ -252,6 +252,30 @@ function sendContentResponse(c: Context, completion: ChatCompletion): Response {
     return c.text("");
 }
 
+/**
+ * Strip user-content fields from request params before echoing them in an
+ * error response. Keeps diagnostic params (model, seed, temperature, etc.)
+ * so callers can correlate failures, drops anything that could contain
+ * prompts, tool definitions, or audio blobs.
+ */
+function sanitizeRequestParameters(
+    requestData: RequestData | null,
+): Record<string, unknown> {
+    if (!requestData) return {};
+    const {
+        messages: _messages,
+        tools: _tools,
+        tool_choice: _toolChoice,
+        audio: _audio,
+        response_format: _responseFormat,
+        stop: _stop,
+        logit_bias: _logitBias,
+        user: _user,
+        ...safe
+    } = requestData;
+    return safe;
+}
+
 function sendErrorResponse(
     c: Context,
     error: ServiceError,
@@ -266,7 +290,7 @@ function sendErrorResponse(
         error: errorType,
         message: error.message || "An error occurred",
         requestId: Math.random().toString(36).substring(7),
-        requestParameters: requestData || {},
+        requestParameters: sanitizeRequestParameters(requestData),
     };
     if (errorDetails) errorResponse.details = errorDetails;
 

--- a/text.pollinations.ai/server.ts
+++ b/text.pollinations.ai/server.ts
@@ -252,30 +252,6 @@ function sendContentResponse(c: Context, completion: ChatCompletion): Response {
     return c.text("");
 }
 
-/**
- * Strip user-content fields from request params before echoing them in an
- * error response. Keeps diagnostic params (model, seed, temperature, etc.)
- * so callers can correlate failures, drops anything that could contain
- * prompts, tool definitions, or audio blobs.
- */
-function sanitizeRequestParameters(
-    requestData: RequestData | null,
-): Record<string, unknown> {
-    if (!requestData) return {};
-    const {
-        messages: _messages,
-        tools: _tools,
-        tool_choice: _toolChoice,
-        audio: _audio,
-        response_format: _responseFormat,
-        stop: _stop,
-        logit_bias: _logitBias,
-        user: _user,
-        ...safe
-    } = requestData;
-    return safe;
-}
-
 function sendErrorResponse(
     c: Context,
     error: ServiceError,
@@ -290,7 +266,6 @@ function sendErrorResponse(
         error: errorType,
         message: error.message || "An error occurred",
         requestId: Math.random().toString(36).substring(7),
-        requestParameters: sanitizeRequestParameters(requestData),
     };
     if (errorDetails) errorResponse.details = errorDetails;
 


### PR DESCRIPTION
- New `ensureUpstreamOk(response, url)` helper in `error.ts` replaces the repeated `if (!response.ok) { text(); throw UpstreamError {4 fields} }` block at 8 call sites (proxy.ts 3, audio.ts 5).
- Raises `MAX_UPSTREAM_BODY_LENGTH` 4000→16000 and `MAX_ERROR_MESSAGE_LENGTH` 2000→4000 so full upstream error bodies reach Tinybird — today's Klein/grok errors hit the 4000 cap mid-JSON and hid useful context.
- Drops the smart JSON-extraction block in chat/completions. Thin proxy = forward what upstream said, not our interpretation.
- No Tinybird schema changes — existing 3h TTL absorbs the extra bytes.
- -113 lines net. Tests: 28/28 pass.