### PR TITLE
docs: update Klein pod refs and SSH key filenames

### DIFF
--- a/.claude/skills/enter-services/SKILL.md
+++ b/.claude/skills/enter-services/SKILL.md
@@ -32,13 +32,13 @@ Add to `~/.ssh/config`:
 Host enter-services
   HostName 54.147.14.220
   User ubuntu
-  IdentityFile ~/.ssh/enter-services-shared-key
+  IdentityFile ~/.ssh/enter-services-shared
 
 # Staging instance
 Host enter-services-staging
   HostName 44.222.254.250
   User ubuntu
-  IdentityFile ~/.ssh/enter-services-staging-key
+  IdentityFile ~/.ssh/enter-services-staging
 ```
 
 ---

--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -106,23 +106,37 @@ ssh -i ~/.ssh/id_rsa_ovh ubuntu@57.130.31.42 "sudo systemctl restart image-polli
 
 | Property | Value |
 |----------|-------|
-| **Host** | `pi90tfk3sa9t12-8000.proxy.runpod.net` |
+| **Pod ID** | `lqh6weiexk4sth` (current — pod ID changes if recreated) |
+| **Host** | `<pod-id>-8000.proxy.runpod.net` |
 | **Port** | `8000` |
 | **Provider** | RunPod (RTX 3090, community cloud) |
-| **SSH** | `ssh -i <SOPS:SSH_RUNPOD_KLEIN> root@213.144.200.243 -p 10207` |
+| **SSH** | RunPod relay — interactive only: `ssh <pod-id>-<key-id>@ssh.runpod.io -i ~/.ssh/id_ed25519` (get full command from dashboard "Connect" tab) |
 | **Auth** | `x-backend-token` header with `PLN_GPU_TOKEN` |
+| **Config** | `KLEIN_URL` in `image.pollinations.ai/secrets/env.json` (sops); fallback in `image.pollinations.ai/src/models/fluxKleinModel.ts` |
 
 **Health check:**
 ```bash
-curl -s --connect-timeout 5 --max-time 10 https://pi90tfk3sa9t12-8000.proxy.runpod.net/health
+curl -s --connect-timeout 5 --max-time 10 https://lqh6weiexk4sth-8000.proxy.runpod.net/health
 ```
 Expected: `{"status":"ok","model":"black-forest-labs/FLUX.2-klein-4B"}`
 
-**Restart:**
+**Restart (in-pod):**
 ```bash
-ssh -i <SOPS:SSH_RUNPOD_KLEIN> root@213.144.200.243 -p 10207 "/workspace/restart.sh"
+# Open SSH from dashboard, then:
+bash /workspace/restart.sh
 ```
 Wait ~30s for model load, then re-check health.
+
+**Recovery from RunPod host outage:**
+
+Symptom: dashboard banner "*This server has recently suffered a network outage*"; control plane reports RUNNING but HTTPS proxy / SSH / ICMP all unreachable. Restart/reset reschedules onto the same broken host. Recreate on a different host:
+
+1. `runpodctl pod create --name klein-worker-v2 --image runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404 --gpu-id "NVIDIA GeForce RTX 3090" --gpu-count 1 --container-disk-in-gb 20 --volume-in-gb 100 --volume-mount-path /workspace --ports "8000/http,22/tcp" --cloud-type COMMUNITY --env "$(jq -nc --arg t "$(sops -d image.pollinations.ai/secrets/env.json | jq -r .PLN_GPU_TOKEN)" '{PLN_GPU_TOKEN:$t}')"`
+2. SSH via dashboard relay; install deps + drop in `image.pollinations.ai/klein-runpod/handler.py`; start with `nohup python3 -u /workspace/handler.py > /workspace/klein.log 2>&1 &`. Model download is ~24 GB (~5–10 min).
+3. Update `KLEIN_URL` in `image.pollinations.ai/secrets/env.json` (sops) and the hardcoded fallback in `fluxKleinModel.ts` to the new `<pod-id>-8000.proxy.runpod.net`. Deploy `.env` to EC2 image service and restart `image-pollinations.service`.
+4. Verify end-to-end via `gen.pollinations.ai/image/test?model=klein`, then delete the old pod.
+
+Note: the pod uses a generic `runpod/pytorch` image; `handler.py` and `restart.sh` live on the pod volume only (not baked into a Docker image despite `image.pollinations.ai/klein-runpod/Dockerfile`). The pod volume is destroyed on terminate.
 
 ---
 
@@ -241,8 +255,8 @@ For each:
 - **Test token**: Read from `enter.pollinations.ai/.testingtokens` (ENTER_API_TOKEN_REMOTE)
 - **SSH keys**: Stored in SOPS (`enter.pollinations.ai/secrets/prod.vars.json`):
   - `SSH_RUNPOD_FLUX_ZIMAGE` — RunPod Flux+Z-Image pod
-  - `SSH_RUNPOD_KLEIN` — RunPod Klein pod
   - `SSH_LAMBDA_SANA_LTX2_ACESTEP` — Lambda GH200 (LTX-2, ACE-Step, Sana)
+  - Klein uses the RunPod relay (`ssh.runpod.io`) with `~/.ssh/id_ed25519` — get the full command from the dashboard "Connect" tab
   - Extract: `sops -d enter.pollinations.ai/secrets/prod.vars.json | jq -r '.KEY_NAME' > /tmp/key && chmod 600 /tmp/key`
 - **OVH**: `~/.ssh/id_rsa_ovh` (not in SOPS)
 

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -22,21 +22,25 @@ runpodctl pod list             # list pods
 runpodctl pod get <id>         # pod details
 ```
 
-### Pod pi90tfk3sa9t12 — Klein 4B
+### Pod lqh6weiexk4sth — Klein 4B
+
+> Pod ID changes if recreated. Check `runpodctl pod list` and the `KLEIN_URL` env var (sops: `image.pollinations.ai/secrets/env.json`).
 
 - **GPU**: 1x RTX 3090 (24GB) | **Cost**: $0.22/hr (community cloud)
-- **SSH**: `ssh -i <SSH_RUNPOD_KLEIN from SOPS> root@213.144.200.243 -p 10207`
-- **HTTP**: `https://pi90tfk3sa9t12-8000.proxy.runpod.net`
+- **SSH**: RunPod relay — interactive only: `ssh <pod-id>-<key-id>@ssh.runpod.io -i ~/.ssh/id_ed25519` (full command from dashboard "Connect" tab)
+- **HTTP**: `https://lqh6weiexk4sth-8000.proxy.runpod.net`
 - **Service**: FLUX.2 Klein 4B (FastAPI on port 8000)
 - **Auth**: `x-backend-token` header with `PLN_GPU_TOKEN`
-- **Code**: `/workspace/handler.py`
-- **Logs**: `/workspace/handler.log`
-- **Restart**: `ssh ... "/workspace/restart.sh"`
+- **Code**: `/workspace/handler.py` (mirrors `image.pollinations.ai/klein-runpod/handler.py`)
+- **Logs**: `/workspace/klein.log`
+- **Restart**: `bash /workspace/restart.sh` (in-pod)
 
 **Health check:**
 ```bash
-curl -s https://pi90tfk3sa9t12-8000.proxy.runpod.net/health
+curl -s https://lqh6weiexk4sth-8000.proxy.runpod.net/health
 ```
+
+**Recovery from RunPod host outage**: see `.claude/skills/monitor-services/SKILL.md` Klein section. Pod volume is destroyed on terminate; `handler.py`/`restart.sh` must be redeployed onto a fresh pod.
 
 ### Pod hsl3ksl31lvrcc — Flux + Z-Image (4x RTX 4090)
 
@@ -98,14 +102,14 @@ screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nu
 ### Production — enter services
 
 - **Host**: `54.147.14.220`
-- **SSH**: `ssh -i ~/.ssh/enter-services-shared-key ubuntu@54.147.14.220`
+- **SSH**: `ssh -i ~/.ssh/enter-services-shared ubuntu@54.147.14.220`
 - **Image service**: port 16384
 - **Text service**: port 16385
 
 ### Staging
 
 - **Host**: `44.222.254.250`
-- **SSH**: `ssh -i ~/.ssh/enter-services-staging-key ubuntu@44.222.254.250`
+- **SSH**: `ssh -i ~/.ssh/enter-services-staging ubuntu@44.222.254.250`
 
 ## Heartbeat Registration
 
@@ -122,12 +126,13 @@ Extract for use: `sops -d enter.pollinations.ai/secrets/prod.vars.json | jq -r '
 | SOPS key | Provider | Instances |
 |----------|----------|-----------|
 | `SSH_RUNPOD_FLUX_ZIMAGE` | RunPod | Flux+Z-Image pod (`hsl3ksl31lvrcc`) |
-| `SSH_RUNPOD_KLEIN` | RunPod | Klein pod (`pi90tfk3sa9t12`) |
 | `SSH_LAMBDA_SANA_LTX2_ACESTEP` | Lambda Labs | GH200 (LTX-2, ACE-Step, Sana) |
+
+Klein uses the RunPod relay (`ssh.runpod.io`) with `~/.ssh/id_ed25519` — no SOPS key. Get the full SSH command from the dashboard "Connect" tab.
 
 EC2 keys (not in SOPS):
 
 | Key | Provider | Location |
 |-----|----------|----------|
-| `~/.ssh/enter-services-shared-key` | EC2 prod | enter services |
-| `~/.ssh/enter-services-staging-key` | EC2 staging | enter services |
+| `~/.ssh/enter-services-shared` | EC2 prod | enter services |
+| `~/.ssh/enter-services-staging` | EC2 staging | enter services |

--- a/tools/scripts/rotation/README.md
+++ b/tools/scripts/rotation/README.md
@@ -402,14 +402,20 @@ Hosts reached by SSH during `rotate-infra-gpu-token.sh`. SSH keys are stored in 
 | Worker | Pod / Host | SSH key (SOPS) | SSH target | `.env` path | Restart |
 |---|---|---|---|---|---|
 | Flux + Z-Image | RunPod `hsl3ksl31lvrcc` | `SSH_RUNPOD_FLUX_ZIMAGE` | `root@38.65.239.17 -p 19489` | `$HOME/.env` | screen sessions |
-| Klein 4B | RunPod `pi90tfk3sa9t12` | `SSH_RUNPOD_KLEIN` | `root@213.144.200.243 -p 10207` | `/workspace/.env` | `/workspace/restart.sh` |
+| Klein 4B | RunPod `lqh6weiexk4sth` | RunPod relay | `<pod-id>-<key-id>@ssh.runpod.io` (interactive only) | `/workspace/restart.sh` reads `PLN_GPU_TOKEN` from process env | `/workspace/restart.sh` |
 | LTX-2 + ACE-Step + Sana | Lambda Labs GH200 | `SSH_LAMBDA_SANA_LTX2_ACESTEP` | `ubuntu@192.222.51.105` | `$HOME/.env` | `systemctl restart ltx2 acestep sana` |
+
+Klein's pod ID changes if recreated. Verify current ID with `runpodctl pod list` and the `KLEIN_URL` env in `image.pollinations.ai/secrets/env.json`. The relay does not support non-interactive command execution — rotations against Klein currently require a manual edit of `/workspace/restart.sh` (which has the token baked in via `export`) followed by re-running it inside an interactive SSH session.
 
 `MUSIC_SERVICE_URL` in enter's SOPS points at the ACE-Step endpoint on the Lambda GH200 host. It is configuration (not an auth token) and is not rotated — but if the Lambda host changes, this URL has to move with it.
 
 Ad-hoc SSH for debugging a GPU host:
 
 ```bash
-sops -d enter.pollinations.ai/secrets/prod.vars.json | jq -r '.SSH_RUNPOD_KLEIN' > /tmp/key && chmod 600 /tmp/key
-ssh -i /tmp/key root@213.144.200.243 -p 10207
+# Flux + Z-Image
+sops -d enter.pollinations.ai/secrets/prod.vars.json | jq -r '.SSH_RUNPOD_FLUX_ZIMAGE' > /tmp/key && chmod 600 /tmp/key
+ssh -i /tmp/key root@38.65.239.17 -p 19489
+
+# Klein — get full SSH command from RunPod dashboard "Connect" tab (relay)
+ssh <pod-id>-<key-id>@ssh.runpod.io -i ~/.ssh/id_ed25519
 ```


### PR DESCRIPTION
- Klein pod ID swap (`pi90tfk3sa9t12` → `lqh6weiexk4sth`) in skill + GPU_INSTANCES + rotation README
- Klein SSH route is now the RunPod relay (`ssh.runpod.io`, `~/.ssh/id_ed25519`); old `SSH_RUNPOD_KLEIN`/direct-IP path removed from docs
- Add RunPod "host network outage" recovery procedure to `monitor-services/SKILL.md`
- Fix `enter-services-shared-key` → `enter-services-shared` (correct filename) in `enter-services/SKILL.md` and `GPU_INSTANCES.md`

Code change for the `KLEIN_URL` swap is in #10521. SOPS `SSH_RUNPOD_KLEIN` and `worker-bindings.d.ts` cleanup left for a separate refactor.