### PR TITLE
feat(byop): add dev_balance bucket + BYOP markup credit

### DIFF
--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -1,41 +1,50 @@
 # 🌼 Bring Your Own Pollen (BYOP)
 
-Your users pay for their own AI usage. You pay $0.
+Your users connect their Pollinations account to your app and spend their own Pollen on AI generations. Their requests use their wallet, not yours.
 
 ## 🔄 How It Works
 
-1. User connects — via your web app or CLI
-2. Signs in, creates a scoped API key
-3. Their pollen, your app
+1. Your app sends the user to the Pollinations authorization screen.
+2. The user approves a scoped key for your app.
+3. AI requests from your app spend the user's Pollen.
+4. If you use an App Key, usage and earnings are attributed to your account.
 
 Why this is good:
 
-- 💸 **$0 costs** — scales to any number of users without costing you a cent
+- 💸 **$0 costs** — user usage does not spend your Pollen
+- **🌻 Dev earnings** — earn 20% of every Pollen your users spend through your app, credited to your wallet
+- 🔐 **Scoped access** — users approve model limits, budget, and expiry
 - 🔑 **No key management** — the auth flow handles it
 - ⚖️ **Self-regulating** — everyone pays for what they use
 - 🌐 **Works everywhere** — web apps, CLIs, MCP servers, anything
 
-Both flows land on the same authorize screen where users set model restrictions, budget, and expiry. Same key, same pollen, different entry point.
+Both flows land on the same authorize screen where users set model restrictions, budget, and expiry. Same key, same Pollen, different entry point.
 
 ## 🗝️ App Key
 
-An **App Key** is a publishable key (`pk_...`) you create on [enter.pollinations.ai](https://enter.pollinations.ai) specifically for BYOP. It's optional but strongly recommended:
+An **App Key** is a public app identifier (`pk_...`) you create on [enter.pollinations.ai](https://enter.pollinations.ai) specifically for BYOP. It's optional but strongly recommended:
 
 | Without App Key | With App Key |
 |----------------|-------------|
 | Consent screen shows generic hostname | Consent screen shows **your app name + your GitHub** |
 | No traffic attribution | Traffic your app drives is **tracked to your account** |
-| No tier benefit | Real usage → **automatic tier upgrades** → higher pollen grants |
+| No earnings attribution | You earn **20% of every Pollen** your users spend through your app |
 
 To create one, go to [enter.pollinations.ai](https://enter.pollinations.ai) → **Create New App Key**:
 
 ![Create New App Key](https://media.pollinations.ai/aa8ca9fe3110aff7)
 
-Set the **Name** (shows on the consent screen) and **App URL** (your app's domain). The key you get back is your `client_id` (a `pk_...` publishable key; the legacy name `app_key` is still accepted).
+Set the **Name** (shows on the consent screen) and **App URL** (your app's domain). The key you get back is your `client_id` (a `pk_...` App Key; the legacy name `app_key` is still accepted).
 
 When users authorize, this is what they see:
 
 ![Authorize Screen](https://media.pollinations.ai/b030a47e32df2b2b)
+
+## 👛 User Pollen
+
+BYOP requests spend from the user's Pollinations wallet, not your app balance.
+
+Regular models can use the user's free 🌱 Tier Pollen first. Paid-only models require 🌻 Dev earnings or 💳 Top-up Pollen.
 
 ## ⚙️ Web Apps (Redirect Flow)
 
@@ -58,7 +67,7 @@ https://enter.pollinations.ai/authorize?redirect_uri=https://myapp.com&client_id
 
 | Param | What it does | Example |
 |-------|-------------|---------|
-| `client_id` | Your publishable key — shows app name + author on consent screen, tracks traffic for tier upgrades | `pk_abc123` |
+| `client_id` | Your App Key — shows app name + author on consent screen and attributes usage and earnings to your account | `pk_abc123` |
 | `redirect_uri` | Where users return after authorizing — receives the temp API key in the URL fragment | `https://myapp.com` |
 | `state` | Opaque value echoed back on the callback for CSRF protection | `any-random-string` |
 | `scope` | Account access (space or comma separated) | `usage keys` |
@@ -90,7 +99,7 @@ window.location.href = `https://enter.pollinations.ai/authorize?${params}`;
 // Grab key from URL after redirect
 const apiKey = new URLSearchParams(location.hash.slice(1)).get('api_key');
 
-// Use their pollen
+// Use their Pollen
 fetch('https://gen.pollinations.ai/v1/chat/completions', {
   method: 'POST',
   headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },

--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -8,11 +8,11 @@ Pollen is our **prepaid credit system**. **$1 ≈ 1 Pollen** *(pricing may evolv
 
 ## 🧩 Is Pollinations a coding tool or app builder?
 
-**No.** Pollinations is not a code editor, no-code builder, or app development platform like Lovable, Bolt, or Cursor. We provide the **building blocks** that creators integrate into their own apps:
+**No.** Pollinations is not a code editor, no-code builder, or app development platform like Lovable, Bolt, or Cursor. We provide the **building blocks** that developers integrate into their own apps:
 
 - 🤖 **AI Generation APIs** — Access 38+ models (text, image, audio, video) through a single API
 - 💰 **Payment Infrastructure** — Let your app's users pay per use with Pollen credits, so you don't foot the compute bill
-- 📊 **Monetization Tools** — Revenue share (launching Q2), and soon ads SDK — everything you need to earn from your app
+- 📊 **Monetization Tools** — BYOP is live, and ads SDK is coming next
 
 🔧 You build the app your way — with any framework, any tool, any language. Plug in Pollinations for the AI capabilities and the monetization. We're the **engine and the cash register**, not the workshop.
 
@@ -21,21 +21,21 @@ Pollen is our **prepaid credit system**. **$1 ≈ 1 Pollen** *(pricing may evolv
 There are **three ways**:
 
 1. 💳 **Buy It** — Purchase Pollen packs with a credit card. Goes into your wallet and *never expires*. *(Want other payment options? [Vote here](https://github.com/pollinations/pollinations/issues/4826)!)*
-2. 🎁 **Grants** — All tiers receive free Pollen that refills every hour.
-3. 🏆 **Earn It** — Contribute to the ecosystem — code, docs, community support, publishing apps — and unlock higher tiers with bigger grants.
+2. 🌱 **Tier Grants** — All accounts receive free Pollen that refills every hour. Contribute to unlock bigger hourly grants.
+3. **🌻 Dev earnings** — Register a BYOP App Key and receive 20% of the total Pollen charged through your app.
 
 ## 🆓 Can I try it for free?
 
 **Yes!** Register, grab an API key, and start building — **no credit card required**.
 
 - ✅ Every account gets **free Pollen** that refills hourly
-- 📈 Contribute to unlock higher tiers with **bigger grants** (up to 0.8 pollen/hour)
+- 📈 Contribute to unlock higher tiers with **bigger grants** (up to 0.8 Pollen/hour)
 
 ## 💳 What payment methods do you accept?
 
 Currently **credit cards** via Stripe. We're actively exploring more options based on community feedback.
 
-🗳️ **Want to pay differently?** Vote for your preferred method in our [payment methods issue](https://github.com/pollinations/pollinations/issues/4826) — crypto, PayPal, Alipay, and more!
+🗳️ **Want to pay differently?** Vote for your preferred method in our [payment methods issue](https://github.com/pollinations/pollinations/issues/4826) — PayPal, Alipay, and more!
 
 ## 📅 Is there a monthly subscription?
 
@@ -47,21 +47,24 @@ Currently **credit cards** via Stripe. We're actively exploring more options bas
 
 Registration gives you **instant access** to the Pollinations API. Create API keys and start making requests right away:
 
-- **🌐 Publishable Key (pk\_):** For client-side apps *(bound to your domain)*. Rate limits: **1 pollen per IP per hour**.
 - **🔒 Secret Key (sk\_):** For server-side apps only. **No rate limits.**
+- **🖥️ App Key:** For BYOP apps. Shows your app name + GitHub on the consent screen and attributes usage and earnings to your account.
 
-🎁 All registered accounts get **free Pollen** refilled hourly — no purchase required. Active creators unlock higher tiers with bigger grants.
+🎁 All registered accounts get **free Pollen** refilled hourly — no purchase required. Active developers unlock higher tiers with bigger grants.
 
 ## 👛 How does my Pollen wallet work?
 
-You get **one central wallet** for all your applications. It holds two types of Pollen:
+You get **one central wallet** for all your applications, made from three Pollen buckets:
 
-- 🔄 **Tier Pollen** — Free pollen from your tier, refilled automatically every hour. Does not carry over between refills.
-- 💎 **Purchased Pollen** — From packs you've bought. **Never expires.** Top up anytime.
+- **🌱 Tier Pollen** — free Pollen from your tier. Refills every hour.
+- **🌻 Dev earnings** — Pollen your apps receive from BYOP usage.
+- **💳 Top-up Pollen** — Pollen you buy. Does not expire.
 
-⚡ Tier Pollen is always spent **first**, then purchased Pollen kicks in. Some models marked with 💎 **Paid Only** require purchased Pollen and skip tier grants.
+**Spending order:**
 
-⏰ Pollen refills every hour. If a request costs slightly more than estimated, your balance may go briefly negative — the **next refill covers the difference** automatically.
+🌱 Tier Pollen *(skipped for paid-only models)* → 🌻 Dev earnings → 💳 Top-up Pollen
+
+⏰ If a request costs slightly more than estimated, your 🌱 Tier Pollen balance may go briefly negative — the **next refill covers the difference** automatically.
 
 ## 🏅 What are tiers?
 
@@ -77,13 +80,20 @@ All tiers refill every hour. Everyone starts at Spore — the more you build and
 
 ## 🔌 What is BYOP (Bring Your Own Pollen)?
 
-BYOP lets your app's users **pay for their own AI generations** with their Pollen — instead of it coming out of *your* balance.
+BYOP lets your users connect their Pollinations account to your app and spend their own Pollen on AI generations. Their requests use their wallet, not yours.
 
-🚀 **Why it matters:** Without BYOP, every user of your app burns *your* Pollen. With BYOP, your **compute cost drops to zero**. Your users get a seamless experience, and you can scale without worrying about costs.
+**How it works:**
 
-🔄 Every user on the platform gets free Pollen refilled hourly. With BYOP, they spend that Pollen in *your* app — the **Pollinations flywheel**: build an app for free → integrate BYOP → your users arrive with Pollen → they fuel the app → you grow → bigger grants → build bigger.
+1. Your app sends the user to the Pollinations authorization screen.
+2. The user approves a scoped key for your app.
+3. AI requests from your app spend the user's Pollen.
+4. If you use an App Key, usage and earnings are attributed to your account.
 
-🔑 **App Key:** Create an **App Key** (`pk_...`) on [enter.pollinations.ai](https://enter.pollinations.ai) to get the most out of BYOP. With an App Key, the consent screen shows your **app name + GitHub** instead of a generic hostname, and the traffic your app drives is **tracked to your account** — helping you qualify for automatic tier upgrades and higher Pollen grants.
+**Why use it:**
+
+- **No shared balance drain:** user usage does not spend your Pollen.
+- **🌻 Dev earnings:** On BYOP app requests, 20% of the Pollen the user spends is credited to the app's developer.
+- **Scoped access:** users approve a key for your app with model limits, budget, and expiry.
 
 📖 **[Full BYOP guide →](https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md)**
 
@@ -103,7 +113,7 @@ Anything you can imagine — **text**, **images**, **audio**, and **video**, all
 - 🧮 **Scoring System** — Tiers will be based on a transparent score — GitHub activity, API usage, apps shipped, and community contributions.
 - 🔑 **Pollinations Login** — OAuth sign-in for your users. Token handling and production-ready auth.
 - 🏠 **App Hosting** — Ship your app on our infra. No deploy setup, no separate hosting bill.
-- 🌻 **Creator Rewards** — Get recognized for what people build with your app.
+- 📈 **Dev Earnings Analytics** — See which apps are earning Pollen.
 - 🗺️ **App Discovery** — A marketplace where users find your app.
 
 🌱 Plans change. We build in the open and figure it out as we go.

--- a/enter.pollinations.ai/drizzle/0020_add_dev_balance.sql
+++ b/enter.pollinations.ai/drizzle/0020_add_dev_balance.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `dev_balance` real;

--- a/enter.pollinations.ai/drizzle/meta/0020_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,763 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "171546a5-88b1-43a7-9531-8e160868955c",
+  "prevId": "fb76532c-41cb-4838-895c-97d21e83ea6e",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dev_balance": {
+          "name": "dev_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777313809557,
       "tag": "0019_drop_crypto_column",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1777315050308,
+      "tag": "0020_add_dev_balance",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/observability/datasources/d1_user.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_user.datasource
@@ -21,6 +21,7 @@ SCHEMA >
     `tier_balance` Nullable(Float64) `json:$.tier_balance`,
     `pack_balance` Nullable(Float64) `json:$.pack_balance`,
     `crypto_balance` Nullable(Float64) `json:$.crypto_balance`,
+    `dev_balance` Nullable(Float64) `json:$.dev_balance`,
     `last_tier_grant` Nullable(Int64) `json:$.last_tier_grant`,
     `synced_at` DateTime `json:$.synced_at`
 

--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -74,6 +74,10 @@ SCHEMA >
 `total_cost`    Float64 `json:$.totalCost` DEFAULT 0,
 `total_price`   Float64 `json:$.totalPrice` DEFAULT 0,
 
+-- BYOP dev markup (credit credited to pk_ owner's dev_balance; 0 on non-BYOP)
+`dev_credit`   Float64 `json:$.devCredit` DEFAULT 0,
+`byop_markup_pct`  Float32 `json:$.byopMarkupPct` DEFAULT 0,
+
 -- Prompt Moderation
 `moderation_prompt_hate_severity`       LowCardinality(String) `json:$.moderationPromptHateSeverity` DEFAULT 'undefined',
 `moderation_prompt_self_harm_severity`  LowCardinality(String) `json:$.moderationPromptSelfHarmSeverity` DEFAULT 'undefined',

--- a/enter.pollinations.ai/src/billing-config.ts
+++ b/enter.pollinations.ai/src/billing-config.ts
@@ -1,0 +1,18 @@
+/**
+ * BYOP markup applied to requests authenticated by a BYOP-issued sk_ token
+ * (one carrying metadata.clientId). Payer is billed baseline × (1 + MARKUP_PCT);
+ * the delta is credited to the app owner's dev_balance.
+ *
+ * Kill switch: set to 0 to disable entirely.
+ */
+export const BYOP_MARKUP_PCT = 0.25;
+
+export function computeDevCredit(baselinePrice: number): number {
+    if (baselinePrice <= 0 || BYOP_MARKUP_PCT <= 0) return 0;
+    return baselinePrice * BYOP_MARKUP_PCT;
+}
+
+export function computeBilledPrice(baselinePrice: number): number {
+    if (baselinePrice <= 0 || BYOP_MARKUP_PCT <= 0) return baselinePrice;
+    return baselinePrice * (1 + BYOP_MARKUP_PCT);
+}

--- a/enter.pollinations.ai/src/cache.ts
+++ b/enter.pollinations.ai/src/cache.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@logtape/logtape";
+import type { Logger } from "@logtape/logtape";
 
 interface CacheOptions<TArgs extends any[]> {
     log: Logger;

--- a/enter.pollinations.ai/src/client/api.ts
+++ b/enter.pollinations.ai/src/client/api.ts
@@ -1,5 +1,5 @@
-import type { ApiRoutes } from "../index.ts";
 import { hc } from "hono/client";
+import type { ApiRoutes } from "../index.ts";
 
 export const apiClient = hc<ApiRoutes>("/api");
 export type ApiClient = typeof apiClient;

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -179,8 +179,9 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                     >
                                         BYOP
                                     </a>
-                                    <br />🪷 Let your users connect and use
-                                    their own pollen in your app.
+                                    <br />
+                                    Earn 20% of every Pollen your users spend
+                                    through your app.
                                 </>
                             ) : (
                                 "Access AI models for text, image, and audio generation."

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -36,10 +36,9 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
         (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
-
     return (
         <>
-            <div className="flex flex-col gap-2">
+            <div id="keys" className="flex flex-col gap-2 scroll-mt-6">
                 <div className="flex flex-col sm:flex-row justify-between gap-3">
                     <h2 className="font-bold flex-1">Keys</h2>
                     <div className="flex gap-3">
@@ -72,21 +71,20 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                 </p>
                                 <p className="text-sm text-gray-600">
                                     <strong>🖥️ App Key</strong> — users bring
-                                    their own pollen into your app
+                                    their own Pollen, your app earns from usage
                                 </p>
                             </div>
                         )}
                         {visibleKeys.length > 0 && (
                             <div className="rounded-xl bg-amber-50/80 p-4">
                                 <p className="font-semibold text-amber-900 mb-1">
-                                    🪷 Let your users bring their own Pollen
+                                    BYOP App Keys
                                 </p>
                                 <p className="text-sm text-amber-800">
                                     Register an <strong>App Key</strong> so
                                     users can sign in with their own
                                     Pollinations account — web apps, chatbots,
-                                    CLIs, anything. Track usage and activity in
-                                    your app.{" "}
+                                    CLIs, anything.{" "}
                                     <a
                                         href="https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md"
                                         target="_blank"

--- a/enter.pollinations.ai/src/client/components/auth/app-attribution.tsx
+++ b/enter.pollinations.ai/src/client/components/auth/app-attribution.tsx
@@ -3,6 +3,7 @@ import { InfoTip } from "../ui/info-tip.tsx";
 type Attribution = {
     appName?: string;
     githubUsername?: string;
+    found?: boolean;
 };
 
 type AppAttributionProps = {
@@ -21,12 +22,16 @@ export function AppAttribution({
     const displayName =
         attribution?.appName ??
         (isDeviceMode ? "A device" : redirectHostname || "An app");
+    const tipText = attribution?.found
+        ? "Same as copy-pasting an API key into their app. Only share with apps you trust. The developer earns 20%."
+        : "Same as copy-pasting an API key into their app. Only share with apps you trust.";
+
     return (
         <>
             <p className="text-gray-900">
                 <span className="font-bold text-lg">{displayName}</span>{" "}
                 <InfoTip
-                    text="Same as copy-pasting an API key into their app. Only share with apps you trust."
+                    text={tipText}
                     label="API key sharing warning"
                     tone="amber"
                     icon="!"

--- a/enter.pollinations.ai/src/client/components/balance/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/pollen-balance.tsx
@@ -1,7 +1,6 @@
-import { type FC, useState } from "react";
-import { formatPollen } from "@/client/lib/format-pollen.ts";
+import { type FC, useId, useState } from "react";
+import { formatPollen, toFinitePollen } from "@/client/lib/format-pollen.ts";
 import { formatPollenPackValue, POLLEN_PACKS } from "@/pollen-packs.ts";
-import { getTierColor, getTierEmoji } from "@/tier-config.ts";
 import { Button } from "../button.tsx";
 import { Card } from "../ui/card.tsx";
 import { Panel } from "../ui/panel.tsx";
@@ -9,72 +8,78 @@ import { Tooltip } from "../ui/tooltip.tsx";
 import { PaymentTrustBadge } from "./payment-trust-badge.tsx";
 
 type PollenBalanceProps = {
-    tierBalance: number;
-    packBalance: number;
-    tier?: string;
+    tierBalance?: unknown;
+    devBalance?: unknown;
+    packBalance?: unknown;
 };
 
 type GaugeSegmentProps = {
     percentage: number;
     value: number;
     label: string;
-    color: "amber" | "orange" | "blue" | "green" | "pink" | "gray" | "violet";
     title: string;
-    position: "left" | "right";
-    offset?: number;
+    offset: number;
+    barClassName: string;
+    textClassName: string;
+    isTooltipActive: boolean;
+    tooltipId: string;
+    onTooltipClose: () => void;
+    onTooltipOpen: () => void;
 };
-
-const GAUGE_COLOR_CLASSES = {
-    amber: { bg: "bg-amber-200", text: "text-amber-900" },
-    orange: { bg: "bg-orange-300", text: "text-orange-950" },
-    blue: { bg: "bg-blue-200", text: "text-blue-900" },
-    green: { bg: "bg-green-200", text: "text-green-900" },
-    pink: { bg: "bg-pink-200", text: "text-pink-900" },
-    violet: { bg: "bg-violet-200", text: "text-violet-950" },
-    gray: { bg: "bg-gray-300", text: "text-gray-900" },
-} as const;
 
 const PollenGaugeSegment: FC<GaugeSegmentProps> = ({
     percentage,
     value,
     label,
-    color,
     title,
-    position,
-    offset = 0,
+    offset,
+    barClassName,
+    textClassName,
+    isTooltipActive,
+    tooltipId,
+    onTooltipClose,
+    onTooltipOpen,
 }) => {
-    const { bg: bgColor, text: textColor } = GAUGE_COLOR_CLASSES[color];
-
-    const style =
-        position === "left"
-            ? { width: `${percentage}%` }
-            : { left: `${offset}%`, width: `${percentage}%` };
-
     return (
-        <div
-            className={`absolute inset-y-0 ${bgColor} transition-all duration-500 ease-out cursor-help`}
-            style={style}
-            title={title}
+        <button
+            type="button"
+            className={`absolute inset-y-0 ${barClassName} cursor-default appearance-none border-0 p-0 text-center transition-all duration-500 ease-out focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-700/45`}
+            style={{ left: `${offset}%`, width: `${percentage}%` }}
+            aria-label={title.replace(/\n/g, ". ")}
+            aria-describedby={isTooltipActive ? tooltipId : undefined}
+            onBlur={onTooltipClose}
+            onClick={(event) => {
+                event.stopPropagation();
+                onTooltipOpen();
+            }}
+            onFocus={onTooltipOpen}
+            onMouseEnter={onTooltipOpen}
+            onMouseLeave={onTooltipClose}
         >
-            <div className="absolute inset-0 flex items-center justify-center gap-1">
-                <span
-                    className={`${textColor} font-bold text-sm whitespace-nowrap`}
-                >
-                    {label} {formatPollen(value)}
+            <div
+                className={`${textClassName} absolute inset-0 flex flex-col items-center justify-center px-1 leading-none`}
+            >
+                <span className="truncate whitespace-nowrap text-[9px] font-semibold uppercase sm:text-[10px]">
+                    {label}
+                </span>
+                <span className="truncate whitespace-nowrap text-[11px] font-bold tabular-nums sm:text-sm">
+                    {formatPollen(value)}
                 </span>
             </div>
-        </div>
+        </button>
     );
 };
 
 export const PollenBalance: FC<PollenBalanceProps> = ({
     tierBalance,
+    devBalance,
     packBalance,
-    tier = "spore",
 }) => {
     const [emailCopied, setEmailCopied] = useState(false);
-    const tierEmoji = getTierEmoji(tier);
-    const tierColor = getTierColor(tier) as GaugeSegmentProps["color"];
+    const [activeGaugeSegment, setActiveGaugeSegment] = useState<string | null>(
+        null,
+    );
+    const gaugeTooltipId = useId();
 
     const copyEmail = () => {
         navigator.clipboard.writeText("billing@pollinations.ai");
@@ -82,35 +87,86 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
         setTimeout(() => setEmailCopied(false), 2000);
     };
     // Clamp at 0 for display — individual buckets can go slightly negative from overage
-    const displayTier = Math.max(0, tierBalance);
-    const displayPaid = Math.max(0, packBalance);
-    const totalPollen = displayTier + displayPaid;
+    const displayTier = Math.max(0, toFinitePollen(tierBalance));
+    const displayDev = Math.max(0, toFinitePollen(devBalance));
+    const displayTopUps = Math.max(0, toFinitePollen(packBalance));
+    const totalPollen = displayTier + displayDev + displayTopUps;
+    const gaugeHeightClass = "h-[40px] sm:h-[46px]";
 
-    function calculatePercentage(value: number, total: number): number {
-        return total > 0 ? (value / total) * 100 : 0;
-    }
+    type Segment = Omit<
+        GaugeSegmentProps,
+        | "percentage"
+        | "offset"
+        | "isTooltipActive"
+        | "tooltipId"
+        | "onTooltipClose"
+        | "onTooltipOpen"
+    > & {
+        key: string;
+    };
 
-    const rawPaidPercentage = calculatePercentage(displayPaid, totalPollen);
-    const gaugeHeightClass = "h-[30px] sm:h-[34px]";
-    const hideTierGaugeSegment = tier === "microbe" && displayTier === 0;
+    const segments: Segment[] = [
+        {
+            key: "topups",
+            value: displayTopUps,
+            label: "💳 Top-up",
+            title: `💳 Top-up: ${formatPollen(displayTopUps)} Pollen\nPollen you bought via packs.`,
+            barClassName: "bg-amber-300",
+            textClassName: "text-amber-950",
+        },
+        {
+            key: "byop",
+            value: displayDev,
+            label: "🌻 Earnings",
+            title: `🌻 Dev earnings: ${formatPollen(displayDev)} Pollen\nPollen earned from BYOP app usage.`,
+            barClassName: "bg-amber-200",
+            textClassName: "text-amber-950",
+        },
+        {
+            key: "tier",
+            value: displayTier,
+            label: "🌱 Tier",
+            title: `🌱 Tier: ${formatPollen(displayTier)} Pollen\nFree hourly Pollen from your current tier.`,
+            barClassName: "bg-amber-100",
+            textClassName: "text-amber-900",
+        },
+    ];
 
-    // Ensure both segments are always visible (min width to fit labels)
-    const MIN_SEGMENT = 20;
-    let paidPercentage: number;
-    let freePercentage: number;
-    if (hideTierGaugeSegment) {
-        paidPercentage = displayPaid > 0 ? 100 : 0;
-        freePercentage = 0;
-    } else if (totalPollen > 0) {
-        paidPercentage = Math.max(
-            MIN_SEGMENT,
-            Math.min(100 - MIN_SEGMENT, rawPaidPercentage),
-        );
-        freePercentage = 100 - paidPercentage;
-    } else {
-        paidPercentage = 50;
-        freePercentage = 50;
-    }
+    const rawPercentages =
+        totalPollen > 0
+            ? segments.map((segment) => (segment.value / totalPollen) * 100)
+            : segments.map(() => 100 / segments.length);
+    const minSegment = 16;
+    const pinned = rawPercentages.map((percentage) => percentage < minSegment);
+    const pinnedTotal = pinned.filter(Boolean).length * minSegment;
+    const remainingRaw = rawPercentages.reduce(
+        (sum, percentage, index) => sum + (pinned[index] ? 0 : percentage),
+        0,
+    );
+    const displayPercentages = rawPercentages.map((percentage, index) => {
+        if (pinned[index]) return minSegment;
+        if (remainingRaw <= 0) return (100 - pinnedTotal) / segments.length;
+        return (percentage / remainingRaw) * (100 - pinnedTotal);
+    });
+
+    let currentOffset = 0;
+    const gaugeSegments = segments.map((segment, index) => {
+        const percentage = displayPercentages[index] ?? 0;
+        const offset = currentOffset;
+        currentOffset += percentage;
+        return { ...segment, percentage, offset };
+    });
+    const activeSegment = gaugeSegments.find(
+        (segment) => segment.key === activeGaugeSegment,
+    );
+    const activeTooltipCenter = activeSegment
+        ? Math.max(
+              18,
+              Math.min(82, activeSegment.offset + activeSegment.percentage / 2),
+          )
+        : 50;
+    const [tooltipTitle = "", tooltipBody = ""] =
+        activeSegment?.title.split("\n") ?? [];
 
     return (
         <Panel color="amber">
@@ -122,34 +178,48 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                         {formatPollen(totalPollen)} pollen
                     </span>
                     {/* Gauge */}
-                    <div className="w-full max-w-[540px]">
+                    <div className="relative w-full max-w-[540px]">
                         <div
-                            className={`relative ${gaugeHeightClass} bg-gray-200 rounded-full overflow-hidden border-2 border-amber-300`}
+                            className={`relative ${gaugeHeightClass} rounded-full overflow-hidden border-2 border-amber-300 bg-amber-100`}
                         >
-                            {/* Paid Pollen - Soft purple for paid (pack) */}
-                            {paidPercentage > 0 && (
+                            {gaugeSegments.map((segment) => (
                                 <PollenGaugeSegment
-                                    percentage={paidPercentage}
-                                    value={displayPaid}
-                                    label="🪷"
-                                    color="amber"
-                                    title={`🪷 Purchased: ${formatPollen(displayPaid)} pollen\nFrom packs you've bought\nRequired for 🪷 Paid Only models; used after tier grants for others`}
-                                    position="left"
+                                    key={segment.key}
+                                    percentage={segment.percentage}
+                                    value={segment.value}
+                                    label={segment.label}
+                                    title={segment.title}
+                                    offset={segment.offset}
+                                    barClassName={segment.barClassName}
+                                    textClassName={segment.textClassName}
+                                    isTooltipActive={
+                                        activeGaugeSegment === segment.key
+                                    }
+                                    tooltipId={gaugeTooltipId}
+                                    onTooltipClose={() =>
+                                        setActiveGaugeSegment(null)
+                                    }
+                                    onTooltipOpen={() =>
+                                        setActiveGaugeSegment(segment.key)
+                                    }
                                 />
-                            )}
-                            {/* Free Pollen - Soft teal for free */}
-                            {!hideTierGaugeSegment && freePercentage > 0 && (
-                                <PollenGaugeSegment
-                                    percentage={freePercentage}
-                                    value={displayTier}
-                                    label={tierEmoji}
-                                    color={tierColor}
-                                    title={`${tierEmoji} Tier: ${formatPollen(displayTier)} pollen\nFree pollen from your tier, refills periodically\nUsed first, except for 🪷 Paid Only models`}
-                                    position="right"
-                                    offset={paidPercentage}
-                                />
-                            )}
+                            ))}
                         </div>
+                        {activeSegment && (
+                            <span
+                                id={gaugeTooltipId}
+                                role="tooltip"
+                                className="pointer-events-none absolute top-full z-50 mt-2 w-[240px] max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-left text-xs text-gray-800 shadow-lg"
+                                style={{ left: `${activeTooltipCenter}%` }}
+                            >
+                                <span className="block font-semibold text-gray-900">
+                                    {tooltipTitle}
+                                </span>
+                                <span className="mt-1 block whitespace-normal leading-snug">
+                                    {tooltipBody}
+                                </span>
+                            </span>
+                        )}
                     </div>
                 </div>
             </div>
@@ -166,8 +236,8 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                                 Buy Pollen
                             </h3>
                             <p className="text-sm text-amber-800">
-                                Choose a pack below. 🧪 Beta bonus is already
-                                included, with larger packs getting more.
+                                Choose a pack. Larger packs include a bigger
+                                beta bonus.
                             </p>
                         </div>
 
@@ -180,7 +250,7 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                                     color="amber"
                                     weight="light"
                                     title={`Buy $${pack.amountUsd} pollen pack`}
-                                    className="btn-shimmer w-full min-w-0 justify-self-stretch whitespace-nowrap border border-amber-300/70 px-3 text-center text-xs shadow-none sm:w-[132px] sm:justify-self-center sm:text-sm"
+                                    className="btn-shimmer w-full min-w-0 justify-self-stretch whitespace-nowrap border border-amber-300/70 px-3 text-center text-xs shadow-none sm:w-[156px] sm:justify-self-center sm:text-sm"
                                 >
                                     <span className="font-semibold text-amber-900">
                                         ${pack.amountUsd}
@@ -189,10 +259,10 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                                         /
                                     </span>
                                     <span className="font-medium text-amber-900">
-                                        🪷{" "}
                                         {formatPollenPackValue(
                                             pack.pollenGrant,
-                                        )}
+                                        )}{" "}
+                                        pollen
                                     </span>
                                 </Button>
                             ))}

--- a/enter.pollinations.ai/src/client/components/balance/tier-panel.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/tier-panel.tsx
@@ -69,7 +69,7 @@ const MicrobeLimitedPanel: FC = () => (
     </Panel>
 );
 
-// ─── Tier screen (spore + creator tiers) ─────────────────────
+// ─── Tier screen (active tier display) ─────────────────────
 
 const TierScreen: FC<{
     tier: TierStatus;

--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -22,11 +22,11 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
-        date: "2026-04-17",
-        emoji: "💰",
-        title: "Transparent Pricing: Cost vs Price",
+        date: "2026-04-23",
+        emoji: "🌻",
+        title: "Dev earnings for BYOP",
         description:
-            "The registry now tracks provider cost separately from user price. See the [pricing table](/#pricing) for the rates you pay.",
+            "Register a BYOP App Key — 20% of what users spend on your app comes back to you as Pollen. [Create an App Key](/#keys)",
     },
 ];
 

--- a/enter.pollinations.ai/src/client/components/pricing/Pricing.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/Pricing.tsx
@@ -8,10 +8,15 @@ import { useModelStats } from "./use-model-stats.ts";
 
 type PricingProps = {
     tierBalance?: number;
+    devBalance?: number;
     packBalance?: number;
 };
 
-export const Pricing: FC<PricingProps> = ({ tierBalance, packBalance }) => {
+export const Pricing: FC<PricingProps> = ({
+    tierBalance,
+    devBalance,
+    packBalance,
+}) => {
     useEffect(() => {
         if (window.location.hash === "#models") {
             const el = document.getElementById("models");
@@ -62,6 +67,7 @@ export const Pricing: FC<PricingProps> = ({ tierBalance, packBalance }) => {
                         audioModels={audioModels}
                         textModels={textModels}
                         tierBalance={tierBalance}
+                        devBalance={devBalance}
                         packBalance={packBalance}
                     />
                 </div>
@@ -73,20 +79,13 @@ export const Pricing: FC<PricingProps> = ({ tierBalance, packBalance }) => {
                             className="text-xs !border-transparent"
                         >
                             <div className="font-bold text-gray-900 uppercase tracking-wide mb-2">
-                                💡 How Pollen is Spent
+                                💡 How Pollen Works
                             </div>
                             <div className="space-y-1 text-xs text-gray-500">
                                 <div>
-                                    1. Tier grants (refilled hourly) are used
-                                    first
-                                </div>
-                                <div>
-                                    2. Purchased pollen is used after tier
-                                    grants are depleted
-                                </div>
-                                <div className="text-purple-700 mt-2">
-                                    ⚠️ <strong>Exception:</strong> 🪷 Paid Only
-                                    models require purchased pollen only
+                                    - Spending order: 🌱 Tier Pollen (skipped
+                                    for paid-only models) → 🌻 Dev earnings → 💳
+                                    Top-up Pollen
                                 </div>
                             </div>
                         </Card>

--- a/enter.pollinations.ai/src/client/components/pricing/calculations.ts
+++ b/enter.pollinations.ai/src/client/components/pricing/calculations.ts
@@ -8,7 +8,9 @@
 import millify from "millify";
 import type { ModelPrice } from "./types.ts";
 
-export const TOP_UP_TOOLTIP = "🔒 Top up to use this model";
+export const TOP_UP_TOOLTIP = "Top up to use this model";
+export const PAID_ONLY_TOOLTIP =
+    "Requires 💳 Top-up Pollen or 🌻 Dev earnings. 🌱 Tier Pollen cannot be used.";
 
 /** Format number as coarse estimate (not precise - it's an average) */
 function formatCount(num: number): string {
@@ -35,8 +37,6 @@ export function calculatePerPollen(model: ModelPrice): string {
 
 /**
  * Calculate how many requests the user can afford with their current balance.
- * For paid-only models: only packBalance.
- * For free models: tierBalance + packBalance.
  * Returns "0" when balance is insufficient, "—" when no cost data.
  */
 export function calculateForBalance(

--- a/enter.pollinations.ai/src/client/components/pricing/model-info.ts
+++ b/enter.pollinations.ai/src/client/components/pricing/model-info.ts
@@ -153,7 +153,7 @@ export const isNewModel = (modelName: string): boolean => {
 };
 
 /**
- * Check if a model requires paid balance only (no tier balance)
+ * Check if a model requires non-tier balance.
  */
 export const isPaidOnly = (modelName: string): boolean => {
     const service = getModelDefinition(modelName as ModelName);

--- a/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
@@ -1,9 +1,11 @@
 import { type FC, useState } from "react";
+import { toFinitePollen } from "@/client/lib/format-pollen.ts";
 import { cn } from "../../../util.ts";
 import { Badge } from "../ui/badge.tsx";
 import {
     calculateForBalance,
     calculatePerPollen,
+    PAID_ONLY_TOOLTIP,
     TOP_UP_TOOLTIP,
 } from "./calculations.ts";
 import {
@@ -24,12 +26,14 @@ import type { ModelPrice } from "./types.ts";
 type ModelRowProps = {
     model: ModelPrice;
     tierBalance?: number;
+    devBalance?: number;
     packBalance?: number;
 };
 
 export const ModelRow: FC<ModelRowProps> = ({
     model,
     tierBalance,
+    devBalance,
     packBalance,
 }) => {
     const modelDisplayName = getModelDisplayName(model.name);
@@ -45,9 +49,10 @@ export const ModelRow: FC<ModelRowProps> = ({
     const showAlpha = isAlpha(model.name);
 
     const isSignedIn = packBalance !== undefined;
-    const paidBalance = packBalance ?? 0;
-    const totalBalance = (tierBalance ?? 0) + paidBalance;
-    const effectiveBalance = showPaidOnly ? paidBalance : totalBalance;
+    const nonTierBalance =
+        toFinitePollen(devBalance) + toFinitePollen(packBalance);
+    const totalBalance = toFinitePollen(tierBalance) + nonTierBalance;
+    const effectiveBalance = showPaidOnly ? nonTierBalance : totalBalance;
 
     const genPerPollen = calculatePerPollen(model);
     const balanceRequests = isSignedIn
@@ -230,13 +235,7 @@ export const ModelRow: FC<ModelRowProps> = ({
                                 </Tooltip>
                             )}
                             {showPaidOnly && (
-                                <Tooltip
-                                    content={
-                                        isDisabled
-                                            ? TOP_UP_TOOLTIP
-                                            : "This model uses purchased pollen only."
-                                    }
-                                >
+                                <Tooltip content={PAID_ONLY_TOOLTIP}>
                                     <Badge color="purple" size="sm">
                                         PAID
                                     </Badge>
@@ -254,7 +253,9 @@ export const ModelRow: FC<ModelRowProps> = ({
                         content={
                             <span className="text-xs">
                                 {isDisabled
-                                    ? TOP_UP_TOOLTIP
+                                    ? showPaidOnly
+                                        ? PAID_ONLY_TOOLTIP
+                                        : TOP_UP_TOOLTIP
                                     : `≈ ${balanceRequests} with current balance`}
                             </span>
                         }

--- a/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
@@ -3,6 +3,7 @@ import {
     type ModelName,
 } from "@shared/registry/registry.ts";
 import { type FC, type MouseEvent, useState } from "react";
+import { toFinitePollen } from "@/client/lib/format-pollen.ts";
 import { cn } from "../../../util.ts";
 import { Button } from "../button.tsx";
 import { Badge } from "../ui/badge.tsx";
@@ -33,6 +34,7 @@ type UnifiedModelTableProps = {
     textModels: ModelPrice[];
     audioModels: ModelPrice[];
     tierBalance?: number;
+    devBalance?: number;
     packBalance?: number;
 };
 
@@ -133,6 +135,7 @@ type TabContentProps = {
     sortKey: SortKey;
     sortDir: SortDir;
     tierBalance?: number;
+    devBalance?: number;
     packBalance?: number;
 };
 
@@ -142,6 +145,7 @@ const TabContent: FC<TabContentProps> = ({
     sortKey,
     sortDir,
     tierBalance,
+    devBalance,
     packBalance,
 }) => {
     const sorted = sortModels(models, sortKey, sortDir);
@@ -159,6 +163,7 @@ const TabContent: FC<TabContentProps> = ({
                         key={model.name}
                         model={model}
                         tierBalance={tierBalance}
+                        devBalance={devBalance}
                         packBalance={packBalance}
                     />
                 ))}
@@ -174,6 +179,7 @@ const TabContent: FC<TabContentProps> = ({
                                 key={model.name}
                                 model={model}
                                 tierBalance={tierBalance}
+                                devBalance={devBalance}
                                 packBalance={packBalance}
                             />
                         ))}
@@ -188,6 +194,7 @@ const TabContent: FC<TabContentProps> = ({
                         key={model.name}
                         model={model}
                         tierBalance={tierBalance}
+                        devBalance={devBalance}
                         packBalance={packBalance}
                     />
                 ))}
@@ -203,6 +210,7 @@ const TabContent: FC<TabContentProps> = ({
                                 key={model.name}
                                 model={model}
                                 tierBalance={tierBalance}
+                                devBalance={devBalance}
                                 packBalance={packBalance}
                             />
                         ))}
@@ -218,12 +226,14 @@ const TabContent: FC<TabContentProps> = ({
 type MobileModelRowProps = {
     model: ModelPrice;
     tierBalance?: number;
+    devBalance?: number;
     packBalance?: number;
 };
 
 const MobileModelRow: FC<MobileModelRowProps> = ({
     model,
     tierBalance,
+    devBalance,
     packBalance,
 }) => {
     const [expanded, setExpanded] = useState(false);
@@ -238,9 +248,10 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
     const showAlpha = isAlpha(model.name);
 
     const isSignedIn = packBalance !== undefined;
-    const paidBalance = packBalance ?? 0;
-    const totalBalance = (tierBalance ?? 0) + paidBalance;
-    const effectiveBalance = showPaidOnly ? paidBalance : totalBalance;
+    const nonTierBalance =
+        toFinitePollen(devBalance) + toFinitePollen(packBalance);
+    const totalBalance = toFinitePollen(tierBalance) + nonTierBalance;
+    const effectiveBalance = showPaidOnly ? nonTierBalance : totalBalance;
 
     const perPollen = calculatePerPollen(model);
     const balanceRequests = isSignedIn
@@ -557,6 +568,7 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
     textModels,
     audioModels,
     tierBalance,
+    devBalance,
     packBalance,
 }) => {
     const sections: { type: SectionType; models: ModelPrice[] }[] = [
@@ -677,6 +689,7 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
                     sortKey={sortKey}
                     sortDir={sortDir}
                     tierBalance={tierBalance}
+                    devBalance={devBalance}
                     packBalance={packBalance}
                 />
             )}

--- a/enter.pollinations.ai/src/client/lib/format-pollen.ts
+++ b/enter.pollinations.ai/src/client/lib/format-pollen.ts
@@ -1,3 +1,11 @@
-export function formatPollen(value: number): string {
-    return value.toFixed(value > 0 && value < 1 ? 3 : 2);
+export function toFinitePollen(value: unknown): number {
+    if (value === null || value === undefined) return 0;
+    const numericValue =
+        typeof value === "number" ? value : Number.parseFloat(String(value));
+    return Number.isFinite(numericValue) ? numericValue : 0;
+}
+
+export function formatPollen(value: unknown): string {
+    const safeValue = toFinitePollen(value);
+    return safeValue.toFixed(safeValue > 0 && safeValue < 1 ? 3 : 2);
 }

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -28,7 +28,7 @@ import {
     sanitizeAuthorizeAccountPermissions,
 } from "../lib/authorize-config.ts";
 import { createKeyWithPermissions } from "../lib/create-api-key.ts";
-import { formatPollen } from "../lib/format-pollen.ts";
+import { formatPollen, toFinitePollen } from "../lib/format-pollen.ts";
 
 type Attribution = {
     found: boolean;
@@ -255,7 +255,9 @@ function AuthorizeComponent() {
             .then((data) => {
                 if (!data) return;
                 setTotalBalance(
-                    (data.tierBalance ?? 0) + (data.packBalance ?? 0),
+                    toFinitePollen(data.tierBalance) +
+                        toFinitePollen(data.devBalance) +
+                        toFinitePollen(data.packBalance),
                 );
             })
             .catch(() => {});

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -21,6 +21,7 @@ import {
     type UsagePeriodSelection,
 } from "../components/usage-analytics";
 import { createKeyWithPermissions } from "../lib/create-api-key.ts";
+import { toFinitePollen } from "../lib/format-pollen.ts";
 
 const DETAILED_USAGE_DOWNLOAD_LIMIT = 50_000;
 
@@ -45,8 +46,9 @@ export const Route = createFileRoute("/")({
                     .then((r) => (r.ok ? r.json() : null)),
             ]);
         const apiKeys = apiKeysResult.data || [];
-        const tierBalance = d1BalanceResult?.tierBalance ?? 0;
-        const packBalance = d1BalanceResult?.packBalance ?? 0;
+        const tierBalance = toFinitePollen(d1BalanceResult?.tierBalance);
+        const devBalance = toFinitePollen(d1BalanceResult?.devBalance);
+        const packBalance = toFinitePollen(d1BalanceResult?.packBalance);
         // Prefer D1 — session (KV-cached) may hold a stale username after relog.
         const githubUsername =
             profileResult?.githubUsername ?? context.user?.githubUsername ?? "";
@@ -57,6 +59,7 @@ export const Route = createFileRoute("/")({
             apiKeys,
             tierData,
             tierBalance,
+            devBalance,
             packBalance,
         };
     },
@@ -70,6 +73,7 @@ function RouteComponent() {
         apiKeys,
         tierData,
         tierBalance,
+        devBalance,
         packBalance,
     } = Route.useLoaderData();
 
@@ -259,8 +263,8 @@ function RouteComponent() {
                     {activeTab === "balance" && (
                         <PollenBalance
                             tierBalance={tierBalance}
+                            devBalance={devBalance}
                             packBalance={packBalance}
-                            tier={tierData?.active?.tier}
                         />
                     )}
                     {activeTab === "usage" && (
@@ -284,7 +288,11 @@ function RouteComponent() {
                     onUpdate={handleUpdateApiKey}
                     onDelete={handleDeleteApiKey}
                 />
-                <Pricing tierBalance={tierBalance} packBalance={packBalance} />
+                <Pricing
+                    tierBalance={tierBalance}
+                    devBalance={devBalance}
+                    packBalance={packBalance}
+                />
                 <FAQ />
                 <Footer />
             </div>

--- a/enter.pollinations.ai/src/content-filter.ts
+++ b/enter.pollinations.ai/src/content-filter.ts
@@ -1,6 +1,6 @@
-import {
-    type ContentFilterResult,
-    type ContentFilterSeverity,
+import type {
+    ContentFilterResult,
+    ContentFilterSeverity,
 } from "@/schemas/openai.ts";
 
 const severityOrder: Record<ContentFilterSeverity, number> = {

--- a/enter.pollinations.ai/src/db/schema/better-auth.ts
+++ b/enter.pollinations.ai/src/db/schema/better-auth.ts
@@ -32,6 +32,7 @@ export const user = sqliteTable("user", {
   tier: text("tier").default("spore").notNull(),
   tierBalance: real("tier_balance"),
   packBalance: real("pack_balance"),
+  devBalance: real("dev_balance"),
   lastTierGrant: integer("last_tier_grant"),
 }, (table) => [
   index("idx_user_email").on(table.email),

--- a/enter.pollinations.ai/src/db/schema/event.ts
+++ b/enter.pollinations.ai/src/db/schema/event.ts
@@ -81,6 +81,10 @@ export type TinybirdEvent = {
     totalCost: number;
     totalPrice: number;
 
+    // BYOP dev markup (populated when request was authenticated by a BYOP sk_)
+    devCredit?: number;
+    byopMarkupPct?: number;
+
     // Prompt Moderation
     moderationPromptHateSeverity?: string;
     moderationPromptSelfHarmSeverity?: string;

--- a/enter.pollinations.ai/src/env.ts
+++ b/enter.pollinations.ai/src/env.ts
@@ -1,5 +1,5 @@
-import { RequestIdVariables } from "hono/request-id";
-import { LoggerVariables } from "./middleware/logger.ts";
+import type { RequestIdVariables } from "hono/request-id";
+import type { LoggerVariables } from "./middleware/logger.ts";
 
 export type ErrorVariables = {
     error?: Error;

--- a/enter.pollinations.ai/src/logger.ts
+++ b/enter.pollinations.ai/src/logger.ts
@@ -1,14 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { inspect } from "node:util";
-import { applyColor } from "@/util";
 import {
     configure,
-    getConsoleSink,
+    type FormattedValues,
     getAnsiColorFormatter,
+    getConsoleSink,
     getJsonLinesFormatter,
-    FormattedValues,
-    LogLevel,
+    type LogLevel,
 } from "@logtape/logtape";
+import { applyColor } from "@/util";
 
 export type LogFormat = "json" | "text";
 

--- a/enter.pollinations.ai/src/middleware/alias.ts
+++ b/enter.pollinations.ai/src/middleware/alias.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from "hono/factory";
 import { routePath } from "hono/route";
-import { LoggerVariables } from "@/middleware/logger.ts";
+import type { LoggerVariables } from "@/middleware/logger.ts";
 
 type AliasEnv = {
     Bindings: CloudflareBindings;

--- a/enter.pollinations.ai/src/middleware/balance.ts
+++ b/enter.pollinations.ai/src/middleware/balance.ts
@@ -5,6 +5,9 @@ import { HTTPException } from "hono/http-exception";
 import { user as userTable } from "@/db/schema/better-auth.ts";
 import type { AuthVariables } from "@/middleware/auth.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
+import type { UserBalance } from "@/utils/balance-deduction.ts";
+
+export type { UserBalance } from "@/utils/balance-deduction.ts";
 
 type BalanceCheckResult = {
     selectedMeterId: string;
@@ -12,25 +15,24 @@ type BalanceCheckResult = {
     balances: Record<string, number>;
 };
 
-export type UserBalance = {
-    tierBalance: number;
-    packBalance: number;
-};
-
 /**
  * Get the total available balance across relevant buckets.
- * For paid-only models: pack only.
- * For regular models: tier + pack (only positive buckets).
+ * For paid-only models: dev + pack.
+ * For regular models: tier + dev + pack (only positive buckets).
  */
 export function getAvailableBalance(
     balances: UserBalance,
     isPaidOnly = false,
 ): number {
     if (isPaidOnly) {
-        return Math.max(0, balances.packBalance);
+        return (
+            Math.max(0, balances.devBalance) + Math.max(0, balances.packBalance)
+        );
     }
     return (
-        Math.max(0, balances.tierBalance) + Math.max(0, balances.packBalance)
+        Math.max(0, balances.tierBalance) +
+        Math.max(0, balances.devBalance) +
+        Math.max(0, balances.packBalance)
     );
 }
 
@@ -56,11 +58,13 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
     const db = drizzle(c.env.DB);
 
     // Get balance from D1 only
-    // Pack balance is updated via webhooks, tier balance via hourly cron refill
+    // Pack balance is updated via webhooks, tier balance via hourly cron refill,
+    // dev balance via BYOP markup credits in track middleware
     const getBalance = async (userId: string): Promise<UserBalance> => {
         const users = await db
             .select({
                 tierBalance: userTable.tierBalance,
+                devBalance: userTable.devBalance,
                 packBalance: userTable.packBalance,
             })
             .from(userTable)
@@ -70,11 +74,11 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
         const user = users[0];
         return {
             tierBalance: user?.tierBalance ?? 0,
+            devBalance: user?.devBalance ?? 0,
             packBalance: user?.packBalance ?? 0,
         };
     };
 
-    // Helper to fetch balance with error handling
     const fetchBalanceWithErrorHandling = async (
         userId: string,
     ): Promise<UserBalance> => {
@@ -91,33 +95,49 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
         }
     };
 
-    // Helper to determine selected balance source
+    // Mirror the priority used by atomicDeductUserBalance:
+    // tier → dev → pack (paid-only skips only tier).
     const determineBalanceSource = (
         balances: UserBalance,
         isPaidOnly = false,
     ): { source: string; slug: string } => {
         if (isPaidOnly) {
+            if (balances.devBalance > 0) {
+                return { source: "dev", slug: "v1:meter:dev" };
+            }
             return { source: "pack", slug: "v1:meter:pack" };
         }
 
-        // Regular: tier → pack
         if (balances.tierBalance > 0) {
             return { source: "tier", slug: "v1:meter:tier" };
+        }
+        if (balances.devBalance > 0) {
+            return { source: "dev", slug: "v1:meter:dev" };
         }
         return { source: "pack", slug: "v1:meter:pack" };
     };
 
+    const allBalancesMap = (b: UserBalance): Record<string, number> => ({
+        "v1:meter:tier": b.tierBalance,
+        "v1:meter:dev": b.devBalance,
+        "v1:meter:pack": b.packBalance,
+    });
+
     const requirePositiveBalance = async (userId: string, message?: string) => {
         const balances = await fetchBalanceWithErrorHandling(userId);
-        // Check if any individual bucket is positive (don't sum — negative buckets shouldn't cancel out positive ones)
+        // Check each bucket individually — summing would let a negative bucket
+        // cancel out a positive one and block admission incorrectly.
         const hasPositiveBalance =
-            balances.tierBalance > 0 || balances.packBalance > 0;
+            balances.tierBalance > 0 ||
+            balances.devBalance > 0 ||
+            balances.packBalance > 0;
 
         log.debug(
-            "Local pollen balance for user {userId}: tier={tierBalance}, pack={packBalance}",
+            "Local pollen balance for user {userId}: tier={tierBalance}, dev={devBalance}, pack={packBalance}",
             {
                 userId,
                 tierBalance: balances.tierBalance,
+                devBalance: balances.devBalance,
                 packBalance: balances.packBalance,
             },
         );
@@ -127,15 +147,11 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
             c.var.balance.balanceCheckResult = {
                 selectedMeterId: `local:${source}`,
                 selectedMeterSlug: slug,
-                balances: {
-                    "v1:meter:tier": balances.tierBalance,
-                    "v1:meter:pack": balances.packBalance,
-                },
+                balances: allBalancesMap(balances),
             };
             return;
         }
 
-        // no positive balance - 402 for all billing/payment issues
         throw new HTTPException(402, {
             message: message || "Your pollen balance is too low.",
         });
@@ -144,12 +160,17 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
     const requirePaidBalance = async (userId: string, message?: string) => {
         const balances = await fetchBalanceWithErrorHandling(userId);
 
-        const hasPositivePaidBalance = balances.packBalance > 0;
+        const hasPositivePaidBalance =
+            balances.devBalance > 0 || balances.packBalance > 0;
 
-        log.debug("Paid balance check for user {userId}: pack={packBalance}", {
-            userId,
-            packBalance: balances.packBalance,
-        });
+        log.debug(
+            "Non-tier balance check for user {userId}: dev={devBalance}, pack={packBalance}",
+            {
+                userId,
+                devBalance: balances.devBalance,
+                packBalance: balances.packBalance,
+            },
+        );
 
         if (hasPositivePaidBalance) {
             const { source, slug } = determineBalanceSource(balances, true);
@@ -157,18 +178,18 @@ export const balance = createMiddleware<BalanceEnv>(async (c, next) => {
                 selectedMeterId: `local:${source}`,
                 selectedMeterSlug: slug,
                 balances: {
-                    "v1:meter:tier": 0, // Tier not available for paid-only
+                    "v1:meter:tier": 0,
+                    "v1:meter:dev": balances.devBalance,
                     "v1:meter:pack": balances.packBalance,
                 },
             };
             return;
         }
 
-        // No paid balance available
         throw new HTTPException(402, {
             message:
                 message ||
-                "This model requires a paid balance. Tier balance cannot be used.",
+                "This model requires 💳 Top-up Pollen or 🌻 Dev earnings. 🌱 Tier Pollen cannot be used.",
         });
     };
 

--- a/enter.pollinations.ai/src/middleware/track.ts
+++ b/enter.pollinations.ai/src/middleware/track.ts
@@ -48,6 +48,7 @@ import {
     ContentFilterSeveritySchema,
 } from "@/schemas/openai.ts";
 import { generateRandomId, removeUnset } from "@/util.ts";
+import type { MarkupResolution } from "@/utils/track-helpers.ts";
 import { handleBalanceDeduction } from "@/utils/track-helpers.ts";
 import type { BalanceVariables } from "./balance.ts";
 import type { LoggerVariables } from "./logger.ts";
@@ -177,6 +178,21 @@ export const track = (eventType: EventType) =>
 
                 const ipHash = await hashIp(clientIp, c.env.BETTER_AUTH_SECRET);
 
+                // Deduct payer + credit dev BEFORE emitting the event so
+                // dev_credit on the event reflects the ledger, not our intent.
+                // If the credit fails, handleBalanceDeduction returns markup=null
+                // and the event records dev_credit=0.
+                const { markup } = await handleBalanceDeduction({
+                    db,
+                    isBilledUsage: responseTracking.isBilledUsage,
+                    totalPrice: responseTracking.price?.totalPrice,
+                    userId: userTracking.userId,
+                    apiKeyId: c.var.auth?.apiKey?.id,
+                    apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
+                    apiKeyClientId: userTracking.apiKeyClientId,
+                    modelResolved: c.var.model?.resolved,
+                });
+
                 const finalEvent = createTrackingEvent({
                     id: generateRandomId(),
                     requestId: c.get("requestId"),
@@ -191,6 +207,7 @@ export const track = (eventType: EventType) =>
                     balanceTracking,
                     requestTracking,
                     responseTracking,
+                    markup,
                     errorTracking: collectErrorData(response, c.get("error")),
                 });
 
@@ -203,6 +220,7 @@ export const track = (eventType: EventType) =>
                         '  selectedMeterSlug="{event.selectedMeterSlug}"',
                         "  totalCost={event.totalCost}",
                         "  totalPrice={event.totalPrice}",
+                        "  devCredit={event.devCredit}",
                     ].join("\n"),
                     { event: finalEvent },
                 );
@@ -213,17 +231,6 @@ export const track = (eventType: EventType) =>
                     c.env.TINYBIRD_INGEST_TOKEN,
                     log,
                 );
-
-                // Handle balance deduction for both API keys and users
-                await handleBalanceDeduction({
-                    db,
-                    isBilledUsage: responseTracking.isBilledUsage,
-                    totalPrice: responseTracking.price?.totalPrice,
-                    userId: userTracking.userId,
-                    apiKeyId: c.var.auth?.apiKey?.id,
-                    apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
-                    modelResolved: c.var.model?.resolved,
-                });
             })(),
         );
     });
@@ -433,6 +440,7 @@ type TrackingEventInput = {
     balanceTracking: BalanceData;
     requestTracking: RequestTrackingData;
     responseTracking: ResponseTrackingData;
+    markup: MarkupResolution | null;
     errorTracking?: ErrorData;
 };
 
@@ -450,6 +458,7 @@ function createTrackingEvent({
     balanceTracking,
     requestTracking,
     responseTracking,
+    markup,
     errorTracking,
 }: TrackingEventInput): InsertGenerationEvent {
     return {
@@ -483,6 +492,9 @@ function createTrackingEvent({
 
         totalCost: responseTracking.cost?.totalCost || 0,
         totalPrice: responseTracking.price?.totalPrice || 0,
+
+        devCredit: markup?.devCredit ?? 0,
+        byopMarkupPct: markup?.markupPct ?? 0,
 
         ...responseTracking.contentFilterResults,
         ...errorTracking,

--- a/enter.pollinations.ai/src/middleware/validator.ts
+++ b/enter.pollinations.ai/src/middleware/validator.ts
@@ -1,7 +1,7 @@
 import type { ValidationTargets } from "hono";
 import { validator as zValidator } from "hono-openapi";
-import { z, ZodError } from "zod";
-import { $ZodIssue } from "zod/v4/core";
+import { ZodError, type z } from "zod";
+import type { $ZodIssue } from "zod/v4/core";
 
 const validationTargetMessages: { [key in keyof ValidationTargets]: string } = {
     query: "Query parameter validation failed",

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -719,6 +719,7 @@ export const accountRoutes = new Hono<Env>()
             const users = await db
                 .select({
                     tierBalance: userTable.tierBalance,
+                    devBalance: userTable.devBalance,
                     packBalance: userTable.packBalance,
                 })
                 .from(userTable)
@@ -726,12 +727,16 @@ export const accountRoutes = new Hono<Env>()
                 .limit(1);
 
             const tierBalance = users[0]?.tierBalance ?? 0;
+            const devBalance = users[0]?.devBalance ?? 0;
             const packBalance = users[0]?.packBalance ?? 0;
 
             // Clamp each bucket at 0 before summing — individual buckets can go negative
             // from overage but shouldn't reduce the visible total
             return c.json({
-                balance: Math.max(0, tierBalance) + Math.max(0, packBalance),
+                balance:
+                    Math.max(0, tierBalance) +
+                    Math.max(0, devBalance) +
+                    Math.max(0, packBalance),
             });
         },
     )

--- a/enter.pollinations.ai/src/routes/customer.ts
+++ b/enter.pollinations.ai/src/routes/customer.ts
@@ -19,14 +19,13 @@ export const customerRoutes = new Hono<Env>()
         describeRoute({
             tags: ["👤 Account"],
             description:
-                "Get detailed balance breakdown for the current user (tier, pack).",
+                "Get detailed balance breakdown for the current user (tier, dev, pack).",
             hide: ({ c }) => c?.env.ENVIRONMENT === "production", // Internal endpoint
         }),
         async (c) => {
             const user = c.var.auth.requireUser();
-            const { tierBalance, packBalance } = await c.var.balance.getBalance(
-                user.id,
-            );
+            const { tierBalance, devBalance, packBalance } =
+                await c.var.balance.getBalance(user.id);
             const db = drizzle(c.env.DB);
             const users = await db
                 .select({ lastTierGrant: userTable.lastTierGrant })
@@ -37,6 +36,7 @@ export const customerRoutes = new Hono<Env>()
 
             return c.json({
                 tierBalance,
+                devBalance,
                 packBalance,
                 lastTierGrant,
             });

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -352,7 +352,7 @@ function generateLLMDoc(): string {
 
     lines.push("### GET /api/account/balance");
     lines.push(
-        "Returns { balance } — remaining pollen (sum of tier + pack + crypto). If API key has a budget, returns key budget instead.",
+        "Returns { balance } — remaining pollen. If API key has a budget, returns key budget instead.",
     );
     lines.push(
         "Requires `account:usage` permission when using an API key without a budget of its own.",

--- a/enter.pollinations.ai/src/routes/model-stats.ts
+++ b/enter.pollinations.ai/src/routes/model-stats.ts
@@ -4,8 +4,8 @@
  * to avoid duplicate caching and Tinybird calls
  */
 
-import { Hono } from "hono";
 import { getLogger } from "@logtape/logtape";
+import { Hono } from "hono";
 import type { Env } from "../env.ts";
 import { getModelStats } from "../utils/model-stats.ts";
 

--- a/enter.pollinations.ai/src/routes/proxy.ts
+++ b/enter.pollinations.ai/src/routes/proxy.ts
@@ -188,7 +188,7 @@ function filterModelsByPermissions<
 function hasPaidBalance(c: any): boolean | undefined {
     const user = c.var?.auth?.user;
     if (!user) return undefined;
-    return (user.packBalance ?? 0) > 0;
+    return (user.devBalance ?? 0) > 0 || (user.packBalance ?? 0) > 0;
 }
 
 export const proxyRoutes = new Hono<Env>()

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -1,10 +1,11 @@
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import type Stripe from "stripe";
 import { getPollenPack } from "@/pollen-packs.ts";
 import { user as userTable } from "../db/schema/better-auth.ts";
 import type { Env } from "../env.ts";
+import { atomicCreditUserBalance } from "../utils/balance-deduction.ts";
 import { createStripeClient, verifyWebhookSignature } from "../utils/stripe.ts";
 
 interface StripeEventData {
@@ -139,12 +140,7 @@ const handleCheckoutSessionCompleted = async (
     }
 
     // Credit pollen to packBalance (cumulative)
-    await db
-        .update(userTable)
-        .set({
-            packBalance: sql`COALESCE(${userTable.packBalance}, 0) + ${creditsToAdd}`,
-        })
-        .where(eq(userTable.id, userId));
+    await atomicCreditUserBalance(db, userId, "pack", creditsToAdd);
 
     console.log(
         pack

--- a/enter.pollinations.ai/src/routes/webhooks.ts
+++ b/enter.pollinations.ai/src/routes/webhooks.ts
@@ -6,12 +6,11 @@ import {
     validateEvent,
     WebhookVerificationError,
 } from "@polar-sh/sdk/webhooks";
-import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { user as userTable } from "../db/schema/better-auth.ts";
 import type { Env } from "../env.ts";
+import { atomicCreditUserBalance } from "../utils/balance-deduction.ts";
 
 const log = getLogger(["hono", "webhooks"]);
 
@@ -222,16 +221,12 @@ async function handlePackBenefitGrant(
 
     try {
         // Pack purchase: ADD to pack_balance (cumulative)
-        const result = await db
-            .update(userTable)
-            .set({
-                packBalance: sql`COALESCE(${userTable.packBalance}, 0) + ${units}`,
-            })
-            .where(eq(userTable.id, externalId))
-            .returning({
-                id: userTable.id,
-                packBalance: userTable.packBalance,
-            });
+        const { ok, newBalance } = await atomicCreditUserBalance(
+            db,
+            externalId,
+            "pack",
+            units,
+        );
 
         // Structured logging for Cloudflare dashboard filtering via properties.eventType
         log.info(
@@ -242,12 +237,12 @@ async function handlePackBenefitGrant(
                 units,
                 orderId,
                 email: payload.data.customer.email ?? "unknown",
-                newBalance: result[0]?.packBalance ?? null,
-                rowsUpdated: result.length,
+                newBalance,
+                rowsUpdated: ok ? 1 : 0,
             },
         );
 
-        if (result.length === 0) {
+        if (!ok) {
             log.warn(
                 "⚠️ PACK_PURCHASE_NO_USER: user={userId} not found in database orderId={orderId}",
                 {

--- a/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
+++ b/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
@@ -28,7 +28,7 @@ const TABLES: TableConfig[] = [
         datasource: "d1_user",
         query: `SELECT id, name, email, email_verified, image, created_at, updated_at,
                        role, banned, ban_reason, ban_expires, github_id, github_username,
-                       tier, tier_balance, pack_balance, last_tier_grant
+                       tier, tier_balance, pack_balance, dev_balance, last_tier_grant
                 FROM user`,
     },
     {

--- a/enter.pollinations.ai/src/util.ts
+++ b/enter.pollinations.ai/src/util.ts
@@ -112,10 +112,10 @@ export function safeRound(amount: number, precision: number = 6): number {
         return 0;
     }
     // Handle very small amounts (avoid floating point issues)
-    if (Math.abs(amount) < Math.pow(10, -(precision + 2))) {
+    if (Math.abs(amount) < 10 ** -(precision + 2)) {
         return 0;
     }
-    const factor = Math.pow(10, precision);
+    const factor = 10 ** precision;
     return Math.round(amount * factor) / factor;
 }
 
@@ -139,8 +139,8 @@ export function exponentialBackoffDelay(
 
     if (attempt === 0) return 0;
 
-    const base = Math.pow(maxDelay / minDelay, 1 / (maxAttempts - 1));
-    const delay = minDelay * Math.pow(base, attempt - 1);
+    const base = (maxDelay / minDelay) ** (1 / (maxAttempts - 1));
+    const delay = minDelay * base ** (attempt - 1);
 
     if (jitter > 0) {
         const jitterRange = delay * jitter;

--- a/enter.pollinations.ai/src/utils/api-docs.ts
+++ b/enter.pollinations.ai/src/utils/api-docs.ts
@@ -1,11 +1,11 @@
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { resolver } from "hono-openapi";
 import {
     createErrorResponseSchema,
     type ErrorStatusCode,
     getDefaultErrorMessage,
     KNOWN_ERROR_STATUS_CODES,
 } from "@/error.ts";
-import { resolver } from "hono-openapi";
-import { ContentfulStatusCode } from "hono/utils/http-status";
 
 function createErrorResponseDescription(status: ContentfulStatusCode) {
     return {

--- a/enter.pollinations.ai/src/utils/balance-deduction.ts
+++ b/enter.pollinations.ai/src/utils/balance-deduction.ts
@@ -3,85 +3,138 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { user as userTable } from "../db/schema/better-auth.ts";
 
 /**
+ * Balance buckets, in the order they are consumed by atomicDeductUserBalance.
+ *
+ * - tier: free, hourly-refilled allowance per tier
+ * - dev: earnings from BYOP markup on apps the user owns (spendable)
+ * - pack: purchased via Stripe/Polar, cumulative
+ */
+export const BALANCE_BUCKETS = ["tier", "dev", "pack"] as const;
+export type Bucket = (typeof BALANCE_BUCKETS)[number];
+
+export type UserBalance = Record<`${Bucket}Balance`, number>;
+
+const BUCKET_COLUMNS = {
+    tier: userTable.tierBalance,
+    dev: userTable.devBalance,
+    pack: userTable.packBalance,
+} as const satisfies Record<Bucket, unknown>;
+
+/**
  * Atomically deducts pollen from user balance.
  *
- * If the user has no positive pack balance, always deducts from tier.
- * Tier resets hourly so going negative is fine — prevents spillover into pack.
- *
- * If the user has a positive pack balance, uses priority: tier → pack.
- * Lets users who purchased packs use them after tier runs out.
+ * Priority when non-tier balance is positive: tier → dev → pack.
+ * If no positive non-tier balance, always deducts from tier —
+ * tier refills hourly so going negative is fine and prevents spillover into
+ * non-tier buckets.
  */
 export async function atomicDeductUserBalance(
     db: DrizzleD1Database,
     userId: string,
     amount: number,
-): Promise<void> {
-    if (amount <= 0) return;
+): Promise<{ ok: boolean }> {
+    if (amount <= 0) return { ok: true };
 
-    await db.run(sql`
+    const result = await db.run(sql`
 		UPDATE ${userTable}
 		SET
 			tier_balance = CASE
-				WHEN COALESCE(pack_balance, 0) <= 0 THEN COALESCE(tier_balance, 0) - ${amount}
+				WHEN (COALESCE(pack_balance, 0) + COALESCE(dev_balance, 0)) <= 0 THEN COALESCE(tier_balance, 0) - ${amount}
 				WHEN COALESCE(tier_balance, 0) > 0 THEN COALESCE(tier_balance, 0) - ${amount}
 				ELSE tier_balance
 			END,
+			dev_balance = CASE
+				WHEN (COALESCE(pack_balance, 0) + COALESCE(dev_balance, 0)) <= 0 THEN dev_balance
+				WHEN COALESCE(tier_balance, 0) <= 0 AND COALESCE(dev_balance, 0) > 0 THEN COALESCE(dev_balance, 0) - ${amount}
+				ELSE dev_balance
+			END,
 			pack_balance = CASE
-				WHEN COALESCE(pack_balance, 0) <= 0 THEN pack_balance
-				WHEN COALESCE(tier_balance, 0) <= 0 THEN COALESCE(pack_balance, 0) - ${amount}
+				WHEN (COALESCE(pack_balance, 0) + COALESCE(dev_balance, 0)) <= 0 THEN pack_balance
+				WHEN COALESCE(tier_balance, 0) <= 0 AND COALESCE(dev_balance, 0) <= 0 THEN COALESCE(pack_balance, 0) - ${amount}
 				ELSE pack_balance
 			END
 		WHERE id = ${userId}
 	`);
+
+    return { ok: (result.meta.changes ?? 0) > 0 };
 }
 
 /**
  * Atomically deducts pollen from API key balance.
  * The `AND pollen_balance IS NOT NULL` guard means keys with NULL balance
  * (= unlimited budget) are never touched — no COALESCE needed here.
- *
- * @param db - Drizzle database instance
- * @param apiKeyTable - API key table
- * @param apiKeyId - API key ID to deduct from
- * @param amount - Amount of pollen to deduct
- * @returns Promise that resolves when deduction is complete
  */
 export async function atomicDeductApiKeyBalance(
     db: DrizzleD1Database,
     apiKeyTable: any,
     apiKeyId: string,
     amount: number,
-): Promise<void> {
-    if (amount <= 0) return;
+): Promise<{ ok: boolean }> {
+    if (amount <= 0) return { ok: true };
 
-    await db.run(sql`
+    const result = await db.run(sql`
 		UPDATE ${apiKeyTable}
 		SET pollen_balance = pollen_balance - ${amount}
 		WHERE id = ${apiKeyId}
 		AND pollen_balance IS NOT NULL
 	`);
+
+    return { ok: (result.meta.changes ?? 0) > 0 };
 }
 
-export type UserBalances = {
-    tierBalance: number;
-    packBalance: number;
-};
+/**
+ * Atomically adjusts any user balance bucket by a positive or negative amount.
+ *
+ * Returns { ok } — false means the user row was missing (UPDATE affected 0
+ * rows). `newBalance` is the post-adjustment value when available. Throws on
+ * D1 errors — the caller decides how to react.
+ */
+export async function atomicAdjustUserBalance(
+    db: DrizzleD1Database,
+    userId: string,
+    bucket: Bucket,
+    amount: number,
+): Promise<{ ok: boolean; newBalance: number | null }> {
+    if (amount === 0) return { ok: true, newBalance: null };
+
+    const column = BUCKET_COLUMNS[bucket];
+    const rows = await db
+        .update(userTable)
+        .set({ [`${bucket}Balance`]: sql`COALESCE(${column}, 0) + ${amount}` })
+        .where(sql`${userTable.id} = ${userId}`)
+        .returning({ newBalance: column });
+
+    return {
+        ok: rows.length > 0,
+        newBalance: rows[0]?.newBalance ?? null,
+    };
+}
+
+/**
+ * Atomically credits pollen to any user balance bucket.
+ */
+export async function atomicCreditUserBalance(
+    db: DrizzleD1Database,
+    userId: string,
+    bucket: Bucket,
+    amount: number,
+): Promise<{ ok: boolean; newBalance: number | null }> {
+    if (amount <= 0) return { ok: true, newBalance: null };
+    return atomicAdjustUserBalance(db, userId, bucket, amount);
+}
 
 /**
  * Gets the current balances for a user.
  * Useful for logging or displaying balance information.
- *
- * @param db - Drizzle database instance
- * @param userId - User ID to get balances for
- * @returns Object with tier and pack balances
  */
 export async function getUserBalances(
     db: DrizzleD1Database,
     userId: string,
-): Promise<UserBalances> {
+): Promise<UserBalance> {
     const result = await db
         .select({
             tierBalance: userTable.tierBalance,
+            devBalance: userTable.devBalance,
             packBalance: userTable.packBalance,
         })
         .from(userTable)
@@ -91,49 +144,61 @@ export async function getUserBalances(
     const user = result[0];
     return {
         tierBalance: user?.tierBalance ?? 0,
+        devBalance: user?.devBalance ?? 0,
         packBalance: user?.packBalance ?? 0,
     };
 }
 
-export type DeductionSource = {
-    fromTier: number;
-    fromPack: number;
-};
+export type DeductionSource = Record<`from${Capitalize<Bucket>}`, number>;
 
 /**
  * Identifies which single balance bucket a deduction comes from.
- * Matches the logic in atomicDeductUserBalance:
- * - If no positive pack balance → always tier
- * - Otherwise: tier → pack
+ * Mirrors the CASE logic in atomicDeductUserBalance:
+ * - If no positive non-tier balance → always tier
+ * - Otherwise: tier → dev → pack
  */
 export function identifyDeductionSource(
-    tierBalance: number,
-    packBalance: number,
+    balances: UserBalance,
     amount: number,
 ): DeductionSource {
-    if (packBalance <= 0) return { fromTier: amount, fromPack: 0 };
-    if (tierBalance > 0) return { fromTier: amount, fromPack: 0 };
-    return { fromTier: 0, fromPack: amount };
+    const zero: DeductionSource = {
+        fromTier: 0,
+        fromDev: 0,
+        fromPack: 0,
+    };
+    const { tierBalance, devBalance, packBalance } = balances;
+
+    if (devBalance + packBalance <= 0) return { ...zero, fromTier: amount };
+    if (tierBalance > 0) return { ...zero, fromTier: amount };
+    if (devBalance > 0) return { ...zero, fromDev: amount };
+    return { ...zero, fromPack: amount };
 }
 
 /**
- * Atomically deducts pollen from paid balance only (excluding tier_balance).
- *
- * @param db - Drizzle database instance
- * @param userId - User ID to deduct from
- * @param amount - Amount of pollen to deduct
- * @returns Promise that resolves when deduction is complete
+ * Atomically deducts pollen from non-tier balances only.
+ * Picks the first positive bucket: dev → pack.
+ * Full amount from one bucket.
  */
 export async function atomicDeductPaidBalance(
     db: DrizzleD1Database,
     userId: string,
     amount: number,
-): Promise<void> {
-    if (amount <= 0) return;
+): Promise<{ ok: boolean }> {
+    if (amount <= 0) return { ok: true };
 
-    await db.run(sql`
+    const result = await db.run(sql`
 		UPDATE ${userTable}
-		SET pack_balance = COALESCE(pack_balance, 0) - ${amount}
+		SET
+			dev_balance = CASE
+				WHEN COALESCE(dev_balance, 0) > 0 THEN COALESCE(dev_balance, 0) - ${amount}
+				ELSE dev_balance
+			END,
+			pack_balance = CASE
+				WHEN COALESCE(dev_balance, 0) <= 0 THEN COALESCE(pack_balance, 0) - ${amount}
+				ELSE pack_balance
+			END
 		WHERE id = ${userId}
 	`);
+
+    return { ok: (result.meta.changes ?? 0) > 0 };
 }

--- a/enter.pollinations.ai/src/utils/generation-access.ts
+++ b/enter.pollinations.ai/src/utils/generation-access.ts
@@ -52,7 +52,7 @@ export async function checkBalance(
     if (isPaidOnly) {
         await balance.requirePaidBalance(
             auth.user.id,
-            "This model requires a paid balance. Tier balance cannot be used.",
+            "This model requires 💳 Top-up Pollen or 🌻 Dev earnings. 🌱 Tier Pollen cannot be used.",
         );
         return;
     }

--- a/enter.pollinations.ai/src/utils/text-cache.ts
+++ b/enter.pollinations.ai/src/utils/text-cache.ts
@@ -4,9 +4,9 @@
  * Following the "thin proxy" design principle - keeping logic simple and minimal
  */
 
-import type { Context } from "hono";
 import type { Logger } from "@logtape/logtape";
 import stableStringify from "fast-json-stable-stringify";
+import type { Context } from "hono";
 
 // Parameters to exclude from cache key (auth + cache control)
 const EXCLUDED_PARAMS = ["key", "no-cache"];

--- a/enter.pollinations.ai/src/utils/track-helpers.ts
+++ b/enter.pollinations.ai/src/utils/track-helpers.ts
@@ -1,9 +1,13 @@
 import { getLogger } from "@logtape/logtape";
 import type { ModelName } from "@shared/registry/registry.ts";
 import { getModelDefinition } from "@shared/registry/registry.ts";
+import { eq } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { BYOP_MARKUP_PCT, computeDevCredit } from "@/billing-config.ts";
 import { apikey as apikeyTable } from "@/db/schema/better-auth.ts";
 import {
+    atomicAdjustUserBalance,
+    atomicCreditUserBalance,
     atomicDeductApiKeyBalance,
     atomicDeductPaidBalance,
     atomicDeductUserBalance,
@@ -13,6 +17,12 @@ import {
 
 const log = getLogger(["track", "helpers"]);
 
+export type MarkupResolution = {
+    devUserId: string;
+    devCredit: number;
+    markupPct: number;
+};
+
 interface DeductionParams {
     db: DrizzleD1Database;
     isBilledUsage: boolean;
@@ -20,15 +30,52 @@ interface DeductionParams {
     userId?: string;
     apiKeyId?: string;
     apiKeyPollenBalance?: number | null;
+    apiKeyClientId?: string;
     modelResolved?: string;
 }
 
 /**
- * Handles balance deduction for both API keys and users after billable requests
+ * Resolves the dev user id from a BYOP sk_ token's clientId (= pk_ row id).
+ * Returns null if the clientId is missing, invalid, or the pk_ row can't be found.
+ */
+export async function resolveDevMarkup(
+    db: DrizzleD1Database,
+    apiKeyClientId: string | undefined,
+    baselinePrice: number,
+): Promise<MarkupResolution | null> {
+    if (!apiKeyClientId) return null;
+    const credit = computeDevCredit(baselinePrice);
+    if (credit <= 0) return null;
+
+    const [clientRow] = await db
+        .select({ userId: apikeyTable.userId })
+        .from(apikeyTable)
+        .where(eq(apikeyTable.id, apiKeyClientId))
+        .limit(1);
+
+    if (!clientRow?.userId) return null;
+
+    return {
+        devUserId: clientRow.userId,
+        devCredit: credit,
+        markupPct: BYOP_MARKUP_PCT,
+    };
+}
+
+/**
+ * Handles balance deduction and BYOP dev credit for billable requests.
+ *
+ * Non-BYOP: deduct baseline from payer + api key budget.
+ * BYOP (apiKeyClientId present): deduct billed (baseline × 1+markup) from payer
+ * and api key budget; credit markup to dev's dev_balance.
+ *
+ * Returns the applied markup (if any) so the caller can record it on the
+ * generation event. On any billing failure this throws after best-effort
+ * compensation so the event is not emitted with a misleading dev credit.
  */
 export async function handleBalanceDeduction(
     params: DeductionParams,
-): Promise<void> {
+): Promise<{ markup: MarkupResolution | null }> {
     const {
         db,
         isBilledUsage,
@@ -36,20 +83,99 @@ export async function handleBalanceDeduction(
         userId,
         apiKeyId,
         apiKeyPollenBalance,
+        apiKeyClientId,
         modelResolved,
     } = params;
 
-    if (!isBilledUsage || !totalPrice) return;
+    if (!isBilledUsage || !totalPrice) return { markup: null };
 
-    // Handle API key budget deduction
-    if (apiKeyId && hasApiKeyBudget(apiKeyPollenBalance)) {
-        await deductApiKeyBalance(db, apiKeyId, totalPrice);
+    const resolved = await resolveDevMarkup(db, apiKeyClientId, totalPrice);
+    let devCredited = false;
+    let markup: MarkupResolution | null = resolved;
+    if (resolved) {
+        try {
+            const { ok } = await atomicCreditUserBalance(
+                db,
+                resolved.devUserId,
+                "dev",
+                resolved.devCredit,
+            );
+            if (!ok) {
+                log.error(
+                    "Dev credit UPDATE affected 0 rows for {devUserId} — dev row missing, skipping markup",
+                    { devUserId: resolved.devUserId },
+                );
+                markup = null;
+            } else {
+                devCredited = true;
+            }
+        } catch (error) {
+            log.error(
+                "Dev credit failed for {devUserId}: {error} — skipping markup",
+                {
+                    devUserId: resolved.devUserId,
+                    error: error instanceof Error ? error.message : error,
+                },
+            );
+            markup = null;
+        }
     }
 
-    // Handle user balance deduction
-    if (userId) {
-        await deductUserBalance(db, userId, totalPrice, modelResolved);
+    const billedPrice = totalPrice + (markup?.devCredit ?? 0);
+
+    try {
+        // Handle API key budget deduction — docks the full billed amount since
+        // the user authorized the app to spend up to this budget, markup
+        // included.
+        if (apiKeyId && hasApiKeyBudget(apiKeyPollenBalance)) {
+            await deductApiKeyBalance(db, apiKeyId, billedPrice);
+        }
+
+        // Handle user balance deduction (full billed amount).
+        if (userId) {
+            await deductUserBalance(db, userId, billedPrice, modelResolved);
+        }
+    } catch (error) {
+        if (devCredited && resolved) {
+            try {
+                await atomicAdjustUserBalance(
+                    db,
+                    resolved.devUserId,
+                    "dev",
+                    -resolved.devCredit,
+                );
+                log.warn(
+                    "Reverted dev credit for {devUserId} after payer debit failure",
+                    { devUserId: resolved.devUserId },
+                );
+            } catch (revertError) {
+                log.error(
+                    "Failed to revert dev credit for {devUserId}: {error}",
+                    {
+                        devUserId: resolved.devUserId,
+                        error:
+                            revertError instanceof Error
+                                ? revertError.message
+                                : String(revertError),
+                    },
+                );
+            }
+        }
+        throw error;
     }
+
+    if (markup) {
+        log.debug(
+            "Credited {credit} pollen to dev {devUserId} (markup={pct}%)",
+            {
+                credit: markup.devCredit,
+                devUserId: markup.devUserId,
+                pct: (markup.markupPct * 100).toFixed(0),
+            },
+        );
+    }
+
+    return { markup };
 }
 
 function hasApiKeyBudget(
@@ -63,18 +189,26 @@ async function deductApiKeyBalance(
     apiKeyId: string,
     amount: number,
 ): Promise<void> {
-    try {
-        await atomicDeductApiKeyBalance(db, apikeyTable, apiKeyId, amount);
-        log.debug("Decremented {price} pollen from API key {keyId} budget", {
-            price: amount,
-            keyId: apiKeyId,
-        });
-    } catch (error) {
+    const { ok } = await atomicDeductApiKeyBalance(
+        db,
+        apikeyTable,
+        apiKeyId,
+        amount,
+    );
+    if (!ok) {
+        const error = new Error(
+            `API key budget deduction affected 0 rows for ${apiKeyId}`,
+        );
         log.error("Failed to decrement API key budget for {keyId}: {error}", {
             keyId: apiKeyId,
-            error: error instanceof Error ? error.message : error,
+            error: error.message,
         });
+        throw error;
     }
+    log.debug("Decremented {price} pollen from API key {keyId} budget", {
+        price: amount,
+        keyId: apiKeyId,
+    });
 }
 
 async function deductUserBalance(
@@ -83,45 +217,56 @@ async function deductUserBalance(
     amount: number,
     modelResolved?: string,
 ): Promise<void> {
-    try {
-        const isPaidOnly = modelResolved
-            ? (getModelDefinition(modelResolved as ModelName).paidOnly ?? false)
-            : false;
+    const isPaidOnly = modelResolved
+        ? (getModelDefinition(modelResolved as ModelName).paidOnly ?? false)
+        : false;
 
-        if (isPaidOnly) {
-            await atomicDeductPaidBalance(db, userId, amount);
-            log.debug(
-                "Decremented {price} pollen from user {userId} (paid-only model, tier excluded)",
-                { price: amount, userId },
+    if (isPaidOnly) {
+        const { ok } = await atomicDeductPaidBalance(db, userId, amount);
+        if (!ok) {
+            const error = new Error(
+                `Paid-only user balance deduction affected 0 rows for ${userId}`,
             );
-            return;
+            log.error(
+                "Failed to decrement user balance for {userId}: {error}",
+                {
+                    userId,
+                    error: error.message,
+                },
+            );
+            throw error;
         }
-
-        // Regular deduction flow
-        // Note: TOCTOU — balances may shift between this read and the UPDATE in
-        // atomicDeductUserBalance due to concurrent requests.  The SQL CASE always
-        // picks the correct bucket; only the logged split below may mismatch.
-        const balancesBefore = await getUserBalances(db, userId);
-        const deductionSource = identifyDeductionSource(
-            balancesBefore.tierBalance,
-            balancesBefore.packBalance,
-            amount,
-        );
-
-        await atomicDeductUserBalance(db, userId, amount);
-
         log.debug(
-            "Decremented {price} pollen from user {userId} (tier: -{fromTier}, pack: -{fromPack})",
-            {
-                price: amount,
-                userId,
-                ...deductionSource,
-            },
+            "Decremented {price} pollen from user {userId} (paid-only model, tier excluded)",
+            { price: amount, userId },
         );
-    } catch (error) {
+        return;
+    }
+
+    // Regular deduction flow
+    // Note: TOCTOU — balances may shift between this read and the UPDATE in
+    // atomicDeductUserBalance due to concurrent requests. The SQL CASE always
+    // picks the correct bucket; only the logged split below may mismatch.
+    const balancesBefore = await getUserBalances(db, userId);
+    const deductionSource = identifyDeductionSource(balancesBefore, amount);
+    const { ok } = await atomicDeductUserBalance(db, userId, amount);
+    if (!ok) {
+        const error = new Error(
+            `User balance deduction affected 0 rows for ${userId}`,
+        );
         log.error("Failed to decrement user balance for {userId}: {error}", {
             userId,
-            error: error instanceof Error ? error.message : String(error),
+            error: error.message,
         });
+        throw error;
     }
+
+    log.debug(
+        "Decremented {price} pollen from user {userId} (tier: -{fromTier}, dev: -{fromDev}, pack: -{fromPack})",
+        {
+            price: amount,
+            userId,
+            ...deductionSource,
+        },
+    );
 }

--- a/enter.pollinations.ai/test/balance-check.test.ts
+++ b/enter.pollinations.ai/test/balance-check.test.ts
@@ -6,21 +6,30 @@ describe("getAvailableBalance", () => {
         expect(
             getAvailableBalance({
                 tierBalance: 0.1,
+                devBalance: 0.15,
                 packBalance: 0.2,
             }),
-        ).toBeCloseTo(0.3);
+        ).toBeCloseTo(0.45);
     });
 
-    it("excludes tier for paid-only models", () => {
+    it("excludes only tier for paid-only models", () => {
         expect(
-            getAvailableBalance({ tierBalance: 10, packBalance: 0.5 }, true),
-        ).toBeCloseTo(0.5);
+            getAvailableBalance(
+                {
+                    tierBalance: 10,
+                    devBalance: 2,
+                    packBalance: 0.5,
+                },
+                true,
+            ),
+        ).toBeCloseTo(2.5);
     });
 
     it("ignores negative buckets", () => {
         expect(
             getAvailableBalance({
                 tierBalance: -1,
+                devBalance: -0.2,
                 packBalance: 0.3,
             }),
         ).toBeCloseTo(0.3);
@@ -30,6 +39,7 @@ describe("getAvailableBalance", () => {
         expect(
             getAvailableBalance({
                 tierBalance: -1,
+                devBalance: 0,
                 packBalance: 0,
             }),
         ).toBe(0);

--- a/enter.pollinations.ai/test/byop-markup.test.ts
+++ b/enter.pollinations.ai/test/byop-markup.test.ts
@@ -1,0 +1,386 @@
+import { env } from "cloudflare:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, test } from "vitest";
+import {
+    BYOP_MARKUP_PCT,
+    computeBilledPrice,
+    computeDevCredit,
+} from "@/billing-config.ts";
+import {
+    apikey as apikeyTable,
+    user as userTable,
+} from "@/db/schema/better-auth.ts";
+import {
+    atomicCreditUserBalance,
+    atomicDeductUserBalance,
+    getUserBalances,
+} from "@/utils/balance-deduction.ts";
+import {
+    handleBalanceDeduction,
+    resolveDevMarkup,
+} from "@/utils/track-helpers.ts";
+
+describe("BYOP markup", () => {
+    describe("computeDevCredit", () => {
+        test("returns baseline × markup for positive prices", () => {
+            expect(computeDevCredit(1)).toBeCloseTo(BYOP_MARKUP_PCT, 10);
+            expect(computeDevCredit(4)).toBeCloseTo(4 * BYOP_MARKUP_PCT, 10);
+        });
+
+        test("returns 0 for zero or negative prices", () => {
+            expect(computeDevCredit(0)).toBe(0);
+            expect(computeDevCredit(-1)).toBe(0);
+        });
+    });
+
+    describe("computeBilledPrice", () => {
+        test("billed = baseline + credit", () => {
+            expect(computeBilledPrice(1)).toBeCloseTo(1 + BYOP_MARKUP_PCT, 10);
+            expect(computeBilledPrice(4)).toBeCloseTo(
+                4 * (1 + BYOP_MARKUP_PCT),
+                10,
+            );
+        });
+    });
+
+    describe("resolveDevMarkup", () => {
+        test("returns null when clientId missing", async () => {
+            const db = drizzle(env.DB);
+            expect(await resolveDevMarkup(db, undefined, 1)).toBeNull();
+            expect(await resolveDevMarkup(db, "", 1)).toBeNull();
+        });
+
+        test("returns null when baseline price is 0", async () => {
+            const db = drizzle(env.DB);
+            expect(await resolveDevMarkup(db, "pk_doesnotexist", 0)).toBeNull();
+        });
+
+        test("returns null when pk_ row doesn't exist", async () => {
+            const db = drizzle(env.DB);
+            expect(await resolveDevMarkup(db, "pk_doesnotexist", 1)).toBeNull();
+        });
+
+        test("returns markup resolution when pk_ row exists", async () => {
+            const db = drizzle(env.DB);
+            const devId = "test-creator-resolve";
+            const pkId = "pk_test_resolve";
+
+            await db
+                .insert(userTable)
+                .values({
+                    id: devId,
+                    email: `${devId}@test.com`,
+                    name: devId,
+                    tier: "spore",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                })
+                .onConflictDoNothing();
+
+            await db
+                .insert(apikeyTable)
+                .values({
+                    id: pkId,
+                    userId: devId,
+                    name: "test-app",
+                    key: `hashed-${pkId}`,
+                    enabled: true,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                })
+                .onConflictDoNothing();
+
+            const result = await resolveDevMarkup(db, pkId, 4);
+            expect(result).not.toBeNull();
+            expect(result?.devUserId).toBe(devId);
+            expect(result?.devCredit).toBeCloseTo(4 * BYOP_MARKUP_PCT, 10);
+            expect(result?.markupPct).toBe(BYOP_MARKUP_PCT);
+        });
+    });
+
+    describe("atomicCreditUserBalance (dev bucket)", () => {
+        test("credits dev_balance; ok=true", async () => {
+            const db = drizzle(env.DB);
+            const userId = "test-creator-credit";
+            await db.delete(userTable).where(sql`${userTable.id} = ${userId}`);
+            await db.insert(userTable).values({
+                id: userId,
+                email: `${userId}@test.com`,
+                name: userId,
+                tier: "spore",
+                devBalance: 5,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            const { ok, newBalance } = await atomicCreditUserBalance(
+                db,
+                userId,
+                "dev",
+                2,
+            );
+            expect(ok).toBe(true);
+            expect(newBalance).toBe(7);
+            expect((await getUserBalances(db, userId)).devBalance).toBe(7);
+        });
+
+        test("missing user → ok=false", async () => {
+            const db = drizzle(env.DB);
+            const { ok, newBalance } = await atomicCreditUserBalance(
+                db,
+                "user-does-not-exist",
+                "dev",
+                1,
+            );
+            expect(ok).toBe(false);
+            expect(newBalance).toBeNull();
+        });
+    });
+
+    describe("deduction priority with dev_balance", () => {
+        test("spends tier → dev → pack", async () => {
+            const db = drizzle(env.DB);
+            const userId = "test-priority-creator";
+
+            await db.delete(userTable).where(sql`${userTable.id} = ${userId}`);
+            await db.insert(userTable).values({
+                id: userId,
+                email: `${userId}@test.com`,
+                name: userId,
+                tier: "flower",
+                tierBalance: 2,
+                devBalance: 3,
+                packBalance: 10,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            // 1 from tier (tier positive)
+            await atomicDeductUserBalance(db, userId, 1);
+            let b = await getUserBalances(db, userId);
+            expect(b.tierBalance).toBe(1);
+            expect(b.devBalance).toBe(3);
+
+            // Drain tier, then next goes to dev
+            await atomicDeductUserBalance(db, userId, 1); // tier → 0
+            await atomicDeductUserBalance(db, userId, 2); // dev → 1 (tier 0 → goes negative)
+            b = await getUserBalances(db, userId);
+            // tier CASE: paid balance > 0, tier ≤ 0 → tier unchanged
+            expect(b.tierBalance).toBe(0);
+            expect(b.devBalance).toBe(1);
+            expect(b.packBalance).toBe(10);
+
+            // Drain dev, then pack
+            await atomicDeductUserBalance(db, userId, 1); // dev → 0
+            await atomicDeductUserBalance(db, userId, 4); // pack → 6
+            b = await getUserBalances(db, userId);
+            expect(b.devBalance).toBe(0);
+            expect(b.packBalance).toBe(6);
+        });
+    });
+
+    describe("handleBalanceDeduction — BYOP markup", () => {
+        async function setupPayerAndDev() {
+            const db = drizzle(env.DB);
+            const payerId = "test-payer-markup";
+            const devId = "test-creator-markup";
+            const pkId = "pk_markup_test";
+
+            await db
+                .delete(userTable)
+                .where(sql`${userTable.id} IN (${payerId}, ${devId})`);
+            await db
+                .delete(apikeyTable)
+                .where(sql`${apikeyTable.id} = ${pkId}`);
+
+            await db.insert(userTable).values([
+                {
+                    id: payerId,
+                    email: `${payerId}@test.com`,
+                    name: payerId,
+                    tier: "flower",
+                    tierBalance: 2,
+                    devBalance: 0,
+                    packBalance: 0,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+                {
+                    id: devId,
+                    email: `${devId}@test.com`,
+                    name: devId,
+                    tier: "spore",
+                    devBalance: 0,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            ]);
+
+            await db.insert(apikeyTable).values({
+                id: pkId,
+                userId: devId,
+                name: "markup-app",
+                key: `hashed-${pkId}`,
+                enabled: true,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            return { db, payerId, devId, pkId };
+        }
+
+        test("non-BYOP request: bills baseline, no dev credit", async () => {
+            const { db, payerId, devId } = await setupPayerAndDev();
+
+            const { markup } = await handleBalanceDeduction({
+                db,
+                isBilledUsage: true,
+                totalPrice: 0.5,
+                userId: payerId,
+                apiKeyClientId: undefined,
+            });
+
+            expect(markup).toBeNull();
+            expect(
+                (await getUserBalances(db, payerId)).tierBalance,
+            ).toBeCloseTo(2 - 0.5, 10);
+            expect((await getUserBalances(db, devId)).devBalance).toBe(0);
+        });
+
+        test("BYOP request: bills baseline+markup, credits dev_balance", async () => {
+            const { db, payerId, devId, pkId } = await setupPayerAndDev();
+
+            const { markup } = await handleBalanceDeduction({
+                db,
+                isBilledUsage: true,
+                totalPrice: 1,
+                userId: payerId,
+                apiKeyClientId: pkId,
+            });
+
+            expect(markup).not.toBeNull();
+            expect(markup?.devUserId).toBe(devId);
+            expect(markup?.devCredit).toBeCloseTo(BYOP_MARKUP_PCT, 10);
+
+            // Payer loses baseline + markup from tier_balance
+            expect(
+                (await getUserBalances(db, payerId)).tierBalance,
+            ).toBeCloseTo(2 - 1 - BYOP_MARKUP_PCT, 10);
+
+            // Dev's dev_balance (not pack_balance) gets the markup
+            const dev = await getUserBalances(db, devId);
+            expect(dev.devBalance).toBeCloseTo(BYOP_MARKUP_PCT, 10);
+            expect(dev.packBalance).toBe(0);
+        });
+
+        test("self-dealing: dev == payer still gets markup credited", async () => {
+            const db = drizzle(env.DB);
+            const userId = "test-self-deal";
+            const pkId = "pk_self_deal";
+
+            await db.delete(userTable).where(sql`${userTable.id} = ${userId}`);
+            await db
+                .delete(apikeyTable)
+                .where(sql`${apikeyTable.id} = ${pkId}`);
+
+            await db.insert(userTable).values({
+                id: userId,
+                email: `${userId}@test.com`,
+                name: userId,
+                tier: "flower",
+                tierBalance: 2,
+                devBalance: 0,
+                packBalance: 0,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+            await db.insert(apikeyTable).values({
+                id: pkId,
+                userId,
+                name: "self-deal-app",
+                key: `hashed-${pkId}`,
+                enabled: true,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            await handleBalanceDeduction({
+                db,
+                isBilledUsage: true,
+                totalPrice: 1,
+                userId,
+                apiKeyClientId: pkId,
+            });
+
+            const b = await getUserBalances(db, userId);
+            // Net: -1 - markup from tier, +markup to dev (tier → dev conversion)
+            expect(b.tierBalance).toBeCloseTo(2 - 1 - BYOP_MARKUP_PCT, 10);
+            expect(b.devBalance).toBeCloseTo(BYOP_MARKUP_PCT, 10);
+        });
+
+        test("cache hit / unbilled: no credit, no deduction", async () => {
+            const { db, payerId, devId, pkId } = await setupPayerAndDev();
+
+            const { markup } = await handleBalanceDeduction({
+                db,
+                isBilledUsage: false,
+                totalPrice: 1,
+                userId: payerId,
+                apiKeyClientId: pkId,
+            });
+
+            expect(markup).toBeNull();
+            expect((await getUserBalances(db, payerId)).tierBalance).toBe(2);
+            expect((await getUserBalances(db, devId)).devBalance).toBe(0);
+        });
+
+        test("unknown pk_: markup=null, payer billed baseline only", async () => {
+            // Sk_ carries a clientId that resolves to no pk_ row.
+            // resolveDevMarkup returns null, no markup is levied, payer
+            // pays baseline. Event will record dev_credit=0.
+            const db = drizzle(env.DB);
+            const payerId = "test-payer-unknown-pk";
+
+            await db.delete(userTable).where(sql`${userTable.id} = ${payerId}`);
+            await db.insert(userTable).values({
+                id: payerId,
+                email: `${payerId}@test.com`,
+                name: payerId,
+                tier: "flower",
+                tierBalance: 2,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+
+            const { markup } = await handleBalanceDeduction({
+                db,
+                isBilledUsage: true,
+                totalPrice: 1,
+                userId: payerId,
+                apiKeyClientId: "pk_nonexistent_creator",
+            });
+
+            expect(markup).toBeNull();
+            expect(
+                (await getUserBalances(db, payerId)).tierBalance,
+            ).toBeCloseTo(2 - 1, 10);
+        });
+
+        test("reverts dev credit when payer deduction fails", async () => {
+            const { db, devId, pkId } = await setupPayerAndDev();
+
+            await expect(
+                handleBalanceDeduction({
+                    db,
+                    isBilledUsage: true,
+                    totalPrice: 1,
+                    userId: "missing-payer-row",
+                    apiKeyClientId: pkId,
+                }),
+            ).rejects.toThrow(/affected 0 rows/);
+
+            expect((await getUserBalances(db, devId)).devBalance).toBe(0);
+        });
+    });
+});

--- a/enter.pollinations.ai/test/deduplication.test.ts
+++ b/enter.pollinations.ai/test/deduplication.test.ts
@@ -1,7 +1,7 @@
 import { SELF } from "cloudflare:test";
-import { test } from "./fixtures.ts";
-import { expect } from "vitest";
 import { getLogger } from "@logtape/logtape";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
 
 const textEndpoint = "http://localhost:3000/api/generate/v1/chat/completions";
 const log = getLogger(["test", "deduplication"]);

--- a/enter.pollinations.ai/test/integration/text-cache.test.ts
+++ b/enter.pollinations.ai/test/integration/text-cache.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
-import { test } from "../fixtures.ts";
 import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
 
 type TextCacheHeaders = {
     cache: "HIT" | "MISS" | "BYPASS";

--- a/enter.pollinations.ai/test/integration/tier-balance.test.ts
+++ b/enter.pollinations.ai/test/integration/tier-balance.test.ts
@@ -360,33 +360,46 @@ describe("Tier Balance Management", () => {
         });
 
         test("identifyDeductionSource should pick single bucket", () => {
-            // Tier is positive, has pack — tier first
-            const fromTier = identifyDeductionSource(5, 5, 7);
+            const b = (tier: number, dev: number, pack: number) => ({
+                tierBalance: tier,
+                devBalance: dev,
+                packBalance: pack,
+            });
+
+            // Tier is positive, has paid balance — tier first
+            const fromTier = identifyDeductionSource(b(5, 3, 5), 7);
             expect(fromTier.fromTier).toBe(7);
+            expect(fromTier.fromDev).toBe(0);
             expect(fromTier.fromPack).toBe(0);
 
-            // Tier zero, pack positive — falls to pack
-            const fromPack = identifyDeductionSource(0, 8, 5);
-            expect(fromPack.fromTier).toBe(0);
-            expect(fromPack.fromPack).toBe(5);
+            // Tier zero, dev positive — falls to dev
+            const fromDev = identifyDeductionSource(b(0, 4, 0), 7);
+            expect(fromDev.fromDev).toBe(7);
+            expect(fromDev.fromTier).toBe(0);
+            expect(fromDev.fromPack).toBe(0);
 
-            // No pack balance — always tier, never spills
-            const noPaid = identifyDeductionSource(0, 0, 3);
+            // Tier/dev zero, pack positive — falls to pack
+            const fromPack = identifyDeductionSource(b(0, 0, 8), 5);
+            expect(fromPack.fromPack).toBe(5);
+            expect(fromPack.fromTier).toBe(0);
+
+            // No paid/dev balance — always tier, never spills
+            const noPaid = identifyDeductionSource(b(0, 0, 0), 3);
             expect(noPaid.fromTier).toBe(3);
             expect(noPaid.fromPack).toBe(0);
 
-            // Negative tier, no pack — always tier
-            const negTierNoPaid = identifyDeductionSource(-3, 0, 4);
-            expect(negTierNoPaid.fromTier).toBe(4);
-            expect(negTierNoPaid.fromPack).toBe(0);
+            // Negative tier, positive dev — falls to dev
+            const negTierPosDev = identifyDeductionSource(b(-3, 2, 0), 4);
+            expect(negTierPosDev.fromDev).toBe(4);
+            expect(negTierPosDev.fromTier).toBe(0);
 
-            // Negative tier, positive pack — falls to pack
-            const negTierPosPack = identifyDeductionSource(-3, 2, 4);
-            expect(negTierPosPack.fromTier).toBe(0);
+            // Negative tier, no dev, positive pack — falls to pack
+            const negTierPosPack = identifyDeductionSource(b(-3, 0, 2), 4);
             expect(negTierPosPack.fromPack).toBe(4);
+            expect(negTierPosPack.fromTier).toBe(0);
 
-            // All negative — no pack balance, always tier
-            const allNeg = identifyDeductionSource(-3, -1, 5);
+            // All negative — no paid balance, always tier
+            const allNeg = identifyDeductionSource(b(-3, -1, -2), 5);
             expect(allNeg.fromTier).toBe(5);
             expect(allNeg.fromPack).toBe(0);
         });
@@ -549,7 +562,7 @@ describe("Tier Balance Management", () => {
             expect(response.status).toBe(402);
             const error = await response.json();
             expect(error.error?.message).toMatch(
-                /requires a paid balance|Insufficient balance/,
+                /requires .*Top-up Pollen.*Dev earnings|Insufficient balance/,
             );
         });
 
@@ -643,7 +656,7 @@ describe("Tier Balance Management", () => {
             expect(response.status).toBe(402);
             const error = await response.json();
             expect(error.error?.message).toMatch(
-                /requires a paid balance|Insufficient balance/,
+                /requires .*Top-up Pollen.*Dev earnings|Insufficient balance/,
             );
         });
 
@@ -779,11 +792,11 @@ describe("Tier Balance Management", () => {
             expect(response.status).toBe(200);
         });
 
-        test("atomicDeductPaidBalance should skip tier balance", async () => {
+        test("atomicDeductPaidBalance should skip tier and prefer dev over pack", async () => {
             const db = drizzle(env.DB);
             const userId = "test-paid-deduct";
 
-            // Setup user with tier and pack balance
+            // Setup user with tier, dev, and pack balance
             await db
                 .insert(userTable)
                 .values({
@@ -792,6 +805,7 @@ describe("Tier Balance Management", () => {
                     name: "Paid Deduct Test",
                     tier: "flower",
                     tierBalance: 10,
+                    devBalance: 2,
                     packBalance: 5,
                     createdAt: new Date(),
                     updatedAt: new Date(),
@@ -800,30 +814,34 @@ describe("Tier Balance Management", () => {
                     target: userTable.id,
                     set: {
                         tierBalance: 10,
+                        devBalance: 2,
                         packBalance: 5,
                     },
                 });
 
-            // Deduct 2 pollen using paid-only deduction (all from pack)
+            // Deduct 2 pollen using paid-only deduction (all from dev)
             await atomicDeductPaidBalance(db, userId, 2);
 
             let balances = await getUserBalances(db, userId);
             expect(balances.tierBalance).toBe(10); // Unchanged - tier is skipped
-            expect(balances.packBalance).toBe(3); // 5 - 2
+            expect(balances.devBalance).toBe(0); // 2 - 2
+            expect(balances.packBalance).toBe(5); // Unchanged
 
-            // Deduct 4 more (pack still positive → all from pack, goes negative)
+            // Deduct 4 more (dev empty → all from pack)
             await atomicDeductPaidBalance(db, userId, 4);
 
             balances = await getUserBalances(db, userId);
             expect(balances.tierBalance).toBe(10); // Still unchanged
-            expect(balances.packBalance).toBe(-1); // 3 - 4 (goes negative)
+            expect(balances.devBalance).toBe(0); // Unchanged
+            expect(balances.packBalance).toBe(1); // 5 - 4
 
-            // Deduct 7 more (pack already negative → all from pack)
+            // Deduct 7 more (dev still empty → all from pack, goes negative)
             await atomicDeductPaidBalance(db, userId, 7);
 
             balances = await getUserBalances(db, userId);
             expect(balances.tierBalance).toBe(10); // Still unchanged
-            expect(balances.packBalance).toBe(-8); // -1 - 7 (more negative)
+            expect(balances.devBalance).toBe(0); // Unchanged
+            expect(balances.packBalance).toBe(-6); // 1 - 7 (goes negative)
         });
 
         test("should show paid_only field in model info", async () => {
@@ -876,6 +894,45 @@ describe("Tier Balance Management", () => {
             const response = await SELF.fetch(
                 "http://localhost:3000/api/generate/text/models",
                 { headers: { authorization: `Bearer ${paidApiKey}` } },
+            );
+            expect(response.status).toBe(200);
+            const models = (await response.json()) as any[];
+
+            const claudeLarge = models.find(
+                (m: any) => m.name === "claude-large",
+            );
+            expect(claudeLarge).toBeDefined();
+            expect(claudeLarge.paid_only).toBe(true);
+        });
+
+        test("should show paid_only models when user has Dev earnings", async ({
+            apiKey,
+            sessionToken,
+        }) => {
+            const db = drizzle(env.DB);
+            const sessionResponse = await SELF.fetch(
+                "http://localhost:3000/api/auth/get-session",
+                {
+                    headers: {
+                        cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+            const session = await sessionResponse.json();
+            const userId = session.user.id;
+
+            await db
+                .update(userTable)
+                .set({
+                    tierBalance: 0,
+                    devBalance: 2,
+                    packBalance: 0,
+                })
+                .where(sql`${userTable.id} = ${userId}`);
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/generate/text/models",
+                { headers: { authorization: `Bearer ${apiKey}` } },
             );
             expect(response.status).toBe(200);
             const models = (await response.json()) as any[];

--- a/enter.pollinations.ai/test/mocks/fetch.ts
+++ b/enter.pollinations.ai/test/mocks/fetch.ts
@@ -1,6 +1,6 @@
+import { getLogger } from "@logtape/logtape";
 import type { Hono } from "hono";
 import { vi } from "vitest";
-import { getLogger } from "@logtape/logtape";
 
 const originalFetch = globalThis.fetch;
 const activeRequests = new Set<Promise<any>>();

--- a/enter.pollinations.ai/test/mocks/polar.ts
+++ b/enter.pollinations.ai/test/mocks/polar.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
+import type { PolarEvent } from "@/events.ts";
 import { createHonoMockHandler, type MockAPI } from "./fetch.ts";
-import { PolarEvent } from "@/events.ts";
 
 export type MockPolarState = {
     events: PolarEvent[];

--- a/enter.pollinations.ai/test/setup/snapshot-server.ts
+++ b/enter.pollinations.ai/test/setup/snapshot-server.ts
@@ -1,9 +1,9 @@
-import { serve } from "@hono/node-server";
-import { Hono } from "hono";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { TestProject } from "vitest/node";
+import { serve } from "@hono/node-server";
 import { getLogger } from "@logtape/logtape";
+import { Hono } from "hono";
+import type { TestProject } from "vitest/node";
 
 const SNAPSHOTS_DIR = path.join(process.cwd(), "test", "mocks", "snapshots");
 

--- a/pollinations.ai/src/copy/content/apps.ts
+++ b/pollinations.ai/src/copy/content/apps.ts
@@ -16,14 +16,14 @@ export const APPS_PAGE = {
     submitCtaTitle: "Built something cool?",
     submitCtaDescription: "Get featured in the showcase and level up!",
     submitCtaButton: "Submit App",
-    pollenCtaTitle: "🏵️ Add Pollen to Your App",
+    pollenCtaTitle: "🌻 Dev earnings with your app",
     pollenCtaDescription:
-        "Let users sign in with their own Pollinations account.",
+        "BYOP app requests include a 25% markup for 🌻 Dev earnings. App developers receive 20% of the total Pollen charged.",
     pollenCtaButton: "Learn More",
 
     // Badges & tooltips
     pollenBadge: "🏵️ POLLEN",
-    pollenTooltip: "Sign in with Pollinations — Pollen covers usage",
+    pollenTooltip: "Sign in with Pollinations — users cover usage",
     buzzBadge: "🐝 BUZZ",
     buzzTooltip: "100+ API requests in the last 24 hours",
     newBadge: "🫧 FRESH",
@@ -36,7 +36,7 @@ export const APPS_PAGE = {
     sortLabel: "Sort by",
 
     // Legend
-    pollenLegendDesc: "In-app user sign in",
+    pollenLegendDesc: "BYOP user sign in",
     pollenDocsLink: "</> Docs",
     buzzLegendDesc: "100+ requests / 24h",
     newLegendDesc: "Recently added",

--- a/pollinations.ai/src/copy/content/auth.ts
+++ b/pollinations.ai/src/copy/content/auth.ts
@@ -26,6 +26,7 @@ export const AUTH_COPY = {
 
     // BYOP CTA
     byopTitle: "🐝 Register your app for BYOP",
-    byopDescription: "🌼 Let your users bring their own Pollen.",
+    byopDescription:
+        "BYOP app requests include a 25% markup for 🌻 Dev earnings. App developers receive 20% of the total Pollen charged.",
     byopLink: "Learn about BYOP",
 };

--- a/pollinations.ai/src/copy/content/community.ts
+++ b/pollinations.ai/src/copy/content/community.ts
@@ -10,7 +10,7 @@ export const COMMUNITY_PAGE = {
         "🌸 pollinations.ai is open source — the code, the roadmap, the conversations.",
     subtitleBold: "Contributors shape the platform directly.",
     subtitleSuffix:
-        " Your PR can land in production tomorrow, and starting Q2, every contribution earns you Pollen. 🌿",
+        " Your PR can land in production tomorrow, and BYOP apps can receive 🌻 Dev earnings. 🌿",
     heroStat1: "17K+",
     heroStat1Label: "Discord members",
     heroStat2: "4K+",

--- a/pollinations.ai/src/copy/content/hello.ts
+++ b/pollinations.ai/src/copy/content/hello.ts
@@ -24,7 +24,7 @@ export const HELLO_PAGE = {
     howItWorksTitle: "How it works",
     howItWorksBuildDesc: "Use one API across models.",
     howItWorksShipDesc: "Start free with regular compute refills.",
-    howItWorksGetPaidDesc: "Your users get their own compute.",
+    howItWorksGetPaidDesc: "As usage grows, your app receives Dev earnings.",
 
     // Start free section
     startFreeTitle: "Start free",
@@ -51,8 +51,8 @@ export const HELLO_PAGE = {
             pillColor: "bg-tertiary-light",
         },
         {
-            pre: "As your app grows, you ",
-            bold: "get more compute",
+            pre: "As usage grows, your app receives ",
+            bold: "Dev earnings",
             post: "",
             emoji: "📈",
             pillColor: "bg-secondary-light",
@@ -116,7 +116,7 @@ export const HELLO_PAGE = {
         {
             emoji: "🤝",
             title: "For your users",
-            desc: "Each user who signs in gets free hourly compute to try your app.\nWhen they need more, it just works — no Stripe setup on your end.",
+            desc: "Each user who signs in gets free hourly compute to try your app.\nBYOP app requests include a 25% markup for 🌻 Dev earnings — no Stripe setup on your end.",
             linkText: "🔌 Set up for your app",
             linkUrl: "byopDocs",
             fullWidth: true,
@@ -149,8 +149,9 @@ export const HELLO_PAGE = {
         },
         {
             emoji: "🌻",
-            title: "Rewards",
-            description: "People use your app, you earn pollen.",
+            title: "Dev earnings",
+            description:
+                "App developers receive 20% of the total Pollen charged.",
         },
         {
             emoji: "🗺️",

--- a/pollinations.ai/src/copy/content/play.ts
+++ b/pollinations.ai/src/copy/content/play.ts
@@ -114,11 +114,12 @@ export const PLAY_PAGE = {
         "Never expose in client-side code, git repos, or public URLs",
     appKeyLabel: "App Key",
     appKeyFeature1: "🌼 Identifies your app in the BYOP consent screen",
-    appKeyFeature2: "📈 Traffic attribution",
+    appKeyFeature2: "🌻 Dev earnings",
     appKeyNote:
-        "For developers building apps where users bring their own Pollen. Create one at enter.pollinations.ai.",
+        "For developers building apps where users bring their own Pollen. App developers receive 20% of the total Pollen charged.",
     byopLabel: "Bring Your Own Pollen",
-    byopDescription: "Building an app? Let users bring their own Pollen.",
+    byopDescription:
+        "Building an app? BYOP app requests include a 25% markup for 🌻 Dev earnings.",
     getKeyButton: "Get Your Key",
     byopButton: "Learn more",
 


### PR DESCRIPTION
## Summary

- Adds 4th balance bucket: `dev_balance` (BYOP earnings)
- Cascade: tier → dev → pack (paid-only models: dev → pack, tier excluded)
- BYOP requests crediting: 20% markup on baseline price → dev's `dev_balance`, sourced from `sk_`'s `clientId` (= `pk_` row id)
- Migration `0020_add_dev_balance.sql`: `ALTER TABLE user ADD COLUMN dev_balance REAL`
- D1→Tinybird sync includes new column; `generation_event` records `devCredit` + `byopMarkupPct`

## Notes

- Rebased on top of #10503 (crypto column drop), so this PR adds only `dev_balance`
- `BYOP_MARKUP_PCT` lives in `billing-config.ts` for easy tuning
- BYOP credit failure path: dev credit reverted on payer-side debit failure (`atomicAdjustUserBalance`)

## Test plan

- [x] `npx vitest run test/balance-check.test.ts test/byop-markup.test.ts test/integration/tier-balance.test.ts` → 52/52 pass
- [x] Local D1 migrations apply cleanly
- [ ] Verify dev credit shows up on `/account` after BYOP request
- [ ] Verify Tinybird `d1_user.dev_balance` column populates after first sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)