### PR TITLE
fix: align key modal blue styling

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/account-permissions-input.tsx
@@ -76,7 +76,7 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
     allowedModels,
     onModelsChange,
     visiblePermissions,
-    theme = "green",
+    theme = "blue",
     showApiName = true,
     modelsInitiallyExpanded = false,
 }) => {
@@ -330,7 +330,7 @@ const ModelCategory: FC<{
     toggleCategory,
     isCategoryAllSelected,
     showApiName = true,
-    theme = "green",
+    theme = "blue",
 }) => (
     <div>
         <div className="flex items-center justify-between mb-1">

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -18,7 +18,6 @@ type ApiKeyDialogProps = {
     onSubmit: (state: CreateApiKey) => Promise<CreateApiKeyResponse>;
     onComplete: () => void;
     triggerLabel?: string;
-    triggerColor?: "blue" | "green" | "purple" | "amber";
     triggerClassName?: string;
     /** Simplified mode: hides key type selector, permissions, budget, expiry. Shows only name + URL. */
     simplified?: boolean;
@@ -28,7 +27,6 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
     onSubmit,
     onComplete,
     triggerLabel = "Create new key",
-    triggerColor = "blue",
     triggerClassName,
     simplified = false,
 }) => {
@@ -124,18 +122,11 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
             isSubmitting ||
             noModelsSelected ||
             isMissingRedirectUris);
-    const keyTypeStyles =
-        keyType === "publishable"
-            ? {
-                  editableInputClasses:
-                      "border-blue-300 focus:outline-none focus-visible:border-blue-500 focus-visible:ring-1 focus-visible:ring-blue-500/60",
-                  readOnlyInputClasses: "border-blue-300 bg-blue-100",
-              }
-            : {
-                  editableInputClasses:
-                      "border-violet-300 focus:outline-none focus-visible:border-violet-500 focus-visible:ring-1 focus-visible:ring-violet-500/60",
-                  readOnlyInputClasses: "border-violet-300 bg-violet-100",
-              };
+    const keyInputStyles = {
+        editableInputClasses:
+            "border-blue-200 bg-blue-50 focus:outline-none focus-visible:border-blue-300 focus-visible:ring-1 focus-visible:ring-blue-200",
+        readOnlyInputClasses: "border-blue-200 bg-blue-50",
+    };
 
     function getButtonText(): string {
         if (copied) return "Copied! Closing...";
@@ -155,6 +146,7 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
         <Button
             type={createdKey ? "button" : "submit"}
             onClick={createdKey ? handleCopyAndClose : undefined}
+            color="blue"
             className="disabled:opacity-50"
             disabled={isCreateDisabled}
         >
@@ -190,19 +182,19 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
             >
                 <Button
                     as="div"
-                    color={triggerColor}
+                    color="blue"
                     weight="light"
                     className="shrink-0 whitespace-nowrap"
                 >
                     {triggerLabel}
                 </Button>
             </Dialog.Trigger>
-            <Dialog.Backdrop className="fixed inset-0 z-[100] bg-green-950/50" />
+            <Dialog.Backdrop className="fixed inset-0 z-[100] bg-gray-950/50" />
             <Dialog.Positioner className="fixed inset-0 z-[110] flex h-dvh items-start justify-center overflow-hidden p-4">
                 <Dialog.Content
                     className={cn(
                         "my-auto flex max-h-[calc(100dvh-2rem)] w-full max-w-2xl flex-col overflow-hidden rounded-lg border-4 shadow-lg",
-                        "bg-white border-green-950",
+                        "border-blue-300 bg-white",
                     )}
                 >
                     <div className="shrink-0 p-6 pb-4">
@@ -217,7 +209,7 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                         href="https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md"
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="text-green-700 underline hover:text-green-900"
+                                        className="text-blue-700 underline hover:text-blue-900"
                                     >
                                         BYOP
                                     </a>
@@ -259,8 +251,8 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                     className={cn(
                                         "flex-1 px-3 py-2 border rounded-lg",
                                         createdKey
-                                            ? `${keyTypeStyles.readOnlyInputClasses} font-mono text-xs`
-                                            : keyTypeStyles.editableInputClasses,
+                                            ? `${keyInputStyles.readOnlyInputClasses} font-mono text-xs`
+                                            : keyInputStyles.editableInputClasses,
                                     )}
                                     placeholder={
                                         createdKey ? "" : "Enter API key name"
@@ -321,7 +313,6 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                     value={keyPermissions}
                                     disabled={isSubmitting}
                                     inline
-                                    theme="violet"
                                 />
                             )}
                         </div>
@@ -330,7 +321,8 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                             {!createdKey && (
                                 <Button
                                     type="button"
-                                    weight="outline"
+                                    color="red"
+                                    weight="light"
                                     onClick={() => setIsOpen(false)}
                                     className="disabled:opacity-50"
                                     disabled={isSubmitting}

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -189,7 +189,6 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                 onSubmit={onCreate}
                                 onComplete={() => {}}
                                 triggerLabel="🔑 + API Key"
-                                triggerColor="blue"
                             />
                         </div>
                         {!sortedApiKeys.length && (
@@ -229,7 +228,6 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                 onSubmit={onCreate}
                                 onComplete={() => {}}
                                 triggerLabel="🖥️ + Add App"
-                                triggerColor="blue"
                                 simplified
                             />
                         </div>

--- a/enter.pollinations.ai/src/client/components/api-keys/delete-confirmation.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/delete-confirmation.tsx
@@ -17,9 +17,9 @@ export const DeleteConfirmation: FC<DeleteConfirmationProps> = ({
         open={!!deleteId}
         onOpenChange={({ open }) => !open && onCancel()}
     >
-        <Dialog.Backdrop className="fixed inset-0 bg-green-950/50 z-[100]" />
+        <Dialog.Backdrop className="fixed inset-0 z-[100] bg-gray-950/50" />
         <Dialog.Positioner className="fixed inset-0 flex items-center justify-center p-4 z-[100]">
-            <Dialog.Content className="bg-green-100 border-green-950 border-4 rounded-lg shadow-lg max-w-md w-full p-6">
+            <Dialog.Content className="w-full max-w-md rounded-lg border-4 border-blue-300 bg-white p-6 shadow-lg">
                 <Dialog.Title className="text-lg font-semibold mb-4">
                     Delete API Key
                 </Dialog.Title>
@@ -28,7 +28,12 @@ export const DeleteConfirmation: FC<DeleteConfirmationProps> = ({
                     cannot be undone.
                 </p>
                 <div className="flex gap-2 justify-end">
-                    <Button type="button" weight="outline" onClick={onCancel}>
+                    <Button
+                        type="button"
+                        color="red"
+                        weight="light"
+                        onClick={onCancel}
+                    >
                         Cancel
                     </Button>
                     <Button

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -130,12 +130,12 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
 
     return (
         <Dialog.Root open onOpenChange={({ open }) => !open && onClose()}>
-            <Dialog.Backdrop className="fixed inset-0 z-[100] bg-green-950/50" />
+            <Dialog.Backdrop className="fixed inset-0 z-[100] bg-gray-950/50" />
             <Dialog.Positioner className="fixed inset-0 z-[110] flex h-dvh items-start justify-center overflow-hidden p-4">
                 <Dialog.Content
                     className={cn(
                         "my-auto flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-lg border-4 shadow-lg",
-                        "bg-green-100 border-green-950",
+                        "border-blue-300 bg-white",
                     )}
                 >
                     <div className="shrink-0 p-6 pb-4">
@@ -165,7 +165,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                                         className={cn(
                                             "font-mono text-sm cursor-pointer transition-all",
                                             copied
-                                                ? "text-green-600 font-semibold"
+                                                ? "text-blue-700 font-semibold"
                                                 : "text-blue-600 hover:text-blue-800 hover:underline",
                                         )}
                                     >
@@ -200,7 +200,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                                     type="text"
                                     value={name}
                                     onChange={(e) => setName(e.target.value)}
-                                    className="flex-1"
+                                    className="flex-1 border-blue-200 bg-blue-50 focus-visible:border-blue-300 focus-visible:ring-blue-200"
                                     placeholder="Enter API key name"
                                     disabled={isSubmitting}
                                 />
@@ -227,7 +227,8 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                     <div className="flex gap-2 justify-end p-6 pt-4 shrink-0">
                         <Button
                             type="button"
-                            weight="outline"
+                            color="red"
+                            weight="light"
                             onClick={onClose}
                             disabled={isSubmitting}
                         >
@@ -235,6 +236,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                         </Button>
                         <Button
                             type="button"
+                            color="blue"
                             onClick={handleSave}
                             disabled={isSubmitting}
                         >

--- a/enter.pollinations.ai/src/client/components/api-keys/expiry-days-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/expiry-days-input.tsx
@@ -26,7 +26,7 @@ export const ExpiryDaysInput: FC<ExpiryDaysInputProps> = ({
     onChange,
     disabled = false,
     inline = false,
-    theme = "green",
+    theme = "blue",
 }) => {
     const {
         input: { classes: inputClasses },

--- a/enter.pollinations.ai/src/client/components/api-keys/key-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/key-permissions.tsx
@@ -2,7 +2,6 @@ import type { FC } from "react";
 import { useState } from "react";
 import { AccountPermissionsInput } from "./account-permissions-input.tsx";
 import { ExpiryDaysInput } from "./expiry-days-input.tsx";
-import type { PermissionUiTheme } from "./permission-ui.ts";
 import { PollenBudgetInput } from "./pollen-budget-input.tsx";
 
 export interface KeyPermissions {
@@ -42,7 +41,6 @@ interface KeyPermissionsInputsProps {
     value: ReturnType<typeof useKeyPermissions>;
     disabled?: boolean;
     inline?: boolean;
-    theme?: PermissionUiTheme;
     modelsInitiallyExpanded?: boolean;
 }
 
@@ -53,7 +51,6 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
     value,
     disabled = false,
     inline = false,
-    theme = "green",
     modelsInitiallyExpanded = false,
 }) => {
     const {
@@ -72,14 +69,12 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
                 onChange={setPollenBudget}
                 disabled={disabled}
                 inline={inline}
-                theme={theme}
             />
             <ExpiryDaysInput
                 value={permissions.expiryDays}
                 onChange={setExpiryDays}
                 disabled={disabled}
                 inline={inline}
-                theme={theme}
             />
             <hr className="border-gray-200" />
             <AccountPermissionsInput
@@ -88,7 +83,6 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
                 disabled={disabled}
                 allowedModels={permissions.allowedModels}
                 onModelsChange={setAllowedModels}
-                theme={theme}
                 modelsInitiallyExpanded={modelsInitiallyExpanded}
             />
         </div>

--- a/enter.pollinations.ai/src/client/components/api-keys/permission-ui.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/permission-ui.ts
@@ -1,17 +1,15 @@
-export type PermissionUiTheme = "green" | "amber" | "blue" | "violet";
-export type PermissionInfoTone = "pink" | "amber" | "blue" | "violet";
+export type PermissionUiTheme = "amber" | "blue";
+export type PermissionInfoTone = "amber" | "blue";
 
 type PermissionUiFrameConfig = {
     selectedClasses: string;
     selectedHoverClasses: string;
     rowHoverClasses: string;
     focusRingClasses: string;
-    modelHoverClasses: string;
 };
 
 type PermissionUiAccentConfig = {
     actionTextClasses: string;
-    badgeColor: "green" | "amber" | "blue" | "violet";
     tipTone: PermissionInfoTone;
 };
 
@@ -27,26 +25,6 @@ type PermissionUiThemeConfig = {
 
 const PERMISSION_UI_THEMES: Record<PermissionUiTheme, PermissionUiThemeConfig> =
     {
-        green: {
-            row: {
-                selectedClasses: "border-green-400 bg-green-50",
-                selectedHoverClasses:
-                    "hover:bg-green-100 hover:border-green-500",
-                rowHoverClasses: "hover:bg-green-50 hover:border-green-300",
-                focusRingClasses:
-                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-500/60",
-                modelHoverClasses:
-                    "hover:bg-green-50 hover:text-gray-800 hover:border-green-300",
-            },
-            accent: {
-                actionTextClasses: "text-green-800 hover:text-green-950",
-                badgeColor: "green",
-                tipTone: "pink",
-            },
-            input: {
-                classes: "",
-            },
-        },
         amber: {
             row: {
                 selectedClasses: "border-amber-400 bg-amber-100",
@@ -55,12 +33,9 @@ const PERMISSION_UI_THEMES: Record<PermissionUiTheme, PermissionUiThemeConfig> =
                 rowHoverClasses: "hover:bg-amber-50 hover:border-amber-300",
                 focusRingClasses:
                     "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-500/60",
-                modelHoverClasses:
-                    "hover:bg-amber-50 hover:text-gray-800 hover:border-amber-300",
             },
             accent: {
                 actionTextClasses: "text-amber-800 hover:text-amber-950",
-                badgeColor: "amber",
                 tipTone: "amber",
             },
             input: {
@@ -75,38 +50,14 @@ const PERMISSION_UI_THEMES: Record<PermissionUiTheme, PermissionUiThemeConfig> =
                 rowHoverClasses: "hover:bg-blue-50 hover:border-blue-300",
                 focusRingClasses:
                     "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500/60",
-                modelHoverClasses:
-                    "hover:bg-blue-50 hover:text-gray-800 hover:border-blue-300",
             },
             accent: {
                 actionTextClasses: "text-blue-800 hover:text-blue-950",
-                badgeColor: "blue",
                 tipTone: "blue",
             },
             input: {
                 classes:
-                    "bg-blue-50 border-blue-300 focus-visible:border-blue-400 focus-visible:ring-blue-500/60",
-            },
-        },
-        violet: {
-            row: {
-                selectedClasses: "border-violet-300 bg-violet-100",
-                selectedHoverClasses:
-                    "hover:bg-violet-200 hover:border-violet-400",
-                rowHoverClasses: "hover:bg-violet-50 hover:border-violet-300",
-                focusRingClasses:
-                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-violet-500/60",
-                modelHoverClasses:
-                    "hover:bg-violet-50 hover:text-gray-800 hover:border-violet-300",
-            },
-            accent: {
-                actionTextClasses: "text-violet-800 hover:text-violet-950",
-                badgeColor: "violet",
-                tipTone: "violet",
-            },
-            input: {
-                classes:
-                    "bg-violet-50 border-violet-300 focus-visible:border-violet-400 focus-visible:ring-violet-500/60",
+                    "bg-blue-50 border-blue-200 focus-visible:border-blue-300 focus-visible:ring-blue-200",
             },
         },
     };
@@ -116,16 +67,22 @@ const PERMISSION_CATEGORY_PILLS = {
     image: "bg-pink-200 text-pink-900 border-pink-400",
     video: "bg-teal-200 text-teal-900 border-teal-400",
     audio: "bg-violet-200 text-violet-900 border-violet-400",
+    embedding: "bg-indigo-200 text-indigo-900 border-indigo-400",
 } as const;
 
 export function getPermissionUiTheme(
-    theme: PermissionUiTheme,
+    theme: PermissionUiTheme = "blue",
 ): PermissionUiThemeConfig {
     return PERMISSION_UI_THEMES[theme];
 }
 
 export function getPermissionPillClasses(category: string): string {
-    const normalized = category.toLowerCase() === "images" ? "image" : category;
+    const normalized =
+        category.toLowerCase() === "images"
+            ? "image"
+            : category.toLowerCase() === "embeddings"
+              ? "embedding"
+              : category;
     return (
         PERMISSION_CATEGORY_PILLS[
             normalized.toLowerCase() as keyof typeof PERMISSION_CATEGORY_PILLS

--- a/enter.pollinations.ai/src/client/components/api-keys/pollen-budget-input.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/pollen-budget-input.tsx
@@ -26,7 +26,7 @@ export const PollenBudgetInput: FC<PollenBudgetInputProps> = ({
     onChange,
     disabled = false,
     inline = false,
-    theme = "green",
+    theme = "blue",
 }) => {
     const {
         input: { classes: inputClasses },

--- a/enter.pollinations.ai/src/client/components/api-keys/publishable-key-settings.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/publishable-key-settings.tsx
@@ -57,13 +57,14 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
                         type="text"
                         value={uri}
                         onChange={(e) => update(index, e.target.value)}
-                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-600"
+                        className="flex-1 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-200"
                         placeholder="https://myapp.com/auth/callback"
                         disabled={disabled}
                     />
                     {rows.length > 1 && (
                         <Button
                             type="button"
+                            color="blue"
                             weight="outline"
                             onClick={() => remove(index)}
                             disabled={disabled}
@@ -76,7 +77,8 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
             <div>
                 <Button
                     type="button"
-                    weight="outline"
+                    color="blue"
+                    weight="light"
                     onClick={add}
                     disabled={disabled}
                 >

--- a/enter.pollinations.ai/src/client/components/layout/dashboard-theme.ts
+++ b/enter.pollinations.ai/src/client/components/layout/dashboard-theme.ts
@@ -67,9 +67,10 @@ export const buttonColors = {
             "border-2 border-amber-500 text-amber-900 hover:bg-amber-500 hover:text-white transition-colors",
     },
     blue: {
-        light: "bg-blue-200 text-blue-900",
-        strong: "bg-blue-900 text-blue-50",
-        outline: "border-2 border-blue-900 text-blue-900",
+        light: "bg-blue-200 text-blue-900 hover:bg-blue-300 transition-colors",
+        strong: "bg-blue-200 text-blue-900 hover:bg-blue-300 transition-colors",
+        outline:
+            "border-2 border-blue-300 text-blue-900 hover:bg-blue-100 hover:border-blue-400 transition-colors",
     },
     dark: {
         light: "bg-gray-200 text-gray-900 hover:bg-gray-300",


### PR DESCRIPTION
- Aligns key create/edit/delete dialogs with the Keys tab blue palette.
- Removes the violet/green permission theme path from key dialogs while preserving amber for authorize.
- Uses neutral modal backdrops and softer blue input/focus states.
- Uses filled soft-blue add actions and light-red cancel actions.

Checks:
- `npx biome check --write ...`
- `npm run typecheck`