### PR TITLE
fix: clarify billing access copy

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx
@@ -65,7 +65,7 @@ export const ModelPermissions: FC<ModelPermissionsProps> = ({
                 <span className="flex items-center gap-1.5 text-sm font-semibold mb-2">
                     Models
                     <InfoTip
-                        text="Limit this key to specific models"
+                        text="Limit this key to specific models. Model permission does not waive paid-only or balance requirements."
                         label="Show model access information"
                     />
                 </span>

--- a/enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx
@@ -10,7 +10,9 @@ export const ModelsBadge: FC<{
     const modelCount = models?.length ?? 0;
 
     const tooltipContent = (): ReactNode => {
-        if (isAllModels) return "Access to all models";
+        if (isAllModels) {
+            return "Key can request all models. Paid-only models still require purchased pollen.";
+        }
         if (modelCount === 0) return "No models allowed";
         return (
             <span className="block font-mono text-[11px] leading-relaxed text-left whitespace-nowrap">

--- a/enter.pollinations.ai/src/client/components/balance/payment-trust-badge.tsx
+++ b/enter.pollinations.ai/src/client/components/balance/payment-trust-badge.tsx
@@ -53,7 +53,10 @@ export const PaymentTrustBadge: FC<PaymentTrustBadgeProps> = ({
             </div>
             <div className="flex items-center gap-1.5 text-gray-400 text-xs">
                 <LockIcon />
-                <span>Secure checkout powered by Stripe</span>
+                <span>
+                    Secure checkout powered by Stripe. Payment methods vary by
+                    country, device, and browser.
+                </span>
             </div>
         </div>
     );


### PR DESCRIPTION
- Clarifies that API key model permissions do not bypass paid-only or balance requirements.
- Clarifies that Stripe payment methods vary by country, device, and browser.
- Keeps the change limited to UI copy around model access and checkout expectations.

Billing sensitivity:
- Does not change prices, balances, checkout session creation, paid-only model flags, or deduction logic.
- Reduces confusion around `all models` access versus purchased-pollen requirements.

Validation:
- `biome check --write enter.pollinations.ai/src/client/components/api-keys/model-permissions.tsx enter.pollinations.ai/src/client/components/api-keys/models-badge.tsx enter.pollinations.ai/src/client/components/balance/payment-trust-badge.tsx`
- `npm run typecheck` in `enter.pollinations.ai`

Addresses #6194, #8110, #9285.