### PR TITLE
fix(gen): repair Claude requests and API docs

### DIFF
--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -13,6 +13,7 @@ import { apiKeysRoutes } from "./routes/api-keys.ts";
 import { appLookupRoutes } from "./routes/app-lookup.ts";
 import { customerRoutes } from "./routes/customer.ts";
 import { deviceRoutes } from "./routes/device.ts";
+import { createDocsRoutes } from "./routes/docs.ts";
 import { modelStatsRoutes } from "./routes/model-stats.ts";
 import { stripeRoutes } from "./routes/stripe.ts";
 import { stripeWebhooksRoutes } from "./routes/stripe-webhooks.ts";
@@ -77,6 +78,7 @@ const app = new Hono<Env>()
             c.header("X-Robots-Tag", "noindex, nofollow");
         }
     })
+    .route("/api/docs", createDocsRoutes(api))
     .all("/api/docs", redirectLegacyDocs)
     .all("/api/docs/", redirectLegacyDocs)
     .all("/api/docs/*", redirectLegacyDocs)

--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -50,7 +50,7 @@ function isApiDocsPath(path: string): boolean {
 function redirectLegacyDocs(c: Context<Env>): Response {
     const url = new URL(c.req.url);
     url.protocol = "https:";
-    url.hostname = "gen.pollinations.ai";
+    url.hostname = url.hostname.replace(/(^|\.)enter\./, "$1gen.");
     url.pathname = url.pathname.replace(/^\/api\/docs(?=\/|$)/, "/docs");
     url.pathname = stripTrailingSlash(url.pathname);
     return c.redirect(url.toString(), 301);

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -1099,7 +1099,11 @@ function transformOpenAPISchema(
 export const createDocsRoutes = (apiRouter: Hono<Env>) => {
     return new Hono<Env>()
         .get("/", (c) => {
-            return c.redirect("https://gen.pollinations.ai/docs", 301);
+            const url = new URL(c.req.url);
+            url.protocol = "https:";
+            url.hostname = url.hostname.replace(/(^|\.)enter\./, "$1gen.");
+            url.pathname = "/docs";
+            return c.redirect(url.toString(), 301);
         })
         .get("/llm.txt", (c) => {
             c.header("Cache-Control", "public, max-age=3600");

--- a/enter.pollinations.ai/test/docs-redirect.test.ts
+++ b/enter.pollinations.ai/test/docs-redirect.test.ts
@@ -1,16 +1,32 @@
 import { SELF } from "cloudflare:test";
 import { expect, test } from "vitest";
 
-test("legacy enter docs paths redirect to gen docs", async () => {
+test("legacy enter docs page redirects to gen docs", async () => {
     const response = await SELF.fetch(
-        "https://enter.pollinations.ai/api/docs/open-api/generate-schema?format=json",
+        "https://enter.pollinations.ai/api/docs?format=json",
         { redirect: "manual" },
     );
 
     expect(response.status).toBe(301);
     expect(response.headers.get("Location")).toBe(
-        "https://gen.pollinations.ai/docs/open-api/generate-schema?format=json",
+        "https://gen.pollinations.ai/docs?format=json",
     );
+});
+
+test("enter docs schema remains available for gen service binding", async () => {
+    const response = await SELF.fetch(
+        "https://enter.pollinations.ai/api/docs/open-api/generate-schema",
+        { redirect: "manual" },
+    );
+
+    expect(response.status).toBe(200);
+    const schema = (await response.json()) as {
+        info?: { description?: string };
+        paths?: Record<string, unknown>;
+    };
+
+    expect(schema.info?.description).toContain("Quick Start");
+    expect(schema.paths?.["/account/profile"]).toBeDefined();
 });
 
 test("legacy enter docs redirect keeps the docs path boundary", async () => {

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -6,8 +6,11 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { generateSpecs } from "hono-openapi";
 import type { Env } from "@/env.ts";
+import BYOP_MD from "../../../BRING_YOUR_OWN_POLLEN.md?raw";
 
 type OpenApiSchema = Record<string, unknown>;
+
+const BYOP_DOCS = BYOP_MD.trim();
 
 const IMAGE_ALIASES = new Set(
     Object.values(IMAGE_SERVICES).flatMap((service) => service.aliases),
@@ -64,9 +67,46 @@ function generateLLMDoc(): string {
     return [
         "# Pollinations API",
         "",
+        "> Generate text, images, video, and audio with a single API. OpenAI-compatible — use any OpenAI SDK by changing the base URL.",
+        "",
         "Base URL: https://gen.pollinations.ai",
         "API Keys: https://enter.pollinations.ai",
+        "Docs: https://gen.pollinations.ai/docs",
         "OpenAPI: https://gen.pollinations.ai/docs/open-api/generate-schema",
+        "CLI: `npx @pollinations_ai/cli` (binary: `polli`) — agent-friendly, `--json` everywhere",
+        "",
+        "## Quick Start",
+        "",
+        "### Text (Python, OpenAI SDK)",
+        "",
+        "```python",
+        "from openai import OpenAI",
+        'client = OpenAI(base_url="https://gen.pollinations.ai", api_key="YOUR_API_KEY")',
+        'response = client.chat.completions.create(model="openai", messages=[{"role": "user", "content": "Hello!"}])',
+        "print(response.choices[0].message.content)",
+        "```",
+        "",
+        "### Image (URL — no code needed)",
+        "",
+        "```",
+        "https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux",
+        "```",
+        "",
+        "### Audio (cURL)",
+        "",
+        "```bash",
+        'curl "https://gen.pollinations.ai/audio/Hello%20world?voice=nova" \\',
+        '  -H "Authorization: Bearer YOUR_API_KEY" -o speech.mp3',
+        "```",
+        "",
+        "## Authentication",
+        "",
+        "All generation requests require an API key. Model listing endpoints work without auth.",
+        "",
+        "- Header: `Authorization: Bearer YOUR_API_KEY`",
+        "- Query param: `?key=YOUR_API_KEY`",
+        "",
+        "Key types: `sk_` (secret, server-side) | `pk_` (publishable, client-side, rate limited)",
         "",
         "## Generation",
         "",
@@ -88,13 +128,38 @@ function generateLLMDoc(): string {
         "- GET /image/models",
         "- GET /audio/models",
         "",
-        "## Account API",
+        "## Account",
         "",
-        "Account and API-key routes are available through gen at /account/*.",
+        "All account endpoints require authentication (API key or session). API keys need the relevant `account:<scope>` permission.",
+        "Base path: /account",
         "",
-        "## Authentication",
+        "### GET /account/profile",
         "",
-        "Use Authorization: Bearer YOUR_API_KEY. The ?key= query parameter is also accepted for simple GET endpoints.",
+        "Returns user profile. `githubUsername`, `image`, `tier`, and `nextResetAt` are always included. `name` and `email` are included only when the API key has the `account:profile` permission.",
+        "",
+        "### GET /account/balance",
+        "",
+        "Returns remaining pollen. If the API key has a budget, returns key budget instead.",
+        "",
+        "### GET /account/usage",
+        "",
+        "Per-request usage history: model, token counts, cost, response time.",
+        "",
+        "## Media Storage",
+        "",
+        "Base URL: https://media.pollinations.ai",
+        "Content-addressed file storage. Upload requires API key; retrieval is public.",
+        "",
+        "## Errors",
+        "",
+        "JSON: {status, success: false, error: {code, message}}",
+        "- 400: Invalid parameters",
+        "- 401: Missing/invalid API key",
+        "- 402: Insufficient balance",
+        "- 403: Permission denied",
+        "- 500: Server error",
+        "",
+        BYOP_DOCS,
     ].join("\n");
 }
 
@@ -125,11 +190,62 @@ function generationDocumentation(): OpenApiSchema {
             title: "Pollinations API",
             version: "0.3.0",
             description: [
-                "Generate text, images, video, and audio with a single API.",
+                "## Introduction",
+                "",
+                "Generate text, images, video, and audio with a single API. OpenAI-compatible — use any OpenAI SDK by changing the base URL.",
                 "",
                 "**Base URL:** `https://gen.pollinations.ai`",
                 "",
                 "**Get your API key:** [enter.pollinations.ai](https://enter.pollinations.ai)",
+                "",
+                "## Overview",
+                "",
+                "| Capability | Endpoint | Format |",
+                "|---|---|---|",
+                "| ✍️ **Text Generation** | `POST /v1/chat/completions` | OpenAI-compatible |",
+                "| ✍️ **Simple Text** | `GET /text/{prompt}` | Plain text |",
+                "| 🖼️ **Image Generation** | `GET /image/{prompt}` | JPEG / PNG |",
+                "| 🎬 **Video Generation** | `GET /video/{prompt}` | MP4 |",
+                "| 🔊 **Text-to-Speech** | `GET /audio/{text}` | MP3 |",
+                "| 🔊 **Transcription** | `POST /v1/audio/transcriptions` | JSON |",
+                "| 🤖 **Model Discovery** | `GET /v1/models` | JSON |",
+                "",
+                "## Quick Start",
+                "",
+                "### Generate an Image",
+                "",
+                "Paste this URL in your browser — no code needed:",
+                "",
+                "```",
+                "https://gen.pollinations.ai/image/a%20cat%20in%20space",
+                "```",
+                "",
+                "### Generate Text (OpenAI-compatible)",
+                "",
+                "```bash",
+                "curl https://gen.pollinations.ai/v1/chat/completions \\",
+                '  -H "Authorization: Bearer YOUR_API_KEY" \\',
+                '  -H "Content-Type: application/json" \\',
+                '  -d \'{"model": "openai", "messages": [{"role": "user", "content": "Hello!"}]}\'',
+                "```",
+                "",
+                "### Generate Speech",
+                "",
+                "```bash",
+                'curl "https://gen.pollinations.ai/audio/Hello%20world?voice=nova" \\',
+                '  -H "Authorization: Bearer YOUR_API_KEY" -o speech.mp3',
+                "```",
+                "",
+                "## Authentication",
+                "",
+                "All generation requests require an API key from [enter.pollinations.ai](https://enter.pollinations.ai). Model listing endpoints work without authentication.",
+                "",
+                "| Type | Prefix | Use case | Rate limits |",
+                "|------|--------|----------|-------------|",
+                "| Secret | `sk_` | Server-side apps | None |",
+                "| Publishable | `pk_` | Client-side apps (beta) | 1 pollen/IP/hour |",
+                "",
+                BYOP_DOCS,
             ].join("\n"),
         },
         components: {
@@ -147,24 +263,103 @@ function generationDocumentation(): OpenApiSchema {
         tags: [
             {
                 name: "✍️ Text Generation",
-                description: `Text models: ${textModelDisplayNames}`,
+                description: [
+                    "Generate text responses using AI models. Fully compatible with the OpenAI Chat Completions API — use any OpenAI SDK by changing the base URL.",
+                    "",
+                    "| Endpoint | Best for |",
+                    "|----------|----------|",
+                    "| `POST /v1/chat/completions` | Full OpenAI compatibility — streaming, tools, vision, structured outputs |",
+                    "| `GET /text/{prompt}` | Quick prototyping — simple GET, returns plain text |",
+                    "",
+                    `**Available models:** ${textModelDisplayNames}`,
+                ].join("\n"),
             },
             {
                 name: "🖼️ Image Generation",
-                description: `Image models: ${imageModelDisplayNames}`,
+                description: [
+                    "Generate images from text prompts via a simple GET request. Returns JPEG or PNG.",
+                    "",
+                    "```",
+                    "https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux",
+                    "```",
+                    "",
+                    `**Available models:** ${imageModelDisplayNames}`,
+                ].join("\n"),
             },
             {
                 name: "🎬 Video Generation",
-                description: `Video models: ${videoModelDisplayNames}`,
+                description: [
+                    "Generate videos from text prompts or reference images. Returns MP4.",
+                    "",
+                    "```",
+                    "https://gen.pollinations.ai/video/sunset%20timelapse?model=veo&duration=4",
+                    "```",
+                    "",
+                    `**Available models:** ${videoModelDisplayNames}`,
+                ].join("\n"),
             },
             {
                 name: "🔊 Audio Generation",
-                description: `Audio models: ${audioModelDisplayNames}. Voices: ${ELEVENLABS_VOICES.join(", ")}`,
+                description: [
+                    "Text-to-speech, music generation, and audio transcription.",
+                    "",
+                    "| Endpoint | Description |",
+                    "|----------|-------------|",
+                    "| `GET /audio/{text}` | Simple URL-based TTS or music generation |",
+                    "| `POST /v1/audio/speech` | OpenAI-compatible TTS |",
+                    "| `POST /v1/audio/transcriptions` | Speech-to-text transcription |",
+                    "",
+                    `**Audio models:** ${audioModelDisplayNames}`,
+                    "",
+                    `**Available voices:** ${ELEVENLABS_VOICES.join(", ")}`,
+                ].join("\n"),
             },
             {
                 name: "🤖 Models",
-                description:
-                    "Discover available models with pricing, capabilities, and metadata.",
+                description: [
+                    "Discover available models with pricing, capabilities, and metadata. No authentication required.",
+                    "",
+                    "| Endpoint | Returns |",
+                    "|----------|---------|",
+                    '| `GET /v1/models` | Text models in OpenAI format (`{object: "list", data: [...]}`) |',
+                    "| `GET /text/models` | Text models with pricing, context window, tool support |",
+                    "| `GET /image/models` | Image & video models with capabilities and pricing |",
+                    "| `GET /audio/models` | Audio models with supported voices |",
+                ].join("\n"),
+            },
+            {
+                name: "👤 Account",
+                description: [
+                    "Manage your account, check your pollen balance, and view usage history. All endpoints require authentication.",
+                    "",
+                    "| Endpoint | Description |",
+                    "|----------|-------------|",
+                    "| `GET /account/profile` | GitHub username and profile image |",
+                    "| `GET /account/balance` | Current pollen balance |",
+                    "| `GET /account/usage` | Per-request history with costs |",
+                    "| `GET /account/usage/daily` | Daily aggregated usage for dashboards |",
+                    "| `GET /account/key` | API key validity, type, and permissions |",
+                    "",
+                    "When using API keys, specific permissions may be required, such as `account:usage` or `account:profile`.",
+                ].join("\n"),
+            },
+            {
+                name: "📦 Media Storage",
+                description: [
+                    "Content-addressed media storage. Upload and retrieve images, audio, and video by content hash.",
+                    "",
+                    "| Endpoint | Description |",
+                    "|----------|-------------|",
+                    "| `POST /upload` | Upload a file, receive a content-addressed URL |",
+                    "| `GET /{hash}` | Retrieve a previously uploaded file |",
+                    "| `GET /{hash}/metadata` | Get file metadata as JSON |",
+                    "",
+                    "**Base URL:** https://media.pollinations.ai",
+                ].join("\n"),
+            },
+            {
+                name: "🌸 Bring Your Own Pollen",
+                description: BYOP_DOCS,
             },
         ],
     };
@@ -204,7 +399,71 @@ async function fetchEnterSchema(c: Context<Env>) {
     if (!response.ok) return undefined;
 
     const schema = (await response.json()) as OpenApiSchema;
-    return stripGenerationPaths(schema);
+    return transformEnterSchema(stripGenerationPaths(schema));
+}
+
+async function fetchMediaSchema(): Promise<OpenApiSchema | undefined> {
+    const response = await fetch("https://media.pollinations.ai/openapi.json");
+    if (!response.ok) return undefined;
+    const schema = (await response.json()) as OpenApiSchema;
+
+    for (const operations of Object.values(asRecord(schema.paths))) {
+        if (!operations || typeof operations !== "object") continue;
+        (operations as OpenApiSchema).servers = [
+            { url: "https://media.pollinations.ai" },
+        ];
+        for (const operation of Object.values(operations as OpenApiSchema)) {
+            if (!operation || typeof operation !== "object") continue;
+            const record = operation as { tags?: unknown };
+            if (!Array.isArray(record.tags)) continue;
+            record.tags = record.tags.map((tag) =>
+                tag === "media.pollinations.ai" ? "📦 Media Storage" : tag,
+            );
+        }
+    }
+
+    return schema;
+}
+
+function transformEnterSchema(schema: OpenApiSchema): OpenApiSchema {
+    const paths: OpenApiSchema = {};
+    for (const [path, value] of Object.entries(asRecord(schema.paths))) {
+        if (!isPublicAccountPath(path)) continue;
+        const publicPath = path.replace(/^\/api\/account(?=\/|$)/, "/account");
+        paths[publicPath] = value;
+    }
+    return { ...schema, tags: tagsForPaths(schema, paths), paths };
+}
+
+function isPublicAccountPath(path: string): boolean {
+    return (
+        path === "/account" ||
+        path.startsWith("/account/") ||
+        path === "/api/account" ||
+        path.startsWith("/api/account/")
+    );
+}
+
+function tagsForPaths(
+    schema: OpenApiSchema,
+    paths: OpenApiSchema,
+): OpenApiSchema[] {
+    const usedTags = new Set<string>();
+    for (const pathItem of Object.values(paths)) {
+        if (!pathItem || typeof pathItem !== "object") continue;
+        for (const operation of Object.values(pathItem as OpenApiSchema)) {
+            if (!operation || typeof operation !== "object") continue;
+            const tags = (operation as { tags?: unknown }).tags;
+            if (!Array.isArray(tags)) continue;
+            for (const tag of tags) {
+                if (typeof tag === "string") usedTags.add(tag);
+            }
+        }
+    }
+
+    return asRecordArray(schema.tags).filter(
+        (tag) => typeof tag.name === "string" && usedTags.has(tag.name),
+    );
 }
 
 function stripGenerationPaths(schema: OpenApiSchema): OpenApiSchema {
@@ -238,26 +497,39 @@ function isGenerationPath(path: string): boolean {
 function mergeSchemas(
     generationSchema: OpenApiSchema,
     enterSchema?: OpenApiSchema,
+    mediaSchema?: OpenApiSchema,
 ): OpenApiSchema {
-    if (!enterSchema) return generationSchema;
-
-    return filterAliases({
-        ...enterSchema,
+    const merged = filterAliases({
+        ...(enterSchema ?? {}),
         ...generationSchema,
         info: generationSchema.info,
         servers: generationSchema.servers,
         security: generationSchema.security,
         tags: mergeTags(
             asRecordArray(generationSchema.tags),
-            asRecordArray(enterSchema.tags),
+            asRecordArray(enterSchema?.tags),
         ),
         components: mergeComponents(
-            asRecord(enterSchema.components),
+            asRecord(enterSchema?.components),
             asRecord(generationSchema.components),
         ),
         paths: {
-            ...asRecord(enterSchema.paths),
+            ...asRecord(enterSchema?.paths),
             ...asRecord(generationSchema.paths),
+        },
+    });
+
+    if (!mediaSchema) return merged;
+
+    return filterAliases({
+        ...merged,
+        components: mergeComponents(
+            asRecord(merged.components),
+            asRecord(mediaSchema.components),
+        ),
+        paths: {
+            ...asRecord(merged.paths),
+            ...asRecord(mediaSchema.paths),
         },
     });
 }
@@ -340,11 +612,15 @@ export function createDocsRoutes(genApp: Hono<Env>): Hono<Env> {
             return c.text(LLM_DOC_TEXT);
         })
         .get("/open-api/generate-schema", async (c) => {
-            const [generationSchema, enterSchema] = await Promise.all([
-                getGenerationSchema(genApp),
-                fetchEnterSchema(c).catch(() => undefined),
-            ]);
+            const [generationSchema, enterSchema, mediaSchema] =
+                await Promise.all([
+                    getGenerationSchema(genApp),
+                    fetchEnterSchema(c).catch(() => undefined),
+                    fetchMediaSchema().catch(() => undefined),
+                ]);
 
-            return c.json(mergeSchemas(generationSchema, enterSchema));
+            return c.json(
+                mergeSchemas(generationSchema, enterSchema, mediaSchema),
+            );
         });
 }

--- a/gen.pollinations.ai/src/text/textGenerationUtils.ts
+++ b/gen.pollinations.ai/src/text/textGenerationUtils.ts
@@ -1,11 +1,15 @@
 import debug from "debug";
-import type { ChatMessage, TransformOptions } from "./types.js";
+import type { ChatMessage, ServiceError, TransformOptions } from "./types.js";
 
 const log = debug("pollinations:utils");
 
 export function validateAndNormalizeMessages(messages: unknown): ChatMessage[] {
     if (!Array.isArray(messages) || messages.length === 0) {
-        throw new Error("Messages must be a non-empty array");
+        const error = new Error(
+            "Messages must be a non-empty array",
+        ) as ServiceError;
+        error.status = 400;
+        throw error;
     }
 
     return messages.map((raw: unknown) => {

--- a/gen.pollinations.ai/src/vite-env.d.ts
+++ b/gen.pollinations.ai/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md?raw" {
+    const content: string;
+    export default content;
+}

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -2,7 +2,7 @@ import {
     createExecutionContext,
     waitOnExecutionContext,
 } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index.ts";
 
 function envWithEnterSchema(schema: unknown): CloudflareBindings {
@@ -20,12 +20,36 @@ function envWithEnterSchema(schema: unknown): CloudflareBindings {
 }
 
 describe("docs routes", () => {
-    it("serves a gen-owned OpenAPI schema and merges non-generation enter paths", async () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("serves a gen-owned OpenAPI schema and merges public account paths only", async () => {
         const ctx = createExecutionContext();
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    paths: {
+                        "/{hash}": {
+                            get: {
+                                tags: ["media.pollinations.ai"],
+                            },
+                        },
+                    },
+                    components: {
+                        schemas: {
+                            MediaOnly: { type: "object" },
+                        },
+                    },
+                }),
+                { headers: { "Content-Type": "application/json" } },
+            ),
+        );
+
         const enterSchema = {
             openapi: "3.1.0",
             info: { title: "Enter", version: "0.0.0" },
-            tags: [{ name: "Account" }],
+            tags: [{ name: "👤 Account" }, { name: "Customer" }],
             components: {
                 schemas: {
                     EnterOnly: { type: "object" },
@@ -33,6 +57,9 @@ describe("docs routes", () => {
             },
             paths: {
                 "/account/key": { get: { tags: ["Account"] } },
+                "/api/account/profile": { get: { tags: ["👤 Account"] } },
+                "/api/customer/portal": { get: { tags: ["Customer"] } },
+                "/api-keys": { get: { tags: ["Customer"] } },
                 "/generate/text/{prompt}": { get: { tags: ["Old"] } },
             },
         };
@@ -48,8 +75,10 @@ describe("docs routes", () => {
 
         expect(response.status).toBe(200);
         const schema = (await response.json()) as {
+            info: { description: string };
             paths: Record<string, unknown>;
             servers: { url: string }[];
+            tags: { name: string; description?: string }[];
             components: { schemas: Record<string, unknown> };
         };
 
@@ -59,9 +88,24 @@ describe("docs routes", () => {
         expect(schema.paths["/v1/chat/completions"]).toBeDefined();
         expect(schema.paths["/image/{prompt}"]).toBeDefined();
         expect(schema.paths["/account/key"]).toBeDefined();
+        expect(schema.paths["/account/profile"]).toBeDefined();
         expect(schema.paths["/api/account/key"]).toBeUndefined();
+        expect(schema.paths["/api/account/profile"]).toBeUndefined();
+        expect(schema.paths["/api/customer/portal"]).toBeUndefined();
+        expect(schema.paths["/api-keys"]).toBeUndefined();
         expect(schema.paths["/generate/text/{prompt}"]).toBeUndefined();
+        expect(schema.paths["/{hash}"]).toBeDefined();
+        expect(schema.info.description).toContain("Quick Start");
+        expect(schema.info.description).toContain("Bring Your Own Pollen");
+        expect(schema.tags.map((tag) => tag.name)).toContain(
+            "🌸 Bring Your Own Pollen",
+        );
+        expect(schema.tags.map((tag) => tag.name)).toContain(
+            "📦 Media Storage",
+        );
+        expect(schema.tags.map((tag) => tag.name)).not.toContain("Customer");
         expect(schema.components.schemas.EnterOnly).toBeDefined();
+        expect(schema.components.schemas.MediaOnly).toBeDefined();
     });
 
     it("does not add noindex to docs responses at the worker boundary", async () => {

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -26,15 +26,15 @@ export function openaiUsageToUsage(openaiUsage: {
     completion_tokens: number;
     total_tokens: number;
     prompt_tokens_details?: {
-        cached_tokens?: number;
-        audio_tokens?: number;
-        image_tokens?: number;
+        cached_tokens?: number | null;
+        audio_tokens?: number | null;
+        image_tokens?: number | null;
     } | null;
     completion_tokens_details?: {
-        reasoning_tokens?: number;
-        audio_tokens?: number;
-        accepted_prediction_tokens?: number;
-        rejected_prediction_tokens?: number;
+        reasoning_tokens?: number | null;
+        audio_tokens?: number | null;
+        accepted_prediction_tokens?: number | null;
+        rejected_prediction_tokens?: number | null;
     } | null;
 }): Usage {
     const promptDetailTokens =

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -322,8 +322,8 @@ export const CreateChatCompletionRequestSchema = z
             .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
             .optional(),
         thinking_budget: z.number().int().min(0).optional(),
-        temperature: z.number().min(0).max(2).nullable().optional().default(1),
-        top_p: z.number().min(0).max(1).nullable().optional().default(1),
+        temperature: z.number().min(0).max(2).nullable().optional(),
+        top_p: z.number().min(0).max(1).nullable().optional(),
         tools: z.array(ChatCompletionToolSchema).optional(),
         tool_choice: ChatCompletionToolChoiceOptionSchema.optional(),
         parallel_tool_calls: z.boolean().optional().default(true),

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -408,21 +408,21 @@ export const CompletionUsageSchema = z
                     .number()
                     .int()
                     .nonnegative()
-                    .optional(),
-                audio_tokens: z.number().int().nonnegative().optional(),
-                reasoning_tokens: z.number().int().nonnegative().optional(),
+                    .nullish(),
+                audio_tokens: z.number().int().nonnegative().nullish(),
+                reasoning_tokens: z.number().int().nonnegative().nullish(),
                 rejected_prediction_tokens: z
                     .number()
                     .int()
                     .nonnegative()
-                    .optional(),
+                    .nullish(),
             })
             .nullish(),
         prompt_tokens: z.number().int().nonnegative(),
         prompt_tokens_details: z
             .object({
-                audio_tokens: z.number().int().nonnegative().optional(),
-                cached_tokens: z.number().int().nonnegative().optional(),
+                audio_tokens: z.number().int().nonnegative().nullish(),
+                cached_tokens: z.number().int().nonnegative().nullish(),
             })
             .nullish(),
         total_tokens: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- Fixes Bedrock-routed Claude requests by no longer injecting `temperature: 1` and `top_p: 1` when clients omit those fields.
- Returns a client 400 for empty `messages: []` instead of surfacing it as an internal 500.
- Accepts `null` audio token fields in OpenAI-compatible usage responses, fixing Gemini audio-input response validation.
- Restores the rich API docs on `gen.pollinations.ai/docs`: Quick Start, auth guidance, BYOP markdown, model/docs prose, media docs, and public `/account/*` metadata.
- Keeps enter-owned control-plane paths out of the gen OpenAPI spec unless they are actually exposed through gen.

## Why
- After the gateway move, gen forwards Zod-parsed request bodies. Defaults in the schema were being sent upstream, which Bedrock rejects for Claude.
- The docs moved to gen, but the old rich docs content still lived under enter and was hidden by the `/api/docs/*` redirect.
- Some response schemas were stricter than real provider responses (`audio_tokens: null`).

## Test plan
- [x] `npx biome check --write shared/schemas/openai.ts shared/registry/usage-headers.ts gen.pollinations.ai/src/text/textGenerationUtils.ts enter.pollinations.ai/src/index.ts`
- [x] `npx biome check --write gen.pollinations.ai/src/routes/docs.ts gen.pollinations.ai/src/vite-env.d.ts gen.pollinations.ai/test/docs.test.ts enter.pollinations.ai/src/routes/docs.ts enter.pollinations.ai/test/docs-redirect.test.ts`
- [x] `npx tsc --noEmit` in `gen.pollinations.ai`
- [x] `npx tsc --noEmit` in `enter.pollinations.ai`
- [x] `npm run test -- --run test/docs.test.ts test/index.test.ts` in `gen.pollinations.ai`
- [x] `npm run test -- --run test/docs-redirect.test.ts` in `enter.pollinations.ai`
- [x] Staging verified earlier for Claude/Bedrock, empty messages, Gemini audio tokens, and staging docs redirect.

polly please review
