### PR TITLE
feat: require checkout consent for Pollen purchases

### DIFF
--- a/enter.pollinations.ai/src/checkout-consent.ts
+++ b/enter.pollinations.ai/src/checkout-consent.ts
@@ -1,0 +1,17 @@
+/**
+ * Stripe Checkout consent text shown next to the required terms-of-service
+ * checkbox. The version is the legal-proof anchor: the canonical text for
+ * each version lives in git history.
+ */
+
+export const ONE_TIME_CONSENT_VERSION = "v1-2026-05-07";
+
+export const ONE_TIME_CONSENT_MESSAGE =
+    "I agree to the " +
+    "[Terms of Service](https://pollinations.ai/terms), " +
+    "[Privacy Policy](https://pollinations.ai/privacy), and " +
+    "[Refunds & Cancellations Policy](https://pollinations.ai/refunds). " +
+    "I expressly request that Pollen be credited to my account immediately " +
+    "upon payment, and acknowledge that once Pollen is provisioned, " +
+    "I lose my 14-day right of withdrawal for digital content under " +
+    "EU/EEA consumer law.";

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -168,6 +168,32 @@ const handleCheckoutSessionCompleted = async (
         return { success: false, message: "Invalid payment amount" };
     }
 
+    // Defense in depth for sessions created after consentVersion was added:
+    // Stripe should enforce the required checkbox before payment completes.
+    // Older in-flight sessions did not have this metadata, so keep crediting
+    // them after payment instead of charging a user without provisioning.
+    const requiresConsentAcceptance = metadata.consentVersion !== undefined;
+    if (
+        requiresConsentAcceptance &&
+        session.consent?.terms_of_service !== "accepted"
+    ) {
+        console.error(
+            `Stripe checkout missing consent acceptance: session=${session.id} consent=${session.consent?.terms_of_service ?? "null"}`,
+        );
+        return {
+            success: false,
+            message: "Checkout completed without required consent acceptance",
+        };
+    }
+    if (
+        !requiresConsentAcceptance &&
+        session.consent?.terms_of_service !== "accepted"
+    ) {
+        console.warn(
+            `Stripe checkout session has no consentVersion; treating as legacy session: session=${session.id}`,
+        );
+    }
+
     if (!pack && metadata.packAmount) {
         console.error("Missing or invalid packAmount in checkout session:", {
             sessionId: session.id,

--- a/enter.pollinations.ai/src/routes/stripe.ts
+++ b/enter.pollinations.ai/src/routes/stripe.ts
@@ -6,6 +6,10 @@ import {
     POLLEN_PACKS,
 } from "@/pollen-packs.ts";
 import { createAuth } from "../auth.ts";
+import {
+    ONE_TIME_CONSENT_MESSAGE,
+    ONE_TIME_CONSENT_VERSION,
+} from "../checkout-consent.ts";
 import type { Env } from "../env.ts";
 import { createStripeClient } from "../utils/stripe.ts";
 
@@ -87,6 +91,18 @@ export const stripeRoutes = new Hono<Env>()
                 // Always create customer for invoicing
                 customer_creation: "always",
                 customer_email: userEmail,
+                // Required terms-of-service checkbox carries the immediate-
+                // delivery waiver: EU/EEA consumers expressly request immediate
+                // provisioning and acknowledge loss of the 14-day withdrawal
+                // right once Pollen is credited.
+                consent_collection: {
+                    terms_of_service: "required",
+                },
+                custom_text: {
+                    terms_of_service_acceptance: {
+                        message: ONE_TIME_CONSENT_MESSAGE,
+                    },
+                },
                 // Invoice creation after payment
                 invoice_creation: {
                     enabled: true,
@@ -97,10 +113,12 @@ export const stripeRoutes = new Hono<Env>()
                     },
                 },
                 // Metadata links the completed checkout back to the shared pack
-                // definition used by the webhook.
+                // definition used by the webhook. consentVersion pins the
+                // session to the exact consent text the user saw.
                 metadata: {
                     userId,
                     packAmount: String(pack.amountUsd),
+                    consentVersion: ONE_TIME_CONSENT_VERSION,
                 },
                 success_url: `${successUrl}?stripe_success=true&session_id={CHECKOUT_SESSION_ID}`,
                 cancel_url: `${cancelUrl}?stripe_canceled=true`,

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -4,6 +4,10 @@ import { user as userTable } from "@shared/db/better-auth.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
+import {
+    ONE_TIME_CONSENT_MESSAGE,
+    ONE_TIME_CONSENT_VERSION,
+} from "../../src/checkout-consent.ts";
 import { test } from "../fixtures.ts";
 
 const base = "http://localhost:3000/api/stripe";
@@ -208,4 +212,98 @@ test("POST /api/webhooks/stripe credits legacy sessions without packAmount only 
         WHERE session_id = 'cs_test_legacy_checkout'`,
     ).first<{ count: number }>();
     expect(processedEvent?.count).toBe(1);
+});
+
+test("POST /api/webhooks/stripe rejects checkout sessions missing consent acceptance", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    const db = drizzle(env.DB);
+    const [user] = await db
+        .select({ id: userTable.id, packBalance: userTable.packBalance })
+        .from(userTable)
+        .limit(1);
+
+    expect(user).toBeTruthy();
+    if (!user) {
+        throw new Error("Expected seeded test user");
+    }
+
+    await db
+        .update(userTable)
+        .set({ packBalance: 0 })
+        .where(eq(userTable.id, user.id));
+
+    const checkoutEvent = {
+        id: "evt_test_no_consent",
+        type: "checkout.session.completed",
+        livemode: false,
+        data: {
+            object: {
+                id: "cs_test_no_consent",
+                object: "checkout.session",
+                metadata: {
+                    userId: user.id,
+                    consentVersion: ONE_TIME_CONSENT_VERSION,
+                },
+                payment_status: "paid",
+                amount_subtotal: 500,
+                amount_total: 500,
+                currency: "usd",
+                customer_email: "no-consent@example.com",
+                payment_method_types: ["card"],
+                // consent intentionally omitted — webhook must refuse to credit
+            },
+        },
+    };
+
+    const payload = JSON.stringify(checkoutEvent);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/webhooks/stripe",
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "stripe-signature": signStripePayload(payload),
+                cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: payload,
+        },
+    );
+
+    // Webhook always 200s to ack receipt, but credit must be skipped
+    expect(response.status).toBe(200);
+
+    const [updatedUser] = await db
+        .select({ packBalance: userTable.packBalance })
+        .from(userTable)
+        .where(eq(userTable.id, user.id))
+        .limit(1);
+    expect(updatedUser?.packBalance).toBe(0);
+
+    const processedEvent = await env.DB.prepare(
+        `SELECT COUNT(*) AS count
+        FROM stripe_checkout_credits
+        WHERE session_id = 'cs_test_no_consent'`,
+    ).first<{ count: number }>();
+    expect(processedEvent?.count).toBe(0);
+});
+
+test("checkout consent constants are present and well-formed", () => {
+    expect(ONE_TIME_CONSENT_VERSION).toMatch(/^v\d+-\d{4}-\d{2}-\d{2}$/);
+    expect(ONE_TIME_CONSENT_MESSAGE).toContain(
+        "[Terms of Service](https://pollinations.ai/terms)",
+    );
+    expect(ONE_TIME_CONSENT_MESSAGE).toContain(
+        "[Privacy Policy](https://pollinations.ai/privacy)",
+    );
+    expect(ONE_TIME_CONSENT_MESSAGE).toContain(
+        "[Refunds & Cancellations Policy](https://pollinations.ai/refunds)",
+    );
+    expect(ONE_TIME_CONSENT_MESSAGE).toContain("14-day right of withdrawal");
+    // Stripe custom_text fields are limited to 1200 chars
+    expect(ONE_TIME_CONSENT_MESSAGE.length).toBeLessThanOrEqual(1200);
 });


### PR DESCRIPTION
- Adds a shared one-time Pollen checkout consent message and version.
- Requires Stripe Checkout terms acceptance before payment completion.
- Stamps the consent version on Checkout Session metadata.
- Skips crediting new sessions that lack accepted consent, while treating older sessions as legacy.

Validation:
- `npx biome check --write ...`
- `npx vitest run test/integration/stripe.test.ts`