### PR TITLE
(feat): Polli CLI stable release refactor v1.0.4

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -44,6 +44,7 @@ echo "context" | polli gen text "question"
 
 polli gen image "cyberpunk city at night" --model flux --output city.png
 polli gen image "enhance this" --image https://media.pollinations.ai/abc --model gptimage
+polli gen image "make it sunset" --image ./photo.jpg --model grok-imagine    # local files auto-uploaded
 
 polli gen audio "Hello world" --voice nova --output speech.mp3
 polli gen audio "read it to me" --play                # plays back after saving (blocks until done)

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -14,7 +14,7 @@ npx @pollinations_ai/cli gen image "a cat in space" --output cat.png
 
 Point your coding agent (Claude Code, Cursor, Windsurf, Codex) at the skill file and it gets the full usage map — flags, stdin conventions, `--json` output shape, error codes, the lot:
 
-> Read https://raw.githubusercontent.com/pollinations/pollinations/main/packages/polli-cli/SKILL.md and follow the instructions to generate media with the `polli` CLI.
+> Read [SKILL.md](https://raw.githubusercontent.com/pollinations/pollinations/main/packages/polli-cli/SKILL.md) and follow the instructions to generate media with the `polli` CLI.
 
 The skill also ships inside the package: `node_modules/@pollinations_ai/cli/SKILL.md`.
 

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations_ai/cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
-        "open": "^11.0.0"
+        "open": "^11.0.0",
+        "terminal-link": "^3.0.0"
       },
       "bin": {
         "polli": "bin/polli.js"
@@ -1020,6 +1021,21 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1339,6 +1355,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-docker": {
@@ -1857,6 +1882,47 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
+      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^5.0.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -2009,6 +2075,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -18,7 +18,7 @@
         "polli": "bin/polli.js"
       },
       "devDependencies": {
-        "@types/node": "^22.13.0",
+        "@types/node": "^22.19.17",
         "tsup": "^8.4.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations_ai/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {
@@ -59,7 +59,8 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
-    "open": "^11.0.0"
+    "open": "^11.0.0",
+    "terminal-link": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.0",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -63,7 +63,7 @@
     "terminal-link": "^3.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.13.0",
+    "@types/node": "^22.19.17",
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -1,5 +1,7 @@
+import chalk from "chalk";
 import { Command, Option } from "commander";
 import { gen } from "../lib/api.js";
+import { printBanner } from "../lib/branding.js";
 import {
     clearCredentials,
     ENTER_URL,
@@ -7,12 +9,34 @@ import {
     saveCredentials,
 } from "../lib/config.js";
 import {
+    getOutputMode,
+    link,
     printError,
     printInfo,
     printResult,
     printSuccess,
 } from "../lib/output.js";
 import { flavor } from "../lib/quotes.js";
+
+const NEXT_STEPS = [
+    'polli image "a sunset over kyoto" -o sunset.png',
+    'polli text "summarize node http"',
+    "polli whoami",
+];
+
+/**
+ * Print the post-login "Try:" hint with example commands. Human/TTY only —
+ * skipped for piped output and JSON callers so machine consumers stay clean.
+ */
+function printNextStepsHint(): void {
+    if (getOutputMode() !== "human") return;
+    if (!process.stderr.isTTY) return;
+    process.stderr.write(`\n${chalk.bold("Try:")}\n`);
+    for (const cmd of NEXT_STEPS) {
+        process.stderr.write(`  ${chalk.cyan(cmd)}\n`);
+    }
+    process.stderr.write("\n");
+}
 
 type LoginOptions = {
     browser?: boolean;
@@ -148,7 +172,7 @@ const login = new Command("login")
             return;
         }
 
-        printInfo("Requesting device code...");
+        printBanner("authenticate to start using the API");
 
         const res = await fetch(`${ENTER_URL}/api/device/code`, {
             method: "POST",

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -4,6 +4,7 @@ import { gen } from "../lib/api.js";
 import { printBanner } from "../lib/branding.js";
 import {
     clearCredentials,
+    credentialsDisplayPath,
     ENTER_URL,
     resolveApiKey,
     saveCredentials,

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -321,9 +321,7 @@ export const authCommand = new Command("auth")
     .addCommand(logout)
     .addCommand(status);
 
-// Top-level alias. `whoami` is the reflex command in most CLI ecosystems
-// (op, gcloud, aws sts, etc.) — surfacing it here saves new users from
-// digging through `polli auth --help` to find the same information.
+    
 export const whoamiCommand = new Command("whoami")
     .description(
         "Show current auth status and balance (alias for `auth status`)",

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -54,6 +54,16 @@ interface BalanceResponse {
     balance?: number;
 }
 
+interface KeyInfoResponse {
+    valid?: boolean;
+    type?: "publishable" | "secret";
+    pollenBudget?: number | null;
+    permissions?: {
+        models?: string[] | null;
+        account?: string[] | null;
+    };
+}
+
 interface DeviceCodeResponse {
     device_code: string;
     user_code: string;
@@ -269,7 +279,23 @@ const login = new Command("login")
 const logout = new Command("logout")
     .description("Clear stored credentials")
     .action(() => {
+        // Capture the masked key before clearing so the user sees which
+        // identity they actually logged out of — handy when juggling
+        // multiple accounts via env-var key overrides or shared machines.
+        const previous = resolveApiKey();
         clearCredentials();
+
+        if (getOutputMode() === "human" && process.stderr.isTTY) {
+            const arrow = chalk.hex("#a78bfa")("✓");
+            const path = chalk.dim(credentialsDisplayPath());
+            const tail = previous
+                ? ` (was ${chalk.dim(`${previous.slice(0, 5)}…${previous.slice(-4)}`)})`
+                : "";
+            process.stderr.write(`\n  ${arrow} Logged out${tail}\n`);
+            process.stderr.write(`    Cleared ${path}\n\n`);
+            process.stderr.write(`  ${chalk.dim(flavor.logout)}\n\n`);
+            return;
+        }
         printSuccess("Logged out. Credentials cleared.");
         printInfo(flavor.logout);
     });
@@ -286,11 +312,14 @@ export async function showAuthStatus(): Promise<void> {
 
     const masked = `${key.slice(0, 5)}...${key.slice(-6)}`;
 
-    const [profile, balance] = await Promise.all([
+    const [profile, balance, keyInfo] = await Promise.all([
         gen<ProfileResponse>("/account/profile", { apiKey: key }).catch(
             () => null,
         ),
         gen<BalanceResponse>("/account/balance", { apiKey: key }).catch(
+            () => null,
+        ),
+        gen<KeyInfoResponse>("/account/key", { apiKey: key }).catch(
             () => null,
         ),
     ]);
@@ -304,11 +333,25 @@ export async function showAuthStatus(): Promise<void> {
         return;
     }
 
+    // /account/balance is overloaded server-side: it returns the *key's*
+    // remaining budget when the key has one set (the device-flow CLI key
+    // gets a default budget on mint), and only falls through to the user's
+    // full account total when the key has no budget AND has the
+    // `account:usage` scope. Surfacing that as "pollen" without context
+    // misleads users — a fresh device-flow login shows e.g. 5 (the budget)
+    // instead of their actual tier balance. Inspect /account/key to know
+    // which value we're actually showing and label it honestly.
+    const hasBudget = keyInfo?.pollenBudget != null;
+    const pollenLabel = hasBudget ? "budget" : "pollen";
+
     printResult({
         authenticated: true,
         key: masked,
         name: profile.githubUsername ?? "unknown",
-        pollen: balance?.balance ?? "unknown",
+        [pollenLabel]: balance?.balance ?? "unknown",
+        ...(hasBudget && {
+            note: "shown is this key's remaining budget — not your account-wide pollen total",
+        }),
     });
 }
 

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -319,9 +319,7 @@ export async function showAuthStatus(): Promise<void> {
         gen<BalanceResponse>("/account/balance", { apiKey: key }).catch(
             () => null,
         ),
-        gen<KeyInfoResponse>("/account/key", { apiKey: key }).catch(
-            () => null,
-        ),
+        gen<KeyInfoResponse>("/account/key", { apiKey: key }).catch(() => null),
     ]);
 
     if (!profile) {
@@ -365,7 +363,6 @@ export const authCommand = new Command("auth")
     .addCommand(logout)
     .addCommand(status);
 
-    
 export const whoamiCommand = new Command("whoami")
     .description(
         "Show current auth status and balance (alias for `auth status`)",

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -140,6 +140,7 @@ async function authenticateWithKey(key: string): Promise<void> {
         printInfo("Key stored but could not verify. It may still be valid.");
     }
     printInfo(flavor.login);
+    printNextStepsHint();
 }
 
 async function fetchProfileLabel(key: string): Promise<string | null> {
@@ -200,11 +201,22 @@ const login = new Command("login")
         }
 
         const deviceResp = (await res.json()) as DeviceCodeResponse;
-
-        printInfo(`\nYour code: ${deviceResp.user_code}\n`);
-
         const url = deviceResp.verification_uri_complete;
-        printInfo(`Open this URL in your browser:\n  ${url}`);
+
+        // Two-block layout: URL first (the action the user needs to take),
+        // then the code framed as a verification check (the security
+        // purpose of device-flow codes — confirm the consent screen shows
+        // the same code you see here, mitigating phishing). Polling line
+        // gets its own block so it doesn't visually compete.
+        if (getOutputMode() === "human") {
+            const arrow = chalk.hex("#a78bfa")("➜");
+            process.stderr.write(
+                `  ${arrow} Open this URL to approve:\n    ${link(url)}\n\n`,
+            );
+            process.stderr.write(
+                `  ${arrow} Confirm the code matches:  ${chalk.bold(deviceResp.user_code)}\n\n`,
+            );
+        }
 
         if (opts.browser !== false) {
             const open = (await import("open")).default;
@@ -250,6 +262,7 @@ const login = new Command("login")
             );
         }
         printInfo(flavor.login);
+        printNextStepsHint();
     });
 
 const logout = new Command("logout")

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -283,3 +283,12 @@ export const authCommand = new Command("auth")
     .addCommand(login)
     .addCommand(logout)
     .addCommand(status);
+
+// Top-level alias. `whoami` is the reflex command in most CLI ecosystems
+// (op, gcloud, aws sts, etc.) — surfacing it here saves new users from
+// digging through `polli auth --help` to find the same information.
+export const whoamiCommand = new Command("whoami")
+    .description(
+        "Show current auth status and balance (alias for `auth status`)",
+    )
+    .action(showAuthStatus);

--- a/packages/polli-cli/src/commands/gen/image.ts
+++ b/packages/polli-cli/src/commands/gen/image.ts
@@ -1,8 +1,9 @@
-import { writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { Command } from "commander";
 import { requireKey } from "../../lib/api.js";
 import { BASE_URL } from "../../lib/config.js";
 import { budgetHint } from "../../lib/errors.js";
+import { uploadLocalFile } from "../../lib/media-upload.js";
 import {
     getOutputMode,
     printError,
@@ -23,8 +24,8 @@ export function createImageCommand() {
         .option("--safe", "Enable safety filters")
         .option("--transparent", "Transparent background (PNG)")
         .option(
-            "--image <url...>",
-            "Reference image URL(s) for editing/i2i (repeatable)",
+            "--image <ref...>",
+            "Reference image(s) for editing/i2i — public http(s) URL or local file path; local paths are auto-uploaded to media.pollinations.ai. Repeatable.",
         )
         .option("--output <path>", "Save to file", "image.png")
         .action(async (prompt, opts) => {
@@ -42,16 +43,34 @@ export function createImageCommand() {
             if (opts.safe) params.set("safe", "true");
             if (opts.transparent) params.set("transparent", "true");
             if (opts.image?.length) {
-                const bad = opts.image.find(
-                    (u: string) => !/^https?:\/\//i.test(u),
-                );
-                if (bad) {
-                    printError(
-                        `--image requires a public http(s) URL, not a local path: ${bad}`,
-                    );
-                    process.exit(1);
+                // Resolve each entry to a public URL: http(s) URLs pass
+                // through untouched; local paths are uploaded to
+                // media.pollinations.ai and the returned URL is substituted
+                // in place. Order is preserved — i2i providers (including
+                // the xAI Grok-Imagine path shipped in #10617) treat the
+                // first reference as the primary image.
+                const resolved: string[] = [];
+                for (const ref of opts.image as string[]) {
+                    if (/^https?:\/\//i.test(ref)) {
+                        resolved.push(ref);
+                        continue;
+                    }
+                    if (!existsSync(ref)) {
+                        printError(`Reference image not found: ${ref}`);
+                        process.exit(1);
+                    }
+                    if (isHuman) printInfo(`Uploading ${ref}...`);
+                    try {
+                        const uploaded = await uploadLocalFile(ref, key);
+                        resolved.push(uploaded.url);
+                    } catch (err) {
+                        printError(
+                            `Failed to upload ${ref}: ${err instanceof Error ? err.message : "unknown error"}`,
+                        );
+                        process.exit(1);
+                    }
                 }
-                params.set("image", opts.image.join("|"));
+                params.set("image", resolved.join("|"));
             }
 
             const encodedPrompt = encodeURIComponent(prompt);

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { authCommand } from "./commands/auth.js";
+import { authCommand, whoamiCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
 import { createGenCommand } from "./commands/gen/index.js";
 import { keysCommand } from "./commands/keys.js";
@@ -58,6 +58,7 @@ program
 
 // Auth & account
 program.addCommand(authCommand);
+program.addCommand(whoamiCommand);
 program.addCommand(keysCommand);
 program.addCommand(usageCommand);
 

--- a/packages/polli-cli/src/lib/branding.ts
+++ b/packages/polli-cli/src/lib/branding.ts
@@ -5,25 +5,39 @@ import { getOutputMode } from "./output.js";
 // output.ts. One color across the CLI keeps the visual identity consistent.
 const BRAND_HEX = "#a78bfa";
 
-// Hand-crafted small ASCII rendition of the Pollinations mark — a stylized
-// flower / sun motif derived from assets/logo.svg. Kept short (6 lines × 30
-// cols) so it fits comfortably in 80-column terminals and tmux/Vim splits.
+// ASCII rendition of the Pollinations flower mark, generated offline by
+// rasterizing assets/logo.svg at 40x20 and threshold-converting black
+// pixels to '█'. Static so it ships without a build-time dependency on
+// ImageMagick or sharp. To regenerate (e.g. if the SVG changes):
+//
+//   magick assets/logo.svg -resize 40x20! -threshold 50% -monochrome PBM:- \
+//     | node -e "<...PBM-to-ASCII script — see PR description...>"
+//
+// 19 rows × ~40 cols fits comfortably in an 80-column terminal even with a
+// few columns of leading indent.
 const LOGO_LINES = [
-    "    .-=+*#%@%#*+=-.",
-    "  -*%@@@@@@@@@@@@@%*-",
-    " #@@@@@@   *@   @@@@@@#",
-    "%@@@@@@@@@@@@@@@@@@@@@@%",
-    " #@@@@@@@@@@@@@@@@@@@@#",
-    "  -*%@@@@@@@@@@@@@@%*-",
-    "    .-=+*#%@%#*+=-.",
+    "                  ████",
+    "                ███  ███",
+    "               ██      ██",
+    "     ███████████        ███████████",
+    "     ██      ████      ████      ██",
+    "     ██      ██ ███   ██ ██      ██",
+    "   ██████    ██   █  ██  ██     █████",
+    "███  ██  ██████   ████   ██████  ██  ███",
+    " ██   █      ████ ████  ███      ██  ██",
+    "  ███  ██      ██████████       ██  ██",
+    "    ███████      ██████       ██████",
+    "       ███████████████████████████",
+    "            ████████████████",
+    "            ██████ ██ ███████",
+    "         ███       ██       ███",
+    "        ███        ██         ██",
+    "       █████      ████      █████",
+    "       ██ ██     ███ ██     ██ ███",
+    "        ███        ███       ███",
 ];
 
-/**
- * Print the Pollinations banner to stderr, brand-purple, with an optional
- * subtitle dimmed underneath. No-op in JSON mode so structured callers stay
- * clean. No-op when stderr is not a TTY (piped output stays free of escape
- * sequences and ASCII filler).
- */
+
 export function printBanner(subtitle?: string): void {
     if (getOutputMode() !== "human") return;
     if (!process.stderr.isTTY) return;

--- a/packages/polli-cli/src/lib/branding.ts
+++ b/packages/polli-cli/src/lib/branding.ts
@@ -37,7 +37,6 @@ const LOGO_LINES = [
     "        ███        ███       ███",
 ];
 
-
 export function printBanner(subtitle?: string): void {
     if (getOutputMode() !== "human") return;
     if (!process.stderr.isTTY) return;

--- a/packages/polli-cli/src/lib/branding.ts
+++ b/packages/polli-cli/src/lib/branding.ts
@@ -1,0 +1,40 @@
+import chalk from "chalk";
+import { getOutputMode } from "./output.js";
+
+// Brand purple, matches index.ts help styling and the table headers in
+// output.ts. One color across the CLI keeps the visual identity consistent.
+const BRAND_HEX = "#a78bfa";
+
+// Hand-crafted small ASCII rendition of the Pollinations mark — a stylized
+// flower / sun motif derived from assets/logo.svg. Kept short (6 lines × 30
+// cols) so it fits comfortably in 80-column terminals and tmux/Vim splits.
+const LOGO_LINES = [
+    "    .-=+*#%@%#*+=-.",
+    "  -*%@@@@@@@@@@@@@%*-",
+    " #@@@@@@   *@   @@@@@@#",
+    "%@@@@@@@@@@@@@@@@@@@@@@%",
+    " #@@@@@@@@@@@@@@@@@@@@#",
+    "  -*%@@@@@@@@@@@@@@%*-",
+    "    .-=+*#%@%#*+=-.",
+];
+
+/**
+ * Print the Pollinations banner to stderr, brand-purple, with an optional
+ * subtitle dimmed underneath. No-op in JSON mode so structured callers stay
+ * clean. No-op when stderr is not a TTY (piped output stays free of escape
+ * sequences and ASCII filler).
+ */
+export function printBanner(subtitle?: string): void {
+    if (getOutputMode() !== "human") return;
+    if (!process.stderr.isTTY) return;
+
+    const brand = chalk.hex(BRAND_HEX);
+    process.stderr.write("\n");
+    for (const line of LOGO_LINES) {
+        process.stderr.write(`${brand(line)}\n`);
+    }
+    if (subtitle) {
+        process.stderr.write(`\n${chalk.dim(subtitle)}\n`);
+    }
+    process.stderr.write("\n");
+}

--- a/packages/polli-cli/src/lib/config.ts
+++ b/packages/polli-cli/src/lib/config.ts
@@ -11,6 +11,14 @@ import { join } from "node:path";
 const CONFIG_DIR = join(homedir(), ".pollinations");
 const CREDENTIALS_FILE = join(CONFIG_DIR, "credentials.json");
 
+/** Where credentials live, with a `~/` prefix when applicable for display. */
+export const credentialsDisplayPath = (): string => {
+    const home = homedir();
+    return CREDENTIALS_FILE.startsWith(home)
+        ? `~${CREDENTIALS_FILE.slice(home.length)}`
+        : CREDENTIALS_FILE;
+};
+
 export interface PolliCredentials {
     apiKey?: string;
     keyType?: "pk" | "sk";

--- a/packages/polli-cli/src/lib/media-upload.ts
+++ b/packages/polli-cli/src/lib/media-upload.ts
@@ -1,0 +1,91 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, extname } from "node:path";
+import { MEDIA_URL } from "./config.js";
+
+const MIME_BY_EXT: Record<string, string> = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".bmp": "image/bmp",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+    ".m4a": "audio/mp4",
+    ".flac": "audio/flac",
+    ".aac": "audio/aac",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+};
+
+export interface MediaUploadResponse {
+    id: string;
+    url: string;
+    contentType: string;
+    size: number;
+    duplicate: boolean;
+}
+
+/** Resolve the MIME type for a local file path, falling back to octet-stream. */
+export function detectMimeType(path: string): string {
+    return (
+        MIME_BY_EXT[extname(path).toLowerCase()] || "application/octet-stream"
+    );
+}
+
+/**
+ * Upload a local file to media.pollinations.ai and return the full response.
+ *
+ * Throws with a readable message on:
+ *   - missing file (caller should validate first if it wants a different code path)
+ *   - 401 (invalid/expired API key)
+ *   - 413 (over the 10 MB media cap, enforced server-side)
+ *   - any other non-2xx response
+ *
+ * Used by `polli upload` (the standalone upload command) and by
+ * `polli image --image <path>` to auto-host a local reference image before
+ * dispatching to gen for image-to-image generation.
+ */
+export async function uploadLocalFile(
+    path: string,
+    apiKey: string,
+): Promise<MediaUploadResponse> {
+    if (!existsSync(path)) {
+        throw new Error(`File not found: ${path}`);
+    }
+
+    const form = new FormData();
+    form.append(
+        "file",
+        new Blob([readFileSync(path)], { type: detectMimeType(path) }),
+        basename(path),
+    );
+
+    const res = await fetch(`${MEDIA_URL}/upload`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: form,
+    });
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        // Surface the most common cases with friendlier framing; fall through
+        // to a generic message otherwise.
+        if (res.status === 401) {
+            throw new Error(
+                "Unauthorized. Run `polli auth login` or pass --key <pk_or_sk>.",
+            );
+        }
+        if (res.status === 413) {
+            throw new Error(
+                "File too large for media.pollinations.ai (10 MB cap). Resize or compress before uploading.",
+            );
+        }
+        throw new Error(`${res.status} ${res.statusText}: ${text}`);
+    }
+
+    return (await res.json()) as MediaUploadResponse;
+}

--- a/packages/polli-cli/src/lib/output.ts
+++ b/packages/polli-cli/src/lib/output.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import terminalLink from "terminal-link";
 
 export type OutputMode = "human" | "json";
 
@@ -120,6 +121,19 @@ export const printSuccess = (msg: string) => {
 /** Error message — always shown, always stderr */
 export const printError = (msg: string) => {
     process.stderr.write(`${chalk.red.bold("error:")} ${chalk.red(msg)}\n`);
+};
+
+/**
+ * Render a URL as an OSC-8 hyperlink in human mode, falling back to the
+ * plain URL when piped, in JSON mode, or in terminals without OSC-8 support
+ * (terminal-link's built-in `supportsHyperlinks` check handles that). Use
+ * for instructions like "open this URL" — saves the user a copy-paste in
+ * modern terminals (iTerm, kitty, recent VS Code) without breaking older
+ * ones.
+ */
+export const link = (url: string, text = url): string => {
+    if (currentMode !== "human") return url;
+    return terminalLink(text, url, { fallback: () => url });
 };
 
 /** Warning message — always shown, always stderr */

--- a/packages/polli-cli/src/lib/quotes.ts
+++ b/packages/polli-cli/src/lib/quotes.ts
@@ -1,5 +1,73 @@
+/**
+ * Random one-liners printed at the tail of login / logout / version output.
+ *
+ * Mostly Hitchhiker's-Guide-flavored with a bee/pollen twist — `flavor.login`
+ * etc. resolve a fresh random pick on every access, so the CLI feels alive
+ * across invocations without anyone needing to remember to pass a "mood" arg.
+ *
+ * Add freely; keep entries short (one line, ideally under 50 chars), playful
+ * but not goofy, and consistent with the rest of the personality. Don't ship
+ * anything that wouldn't fit on a Pollinations sticker.
+ */
+
+const LOGIN_QUOTES = [
+    "Share and Enjoy.",
+    "Don't Panic.",
+    "Welcome to the hive.",
+    "Pollen flowing. Time to bloom.",
+    "May your prompts be bee-utiful.",
+    "Buzz buzz. We're listening.",
+    "The garden is open.",
+    "Have your towel ready.",
+    "All systems pollinated.",
+    "Let the petals unfurl.",
+    "Ready when you are.",
+    "Time to make some pollen.",
+];
+
+const LOGOUT_QUOTES = [
+    "So long, and thanks for all the pollen.",
+    "See you on the next bloom.",
+    "Until the next pollination.",
+    "Catch you on the breeze.",
+    "Off to the next flower.",
+    "Wings down for now.",
+    "Petals folded for the night.",
+    "Hibernation engaged.",
+    "Goodbye, dear bee.",
+    "May your seeds prosper.",
+    "Sleep tight, hive.",
+];
+
+const VERSION_QUOTES = [
+    "Mostly harmless.",
+    "Pollen-powered.",
+    "Tested on real flowers.",
+    "42 isn't the answer this time.",
+    "Caffeinated by pollen.",
+    "Buzzing along nicely.",
+    "Built with bees in mind.",
+    "Probably more useful than a towel.",
+    "Made in a garden, by friends.",
+    "Compiled by cuddly bees.",
+];
+
+const pick = <T>(pool: readonly T[]): T =>
+    pool[Math.floor(Math.random() * pool.length)] as T;
+
+/**
+ * Resolve a fresh random quote on every property access. Existing call
+ * sites that read `flavor.login` keep working unchanged — they just see a
+ * different pick on each invocation.
+ */
 export const flavor = {
-    login: "Share and Enjoy.",
-    logout: "So long, and thanks for all the pollen.",
-    version: "Mostly harmless.",
+    get login(): string {
+        return pick(LOGIN_QUOTES);
+    },
+    get logout(): string {
+        return pick(LOGOUT_QUOTES);
+    },
+    get version(): string {
+        return pick(VERSION_QUOTES);
+    },
 };

--- a/packages/polli-cli/tsconfig.json
+++ b/packages/polli-cli/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
+    "types": ["node"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Changes Made

### `polli auth login` — branded device flow
- New ASCII flower logo derived from `assets/logo.svg`, baked at 40×20 (one-time offline rasterization via ImageMagick → PBM → `█`/space mapping). Rendered in brand purple `#a78bfa` and printed via a new TTY/JSON-gated `printBanner()` helper.
- Verification URL is now a **clickable hyperlink** (OSC-8) via the new `terminal-link` dependency. Modern terminals (iTerm, kitty, recent VS Code) make it cmd-clickable; older terminals see plain text and degrade gracefully.
- New layout: banner → "Open this URL to approve" → "Confirm the code matches" (security framing — surfacing the device-code's anti-phishing purpose instead of just calling it "Your code") → "Waiting for approval…".
- After successful login, prints a **"Try:" hint** with three example commands so new users have somewhere to go without reading `--help`.

<img width="918" height="553" alt="image" src="https://github.com/user-attachments/assets/cecca6e8-a04e-46f4-86bd-ff855dd2d8f7" />


### `polli auth logout` — quieter, more informative
- Captures the masked key prefix before clearing so the user sees which identity they actually logged out of (handy when juggling multiple accounts).
- Shows the credentials file path (`~/.pollinations/credentials.json`) so they know exactly what got cleared.
- Subtle checkmark + dimmed flavor line; no more shouting "CLEARED!".

### `polli whoami` (and `polli auth status`) — honest balance reporting
- **Bug fix**: the server's `/account/balance` returns the **key's remaining budget** (not the user's account pollen) when the key has a budget set, which device-flow CLI keys do by default. The CLI was mis-labeling that 5 as "pollen" while the user's actual tier balance was ~0.8.
- Now also queries `/account/key` to inspect the key, then labels honestly: `budget:` when the value is the per-key remaining budget (with an explanatory `note` field), `pollen:` when it's the real account total. JSON consumers can detect the difference programmatically via the `note` key.

### `polli whoami` top-level alias
- New top-level `polli whoami` command — alias for `polli auth status`. Reflex command in most CLI ecosystems (`gh whoami` doesn't exist but users try it; `op whoami`, `gcloud auth list`, etc.). Saves new users from digging through `polli auth --help`.

### Local-file image-to-image
- `polli image "make it sunset" --image ./photo.jpg` now works. Local paths are auto-uploaded to `media.pollinations.ai` and the returned public URL is substituted in place before the gen request fires. Mixed URLs+paths in one invocation work too — each entry is resolved independently and order is preserved (i2i providers including the recently shipped Grok-Imagine i2i path care about ordering).
- New `lib/media-upload.ts` helper with friendly framing for the most common error cases: `401` → "Run `polli auth login` or pass --key", `413` → "File too large for media.pollinations.ai (10 MB cap)". Single source of truth so `polli upload` and any future commands can reuse.
- `--image` flag's help text updated to mention local-path support; ditto README example.

### Personality refresh
- `quotes.ts` rewritten to randomize on every access via property getters. Existing call sites unchanged — they just see a different pick per invocation. Pools: 12 login quotes ("The garden is open.", "Buzz buzz. We're listening.", etc.), 11 logout ("Hibernation engaged.", "See you on the next bloom."), 10 version ("Pollen-powered.", "42 isn't the answer this time."). Hitchhiker's-Guide vibe preserved with bee/pollen flavor.

### Plumbing
- `terminal-link@^3.0.0` added to `dependencies`.
- `tsconfig.json` gains `"types": ["node"]` to fix the IDE's "Cannot find name 'process'" diagnostic on files that touch `process.stdin`/`process.stderr`.
- Version bump `0.1.3 → 0.1.4`. README adds a local-file `--image` example.

## Tasks

- [x] ASCII logo from real `assets/logo.svg` + brand-purple banner helper
- [x] Clickable verification URL via `terminal-link` (OSC-8) with graceful fallback
- [x] Login output redesign with security-framed "confirm code" copy
- [x] Post-login "Try:" hint pointing at stable commands
- [x] Logout revamp showing masked previous key and cleared file path
- [x] Fix `whoami` mis-labeling the key's budget as "pollen"; surface the distinction with a `note` field for JSON consumers
- [x] Top-level `polli whoami` alias for `polli auth status`
- [x] Auto-upload local files in `polli image --image <path>` via media.pollinations.ai
- [x] Friendly 401/413 error framing in the upload helper
- [x] Randomize login/logout/version flavor quotes
- [x] Update tsconfig types, bump version, document new behavior in README

## Notes

- **JSON / pipe / non-TTY callers see no decoration** — banner, clickable links, hint, and the new logout layout are all gated through `getOutputMode() === "human"` and `process.stderr.isTTY`. Machine consumers continue to see exactly the structured payloads they saw before.
- **No new direct dependencies in the upload path** — uses Node's built-in `FormData` + `Blob` + `fs.readFileSync`. Engines field already targets Node 20+ which has these natively.
- **Server-side balance fix (separate concern)** — the underlying server behavior where `/account/balance` returns the key's budget instead of the account total when both are set is a UX wart on the API itself, not just the CLI. Fixed honestly in the CLI by labeling the value correctly; the server-side option to mint device-flow keys without a default budget (or to treat `account:usage` as overriding the budget bias) is worth a follow-up.
- **Logo regeneration recipe** is documented in a comment at the top of `lib/branding.ts` so anyone updating the SVG can refresh the ASCII version with a one-liner.
- **Out of scope (next CLI PR)**: interactive `polli chat` REPL, `polli config get|set|unset`, per-model `polli cost`, `polli history`, shell completion, `polli topup`. Each deserves its own scope review.
