### PR TITLE
security: validate redirect_uri scheme and stop mirroring it on Deny

### DIFF
--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -56,9 +56,22 @@ function parseNumber(val: unknown): number | null {
     return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * Parse a caller-supplied redirect URL and reject anything that isn't a
+ * plain http(s) target. `new URL()` happily accepts `javascript:`, `data:`,
+ * `file:`, `blob:`, etc. — assigning any of those to `window.location.href`
+ * would execute attacker-controlled JS in the enter.pollinations.ai origin
+ * (full session-cookie + same-origin compromise), or load attacker payloads
+ * straight into the user's browser. Only http/https are valid OAuth-style
+ * callbacks for this flow.
+ */
 function safeParseUrl(url: string): URL | null {
     try {
-        return new URL(url);
+        const parsed = new URL(url);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            return null;
+        }
+        return parsed;
     } catch {
         return null;
     }
@@ -390,15 +403,15 @@ function AuthorizeComponent() {
                 // Best-effort deny
             }
             setDeviceOutcome("denied");
-        } else if (parsedRedirectUrl) {
-            const url = new URL(parsedRedirectUrl.href);
-            const hash = new URLSearchParams({ error: "access_denied" });
-            if (state) hash.set("state", state);
-            url.hash = hash.toString();
-            window.location.href = url.toString();
-        } else {
-            navigate({ to: "/" });
+            return;
         }
+        // Browser flow: do NOT navigate to the caller-supplied redirect_uri
+        // on Deny. Mirroring it (even with `error=access_denied`) hands the
+        // attacker a one-click handoff to their own page after the user
+        // explicitly refused — the perfect setup for a "your auth failed,
+        // click to retry" phishing follow-up. A Deny click should be a
+        // terminal action that keeps the user on enter.pollinations.ai.
+        navigate({ to: "/" });
     }
 
     if (deviceOutcome !== "pending") {


### PR DESCRIPTION
## Changes Made

- **Scheme allowlist on `redirect_uri`**: the helper that parses caller-supplied redirect URLs now rejects anything whose protocol isn't `http:` or `https:`. The previous implementation was a bare `new URL()` which happily accepts `javascript:`, `data:`, `file:`, `blob:`, and other dangerous schemes. Combined with the post-authorize `window.location.href = redirect_uri + "#api_key=…"` assignment, that meant an attacker-controlled `javascript:` URI would execute arbitrary script in the `enter.pollinations.ai` origin — a full session-cookie / same-origin compromise, dramatically worse than just leaking one `sk_`.
- **Deny path no longer mirrors `redirect_uri`**: in browser mode, clicking Deny now navigates the user back to `/` on `enter.pollinations.ai` unconditionally instead of redirecting to the caller-supplied URL with `#error=access_denied`. The old behavior handed an attacker a one-click handoff into their own page *after* the user explicitly refused — the perfect setup for a "your authentication failed, click here to retry" phishing follow-up. Deny should be terminal; the user should never be punted off-site by it.
- **Inline rationale**: both changes carry comments explaining the threat model so a future contributor doesn't reintroduce the wildcard parser "for flexibility" or restore the deny-path redirect "for OAuth UX parity."

## Why

This is a separate vulnerability from the per-key redirect-URI allowlist landing in #10524. That PR defends against confused-deputy attacks (attacker pairs a victim app's `pk_` with their own redirect URL). This PR defends against the simpler open-redirect / scheme-injection class:

- **Attacker uses their own `pk_`** (or no `pk_` at all) and an attacker redirect URL. The allowlist from #10524 would happily match because the attacker registered the URL on their own key. The consent screen says "Unverified app" (per #10526) but a confused user who clicks Authorize still ships a freshly-minted `sk_` to attacker.com via the URL fragment.
- **Attacker uses `javascript:` as the redirect**. The minted `sk_` is appended to the `javascript:` URI as a fragment and the browser executes the resulting script in the `enter.pollinations.ai` origin. Now the attacker has document.cookie access, can call any authenticated API on the user's behalf, and the leaked `sk_` is the least of the user's problems.
- **Attacker uses Deny as a tracking / phishing channel**. Even when the user does the right thing, they end up on attacker.com — fingerprinted as a Pollinations user who actively rejected an auth grant, primed for follow-up social engineering.

The allowlist work in #10524 is necessary but not sufficient. This PR closes the residual class.

## Tasks

- [x] Restrict `safeParseUrl` to http/https only
- [x] Remove caller-redirect mirroring from `handleDeny`
- [x] Document the threat model inline so the protections aren't reverted in future cleanup
- [x] Keep the existing "Invalid redirect URL format" error path so rejections surface as an in-page error rather than silent failures

## Notes

- **Scope is intentionally surgical**. ~22 lines net diff, two functions touched, no UI changes, no schema changes, no tests required because the existing rejection plumbing already covers the new failure path. Easier to review, easier to backport.
- **Caller-supplied `#hash` is already discarded**. The Authorize path reassigns `url.hash` after copying the parsed redirect URL, so any attacker-supplied fragment on the original `redirect_uri` is overwritten before the browser navigates. Verified during review — no fix needed there.
- **Device-flow Deny is unchanged**. That branch posts to `/api/device/deny` server-side and shows a local "Access Denied" screen — it never used a caller redirect, so it stays as-is.
- **Interaction with #10524**: complementary, not overlapping. Once both land, the order of defenses for `/authorize` becomes: (1) scheme check rejects non-http(s), (2) per-key allowlist rejects redirects that don't match the registered `pk_`, (3) consent UI shows the "Unverified app" warning chrome (#10526) when attribution can't be established. Three independent layers, each useful on its own.