### PR TITLE
fix(enter): 308-redirect /api/generate/* to gen

### DIFF
--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -82,6 +82,17 @@ const app = new Hono<Env>()
     .all("/api/docs", redirectLegacyDocs)
     .all("/api/docs/", redirectLegacyDocs)
     .all("/api/docs/*", redirectLegacyDocs)
+    .all("/api/generate/*", (c) => {
+        const url = new URL(c.req.url);
+        url.hostname = url.hostname.replace(/(^|\.)enter\./, "$1gen.");
+        url.pathname = url.pathname.replace(/^\/api\/generate/, "");
+        c.header("Deprecation", "true");
+        c.header(
+            "Link",
+            '<https://gen.pollinations.ai>; rel="successor-version"',
+        );
+        return c.redirect(url.toString(), 308);
+    })
     .route("/api", api);
 
 app.notFound(async (c: Context<Env>) => {


### PR DESCRIPTION
## Summary

- ~145 req/2min still hit `enter.pollinations.ai/api/generate/*` and were 404'ing since the gateway moved to `gen.pollinations.ai`
- Adds 308 redirect to the canonical `gen.pollinations.ai/<path>` (preserves method + body for POSTs)
- Sends `Deprecation: true` + RFC 8288 `Link: rel="successor-version"` so SDK clients learn the new URL
- Mirrors existing `/api/docs` redirect pattern

## Test plan

- [ ] `curl -i https://enter.pollinations.ai/api/generate/v1/models` returns `308` with `Location: https://gen.pollinations.ai/v1/models`
- [ ] `curl -iL -X POST https://enter.pollinations.ai/api/generate/v1/chat/completions -H "Authorization: Bearer $TOKEN" -d '{"model":"openai","messages":[...]}'` returns 200 from gen
- [ ] Wrangler tail confirms legacy 404s drain over time