### PR TITLE
fix: keep image prompt enhancement opt-in

### DIFF
--- a/gen.pollinations.ai/src/image/normalizeAndTranslatePrompt.ts
+++ b/gen.pollinations.ai/src/image/normalizeAndTranslatePrompt.ts
@@ -14,17 +14,17 @@ export type MinimalRequest = {
 
 export const normalizeAndTranslatePrompt = async (
     originalPrompt: string,
-    req: MinimalRequest,
+    _req: MinimalRequest,
     timingInfo: TimingStep[],
     safeParams: ImageParams,
 ) => {
     // if it is not a string make it a string
     originalPrompt = `${originalPrompt}`;
 
-    let { enhance, seed } = safeParams;
+    const { enhance, seed } = safeParams;
 
     // Generate a memoization key that includes the seed
-    const memoKey = `${originalPrompt}_seed_${seed}`;
+    const memoKey = `${originalPrompt}_seed_${seed}_enhance_${enhance}`;
 
     if (memoizedPrompts.has(memoKey)) {
         return memoizedPrompts.get(memoKey);
@@ -41,14 +41,8 @@ export const normalizeAndTranslatePrompt = async (
     // Sanitize prompt
     prompt = sanitizeString(prompt);
 
-    // If the user's accept-language isn't English, assume the prompt may need
-    // translation/enhancement. The prompt enhancer (LLM) handles this — there
-    // is no separate translation service.
-    const acceptLanguage = req.headers["accept-language"];
-    const englishLikely =
-        typeof acceptLanguage === "string" && acceptLanguage.startsWith("en");
-    if (!englishLikely) enhance = true;
-
+    // Keep enhancement opt-in. Inferring it from headers can create hidden
+    // text-model usage for image-only requests.
     if (enhance) {
         logPrompt("pimping prompt", prompt, seed);
         prompt = (await pimpPrompt(prompt, seed)) || prompt;

--- a/gen.pollinations.ai/test/image/normalizeAndTranslatePrompt.test.ts
+++ b/gen.pollinations.ai/test/image/normalizeAndTranslatePrompt.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest";
+import { normalizeAndTranslatePrompt } from "../../src/image/normalizeAndTranslatePrompt.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+
+const baseParams: ImageParams = {
+    width: 1024,
+    height: 1024,
+    seed: 42,
+    model: "zimage",
+    enhance: false,
+    negative_prompt: "worst quality, blurry",
+    nofeed: false,
+    safe: false,
+    quality: "medium",
+    image: [],
+    transparent: false,
+    reasoning: "balanced",
+    audio: true,
+};
+
+test("does not infer prompt enhancement from accept-language", async () => {
+    const timingInfo: Array<{ step: string; timestamp: number }> = [];
+
+    const result = await normalizeAndTranslatePrompt(
+        "un paisaje",
+        { headers: { "accept-language": "es-ES,es;q=0.9" }, url: "/" },
+        timingInfo,
+        baseParams,
+    );
+
+    expect(result).toMatchObject({
+        prompt: "un paisaje",
+        wasPimped: false,
+    });
+});
+
+test("memoized prompt normalization keeps enhance mode separate", async () => {
+    const request = { headers: {}, url: "/" };
+
+    const plain = await normalizeAndTranslatePrompt(
+        "same prompt",
+        request,
+        [],
+        baseParams,
+    );
+    const enhanced = await normalizeAndTranslatePrompt(
+        "same prompt",
+        request,
+        [],
+        { ...baseParams, enhance: true },
+    );
+
+    expect(plain.wasPimped).toBe(false);
+    expect(enhanced.wasPimped).toBe(true);
+});


### PR DESCRIPTION
- Keeps image prompt enhancement controlled by the explicit `enhance` parameter.
- Removes `Accept-Language` inference that could create hidden prompt-enhancement behavior for image requests.
- Separates prompt normalization cache entries by `enhance` mode.
- Adds focused coverage for non-English `Accept-Language` and cache separation.

Billing sensitivity:
- Does not change prices, paid-only flags, balances, checkout, or deductions.
- Reduces risk of unexpected text-model work attached to image-only calls.

Validation:
- `biome check --write gen.pollinations.ai/src/image/normalizeAndTranslatePrompt.ts gen.pollinations.ai/test/image/normalizeAndTranslatePrompt.test.ts`
- `npm run typecheck` in `gen.pollinations.ai`
- Direct TS smoke test for prompt normalization behavior

Addresses #9484.