### PR TITLE
update banner: announce paid models (ElevenLabs Music/TTS, GPT Image 2)

### DIFF
--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -22,11 +22,11 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
-        date: "2026-04-17",
-        emoji: "💰",
-        title: "Transparent Pricing: Cost vs Price",
+        date: "2026-04-28",
+        emoji: "🎉",
+        title: "New paid models",
         description:
-            "The registry now tracks provider cost separately from user price. See the [pricing table](/#pricing) for the rates you pay.",
+            "ElevenLabs Music, ElevenLabs TTS, and GPT Image 2 are now available as paid models. [Check them out](/#models).",
     },
 ];
 

--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -24,9 +24,8 @@ const PINNED_NEWS: Highlight[] = [
     {
         date: "2026-04-28",
         emoji: "💸",
-        title: "ElevenLabs Music, ElevenLabs TTS and GPT Image 2 moved to paid",
-        description:
-            "These models are no longer free. See the [pricing table](/#models) for current rates.",
+        title: "ElevenLabs Music, ElevenLabs TTS and GPT Image 2 moving to paid",
+        description: "Starting May 1, 2026, these models will no longer be free.",
     },
 ];
 

--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -23,10 +23,10 @@ interface Highlight {
 const PINNED_NEWS: Highlight[] = [
     {
         date: "2026-04-28",
-        emoji: "🎉",
-        title: "New paid models",
+        emoji: "💸",
+        title: "ElevenLabs Music, ElevenLabs TTS and GPT Image 2 moved to paid",
         description:
-            "ElevenLabs Music, ElevenLabs TTS, and GPT Image 2 are now available as paid models. [Check them out](/#models).",
+            "These models are no longer free. See the [pricing table](/#models) for current rates.",
     },
 ];
 


### PR DESCRIPTION
Replaces the existing pinned news banner item with an announcement that ElevenLabs Music, ElevenLabs TTS, and GPT Image 2 have moved from free to paid. Links to the pricing/models table at `/#models`.