### PR TITLE
fix(nova-canvas): use FetchHttpHandler in Workers runtime

### DIFF
--- a/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
@@ -102,6 +102,7 @@ export async function callNovaCanvasAPI(
     const { BedrockRuntimeClient, InvokeModelCommand } = await import(
         "@aws-sdk/client-bedrock-runtime"
     );
+    const { FetchHttpHandler } = await import("@smithy/fetch-http-handler");
 
     const client = new BedrockRuntimeClient({
         region,
@@ -109,6 +110,7 @@ export async function callNovaCanvasAPI(
             accessKeyId,
             secretAccessKey,
         },
+        requestHandler: new FetchHttpHandler(),
     });
 
     const imageGenerationConfig = {


### PR DESCRIPTION
nova-canvas was returning 500s in production with `http2.connect method is not implemented`. Bedrock SDK defaults to `NodeHttpHandler`, which relies on Node's `http2` module — not available in Cloudflare Workers.

Fix: pass `new FetchHttpHandler()` as `requestHandler` on the `BedrockRuntimeClient`, matching the pattern already used in `gen.pollinations.ai/src/utils/bedrock-guardrail.ts`. Package is already in deps.

Verified locally with `npm run typecheck`. Should clear the nova-canvas row on monitor.pollinations.ai once deployed.