### PR TITLE
refactor: centralize dashboard color system

### DIFF
--- a/enter.pollinations.ai/src/client/components/layout/dashboard-theme.ts
+++ b/enter.pollinations.ai/src/client/components/layout/dashboard-theme.ts
@@ -29,6 +29,13 @@ export const DASHBOARD_PAGES: DashboardPage[] = [
     "models",
 ];
 
+// Page → theme lookup, derived from DASHBOARD_NAV_ITEMS.
+// Pages should read their theme from here so flipping a nav item's `theme`
+// retheme the corresponding page in one edit.
+export const dashboardThemeByPage = Object.fromEntries(
+    DASHBOARD_NAV_ITEMS.map(({ id, theme }) => [id, theme]),
+) as Record<DashboardPage, DashboardTheme>;
+
 // ─── Color palette (single source of truth) ──────────────────
 // `Panel`, `Card`, and `Button` import their slice from here.
 // `dashboardThemeClasses` (below) rolls these up for the 7 nav themes.
@@ -172,6 +179,210 @@ export const tabColors = {
     { active: string; inactive: string }
 >;
 
+// Per-theme token bundle for page chrome — literal class strings so Tailwind's JIT picks them up.
+// Covers per-page-themed surfaces only: text, borders, backgrounds, dividers, ring accents,
+// and scrollbar thumb. Out of scope: neutral grays/reds (loading/error/disabled), tier/modality
+// semantic colors, and Tag badge styling (`tagColors` in `ui/tag.tsx`).
+export const themeTokens = {
+    amber: {
+        text: {
+            label: "text-amber-600",
+            base: "text-amber-900",
+            strong: "text-amber-950",
+            muted: "text-amber-800/75",
+            soft: "text-amber-700",
+            softer: "text-amber-700/60",
+        },
+        border: {
+            idle: "border-amber-300",
+            soft: "border-amber-300/70",
+            subtle: "border-amber-200",
+        },
+        bg: {
+            idle: "bg-amber-50/80",
+            subtle: "bg-amber-50/50",
+            hover: "hover:bg-amber-100",
+            active: "bg-amber-200",
+            soft: "hover:bg-amber-50",
+        },
+        divide: "divide-amber-300/70",
+        ring: "ring-amber-400/70",
+        scrollbar: "scrollbar-theme-amber",
+    },
+    blue: {
+        text: {
+            label: "text-blue-600",
+            base: "text-blue-900",
+            strong: "text-blue-950",
+            muted: "text-blue-800/75",
+            soft: "text-blue-700",
+            softer: "text-blue-700/60",
+        },
+        border: {
+            idle: "border-blue-300",
+            soft: "border-blue-300/70",
+            subtle: "border-blue-200",
+        },
+        bg: {
+            idle: "bg-blue-50/80",
+            subtle: "bg-blue-50/50",
+            hover: "hover:bg-blue-100",
+            active: "bg-blue-200",
+            soft: "hover:bg-blue-50",
+        },
+        divide: "divide-blue-300/70",
+        ring: "ring-blue-400/70",
+        scrollbar: "scrollbar-theme-blue",
+    },
+    gray: {
+        text: {
+            label: "text-gray-600",
+            base: "text-gray-900",
+            strong: "text-gray-950",
+            muted: "text-gray-800/75",
+            soft: "text-gray-700",
+            softer: "text-gray-700/60",
+        },
+        border: {
+            idle: "border-gray-300",
+            soft: "border-gray-300/70",
+            subtle: "border-gray-200",
+        },
+        bg: {
+            idle: "bg-gray-50/80",
+            subtle: "bg-gray-50/50",
+            hover: "hover:bg-gray-100",
+            active: "bg-gray-200",
+            soft: "hover:bg-gray-50",
+        },
+        divide: "divide-gray-300/70",
+        ring: "ring-gray-400/70",
+        scrollbar: "scrollbar-theme-gray",
+    },
+    green: {
+        text: {
+            label: "text-green-600",
+            base: "text-green-900",
+            strong: "text-green-950",
+            muted: "text-green-800/75",
+            soft: "text-green-700",
+            softer: "text-green-700/60",
+        },
+        border: {
+            idle: "border-green-300",
+            soft: "border-green-300/70",
+            subtle: "border-green-200",
+        },
+        bg: {
+            idle: "bg-green-50/80",
+            subtle: "bg-green-50/50",
+            hover: "hover:bg-green-100",
+            active: "bg-green-200",
+            soft: "hover:bg-green-50",
+        },
+        divide: "divide-green-300/70",
+        ring: "ring-green-400/70",
+        scrollbar: "scrollbar-theme-green",
+    },
+    pink: {
+        text: {
+            label: "text-pink-600",
+            base: "text-pink-900",
+            strong: "text-pink-950",
+            muted: "text-pink-800/75",
+            soft: "text-pink-700",
+            softer: "text-pink-700/60",
+        },
+        border: {
+            idle: "border-pink-300",
+            soft: "border-pink-300/70",
+            subtle: "border-pink-200",
+        },
+        bg: {
+            idle: "bg-pink-50/80",
+            subtle: "bg-pink-50/50",
+            hover: "hover:bg-pink-100",
+            active: "bg-pink-200",
+            soft: "hover:bg-pink-50",
+        },
+        divide: "divide-pink-300/70",
+        ring: "ring-pink-400/70",
+        scrollbar: "scrollbar-theme-pink",
+    },
+    teal: {
+        text: {
+            label: "text-teal-600",
+            base: "text-teal-900",
+            strong: "text-teal-950",
+            muted: "text-teal-800/75",
+            soft: "text-teal-700",
+            softer: "text-teal-700/60",
+        },
+        border: {
+            idle: "border-teal-300",
+            soft: "border-teal-300/70",
+            subtle: "border-teal-200",
+        },
+        bg: {
+            idle: "bg-teal-50/80",
+            subtle: "bg-teal-50/50",
+            hover: "hover:bg-teal-100",
+            active: "bg-teal-200",
+            soft: "hover:bg-teal-50",
+        },
+        divide: "divide-teal-300/70",
+        ring: "ring-teal-400/70",
+        scrollbar: "scrollbar-theme-teal",
+    },
+    violet: {
+        text: {
+            label: "text-violet-600",
+            base: "text-violet-900",
+            strong: "text-violet-950",
+            muted: "text-violet-800/75",
+            soft: "text-violet-700",
+            softer: "text-violet-700/60",
+        },
+        border: {
+            idle: "border-violet-300",
+            soft: "border-violet-300/70",
+            subtle: "border-violet-200",
+        },
+        bg: {
+            idle: "bg-violet-50/80",
+            subtle: "bg-violet-50/50",
+            hover: "hover:bg-violet-100",
+            active: "bg-violet-200",
+            soft: "hover:bg-violet-50",
+        },
+        divide: "divide-violet-300/70",
+        ring: "ring-violet-400/70",
+        scrollbar: "scrollbar-theme-violet",
+    },
+} as const satisfies Record<DashboardTheme, ThemeTokens>;
+
+export type ThemeTokens = {
+    text: {
+        label: string;
+        base: string;
+        strong: string;
+        muted: string;
+        soft: string;
+        softer: string;
+    };
+    border: { idle: string; soft: string; subtle: string };
+    bg: {
+        idle: string;
+        subtle: string;
+        hover: string;
+        active: string;
+        soft: string;
+    };
+    divide: string;
+    ring: string;
+    scrollbar: string;
+};
+
 export const dashboardThemeClasses: Record<
     DashboardTheme,
     {
@@ -182,6 +393,8 @@ export const dashboardThemeClasses: Record<
         card: string;
         button: (typeof buttonColors)[keyof typeof buttonColors];
         tab: (typeof tabColors)[keyof typeof tabColors];
+        pill: (typeof pillColors)[keyof typeof pillColors];
+        tokens: ThemeTokens;
     }
 > = {
     amber: {
@@ -192,6 +405,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.amber,
         button: buttonColors.amber,
         tab: tabColors.amber,
+        pill: pillColors.amber,
+        tokens: themeTokens.amber,
     },
     blue: {
         title: "text-blue-950",
@@ -201,6 +416,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.blue,
         button: buttonColors.blue,
         tab: tabColors.blue,
+        pill: pillColors.blue,
+        tokens: themeTokens.blue,
     },
     gray: {
         title: "text-gray-950",
@@ -210,6 +427,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.gray,
         button: buttonColors.gray,
         tab: tabColors.gray,
+        pill: pillColors.gray,
+        tokens: themeTokens.gray,
     },
     green: {
         title: "text-green-950",
@@ -219,6 +438,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.green,
         button: buttonColors.green,
         tab: tabColors.green,
+        pill: pillColors.green,
+        tokens: themeTokens.green,
     },
     pink: {
         title: "text-pink-950",
@@ -228,6 +449,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.pink,
         button: buttonColors.pink,
         tab: tabColors.pink,
+        pill: pillColors.pink,
+        tokens: themeTokens.pink,
     },
     teal: {
         title: "text-teal-950",
@@ -237,6 +460,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.teal,
         button: buttonColors.teal,
         tab: tabColors.teal,
+        pill: pillColors.teal,
+        tokens: themeTokens.teal,
     },
     violet: {
         title: "text-violet-950",
@@ -246,6 +471,8 @@ export const dashboardThemeClasses: Record<
         card: cardColors.violet,
         button: buttonColors.violet,
         tab: tabColors.violet,
+        pill: pillColors.violet,
+        tokens: themeTokens.violet,
     },
 };
 

--- a/enter.pollinations.ai/src/client/components/ui/tag.tsx
+++ b/enter.pollinations.ai/src/client/components/ui/tag.tsx
@@ -5,7 +5,7 @@ const tagColors = {
     gray: "bg-gray-200 text-gray-900",
     green: "bg-green-200 text-gray-900",
     pink: "bg-pink-200 text-gray-900",
-    amber: "bg-amber-200 text-amber-950",
+    amber: "bg-amber-200 text-amber-900",
     orange: "bg-orange-300 text-orange-950",
     blue: "bg-blue-100 text-blue-700",
     purple: "bg-purple-200 text-gray-900",

--- a/enter.pollinations.ai/src/client/components/usage-analytics/multi-select.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/multi-select.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/util.ts";
 import { useAutoHideScrollbar } from "../../hooks/use-auto-hide-scrollbar.ts";
+import { type DashboardTheme, themeTokens } from "../layout/dashboard-theme.ts";
 
 type MultiSelectProps = {
     options: { value: string; label: string }[];
@@ -12,6 +13,7 @@ type MultiSelectProps = {
     disabledText?: string;
     align?: "start" | "end";
     label?: string;
+    theme: DashboardTheme;
 };
 
 export const MultiSelect: FC<MultiSelectProps> = ({
@@ -23,7 +25,9 @@ export const MultiSelect: FC<MultiSelectProps> = ({
     disabledText,
     align = "start",
     label,
+    theme,
 }) => {
+    const tokens = themeTokens[theme];
     const [open, setOpen] = useState(false);
     const [openDirection, setOpenDirection] = useState<"up" | "down">("up");
     const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
@@ -100,7 +104,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
     return (
         <div ref={ref} className="relative group flex items-center gap-2">
             {label && (
-                <span className="text-xs font-medium text-pink-800/75">
+                <span className={cn("text-xs font-medium", tokens.text.muted)}>
                     {label}
                 </span>
             )}
@@ -111,20 +115,28 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 className={cn(
                     "inline-flex min-h-8 min-w-[140px] items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200",
                     disabled
-                        ? "cursor-not-allowed border-pink-200 bg-pink-50/50 opacity-60"
+                        ? cn(
+                              "cursor-not-allowed opacity-60",
+                              tokens.border.subtle,
+                              tokens.bg.subtle,
+                          )
                         : open
-                          ? "border-pink-300 bg-pink-200"
-                          : "border-pink-300 bg-pink-50/80 hover:bg-pink-100",
+                          ? cn(tokens.border.idle, tokens.bg.active)
+                          : cn(
+                                tokens.border.idle,
+                                tokens.bg.idle,
+                                tokens.bg.hover,
+                            ),
                 )}
             >
                 <span
                     className={cn(
                         "truncate flex-1 text-left",
                         disabled
-                            ? "text-pink-700/60"
+                            ? tokens.text.softer
                             : open
-                              ? "text-pink-950"
-                              : "text-pink-900",
+                              ? tokens.text.strong
+                              : tokens.text.base,
                     )}
                 >
                     {displayText}
@@ -132,7 +144,9 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 <svg
                     className={cn(
                         "w-3 h-3 transition-transform",
-                        open ? "rotate-180 text-pink-950" : "text-pink-700",
+                        open
+                            ? cn("rotate-180", tokens.text.strong)
+                            : tokens.text.soft,
                     )}
                     fill="none"
                     viewBox="0 0 24 24"
@@ -155,7 +169,8 @@ export const MultiSelect: FC<MultiSelectProps> = ({
             {open && !disabled && (
                 <div
                     className={cn(
-                        "min-w-[320px] overflow-hidden rounded-lg border border-pink-300 bg-white shadow-lg z-50",
+                        "min-w-[320px] overflow-hidden rounded-lg border bg-white shadow-lg z-50",
+                        tokens.border.idle,
                         !dropdownStyle.position && "absolute",
                         !dropdownStyle.position &&
                             (openDirection === "up"
@@ -168,7 +183,10 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                 >
                     <div
                         ref={scrollAreaRef}
-                        className="max-h-64 overflow-y-auto overflow-x-hidden scrollbar-subtle scrollbar-theme-pink"
+                        className={cn(
+                            "max-h-64 overflow-y-auto overflow-x-hidden scrollbar-subtle",
+                            tokens.scrollbar,
+                        )}
                     >
                         <button
                             type="button"
@@ -176,16 +194,24 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                             className={cn(
                                 "w-full px-3 py-2 text-left text-xs transition-colors flex items-center gap-3",
                                 isAllSelected
-                                    ? "bg-pink-200 text-pink-950 font-medium"
-                                    : "text-pink-900 hover:bg-pink-50",
+                                    ? cn(
+                                          tokens.bg.active,
+                                          tokens.text.strong,
+                                          "font-medium",
+                                      )
+                                    : cn(tokens.text.base, tokens.bg.soft),
                             )}
                         >
                             <span
                                 className={cn(
                                     "w-4 h-4 rounded border flex items-center justify-center text-xs flex-shrink-0",
                                     isAllSelected
-                                        ? "bg-pink-200 border-pink-300 text-pink-950"
-                                        : "border-pink-300",
+                                        ? cn(
+                                              tokens.bg.active,
+                                              tokens.border.idle,
+                                              tokens.text.strong,
+                                          )
+                                        : tokens.border.idle,
                                 )}
                             >
                                 {isAllSelected && "✓"}
@@ -202,16 +228,26 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                                     className={cn(
                                         "w-full px-3 py-2 text-left text-xs transition-colors flex items-center gap-3",
                                         isChecked
-                                            ? "bg-pink-200 text-pink-950"
-                                            : "text-pink-900 hover:bg-pink-50",
+                                            ? cn(
+                                                  tokens.bg.active,
+                                                  tokens.text.strong,
+                                              )
+                                            : cn(
+                                                  tokens.text.base,
+                                                  tokens.bg.soft,
+                                              ),
                                     )}
                                 >
                                     <span
                                         className={cn(
                                             "w-4 h-4 rounded border flex items-center justify-center text-xs flex-shrink-0",
                                             isChecked
-                                                ? "bg-pink-200 border-pink-300 text-pink-950"
-                                                : "border-pink-300",
+                                                ? cn(
+                                                      tokens.bg.active,
+                                                      tokens.border.idle,
+                                                      tokens.text.strong,
+                                                  )
+                                                : tokens.border.idle,
                                         )}
                                     >
                                         {isChecked && "✓"}

--- a/enter.pollinations.ai/src/client/components/usage-analytics/period-picker.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/period-picker.tsx
@@ -1,6 +1,7 @@
-import type { FC, ReactNode } from "react";
+import type { FC } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/util.ts";
+import { type DashboardTheme, themeTokens } from "../layout/dashboard-theme.ts";
 import { TabButton } from "../ui/tab-button.tsx";
 import {
     addUtcDays,
@@ -16,6 +17,7 @@ import type { PeriodGranularity, UsagePeriodSelection } from "./types.ts";
 type PeriodPickerProps = {
     value: UsagePeriodSelection;
     onChange: (value: UsagePeriodSelection) => void;
+    theme: DashboardTheme;
 };
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -72,7 +74,12 @@ function viewBounds(
     return { start, end: addUtcMonths(start, 1) };
 }
 
-export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
+export const PeriodPicker: FC<PeriodPickerProps> = ({
+    value,
+    onChange,
+    theme,
+}) => {
+    const tokens = themeTokens[theme];
     const [open, setOpen] = useState(false);
     const [viewDate, setViewDate] = useState<Date>(() => periodDate(value));
     const ref = useRef<HTMLDivElement>(null);
@@ -147,7 +154,7 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                     (granularity) => (
                         <TabButton
                             key={granularity}
-                            theme="pink"
+                            theme={theme}
                             active={value.granularity === granularity}
                             onClick={() => setGranularity(granularity)}
                         >
@@ -165,8 +172,13 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                 onClick={() => setOpen((isOpen) => !isOpen)}
                 className={cn(
                     "inline-flex min-h-8 min-w-[150px] items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-left text-xs font-medium",
-                    "border-pink-300 bg-pink-50/80 text-pink-900 transition-all duration-200 ease-out hover:bg-pink-100",
-                    open && "bg-pink-200 text-pink-950 shadow-sm",
+                    tokens.border.idle,
+                    tokens.bg.idle,
+                    tokens.text.base,
+                    "transition-all duration-200 ease-out",
+                    tokens.bg.hover,
+                    open &&
+                        cn(tokens.bg.active, tokens.text.strong, "shadow-sm"),
                 )}
             >
                 <span>{formatPeriodLabel(value)}</span>
@@ -194,7 +206,10 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                 <div
                     role="dialog"
                     aria-label="Usage period picker"
-                    className="absolute left-0 top-full z-30 mt-2 w-[304px] rounded-xl border border-pink-300 bg-white p-3 shadow-lg transition-opacity duration-200 ease-out"
+                    className={cn(
+                        "absolute left-0 top-full z-30 mt-2 w-[304px] rounded-xl border bg-white p-3 shadow-lg transition-opacity duration-200 ease-out",
+                        tokens.border.idle,
+                    )}
                 >
                     <div className="mb-3 flex items-center justify-between">
                         <button
@@ -207,14 +222,21 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                             disabled={previousDisabled}
                             onClick={() => setViewDate(previousViewDate)}
                             className={cn(
-                                "rounded-full px-2 py-1 text-xs font-semibold text-pink-900 transition-colors hover:bg-pink-50",
+                                "rounded-full px-2 py-1 text-xs font-semibold transition-colors",
+                                tokens.text.base,
+                                tokens.bg.soft,
                                 previousDisabled &&
                                     "cursor-not-allowed opacity-30 hover:bg-transparent",
                             )}
                         >
                             {"<"}
                         </button>
-                        <div className="text-sm font-bold text-pink-900">
+                        <div
+                            className={cn(
+                                "text-sm font-bold",
+                                tokens.text.base,
+                            )}
+                        >
                             {viewLabel}
                         </div>
                         <button
@@ -227,7 +249,9 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                             disabled={nextDisabled}
                             onClick={() => setViewDate(nextViewDate)}
                             className={cn(
-                                "rounded-full px-2 py-1 text-xs font-semibold text-pink-900 transition-colors hover:bg-pink-50",
+                                "rounded-full px-2 py-1 text-xs font-semibold transition-colors",
+                                tokens.text.base,
+                                tokens.bg.soft,
                                 nextDisabled &&
                                     "cursor-not-allowed opacity-30 hover:bg-transparent",
                             )}
@@ -272,8 +296,14 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                                         className={cn(
                                             "rounded-md px-3 py-2 text-xs font-medium transition-colors duration-150",
                                             selected
-                                                ? "bg-pink-200 text-pink-950"
-                                                : "text-gray-700 hover:bg-pink-50",
+                                                ? cn(
+                                                      tokens.bg.active,
+                                                      tokens.text.strong,
+                                                  )
+                                                : cn(
+                                                      "text-gray-700",
+                                                      tokens.bg.soft,
+                                                  ),
                                             !selectable &&
                                                 "cursor-not-allowed text-gray-300 hover:bg-transparent",
                                         )}
@@ -331,10 +361,16 @@ export const PeriodPicker: FC<PeriodPickerProps> = ({ value, onChange }) => {
                                                 !inCurrentMonth &&
                                                     "text-gray-300",
                                                 sameUtcDay(date, today) &&
-                                                    "ring-1 ring-pink-400/70",
+                                                    cn("ring-1", tokens.ring),
                                                 selected
-                                                    ? "bg-pink-200 text-pink-950"
-                                                    : "text-gray-700 hover:bg-pink-50",
+                                                    ? cn(
+                                                          tokens.bg.active,
+                                                          tokens.text.strong,
+                                                      )
+                                                    : cn(
+                                                          "text-gray-700",
+                                                          tokens.bg.soft,
+                                                      ),
                                                 !selectable &&
                                                     "cursor-not-allowed text-gray-300 hover:bg-transparent",
                                             )}

--- a/enter.pollinations.ai/src/client/components/usage-analytics/stat.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/stat.tsx
@@ -1,17 +1,33 @@
 import type { FC, ReactNode } from "react";
+import { cn } from "@/util.ts";
+import { type DashboardTheme, themeTokens } from "../layout/dashboard-theme.ts";
 
 type StatProps = {
     label: string;
     value: ReactNode;
+    theme: DashboardTheme;
 };
 
-export const Stat: FC<StatProps> = ({ label, value }) => (
-    <div className="flex flex-col">
-        <span className="text-[10px] uppercase tracking-wide text-pink-600 font-bold">
-            {label}
-        </span>
-        <span className="text-lg font-bold text-pink-950 tabular-nums">
-            {value}
-        </span>
-    </div>
-);
+export const Stat: FC<StatProps> = ({ label, value, theme }) => {
+    const tokens = themeTokens[theme];
+    return (
+        <div className="flex flex-col">
+            <span
+                className={cn(
+                    "text-[10px] uppercase tracking-wide font-bold",
+                    tokens.text.label,
+                )}
+            >
+                {label}
+            </span>
+            <span
+                className={cn(
+                    "text-lg font-bold tabular-nums",
+                    tokens.text.strong,
+                )}
+            >
+                {value}
+            </span>
+        </div>
+    );
+};

--- a/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
+++ b/enter.pollinations.ai/src/client/components/usage-analytics/usage-graph.tsx
@@ -2,8 +2,13 @@ import type { TierStatus } from "@shared/tier-config.ts";
 import { getTierColor, TIER_EMOJIS } from "@shared/tier-config.ts";
 import type { FC, ReactNode } from "react";
 import { useEffect, useState } from "react";
+import { cn } from "@/util.ts";
 import { DashboardSection } from "../layout/dashboard-section.tsx";
-import { pillColors } from "../layout/dashboard-theme.ts";
+import {
+    type DashboardTheme,
+    pillColors,
+    themeTokens,
+} from "../layout/dashboard-theme.ts";
 import { TabButton } from "../ui/tab-button.tsx";
 import { Tag } from "../ui/tag.tsx";
 import { Chart } from "./chart";
@@ -19,6 +24,7 @@ type UsageGraphProps = {
     onPeriodChange: (period: UsagePeriodSelection) => void;
     apiKeys: Array<{ id: string; name: string }>;
     action?: ReactNode;
+    theme: DashboardTheme;
 };
 
 export const UsageGraph: FC<UsageGraphProps> = ({
@@ -27,7 +33,9 @@ export const UsageGraph: FC<UsageGraphProps> = ({
     onPeriodChange,
     apiKeys,
     action,
+    theme,
 }) => {
+    const tokens = themeTokens[theme];
     const [filters, setFilters] = useState<Omit<FilterState, "period">>({
         metric: "pollen",
         selectedKeyIds: [],
@@ -75,7 +83,7 @@ export const UsageGraph: FC<UsageGraphProps> = ({
         <div className="flex flex-col gap-6">
             <DashboardSection
                 title="Activity"
-                theme="pink"
+                theme={theme}
                 framed
                 action={action}
             >
@@ -85,13 +93,14 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                             <PeriodPicker
                                 value={period}
                                 onChange={onPeriodChange}
+                                theme={theme}
                             />
                             <div className="flex items-stretch [&>button]:rounded-none [&>button]:border-l-0 [&>button:first-child]:rounded-l-full [&>button:first-child]:border-l [&>button:last-child]:rounded-r-full">
                                 {(["requests", "pollen"] as Metric[]).map(
                                     (m) => (
                                         <TabButton
                                             key={m}
-                                            theme="pink"
+                                            theme={theme}
                                             active={filters.metric === m}
                                             onClick={() =>
                                                 setFilters((f) => ({
@@ -123,6 +132,7 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                 disabledText="None"
                                 align="end"
                                 label="Models"
+                                theme={theme}
                             />
                             <MultiSelect
                                 options={keySelectOptions}
@@ -138,11 +148,12 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                 disabledText="None"
                                 align="end"
                                 label="API Keys"
+                                theme={theme}
                             />
                         </div>
                     </div>
 
-                    <div className="border-t border-pink-300/70 pt-4">
+                    <div className={cn("border-t pt-4", tokens.border.soft)}>
                         {loading && (
                             <div className="flex items-center justify-center h-[180px]">
                                 <p className="text-sm text-gray-400 animate-[pulse_2s_ease-in-out_infinite]">
@@ -177,7 +188,13 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                     </div>
 
                     {!loading && !error && (
-                        <div className="flex flex-col gap-4 border-t border-pink-300/70 pt-4 sm:flex-row sm:gap-0 sm:divide-x sm:divide-pink-300/70">
+                        <div
+                            className={cn(
+                                "flex flex-col gap-4 border-t pt-4 sm:flex-row sm:gap-0 sm:divide-x",
+                                tokens.border.soft,
+                                tokens.divide,
+                            )}
+                        >
                             <div className="flex-1 sm:px-4 sm:first:pl-0 sm:last:pr-0">
                                 <UsageStatCard
                                     label="Requests"
@@ -185,8 +202,10 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                     detail={
                                         <ModalityPills
                                             breakdown={stats.requestsByModality}
+                                            theme={theme}
                                         />
                                     }
+                                    theme={theme}
                                 />
                             </div>
                             <div className="flex-1 sm:px-4 sm:first:pl-0 sm:last:pr-0">
@@ -205,13 +224,14 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                             <Tag
                                                 color="amber"
                                                 size="lg"
-                                                className="font-semibold text-amber-900"
+                                                className="font-semibold"
                                             >
                                                 🪷{" "}
                                                 {formatPollen(stats.paidPollen)}
                                             </Tag>
                                         </div>
                                     }
+                                    theme={theme}
                                 />
                             </div>
                             <div className="flex-1 sm:px-4 sm:first:pl-0 sm:last:pr-0">
@@ -226,9 +246,12 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                         stats.topModel ? (
                                             <div className="flex flex-wrap items-center gap-2">
                                                 <Tag
-                                                    color="pink"
+                                                    color={theme}
                                                     size="lg"
-                                                    className="font-semibold text-pink-900"
+                                                    className={cn(
+                                                        "font-semibold",
+                                                        tokens.text.base,
+                                                    )}
                                                     title={`${stats.topModel.requests.toLocaleString()} request${stats.topModel.requests === 1 ? "" : "s"}`}
                                                 >
                                                     <span aria-hidden="true">
@@ -241,7 +264,7 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                                 <Tag
                                                     color="amber"
                                                     size="lg"
-                                                    className="font-semibold text-amber-900"
+                                                    className="font-semibold"
                                                     title={`${formatPollen(stats.topModel.pollen)} pollen`}
                                                 >
                                                     <span aria-hidden="true">
@@ -259,6 +282,7 @@ export const UsageGraph: FC<UsageGraphProps> = ({
                                             "No model usage yet"
                                         )
                                     }
+                                    theme={theme}
                                 />
                             </div>
                         </div>
@@ -284,23 +308,41 @@ const UsageStatCard: FC<{
     label: string;
     value: ReactNode;
     detail?: ReactNode;
-}> = ({ label, value, detail }) => (
-    <div className="text-sm">
-        <div className="text-[10px] uppercase tracking-wide text-pink-600 font-bold">
-            {label}
+    theme: DashboardTheme;
+}> = ({ label, value, detail, theme }) => {
+    const tokens = themeTokens[theme];
+    return (
+        <div className="text-sm">
+            <div
+                className={cn(
+                    "text-[10px] uppercase tracking-wide font-bold",
+                    tokens.text.label,
+                )}
+            >
+                {label}
+            </div>
+            <div
+                className={cn(
+                    "mt-1 min-h-8 break-words text-2xl font-bold leading-tight tabular-nums",
+                    tokens.text.strong,
+                )}
+            >
+                {value}
+            </div>
+            {detail && (
+                <div className={cn("mt-2 text-xs", tokens.text.muted)}>
+                    {detail}
+                </div>
+            )}
         </div>
-        <div className="mt-1 min-h-8 break-words text-2xl font-bold leading-tight text-pink-950 tabular-nums">
-            {value}
-        </div>
-        {detail && (
-            <div className="mt-2 text-xs text-pink-800/75">{detail}</div>
-        )}
-    </div>
-);
+    );
+};
 
-const ModalityPills: FC<{ breakdown: Record<ModelModality, number> }> = ({
-    breakdown,
-}) => {
+const ModalityPills: FC<{
+    breakdown: Record<ModelModality, number>;
+    theme: DashboardTheme;
+}> = ({ breakdown, theme }) => {
+    const tokens = themeTokens[theme];
     const entries = (Object.keys(MODALITY_META) as ModelModality[])
         .map((modality) => ({ modality, count: breakdown[modality] }))
         .filter(({ count }) => count > 0);
@@ -312,9 +354,9 @@ const ModalityPills: FC<{ breakdown: Record<ModelModality, number> }> = ({
                 return (
                     <Tag
                         key={modality}
-                        color="pink"
+                        color={theme}
                         size="lg"
-                        className="font-semibold text-pink-900"
+                        className={cn("font-semibold", tokens.text.base)}
                         title={`${count.toLocaleString()} ${label} request${count === 1 ? "" : "s"}`}
                     >
                         <span aria-hidden="true">{emoji}</span>

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -18,7 +18,10 @@ import {
     type DashboardPage,
     DashboardShell,
 } from "../components/layout/dashboard-shell.tsx";
-import { isDashboardPage } from "../components/layout/dashboard-theme.ts";
+import {
+    dashboardThemeByPage,
+    isDashboardPage,
+} from "../components/layout/dashboard-theme.ts";
 import { UpdatesPage } from "../components/layout/updates-page.tsx";
 import { Pricing } from "../components/pricing";
 import {
@@ -256,10 +259,11 @@ function RouteComponent() {
                     period={usagePeriod}
                     onPeriodChange={setUsagePeriod}
                     apiKeys={selectableKeys}
+                    theme={dashboardThemeByPage.usage}
                     action={
                         <Button
                             as="button"
-                            color="pink"
+                            color={dashboardThemeByPage.usage}
                             weight="light"
                             onClick={downloadDetailedUsage}
                             className="flex items-center gap-1.5"

--- a/enter.pollinations.ai/src/client/style.css
+++ b/enter.pollinations.ai/src/client/style.css
@@ -129,6 +129,14 @@
         --scrollbar-thumb-color: rgba(124, 58, 237, 0.6);
     }
 
+    .scrollbar-theme-teal {
+        --scrollbar-thumb-color: rgba(13, 148, 136, 0.6);
+    }
+
+    .scrollbar-theme-gray {
+        --scrollbar-thumb-color: rgba(75, 85, 99, 0.6);
+    }
+
     .scrollbar-subtle::-webkit-scrollbar {
         width: 12px;
         height: 12px;


### PR DESCRIPTION
Centralizes per-page-themed colors for the Usage page so retheming the page is a one-line edit in `dashboard-theme.ts`.

- Adds a per-theme token bundle (`themeTokens`) in `layout/dashboard-theme.ts` with literal Tailwind class strings for text, border, background, divider, ring, and scrollbar — keyed by `DashboardTheme`. Out-of-scope semantic colors (neutrals, errors, tier, modality, Tag badge styling) are explicitly called out.
- Adds `dashboardThemeByPage` derived from `DASHBOARD_NAV_ITEMS`. The Usage route reads `dashboardThemeByPage.usage` for both `<UsageGraph theme={…}>` and the CSV `<Button color={…}>`, so flipping the nav item retheme everything.
- Refactors `PeriodPicker`, `MultiSelect`, `Stat`, and `UsageGraph` to require a `theme: DashboardTheme` prop and pull every per-page-themed class from `themeTokens[theme]`. Drops all hardcoded pink classes from `usage-analytics/`.
- Adds the two missing scrollbar variants (`scrollbar-theme-teal`, `scrollbar-theme-gray`) so every `DashboardTheme` has a matching scrollbar class.
- Folds the redundant `text-amber-900` override that every `<Tag color="amber">` callsite was applying into `tagColors.amber`. No other consumer of amber Tag exists.

Verified with `npm run typecheck`, `npx biome check`, and a grep for hardcoded `(text|bg|border|ring|divide|hover:bg)-(pink|amber|yellow|teal|blue|violet|orange|green)-*` in `usage-analytics/` (zero hits).

To sanity-test: change `{ id: "usage", theme: "pink" }` to any other theme in `DASHBOARD_NAV_ITEMS`, reload `/usage` — picker, tabs, multi-selects, scrollbar, dividers, stat-card text, modality tags, and the Download CSV button should all switch.