### PR TITLE
fix(mistral): route to Azure Foundry mistral-small-2503

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -56,7 +56,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "mistral",
-        config: portkeyConfig["mistral-small-3.2-24b-instruct-2506"],
+        config: portkeyConfig["mistral-small-2503"],
     },
     {
         name: "deepseek",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -117,13 +117,13 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "accounts/fireworks/models/kimi-k2p6",
         }),
 
-    // -- OVHcloud Mistral (cheaper than Azure, same model) ---------------------
-    "mistral-small-3.2-24b-instruct-2506": () =>
-        createOVHcloudMistralConfig({
-            model: "Mistral-Small-3.2-24B-Instruct-2506",
-        }),
-
-    // -- Azure (Myceli Prod — eastus, Mistral Large) --------------------------
+    // -- Azure (Myceli Prod — eastus, Mistral Small + Large) ------------------
+    "mistral-small-2503": () =>
+        createAzureModelConfig(
+            process.env.AZURE_MYCELI_PROD_API_KEY,
+            "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/deployments/mistral-small-2503/chat/completions?api-version=2024-12-01-preview",
+            "mistral-small-2503",
+        ),
     "Mistral-Large-3": () =>
         createAzureModelConfig(
             process.env.AZURE_MYCELI_PROD_API_KEY,

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -141,11 +141,13 @@ export const TEXT_SERVICES = {
     "mistral": {
         aliases: [
             "mistral-small",
+            "mistral-small-3.1",
+            "mistral-small-2503",
             "mistral-small-3.2",
             "mistral-small-3.2-24b-instruct-2506",
         ],
-        modelId: "Mistral-Small-3.2-24B-Instruct-2506",
-        provider: "ovhcloud",
+        modelId: "mistral-small-2503",
+        provider: "azure",
         brand: "Mistral",
         category: "text",
         cost: [
@@ -155,7 +157,7 @@ export const TEXT_SERVICES = {
                 completionTextTokens: perMillion(0.3),
             },
         ],
-        description: "Mistral Small 3.2 - Efficient & Cost-Effective",
+        description: "Mistral Small 3.1 - Efficient & Cost-Effective",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,


### PR DESCRIPTION
OVH Cloud Mistral has been timing out 10-21% of requests since ~06:00 UTC today, all hitting our 90s gateway ceiling. Swapping to a new MaaS deployment of `mistral-small-2503` on the existing `myceli-prod-eastus` Azure resource (same account already serving Mistral-Large-3, GPT-5.x, Grok, etc — covered by sponsorship credits).

**Burst tests vs new endpoint:**
| Concurrent | Success | p50 | p95 |
|---|---|---|---|
| 5 | 5/5 | 1.13s | 1.22s |
| 10 | 10/10 | 1.29s | 1.61s |
| 20 | 20/20 | 1.27s | 2.59s |

vs current OVH today: 14% timeouts at 90s.

**Version note:** Azure Foundry hosts `mistral-small-2503` (Mistral Small 3.1), not `2506` (3.2) — 3.2 isn't on Foundry yet. Per Mistral's release notes, 3.2 is a fine-tune fix on 3.1 (reduced repetition + better instruction following) — same 24B base, 128K context, text+image input. Aliases preserve `mistral-small-3.2` and `mistral-small-3.2-24b-instruct-2506` for clients pinning those names.

**Capacity:** Mistral MaaS on Azure offers a single `GlobalStandard` SKU with `capacity=1` (no provisioned throughput option). Default rate limits aren't surfaced in headers but had massive headroom at 20 concurrent — no signs of pressure.

Cost field left as-is in the registry pending authoritative Azure consumption pricing for this SKU.