### PR TITLE
fix: resolve nova-fast fallback strategy model name

### DIFF
--- a/gen.pollinations.ai/src/text/utils/modelResolver.ts
+++ b/gen.pollinations.ai/src/text/utils/modelResolver.ts
@@ -16,6 +16,15 @@ function modelResolutionError(message: string): ServiceError {
     return error;
 }
 
+function extractFallbackModel(
+    config: Record<string, unknown>,
+): string | undefined {
+    const targets = config.targets as
+        | Array<{ override_params?: { model?: string } }>
+        | undefined;
+    return targets?.[0]?.override_params?.model;
+}
+
 /**
  * Resolves model configuration and sets up internal properties.
  * User-provided options take precedence over model defaults.
@@ -45,7 +54,8 @@ export function resolveModelConfig(
     const usedModel = (config.model ||
         config["azure-model-name"] ||
         config["azure-deployment-id"] ||
-        config["vertex-model-id"]) as string;
+        config["vertex-model-id"] ||
+        extractFallbackModel(config)) as string;
 
     log(
         "Processing request for model:",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -34,6 +34,12 @@ describe("resolveModelConfig", () => {
         expect(result.options.max_tokens).toBeUndefined();
     });
 
+    it("resolves fallback-strategy configs to the first target's model", () => {
+        const result = resolveModelConfig(messages, { model: "nova-fast" });
+
+        expect(result.options.model).toBe("amazon.nova-micro-v1:0");
+    });
+
     it("marks missing model configs as 404 errors", () => {
         expect(() =>
             resolveModelConfig(messages, { model: "not-a-real-model" }),


### PR DESCRIPTION
## Summary
- `nova-fast` uses a Portkey fallback strategy with the model nested in `targets[].override_params.model`
- `resolveModelConfig` only checked top-level `config.model` / `azure-*` / `vertex-*` fields, returning undefined
- New throw at `genericOpenAIClient.ts:145` (added in #10555) then errored every request with `"Model is required"`
- **99% failure rate, 75 distinct users, ~27k 500s/hour** since #10555 merged at 11:45 UTC
- Adds `extractFallbackModel(config)` reading `targets[0].override_params.model` as a final fallback

## Test plan
- [x] `npx vitest run test/text/utils/modelResolver.test.ts` — 5/5 pass (includes new nova-fast assertion)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [ ] Post-deploy: verify `curl -d '{"model":"nova-fast",...}' /v1/chat/completions` returns 200
- [ ] Post-deploy: confirm Tinybird `model_used` shows `amazon.nova-micro-v1:0` (currently `"undefined"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)