### PR TITLE
refactor(image): fetchUpstream helper + propagate upstreamUrl in errors

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -557,7 +557,7 @@ const callGPTImageWithEndpoint = async (
             config.provider === "azure" && response.status === 403
                 ? 502
                 : response.status;
-        throw new HttpError(errorText, status);
+        throw new HttpError(errorText, status, undefined, endpoint);
     }
 
     const data = (await response.json()) as {

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -166,12 +166,22 @@ function mediaHeaders(
     return headers;
 }
 
+function safeUpstreamUrl(value: string | undefined): URL | undefined {
+    if (!value) return undefined;
+    try {
+        return new URL(value);
+    } catch {
+        return undefined;
+    }
+}
+
 function throwImageError(error: unknown, c: ImageContext): never {
     if (error instanceof UpstreamError) throw error;
     if (error instanceof HttpError) {
         throw new UpstreamError(error.status as ContentfulStatusCode, {
             message: error.message,
-            requestUrl: new URL(c.req.url),
+            requestUrl:
+                safeUpstreamUrl(error.upstreamUrl) ?? new URL(c.req.url),
             upstreamStatus: error.status,
             responseBody: JSON.stringify(error.details || {}),
             cause: error,

--- a/gen.pollinations.ai/src/image/httpError.ts
+++ b/gen.pollinations.ai/src/image/httpError.ts
@@ -1,17 +1,30 @@
 /**
- * Custom HTTP error class with status code
- * Simple error class that adds a status property to Error
- * for passing HTTP status codes through the error chain
+ * Custom HTTP error class with status code.
+ *
+ * Adds a status code and optional details/upstream URL to Error for passing
+ * HTTP status codes through the error chain. `upstreamUrl` is the URL of the
+ * upstream backend that produced the error (e.g. an LTX-2 enqueue endpoint),
+ * threaded through to UpstreamError.requestUrl in the error envelope so
+ * `upstreamHost` reflects the actual backend rather than the gen.pollinations.ai
+ * request URL. Callers must not pass URLs that include credentials in query
+ * strings; this codebase auths via headers, not query strings.
  */
 export class HttpError extends Error {
     status: number;
     details?: any;
+    upstreamUrl?: string;
 
-    constructor(message: string, status: number = 500, details?: any) {
+    constructor(
+        message: string,
+        status: number = 500,
+        details?: any,
+        upstreamUrl?: string,
+    ) {
         super(message);
         this.name = "HttpError";
         this.status = status;
         this.details = details;
+        this.upstreamUrl = upstreamUrl;
 
         // Maintains proper stack trace for where our error was thrown (only available on V8)
         Error.captureStackTrace(this, HttpError);

--- a/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
+++ b/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
@@ -206,7 +206,7 @@ export async function callAzureFluxKontext(
 
     if (!response.ok) {
         const errorText = await response.text();
-        throw new HttpError(errorText, response.status);
+        throw new HttpError(errorText, response.status, undefined, endpoint);
     }
 
     const data = (await response.json()) as {
@@ -219,7 +219,12 @@ export async function callAzureFluxKontext(
     };
 
     if (!data.data || !data.data[0] || !data.data[0].b64_json) {
-        throw new Error("Invalid response from Azure Flux Kontext API");
+        throw new HttpError(
+            "Invalid response from Azure Flux Kontext API",
+            500,
+            undefined,
+            endpoint,
+        );
     }
 
     // Convert base64 to buffer

--- a/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
+++ b/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
@@ -4,6 +4,7 @@ import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { base64ToBuffer, downloadUserImage } from "../utils/imageDownload.ts";
 
 const logOps = debug("pollinations:flux-klein:ops");
@@ -83,31 +84,24 @@ export const callFluxKleinAPI = async (
             headers["x-backend-token"] = backendToken;
         }
 
-        const response = await fetch(getKleinGenerateUrl(), {
+        const kleinUrl = getKleinGenerateUrl();
+        const response = await fetchUpstream(kleinUrl, {
             method: "POST",
             headers,
             body: JSON.stringify(body),
+            errorLabel: "Klein API request failed",
         });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            logError(
-                "Klein API failed, status:",
-                response.status,
-                "response:",
-                errorText,
-            );
-            throw new HttpError(
-                `Klein API request failed: ${errorText}`,
-                response.status,
-            );
-        }
 
         const result = await response.json();
         const item = Array.isArray(result) ? result[0] : result;
 
         if (!item?.image) {
-            throw new Error("Klein API returned no image");
+            throw new HttpError(
+                "Klein API returned no image",
+                500,
+                undefined,
+                kleinUrl,
+            );
         }
 
         const imageBuffer = base64ToBuffer(item.image);

--- a/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
@@ -4,6 +4,7 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import type { VideoGenerationResult } from "./veoVideoModel.ts";
 
 // Logger
@@ -108,27 +109,25 @@ async function enqueueLtx2Job(
 
     logOps("Enqueuing LTX-2 job:", requestBody);
 
-    const response = await fetch(`${getLtx2BaseUrl()}/enqueue`, {
+    const enqueueUrl = `${getLtx2BaseUrl()}/enqueue`;
+    const response = await fetchUpstream(enqueueUrl, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
             ...backendHeaders(),
         },
         body: JSON.stringify(requestBody),
+        errorLabel: "Failed to enqueue video generation",
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError("Enqueue failed:", response.status, errorText);
-        throw new HttpError(
-            `Failed to enqueue video generation: ${errorText}`,
-            response.status,
-        );
-    }
 
     const data = (await response.json()) as { prompt_id?: string };
     if (!data.prompt_id) {
-        throw new HttpError("No prompt_id returned from enqueue", 500);
+        throw new HttpError(
+            "No prompt_id returned from enqueue",
+            500,
+            undefined,
+            enqueueUrl,
+        );
     }
 
     logOps("Job enqueued with prompt_id:", data.prompt_id);
@@ -181,6 +180,8 @@ async function pollLtx2Status(
                 throw new HttpError(
                     `Video generation failed: ${data.error || "Unknown error"}`,
                     500,
+                    undefined,
+                    statusUrl,
                 );
             }
         } catch (error) {
@@ -196,6 +197,8 @@ async function pollLtx2Status(
     throw new HttpError(
         `Video generation timed out after ${DEFAULT_TIMEOUT_SECS} seconds`,
         504,
+        undefined,
+        statusUrl,
     );
 }
 
@@ -221,7 +224,12 @@ async function fetchLtx2Result(promptId: string): Promise<Buffer> {
     }
 
     if (!response) {
-        throw new HttpError("Failed to fetch video result: no response", 502);
+        throw new HttpError(
+            "Failed to fetch video result: no response",
+            502,
+            undefined,
+            resultUrl,
+        );
     }
 
     if (!response.ok) {
@@ -229,6 +237,8 @@ async function fetchLtx2Result(promptId: string): Promise<Buffer> {
             throw new HttpError(
                 "Video result still not ready after retries",
                 504,
+                undefined,
+                resultUrl,
             );
         }
         const errorText = await response.text();
@@ -236,6 +246,8 @@ async function fetchLtx2Result(promptId: string): Promise<Buffer> {
         throw new HttpError(
             `Failed to fetch video result: ${errorText}`,
             response.status,
+            undefined,
+            resultUrl,
         );
     }
 

--- a/gen.pollinations.ai/src/image/models/prunaModel.ts
+++ b/gen.pollinations.ai/src/image/models/prunaModel.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { base64ToBuffer, bufferToUint8Array } from "../utils/imageDownload.ts";
 
 import type { VideoGenerationResult } from "./veoVideoModel.ts";
@@ -87,7 +88,7 @@ async function submitPrediction(
 
     logOps(`Submitting ${model} prediction:`, JSON.stringify(input, null, 2));
 
-    const response = await fetch(PREDICTIONS_URL, {
+    const response = await fetchUpstream(PREDICTIONS_URL, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -95,16 +96,8 @@ async function submitPrediction(
             "Model": model,
         },
         body: JSON.stringify({ input }),
+        errorLabel: "Pruna API request failed",
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError(`Pruna API submit failed (${response.status}):`, errorText);
-        throw new HttpError(
-            `Pruna API request failed: ${errorText}`,
-            response.status,
-        );
-    }
 
     return (await response.json()) as PrunaPredictionResponse;
 }
@@ -137,19 +130,12 @@ async function uploadImageToPruna(imageData: string): Promise<string> {
     const formData = new FormData();
     formData.append("content", blob, `image.${ext}`);
 
-    const response = await fetch(FILES_URL, {
+    const response = await fetchUpstream(FILES_URL, {
         method: "POST",
         headers: { apikey: apiKey },
         body: formData,
+        errorLabel: "Pruna file upload failed",
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        throw new HttpError(
-            `Pruna file upload failed: ${errorText}`,
-            response.status,
-        );
-    }
 
     const result = (await response.json()) as { urls: { get: string } };
     logOps("Uploaded image to Pruna:", result.urls.get);
@@ -194,6 +180,8 @@ async function pollPrediction(
                 throw new HttpError(
                     `Pruna poll failed: ${errorText}`,
                     response.status,
+                    undefined,
+                    statusUrl,
                 );
             }
             await sleep(POLL_DELAY_MS);
@@ -209,6 +197,8 @@ async function pollPrediction(
                     throw new HttpError(
                         "Pruna succeeded but no generation_url",
                         500,
+                        undefined,
+                        statusUrl,
                     );
                 }
                 return data.generation_url;
@@ -217,6 +207,8 @@ async function pollPrediction(
                 throw new HttpError(
                     `Pruna generation failed: ${data.error || data.message || "unknown error"}`,
                     500,
+                    undefined,
+                    statusUrl,
                 );
 
             case "starting":
@@ -227,7 +219,12 @@ async function pollPrediction(
         await sleep(POLL_DELAY_MS);
     }
 
-    throw new HttpError("Pruna generation timed out", 504);
+    throw new HttpError(
+        "Pruna generation timed out",
+        504,
+        undefined,
+        statusUrl,
+    );
 }
 
 /**
@@ -236,17 +233,11 @@ async function pollPrediction(
 async function downloadResult(deliveryUrl: string): Promise<Buffer> {
     const apiKey = getImageEnv("PRUNA_API_KEY");
 
-    const response = await fetch(deliveryUrl, {
+    const response = await fetchUpstream(deliveryUrl, {
         method: "GET",
         headers: apiKey ? { "apikey": apiKey } : {},
+        errorLabel: "Pruna delivery download failed",
     });
-
-    if (!response.ok) {
-        throw new HttpError(
-            `Pruna delivery download failed: ${response.status}`,
-            response.status,
-        );
-    }
 
     return Buffer.from(await response.arrayBuffer());
 }

--- a/gen.pollinations.ai/src/image/models/qwenImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/qwenImageModel.ts
@@ -4,6 +4,7 @@ import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 
 const logOps = debug("pollinations:qwen-image:ops");
@@ -240,23 +241,15 @@ async function callDashScopeImageAPI(
     });
     logOps("DashScope image request:", safeBody);
 
-    const response = await fetch(DASHSCOPE_API_BASE, {
+    const response = await fetchUpstream(DASHSCOPE_API_BASE, {
         method: "POST",
         headers: {
             Authorization: `Bearer ${apiKey}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
+        errorLabel: "DashScope image API failed",
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError("DashScope image API failed:", response.status, errorText);
-        throw new HttpError(
-            `DashScope image API failed: ${errorText}`,
-            response.status,
-        );
-    }
 
     const data: QwenImageResponse = await response.json();
 
@@ -264,25 +257,27 @@ async function callDashScopeImageAPI(
         throw new HttpError(
             `DashScope image error: ${data.message || data.code}`,
             400,
+            undefined,
+            DASHSCOPE_API_BASE,
         );
     }
 
     const imageUrl = data.output?.choices?.[0]?.message?.content?.[0]?.image;
     if (!imageUrl) {
-        throw new HttpError("No image URL in DashScope response", 500);
+        throw new HttpError(
+            "No image URL in DashScope response",
+            500,
+            undefined,
+            DASHSCOPE_API_BASE,
+        );
     }
 
     logOps("Image generated, downloading from:", imageUrl);
     progress.updateBar(requestId, 80, "Processing", "Downloading image...");
 
-    const imageResponse = await fetch(imageUrl);
-    if (!imageResponse.ok) {
-        throw new HttpError(
-            `Failed to download generated image: ${imageResponse.status}`,
-            500,
-        );
-    }
-
+    const imageResponse = await fetchUpstream(imageUrl, {
+        errorLabel: "Failed to download generated image",
+    });
     const buffer = Buffer.from(await imageResponse.arrayBuffer());
     logOps(`Image downloaded, size: ${(buffer.length / 1024).toFixed(1)} KB`);
     progress.updateBar(requestId, 95, "Success", "Image generation completed");

--- a/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 import { calculateVideoResolution } from "../utils/videoResolution.ts";
 
@@ -210,27 +211,15 @@ async function generateSeedanceVideo(
 
     const generateEndpoint =
         "https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks";
-    const generateResponse = await fetch(generateEndpoint, {
+    const generateResponse = await fetchUpstream(generateEndpoint, {
         method: "POST",
         headers: {
             "Authorization": `Bearer ${apiKey}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
+        errorLabel: `${config.displayName} API request failed`,
     });
-
-    if (!generateResponse.ok) {
-        const errorText = await generateResponse.text();
-        logError(
-            `${config.displayName} API failed:`,
-            generateResponse.status,
-            errorText,
-        );
-        throw new HttpError(
-            `${config.displayName} API request failed: ${errorText}`,
-            generateResponse.status,
-        );
-    }
 
     const generateData: SeedanceTaskResponse = await generateResponse.json();
     logOps("Generate response:", JSON.stringify(generateData, null, 2));
@@ -240,6 +229,8 @@ async function generateSeedanceVideo(
         throw new HttpError(
             `${config.displayName} API did not return task ID`,
             500,
+            undefined,
+            generateEndpoint,
         );
     }
 
@@ -367,7 +358,12 @@ async function pollSeedanceTask(
             const videoUrl = pollData.content?.video_url;
 
             if (!videoUrl) {
-                throw new HttpError("No video URL in completed response", 500);
+                throw new HttpError(
+                    "No video URL in completed response",
+                    500,
+                    undefined,
+                    pollUrl,
+                );
             }
 
             logOps("Video URL:", videoUrl);
@@ -380,14 +376,9 @@ async function pollSeedanceTask(
                 "Downloading video...",
             );
 
-            const videoResponse = await fetch(videoUrl);
-
-            if (!videoResponse.ok) {
-                throw new HttpError(
-                    `Failed to download video: ${videoResponse.status}`,
-                    500,
-                );
-            }
+            const videoResponse = await fetchUpstream(videoUrl, {
+                errorLabel: "Failed to download video",
+            });
 
             const buffer = Buffer.from(await videoResponse.arrayBuffer());
             logOps(
@@ -410,7 +401,7 @@ async function pollSeedanceTask(
             const errorMsg =
                 pollData.error?.message || "Video generation failed";
             logError("Seedance generation error:", pollData.error);
-            throw new HttpError(errorMsg, 500);
+            throw new HttpError(errorMsg, 500, undefined, pollUrl);
         }
 
         // Status is still pending/queued/generating - wait and try again
@@ -419,5 +410,10 @@ async function pollSeedanceTask(
         delayMs = Math.min(delayMs * 1.1, 5000);
     }
 
-    throw new HttpError("Video generation timed out after 4 minutes", 504);
+    throw new HttpError(
+        "Video generation timed out after 4 minutes",
+        504,
+        undefined,
+        pollUrl,
+    );
 }

--- a/gen.pollinations.ai/src/image/models/seedreamModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedreamModel.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../httpError.ts";
 import { getScaledDimensions } from "../models.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 
 // Logger
@@ -279,40 +280,29 @@ async function generateWithSeedream(
     logOps("Seedream API request body:", JSON.stringify(requestBody, null, 2));
 
     // Make API call
-    const response = await fetch(
-        "https://ark.ap-southeast.bytepluses.com/api/v3/images/generations",
-        {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify(requestBody),
+    const seedreamUrl =
+        "https://ark.ap-southeast.bytepluses.com/api/v3/images/generations";
+    // Pass through the original status code from Seedream API
+    // 400 errors are client errors (invalid parameters, content policy, etc.)
+    const response = await fetchUpstream(seedreamUrl, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${apiKey}`,
         },
-    );
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError(
-            `Seedream API request failed, status:`,
-            response.status,
-            "response:",
-            errorText,
-        );
-        // Pass through the original status code from Seedream API
-        // 400 errors are client errors (invalid parameters, content policy, etc.)
-        throw new HttpError(
-            `Seedream API request failed: ${errorText}`,
-            response.status,
-        );
-    }
+        body: JSON.stringify(requestBody),
+        errorLabel: "Seedream API request failed",
+    });
 
     const data = (await response.json()) as SeedreamResponse;
     logOps("Seedream API response:", JSON.stringify(data, null, 2));
 
     if (!data.data || !data.data[0] || !data.data[0].url) {
-        throw new Error(
+        throw new HttpError(
             "Invalid response from Seedream API - no image URL received",
+            500,
+            undefined,
+            seedreamUrl,
         );
     }
 
@@ -327,14 +317,9 @@ async function generateWithSeedream(
     const imageUrl = data.data[0].url;
     logOps("Downloading image from URL:", imageUrl);
 
-    const imageResponse = await fetch(imageUrl);
-
-    if (!imageResponse.ok) {
-        throw new Error(
-            `Failed to download image: ${imageResponse.status} ${imageResponse.statusText}`,
-        );
-    }
-
+    const imageResponse = await fetchUpstream(imageUrl, {
+        errorLabel: "Failed to download image",
+    });
     const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
     logOps("Downloaded image, buffer size:", imageBuffer.length);
 

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 import { calculateVideoResolution } from "../utils/videoResolution.ts";
 
@@ -223,33 +224,26 @@ export const callVeoAPI = async (
     const generateEndpoint = `https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/publishers/google/models/${MODEL_ID}:predictLongRunning`;
     logOps("Generate endpoint:", generateEndpoint);
 
-    const generateResponse = await fetch(generateEndpoint, {
+    const generateResponse = await fetchUpstream(generateEndpoint, {
         method: "POST",
         headers: {
             "Authorization": `Bearer ${accessToken}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
+        errorLabel: "Veo API request failed",
     });
-
-    if (!generateResponse.ok) {
-        const errorText = await generateResponse.text();
-        logError(
-            "Veo API generate request failed:",
-            generateResponse.status,
-            errorText,
-        );
-        throw new HttpError(
-            `Veo API request failed: ${errorText}`,
-            generateResponse.status,
-        );
-    }
 
     const generateData: VeoOperationResponse = await generateResponse.json();
     logOps("Generate response:", JSON.stringify(generateData, null, 2));
 
     if (!generateData.name) {
-        throw new HttpError("Veo API did not return operation name", 500);
+        throw new HttpError(
+            "Veo API did not return operation name",
+            500,
+            undefined,
+            generateEndpoint,
+        );
     }
 
     // Step 2: Poll for completion using fetchPredictOperation
@@ -359,6 +353,8 @@ async function pollVeoOperation(
                 throw new HttpError(
                     `Video generation failed: ${pollData.error.message}`,
                     isClientError ? 400 : 500,
+                    undefined,
+                    pollUrl,
                 );
             }
 
@@ -388,11 +384,18 @@ async function pollVeoOperation(
                     throw new HttpError(
                         "Video returned as GCS URI which is not supported",
                         500,
+                        undefined,
+                        pollUrl,
                     );
                 }
             }
 
-            throw new HttpError("No video data in response", 500);
+            throw new HttpError(
+                "No video data in response",
+                500,
+                undefined,
+                pollUrl,
+            );
         }
 
         // Not done yet, wait and try again
@@ -400,5 +403,10 @@ async function pollVeoOperation(
         delayMs = Math.min(delayMs * 1.2, 30000); // Exponential backoff, cap at 30s
     }
 
-    throw new HttpError("Video generation timed out after 3 minutes", 504);
+    throw new HttpError(
+        "Video generation timed out after 3 minutes",
+        504,
+        undefined,
+        pollUrl,
+    );
 }

--- a/gen.pollinations.ai/src/image/models/wanImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanImageModel.ts
@@ -4,6 +4,7 @@ import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 
 const logOps = debug("pollinations:wan-image:ops");
@@ -194,23 +195,15 @@ async function callDashScopeWanImageAPI(
     });
     logOps("DashScope Wan image request:", safeBody);
 
-    const response = await fetch(DASHSCOPE_API_BASE, {
+    const response = await fetchUpstream(DASHSCOPE_API_BASE, {
         method: "POST",
         headers: {
             Authorization: `Bearer ${apiKey}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
+        errorLabel: `${modelLabel} API failed`,
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError(`${modelLabel} API failed:`, response.status, errorText);
-        throw new HttpError(
-            `${modelLabel} API failed: ${errorText}`,
-            response.status,
-        );
-    }
 
     const data: WanImageResponse = await response.json();
 
@@ -218,25 +211,27 @@ async function callDashScopeWanImageAPI(
         throw new HttpError(
             `${modelLabel} error: ${data.message || data.code}`,
             400,
+            undefined,
+            DASHSCOPE_API_BASE,
         );
     }
 
     const imageUrl = data.output?.choices?.[0]?.message?.content?.[0]?.image;
     if (!imageUrl) {
-        throw new HttpError(`No image URL in ${modelLabel} response`, 500);
+        throw new HttpError(
+            `No image URL in ${modelLabel} response`,
+            500,
+            undefined,
+            DASHSCOPE_API_BASE,
+        );
     }
 
     logOps("Image generated, downloading from:", imageUrl);
     progress.updateBar(requestId, 80, "Processing", "Downloading image...");
 
-    const imageResponse = await fetch(imageUrl);
-    if (!imageResponse.ok) {
-        throw new HttpError(
-            `Failed to download generated image: ${imageResponse.status}`,
-            500,
-        );
-    }
-
+    const imageResponse = await fetchUpstream(imageUrl, {
+        errorLabel: "Failed to download generated image",
+    });
     const buffer = Buffer.from(await imageResponse.arrayBuffer());
     logOps(`Image downloaded, size: ${(buffer.length / 1024).toFixed(1)} KB`);
     progress.updateBar(requestId, 95, "Success", "Image generation completed");

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 import { calculateVideoResolution } from "../utils/videoResolution.ts";
 
@@ -197,13 +198,9 @@ async function downloadVideo(
 ): Promise<Buffer> {
     progress.updateBar(requestId, 90, "Processing", "Downloading video...");
 
-    const response = await fetch(videoUrl);
-    if (!response.ok) {
-        throw new HttpError(
-            `Failed to download video: ${response.status}`,
-            500,
-        );
-    }
+    const response = await fetchUpstream(videoUrl, {
+        errorLabel: "Failed to download video",
+    });
 
     const buffer = Buffer.from(await response.arrayBuffer());
     logOps(
@@ -358,27 +355,17 @@ async function createDashScopeTask(
         "Initiating video generation...",
     );
 
-    const response = await fetch(
-        `${DASHSCOPE_API_BASE}/services/aigc/video-generation/video-synthesis`,
-        {
-            method: "POST",
-            headers: {
-                "Authorization": `Bearer ${apiKey}`,
-                "Content-Type": "application/json",
-                "X-DashScope-Async": "enable",
-            },
-            body: JSON.stringify(requestBody),
+    const submitUrl = `${DASHSCOPE_API_BASE}/services/aigc/video-generation/video-synthesis`;
+    const response = await fetchUpstream(submitUrl, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+            "X-DashScope-Async": "enable",
         },
-    );
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError("DashScope API failed:", response.status, errorText);
-        throw new HttpError(
-            `DashScope API request failed: ${errorText}`,
-            response.status,
-        );
-    }
+        body: JSON.stringify(requestBody),
+        errorLabel: "DashScope API request failed",
+    });
 
     const data: WanTaskResponse = await response.json();
     logOps("Task creation response:", JSON.stringify(data, null, 2));
@@ -387,12 +374,19 @@ async function createDashScopeTask(
         throw new HttpError(
             `DashScope API error: ${data.message || data.code}`,
             400,
+            undefined,
+            submitUrl,
         );
     }
 
     const taskId = data.output?.task_id;
     if (!taskId) {
-        throw new HttpError("DashScope API did not return task ID", 500);
+        throw new HttpError(
+            "DashScope API did not return task ID",
+            500,
+            undefined,
+            submitUrl,
+        );
     }
 
     progress.updateBar(
@@ -438,13 +432,18 @@ async function pollWanTask(
         }
 
         if (pollResult.status === "failed") {
-            throw new HttpError(pollResult.error, 500);
+            throw new HttpError(pollResult.error, 500, undefined, pollUrl);
         }
 
         await sleep(POLL_DELAY_MS);
     }
 
-    throw new HttpError("Video generation timed out after 5 minutes", 504);
+    throw new HttpError(
+        "Video generation timed out after 5 minutes",
+        504,
+        undefined,
+        pollUrl,
+    );
 }
 
 /**
@@ -500,7 +499,12 @@ async function pollTaskOnce(
     switch (taskStatus) {
         case "SUCCEEDED":
             if (!data.output?.video_url) {
-                throw new HttpError("No video URL in completed response", 500);
+                throw new HttpError(
+                    "No video URL in completed response",
+                    500,
+                    undefined,
+                    pollUrl,
+                );
             }
             return {
                 status: "completed",

--- a/gen.pollinations.ai/src/image/models/xaiModel.ts
+++ b/gen.pollinations.ai/src/image/models/xaiModel.ts
@@ -4,6 +4,7 @@ import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 
 const logOps = debug("pollinations:xai:ops");
 const logError = debug("pollinations:xai:error");
@@ -95,42 +96,34 @@ export async function callXaiImageAPI(
 
     logOps("Request body:", JSON.stringify(requestBody));
 
-    const response = await fetch(endpoint, {
+    const response = await fetchUpstream(endpoint, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify(requestBody),
+        errorLabel: "xAI image generation failed",
     });
-
-    if (!response.ok) {
-        const errorText = await response.text();
-        logError("xAI request failed:", response.status, errorText);
-        throw new HttpError(
-            `xAI image generation failed: ${errorText}`,
-            response.status,
-        );
-    }
 
     const data = (await response.json()) as { data?: Array<{ url?: string }> };
     const result = data.data?.[0];
 
     if (!result?.url) {
-        throw new HttpError("xAI returned no image URL", 500);
+        throw new HttpError(
+            "xAI returned no image URL",
+            500,
+            undefined,
+            endpoint,
+        );
     }
 
     logOps("Downloading result from URL:", result.url);
     progress.updateBar(requestId, 70, "Processing", "Downloading result...");
 
-    const imageResponse = await fetch(result.url);
-    if (!imageResponse.ok) {
-        throw new HttpError(
-            `Failed to download xAI result: ${imageResponse.status}`,
-            500,
-        );
-    }
-
+    const imageResponse = await fetchUpstream(result.url, {
+        errorLabel: "Failed to download xAI result",
+    });
     const buffer = Buffer.from(await imageResponse.arrayBuffer());
     progress.updateBar(
         requestId,

--- a/gen.pollinations.ai/src/image/models/xaiVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/xaiVideoModel.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
 
 const logOps = debug("pollinations:xai-video:ops");
 const logError = debug("pollinations:xai-video:error");
@@ -91,23 +92,15 @@ export async function callXaiVideoAPI(
 
     logOps("Request body:", JSON.stringify(requestBody));
 
-    const submitResponse = await fetch(XAI_VIDEO_API_URL, {
+    const submitResponse = await fetchUpstream(XAI_VIDEO_API_URL, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify(requestBody),
+        errorLabel: "xAI video generation request failed",
     });
-
-    if (!submitResponse.ok) {
-        const errorText = await submitResponse.text();
-        logError("xAI video submit failed:", submitResponse.status, errorText);
-        throw new HttpError(
-            `xAI video generation request failed: ${errorText}`,
-            submitResponse.status,
-        );
-    }
 
     const submitData = (await submitResponse.json()) as {
         id?: string;
@@ -116,7 +109,12 @@ export async function callXaiVideoAPI(
     const videoId = submitData.id ?? submitData.request_id;
 
     if (!videoId) {
-        throw new HttpError("xAI video API did not return a request ID", 500);
+        throw new HttpError(
+            "xAI video API did not return a request ID",
+            500,
+            undefined,
+            XAI_VIDEO_API_URL,
+        );
     }
 
     logOps("Video generation submitted, ID:", videoId);
@@ -173,7 +171,8 @@ async function pollXaiVideoStatus(
             `Generating video... (${attempt}/${maxAttempts})`,
         );
 
-        const pollResponse = await fetch(`${XAI_VIDEO_POLL_URL}/${videoId}`, {
+        const pollUrl = `${XAI_VIDEO_POLL_URL}/${videoId}`;
+        const pollResponse = await fetch(pollUrl, {
             headers: {
                 Authorization: `Bearer ${apiKey}`,
             },
@@ -186,6 +185,8 @@ async function pollXaiVideoStatus(
                 throw new HttpError(
                     `xAI video poll failed: ${errorText}`,
                     pollResponse.status,
+                    undefined,
+                    pollUrl,
                 );
             }
             await sleep(delayMs);
@@ -200,6 +201,8 @@ async function pollXaiVideoStatus(
             throw new HttpError(
                 `xAI video generation failed: ${pollData.error ?? "unknown error"}`,
                 500,
+                undefined,
+                pollUrl,
             );
         }
 
@@ -208,6 +211,8 @@ async function pollXaiVideoStatus(
                 throw new HttpError(
                     "xAI video succeeded but returned no URL",
                     500,
+                    undefined,
+                    pollUrl,
                 );
             }
 
@@ -219,14 +224,9 @@ async function pollXaiVideoStatus(
                 "Downloading video...",
             );
 
-            const downloadResponse = await fetch(pollData.video.url);
-            if (!downloadResponse.ok) {
-                throw new HttpError(
-                    `Failed to download xAI video: ${downloadResponse.status}`,
-                    500,
-                );
-            }
-
+            const downloadResponse = await fetchUpstream(pollData.video.url, {
+                errorLabel: "Failed to download xAI video",
+            });
             const buffer = Buffer.from(await downloadResponse.arrayBuffer());
             logOps(
                 `Video downloaded, size: ${(buffer.length / 1024 / 1024).toFixed(2)} MB`,
@@ -238,5 +238,10 @@ async function pollXaiVideoStatus(
         delayMs = Math.min(delayMs * 1.2, 15000);
     }
 
-    throw new HttpError("xAI video generation timed out after 3 minutes", 504);
+    throw new HttpError(
+        "xAI video generation timed out after 3 minutes",
+        504,
+        undefined,
+        `${XAI_VIDEO_POLL_URL}/${videoId}`,
+    );
 }

--- a/gen.pollinations.ai/src/image/utils/fetchUpstream.ts
+++ b/gen.pollinations.ai/src/image/utils/fetchUpstream.ts
@@ -1,0 +1,37 @@
+import { HttpError } from "../httpError.ts";
+
+type FetchUpstreamOptions = RequestInit & {
+    /**
+     * Prefix for the error message thrown on non-ok responses.
+     * Defaults to "Upstream request failed".
+     */
+    errorLabel?: string;
+};
+
+/**
+ * fetch() wrapper that throws HttpError(status, ..., upstreamUrl) on non-ok
+ * responses. Use for upstream backend calls where the URL should appear in
+ * error reports (handler.ts threads it through to UpstreamError.requestUrl).
+ *
+ * Returns the Response on success. Caller is responsible for `await response.json()`
+ * or similar — keeping body parsing in the caller preserves typing.
+ */
+export async function fetchUpstream(
+    url: string,
+    options: FetchUpstreamOptions = {},
+): Promise<Response> {
+    const { errorLabel = "Upstream request failed", ...init } = options;
+    const response = await fetch(url, init);
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new HttpError(
+            body ? `${errorLabel}: ${body}` : errorLabel,
+            response.status,
+            undefined,
+            url,
+        );
+    }
+
+    return response;
+}

--- a/gen.pollinations.ai/test/image/fetchUpstream.test.ts
+++ b/gen.pollinations.ai/test/image/fetchUpstream.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../../src/image/httpError.ts";
+import { fetchUpstream } from "../../src/image/utils/fetchUpstream.ts";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("fetchUpstream", () => {
+    it("returns the response unchanged on 2xx", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response('{"ok":true}', { status: 200 }),
+        );
+
+        const response = await fetchUpstream("https://example.com/api");
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ ok: true });
+    });
+
+    it("throws HttpError with upstreamUrl populated on non-ok response", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response("backend exploded", { status: 502 }),
+        );
+
+        const url = "https://example.com/api/v1/foo?id=bar";
+        await expect(
+            fetchUpstream(url, { errorLabel: "Foo failed" }),
+        ).rejects.toMatchObject({
+            name: "HttpError",
+            status: 502,
+            upstreamUrl: url,
+            message: "Foo failed: backend exploded",
+        });
+    });
+
+    it("falls back to a generic message when the upstream body is empty", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response("", { status: 503 }),
+        );
+
+        await expect(
+            fetchUpstream("https://example.com/api"),
+        ).rejects.toMatchObject({
+            message: "Upstream request failed",
+            status: 503,
+        });
+    });
+
+    it("propagates the request init (headers, method, body)", async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response("ok", { status: 200 }));
+
+        await fetchUpstream("https://example.com/api", {
+            method: "POST",
+            headers: { Authorization: "Bearer xyz" },
+            body: JSON.stringify({ foo: 1 }),
+            errorLabel: "ignored on success",
+        });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [, init] = fetchSpy.mock.calls[0];
+        expect(init).toMatchObject({
+            method: "POST",
+            headers: { Authorization: "Bearer xyz" },
+            body: JSON.stringify({ foo: 1 }),
+        });
+        // errorLabel must not be passed to fetch as a RequestInit field
+        expect(init).not.toHaveProperty("errorLabel");
+    });
+});
+
+describe("fetchUpstream + HttpError integration", () => {
+    it("HttpError carries the URL exactly as fetched (no stripping)", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response("nope", { status: 500 }),
+        );
+
+        const url =
+            "https://ltx2-backend.pollinations.ai/result?prompt_id=abc-123";
+        try {
+            await fetchUpstream(url);
+            expect.fail("should have thrown");
+        } catch (e) {
+            expect(e).toBeInstanceOf(HttpError);
+            expect((e as HttpError).upstreamUrl).toBe(url);
+        }
+    });
+});

--- a/gen.pollinations.ai/test/image/httpError.test.ts
+++ b/gen.pollinations.ai/test/image/httpError.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { HttpError } from "../../src/image/httpError.ts";
+
+describe("HttpError.upstreamUrl", () => {
+    it("preserves the full URL including query string for observability", () => {
+        const url =
+            "https://ltx2-backend.pollinations.ai/result?prompt_id=abc-123";
+        const err = new HttpError("Failed", 502, undefined, url);
+        expect(err.upstreamUrl).toBe(url);
+    });
+
+    it("returns undefined when no URL is provided", () => {
+        const err = new HttpError("Failed", 502);
+        expect(err.upstreamUrl).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `src/image/utils/fetchUpstream.ts` — fetch wrapper that throws `HttpError(status, ..., url)` on non-ok responses, collapsing the recurring `fetch` + ok-check + `text()` + `throw` pattern (~8 lines → 1 call).
- Adds `upstreamUrl?: string` field on `HttpError`, threaded through to `UpstreamError.requestUrl` so the error envelope's `upstreamHost` reflects the actual backend (e.g. `ltx2-backend.pollinations.ai`) instead of the gen.pollinations.ai request URL.
- Migrates all image and video model files (flux-klein, ltx2-video, seedance-video, veo-video, wan-video, xai-video, qwen-image, wan-image, xai image, seedream, azure flux-kontext, pruna, createAndReturnImages) to either use `fetchUpstream` for primary fetches or to tag thrown `HttpError`s with the URL they polled.
- Internal upstream URLs in this codebase don't carry credentials in query strings (auth goes in headers), so `prompt_id`s and similar IDs are kept for cross-referencing logs.
- Net **-64 LOC** repo-wide despite the new helper + tests.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 127/127 pass (3 new tests for `fetchUpstream`, 2 for `HttpError.upstreamUrl`)
- [x] biome check passes

## Follow-up to

#10663 (LTX-2 outage hot-fix) — that PR landed the minimal env-var + retry fix; this PR is the broader observability/refactor work that was intentionally split out.