### PR TITLE
fix: mark ElevenLabs audio models alpha

### DIFF
--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -68,6 +68,7 @@ export const AUDIO_SERVICES = {
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
+        alpha: true,
     },
     elevenmusic: {
         aliases: ["music"],
@@ -88,6 +89,7 @@ export const AUDIO_SERVICES = {
             "ElevenLabs Music - Generate studio-grade music from text prompts",
         inputModalities: ["text"],
         outputModalities: ["audio"],
+        alpha: true,
     },
     whisper: {
         aliases: ["whisper-1", "whisper-large-v3"],


### PR DESCRIPTION
- Marks ElevenLabs speech and music models as alpha in the shared audio registry.
- Keeps audio model visibility metadata aligned with current availability.