### PR TITLE
fix(polli-cli): accept piped auth token

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -30,6 +30,7 @@ Every command is agent-friendly:
 ```bash
 npm install -g @pollinations_ai/cli     # installs the `polli` binary
 polli auth login                         # device-flow via enter.pollinations.ai
+printf '%s' "$POLLINATIONS_API_KEY" | polli auth login --with-token
 ```
 
 Credentials land at `~/.pollinations/credentials.json`. For one-off runs pass `--key sk_...` or set `POLLINATIONS_API_KEY`. Get keys at [enter.pollinations.ai](https://enter.pollinations.ai).

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -21,6 +21,7 @@ Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video;
 | Intent | Command |
 |---|---|
 | Log in once | `polli auth login` |
+| Store an existing key | `printf '%s' "$POLLINATIONS_API_KEY" \| polli auth login --with-token` |
 | Generate image | `polli gen image "<prompt>" --output out.png` |
 | Generate text | `polli gen text "<prompt>"` |
 | Text with stdin as context | `echo "<ctx>" \| polli gen text "<question>"` |
@@ -38,7 +39,9 @@ Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video;
 
 ## Setup
 
-One-time: `polli auth login` (device-flow). Verify with `polli auth status`.
+One-time: `polli auth login` (device-flow). To store an existing key, run
+`printf '%s' "$POLLINATIONS_API_KEY" | polli auth login --with-token`. Verify
+with `polli auth status`.
 Override the stored key for a single command with `--key <key>`.
 
 ## Recipes

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations_ai/cli",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { gen } from "../lib/api.js";
 import {
     clearCredentials,
@@ -13,6 +13,12 @@ import {
     printSuccess,
 } from "../lib/output.js";
 import { flavor } from "../lib/quotes.js";
+
+type LoginOptions = {
+    browser?: boolean;
+    token?: string;
+    withToken?: boolean;
+};
 
 interface ProfileResponse {
     githubUsername?: string | null;
@@ -75,6 +81,43 @@ function storeKey(key: string): void {
     saveCredentials({ apiKey: key, keyType });
 }
 
+function assertApiKey(key: string): string {
+    const trimmed = key.trim();
+    if (!trimmed.startsWith("pk_") && !trimmed.startsWith("sk_")) {
+        printError("Invalid key format. Must start with pk_ or sk_");
+        process.exit(1);
+    }
+    return trimmed;
+}
+
+async function readStdinToken(): Promise<string> {
+    if (process.stdin.isTTY) {
+        printError(
+            "--with-token expects a key on stdin, e.g. printf '%s' \"$KEY\" | polli auth login --with-token",
+        );
+        process.exit(1);
+    }
+
+    let text = "";
+    for await (const chunk of process.stdin) {
+        text += chunk;
+    }
+    return text.trim();
+}
+
+async function authenticateWithKey(key: string): Promise<void> {
+    storeKey(key);
+    printSuccess("Authenticated. Key stored.");
+
+    const label = await fetchProfileLabel(key);
+    if (label) {
+        printSuccess(label);
+    } else {
+        printInfo("Key stored but could not verify. It may still be valid.");
+    }
+    printInfo(flavor.login);
+}
+
 async function fetchProfileLabel(key: string): Promise<string | null> {
     const profile = await gen<ProfileResponse>("/account/profile", {
         apiKey: key,
@@ -85,28 +128,23 @@ async function fetchProfileLabel(key: string): Promise<string | null> {
 
 const login = new Command("login")
     .description("Authenticate with Pollinations")
-    .option("--token <key>", "API key (pk_ or sk_) for direct auth")
+    .addOption(
+        new Option(
+            "--token <key>",
+            "API key (pk_ or sk_) for direct auth",
+        ).hideHelp(),
+    )
+    .option("--with-token", "Read an existing API key from stdin")
     .option("--no-browser", "Print URL instead of opening browser")
-    .action(async (opts) => {
+    .action(async (opts: LoginOptions) => {
         if (opts.token) {
-            const key = opts.token as string;
-            if (!key.startsWith("pk_") && !key.startsWith("sk_")) {
-                printError("Invalid key format. Must start with pk_ or sk_");
-                process.exit(1);
-            }
+            await authenticateWithKey(assertApiKey(opts.token));
+            return;
+        }
 
-            storeKey(key);
-            printSuccess("Authenticated. Key stored.");
-
-            const label = await fetchProfileLabel(key);
-            if (label) {
-                printSuccess(label);
-            } else {
-                printInfo(
-                    "Key stored but could not verify. It may still be valid.",
-                );
-            }
-            printInfo(flavor.login);
+        if (opts.withToken) {
+            const key = assertApiKey(await readStdinToken());
+            await authenticateWithKey(key);
             return;
         }
 
@@ -123,7 +161,9 @@ const login = new Command("login")
             printError(
                 `Failed to start device flow: ${err instanceof Error ? err.message : err}`,
             );
-            printInfo("Fallback: polli auth login --token <your-key>");
+            printInfo(
+                "Fallback: printf '%s' '<your-key>' | polli auth login --with-token",
+            );
             printInfo("Get your key at: https://enter.pollinations.ai");
             process.exit(1);
         });
@@ -140,17 +180,13 @@ const login = new Command("login")
         printInfo(`\nYour code: ${deviceResp.user_code}\n`);
 
         const url = deviceResp.verification_uri_complete;
+        printInfo(`Open this URL in your browser:\n  ${url}`);
+
         if (opts.browser !== false) {
             const open = (await import("open")).default;
-            await open(url).then(
-                () =>
-                    printInfo(
-                        "Browser opened. Sign in with GitHub and approve the code.",
-                    ),
-                () => printInfo(`Open this URL in your browser:\n  ${url}`),
+            await open(url).catch(() =>
+                printInfo("Could not open browser automatically."),
             );
-        } else {
-            printInfo(`Open this URL in your browser:\n  ${url}`);
         }
 
         printInfo("Waiting for approval...");

--- a/packages/polli-cli/src/lib/api.ts
+++ b/packages/polli-cli/src/lib/api.ts
@@ -15,7 +15,9 @@ export const requireKey = (): string => {
     const key = resolveApiKey();
     if (!key) {
         printError("Not logged in. Run: polli auth login");
-        printError("Or use: polli auth login --token <your-key>");
+        printError(
+            "Or pipe a key: printf '%s' '<your-key>' | polli auth login --with-token",
+        );
         process.exit(1);
     }
     return key;


### PR DESCRIPTION
- Add `polli auth login --with-token` to store an existing API key from stdin.
- Keep `polli auth login --token <key>` accepted as a hidden compatibility path, so this is not breaking.
- Always print the device login URL before trying to open a browser, without the extra browser-open success line.
- Bump `@pollinations_ai/cli` to `0.1.3`.
- Checked with Biome, help output, stdin-token smoke tests, hidden `--token` compatibility smoke test, invalid-token rejection, and the TTY guard. Local package build is blocked because `tsup` is not installed in this checkout.