### PR TITLE
chore(observability): restore polar_event and crypto_event datasource files

### DIFF
--- a/enter.pollinations.ai/observability/datasources/crypto_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/crypto_event.datasource
@@ -1,0 +1,18 @@
+TOKEN tinybird_ingest APPEND
+
+DESCRIPTION >
+NOWPayments crypto webhook events (payments) with full JSON payload
+
+SCHEMA >
+`timestamp` DateTime `json:$.timestamp` DEFAULT now(),
+`event_type` LowCardinality(String) `json:$.event_type` DEFAULT '',
+`user_id` String `json:$.user_id` DEFAULT '',
+`payment_id` String `json:$.payment_id` DEFAULT '',
+`order_id` String `json:$.order_id` DEFAULT '',
+`pay_currency` LowCardinality(String) `json:$.pay_currency` DEFAULT '',
+`payload` String `json:$.payload`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "timestamp, event_type, user_id"
+ENGINE_PRIMARY_KEY "timestamp, event_type"

--- a/enter.pollinations.ai/observability/datasources/polar_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/polar_event.datasource
@@ -1,0 +1,18 @@
+TOKEN tinybird_ingest APPEND
+
+DESCRIPTION >
+Polar webhook events (payments, subscriptions, benefits) with full JSON payload
+
+SCHEMA >
+`timestamp` DateTime `json:$.timestamp` DEFAULT now(),
+`event_type` LowCardinality(String) `json:$.event_type` DEFAULT '',
+`user_id` String `json:$.user_id` DEFAULT '',
+`customer_id` String `json:$.customer_id` DEFAULT '',
+`product_id` String `json:$.product_id` DEFAULT '',
+`data_id` String `json:$.data_id` DEFAULT '',
+`payload` String `json:$.payload`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "timestamp, event_type, user_id"
+ENGINE_PRIMARY_KEY "timestamp, event_type"


### PR DESCRIPTION
Polar (10.6M rows, 1.38 GB) and crypto (119 rows) datasources still exist on Tinybird with their historical data. The `.datasource` files were removed in #10625 (Polar) and #10500 (crypto) along with the ingest code, but the deployed tables were never dropped.

Restoring the files (verbatim from git history, matching the live schema) so the repo state matches Tinybird. Without this, every `tb --cloud deploy --check` flags both as pending destructive deletions and blocks unrelated deploys.

No code paths write to these tables anymore — the files are kept solely so the historical rows are preserved and the deploy diff is clean.

Validated: `tb --cloud deploy --check --wait` from `enter.pollinations.ai/observability` is now clean for these two (only unrelated d1_apikey + app_top_weekly modifications remain).