### PR TITLE
fix: persist BYOP attribution

### DIFF
--- a/enter.pollinations.ai/drizzle/0022_byop-client-key-id.sql
+++ b/enter.pollinations.ai/drizzle/0022_byop-client-key-id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `apikey` ADD `byop_client_key_id` text;--> statement-breakpoint
+CREATE INDEX `idx_apikey_byop_client_key_id` ON `apikey` (`byop_client_key_id`);

--- a/enter.pollinations.ai/drizzle/0022_dapper_lockheed.sql
+++ b/enter.pollinations.ai/drizzle/0022_dapper_lockheed.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `apikey` ADD `byop_client_key_id` text;--> statement-breakpoint
-CREATE INDEX `idx_apikey_byop_client_key_id` ON `apikey` (`byop_client_key_id`);

--- a/enter.pollinations.ai/drizzle/0022_dapper_lockheed.sql
+++ b/enter.pollinations.ai/drizzle/0022_dapper_lockheed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `apikey` ADD `byop_client_key_id` text;--> statement-breakpoint
+CREATE INDEX `idx_apikey_byop_client_key_id` ON `apikey` (`byop_client_key_id`);

--- a/enter.pollinations.ai/drizzle/0023_byop-backfill.sql
+++ b/enter.pollinations.ai/drizzle/0023_byop-backfill.sql
@@ -1,6 +1,5 @@
 -- Backfill BYOP attribution for secret keys created before byop_client_key_id
--- became a first-class column. This intentionally does not opt existing
--- publishable keys into developer earnings.
+-- became a first-class column.
 
 UPDATE `apikey`
 SET `byop_client_key_id` = json_extract(`metadata`, '$.clientId')

--- a/enter.pollinations.ai/drizzle/0023_byop-backfill.sql
+++ b/enter.pollinations.ai/drizzle/0023_byop-backfill.sql
@@ -1,0 +1,21 @@
+-- Backfill BYOP attribution for secret keys created before byop_client_key_id
+-- became a first-class column. This intentionally does not opt existing
+-- publishable keys into developer earnings.
+
+UPDATE `apikey`
+SET `byop_client_key_id` = json_extract(`metadata`, '$.clientId')
+WHERE `byop_client_key_id` IS NULL
+  AND `prefix` = 'sk'
+  AND json_valid(`metadata`)
+  AND json_extract(`metadata`, '$.clientId') IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM `apikey` AS `client_key`
+    WHERE `client_key`.`id` = json_extract(`apikey`.`metadata`, '$.clientId')
+      AND `client_key`.`prefix` = 'pk'
+      AND COALESCE(`client_key`.`enabled`, 1) = 1
+      AND (
+        `client_key`.`expires_at` IS NULL
+        OR `client_key`.`expires_at` > CAST(strftime('%s', 'now') AS integer)
+      )
+  );

--- a/enter.pollinations.ai/drizzle/meta/0022_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0022_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "60710c27-b060-44a5-a002-2446b13f0256",
+  "id": "4b2281cf-18b6-4bed-9be3-f9cd0547591c",
   "prevId": "d4b78ed6-f24c-4cbc-a7de-0ddc2ba43118",
   "tables": {
     "account": {

--- a/enter.pollinations.ai/drizzle/meta/0022_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,845 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "60710c27-b060-44a5-a002-2446b13f0256",
+  "prevId": "d4b78ed6-f24c-4cbc-a7de-0ddc2ba43118",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/0023_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0023_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "603f102c-8e2d-4cde-b780-ad191d9ca97e",
-  "prevId": "60710c27-b060-44a5-a002-2446b13f0256",
+  "id": "0df2b212-b504-4a26-b01f-9c3fe22343f5",
+  "prevId": "4b2281cf-18b6-4bed-9be3-f9cd0547591c",
   "version": "6",
   "dialect": "sqlite",
   "tables": {

--- a/enter.pollinations.ai/drizzle/meta/0023_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,845 @@
+{
+  "id": "603f102c-8e2d-4cde-b780-ad191d9ca97e",
+  "prevId": "60710c27-b060-44a5-a002-2446b13f0256",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -155,6 +155,20 @@
       "when": 1777746472187,
       "tag": "0021_left_wolverine",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1777898195219,
+      "tag": "0022_dapper_lockheed",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1777898201480,
+      "tag": "0023_byop-backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -159,14 +159,14 @@
     {
       "idx": 22,
       "version": "6",
-      "when": 1777898195219,
-      "tag": "0022_dapper_lockheed",
+      "when": 1778063624846,
+      "tag": "0022_byop-client-key-id",
       "breakpoints": true
     },
     {
       "idx": 23,
       "version": "6",
-      "when": 1777898201480,
+      "when": 1778063629187,
       "tag": "0023_byop-backfill",
       "breakpoints": true
     }

--- a/enter.pollinations.ai/observability/datasources/d1_apikey.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_apikey.datasource
@@ -25,6 +25,7 @@ SCHEMA >
     `permissions` Nullable(String) `json:$.permissions`,
     `metadata` Nullable(String) `json:$.metadata`,
     `pollen_balance` Nullable(Float64) `json:$.pollen_balance`,
+    `byop_client_key_id` Nullable(String) `json:$.byop_client_key_id`,
     `synced_at` DateTime `json:$.synced_at`
 
 ENGINE "MergeTree"

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -19,7 +19,7 @@ type ApiKeyDialogProps = {
     onComplete: () => void;
     triggerLabel?: string;
     triggerClassName?: string;
-    /** Simplified mode: hides key type selector, permissions, budget, expiry. Shows only name + URL. */
+    /** Simplified mode: hides key type selector, permissions, budget, expiry. Shows only app key settings. */
     simplified?: boolean;
 };
 
@@ -114,14 +114,8 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
         !simplified &&
         Array.isArray(allowedModels) &&
         allowedModels.length === 0;
-    const isMissingRedirectUris =
-        simplified && redirectUris.filter((v) => v.trim()).length === 0;
     const isCreateDisabled =
-        !createdKey &&
-        (!name.trim() ||
-            isSubmitting ||
-            noModelsSelected ||
-            isMissingRedirectUris);
+        !createdKey && (!name.trim() || isSubmitting || noModelsSelected);
     const keyInputStyles = {
         editableInputClasses:
             "border-blue-200 bg-blue-50 focus:outline-none focus-visible:border-blue-300 focus-visible:ring-1 focus-visible:ring-blue-200",
@@ -138,9 +132,7 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
     const createDisabledReason =
         !createdKey && noModelsSelected
             ? "Select at least one model"
-            : !createdKey && isMissingRedirectUris
-              ? "Add at least one redirect URI"
-              : undefined;
+            : undefined;
 
     const submitButton = (
         <Button

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -54,6 +54,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
             ? (apiKey.metadata?.redirectUris as string[])
             : [];
         const primaryRedirectUri = redirectUrisMeta[0] || "";
+        const extraRedirectUriCount = Math.max(0, redirectUrisMeta.length - 1);
         const isApp = isPublishable;
 
         return (
@@ -123,7 +124,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                         </span>
                     </span>
                     {isPublishable && primaryRedirectUri && (
-                        <span>
+                        <span className="inline-flex min-w-0 items-center gap-1">
                             <span className="text-gray-400">Redirect: </span>
                             <a
                                 href={primaryRedirectUri}
@@ -133,6 +134,19 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                             >
                                 {primaryRedirectUri.replace(/^https?:\/\//, "")}
                             </a>
+                            {extraRedirectUriCount > 0 && (
+                                <span
+                                    className="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 font-medium text-blue-700"
+                                    title={redirectUrisMeta
+                                        .slice(1)
+                                        .map((uri) =>
+                                            uri.replace(/^https?:\/\//, ""),
+                                        )
+                                        .join("\n")}
+                                >
+                                    +{extraRedirectUriCount}
+                                </span>
+                            )}
                         </span>
                     )}
                     {!isApp && (
@@ -202,18 +216,29 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                 <DashboardSection title="App" theme="blue" framed>
                     <div className="flex flex-col gap-3">
                         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                            <p className="min-w-0 flex-1 text-sm text-gray-600">
-                                For apps where users sign in with their own
-                                Pollinations account — billed to them.{" "}
+                            <div className="min-w-0 flex-1 text-sm text-gray-600">
+                                <p>
+                                    For apps where users sign in with their own
+                                    Pollinations account and spend their own
+                                    Pollen.
+                                </p>
                                 <a
                                     href="https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="font-medium text-blue-700 underline underline-offset-2 hover:text-blue-900"
+                                    className="mt-1 inline-flex items-center gap-1 font-medium text-blue-700 hover:text-blue-900"
                                 >
-                                    Read the guide
+                                    <span className="underline underline-offset-2">
+                                        Read the guide
+                                    </span>
+                                    <span
+                                        aria-hidden="true"
+                                        className="no-underline"
+                                    >
+                                        ↗
+                                    </span>
                                 </a>
-                            </p>
+                            </div>
                             <ApiKeyDialog
                                 onSubmit={onCreate}
                                 onComplete={() => {}}

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -42,13 +42,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     const sortedAppKeys = sortedKeys.filter(isAppKey);
 
     function isAppKey(apiKey: ApiKey): boolean {
-        const redirectUris = Array.isArray(apiKey.metadata?.redirectUris)
-            ? (apiKey.metadata?.redirectUris as string[])
-            : [];
-        return (
-            apiKey.metadata?.keyType === "publishable" &&
-            redirectUris.length > 0
-        );
+        return apiKey.metadata?.keyType === "publishable";
     }
 
     function renderKeyCard(apiKey: ApiKey) {
@@ -60,7 +54,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
             ? (apiKey.metadata?.redirectUris as string[])
             : [];
         const primaryRedirectUri = redirectUrisMeta[0] || "";
-        const isApp = isPublishable && !!primaryRedirectUri;
+        const isApp = isPublishable;
 
         return (
             <Card
@@ -70,11 +64,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
             >
                 <div className="flex items-center gap-2 mb-2">
                     <Tag color="blue" size="sm">
-                        {isPublishable
-                            ? primaryRedirectUri
-                                ? "🖥️ App"
-                                : "🌐 Publishable"
-                            : "🔒 Secret"}
+                        {isPublishable ? "🖥️ App" : "🔒 Secret"}
                     </Tag>
                     <span className="text-sm font-medium truncate">
                         {apiKey.name}

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -33,6 +33,10 @@ function sameRedirectUris(a: string[], b: string[]): boolean {
     return a.every((v, i) => v === b[i]);
 }
 
+function cleanRedirectUris(uris: string[]): string[] {
+    return uris.map((v) => v.trim()).filter((v) => v !== "");
+}
+
 export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     apiKey,
     onUpdate,
@@ -47,7 +51,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     const plaintextKey = apiKey.metadata?.plaintextKey as string | undefined;
 
     const initialRedirectUris = readInitialRedirectUris(apiKey.metadata);
-    const isAppKey = isPublishable && initialRedirectUris.length > 0;
+    const isAppKey = isPublishable;
     const [redirectUris, setRedirectUris] =
         useState<string[]>(initialRedirectUris);
 
@@ -90,13 +94,12 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
             });
 
             // Save app settings for publishable keys
-            if (
-                isPublishable &&
-                !sameRedirectUris(redirectUris, initialRedirectUris)
-            ) {
-                const cleaned = redirectUris
-                    .map((v) => v.trim())
-                    .filter((v) => v !== "");
+            if (isPublishable) {
+                const cleaned = cleanRedirectUris(redirectUris);
+                if (sameRedirectUris(cleaned, initialRedirectUris)) {
+                    onClose();
+                    return;
+                }
                 const metaRes = await fetch(
                     `/api/api-keys/${apiKey.id}/metadata`,
                     {

--- a/enter.pollinations.ai/src/client/components/api-keys/publishable-key-settings.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/publishable-key-settings.tsx
@@ -20,20 +20,18 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
     onRedirectUrisChange,
     disabled = false,
 }) => {
-    const rows = redirectUris.length > 0 ? redirectUris : [""];
-
     function update(index: number, value: string) {
-        const next = [...rows];
+        const next = [...redirectUris];
         next[index] = value;
-        onRedirectUrisChange(next.filter((v) => v !== "" || rows.length === 1));
+        onRedirectUrisChange(next);
     }
 
     function add() {
-        onRedirectUrisChange([...rows, ""]);
+        onRedirectUrisChange([...redirectUris, ""]);
     }
 
     function remove(index: number) {
-        const next = rows.filter((_, i) => i !== index);
+        const next = redirectUris.filter((_, i) => i !== index);
         onRedirectUrisChange(next);
     }
 
@@ -47,7 +45,12 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
                     Loopback URLs match any port (RFC 8252).
                 </span>
             </div>
-            {rows.map((uri, index) => (
+            {redirectUris.length === 0 && (
+                <p className="rounded-lg border border-dashed border-blue-200 bg-blue-50 px-3 py-2 text-sm text-gray-500">
+                    No redirect URIs
+                </p>
+            )}
+            {redirectUris.map((uri, index) => (
                 <div
                     // biome-ignore lint/suspicious/noArrayIndexKey: stable enough for a small editable list
                     key={index}
@@ -61,17 +64,15 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
                         placeholder="https://myapp.com/auth/callback"
                         disabled={disabled}
                     />
-                    {rows.length > 1 && (
-                        <Button
-                            type="button"
-                            color="blue"
-                            weight="outline"
-                            onClick={() => remove(index)}
-                            disabled={disabled}
-                        >
-                            Remove
-                        </Button>
-                    )}
+                    <Button
+                        type="button"
+                        color="blue"
+                        weight="outline"
+                        onClick={() => remove(index)}
+                        disabled={disabled}
+                    >
+                        Remove
+                    </Button>
                 </div>
             ))}
             <div>

--- a/enter.pollinations.ai/src/client/components/api-keys/publishable-key-settings.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/publishable-key-settings.tsx
@@ -41,9 +41,6 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
                 <Field.Label className="text-sm font-semibold">
                     Redirect URIs
                 </Field.Label>
-                <span className="text-xs text-gray-600">
-                    Loopback URLs match any port (RFC 8252).
-                </span>
             </div>
             {redirectUris.length === 0 && (
                 <p className="rounded-lg border border-dashed border-blue-200 bg-blue-50 px-3 py-2 text-sm text-gray-500">

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -320,11 +320,6 @@ function AuthorizeComponent() {
                             redirectOrigin: parsedRedirectUrl.origin,
                             redirectUri: parsedRedirectUrl.href,
                         }),
-                    ...(attribution?.found && {
-                        clientId: attribution.clientId,
-                        createdForUserId: attribution.userId,
-                        createdForApp: attribution.appName,
-                    }),
                 },
                 permissions: {
                     allowedModels,

--- a/enter.pollinations.ai/src/routes/metadata-utils.ts
+++ b/enter.pollinations.ai/src/routes/metadata-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Parse potentially double-serialized JSON metadata from a DB row.
+ * Parse JSON metadata from a DB row.
  * Returns an empty object for null/undefined/invalid input.
  */
 export function parseMetadata(
@@ -7,9 +7,10 @@ export function parseMetadata(
 ): Record<string, unknown> {
     if (!raw) return {};
     try {
-        let parsed = JSON.parse(raw);
-        if (typeof parsed === "string") parsed = JSON.parse(parsed);
-        return parsed && typeof parsed === "object" ? parsed : {};
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? parsed
+            : {};
     } catch {
         return {};
     }

--- a/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
+++ b/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
@@ -36,7 +36,8 @@ const TABLES: TableConfig[] = [
         query: `SELECT id, name, start, prefix, user_id, refill_interval, refill_amount,
                        last_refill_at, enabled, rate_limit_enabled, rate_limit_time_window,
                        rate_limit_max, request_count, remaining, last_request, expires_at,
-                       created_at, updated_at, permissions, metadata, pollen_balance
+                       created_at, updated_at, permissions, metadata, pollen_balance,
+                       byop_client_key_id
                 FROM apikey`,
     },
     {

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -218,7 +218,6 @@ describe("API Key Management", () => {
                         type: "secret",
                         metadata: {
                             requestedClientId: appKey.key,
-                            clientId: appKey.id,
                             createdForUserId: "spoofed-user",
                             createdForApp: "spoofed-app",
                             redirectUri: "https://legit.example/callback",
@@ -231,13 +230,10 @@ describe("API Key Management", () => {
             expect(matchingResponse.status).toBe(200);
             const matchingCreated = await matchingResponse.json();
             expect(matchingCreated.metadata.createdVia).toBe("redirect-auth");
-            expect(matchingCreated.metadata.clientId).toBe(appKey.id);
-            expect(matchingCreated.metadata.createdForApp).toBe(
-                "registered-app",
-            );
-            expect(matchingCreated.metadata.createdForUserId).not.toBe(
-                "spoofed-user",
-            );
+            expect(matchingCreated.metadata.clientId).toBeUndefined();
+            expect(matchingCreated.metadata.createdForApp).toBeUndefined();
+            expect(matchingCreated.metadata.createdForUserId).toBeUndefined();
+            expect(matchingCreated.byopClientKeyId).toBe(appKey.id);
         });
 
         test("allows device-flow attribution without redirect_uri when client_id matches the device code", async ({
@@ -292,7 +288,6 @@ describe("API Key Management", () => {
                         metadata: {
                             deviceUserCode: userCode,
                             requestedClientId: appKey.key,
-                            clientId: appKey.id,
                             createdForUserId: "spoofed-user",
                             createdForApp: "spoofed-device-app",
                         },
@@ -304,11 +299,10 @@ describe("API Key Management", () => {
             const created = await response.json();
             expect(created.metadata.createdVia).toBe("redirect-auth");
             expect(created.metadata.deviceUserCode).toBe(userCode);
-            expect(created.metadata.clientId).toBe(appKey.id);
-            expect(created.metadata.createdForApp).toBe(
-                "device-registered-app",
-            );
-            expect(created.metadata.createdForUserId).not.toBe("spoofed-user");
+            expect(created.metadata.clientId).toBeUndefined();
+            expect(created.metadata.createdForApp).toBeUndefined();
+            expect(created.metadata.createdForUserId).toBeUndefined();
+            expect(created.byopClientKeyId).toBe(appKey.id);
         });
 
         test("allows unbranded device-flow key creation without caller attribution", async ({
@@ -411,7 +405,6 @@ describe("API Key Management", () => {
                         metadata: {
                             deviceUserCode: userCode,
                             requestedClientId: appKey.key,
-                            clientId: appKey.id,
                             createdForApp: "victim-device-app",
                         },
                     }),

--- a/enter.pollinations.ai/test/metadata-utils.test.ts
+++ b/enter.pollinations.ai/test/metadata-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { parseMetadata } from "../src/routes/metadata-utils.ts";
+
+describe("parseMetadata", () => {
+    test("parses normalized metadata objects", () => {
+        expect(
+            parseMetadata(
+                JSON.stringify({
+                    keyType: "publishable",
+                    redirectUris: ["https://example.com/callback"],
+                }),
+            ),
+        ).toEqual({
+            keyType: "publishable",
+            redirectUris: ["https://example.com/callback"],
+        });
+    });
+
+    test("rejects invalid and non-object metadata", () => {
+        expect(parseMetadata(null)).toEqual({});
+        expect(parseMetadata("not json")).toEqual({});
+        expect(parseMetadata(JSON.stringify(["not", "metadata"]))).toEqual({});
+        expect(parseMetadata(JSON.stringify("double-encoded"))).toEqual({});
+    });
+});

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { handleBalanceDeduction } from "@shared/billing/track-helpers.ts";
+import { apikey as apikeyTable } from "@shared/db/better-auth.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 import {
     calculateCost,
@@ -33,6 +34,7 @@ import {
     ContentFilterResultSchema,
     ContentFilterSeveritySchema,
 } from "@shared/schemas/openai.ts";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { EventSourceParserStream } from "eventsource-parser/stream";
 import type { HonoRequest } from "hono";
@@ -132,6 +134,7 @@ export const track = (eventType: EventType) =>
         const apiKeyMetadata = c.var.auth.apiKey?.metadata as
             | Record<string, unknown>
             | undefined;
+        const byopClientKeyId = c.var.auth.apiKey?.byopClientKeyId;
         const userTracking: UserData = {
             userId: c.var.auth.user?.id,
             userTier: c.var.auth.user?.tier,
@@ -142,14 +145,10 @@ export const track = (eventType: EventType) =>
             apiKeyId: c.var.auth.apiKey?.id,
             apiKeyType: apiKeyMetadata?.keyType as ApiKeyType,
             apiKeyName: c.var.auth.apiKey?.name,
-            apiKeyCreatedVia: apiKeyMetadata?.createdVia as string | undefined,
-            apiKeyCreatedForApp: apiKeyMetadata?.createdForApp as
-                | string
-                | undefined,
-            apiKeyCreatedForUserId: apiKeyMetadata?.createdForUserId as
-                | string
-                | undefined,
-            apiKeyClientId: apiKeyMetadata?.clientId as string | undefined,
+            apiKeyCreatedVia: byopClientKeyId
+                ? "redirect-auth"
+                : (apiKeyMetadata?.createdVia as string | undefined),
+            apiKeyClientId: byopClientKeyId ?? undefined,
         } satisfies UserData;
 
         let responseOverride = null;
@@ -191,6 +190,10 @@ export const track = (eventType: EventType) =>
                 } satisfies BalanceData;
 
                 const ipHash = await hashIp(clientIp, c.env.BETTER_AUTH_SECRET);
+                const byopClientTracking = await resolveByopClientTracking(
+                    db,
+                    byopClientKeyId,
+                );
 
                 const finalEvent = createTrackingEvent({
                     id: generateRandomId(),
@@ -202,7 +205,10 @@ export const track = (eventType: EventType) =>
                     eventType,
                     ipSubnet,
                     ipHash,
-                    userTracking,
+                    userTracking: {
+                        ...userTracking,
+                        ...byopClientTracking,
+                    },
                     balanceTracking,
                     requestTracking,
                     responseTracking,
@@ -834,6 +840,29 @@ type ErrorData = {
     errorMessage?: string;
     // errorStack and errorDetails removed to reduce D1 memory usage
 };
+
+async function resolveByopClientTracking(
+    db: ReturnType<typeof drizzle>,
+    byopClientKeyId: string | null | undefined,
+): Promise<Partial<UserData>> {
+    if (!byopClientKeyId) return {};
+
+    const [clientKey] = await db
+        .select({
+            id: apikeyTable.id,
+            name: apikeyTable.name,
+            userId: apikeyTable.userId,
+        })
+        .from(apikeyTable)
+        .where(eq(apikeyTable.id, byopClientKeyId))
+        .limit(1);
+
+    return {
+        apiKeyClientId: clientKey?.id ?? byopClientKeyId,
+        apiKeyCreatedForApp: clientKey?.name ?? undefined,
+        apiKeyCreatedForUserId: clientKey?.userId ?? undefined,
+    };
+}
 
 function collectErrorData(response: Response, error?: Error): ErrorData {
     if (response.ok && !error) return {};

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -1,6 +1,5 @@
 import { getLogger } from "@logtape/logtape";
 import { handleBalanceDeduction } from "@shared/billing/track-helpers.ts";
-import { apikey as apikeyTable } from "@shared/db/better-auth.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 import {
     calculateCost,
@@ -34,7 +33,6 @@ import {
     ContentFilterResultSchema,
     ContentFilterSeveritySchema,
 } from "@shared/schemas/openai.ts";
-import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { EventSourceParserStream } from "eventsource-parser/stream";
 import type { HonoRequest } from "hono";
@@ -149,6 +147,9 @@ export const track = (eventType: EventType) =>
                 ? "redirect-auth"
                 : (apiKeyMetadata?.createdVia as string | undefined),
             apiKeyClientId: byopClientKeyId ?? undefined,
+            apiKeyCreatedForApp: c.var.auth.apiKey?.byopClientName ?? undefined,
+            apiKeyCreatedForUserId:
+                c.var.auth.apiKey?.byopClientUserId ?? undefined,
         } satisfies UserData;
 
         let responseOverride = null;
@@ -190,10 +191,6 @@ export const track = (eventType: EventType) =>
                 } satisfies BalanceData;
 
                 const ipHash = await hashIp(clientIp, c.env.BETTER_AUTH_SECRET);
-                const byopClientTracking = await resolveByopClientTracking(
-                    db,
-                    byopClientKeyId,
-                );
 
                 const finalEvent = createTrackingEvent({
                     id: generateRandomId(),
@@ -205,10 +202,7 @@ export const track = (eventType: EventType) =>
                     eventType,
                     ipSubnet,
                     ipHash,
-                    userTracking: {
-                        ...userTracking,
-                        ...byopClientTracking,
-                    },
+                    userTracking,
                     balanceTracking,
                     requestTracking,
                     responseTracking,
@@ -840,29 +834,6 @@ type ErrorData = {
     errorMessage?: string;
     // errorStack and errorDetails removed to reduce D1 memory usage
 };
-
-async function resolveByopClientTracking(
-    db: ReturnType<typeof drizzle>,
-    byopClientKeyId: string | null | undefined,
-): Promise<Partial<UserData>> {
-    if (!byopClientKeyId) return {};
-
-    const [clientKey] = await db
-        .select({
-            id: apikeyTable.id,
-            name: apikeyTable.name,
-            userId: apikeyTable.userId,
-        })
-        .from(apikeyTable)
-        .where(eq(apikeyTable.id, byopClientKeyId))
-        .limit(1);
-
-    return {
-        apiKeyClientId: clientKey?.id ?? byopClientKeyId,
-        apiKeyCreatedForApp: clientKey?.name ?? undefined,
-        apiKeyCreatedForUserId: clientKey?.userId ?? undefined,
-    };
-}
 
 function collectErrorData(response: Response, error?: Error): ErrorData {
     if (response.ok && !error) return {};

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -12,9 +12,6 @@ export type CallerMetadata = {
     redirectOrigin?: string;
     deviceUserCode?: string;
     requestedClientId?: string;
-    clientId?: string;
-    createdForUserId?: string;
-    createdForApp?: string;
     description?: string;
 };
 
@@ -60,8 +57,6 @@ type CreateApiKeyAuthClient = {
 
 type VerifiedClientAttribution = {
     clientId: string;
-    createdForUserId: string;
-    createdForApp: string;
 };
 
 export function validateRedirectUriFormat(redirectUri: string): void {
@@ -172,7 +167,6 @@ function isLoopbackHostname(hostname: string): boolean {
 // be set or overridden by callers, even via /api/api-keys metadata patches.
 function pickCallerMetadata(
     metadata: CallerMetadata | undefined,
-    attribution: VerifiedClientAttribution | null,
 ): Record<string, unknown> {
     if (!metadata) return {};
     const out: Record<string, unknown> = {};
@@ -185,11 +179,6 @@ function pickCallerMetadata(
         out.deviceUserCode = metadata.deviceUserCode;
     if (typeof metadata.description === "string")
         out.description = metadata.description;
-    if (attribution) {
-        out.clientId = attribution.clientId;
-        out.createdForUserId = attribution.createdForUserId;
-        out.createdForApp = attribution.createdForApp;
-    }
     return out;
 }
 
@@ -200,12 +189,12 @@ async function validateClientRedirectBinding(
 ): Promise<VerifiedClientAttribution | null> {
     if (!metadata) return null;
     const requestedClientId = metadata.requestedClientId;
-    const storedClientId = metadata.clientId;
 
-    if (
-        typeof requestedClientId !== "string" &&
-        typeof storedClientId !== "string"
-    ) {
+    if (typeof (metadata as Record<string, unknown>).clientId === "string") {
+        rejectInvalidClientId();
+    }
+
+    if (typeof requestedClientId !== "string") {
         return null;
     }
 
@@ -223,11 +212,6 @@ async function validateClientRedirectBinding(
         rejectInvalidClientId();
     }
     const clientKeyId = result.key.id;
-    if (typeof storedClientId === "string" && storedClientId !== clientKeyId) {
-        throw new HTTPException(400, {
-            message: "client_id mismatch",
-        });
-    }
 
     const clientKey = await db.query.apikey.findFirst({
         where: eq(schema.apikey.id, clientKeyId),
@@ -237,8 +221,6 @@ async function validateClientRedirectBinding(
     }
     const attribution = {
         clientId: clientKey.id,
-        createdForUserId: clientKey.userId,
-        createdForApp: clientKey.name ?? "Unknown app",
     };
 
     if (typeof metadata.deviceUserCode === "string") {
@@ -298,7 +280,7 @@ export async function createApiKeyForUser({
         metadata,
     );
 
-    const callerMetadata = pickCallerMetadata(metadata, attribution);
+    const callerMetadata = pickCallerMetadata(metadata);
     if (Array.isArray(callerMetadata.redirectUris)) {
         for (const uri of callerMetadata.redirectUris as string[]) {
             validateRedirectUriFormat(uri);
@@ -352,6 +334,9 @@ export async function createApiKeyForUser({
         metadata: JSON.stringify(finalMetadata),
     };
     if (pollenBudget != null) d1Updates.pollenBalance = pollenBudget;
+    if (!isPublishable && attribution) {
+        d1Updates.byopClientKeyId = attribution.clientId;
+    }
 
     await db
         .update(schema.apikey)
@@ -369,6 +354,8 @@ export async function createApiKeyForUser({
         expiresIn,
         permissions: Object.keys(permissions).length > 0 ? permissions : null,
         pollenBudget: pollenBudget ?? null,
+        byopClientKeyId:
+            !isPublishable && attribution ? attribution.clientId : null,
         metadata: finalMetadata,
     };
 }

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -198,10 +198,7 @@ async function validateClientRedirectBinding(
         return null;
     }
 
-    if (
-        typeof requestedClientId !== "string" ||
-        !requestedClientId.startsWith("pk_")
-    ) {
+    if (!requestedClientId.startsWith("pk_")) {
         rejectInvalidClientId();
     }
 

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -85,9 +85,10 @@ function parseMetadata(
 ): Record<string, unknown> {
     if (!raw) return {};
     try {
-        let parsed = JSON.parse(raw);
-        if (typeof parsed === "string") parsed = JSON.parse(parsed);
-        return parsed && typeof parsed === "object" ? parsed : {};
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? parsed
+            : {};
     } catch {
         return {};
     }

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -15,6 +15,7 @@ export interface AuthenticatedApiKey {
     permissions?: Record<string, string[]>;
     metadata?: Record<string, unknown>;
     pollenBalance?: number | null;
+    byopClientKeyId?: string | null;
     rawKey?: string;
 }
 
@@ -163,7 +164,10 @@ export async function authenticateApiKeyRequest(opts: {
     const userId = typeof key.userId === "string" ? key.userId : undefined;
     const [apiKeyExtra, userData] = await Promise.all([
         db
-            .select({ pollenBalance: schema.apikey.pollenBalance })
+            .select({
+                pollenBalance: schema.apikey.pollenBalance,
+                byopClientKeyId: schema.apikey.byopClientKeyId,
+            })
             .from(schema.apikey)
             .where(eq(schema.apikey.id, keyId))
             .get(),
@@ -188,6 +192,7 @@ export async function authenticateApiKeyRequest(opts: {
             permissions: normalizePermissions(key.permissions),
             metadata: normalizeMetadata(key.metadata),
             pollenBalance: apiKeyExtra?.pollenBalance ?? null,
+            byopClientKeyId: apiKeyExtra?.byopClientKeyId ?? null,
             rawKey: rawApiKey,
         },
         rawApiKey,

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { apiKey } from "better-auth/plugins";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
+import { alias } from "drizzle-orm/sqlite-core";
 import * as schema from "../db/better-auth.ts";
 
 const PUBLISHABLE_KEY_PREFIX = "pk";
@@ -16,6 +17,8 @@ export interface AuthenticatedApiKey {
     metadata?: Record<string, unknown>;
     pollenBalance?: number | null;
     byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    byopClientUserId?: string | null;
     rawKey?: string;
 }
 
@@ -162,13 +165,20 @@ export async function authenticateApiKeyRequest(opts: {
 
     const db = drizzle(opts.env.DB, { schema });
     const userId = typeof key.userId === "string" ? key.userId : undefined;
+    const byopClientKey = alias(schema.apikey, "byop_client_key");
     const [apiKeyExtra, userData] = await Promise.all([
         db
             .select({
                 pollenBalance: schema.apikey.pollenBalance,
                 byopClientKeyId: schema.apikey.byopClientKeyId,
+                byopClientName: byopClientKey.name,
+                byopClientUserId: byopClientKey.userId,
             })
             .from(schema.apikey)
+            .leftJoin(
+                byopClientKey,
+                eq(byopClientKey.id, schema.apikey.byopClientKeyId),
+            )
             .where(eq(schema.apikey.id, keyId))
             .get(),
         userId
@@ -193,6 +203,8 @@ export async function authenticateApiKeyRequest(opts: {
             metadata: normalizeMetadata(key.metadata),
             pollenBalance: apiKeyExtra?.pollenBalance ?? null,
             byopClientKeyId: apiKeyExtra?.byopClientKeyId ?? null,
+            byopClientName: apiKeyExtra?.byopClientName ?? null,
+            byopClientUserId: apiKeyExtra?.byopClientUserId ?? null,
             rawKey: rawApiKey,
         },
         rawApiKey,

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -128,10 +128,12 @@ export const apikey = sqliteTable("apikey", {
   permissions: text("permissions"),
   metadata: text("metadata"),
   pollenBalance: real("pollen_balance"),
+  byopClientKeyId: text("byop_client_key_id"),
 }, (table) => [
   index("idx_apikey_key").on(table.key),
   index('idx_apikey_expires_at').on(table.expiresAt),
   index("idx_apikey_user_id").on(table.userId),
+  index("idx_apikey_byop_client_key_id").on(table.byopClientKeyId),
 ]);
 
 // Drizzle relations for query builder joins

--- a/shared/test/fixtures/index.ts
+++ b/shared/test/fixtures/index.ts
@@ -29,7 +29,6 @@ export const test = base.extend<SharedFixtures>({
         const { key } = await createTestApiKey({
             name: "publishable-test-key",
             type: "publishable",
-            metadata: { createdForApp: "test" },
         });
         await use(key);
     },


### PR DESCRIPTION
- Adds `byop_client_key_id` for verified BYOP-issued secret keys.
- Backfills existing metadata attribution into the trusted column.
- Resolves generation-event app attribution from the stored publishable key.
- Validated with focused enter/gen tests and typechecks.