### PR TITLE
fix: route qwen tts simple audio requests

### DIFF
--- a/.claude/skills/test-model/SKILL.md
+++ b/.claude/skills/test-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-model
-description: Test any model (text, image, video, audio) locally and via gen integration tests
+description: Test any model (text, image, video, audio) locally and via enter integration tests
 ---
 
 # Testing Any Model Locally
@@ -10,8 +10,8 @@ description: Test any model (text, image, video, audio) locally and via gen inte
 | Service | Port | Models |
 |---------|------|--------|
 | `image.pollinations.ai` | 16384 | Image + Video models |
-| `gen.pollinations.ai` | 8788 | Public gateway: Text, Audio, Image/Video proxy |
-| `enter.pollinations.ai` | 3000 | Auth/billing control plane |
+| `text.pollinations.ai` | 16385 | Text/LLM models |
+| `enter.pollinations.ai` | 3000 | Gateway (routes to above + handles audio) |
 
 ## 1. Start services
 
@@ -19,22 +19,21 @@ description: Test any model (text, image, video, audio) locally and via gen inte
 # Image/Video models — start image service
 cd image.pollinations.ai && npm run dev &
 
-# Public generation gateway (text/audio + image/video proxy)
-cd gen.pollinations.ai && npm run dev &
+# Text models — start text service
+cd text.pollinations.ai && npm run dev &
 
-# Enter app (needed when testing auth/account flows directly)
+# Enter gateway (needed for audio, or to test full flow)
 cd enter.pollinations.ai && npm run decrypt-vars && npm run dev &
 ```
 
 ## 2. Get tokens
 
 ```bash
-# For direct image service calls
-TOKEN=$(grep '^PLN_ENTER_TOKEN=' image.pollinations.ai/.env | cut -d= -f2-)
+# For direct image/text service calls
+TOKEN=$(grep PLN_ENTER_TOKEN image.pollinations.ai/.env | cut -d= -f2)
 
-# For gen gateway calls (use local token if present, otherwise remote test token)
-API_KEY=$(grep '^ENTER_API_TOKEN_LOCAL=' enter.pollinations.ai/.testingtokens | cut -d= -f2-)
-[ -n "$API_KEY" ] || API_KEY=$(grep '^ENTER_API_TOKEN_REMOTE=' enter.pollinations.ai/.testingtokens | cut -d= -f2-)
+# For enter gateway calls (use test API key)
+API_KEY=$(grep ENTER_API_TOKEN_LOCAL enter.pollinations.ai/.testingtokens | cut -d= -f2)
 ```
 
 ---
@@ -68,9 +67,16 @@ file /tmp/test-video.mp4
 ## Test a Text Model
 
 ```bash
-# Via gen gateway
+# Via text service directly
 curl -s -w "\nHTTP %{http_code}\n" \
-  "http://localhost:8788/v1/chat/completions" \
+  "http://localhost:16385/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "x-enter-token: $TOKEN" \
+  -d '{"model":"MODEL_NAME","messages":[{"role":"user","content":"Say hello"}],"max_tokens":50}'
+
+# Via enter gateway
+curl -s -w "\nHTTP %{http_code}\n" \
+  "http://localhost:3000/api/generate/v1/chat/completions" \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model":"MODEL_NAME","messages":[{"role":"user","content":"Say hello"}],"max_tokens":50}'
@@ -78,61 +84,65 @@ curl -s -w "\nHTTP %{http_code}\n" \
 
 ## Test an Audio Model
 
-Audio routes through gen gateway only (no standalone service).
+Audio routes through enter gateway only (no standalone service).
 
 ```bash
 # Text-to-speech
-curl -s -o /tmp/test-audio.audio -w "HTTP %{http_code}, %{size_download} bytes\n" \
-  "http://localhost:8788/audio/Hello%20world?voice=alloy&model=MODEL_NAME" \
+curl -s -o /tmp/test-audio.mp3 -w "HTTP %{http_code}, %{size_download} bytes\n" \
+  "http://localhost:3000/api/generate/audio/Hello%20world?voice=alloy&model=MODEL_NAME" \
   -H "Authorization: Bearer $API_KEY"
 
 # OpenAI-compatible TTS
-curl -s -o /tmp/test-tts.audio -w "HTTP %{http_code}, %{size_download} bytes\n" \
-  "http://localhost:8788/v1/audio/speech" \
+curl -s -o /tmp/test-tts.mp3 -w "HTTP %{http_code}, %{size_download} bytes\n" \
+  "http://localhost:3000/api/generate/v1/audio/speech" \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model":"MODEL_NAME","input":"Hello world","voice":"alloy"}'
 
 # Speech-to-text (whisper/scribe)
 curl -s -w "\nHTTP %{http_code}\n" \
-  "http://localhost:8788/v1/audio/transcriptions" \
+  "http://localhost:3000/api/generate/v1/audio/transcriptions" \
   -H "Authorization: Bearer $API_KEY" \
-  -F "file=@/tmp/test-audio.audio" \
+  -F "file=@/tmp/test-audio.mp3" \
   -F "model=MODEL_NAME"
 
-file /tmp/test-audio.audio /tmp/test-tts.audio
+file /tmp/test-audio.mp3
 ```
 
 ---
 
-# Gen Integration Tests
+# Enter Integration Tests
 
-Tests in `gen.pollinations.ai/test/`:
+Tests in `enter.pollinations.ai/test/integration/`:
 
 | File | Models |
 |------|--------|
-| `index.test.ts` | Routing and model endpoint smoke tests |
-| `generation-vcr.test.ts` | VCR-backed text/image/audio generation paths |
-| `audio-*.test.ts` | Focused audio regressions when present |
+| `image.test.ts` | Image models |
+| `video.test.ts` | Video models |
+| `text.test.ts` | Text/LLM models |
+| `audio.test.ts` | TTS, music, transcription |
 
 ## Run tests for a specific model
 
 ```bash
-cd gen.pollinations.ai
+cd enter.pollinations.ai
+npm run decrypt-vars
 npx vitest run --testNamePattern="MODEL_NAME"
 ```
 
 ## Run all tests by type
 
 ```bash
-npx vitest run test/index.test.ts
-npx vitest run test/generation-vcr.test.ts
+npx vitest run test/integration/image.test.ts
+npx vitest run test/integration/video.test.ts
+npx vitest run test/integration/text.test.ts
+npx vitest run test/integration/audio.test.ts
 ```
 
 ## Alias resolution tests (fast, no network)
 
 ```bash
-cd gen.pollinations.ai && npx vitest run test/model-permissions.test.ts
+cd enter.pollinations.ai && npx vitest run test/aliases.test.ts
 ```
 
 ---
@@ -151,15 +161,14 @@ cd gen.pollinations.ai && npx vitest run test/model-permissions.test.ts
 ## Text
 | File | Purpose |
 |------|---------|
-| `gen.pollinations.ai/src/text/configs/modelConfigs.ts` | Model routing config |
-| `gen.pollinations.ai/src/text/availableModels.ts` | Service name to config mapping |
+| `text.pollinations.ai/configs/modelConfigs.ts` | Model routing config |
+| `text.pollinations.ai/availableModels.ts` | Service name to config mapping |
 | `shared/registry/text.ts` | Registry: pricing, provider, aliases |
 
 ## Audio
 | File | Purpose |
 |------|---------|
-| `gen.pollinations.ai/src/routes/audio.ts` | OpenAI-compatible audio route handlers |
-| `gen.pollinations.ai/src/routes/proxy.ts` | Simple `/audio/{text}` route |
+| `enter.pollinations.ai/src/routes/audio.ts` | Audio route handlers |
 | `shared/registry/audio.ts` | Registry: pricing, voices, aliases |
 
 ## Shared
@@ -167,4 +176,4 @@ cd gen.pollinations.ai && npx vitest run test/model-permissions.test.ts
 |------|---------|
 | `<service>/.env` | API keys |
 | `<service>/secrets/env.json` | Encrypted keys (sops) |
-| `gen.pollinations.ai/test/` | Gen gateway tests |
+| `enter.pollinations.ai/test/integration/` | All integration tests |

--- a/.claude/skills/test-model/SKILL.md
+++ b/.claude/skills/test-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-model
-description: Test any model (text, image, video, audio) locally and via enter integration tests
+description: Test any model (text, image, video, audio) locally and via gen integration tests
 ---
 
 # Testing Any Model Locally
@@ -10,8 +10,8 @@ description: Test any model (text, image, video, audio) locally and via enter in
 | Service | Port | Models |
 |---------|------|--------|
 | `image.pollinations.ai` | 16384 | Image + Video models |
-| `text.pollinations.ai` | 16385 | Text/LLM models |
-| `enter.pollinations.ai` | 3000 | Gateway (routes to above + handles audio) |
+| `gen.pollinations.ai` | 8788 | Public gateway: Text, Audio, Image/Video proxy |
+| `enter.pollinations.ai` | 3000 | Auth/billing control plane |
 
 ## 1. Start services
 
@@ -19,21 +19,22 @@ description: Test any model (text, image, video, audio) locally and via enter in
 # Image/Video models — start image service
 cd image.pollinations.ai && npm run dev &
 
-# Text models — start text service
-cd text.pollinations.ai && npm run dev &
+# Public generation gateway (text/audio + image/video proxy)
+cd gen.pollinations.ai && npm run dev &
 
-# Enter gateway (needed for audio, or to test full flow)
+# Enter app (needed when testing auth/account flows directly)
 cd enter.pollinations.ai && npm run decrypt-vars && npm run dev &
 ```
 
 ## 2. Get tokens
 
 ```bash
-# For direct image/text service calls
-TOKEN=$(grep PLN_ENTER_TOKEN image.pollinations.ai/.env | cut -d= -f2)
+# For direct image service calls
+TOKEN=$(grep '^PLN_ENTER_TOKEN=' image.pollinations.ai/.env | cut -d= -f2-)
 
-# For enter gateway calls (use test API key)
-API_KEY=$(grep ENTER_API_TOKEN_LOCAL enter.pollinations.ai/.testingtokens | cut -d= -f2)
+# For gen gateway calls (use local token if present, otherwise remote test token)
+API_KEY=$(grep '^ENTER_API_TOKEN_LOCAL=' enter.pollinations.ai/.testingtokens | cut -d= -f2-)
+[ -n "$API_KEY" ] || API_KEY=$(grep '^ENTER_API_TOKEN_REMOTE=' enter.pollinations.ai/.testingtokens | cut -d= -f2-)
 ```
 
 ---
@@ -67,16 +68,9 @@ file /tmp/test-video.mp4
 ## Test a Text Model
 
 ```bash
-# Via text service directly
+# Via gen gateway
 curl -s -w "\nHTTP %{http_code}\n" \
-  "http://localhost:16385/v1/chat/completions" \
-  -H "Content-Type: application/json" \
-  -H "x-enter-token: $TOKEN" \
-  -d '{"model":"MODEL_NAME","messages":[{"role":"user","content":"Say hello"}],"max_tokens":50}'
-
-# Via enter gateway
-curl -s -w "\nHTTP %{http_code}\n" \
-  "http://localhost:3000/api/generate/v1/chat/completions" \
+  "http://localhost:8788/v1/chat/completions" \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model":"MODEL_NAME","messages":[{"role":"user","content":"Say hello"}],"max_tokens":50}'
@@ -84,65 +78,61 @@ curl -s -w "\nHTTP %{http_code}\n" \
 
 ## Test an Audio Model
 
-Audio routes through enter gateway only (no standalone service).
+Audio routes through gen gateway only (no standalone service).
 
 ```bash
 # Text-to-speech
-curl -s -o /tmp/test-audio.mp3 -w "HTTP %{http_code}, %{size_download} bytes\n" \
-  "http://localhost:3000/api/generate/audio/Hello%20world?voice=alloy&model=MODEL_NAME" \
+curl -s -o /tmp/test-audio.audio -w "HTTP %{http_code}, %{size_download} bytes\n" \
+  "http://localhost:8788/audio/Hello%20world?voice=alloy&model=MODEL_NAME" \
   -H "Authorization: Bearer $API_KEY"
 
 # OpenAI-compatible TTS
-curl -s -o /tmp/test-tts.mp3 -w "HTTP %{http_code}, %{size_download} bytes\n" \
-  "http://localhost:3000/api/generate/v1/audio/speech" \
+curl -s -o /tmp/test-tts.audio -w "HTTP %{http_code}, %{size_download} bytes\n" \
+  "http://localhost:8788/v1/audio/speech" \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model":"MODEL_NAME","input":"Hello world","voice":"alloy"}'
 
 # Speech-to-text (whisper/scribe)
 curl -s -w "\nHTTP %{http_code}\n" \
-  "http://localhost:3000/api/generate/v1/audio/transcriptions" \
+  "http://localhost:8788/v1/audio/transcriptions" \
   -H "Authorization: Bearer $API_KEY" \
-  -F "file=@/tmp/test-audio.mp3" \
+  -F "file=@/tmp/test-audio.audio" \
   -F "model=MODEL_NAME"
 
-file /tmp/test-audio.mp3
+file /tmp/test-audio.audio /tmp/test-tts.audio
 ```
 
 ---
 
-# Enter Integration Tests
+# Gen Integration Tests
 
-Tests in `enter.pollinations.ai/test/integration/`:
+Tests in `gen.pollinations.ai/test/`:
 
 | File | Models |
 |------|--------|
-| `image.test.ts` | Image models |
-| `video.test.ts` | Video models |
-| `text.test.ts` | Text/LLM models |
-| `audio.test.ts` | TTS, music, transcription |
+| `index.test.ts` | Routing and model endpoint smoke tests |
+| `generation-vcr.test.ts` | VCR-backed text/image/audio generation paths |
+| `audio-*.test.ts` | Focused audio regressions when present |
 
 ## Run tests for a specific model
 
 ```bash
-cd enter.pollinations.ai
-npm run decrypt-vars
+cd gen.pollinations.ai
 npx vitest run --testNamePattern="MODEL_NAME"
 ```
 
 ## Run all tests by type
 
 ```bash
-npx vitest run test/integration/image.test.ts
-npx vitest run test/integration/video.test.ts
-npx vitest run test/integration/text.test.ts
-npx vitest run test/integration/audio.test.ts
+npx vitest run test/index.test.ts
+npx vitest run test/generation-vcr.test.ts
 ```
 
 ## Alias resolution tests (fast, no network)
 
 ```bash
-cd enter.pollinations.ai && npx vitest run test/aliases.test.ts
+cd gen.pollinations.ai && npx vitest run test/model-permissions.test.ts
 ```
 
 ---
@@ -161,14 +151,15 @@ cd enter.pollinations.ai && npx vitest run test/aliases.test.ts
 ## Text
 | File | Purpose |
 |------|---------|
-| `text.pollinations.ai/configs/modelConfigs.ts` | Model routing config |
-| `text.pollinations.ai/availableModels.ts` | Service name to config mapping |
+| `gen.pollinations.ai/src/text/configs/modelConfigs.ts` | Model routing config |
+| `gen.pollinations.ai/src/text/availableModels.ts` | Service name to config mapping |
 | `shared/registry/text.ts` | Registry: pricing, provider, aliases |
 
 ## Audio
 | File | Purpose |
 |------|---------|
-| `enter.pollinations.ai/src/routes/audio.ts` | Audio route handlers |
+| `gen.pollinations.ai/src/routes/audio.ts` | OpenAI-compatible audio route handlers |
+| `gen.pollinations.ai/src/routes/proxy.ts` | Simple `/audio/{text}` route |
 | `shared/registry/audio.ts` | Registry: pricing, voices, aliases |
 
 ## Shared
@@ -176,4 +167,4 @@ cd enter.pollinations.ai && npx vitest run test/aliases.test.ts
 |------|---------|
 | `<service>/.env` | API keys |
 | `<service>/secrets/env.json` | Encrypted keys (sops) |
-| `enter.pollinations.ai/test/integration/` | All integration tests |
+| `gen.pollinations.ai/test/` | Gen gateway tests |

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1,8 +1,10 @@
 import type { Logger } from "@logtape/logtape";
 import {
+    type AudioModelName,
     ELEVENLABS_VOICES,
     resolveElevenLabsVoiceId,
 } from "@shared/registry/audio.ts";
+import { getModelDefinition } from "@shared/registry/registry.ts";
 import {
     buildUsageHeaders,
     createAudioSecondsUsage,
@@ -46,7 +48,8 @@ const CreateSpeechRequestSchema = z
             .enum(["mp3", "opus", "aac", "flac", "wav", "pcm"])
             .default("mp3")
             .meta({
-                description: "The audio format for the output.",
+                description:
+                    "The audio format for the output. Qwen TTS currently returns WAV regardless of this setting.",
                 example: "mp3",
             }),
         speed: z.number().min(0.25).max(4.0).default(1.0).meta({
@@ -393,6 +396,13 @@ export async function generateMusic(opts: {
 const QWEN_TTS_ENDPOINT =
     "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 
+const QWEN_TTS_MODELS = [
+    "qwen-tts",
+    "qwen-tts-instruct",
+] as const satisfies readonly AudioModelName[];
+
+type QwenTtsModelName = (typeof QWEN_TTS_MODELS)[number];
+
 const QWEN_TTS_OPENAI_VOICE_MAP: Record<string, string> = {
     alloy: "Chelsie",
     echo: "Ethan",
@@ -411,15 +421,19 @@ function resolveQwenVoice(voice: string): string {
     return QWEN_TTS_OPENAI_VOICE_MAP[voice] ?? voice;
 }
 
+export function isQwenTtsModel(model: string): model is QwenTtsModelName {
+    return QWEN_TTS_MODELS.includes(model as QwenTtsModelName);
+}
+
 export async function generateQwenTts(opts: {
-    model: string;
+    modelName: QwenTtsModelName;
     text: string;
     voice: string;
     instruct?: string;
     apiKey: string;
     log: Logger;
 }): Promise<Response> {
-    const { model, text, voice, instruct, apiKey, log } = opts;
+    const { modelName, text, voice, instruct, apiKey, log } = opts;
 
     if (!apiKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
@@ -427,6 +441,14 @@ export async function generateQwenTts(opts: {
         });
     }
 
+    if (instruct && modelName !== "qwen-tts-instruct") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "The instruct parameter is only supported by qwen-tts-instruct",
+        });
+    }
+
+    const model = getModelDefinition(modelName).modelId;
     const qwenVoice = resolveQwenVoice(voice);
 
     log.info("Qwen TTS request: model={model}, voice={voice}, chars={chars}", {
@@ -438,7 +460,8 @@ export async function generateQwenTts(opts: {
     const body: Record<string, unknown> = {
         model,
         input: { text, voice: qwenVoice },
-        parameters: instruct ? { instruct } : {},
+        parameters:
+            modelName === "qwen-tts-instruct" && instruct ? { instruct } : {},
     };
 
     const rawResponse = await fetch(QWEN_TTS_ENDPOINT, {
@@ -468,12 +491,9 @@ export async function generateQwenTts(opts: {
     );
     const audioBuffer = await audioResponse.arrayBuffer();
 
-    const serviceId = model.includes("instruct")
-        ? "qwen-tts-instruct"
-        : "qwen-tts";
     const usageHeaders = {
         ...buildUsageHeaders(
-            serviceId,
+            modelName,
             createAudioTokenUsage(data.usage?.characters ?? text.length),
         ),
         "x-tts-voice": qwenVoice,
@@ -712,19 +732,12 @@ export const audioRoutes = new Hono<Env>()
             const { seed } = c.req.valid(
                 "json" as never,
             ) as CreateSpeechRequest;
-            if (
-                c.var.model.resolved === "qwen-tts" ||
-                c.var.model.resolved === "qwen-tts-instruct"
-            ) {
+            if (isQwenTtsModel(c.var.model.resolved)) {
                 const { instruct } = c.req.valid(
                     "json" as never,
                 ) as CreateSpeechRequest;
-                const modelId =
-                    c.var.model.resolved === "qwen-tts-instruct"
-                        ? "qwen3-tts-instruct-flash"
-                        : "qwen3-tts-flash";
                 return generateQwenTts({
-                    model: modelId,
+                    modelName: c.var.model.resolved,
                     text: input,
                     voice,
                     instruct,

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -53,6 +53,7 @@ import {
     generateMusic,
     generateQwenTts,
     generateSpeech,
+    isQwenTtsModel,
 } from "./audio.ts";
 
 // Build dynamic model lists from registry for use in API descriptions
@@ -690,7 +691,8 @@ export const proxyRoutes = new Hono<Env>()
                     .enum(["mp3", "opus", "aac", "flac", "wav", "pcm"])
                     .default("mp3")
                     .meta({
-                        description: "Audio output format (TTS only)",
+                        description:
+                            "Audio output format (TTS only). Qwen TTS currently returns WAV regardless of this setting.",
                         example: "mp3",
                     }),
                 model: z.string().optional().meta({
@@ -805,16 +807,9 @@ export const proxyRoutes = new Hono<Env>()
                 instruct?: string;
             };
 
-            if (
-                c.var.model.resolved === "qwen-tts" ||
-                c.var.model.resolved === "qwen-tts-instruct"
-            ) {
-                const modelId =
-                    c.var.model.resolved === "qwen-tts-instruct"
-                        ? "qwen3-tts-instruct-flash"
-                        : "qwen3-tts-flash";
+            if (isQwenTtsModel(c.var.model.resolved)) {
                 return generateQwenTts({
-                    model: modelId,
+                    modelName: c.var.model.resolved,
                     text,
                     voice: voice || "alloy",
                     instruct,

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -51,6 +51,7 @@ import { checkBalance, generationAccess } from "@/utils/generation-access.ts";
 import {
     generateAceStepMusic,
     generateMusic,
+    generateQwenTts,
     generateSpeech,
 } from "./audio.ts";
 
@@ -720,6 +721,11 @@ export const proxyRoutes = new Hono<Env>()
                         "Style/genre tags for music generation (acestep only)",
                     example: "brazilian berimbau instrumental",
                 }),
+                instruct: z.string().optional().meta({
+                    description:
+                        "Emotion/style instruction (qwen-tts-instruct only)",
+                    example: "speak softly and warmly",
+                }),
                 seed: z.coerce
                     .number()
                     .int()
@@ -790,13 +796,32 @@ export const proxyRoutes = new Hono<Env>()
                 });
             }
 
-            const { voice, response_format, seed } = c.req.valid(
+            const { voice, response_format, seed, instruct } = c.req.valid(
                 "query" as never,
             ) as {
                 voice: string;
                 response_format: string;
                 seed?: number;
+                instruct?: string;
             };
+
+            if (
+                c.var.model.resolved === "qwen-tts" ||
+                c.var.model.resolved === "qwen-tts-instruct"
+            ) {
+                const modelId =
+                    c.var.model.resolved === "qwen-tts-instruct"
+                        ? "qwen3-tts-instruct-flash"
+                        : "qwen3-tts-flash";
+                return generateQwenTts({
+                    model: modelId,
+                    text,
+                    voice: voice || "alloy",
+                    instruct,
+                    apiKey: c.env.DASHSCOPE_API_KEY,
+                    log,
+                });
+            }
 
             return generateSpeech({
                 text,

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -334,8 +334,8 @@ fixtureTest(
         expect(calls).toContain(
             "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
         );
-        expect(calls.some((url) => url.includes("api.elevenlabs.io"))).toBe(
-            false,
-        );
+        expect(
+            calls.some((url) => new URL(url).hostname === "api.elevenlabs.io"),
+        ).toBe(false);
     },
 );

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -1,9 +1,15 @@
 import {
     createExecutionContext,
+    env,
     waitOnExecutionContext,
 } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { test as fixtureTest } from "@shared/test/fixtures/index.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index.ts";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 function envWithEnter(
     fetch: Fetcher["fetch"] = async () => new Response("enter"),
@@ -249,3 +255,87 @@ describe("gen worker routing", () => {
         }
     });
 });
+
+fixtureTest(
+    "routes simple qwen audio requests through DashScope",
+    async ({ apiKey }) => {
+        const calls: string[] = [];
+
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+
+                if (
+                    request.url ===
+                    "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
+                ) {
+                    await expect(request.json()).resolves.toMatchObject({
+                        model: "qwen3-tts-flash",
+                        input: {
+                            text: "Hello Qwen",
+                            voice: "Serena",
+                        },
+                        parameters: {},
+                    });
+
+                    return Response.json({
+                        output: {
+                            audio: { url: "https://dashscope.test/audio.wav" },
+                        },
+                        usage: { characters: 10 },
+                    });
+                }
+
+                if (request.url === "https://dashscope.test/audio.wav") {
+                    return new Response(new Uint8Array([82, 73, 70, 70]), {
+                        headers: { "Content-Type": "audio/wav" },
+                    });
+                }
+
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/audio/Hello%20Qwen?model=qwen-tts&voice=nova",
+                {
+                    headers: { Authorization: `Bearer ${apiKey}` },
+                },
+            ),
+            {
+                ...env,
+                DASHSCOPE_API_KEY: "test-dashscope-key",
+            } as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("audio/wav");
+        expect(response.headers.get("x-model-used")).toBe("qwen-tts");
+        expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
+            "10",
+        );
+        expect(response.headers.get("x-tts-voice")).toBe("Serena");
+
+        await waitOnExecutionContext(ctx);
+
+        expect(calls).toContain(
+            "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
+        );
+        expect(calls.some((url) => url.includes("api.elevenlabs.io"))).toBe(
+            false,
+        );
+    },
+);


### PR DESCRIPTION
- Routes simple `/audio/{text}` requests for `qwen-tts` and `qwen-tts-instruct` through the shared Qwen TTS handler instead of falling through to ElevenLabs
- Looks up Qwen provider model IDs from the shared registry and reuses the OpenAI-compatible route helper
- Rejects `instruct` unless the resolved model is `qwen-tts-instruct`
- Documents that Qwen TTS currently returns WAV regardless of `response_format`
- Adds a route regression test covering the simple `/audio/{text}?model=qwen-tts` path

Tests:
- `npx biome check --write gen.pollinations.ai/src/routes/audio.ts gen.pollinations.ai/src/routes/proxy.ts gen.pollinations.ai/test/index.test.ts`
- `npm run typecheck` (in `gen.pollinations.ai`)
- `npx vitest run test/index.test.ts` (in `gen.pollinations.ai`)