### PR TITLE
(patch) Update the publish-package CI

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "packages/sdk/**"
       - "packages/mcp/**"
-      - "packages/ompc/**"
       - "packages/polli-cli/**"
 
 jobs:
@@ -17,7 +16,6 @@ jobs:
     outputs:
       sdk: ${{ steps.changes.outputs.sdk }}
       mcp: ${{ steps.changes.outputs.mcp }}
-      ompc: ${{ steps.changes.outputs.ompc }}
       polli-cli: ${{ steps.changes.outputs.polli-cli }}
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +28,6 @@ jobs:
           changed=$(git diff --name-only HEAD~1 HEAD)
           echo "sdk=$(echo "$changed" | grep -q '^packages/sdk/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "mcp=$(echo "$changed" | grep -q '^packages/mcp/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "ompc=$(echo "$changed" | grep -q '^packages/ompc/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "polli-cli=$(echo "$changed" | grep -q '^packages/polli-cli/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$changed" | grep '^packages/' || true
@@ -140,61 +137,6 @@ jobs:
             const pkg = require('./package.json');
             pkg.name = '@pollinations/mcp';
             pkg.repository = { type: 'git', url: 'https://github.com/pollinations/pollinations.git', directory: 'packages/mcp' };
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
-          "
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          echo "@pollinations:registry=https://npm.pkg.github.com" >> .npmrc
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-ompc:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.ompc == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-
-      - name: Install dependencies
-        working-directory: packages/ompc
-        run: npm ci --ignore-scripts
-
-      - name: Check if version already published
-        id: check
-        working-directory: packages/ompc
-        run: |
-          name=$(node -p "require('./package.json').name")
-          v=$(node -p "require('./package.json').version")
-          if npm view "$name@$v" version >/dev/null 2>&1; then
-            echo "Version $v already on npm — skipping publish"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish to NPM
-        if: steps.check.outputs.skip != 'true'
-        working-directory: packages/ompc
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_KEY }}
-
-      - name: Publish to GitHub Packages
-        if: steps.check.outputs.skip != 'true'
-        working-directory: packages/ompc
-        run: |
-          node -e "
-            const pkg = require('./package.json');
-            pkg.name = '@pollinations/ompc';
-            pkg.repository = { type: 'git', url: 'https://github.com/pollinations/pollinations.git', directory: 'packages/ompc' };
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc


### PR DESCRIPTION
## Changes Made:

- The `@pollinations_ai/ompc` package has been deprecated from the PR #10518 
- This PR removes the package from the CI pipeline 
