### PR TITLE
fix: return 400 for category-mismatched models on wrong endpoint

### DIFF
--- a/enter.pollinations.ai/src/middleware/model.ts
+++ b/enter.pollinations.ai/src/middleware/model.ts
@@ -1,10 +1,22 @@
-import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
-import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { AUDIO_SERVICES, DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
+import { DEFAULT_IMAGE_MODEL, IMAGE_SERVICES } from "@shared/registry/image.ts";
 import { type ModelName, resolveModelName } from "@shared/registry/registry.ts";
-import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
+import { DEFAULT_TEXT_MODEL, TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { EventType } from "@shared/registry/types.ts";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
+
+const SERVICES_BY_EVENT_TYPE = {
+    "generate.text": TEXT_SERVICES,
+    "generate.image": IMAGE_SERVICES,
+    "generate.audio": AUDIO_SERVICES,
+} as const satisfies Record<EventType, Record<string, unknown>>;
+
+const ENDPOINT_LABEL: Record<EventType, string> = {
+    "generate.text": "text",
+    "generate.image": "image",
+    "generate.audio": "audio",
+};
 
 export type ModelVariables = {
     model: {
@@ -76,6 +88,22 @@ export function resolveModel(
                     error instanceof Error
                         ? error.message
                         : `Invalid model: ${model}`,
+            });
+        }
+
+        // Reject models whose category doesn't match this endpoint
+        // (e.g. an audio model sent to /v1/chat/completions). Without this,
+        // the request would be proxied to the wrong backend and surface
+        // as a 5xx upstream error.
+        if (!(resolved in SERVICES_BY_EVENT_TYPE[eventType])) {
+            const actualCategory = (
+                ["generate.text", "generate.image", "generate.audio"] as const
+            ).find((et) => resolved in SERVICES_BY_EVENT_TYPE[et]);
+            const actualLabel = actualCategory
+                ? ENDPOINT_LABEL[actualCategory]
+                : "unknown";
+            throw new HTTPException(400, {
+                message: `Model "${model}" is a ${actualLabel} model and cannot be used on the ${ENDPOINT_LABEL[eventType]} endpoint. Use the ${actualLabel} endpoint instead.`,
             });
         }
 

--- a/enter.pollinations.ai/test/integration/text.test.ts
+++ b/enter.pollinations.ai/test/integration/text.test.ts
@@ -300,6 +300,72 @@ test(
 );
 
 test(
+    "POST /v1/chat/completions with audio model returns 400",
+    { timeout: 30000 },
+    async ({ apiKey, mocks }) => {
+        await mocks.enable("polar", "tinybird", "vcr");
+        const response = await SELF.fetch(
+            `http://localhost:3000/api/generate/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "authorization": `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: "acestep",
+                    messages: [
+                        {
+                            role: "user",
+                            content: TEST_MESSAGE_CONTENT,
+                        },
+                    ],
+                    seed: testSeed(),
+                }),
+            },
+        );
+        const body = await response.text();
+        expect(response.status).toBe(400);
+        const error = JSON.parse(body);
+        expect(error.error.message).toContain("acestep");
+        expect(error.error.message).toContain("audio");
+    },
+);
+
+test(
+    "POST /v1/chat/completions with image model returns 400",
+    { timeout: 30000 },
+    async ({ apiKey, mocks }) => {
+        await mocks.enable("polar", "tinybird", "vcr");
+        const response = await SELF.fetch(
+            `http://localhost:3000/api/generate/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "authorization": `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: "flux",
+                    messages: [
+                        {
+                            role: "user",
+                            content: TEST_MESSAGE_CONTENT,
+                        },
+                    ],
+                    seed: testSeed(),
+                }),
+            },
+        );
+        const body = await response.text();
+        expect(response.status).toBe(400);
+        const error = JSON.parse(body);
+        expect(error.error.message).toContain("flux");
+        expect(error.error.message).toContain("image");
+    },
+);
+
+test(
     "POST /v1/chat/completions should handle empty messages",
     { timeout: 30000 },
     async ({ apiKey, mocks }) => {


### PR DESCRIPTION
Audio/image models sent to the text endpoint (and the inverse) were resolving successfully through `resolveModelName` because the unified `MODEL_REGISTRY` is the union of text+image+audio. The request would then proxy to the wrong backend and surface as a 502 `UpstreamError`. This is what was driving the recent "anomaly" rows in the Model Monitor with 0% success.

Validates the resolved model belongs to the endpoint's service map (`TEXT_SERVICES` / `IMAGE_SERVICES` / `AUDIO_SERVICES`) in `resolveModel()` and throws 400 with a message pointing the caller at the right endpoint.

The check uses service-map keys, not the `category` field, so video models (`category: "video"` but in `IMAGE_SERVICES`) continue to work on the image endpoint — verified with the existing `seedance T2V` test.

Side benefit: `resolveModel` runs before `track`, so rejected requests no longer hit Tinybird and won't pollute Model Monitor with anomaly rows.

- New tests: audio model on `/v1/chat/completions` → 400; image model on `/v1/chat/completions` → 400
- Existing tests still green: invalid model 400, qwen-tts on audio, seedance T2V on image