### PR TITLE
[codex] fix: reject STT models on TTS endpoints

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -440,6 +440,18 @@ export function isQwenTtsModel(model: string): model is QwenTtsModelName {
     return QWEN_TTS_MODELS.includes(model as QwenTtsModelName);
 }
 
+function requireTextToAudioModel(model: string): void {
+    const definition = getModelDefinition(model);
+    const acceptsText = definition.inputModalities?.includes("text");
+    const returnsAudio = definition.outputModalities?.includes("audio");
+
+    if (acceptsText && returnsAudio) return;
+
+    throw new UpstreamError(400 as ContentfulStatusCode, {
+        message: `Model '${model}' is not supported on text-to-audio endpoints. Use /v1/audio/transcriptions for speech-to-text models.`,
+    });
+}
+
 export async function generateQwenTts(opts: {
     modelName: QwenTtsModelName;
     text: string;
@@ -679,6 +691,8 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
     const query = c.req.valid("query" as never) as SimpleAudioQuery;
     text = await applySafety(c, text, query.safe);
 
+    requireTextToAudioModel(c.var.model.resolved);
+
     const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
         .ELEVENLABS_API_KEY;
 
@@ -789,6 +803,8 @@ export const audioRoutes = new Hono<Env>()
                 "json" as never,
             ) as CreateSpeechRequest;
             const safeInput = await applySafety(c, input, safe);
+            requireTextToAudioModel(c.var.model.resolved);
+
             const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
                 .ELEVENLABS_API_KEY;
 

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -4,7 +4,10 @@ import {
     ELEVENLABS_VOICES,
     resolveElevenLabsVoiceId,
 } from "@shared/registry/audio.ts";
-import { getModelDefinition } from "@shared/registry/registry.ts";
+import {
+    getModelDefinition,
+    type ModelName,
+} from "@shared/registry/registry.ts";
 import {
     buildUsageHeaders,
     createAudioSecondsUsage,
@@ -440,7 +443,7 @@ export function isQwenTtsModel(model: string): model is QwenTtsModelName {
     return QWEN_TTS_MODELS.includes(model as QwenTtsModelName);
 }
 
-function requireTextToAudioModel(model: string): void {
+function requireTextToAudioModel(model: ModelName): void {
     const definition = getModelDefinition(model);
     const acceptsText = definition.inputModalities?.includes("text");
     const returnsAudio = definition.outputModalities?.includes("audio");

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -689,9 +689,8 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
     }
 
     const query = c.req.valid("query" as never) as SimpleAudioQuery;
-    text = await applySafety(c, text, query.safe);
-
     requireTextToAudioModel(c.var.model.resolved);
+    text = await applySafety(c, text, query.safe);
 
     const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
         .ELEVENLABS_API_KEY;
@@ -802,8 +801,8 @@ export const audioRoutes = new Hono<Env>()
             const { input, safe, voice, response_format } = c.req.valid(
                 "json" as never,
             ) as CreateSpeechRequest;
-            const safeInput = await applySafety(c, input, safe);
             requireTextToAudioModel(c.var.model.resolved);
+            const safeInput = await applySafety(c, input, safe);
 
             const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
                 .ELEVENLABS_API_KEY;

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -339,3 +339,61 @@ fixtureTest(
         ).toBe(false);
     },
 );
+
+fixtureTest(
+    "rejects transcription models on OpenAI speech endpoint",
+    async ({ apiKey }) => {
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "universal-2",
+                    input: "Hello",
+                }),
+            }),
+            {
+                ...env,
+                ELEVENLABS_API_KEY: "should-not-be-used",
+            } as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            error: {
+                message:
+                    "Model 'universal-2' is not supported on text-to-audio endpoints. Use /v1/audio/transcriptions for speech-to-text models.",
+            },
+        });
+
+        await waitOnExecutionContext(ctx);
+
+        expect(
+            calls.some((url) => new URL(url).hostname === "api.elevenlabs.io"),
+        ).toBe(false);
+    },
+);


### PR DESCRIPTION
- Rejects audio models that are not text-input/audio-output on `/audio/:text` and `/v1/audio/speech`.
- Returns a clear `400` pointing users to `/v1/audio/transcriptions` for speech-to-text models.
- Prevents `universal-2` and `universal-3-pro` requests on TTS routes from falling through to ElevenLabs quota errors.

Checks:
- `npx biome check --write gen.pollinations.ai/src/routes/audio.ts`
- `npx vitest run test/index.test.ts`