### PR TITLE
fix: flatten nova-fast to single-target Bedrock config

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -167,7 +167,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "nova-fast",
-        config: portkeyConfig["nova-micro-fallback"],
+        config: portkeyConfig["nova-micro"],
     },
     {
         name: "nova",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -146,25 +146,8 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- AWS Bedrock (Nova) ---------------------------------------------------
-    "nova-micro-fallback": () => ({
-        strategy: { mode: "fallback" },
-        targets: [
-            {
-                provider: "bedrock",
-                aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
-                aws_region: process.env.AWS_REGION || "us-east-1",
-                override_params: { model: "amazon.nova-micro-v1:0" },
-            },
-            {
-                provider: "bedrock",
-                aws_access_key_id: process.env.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY,
-                aws_region: process.env.AWS_REGION || "us-east-1",
-                override_params: { model: "amazon.nova-lite-v1:0" },
-            },
-        ],
-    }),
+    "nova-micro": () =>
+        createBedrockNativeConfig({ model: "amazon.nova-micro-v1:0" }),
     "nova-2-lite": () =>
         createBedrockNativeConfig({ model: "us.amazon.nova-2-lite-v1:0" }),
 

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -34,6 +34,12 @@ describe("resolveModelConfig", () => {
         expect(result.options.max_tokens).toBeUndefined();
     });
 
+    it("resolves nova-fast to amazon.nova-micro-v1:0", () => {
+        const result = resolveModelConfig(messages, { model: "nova-fast" });
+
+        expect(result.options.model).toBe("amazon.nova-micro-v1:0");
+    });
+
     it("marks missing model configs as 404 errors", () => {
         expect(() =>
             resolveModelConfig(messages, { model: "not-a-real-model" }),


### PR DESCRIPTION
## Summary
- nova-fast used a Portkey fallback strategy (micro→lite for rate-limit spillover) with no top-level `config.model`
- `resolveModelConfig` couldn't extract the model name → `usedModel` undefined → `genericOpenAIClient.ts:145` threw `"Model is required"`
- Rate-limit spillover no longer needed (traffic dropped after power users left)
- 99% failure rate, 75 distinct users, ~27k 500s/hour since #10555 merged

## Test plan
- [x] `npx vitest run test/text/utils/modelResolver.test.ts` — 5/5 pass (incl. new nova-fast assertion)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] Verified config shape: `{provider: "bedrock", aws-region: "us-east-1", model: "amazon.nova-micro-v1:0"}` (matches working `nova` model)
- [ ] Post-deploy: `curl -d '{"model":"nova-fast",...}' /v1/chat/completions` returns 200
- [ ] Post-deploy: Tinybird `model_used` shows `amazon.nova-micro-v1:0` (currently `"undefined"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)