### PR TITLE
fix(polli-cli): update device-flow app key

### DIFF
--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -154,7 +154,7 @@ const login = new Command("login")
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-                client_id: "pk_NgBAArhUeGvSRFba",
+                client_id: "pk_VZF38YW4tQX36SEn",
                 scope: "generate keys usage",
             }),
         }).catch((err) => {


### PR DESCRIPTION
Updates the hardcoded OAuth `client_id` used by `polli auth login` device flow from `pk_NgBAArhUeGvSRFba` to `pk_VZF38YW4tQX36SEn`.