### PR TITLE
fix: clean up enter dashboard sidebar

### DIFF
--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -71,7 +71,6 @@
         "@hono/node-server": "^1.19.6",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.17",
-        "@tanstack/react-router-devtools": "^1.139.3",
         "@tanstack/router-plugin": "^1.139.3",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",

--- a/enter.pollinations.ai/src/client/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/dashboard-shell.tsx
@@ -227,7 +227,7 @@ const DashboardRail: FC<DashboardRailProps> = ({
             aria-label="Dashboard navigation"
         >
             <div className="hidden flex-col gap-2 pb-4 pl-1 md:flex">
-                <Brand />
+                <Brand imageClassName="h-6" />
                 <BrandSocialChips />
             </div>
             <nav className="flex flex-col gap-1">
@@ -275,6 +275,32 @@ const DashboardRail: FC<DashboardRailProps> = ({
                             menuItems={<AccountMenuLinks />}
                         />
                     ) : null)}
+                <div className="flex flex-wrap gap-x-2 gap-y-1 px-3 text-[11px] leading-snug text-green-950/55">
+                    <a
+                        href="https://pollinations.ai/terms"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="transition-colors hover:text-green-950"
+                    >
+                        Terms
+                    </a>
+                    <a
+                        href="https://pollinations.ai/privacy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="transition-colors hover:text-green-950"
+                    >
+                        Privacy
+                    </a>
+                    <a
+                        href="https://pollinations.ai/refunds"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="transition-colors hover:text-green-950"
+                    >
+                        Refunds
+                    </a>
+                </div>
                 <div className="px-3 text-[11px] leading-none text-green-950/45">
                     © 2026 Myceli.AI
                 </div>

--- a/enter.pollinations.ai/src/client/routes/__root.tsx
+++ b/enter.pollinations.ai/src/client/routes/__root.tsx
@@ -1,13 +1,7 @@
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
-import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
 type RouterContext = {};
 
 export const Route = createRootRouteWithContext<RouterContext>()({
-    component: () => (
-        <>
-            <Outlet />
-            <TanStackRouterDevtools />
-        </>
-    ),
+    component: Outlet,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "@hono/node-server": "^1.19.6",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.17",
-        "@tanstack/react-router-devtools": "^1.139.3",
         "@tanstack/router-plugin": "^1.139.3",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
@@ -6253,34 +6252,6 @@
         "react-dom": ">=18.0.0 || >=19.0.0"
       }
     },
-    "node_modules/@tanstack/react-router-devtools": {
-      "version": "1.166.13",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.166.13.tgz",
-      "integrity": "sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/router-devtools-core": "1.167.3"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-router": "^1.168.15",
-        "@tanstack/router-core": "^1.168.11",
-        "react": ">=18.0.0 || >=19.0.0",
-        "react-dom": ">=18.0.0 || >=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@tanstack/router-core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@tanstack/react-store": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
@@ -6319,33 +6290,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/router-devtools-core": {
-      "version": "1.167.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.167.3.tgz",
-      "integrity": "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/router-core": "^1.168.11",
-        "csstype": "^3.0.10"
-      },
-      "peerDependenciesMeta": {
-        "csstype": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tanstack/router-generator": {
@@ -10408,16 +10352,6 @@
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/goober": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
-      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
-      }
     },
     "node_modules/gopd": {
       "version": "1.2.0",


### PR DESCRIPTION
- Reduces the desktop sidebar Pollinations logo size
- Adds Terms, Privacy, and Refunds links to the sidebar footer
- Removes TanStack Router devtools from the app root and dependencies

Checks:
- npx biome check --write enter.pollinations.ai/package.json enter.pollinations.ai/src/client/components/layout/dashboard-shell.tsx enter.pollinations.ai/src/client/routes/__root.tsx package-lock.json
- npm run typecheck --workspace pollinations-enter