### PR TITLE
[codex] fix: keep Scribe free

### DIFF
--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -24,9 +24,9 @@ const PINNED_NEWS: Highlight[] = [
     {
         date: "2026-04-28",
         emoji: "💸",
-        title: "ElevenLabs audio models and GPT Image 2 are now paid",
+        title: "ElevenLabs TTS, Music, and GPT Image 2 are now paid",
         description:
-            "As of May 1, 2026, ElevenLabs TTS, Music, Scribe, and GPT Image 2 require paid pollen.",
+            "As of May 1, 2026, ElevenLabs TTS, Music, and GPT Image 2 require paid pollen.",
     },
 ];
 

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -129,18 +129,11 @@ export const AUDIO_SERVICES = {
         provider: "elevenlabs",
         brand: "ElevenLabs",
         category: "audio",
-        paidOnly: true,
         cost: [
             {
                 date: new Date("2026-02-13").getTime(),
                 // ElevenLabs Scribe: $0.40/hour = $0.0001111/sec
                 promptAudioSeconds: 0.0001111,
-            },
-        ],
-        price: [
-            {
-                date: new Date("2026-02-13").getTime(),
-                promptAudioSeconds: 0.00016665, // $0.60 per hour
             },
         ],
         description:


### PR DESCRIPTION
- Removes `paidOnly` from the `scribe` audio registry entry.
- Removes Scribe's explicit 1.5x `price` override so it falls back to provider cost.
- Updates the dashboard banner copy to list only ElevenLabs TTS, Music, and GPT Image 2 as paid.

Validation:
- `npx biome check --write shared/registry/audio.ts enter.pollinations.ai/src/client/components/layout/news-banner.tsx`
- `npx vitest run test/aliases.test.ts` in `enter.pollinations.ai`