### PR TITLE
feat(finance): deepinfra provider, one-time events, shared sops loader

### DIFF
--- a/apps/operation/finance/bin/rebuild-sheet.mjs
+++ b/apps/operation/finance/bin/rebuild-sheet.mjs
@@ -14,6 +14,7 @@ import {
 import {
     loadConfig,
     loadDotenv,
+    loadSharedModelSecrets,
     loadVendors,
     saveVendors,
 } from "../lib/io.mjs";
@@ -108,7 +109,9 @@ async function resolveVendorsInteractively(rawRows) {
 }
 
 async function main() {
-    // Load secrets (WISE_API_TOKEN, etc.)
+    // Load secrets — shared SOPS file first (provider/model API keys), then
+    // finance's local .env (WISE_API_TOKEN and any local overrides).
+    await loadSharedModelSecrets();
     await loadDotenv();
 
     const config = await loadConfig();
@@ -298,6 +301,21 @@ async function main() {
                 }
             }
         }
+    }
+
+    // One-time events from vendors.json._one_time_events: explicit
+    // (month, vendor, amount) entries for things that don't fit the forecast
+    // rules — one-off fundraises, deposits, refunds, etc. If the vendor has
+    // no Wise history, it's added as a synthetic vendor so it gets its own
+    // row. Remove the entry from vendors.json once the real Wise transaction
+    // lands so the actual amount takes over.
+    const oneTimeEvents = vendors._one_time_events ?? [];
+    for (const event of oneTimeEvents) {
+        if (!extended.data[event.month]) continue;
+        if (!extended.vendors[event.vendor_canonical]) {
+            extended.vendors[event.vendor_canonical] = event.category;
+        }
+        extended.data[event.month][event.vendor_canonical] = event.amount_eur;
     }
 
     const layout = buildLayout(extended, config, {

--- a/apps/operation/finance/bin/update-live.mjs
+++ b/apps/operation/finance/bin/update-live.mjs
@@ -24,7 +24,7 @@ import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadDotenv } from "../lib/io.mjs";
+import { loadDotenv, loadSharedModelSecrets } from "../lib/io.mjs";
 
 const APP_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
 const VENDORS_PATH = join(APP_DIR, "secrets", "vendors.json");
@@ -76,8 +76,10 @@ async function loadProviderModule(providerName) {
 }
 
 async function main() {
-    // Load secrets (RUNPOD_API_KEY, LAMBDA_LABS_API_KEY, etc.) from
-    // apps/operation/finance/secrets/.env into process.env.
+    // Provider/model API keys live in text.pollinations.ai/secrets/env.json
+    // (SOPS-encrypted, source of truth). Decrypt and merge into process.env
+    // first; finance's local .env can still override anything finance-specific.
+    await loadSharedModelSecrets();
     await loadDotenv();
 
     const month = currentMonth();

--- a/apps/operation/finance/lib/io.mjs
+++ b/apps/operation/finance/lib/io.mjs
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import {
     copyFile,
@@ -14,6 +15,17 @@ const CONFIG_PATH = join(APP_DIR, "config.local.json");
 const VENDORS_PATH = join(APP_DIR, "secrets", "vendors.json");
 const INPUT_DIR = join(APP_DIR, "secrets", "input");
 const ENV_PATH = join(APP_DIR, "secrets", ".env");
+// Source-of-truth for provider/model API keys lives with the text service.
+// Finance pulls from there so no key needs to be duplicated locally.
+const SHARED_MODEL_SECRETS_PATH = join(
+    APP_DIR,
+    "..",
+    "..",
+    "..",
+    "text.pollinations.ai",
+    "secrets",
+    "env.json",
+);
 
 export function appDir() {
     return APP_DIR;
@@ -63,6 +75,51 @@ export async function copyIntoInput(sourcePath, destName) {
     const dest = join(INPUT_DIR, destName);
     await copyFile(sourcePath, dest);
     return dest;
+}
+
+/**
+ * Decrypt the text service's SOPS-encrypted env.json (the source of truth
+ * for provider/model API keys) and merge any keys not already set into the
+ * given target. Used so we don't duplicate keys like DEEPINFRA_API_KEY,
+ * ANTHROPIC_API_KEY, etc. into a separate finance .env file.
+ *
+ * No-op if the file is missing or `sops` isn't on PATH / can't decrypt
+ * (e.g. user's age key isn't loaded). Logs a warning in that case so the
+ * caller knows live MTD won't work — but doesn't fail the run, since the
+ * Wise feed and forecast still work without provider keys.
+ */
+export async function loadSharedModelSecrets(target = process.env) {
+    if (!existsSync(SHARED_MODEL_SECRETS_PATH)) return target;
+    const stdout = await new Promise((resolve) => {
+        execFile(
+            "sops",
+            ["-d", SHARED_MODEL_SECRETS_PATH],
+            { timeout: 30_000, maxBuffer: 10 * 1024 * 1024 },
+            (err, out, stderr) => {
+                if (err) {
+                    console.warn(
+                        `Could not decrypt shared model secrets (${SHARED_MODEL_SECRETS_PATH}): ${err.message}\n${stderr || ""}`.trim(),
+                    );
+                    resolve(null);
+                    return;
+                }
+                resolve(out);
+            },
+        );
+    });
+    if (!stdout) return target;
+    let data;
+    try {
+        data = JSON.parse(stdout);
+    } catch (e) {
+        console.warn(`Shared model secrets is not valid JSON: ${e.message}`);
+        return target;
+    }
+    for (const [key, value] of Object.entries(data)) {
+        if (typeof value !== "string") continue;
+        if (target[key] === undefined) target[key] = value;
+    }
+    return target;
 }
 
 /**

--- a/apps/operation/finance/lib/providers/deepinfra.mjs
+++ b/apps/operation/finance/lib/providers/deepinfra.mjs
@@ -1,0 +1,73 @@
+/**
+ * Deep Infra provider — fetches MTD spend via GET /payment/usage.
+ *
+ * Deep Infra is PayAsYouGo (no standing credit pool, no coupons). The
+ * /payment/usage endpoint returns an array of months, each with a
+ * `period` string ("YYYY-MM"), `interval { fr, to }`, and `total_cost`
+ * in USD. We pick the entry matching currentMonth and report its
+ * total_cost as MTD cash.
+ *
+ * Auth: Bearer token via DEEPINFRA_API_KEY in secrets/.env.
+ *
+ * Treated as `kind: "payg"` in vendors.json:
+ *   - balance remaining row: always "—" (no pool)
+ *   - consumed (credits): 0 (no credits)
+ *   - consumed (cash): total_cost for the month
+ *
+ * The card charge lands in Wise the following month, so rebuild-sheet.mjs
+ * injects mtd_cash_usd into nowMonth+1 (same as AWS/Alibaba).
+ */
+
+const USAGE_URL = "https://api.deepinfra.com/payment/usage";
+
+export async function fetchMtd(currentMonth, pool) {
+    const apiKey = process.env.DEEPINFRA_API_KEY;
+    if (!apiKey) {
+        throw new Error(
+            "DEEPINFRA_API_KEY not set (expected in secrets/.env or process.env)",
+        );
+    }
+
+    // Deep Infra requires `from` (Unix epoch seconds) and rejects ranges
+    // longer than ~31 days or "too far in the past". Use start-of-currentMonth
+    // → now, capping `to` at the current time so we never project into the
+    // future (the API rejects that with HTTP 400).
+    const [y, m] = currentMonth.split("-").map(Number);
+    const fromSec = Math.floor(Date.UTC(y, m - 1, 1) / 1000);
+    const toSec = Math.floor(Date.now() / 1000);
+    const url = `${USAGE_URL}?from=${fromSec}&to=${toSec}`;
+
+    const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(
+            `Deep Infra API error ${res.status}: ${body.slice(0, 300)}`,
+        );
+    }
+    const data = await res.json();
+    const months = Array.isArray(data?.months) ? data.months : [];
+
+    // We scoped the query to a single month, so take the period match if
+    // present, otherwise the first entry returned.
+    const entry = months.find((mo) => mo?.period === currentMonth) ?? months[0];
+
+    const totalCost = Number(entry?.total_cost ?? 0);
+    const items = Array.isArray(entry?.items) ? entry.items : [];
+
+    pool.mtd_total_usd = Number(totalCost.toFixed(2));
+    pool.mtd_credit_usd = 0;
+    pool.mtd_cash_usd = Number(totalCost.toFixed(2));
+    pool.as_of = new Date().toISOString().slice(0, 10);
+
+    return {
+        mtd_total_usd: pool.mtd_total_usd,
+        mtd_credit_usd: pool.mtd_credit_usd,
+        mtd_cash_usd: pool.mtd_cash_usd,
+        records: items.length,
+        as_of: pool.as_of,
+        // Payg: no standing balance — orchestrator must skip seed-derived balance.
+        live_balance: true,
+    };
+}


### PR DESCRIPTION
Three changes to the finance runway tracker.

**Deep Infra provider** ([lib/providers/deepinfra.mjs](apps/operation/finance/lib/providers/deepinfra.mjs)) — calls `GET /payment/usage` with `from`/`to` Unix-seconds query params scoped to the current month, returns total_cost as MTD cash. Treated as `kind: "payg"` (no standing balance) like AWS/Alibaba, so the cash injection lands in next month's column when the card charge actually hits Wise. Live MTD verified at \$368 for April.

**One-time events** ([bin/rebuild-sheet.mjs](apps/operation/finance/bin/rebuild-sheet.mjs)) — explicit `(month, vendor, amount)` entries from `vendors.json._one_time_events` are applied after forecast/backfill, with synthetic vendor injection for entries that have no Wise history. Used for one-off fundraises, expected payments at non-forecast rates, etc.

**Shared SOPS loader** ([lib/io.mjs](apps/operation/finance/lib/io.mjs)) — `loadSharedModelSecrets()` decrypts `text.pollinations.ai/secrets/env.json` (the source of truth for provider/model API keys) and merges any keys not already set into `process.env`. Both `rebuild-sheet.mjs` and `update-live.mjs` call it before `loadDotenv`, so finance never duplicates `DEEPINFRA_API_KEY`, `ANTHROPIC_API_KEY`, etc. into a separate local .env.

Local-only secrets (vendors.json, finance/.env) are gitignored — only code changes are in this PR.