### PR TITLE
fix(media): verify API keys against enter directly, not via gen proxy

### DIFF
--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -4,7 +4,12 @@ import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi";
 import { z } from "zod";
 
 const DOMAIN = "media.pollinations.ai";
-const ENTER_VERIFY_URL = "https://gen.pollinations.ai/api/account/key";
+// Talk to enter directly. Going through gen.pollinations.ai works (it
+// proxies /api/account/* to enter) but adds a network hop, an extra
+// dependency on the gen worker being healthy, and breaks the moment the
+// proxy config changes. enter is the authoritative host for key
+// verification.
+const ENTER_VERIFY_URL = "https://enter.pollinations.ai/api/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 10485760; // 10 MB


### PR DESCRIPTION
## Changes Made

- Switched `ENTER_VERIFY_URL` in the media upload service from `https://gen.pollinations.ai/api/account/key` to `https://enter.pollinations.ai/api/account/key`. The constant name was already correct — `ENTER_VERIFY_URL` — but the value was pointing at the wrong host, so the wiring was inconsistent with its own naming.
- Added an inline comment explaining *why* the direct route matters so a future contributor doesn't "fix" it back to gen for consistency with the public docs. Going through gen technically works (gen proxies `/api/account/*` to enter), but it costs a network hop, adds an availability dependency on gen's proxy being healthy, and silently breaks any time someone reshapes the proxy config in gen. `enter` is the authoritative host for key verification — internal services should talk to it directly.

## Why

The recent gen/enter migration ([#10604](https://github.com/pollinations/pollinations/pull/10604), [#10555](https://github.com/pollinations/pollinations/pull/10555), [#10576](https://github.com/pollinations/pollinations/pull/10576)) moved image and text generation under `gen.pollinations.ai` while leaving `/api/account/*` and `/api/auth/*` on `enter`. External callers correctly hit `gen` and let it proxy account routes onward. But internal services that need to verify a user-supplied key on every upload should bypass that proxy — the public gateway exists for *external traffic*, not for our own backends round-tripping through it.

`media.pollinations.ai` was the one place that got the direction wrong post-migration, presumably because the docs (correctly) point external users at `gen` and the URL got copied from there.

## Tasks

- [x] Repoint the verification constant from gen → enter
- [x] Audit the rest of the repo for similar misroutes — only this one site found in active code (test fixture at `gen.pollinations.ai/test/index.test.ts:140` is intentionally asserting the proxy works; doc references in `enter.pollinations.ai/src/routes/docs.ts` and `apps/catgpt/README.md` are public-facing on purpose; everything else is correct)
- [x] Document the routing intent inline so this doesn't drift back

## Notes

- **Behavior on legitimate keys is unchanged.** Both URLs ultimately validate against the same key store; the difference is purely topological (one hop vs. two).
- **Behavior on rejected keys is unchanged.** Same 401 surface, same rejection semantics.
- **No callers of media.pollinations.ai see a difference.** The verify URL is internal to the worker; nothing external observes which host the worker dialed.
- **No infrastructure or auth changes** — `enter.pollinations.ai/api/account/key` was already the authoritative endpoint and accepts the same `Authorization: Bearer …` header media was already sending.
- This is a single-line change, but the cost of *not* fixing it is real: every uploaded media file currently makes a redundant gen → enter hop, and every gen proxy hiccup or config change becomes a media outage. Cheap fix to land, dispproportionately large reliability win.

Fixes #10608