### PR TITLE
fix: route deepseek pro through fireworks

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -326,15 +326,15 @@ export const TEXT_SERVICES = {
     },
     "deepseek-pro": {
         aliases: ["deepseek-v4-pro"],
-        modelId: "deepseek-ai/DeepSeek-V4-Pro",
-        provider: "deepinfra",
+        modelId: "accounts/fireworks/models/deepseek-v4-pro",
+        provider: "fireworks",
         brand: "DeepSeek",
         category: "text",
         cost: [
             {
                 date: new Date("2026-04-24").getTime(),
                 promptTextTokens: perMillion(1.74),
-                promptCachedTokens: perMillion(0.145),
+                promptCachedTokens: perMillion(0.14),
                 completionTextTokens: perMillion(3.48),
             },
         ],
@@ -343,7 +343,7 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
-        contextLength: 65536,
+        contextLength: 1048576,
         isSpecialized: false,
         paidOnly: true,
     },

--- a/text.pollinations.ai/availableModels.ts
+++ b/text.pollinations.ai/availableModels.ts
@@ -60,7 +60,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "deepseek-pro",
-        config: portkeyConfig["deepseek-ai/DeepSeek-V4-Pro"],
+        config: portkeyConfig["accounts/fireworks/models/deepseek-v4-pro"],
     },
     {
         name: "grok",

--- a/text.pollinations.ai/configs/modelConfigs.ts
+++ b/text.pollinations.ai/configs/modelConfigs.ts
@@ -92,9 +92,11 @@ export const portkeyConfig: PortkeyConfigMap = {
         createDeepInfraModelConfig({
             model: "deepseek-ai/DeepSeek-V4-Flash",
         }),
-    "deepseek-ai/DeepSeek-V4-Pro": () =>
-        createDeepInfraModelConfig({
-            model: "deepseek-ai/DeepSeek-V4-Pro",
+
+    // -- Fireworks AI (DeepSeek) ---------------------------------------------
+    "accounts/fireworks/models/deepseek-v4-pro": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/deepseek-v4-pro",
         }),
 
     // -- Fireworks AI (Kimi, GLM, Qwen) --------------------------------------


### PR DESCRIPTION
- Routes `deepseek-pro` to Fireworks via `accounts/fireworks/models/deepseek-v4-pro`.
- Keeps `deepseek` on DeepInfra while avoiding DeepInfra rate limiting for Pro.
- Updates registry provider, cached input cost, and context length to match Fireworks.

Validation:
- `npx biome check --write shared/registry/text.ts text.pollinations.ai/availableModels.ts text.pollinations.ai/configs/modelConfigs.ts`
- `npm run type-check --prefix text.pollinations.ai`
- Local text service returned `200` for `deepseek-pro` with Fireworks model id.