### PR TITLE
fix: scan tail for oversized safety input

### DIFF
--- a/gen.pollinations.ai/src/middleware/safety.ts
+++ b/gen.pollinations.ai/src/middleware/safety.ts
@@ -24,7 +24,7 @@ type SafetyContext = Context<Env>;
 type ChatBody = CreateChatCompletionRequest & Record<string, unknown>;
 type ChatMessage = ChatBody["messages"][number];
 const SAFETY_HEADERS_KEY = "safetyHeaders";
-const SAFETY_MAX_TEXT_CHARS = 20_000;
+const SAFETY_MAX_TEXT_CHARS = 50_000;
 const SAFETY_MAX_TEXT_PARTS = 25;
 
 export type SafetyVariables = {
@@ -49,7 +49,7 @@ export async function applySafetyToTexts(
     const features = getRequestFeatures(safeValue);
     if (features.size === 0) return texts;
 
-    const guardrailInputs = getGuardrailInputs(texts);
+    const guardrailInputs = selectGuardrailInputs(texts);
     if (guardrailInputs.length === 0) return texts;
 
     setSafetyHeader(c, "X-Safety-Applied", [...features].join(","));
@@ -102,7 +102,8 @@ export async function applySafetyToTexts(
     for (const [outputIndex, input] of guardrailInputs.entries()) {
         const redacted = response.outputs?.[outputIndex]?.text;
         if (!redacted || redacted === input.text) continue;
-        safeTexts[input.originalIndex] = redacted;
+        safeTexts[input.originalIndex] =
+            texts[input.originalIndex].slice(0, input.offset) + redacted;
         changed = true;
     }
 
@@ -116,34 +117,34 @@ export async function applySafetyToTexts(
     return texts;
 }
 
-function getGuardrailInputs(texts: string[]) {
-    const inputs: { originalIndex: number; text: string }[] = [];
-    let totalChars = 0;
+function selectGuardrailInputs(texts: string[]) {
+    const inputs: { originalIndex: number; text: string; offset: number }[] =
+        [];
+    let remainingChars = SAFETY_MAX_TEXT_CHARS;
+    let remainingParts = SAFETY_MAX_TEXT_PARTS;
 
-    for (const [index, text] of texts.entries()) {
+    // Keep safety to one Bedrock call. For large requests, scan the latest
+    // text window and leave earlier context unchanged.
+    for (
+        let index = texts.length - 1;
+        index >= 0 && remainingChars > 0 && remainingParts > 0;
+        index--
+    ) {
+        const text = texts[index];
         if (!text.trim()) continue;
 
-        totalChars += text.length;
+        const scannedText =
+            text.length > remainingChars ? text.slice(-remainingChars) : text;
         inputs.push({
             originalIndex: index,
-            text,
+            text: scannedText,
+            offset: text.length - scannedText.length,
         });
+        remainingChars -= scannedText.length;
+        remainingParts--;
     }
 
-    if (
-        inputs.length > SAFETY_MAX_TEXT_PARTS ||
-        totalChars > SAFETY_MAX_TEXT_CHARS
-    ) {
-        throw safetyError(400, "input_too_large", {
-            message: "Request too large for safety checking",
-            safety: {
-                maxTextChars: SAFETY_MAX_TEXT_CHARS,
-                maxTextParts: SAFETY_MAX_TEXT_PARTS,
-            },
-        });
-    }
-
-    return inputs;
+    return inputs.reverse();
 }
 
 function resolveSafeValue(

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -54,7 +54,7 @@ const SAFETY_DOCS = [
     '  -d \'{"model":"openai","messages":[{"role":"user","content":"email me at a@example.com"}]}\'',
     "```",
     "",
-    "When safety is on, oversized input returns `400` instead of forwarding unscanned text.",
+    "Large requests check the latest 50,000 text characters, across up to 25 text parts, in one safety call.",
     "",
     'Blocked requests return `400` with `error.type: "safety_error"`. Safety service failures return `503`. Check `X-Safety-Applied`, `X-Safety-Redacted`, and `X-Safety-Status` headers.',
 ].join("\n");

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -232,26 +232,36 @@ describe("applySafety", () => {
         });
     });
 
-    it("fails closed when a safe prompt exceeds the text budget", async () => {
-        const input = `a@example.com ${"safe tail ".repeat(2_500)}`;
+    it("checks the latest text window when a safe prompt exceeds the text budget", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "tail@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
+            },
+            [{ text: "safe tail {EMAIL}" }],
+        );
+
+        const prefix = `a@example.com ${"safe prefix ".repeat(100)}`;
+        const tail = `${"safe tail ".repeat(5_100)}tail@example.com`;
+        const input = `${prefix}${tail}`;
         const response = await safetyApp().request(
             `/scan/${encodeURIComponent(input)}?safe=privacy`,
             undefined,
             configuredEnv,
         );
 
-        expect(response.status).toBe(400);
-        expect(fetchMock).not.toHaveBeenCalled();
-        expect(await response.json()).toMatchObject({
-            error: {
-                type: "safety_error",
-                code: "input_too_large",
-                safety: {
-                    maxTextChars: 20_000,
-                    maxTextParts: 25,
-                },
-            },
-        });
+        expect(response.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(await response.text()).toBe(
+            `${input.slice(0, input.length - 50_000)}safe tail {EMAIL}`,
+        );
     });
 
     it("fails closed when safe is requested but guardrails are not configured", async () => {
@@ -365,7 +375,24 @@ describe("applySafetyToChatRequest", () => {
         });
     });
 
-    it("fails closed when a safe chat request has too many text parts", async () => {
+    it("checks only the latest chat parts when a safe chat request has too many text parts", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "a@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
+            },
+            Array.from({ length: 25 }, (_, index) => ({
+                text: `redacted ${index + 1}`,
+            })),
+        );
+
         const response = await safetyApp().request(
             "/chat",
             {
@@ -385,14 +412,56 @@ describe("applySafetyToChatRequest", () => {
             configuredEnv,
         );
 
-        expect(response.status).toBe(400);
-        expect(fetchMock).not.toHaveBeenCalled();
-        expect(await response.json()).toMatchObject({
-            error: {
-                type: "safety_error",
-                code: "input_too_large",
+        expect(response.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const body = (await response.json()) as {
+            messages: { content: string }[];
+        };
+        expect(body.messages[0].content).toBe("a@example.com");
+        expect(body.messages[1].content).toBe("redacted 1");
+        expect(body.messages[25].content).toBe("redacted 25");
+    });
+
+    it("checks only the latest characters from an oversized chat part", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "tail@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
             },
-        });
+            [{ text: "safe tail {EMAIL}" }],
+        );
+
+        const prefix = `a@example.com ${"safe prefix ".repeat(100)}`;
+        const tail = `${"safe tail ".repeat(5_100)}tail@example.com`;
+        const input = `${prefix}${tail}`;
+        const response = await safetyApp().request(
+            "/chat",
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    model: "openai",
+                    safe: "privacy",
+                    messages: [{ role: "user", content: input }],
+                }),
+            },
+            configuredEnv,
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const body = (await response.json()) as {
+            messages: { content: string }[];
+        };
+        expect(body.messages[0].content).toBe(
+            `${input.slice(0, input.length - 50_000)}safe tail {EMAIL}`,
+        );
     });
 });
 


### PR DESCRIPTION
- Raises the safety scan window to 50,000 text characters
- Keeps safety to one Bedrock Guardrails call by scanning the latest text window instead of failing oversized input
- Documents the large-request window and updates regression tests

Checks:
- `npx biome check --write gen.pollinations.ai/src/middleware/safety.ts gen.pollinations.ai/src/routes/docs.ts gen.pollinations.ai/test/safety.test.ts`
- `npm run typecheck` in `gen.pollinations.ai`
- `npx vitest run test/safety.test.ts test/docs.test.ts` in `gen.pollinations.ai`
- `npm run test` in `gen.pollinations.ai` (22 files / 119 tests)

Note: safety Guardrails cost is not yet tracked per Pollinations request; this PR only changes the safety input window behavior.