### PR TITLE
rectangular tags for non-button labels in dashboard

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/account-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/account-badge.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Badge } from "../ui/badge.tsx";
+import { Tag } from "../ui/tag.tsx";
 
 export const AccountBadge: FC<{
     permissions: Record<string, string[]> | null;
@@ -10,9 +10,9 @@ export const AccountBadge: FC<{
     return (
         <>
             {account.map((perm) => (
-                <Badge key={perm} color="violet" size="sm">
+                <Tag key={perm} color="violet" size="sm">
                     {perm}
-                </Badge>
+                </Tag>
             ))}
         </>
     );

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { DashboardSection } from "../layout/dashboard-section.tsx";
 import { Card } from "../ui/card.tsx";
 import { IconButton } from "../ui/icon-button.tsx";
+import { Tag } from "../ui/tag.tsx";
 import { AccountBadge } from "./account-badge.tsx";
 import { ApiKeyDialog } from "./api-key-dialog.tsx";
 import { DeleteConfirmation } from "./delete-confirmation.tsx";
@@ -68,13 +69,13 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                 className="!border-transparent transition-colors hover:bg-white/90"
             >
                 <div className="flex items-center gap-2 mb-2">
-                    <span className="px-2 py-0.5 rounded text-xs font-medium shrink-0 bg-blue-100 text-blue-700">
+                    <Tag color="blue" size="sm">
                         {isPublishable
                             ? primaryRedirectUri
                                 ? "🖥️ App"
                                 : "🌐 Publishable"
                             : "🔒 Secret"}
-                    </span>
+                    </Tag>
                     <span className="text-sm font-medium truncate">
                         {apiKey.name}
                     </span>

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -4,9 +4,9 @@ import type { FC } from "react";
 import { useState } from "react";
 import { cn } from "@/util.ts";
 import { Button } from "../button.tsx";
-import { Badge } from "../ui/badge.tsx";
 import { Card } from "../ui/card.tsx";
 import { Input } from "../ui/input.tsx";
+import { Tag } from "../ui/tag.tsx";
 import { Tooltip } from "../ui/tooltip.tsx";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
@@ -144,13 +144,13 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                         </Dialog.Title>
 
                         <div className="flex items-center gap-3">
-                            <Badge color="blue">
+                            <Tag color="blue">
                                 {isAppKey
                                     ? "🖥️ App"
                                     : isPublishable
                                       ? "🌐 Publishable"
                                       : "🔒 Secret"}
-                            </Badge>
+                            </Tag>
                             {isPublishable && plaintextKey ? (
                                 <Tooltip
                                     triggerAs="span"

--- a/enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { cn } from "@/util.ts";
-import { Badge } from "../ui/badge.tsx";
 import { InfoTip } from "../ui/info-tip.tsx";
+import { Tag } from "../ui/tag.tsx";
 import { MODEL_CATEGORIES } from "./model-categories.ts";
 
 type ModelPermissionsProps = {
@@ -97,7 +97,7 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
                     <span className="text-sm font-medium">
                         Allow all models
                     </span>
-                    <Badge
+                    <Tag
                         color={
                             isUnrestricted
                                 ? "green"
@@ -108,7 +108,7 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
                         className="ml-auto"
                     >
                         {`${selectedCount} selected`}
-                    </Badge>
+                    </Tag>
                 </label>
 
                 {/* Show model chips when restricting to specific models */}

--- a/enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from "react";
-import { Badge } from "../ui/badge.tsx";
+import { Tag } from "../ui/tag.tsx";
 import { Tooltip } from "../ui/tooltip.tsx";
 
 export const ModelsBadge: FC<{
@@ -25,13 +25,13 @@ export const ModelsBadge: FC<{
 
     return (
         <Tooltip content={tooltipContent()} ariaLabel="Show allowed models">
-            <Badge
+            <Tag
                 color={isAllModels ? "green" : "amber"}
                 size="sm"
                 className="cursor-default transition-colors hover:brightness-95"
             >
                 {isAllModels ? "All" : modelCount}
-            </Badge>
+            </Tag>
         </Tooltip>
     );
 };

--- a/enter.pollinations.ai/src/client/components/balance/tier-panel.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/tier-panel.tsx
@@ -4,9 +4,9 @@ import {
     type TierStatus,
 } from "@shared/tier-config.ts";
 import type { FC } from "react";
-import { Badge } from "../ui/badge.tsx";
 import { Card } from "../ui/card.tsx";
 import { InfoTip } from "../ui/info-tip.tsx";
+import { Tag } from "../ui/tag.tsx";
 import { TierExplanation } from "./tier-explanation";
 
 const APPEAL_URL =
@@ -86,13 +86,13 @@ const TierScreen: FC<{
                 <span className="text-3xl font-bold text-gray-900">
                     {tierEmoji} {active_tier_name}
                 </span>
-                <Badge
+                <Tag
                     color={getBadgeColor(tier)}
                     size="lg"
                     className="font-semibold"
                 >
                     {pollen} pollen/hour
-                </Badge>
+                </Tag>
             </div>
 
             <p className="text-sm text-gray-500">

--- a/enter.pollinations.ai/src/client/components/pricing/Pricing.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/Pricing.tsx
@@ -66,6 +66,7 @@ export const Pricing: FC<PricingProps> = ({ tierBalance, packBalance }) => {
                             theme="teal"
                             active={activeTab === section}
                             onClick={() => setActiveTab(section)}
+                            className="px-4 pt-1.5 pb-2 text-base"
                         >
                             <span className="font-bold">
                                 {sectionLabels[section]}

--- a/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-row.tsx
@@ -1,6 +1,6 @@
 import { type FC, useState } from "react";
 import { cn } from "../../../util.ts";
-import { Badge } from "../ui/badge.tsx";
+import { Tag } from "../ui/tag.tsx";
 import {
     calculateForBalance,
     calculatePerPollen,
@@ -180,7 +180,7 @@ export const ModelRow: FC<ModelRowProps> = ({
                     >
                         <span>{model.name}</span>
                         {copied && (
-                            <span className="rounded-full bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-700">
+                            <span className="rounded-md bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-700">
                                 copied
                             </span>
                         )}
@@ -193,7 +193,7 @@ export const ModelRow: FC<ModelRowProps> = ({
                         <div className="flex min-w-0 flex-wrap items-center gap-2">
                             {modalityIcons.length > 0 && (
                                 <Tooltip content={modalityLabel}>
-                                    <Badge
+                                    <Tag
                                         color="gray"
                                         size="sm"
                                         className="border border-gray-400/70 bg-gray-100/80 text-gray-900"
@@ -201,12 +201,12 @@ export const ModelRow: FC<ModelRowProps> = ({
                                         {modalityIcons.map((emoji) => (
                                             <span key={emoji}>{emoji}</span>
                                         ))}
-                                    </Badge>
+                                    </Tag>
                                 </Tooltip>
                             )}
                             {capabilityIcons.length > 0 && (
                                 <Tooltip content={capabilityLabel}>
-                                    <Badge
+                                    <Tag
                                         color="gray"
                                         size="sm"
                                         className="border border-gray-400/70 bg-gray-100/80 text-gray-900"
@@ -214,19 +214,19 @@ export const ModelRow: FC<ModelRowProps> = ({
                                         {capabilityIcons.map((emoji) => (
                                             <span key={emoji}>{emoji}</span>
                                         ))}
-                                    </Badge>
+                                    </Tag>
                                 </Tooltip>
                             )}
                             {showNew && (
-                                <Badge color="green" size="sm">
+                                <Tag color="green" size="sm">
                                     NEW
-                                </Badge>
+                                </Tag>
                             )}
                             {showAlpha && (
                                 <Tooltip content="Alpha model — experimental, may be unstable">
-                                    <Badge color="orange" size="sm">
+                                    <Tag color="orange" size="sm">
                                         ALPHA
-                                    </Badge>
+                                    </Tag>
                                 </Tooltip>
                             )}
                             {showPaidOnly && (
@@ -237,9 +237,9 @@ export const ModelRow: FC<ModelRowProps> = ({
                                             : "This model uses purchased pollen only."
                                     }
                                 >
-                                    <Badge color="purple" size="sm">
+                                    <Tag color="purple" size="sm">
                                         PAID
-                                    </Badge>
+                                    </Tag>
                                 </Tooltip>
                             )}
                         </div>
@@ -259,18 +259,12 @@ export const ModelRow: FC<ModelRowProps> = ({
                             </span>
                         }
                     >
-                        <span
-                            className={cn(
-                                "inline-block cursor-default text-sm font-medium bg-teal-200 text-gray-900 px-2.5 py-0.5 rounded-full",
-                            )}
-                        >
+                        <Tag color="teal" className="cursor-default">
                             {genPerPollen}
-                        </span>
+                        </Tag>
                     </Tooltip>
                 ) : (
-                    <span className="inline-block text-sm font-medium bg-teal-200 text-gray-900 px-2.5 py-0.5 rounded-full">
-                        {genPerPollen}
-                    </span>
+                    <Tag color="teal">{genPerPollen}</Tag>
                 )}
             </div>
 

--- a/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
+++ b/enter.pollinations.ai/src/client/components/pricing/model-table.tsx
@@ -4,7 +4,7 @@ import {
 } from "@shared/registry/registry.ts";
 import { type FC, type MouseEvent, useState } from "react";
 import { cn } from "../../../util.ts";
-import { Badge } from "../ui/badge.tsx";
+import { Tag } from "../ui/tag.tsx";
 
 import { calculateForBalance, calculatePerPollen } from "./calculations.ts";
 import {
@@ -323,19 +323,19 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
                                 </span>
                                 <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 content-center">
                                     {showNew && (
-                                        <Badge color="green" size="sm">
+                                        <Tag color="green" size="sm">
                                             NEW
-                                        </Badge>
+                                        </Tag>
                                     )}
                                     {showAlpha && (
-                                        <Badge color="orange" size="sm">
+                                        <Tag color="orange" size="sm">
                                             ALPHA
-                                        </Badge>
+                                        </Tag>
                                     )}
                                     {showPaidOnly && (
-                                        <Badge color="purple" size="sm">
+                                        <Tag color="purple" size="sm">
                                             PAID
-                                        </Badge>
+                                        </Tag>
                                     )}
                                 </div>
                             </div>
@@ -352,7 +352,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
                             >
                                 <span>{model.name}</span>
                                 {copied && (
-                                    <span className="rounded-full bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-700">
+                                    <span className="rounded-md bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-700">
                                         copied
                                     </span>
                                 )}
@@ -369,13 +369,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({
                                 )}
                         </div>
                     </div>
-                    <span
-                        className={cn(
-                            "text-sm font-medium bg-teal-200 text-gray-900 px-2.5 py-0.5 rounded-full shrink-0",
-                        )}
-                    >
-                        {perPollen}
-                    </span>
+                    <Tag color="teal">{perPollen}</Tag>
                 </div>
             </div>
 
@@ -523,7 +517,7 @@ const MobileMetadataBadges: FC<MobileMetadataBadgesProps> = ({
     return (
         <div className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-hidden">
             {modalityIcons.length > 0 && (
-                <Badge
+                <Tag
                     color="gray"
                     size="sm"
                     className="border border-gray-400/70 bg-gray-100/80 text-gray-900"
@@ -531,10 +525,10 @@ const MobileMetadataBadges: FC<MobileMetadataBadgesProps> = ({
                     {modalityIcons.map((emoji) => (
                         <span key={emoji}>{emoji}</span>
                     ))}
-                </Badge>
+                </Tag>
             )}
             {capabilityIcons.length > 0 && (
-                <Badge
+                <Tag
                     color="gray"
                     size="sm"
                     className="border border-gray-400/70 bg-gray-100/80 text-gray-900"
@@ -542,7 +536,7 @@ const MobileMetadataBadges: FC<MobileMetadataBadgesProps> = ({
                     {capabilityIcons.map((emoji) => (
                         <span key={emoji}>{emoji}</span>
                     ))}
-                </Badge>
+                </Tag>
             )}
         </div>
     );

--- a/enter.pollinations.ai/src/client/components/ui/tag.tsx
+++ b/enter.pollinations.ai/src/client/components/ui/tag.tsx
@@ -1,42 +1,45 @@
-import type { FC, PropsWithChildren } from "react";
+import type { ComponentPropsWithoutRef, FC } from "react";
 import { cn } from "../../../util.ts";
 
-const badgeColors = {
+const tagColors = {
     gray: "bg-gray-200 text-gray-900",
     green: "bg-green-200 text-gray-900",
     pink: "bg-pink-200 text-gray-900",
     amber: "bg-amber-200 text-amber-950",
     orange: "bg-orange-300 text-orange-950",
-    blue: "bg-blue-200 text-gray-900",
+    blue: "bg-blue-100 text-blue-700",
     purple: "bg-purple-200 text-gray-900",
     violet: "bg-violet-200 text-violet-950",
     teal: "bg-teal-200 text-gray-900",
     yellow: "bg-yellow-200 text-gray-900",
 } as const;
 
-const badgeSizes = {
-    sm: "px-2.5 py-0.5 text-xs",
+const tagSizes = {
+    sm: "px-2 py-0.5 text-xs",
     md: "px-2.5 py-0.5 text-sm",
     lg: "px-3 py-1 text-sm",
 } as const;
 
-type BadgeProps = PropsWithChildren<{
-    color?: keyof typeof badgeColors;
-    size?: keyof typeof badgeSizes;
-    className?: string;
-}>;
+type TagProps = ComponentPropsWithoutRef<"span"> & {
+    color?: keyof typeof tagColors;
+    size?: keyof typeof tagSizes;
+};
 
-export const Badge: FC<BadgeProps> = ({
+// Rectangular informational label. Use for non-actionable indicators
+// (status, scope, count, type). Round shapes are reserved for buttons.
+export const Tag: FC<TagProps> = ({
     color = "gray",
     size = "md",
     className,
     children,
+    ...rest
 }) => (
     <span
+        {...rest}
         className={cn(
-            "inline-flex items-center gap-1 rounded-full font-medium leading-normal",
-            badgeSizes[size],
-            badgeColors[color],
+            "inline-flex items-center gap-1 rounded-md font-medium leading-normal shrink-0",
+            tagSizes[size],
+            tagColors[color],
             className,
         )}
     >

--- a/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { DashboardSection } from "../layout/dashboard-section.tsx";
 import { pillColors } from "../layout/dashboard-theme.ts";
 import { TabButton } from "../ui/tab-button.tsx";
+import { Tag } from "../ui/tag.tsx";
 import { Chart } from "./chart";
 import { MODALITY_META, type ModelModality } from "./constants";
 import { MultiSelect } from "./multi-select";
@@ -194,16 +195,21 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                     value={formatPollen(stats.totalPollen)}
                                     detail={
                                         <div className="flex flex-wrap items-center gap-2">
-                                            <span
-                                                className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${tierPill.bg} ${tierPill.text}`}
+                                            <Tag
+                                                size="lg"
+                                                className={`font-semibold ${tierPill.bg} ${tierPill.text}`}
                                             >
                                                 {tierEmoji}{" "}
                                                 {formatPollen(stats.tierPollen)}
-                                            </span>
-                                            <span className="inline-flex items-center rounded-full bg-amber-200 px-2.5 py-1 text-xs font-semibold text-amber-900">
+                                            </Tag>
+                                            <Tag
+                                                color="amber"
+                                                size="lg"
+                                                className="font-semibold text-amber-900"
+                                            >
                                                 🪷{" "}
                                                 {formatPollen(stats.paidPollen)}
-                                            </span>
+                                            </Tag>
                                         </div>
                                     }
                                 />
@@ -219,9 +225,11 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                     detail={
                                         stats.topModel ? (
                                             <div className="flex flex-wrap items-center gap-2">
-                                                <span
+                                                <Tag
+                                                    color="pink"
+                                                    size="lg"
+                                                    className="font-semibold text-pink-900"
                                                     title={`${stats.topModel.requests.toLocaleString()} request${stats.topModel.requests === 1 ? "" : "s"}`}
-                                                    className="inline-flex items-center gap-1 rounded-full bg-pink-200 px-2.5 py-1 text-xs font-semibold text-pink-900"
                                                 >
                                                     <span aria-hidden="true">
                                                         🔁
@@ -229,10 +237,12 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                                     <span className="tabular-nums">
                                                         {stats.topModel.requests.toLocaleString()}
                                                     </span>
-                                                </span>
-                                                <span
+                                                </Tag>
+                                                <Tag
+                                                    color="amber"
+                                                    size="lg"
+                                                    className="font-semibold text-amber-900"
                                                     title={`${formatPollen(stats.topModel.pollen)} pollen`}
-                                                    className="inline-flex items-center gap-1 rounded-full bg-amber-200 px-2.5 py-1 text-xs font-semibold text-amber-900"
                                                 >
                                                     <span aria-hidden="true">
                                                         🪷
@@ -243,7 +253,7 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                                                 .pollen,
                                                         )}
                                                     </span>
-                                                </span>
+                                                </Tag>
                                             </div>
                                         ) : (
                                             "No model usage yet"
@@ -300,16 +310,18 @@ const ModalityPills: FC<{ breakdown: Record<ModelModality, number> }> = ({
             {entries.map(({ modality, count }) => {
                 const { emoji, label } = MODALITY_META[modality];
                 return (
-                    <span
+                    <Tag
                         key={modality}
+                        color="pink"
+                        size="lg"
+                        className="font-semibold text-pink-900"
                         title={`${count.toLocaleString()} ${label} request${count === 1 ? "" : "s"}`}
-                        className="inline-flex items-center gap-1 rounded-full bg-pink-200 px-2.5 py-1 text-xs font-semibold text-pink-900"
                     >
                         <span aria-hidden="true">{emoji}</span>
                         <span className="tabular-nums">
                             {count.toLocaleString()}
                         </span>
-                    </span>
+                    </Tag>
                 );
             })}
         </div>


### PR DESCRIPTION
Round shapes are now reserved for buttons. Informational pills (scope, status, tier, model count, NEW/ALPHA/PAID flags, usage stats) use a new `<Tag>` primitive (`rounded-md`) so users can immediately tell what's pressable.

- new `Tag` in `ui/tag.tsx` — mirrors the old `Badge` API (`color`, `size`, `className`) and forwards standard span attrs
- migrated every `<Badge>` consumer plus inline `rounded-full` informational spans on the Pricing and Usage panels
- deleted `ui/badge.tsx` (no remaining callers)
- bumped the Models tab buttons (Image / Video / Audio / Text) to match the `LinkButton` size for visual consistency with the Model Health / Vote buttons

Net: ~85 lines deleted, ~90 added across 11 files. Round = button, rectangular = label.