### PR TITLE
fix: handle Nova Reel input errors

### DIFF
--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -10,8 +10,12 @@ const VALID_IMAGE_MODELS = [
     ...Object.keys(IMAGE_SERVICES),
     ...Object.values(IMAGE_SERVICES).flatMap((service) => service.aliases),
 ] as const;
+const NOVA_REEL_MODELS = new Set([
+    "nova-reel",
+    ...IMAGE_SERVICES["nova-reel"].aliases,
+]);
 
-export const GenerateImageRequestQueryParamsSchema = z.object({
+const GenerateImageRequestQueryParamsBaseSchema = z.object({
     // Image model params
     model: z
         .preprocess(
@@ -23,7 +27,7 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         )
         .meta({
             description:
-                "Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan. See /image/models for full list.",
+                "Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list.",
         }),
     width: z.coerce.number().int().nonnegative().optional().default(1024).meta({
         description:
@@ -48,7 +52,7 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
         .default(0)
         .meta({
             description:
-                "Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance. Other models ignore this parameter.",
+                "Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter.",
         }),
     enhance: z.coerce.boolean().optional().default(false).meta({
         description:
@@ -108,9 +112,9 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
     }),
 
     // Video-specific params
-    duration: z.coerce.number().int().min(1).max(30).optional().meta({
+    duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:
-            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance`: 2-10s. `wan`: 2-15s. `nova-reel`: 6-60s (multiples of 6).",
+            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance`: 2-10s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
     }),
     aspectRatio: z.string().optional().meta({
         description:
@@ -121,6 +125,22 @@ export const GenerateImageRequestQueryParamsSchema = z.object({
             "Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo`, set to `true` to enable audio.",
     }),
 });
+
+export const GenerateImageRequestQueryParamsSchema =
+    GenerateImageRequestQueryParamsBaseSchema.superRefine((params, ctx) => {
+        if (
+            params.duration !== undefined &&
+            params.duration > 30 &&
+            !NOVA_REEL_MODELS.has(params.model)
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["duration"],
+                message:
+                    "Duration above 30 seconds is only supported by nova-reel.",
+            });
+        }
+    });
 
 export type GenerateImageRequestQueryParams = z.infer<
     typeof GenerateImageRequestQueryParamsSchema

--- a/image.pollinations.ai/src/models.ts
+++ b/image.pollinations.ai/src/models.ts
@@ -259,7 +259,7 @@ export const IMAGE_CONFIG = {
         enhance: false,
         isVideo: true,
         defaultDuration: 6,
-        maxDuration: 60,
+        maxDuration: 120,
         defaultResolution: "720p",
     },
 } as const satisfies ImageModelsConfig;

--- a/image.pollinations.ai/src/models/novaReelModel.ts
+++ b/image.pollinations.ai/src/models/novaReelModel.ts
@@ -3,11 +3,96 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
-import { downloadUserImage } from "../utils/imageDownload.ts";
 import type { VideoGenerationResult } from "./veoVideoModel.ts";
 
 const logOps = debug("pollinations:nova-reel:ops");
 const logError = debug("pollinations:nova-reel:error");
+
+const SINGLE_SHOT_PROMPT_LIMIT = 512;
+const MULTI_SHOT_PROMPT_LIMIT = 4000;
+const NOVA_REEL_WIDTH = 1280;
+const NOVA_REEL_HEIGHT = 720;
+
+function getNovaReelDurationSeconds(duration?: number): number {
+    const requestedDuration = duration || 6;
+    return Math.min(120, Math.max(6, Math.round(requestedDuration / 6) * 6));
+}
+
+function getNovaReelInputErrorStatus(message: string): number {
+    const normalized = message.toLowerCase();
+    if (
+        normalized.includes("content filter") ||
+        normalized.includes("maxlength") ||
+        normalized.includes("provided image") ||
+        normalized.includes("detected file mime type") ||
+        normalized.includes("validation") ||
+        normalized.includes("must have dimensions")
+    ) {
+        return 400;
+    }
+    if (
+        normalized.includes("rate limit") ||
+        normalized.includes("capacity limit")
+    ) {
+        return 429;
+    }
+    return 500;
+}
+
+function validateNovaReelRequest({
+    prompt,
+    duration,
+    image,
+}: {
+    prompt: string;
+    duration?: number;
+    image?: string | string[];
+}): void {
+    const durationSeconds = getNovaReelDurationSeconds(duration);
+    const hasImage = Boolean(image && image.length > 0);
+    const isMultiShot = durationSeconds > 6;
+
+    if (hasImage && isMultiShot) {
+        throw new HttpError(
+            "Nova Reel reference images are only supported for 6 second videos.",
+            400,
+        );
+    }
+
+    const promptLimit = isMultiShot
+        ? MULTI_SHOT_PROMPT_LIMIT
+        : SINGLE_SHOT_PROMPT_LIMIT;
+    if (prompt.length > promptLimit) {
+        throw new HttpError(
+            `Nova Reel prompt too long: ${prompt.length} characters. Maximum is ${promptLimit}.`,
+            400,
+        );
+    }
+}
+
+async function normalizeReferenceImage(imageUrl: string): Promise<Buffer> {
+    const [{ default: sharp }, { downloadUserImage }] = await Promise.all([
+        import("sharp"),
+        import("../utils/imageDownload.ts"),
+    ]);
+    const { buffer, mimeType } = await downloadUserImage(imageUrl);
+    logOps("Normalizing reference image for Nova Reel:", { mimeType });
+
+    try {
+        return await sharp(buffer)
+            .resize(NOVA_REEL_WIDTH, NOVA_REEL_HEIGHT, { fit: "cover" })
+            .flatten({ background: { r: 255, g: 255, b: 255 } })
+            .toColorspace("srgb")
+            .png()
+            .toBuffer();
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new HttpError(
+            `Failed to process reference image: ${message}`,
+            400,
+        );
+    }
+}
 
 /**
  * Generate a video using Amazon Nova Reel via Bedrock async invocation
@@ -20,6 +105,18 @@ export async function callNovaReelAPI(
     progress: ProgressManager,
     requestId: string,
 ): Promise<VideoGenerationResult> {
+    // Duration must be a multiple of 6. TEXT_VIDEO = 6s only. MULTI_SHOT_AUTOMATED = 12-120s.
+    const durationSeconds = getNovaReelDurationSeconds(safeParams.duration);
+    const imageParam = safeParams.image as string | string[] | undefined;
+    const hasImage = Boolean(imageParam && imageParam.length > 0);
+    const isMultiShot = durationSeconds > 6;
+
+    validateNovaReelRequest({
+        prompt,
+        duration: safeParams.duration,
+        image: imageParam,
+    });
+
     const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
     const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
     const region = process.env.AWS_REGION || "us-east-1";
@@ -34,15 +131,6 @@ export async function callNovaReelAPI(
             500,
         );
     }
-
-    // Duration must be a multiple of 6. TEXT_VIDEO = 6s only. MULTI_SHOT_AUTOMATED = 12-60s.
-    const requestedDuration = safeParams.duration || 6;
-    const durationSeconds = Math.min(
-        60,
-        Math.max(6, Math.round(requestedDuration / 6) * 6),
-    );
-    const imageParam = safeParams.image as string | string[] | undefined;
-    const hasImage = imageParam && imageParam.length > 0;
 
     logOps("Calling Nova Reel API:", {
         prompt: prompt.substring(0, 100),
@@ -86,7 +174,7 @@ export async function callNovaReelAPI(
             "Processing",
             "Processing reference image...",
         );
-        const { buffer } = await downloadUserImage(imageUrl);
+        const buffer = await normalizeReferenceImage(imageUrl);
         textToVideoParams.images = [
             {
                 format: "png",
@@ -96,7 +184,6 @@ export async function callNovaReelAPI(
     }
 
     // TEXT_VIDEO for 6s single-shot, MULTI_SHOT_AUTOMATED for 12-120s multi-shot
-    const isMultiShot = durationSeconds > 6;
     const requestBody = isMultiShot
         ? {
               taskType: "MULTI_SHOT_AUTOMATED" as const,
@@ -144,7 +231,7 @@ export async function callNovaReelAPI(
         logError("Nova Reel StartAsyncInvoke failed:", message);
         throw new HttpError(
             `Nova Reel video generation failed to start: ${message}`,
-            500,
+            getNovaReelInputErrorStatus(message),
         );
     }
 
@@ -228,7 +315,7 @@ export async function callNovaReelAPI(
                 logError("Nova Reel generation failed:", failureMessage);
                 throw new HttpError(
                     `Nova Reel video generation failed: ${failureMessage}`,
-                    500,
+                    getNovaReelInputErrorStatus(failureMessage),
                 );
             }
 

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -650,7 +650,7 @@ export const IMAGE_SERVICES = {
                 completionVideoSeconds: 0.08, // per sec
             },
         ],
-        description: "Nova Reel - Bedrock Video Generation (6-60s, 720p)",
+        description: "Nova Reel - Bedrock Video Generation (6-120s, 720p)",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },


### PR DESCRIPTION
- Adds Nova Reel preflight validation for prompt length and reference-image usage.
- Maps Bedrock user-correctable Nova Reel failures to 400s instead of 500s.
- Normalizes reference images to Nova Reel's required 1280x720 PNG input.
- Allows Nova Reel durations up to 120s while keeping other image/video models capped at 30s in gateway schema.

Verification:
- npx biome check --write image.pollinations.ai/src/models/novaReelModel.ts
- npm run typecheck --workspace pollinations-gen
- Local image service smoke test returned 400 for a 513-char Nova Reel prompt