### PR TITLE
feat(gen): build with Vite so .md raw imports work

### DIFF
--- a/gen.pollinations.ai/package.json
+++ b/gen.pollinations.ai/package.json
@@ -6,8 +6,10 @@
     "scripts": {
         "decrypt-vars": "sops exec-file --no-fifo ../enter.pollinations.ai/secrets/dev.vars.json 'node scripts/push-generation-secrets.mjs {} local secrets/env.json'",
         "dev": "npm run decrypt-vars && wrangler dev --port 8788 --local --persist-to .wrangler/state --show-interactive-dev-session false",
-        "deploy:staging": "wrangler deploy --env staging",
-        "deploy:production": "wrangler deploy --env production",
+        "build:staging": "CLOUDFLARE_ENV=staging vite build --mode=staging",
+        "build:production": "CLOUDFLARE_ENV=production vite build --mode=production",
+        "deploy:staging": "npm run build:staging && wrangler deploy --env staging",
+        "deploy:production": "npm run build:production && wrangler deploy --env production",
         "push-secrets:staging": "sops exec-file --no-fifo ../enter.pollinations.ai/secrets/staging.vars.json 'node scripts/push-generation-secrets.mjs {} staging secrets/env.json'",
         "push-secrets:production": "sops exec-file --no-fifo ../enter.pollinations.ai/secrets/prod.vars.json 'node scripts/push-generation-secrets.mjs {} production secrets/env.json'",
         "test": "vitest run",
@@ -15,6 +17,7 @@
         "docs:generate": "tsx scripts/generate-apidocs.ts"
     },
     "devDependencies": {
+        "@cloudflare/vite-plugin": "^1.33.2",
         "@cloudflare/vitest-pool-workers": "^0.10.15",
         "@cloudflare/workers-types": "^4.20251202.0",
         "@hono/node-server": "^1.19.14",
@@ -23,6 +26,8 @@
         "@types/node": "24.10.1",
         "tsx": "4.20.6",
         "typescript": "^5.9.3",
+        "vite": "^7.2.4",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "3.2.4",
         "wrangler": "^4.52.1"
     },

--- a/gen.pollinations.ai/vite.config.ts
+++ b/gen.pollinations.ai/vite.config.ts
@@ -1,0 +1,14 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+    server: {
+        port: 8788,
+    },
+    assetsInclude: ["**/*.md"],
+    resolve: {
+        dedupe: ["zod"],
+    },
+    plugins: [tsconfigPaths(), cloudflare()],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
         "zod": "4.3.5"
       },
       "devDependencies": {
+        "@cloudflare/vite-plugin": "^1.33.2",
         "@cloudflare/vitest-pool-workers": "^0.10.15",
         "@cloudflare/workers-types": "^4.20251202.0",
         "@hono/node-server": "^1.19.14",
@@ -128,6 +129,8 @@
         "@types/node": "24.10.1",
         "tsx": "4.20.6",
         "typescript": "^5.9.3",
+        "vite": "^7.2.4",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "3.2.4",
         "wrangler": "^4.52.1"
       }


### PR DESCRIPTION
## Why

PR #10573 added `import BYOP_MD from "../../../BRING_YOUR_OWN_POLLEN.md?raw"` to `gen/src/routes/docs.ts` (plus a `vite-env.d.ts` type declaration), but gen has always been built directly by wrangler/esbuild — which has no loader for `.md`. Production CI failed with:

```
No loader is configured for ".md" files: ../BRING_YOUR_OWN_POLLEN.md?raw
src/routes/docs.ts:9:20:
9 │ import BYOP_MD from "../../../BRING_YOUR_OWN_POLLEN.md?raw"
```

Enter handles this via Vite (`assetsInclude: ["**/*.md"]`). This adds the same Vite layer to gen — minimal config, no React / Tailwind / TanStack Router since gen is a thin worker without UI.

## What

- `vite.config.ts`: `cloudflare()` + `tsconfigPaths()`, `assetsInclude: ["**/*.md"]`, `dedupe: ["zod"]`
- `package.json`: add `build:staging` / `build:production` scripts that run Vite first, then deploy scripts chain to `wrangler deploy`. CI workflow already calls `npm run deploy:production --workspace pollinations-gen`, so no workflow change needed.
- devDependencies: `vite`, `@cloudflare/vite-plugin`, `vite-tsconfig-paths`

## Verified locally

- `npm run build:production --workspace pollinations-gen` ✅ 992 modules transformed, output at `dist/pollinations_gen/`
- `wrangler deploy --env production --dry-run` ✅ uses generated `dist/pollinations_gen/wrangler.json`, all bindings preserved (D1, KV, R2 ×2, DO, ENTER service, EDGE_RATE_LIMITER, env vars)
- Same for `--mode=staging` → `name=pollinations-gen-staging`, route `staging.gen.pollinations.ai`
- `npm test --workspace pollinations-gen`: 18 files, 83 tests ✅
- `npm run typecheck --workspace pollinations-gen` ✅

## Note on the gotcha

`@cloudflare/vite-plugin` auto-generates `dist/<name>/wrangler.json` from `wrangler.toml + CLOUDFLARE_ENV`, and `wrangler deploy` picks that up over the source toml. Same pattern enter uses; deploy scripts wire `CLOUDFLARE_ENV=<env> vite build --mode=<env> && wrangler deploy --env <env>` to keep them in sync.

## Test plan

- [ ] CI: typecheck, tests, dry-run pass
- [ ] On merge: production deploy of gen succeeds (the previously-failing build will now resolve `?raw`)
- [ ] Smoke: `https://gen.pollinations.ai/docs` shows BYOP / Quick Start / Account sections (the docs prose from #10573 that hasn't been live yet)
- [ ] Smoke: `https://gen.pollinations.ai/v1/chat/completions` with model=claude returns 200 (the Bedrock temp/top_p fix from #10573)

🤖 Generated with [Claude Code](https://claude.com/claude-code)