### PR TITLE
fix: standardize Enter tooltip hovers

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "unique-names-generator";
 import { cn } from "@/util.ts";
 import { Button } from "../button.tsx";
+import { Tooltip } from "../ui/tooltip.tsx";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
 import type { CreateApiKey, CreateApiKeyResponse } from "./types.ts";
@@ -140,6 +141,24 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
         if (isSubmitting) return "Creating...";
         return "Create";
     }
+
+    const createDisabledReason =
+        !createdKey && noModelsSelected
+            ? "Select at least one model"
+            : !createdKey && isMissingRedirectUris
+              ? "Add at least one redirect URI"
+              : undefined;
+
+    const submitButton = (
+        <Button
+            type={createdKey ? "button" : "submit"}
+            onClick={createdKey ? handleCopyAndClose : undefined}
+            className="disabled:opacity-50"
+            disabled={isCreateDisabled}
+        >
+            {getButtonText()}
+        </Button>
+    );
 
     return (
         <Dialog.Root
@@ -307,30 +326,17 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                     Cancel
                                 </Button>
                             )}
-                            <span
-                                title={
-                                    !createdKey
-                                        ? noModelsSelected
-                                            ? "Select at least one model"
-                                            : isMissingRedirectUris
-                                              ? "Add at least one redirect URI"
-                                              : undefined
-                                        : undefined
-                                }
-                            >
-                                <Button
-                                    type={createdKey ? "button" : "submit"}
-                                    onClick={
-                                        createdKey
-                                            ? handleCopyAndClose
-                                            : undefined
-                                    }
-                                    className="disabled:opacity-50"
-                                    disabled={isCreateDisabled}
+                            {createDisabledReason ? (
+                                <Tooltip
+                                    triggerAs="span"
+                                    content={createDisabledReason}
+                                    className="inline-flex"
                                 >
-                                    {getButtonText()}
-                                </Button>
-                            </span>
+                                    {submitButton}
+                                </Tooltip>
+                            ) : (
+                                submitButton
+                            )}
                         </div>
                     </form>
                 </Dialog.Content>

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 import { useState } from "react";
 import { cn } from "@/util.ts";
 import { Panel } from "../ui/panel.tsx";
+import { Tooltip } from "../ui/tooltip.tsx";
 import { AccountBadge } from "./account-badge.tsx";
 import { ApiKeyDialog } from "./api-key-dialog.tsx";
 import { DeleteConfirmation } from "./delete-confirmation.tsx";
@@ -136,10 +137,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                     : "🌐 Publishable"
                                                 : "🔒 Secret"}
                                         </span>
-                                        <span
-                                            className="text-sm font-medium truncate"
-                                            title={apiKey.name ?? undefined}
-                                        >
+                                        <span className="text-sm font-medium truncate">
                                             {apiKey.name}
                                         </span>
                                         <span className="flex-1" />
@@ -154,31 +152,43 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                             </span>
                                         )}
                                         <div className="flex gap-1 shrink-0 ml-2 items-center">
-                                            <button
-                                                type="button"
-                                                className="w-6 h-6 flex items-center justify-center rounded bg-blue-50 hover:bg-blue-100 text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
-                                                onClick={() =>
-                                                    setEditingKey(apiKey)
-                                                }
-                                                title="Edit key"
+                                            <Tooltip
+                                                triggerAs="span"
+                                                content="Edit key"
+                                                className="inline-flex"
                                             >
-                                                ✎
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className="w-6 h-6 flex items-center justify-center rounded bg-red-50 hover:bg-red-100 text-red-400 hover:text-red-600 transition-colors text-lg cursor-pointer"
-                                                onClick={() =>
-                                                    setDeleteId(apiKey.id)
-                                                }
-                                                title="Delete key"
+                                                <button
+                                                    type="button"
+                                                    className="w-6 h-6 flex items-center justify-center rounded bg-blue-50 hover:bg-blue-100 text-blue-400 hover:text-blue-600 transition-colors cursor-pointer"
+                                                    onClick={() =>
+                                                        setEditingKey(apiKey)
+                                                    }
+                                                    aria-label="Edit key"
+                                                >
+                                                    ✎
+                                                </button>
+                                            </Tooltip>
+                                            <Tooltip
+                                                triggerAs="span"
+                                                content="Delete key"
+                                                className="inline-flex"
                                             >
-                                                ×
-                                            </button>
+                                                <button
+                                                    type="button"
+                                                    className="w-6 h-6 flex items-center justify-center rounded bg-red-50 hover:bg-red-100 text-red-400 hover:text-red-600 transition-colors text-lg cursor-pointer"
+                                                    onClick={() =>
+                                                        setDeleteId(apiKey.id)
+                                                    }
+                                                    aria-label="Delete key"
+                                                >
+                                                    ×
+                                                </button>
+                                            </Tooltip>
                                         </div>
                                     </div>
                                     {/* Row 2: Stats and Permissions */}
                                     <div className="flex flex-wrap items-center gap-4 text-xs">
-                                        <span title="Created">
+                                        <span>
                                             <span className="text-gray-400">
                                                 Created:{" "}
                                             </span>
@@ -192,7 +202,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                                 )}
                                             </span>
                                         </span>
-                                        <span title="Last used">
+                                        <span>
                                             <span className="text-gray-400">
                                                 Used:{" "}
                                             </span>
@@ -212,9 +222,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                         </span>
                                         {isPublishable &&
                                             primaryRedirectUri && (
-                                                <span
-                                                    title={primaryRedirectUri}
-                                                >
+                                                <span>
                                                     <span className="text-gray-400">
                                                         Redirect:{" "}
                                                     </span>

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "../button.tsx";
 import { Badge } from "../ui/badge.tsx";
 import { Card } from "../ui/card.tsx";
 import { Input } from "../ui/input.tsx";
+import { Tooltip } from "../ui/tooltip.tsx";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
 import type { ApiKey, ApiKeyUpdateParams } from "./types.ts";
@@ -159,19 +160,26 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                                       : "🔒 Secret"}
                             </Badge>
                             {isPublishable && plaintextKey ? (
-                                <button
-                                    type="button"
-                                    onClick={handleCopyKey}
-                                    className={cn(
-                                        "font-mono text-sm cursor-pointer transition-all",
-                                        copied
-                                            ? "text-green-600 font-semibold"
-                                            : "text-blue-600 hover:text-blue-800 hover:underline",
-                                    )}
-                                    title={copied ? "Copied!" : "Click to copy"}
+                                <Tooltip
+                                    triggerAs="span"
+                                    content={
+                                        copied ? "Copied!" : "Click to copy"
+                                    }
+                                    className="inline-flex min-w-0"
                                 >
-                                    {copied ? "✓ Copied!" : plaintextKey}
-                                </button>
+                                    <button
+                                        type="button"
+                                        onClick={handleCopyKey}
+                                        className={cn(
+                                            "font-mono text-sm cursor-pointer transition-all",
+                                            copied
+                                                ? "text-green-600 font-semibold"
+                                                : "text-blue-600 hover:text-blue-800 hover:underline",
+                                        )}
+                                    >
+                                        {copied ? "✓ Copied!" : plaintextKey}
+                                    </button>
+                                </Tooltip>
                             ) : (
                                 <span className="font-mono text-sm text-gray-500">
                                     {apiKey.start}...

--- a/enter.pollinations.ai/src/client/components/api-keys/key-display.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/key-display.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { cn } from "@/util.ts";
+import { Tooltip } from "../ui/tooltip.tsx";
 
 export const KeyDisplay: FC<{ fullKey: string; start: string }> = ({
     fullKey,
@@ -19,18 +20,23 @@ export const KeyDisplay: FC<{ fullKey: string; start: string }> = ({
     };
 
     return (
-        <button
-            type="button"
-            onClick={handleCopy}
-            className={cn(
-                "font-mono text-xs text-left cursor-pointer transition-all",
-                copied
-                    ? "text-green-600 font-semibold"
-                    : "text-blue-600 hover:text-blue-800 hover:underline",
-            )}
-            title={copied ? "Copied!" : "Click to copy full key"}
+        <Tooltip
+            triggerAs="span"
+            content={copied ? "Copied!" : "Click to copy full key"}
+            className="inline-flex"
         >
-            {copied ? "✓ Copied!" : `${start}...`}
-        </button>
+            <button
+                type="button"
+                onClick={handleCopy}
+                className={cn(
+                    "font-mono text-xs text-left cursor-pointer transition-all",
+                    copied
+                        ? "text-green-600 font-semibold"
+                        : "text-blue-600 hover:text-blue-800 hover:underline",
+                )}
+            >
+                {copied ? "✓ Copied!" : `${start}...`}
+            </button>
+        </Tooltip>
     );
 };

--- a/enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx
@@ -1,76 +1,37 @@
-import type { FC } from "react";
-import { useState } from "react";
+import type { FC, ReactNode } from "react";
 import { Badge } from "../ui/badge.tsx";
+import { Tooltip } from "../ui/tooltip.tsx";
 
 export const ModelsBadge: FC<{
     permissions: Record<string, string[]> | null;
 }> = ({ permissions }) => {
-    const [showTooltip, setShowTooltip] = useState(false);
     const models = permissions?.models ?? null;
     const isAllModels = models === null;
     const modelCount = models?.length ?? 0;
 
-    const handleInteraction = (e: React.MouseEvent | React.KeyboardEvent) => {
-        e.stopPropagation();
-        if ("key" in e && e.key !== "Enter" && e.key !== " ") return;
-        if ("key" in e) e.preventDefault();
-        setShowTooltip((prev) => !prev);
-    };
-
-    const tooltipContent = () => {
+    const tooltipContent = (): ReactNode => {
         if (isAllModels) return "Access to all models";
         if (modelCount === 0) return "No models allowed";
         return (
-            <div className="font-mono text-[11px] leading-relaxed text-left whitespace-nowrap">
+            <span className="block font-mono text-[11px] leading-relaxed text-left whitespace-nowrap">
                 {models?.map((model) => (
-                    <div key={model}>{model}</div>
+                    <span className="block" key={model}>
+                        {model}
+                    </span>
                 ))}
-            </div>
+            </span>
         );
     };
 
     return (
-        <button
-            type="button"
-            className="relative inline-flex items-center"
-            onClick={handleInteraction}
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-            onKeyDown={handleInteraction}
-            aria-label="Show allowed models"
-        >
+        <Tooltip content={tooltipContent()} ariaLabel="Show allowed models">
             <Badge
                 color={isAllModels ? "green" : "amber"}
                 size="sm"
-                className="cursor-pointer transition-colors hover:brightness-95"
+                className="cursor-default transition-colors hover:brightness-95"
             >
                 {isAllModels ? "All" : modelCount}
             </Badge>
-            {showTooltip && (
-                <div
-                    className="fixed z-[9999] px-2 py-1.5 bg-gradient-to-r from-pink-50 to-purple-50 text-gray-800 text-xs rounded-lg shadow-lg border border-pink-200 pointer-events-none"
-                    style={{
-                        top: "var(--tooltip-top)",
-                        left: "var(--tooltip-left)",
-                    }}
-                    ref={(el) => {
-                        if (!el) return;
-                        const btn = el.parentElement;
-                        if (!btn) return;
-                        const rect = btn.getBoundingClientRect();
-                        el.style.setProperty(
-                            "--tooltip-top",
-                            `${rect.bottom + 4}px`,
-                        );
-                        el.style.setProperty(
-                            "--tooltip-left",
-                            `${rect.left}px`,
-                        );
-                    }}
-                >
-                    {tooltipContent()}
-                </div>
-            )}
-        </button>
+        </Tooltip>
     );
 };

--- a/enter.pollinations.ai/src/client/components/balance/payment-trust-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/payment-trust-badge.tsx
@@ -19,8 +19,8 @@ const LockIcon: FC = () => (
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
+        aria-hidden="true"
     >
-        <title>Secure</title>
         <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
         <path d="M7 11V7a5 5 0 0 1 10 0v4" />
     </svg>

--- a/enter.pollinations.ai/src/client/components/balance/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/pollen-balance.tsx
@@ -47,7 +47,7 @@ const PollenGaugeSegment: FC<GaugeSegmentProps> = ({
 
     const style =
         position === "left"
-            ? { width: `${percentage}%` }
+            ? { left: 0, width: `${percentage}%` }
             : { left: `${offset}%`, width: `${percentage}%` };
 
     return (

--- a/enter.pollinations.ai/src/client/components/balance/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/pollen-balance.tsx
@@ -19,7 +19,7 @@ type GaugeSegmentProps = {
     value: number;
     label: string;
     color: "amber" | "orange" | "blue" | "green" | "pink" | "gray" | "violet";
-    title: string;
+    tooltipText: string;
     position: "left" | "right";
     offset?: number;
 };
@@ -39,7 +39,7 @@ const PollenGaugeSegment: FC<GaugeSegmentProps> = ({
     value,
     label,
     color,
-    title,
+    tooltipText,
     position,
     offset = 0,
 }) => {
@@ -51,19 +51,24 @@ const PollenGaugeSegment: FC<GaugeSegmentProps> = ({
             : { left: `${offset}%`, width: `${percentage}%` };
 
     return (
-        <div
-            className={`absolute inset-y-0 ${bgColor} transition-all duration-500 ease-out cursor-help`}
+        <Tooltip
+            triggerAs="span"
+            className={`absolute inset-y-0 ${bgColor} cursor-default transition-all duration-500 ease-out`}
             style={style}
-            title={title}
+            content={
+                <span className="block whitespace-pre-line leading-snug">
+                    {tooltipText}
+                </span>
+            }
         >
-            <div className="absolute inset-0 flex items-center justify-center gap-1">
+            <span className="absolute inset-0 flex items-center justify-center gap-1">
                 <span
                     className={`${textColor} font-bold text-sm whitespace-nowrap`}
                 >
                     {label} {formatPollen(value)}
                 </span>
-            </div>
-        </div>
+            </span>
+        </Tooltip>
     );
 };
 
@@ -133,7 +138,7 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                                     value={displayPaid}
                                     label="🪷"
                                     color="amber"
-                                    title={`🪷 Purchased: ${formatPollen(displayPaid)} pollen\nFrom packs you've bought\nRequired for 🪷 Paid Only models; used after tier grants for others`}
+                                    tooltipText={`🪷 Purchased: ${formatPollen(displayPaid)} pollen\nFrom packs you've bought\nRequired for 🪷 Paid Only models; used after tier grants for others`}
                                     position="left"
                                 />
                             )}
@@ -144,7 +149,7 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                                     value={displayTier}
                                     label={tierEmoji}
                                     color={tierColor}
-                                    title={`${tierEmoji} Tier: ${formatPollen(displayTier)} pollen\nFree pollen from your tier, refills periodically\nUsed first, except for 🪷 Paid Only models`}
+                                    tooltipText={`${tierEmoji} Tier: ${formatPollen(displayTier)} pollen\nFree pollen from your tier, refills periodically\nUsed first, except for 🪷 Paid Only models`}
                                     position="right"
                                     offset={paidPercentage}
                                 />
@@ -179,7 +184,6 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                                     href={`/api/stripe/checkout/${pack.amountUsd}`}
                                     color="amber"
                                     weight="light"
-                                    title={`Buy $${pack.amountUsd} pollen pack`}
                                     className="btn-shimmer w-full min-w-0 justify-self-stretch whitespace-nowrap border border-amber-300/70 px-3 text-center text-xs shadow-none sm:w-[132px] sm:justify-self-center sm:text-sm"
                                 >
                                     <span className="font-semibold text-amber-900">

--- a/enter.pollinations.ai/src/client/components/balance/tier-explanation.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/tier-explanation.tsx
@@ -105,7 +105,7 @@ export const TierExplanation: FC<{ currentTier?: TierStatus }> = ({
                         <p className={requirementLabelStyle}>To unlock</p>
                         <p className="text-xs text-gray-500">
                             <Tooltip content={<SeedTooltipContent />}>
-                                <span className="underline decoration-dotted cursor-help">
+                                <span className="cursor-default underline decoration-dotted">
                                     7+ dev points
                                 </span>
                             </Tooltip>

--- a/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
@@ -261,7 +261,7 @@ export const ModelRow: FC<ModelRowProps> = ({
                     >
                         <span
                             className={cn(
-                                "inline-block text-sm font-medium bg-teal-200 text-gray-900 px-2.5 py-0.5 rounded-full cursor-help",
+                                "inline-block cursor-default text-sm font-medium bg-teal-200 text-gray-900 px-2.5 py-0.5 rounded-full",
                             )}
                         >
                             {genPerPollen}

--- a/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
@@ -292,7 +292,6 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
                             strokeWidth={2}
                             aria-hidden="true"
                         >
-                            <title>Expand model details</title>
                             <path
                                 strokeLinecap="round"
                                 strokeLinejoin="round"

--- a/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
@@ -620,6 +620,7 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
                     </span>
                 </button>
                 <Tooltip
+                    triggerAs="span"
                     content={
                         <span className="block w-[220px] whitespace-normal leading-snug">
                             Based on average community usage. Actual costs vary

--- a/enter.pollinations.ai/src/client/components/ui/tooltip.tsx
+++ b/enter.pollinations.ai/src/client/components/ui/tooltip.tsx
@@ -1,4 +1,5 @@
 import {
+    type CSSProperties,
     type FC,
     type MouseEvent,
     type ReactNode,
@@ -9,39 +10,56 @@ import {
 type TooltipProps = {
     children: ReactNode;
     content: ReactNode;
+    ariaLabel?: string;
+    className?: string;
     onClick?: () => void;
+    style?: CSSProperties;
     triggerAs?: "button" | "span";
 };
 
 export const Tooltip: FC<TooltipProps> = ({
     children,
     content,
+    ariaLabel,
+    className,
     onClick,
+    style,
     triggerAs = "button",
 }) => {
     const [showTooltip, setShowTooltip] = useState(false);
-    const [mobileTop, setMobileTop] = useState(0);
+    const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
     const triggerRef = useRef<HTMLElement | null>(null);
 
-    const updateMobilePosition = () => {
+    const updateTooltipPosition = () => {
         if (triggerRef.current) {
             const rect = triggerRef.current.getBoundingClientRect();
-            setMobileTop(rect.bottom + 4);
+            setTooltipPosition({
+                top: rect.bottom + 4,
+                left: rect.left,
+            });
         }
     };
+
+    const triggerClassName =
+        className ??
+        "relative cursor-default text-left inline-flex items-center";
 
     const contentNode = (
         <>
             <span className="md:cursor-default cursor-pointer">{children}</span>
             <span
+                style={{
+                    top: tooltipPosition.top,
+                    left: tooltipPosition.left,
+                }}
                 className={`${
                     showTooltip ? "visible opacity-100" : "invisible opacity-0"
-                } hidden md:block absolute left-0 top-full mt-1 px-3 py-2 bg-white text-gray-800 text-xs rounded-lg shadow-lg border border-gray-200 z-50 pointer-events-none transition-opacity min-w-max`}
+                } hidden md:block fixed px-3 py-2 bg-white text-gray-800 text-xs rounded-lg shadow-lg border border-gray-200 z-50 pointer-events-none transition-opacity min-w-max`}
             >
                 {content}
             </span>
             <span
-                style={{ top: mobileTop }}
+                style={{ top: tooltipPosition.top }}
                 className={`${
                     showTooltip ? "visible opacity-100" : "invisible opacity-0"
                 } md:hidden fixed left-1/2 -translate-x-1/2 px-4 py-3 bg-white text-gray-800 text-xs rounded-lg shadow-xl border border-gray-200 z-50 pointer-events-none transition-opacity max-w-[90vw]`}
@@ -52,17 +70,22 @@ export const Tooltip: FC<TooltipProps> = ({
     );
 
     const sharedProps = {
-        className: "relative cursor-default text-left inline-flex items-center",
-        onMouseEnter: () => setShowTooltip(true),
+        "aria-label": ariaLabel,
+        className: triggerClassName,
+        onMouseEnter: () => {
+            updateTooltipPosition();
+            setShowTooltip(true);
+        },
         onMouseLeave: () => setShowTooltip(false),
         onClick: (e: MouseEvent) => {
             e.stopPropagation();
             if (onClick) {
                 onClick();
             }
-            updateMobilePosition();
+            updateTooltipPosition();
             setShowTooltip((prev) => !prev);
         },
+        style,
     };
 
     if (triggerAs === "span") {
@@ -84,10 +107,12 @@ export const Tooltip: FC<TooltipProps> = ({
                 triggerRef.current = node;
             }}
             type="button"
-            className="relative cursor-default text-left inline-flex items-center"
+            aria-label={ariaLabel}
+            className={triggerClassName}
             onMouseEnter={sharedProps.onMouseEnter}
             onMouseLeave={sharedProps.onMouseLeave}
             onClick={sharedProps.onClick}
+            style={style}
         >
             {contentNode}
         </button>

--- a/enter.pollinations.ai/src/client/components/ui/tooltip.tsx
+++ b/enter.pollinations.ai/src/client/components/ui/tooltip.tsx
@@ -6,6 +6,7 @@ import {
     useRef,
     useState,
 } from "react";
+import { cn } from "@/util.ts";
 
 type TooltipProps = {
     children: ReactNode;
@@ -40,9 +41,10 @@ export const Tooltip: FC<TooltipProps> = ({
         }
     };
 
-    const triggerClassName =
-        className ??
-        "relative cursor-default text-left inline-flex items-center";
+    const triggerClassName = cn(
+        "relative cursor-default text-left inline-flex items-center",
+        className,
+    );
 
     const contentNode = (
         <>
@@ -81,6 +83,9 @@ export const Tooltip: FC<TooltipProps> = ({
             e.stopPropagation();
             if (onClick) {
                 onClick();
+            }
+            if (triggerAs === "span") {
+                return;
             }
             updateTooltipPosition();
             setShowTooltip((prev) => !prev);

--- a/enter.pollinations.ai/src/client/components/ui/tooltip.tsx
+++ b/enter.pollinations.ai/src/client/components/ui/tooltip.tsx
@@ -1,41 +1,38 @@
-import { type FC, type ReactNode, useRef, useState } from "react";
+import {
+    type FC,
+    type MouseEvent,
+    type ReactNode,
+    useRef,
+    useState,
+} from "react";
 
 type TooltipProps = {
     children: ReactNode;
     content: ReactNode;
     onClick?: () => void;
+    triggerAs?: "button" | "span";
 };
 
-export const Tooltip: FC<TooltipProps> = ({ children, content, onClick }) => {
+export const Tooltip: FC<TooltipProps> = ({
+    children,
+    content,
+    onClick,
+    triggerAs = "button",
+}) => {
     const [showTooltip, setShowTooltip] = useState(false);
     const [mobileTop, setMobileTop] = useState(0);
-    const buttonRef = useRef<HTMLButtonElement>(null);
+    const triggerRef = useRef<HTMLElement | null>(null);
 
     const updateMobilePosition = () => {
-        if (buttonRef.current) {
-            const rect = buttonRef.current.getBoundingClientRect();
+        if (triggerRef.current) {
+            const rect = triggerRef.current.getBoundingClientRect();
             setMobileTop(rect.bottom + 4);
         }
     };
 
-    return (
-        <button
-            ref={buttonRef}
-            type="button"
-            className="relative cursor-default text-left inline-flex items-center"
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-            onClick={(e) => {
-                e.stopPropagation();
-                if (onClick) {
-                    onClick();
-                }
-                updateMobilePosition();
-                setShowTooltip((prev) => !prev);
-            }}
-        >
+    const contentNode = (
+        <>
             <span className="md:cursor-default cursor-pointer">{children}</span>
-            {/* Desktop: positioned relative to trigger */}
             <span
                 className={`${
                     showTooltip ? "visible opacity-100" : "invisible opacity-0"
@@ -43,7 +40,6 @@ export const Tooltip: FC<TooltipProps> = ({ children, content, onClick }) => {
             >
                 {content}
             </span>
-            {/* Mobile: horizontally centered on screen, vertically below trigger */}
             <span
                 style={{ top: mobileTop }}
                 className={`${
@@ -52,6 +48,48 @@ export const Tooltip: FC<TooltipProps> = ({ children, content, onClick }) => {
             >
                 {content}
             </span>
+        </>
+    );
+
+    const sharedProps = {
+        className: "relative cursor-default text-left inline-flex items-center",
+        onMouseEnter: () => setShowTooltip(true),
+        onMouseLeave: () => setShowTooltip(false),
+        onClick: (e: MouseEvent) => {
+            e.stopPropagation();
+            if (onClick) {
+                onClick();
+            }
+            updateMobilePosition();
+            setShowTooltip((prev) => !prev);
+        },
+    };
+
+    if (triggerAs === "span") {
+        return (
+            <span
+                ref={(node) => {
+                    triggerRef.current = node;
+                }}
+                {...sharedProps}
+            >
+                {contentNode}
+            </span>
+        );
+    }
+
+    return (
+        <button
+            ref={(node) => {
+                triggerRef.current = node;
+            }}
+            type="button"
+            className="relative cursor-default text-left inline-flex items-center"
+            onMouseEnter={sharedProps.onMouseEnter}
+            onMouseLeave={sharedProps.onMouseLeave}
+            onClick={sharedProps.onClick}
+        >
+            {contentNode}
         </button>
     );
 };

--- a/enter.pollinations.ai/src/client/components/usage-analytics/chart.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/chart.tsx
@@ -7,8 +7,9 @@ const CHART_COLORS = {
     grid: "#e5e7eb", // gray-200
     paidBar: "#fde68a", // amber-200
     paidBarHover: "#fcd34d", // amber-300
-    tooltipBg: "#18181b", // zinc-950
-    tooltipSep: "#374151", // gray-700
+    tooltipBg: "#ffffff",
+    tooltipBorder: "#e5e7eb", // gray-200
+    tooltipSep: "#e5e7eb", // gray-200
 } as const;
 
 const TIER_BAR_COLORS = {
@@ -199,8 +200,6 @@ export const Chart: FC<ChartProps> = ({
                 role="img"
                 aria-label="Usage chart"
             >
-                <title>Usage statistics chart</title>
-
                 {/* Grid lines */}
                 {yTicks.map((t) => (
                     <g key={`tick-${t.value}`}>
@@ -381,13 +380,14 @@ export const Chart: FC<ChartProps> = ({
                                     height={tooltipHeight}
                                     rx="8"
                                     fill={CHART_COLORS.tooltipBg}
-                                    opacity="0.95"
+                                    stroke={CHART_COLORS.tooltipBorder}
+                                    strokeWidth="1"
                                 />
                                 <text
                                     x={tooltipX + 12}
                                     y={tooltipY + 18}
                                     textAnchor="start"
-                                    className="text-xs fill-gray-400"
+                                    className="text-xs fill-gray-500"
                                 >
                                     {dateOnly}
                                 </text>
@@ -395,7 +395,7 @@ export const Chart: FC<ChartProps> = ({
                                     x={tooltipX + 12}
                                     y={tooltipY + 36}
                                     textAnchor="start"
-                                    className="text-sm font-bold fill-white"
+                                    className="text-sm font-bold fill-gray-900"
                                 >
                                     {metric === "requests"
                                         ? "requests"
@@ -433,7 +433,7 @@ export const Chart: FC<ChartProps> = ({
                                                         4 +
                                                         i * lineHeight
                                                     }
-                                                    className="text-xs fill-gray-300"
+                                                    className="text-xs fill-gray-600"
                                                 >
                                                     {truncateLabel(m.label, 22)}
                                                 </text>
@@ -451,7 +451,7 @@ export const Chart: FC<ChartProps> = ({
                                                         i * lineHeight
                                                     }
                                                     textAnchor="end"
-                                                    className="text-xs fill-white font-medium"
+                                                    className="text-xs fill-gray-900 font-medium"
                                                 >
                                                     {formatTooltipVal(
                                                         metric === "requests"

--- a/enter.pollinations.ai/src/client/components/usage-analytics/multi-select.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/multi-select.tsx
@@ -138,8 +138,8 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
+                    aria-hidden="true"
                 >
-                    <title>Toggle dropdown</title>
                     <path
                         strokeLinecap="round"
                         strokeLinejoin="round"
@@ -149,7 +149,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 </svg>
             </button>
             {disabled && (
-                <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-gray-800 text-white text-xs rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-[100]">
+                <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-3 py-2 bg-white text-gray-800 text-xs rounded-lg shadow-lg border border-gray-200 whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-[100]">
                     No items available
                 </span>
             )}

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -245,8 +245,8 @@ function RouteComponent() {
                                         strokeWidth="2"
                                         strokeLinecap="round"
                                         strokeLinejoin="round"
+                                        aria-hidden="true"
                                     >
-                                        <title>Download</title>
                                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                                         <polyline points="7 10 12 15 17 10" />
                                         <line x1="12" y1="15" x2="12" y2="3" />


### PR DESCRIPTION
- Adds shared Tooltip trigger/class/style support so nested buttons are avoided.
- Standardizes Enter tooltip hovers across pricing, balance, API keys, and usage UI.
- Removes native/delayed title hovers and custom dark/gradient tooltip styling where applicable.
- Fixes the balance gauge segment origin after wrapping it with the shared tooltip.

Validation:
- `npx biome check --write` on touched files
- `git diff --check`
- `npm run typecheck` is still blocked by the existing root vs `enter.pollinations.ai` Drizzle/Better Auth duplicate dependency type mismatch, unrelated to this PR.