### PR TITLE
fix: bump image server registry TTL and timeout

### DIFF
--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -10,8 +10,8 @@ type ServerEntry = {
     lastHeartbeat: number;
 };
 
-const SERVER_TIMEOUT = 45000;
-const REGISTRY_TTL_SECONDS = 60;
+const SERVER_TIMEOUT = 180000;
+const REGISTRY_TTL_SECONDS = 240;
 
 let serverRegistry: KVNamespace | null = null;
 let registryEnvironment = "development";


### PR DESCRIPTION
## Summary
- `SERVER_TIMEOUT`: 45s → 180s
- `REGISTRY_TTL_SECONDS`: 60 → 240

## Why

After the production cutover to gen-owned image generation, zimage requests intermittently returned `"No active zimage servers available"` (~30% of bursts) even though `GET /register` showed 2 healthy zimage entries.

Root cause: Cloudflare KV `list({prefix})` is eventually consistent globally (~60s window). With the previous `SERVER_TIMEOUT=45s` filter, a worker hitting an edge with stale list results would drop healthy servers and 500.

Pods heartbeat every 30s. With 180s freshness window plus 240s TTL, a server stays reachable through KV list lag. Trade-off: a genuinely dead pod stays in the registry up to 180s, but `fetchFromLeastBusyServer` already retries 3x on 5xx with a different server, so dead pods get routed away within seconds anyway.

## Test plan
- [ ] Deploy to staging
- [ ] Burst test 10x zimage and 10x flux through staging gen — expect 100% success
- [ ] Merge to main, push to production, repeat burst test

🤖 Generated with [Claude Code](https://claude.com/claude-code)