### PR TITLE
dx: env-aware docs urls in dashboard

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-dialog.tsx
@@ -8,6 +8,7 @@ import {
     uniqueNamesGenerator,
 } from "unique-names-generator";
 import { cn } from "@/util.ts";
+import { genDocsUrl } from "../../config.ts";
 import { Button } from "../button.tsx";
 import { Tooltip } from "../ui/tooltip.tsx";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
@@ -211,7 +212,9 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                         Use that key for API requests paid with
                                         the user&apos;s Pollen.{" "}
                                         <a
-                                            href="https://gen.pollinations.ai/docs#tag/bring-your-own-pollen"
+                                            href={genDocsUrl(
+                                                "#tag/bring-your-own-pollen",
+                                            )}
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             className="text-blue-700 underline hover:text-blue-900"
@@ -275,7 +278,9 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                     Publishable keys (<code>pk_</code>)
                                     deprecated – create via{" "}
                                     <a
-                                        href="https://gen.pollinations.ai/docs#tag/-account/POST/account/keys"
+                                        href={genDocsUrl(
+                                            "#tag/-account/POST/account/keys",
+                                        )}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="text-blue-600 underline hover:text-blue-800"

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -1,6 +1,7 @@
 import { formatDistanceToNowStrict } from "date-fns";
 import type { FC } from "react";
 import { useState } from "react";
+import { genDocsUrl } from "../../config.ts";
 import { DashboardSection } from "../layout/dashboard-section.tsx";
 import { Card } from "../ui/card.tsx";
 import { IconButton } from "../ui/icon-button.tsx";
@@ -242,7 +243,9 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                                     Turn on developer earnings. Users are billed
                                     25% extra, credited to your wallet.{" "}
                                     <a
-                                        href="https://gen.pollinations.ai/docs#tag/bring-your-own-pollen"
+                                        href={genDocsUrl(
+                                            "#tag/bring-your-own-pollen",
+                                        )}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="font-medium text-blue-700 hover:text-blue-900"

--- a/enter.pollinations.ai/src/client/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/dashboard-shell.tsx
@@ -9,6 +9,7 @@ import {
     useState,
 } from "react";
 import { cn } from "@/util.ts";
+import { genDocsUrl } from "../../config.ts";
 import { useScrollLock } from "../../hooks/use-scroll-lock.ts";
 import {
     DASHBOARD_NAV_ITEMS,
@@ -241,7 +242,7 @@ const DashboardRail: FC<DashboardRailProps> = ({
                 ))}
                 <div className="mt-2 border-t border-green-950/10 pt-3">
                     <a
-                        href="https://gen.pollinations.ai/docs"
+                        href={genDocsUrl()}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center justify-between gap-2 rounded-full px-3 py-2 text-left text-[15px] font-medium text-gray-900 transition-colors hover:bg-white/60 hover:text-gray-950"

--- a/enter.pollinations.ai/src/client/config.ts
+++ b/enter.pollinations.ai/src/client/config.ts
@@ -6,18 +6,21 @@ const developmentBaseUrl =
 const environmentConfig = {
     development: {
         baseUrl: developmentBaseUrl,
+        genBaseUrl: "http://localhost:8788",
         authPath: "/api/auth",
         pollenTierMeterId: "1593243f-f646-4df2-9f55-30da37cbc3a0",
         pollenPackMeterId: "9bd156bb-2f2e-4e25-b1c0-1308c076c365",
     },
     staging: {
         baseUrl: "https://staging.enter.pollinations.ai",
+        genBaseUrl: "https://gen.pollinations.ai",
         authPath: "/api/auth",
         pollenTierMeterId: "1593243f-f646-4df2-9f55-30da37cbc3a0",
         pollenPackMeterId: "9bd156bb-2f2e-4e25-b1c0-1308c076c365",
     },
     production: {
         baseUrl: "https://enter.pollinations.ai",
+        genBaseUrl: "https://gen.pollinations.ai",
         authPath: "/api/auth",
         pollenTierMeterId: "b7f3e925-d6c8-4bc8-b40a-291f2793512e",
         pollenPackMeterId: "0960354f-1ad5-40ab-93dd-7b1930913a38",
@@ -26,3 +29,7 @@ const environmentConfig = {
 
 export const config =
     environmentConfig[import.meta.env.MODE as keyof typeof environmentConfig];
+
+export function genDocsUrl(hash = ""): string {
+    return `${config.genBaseUrl}/docs${hash}`;
+}


### PR DESCRIPTION
The four "API Reference" / "Read the guide" links in the dashboard hardcode `https://gen.pollinations.ai/docs`, so clicking them in local dev (port 3000) sends you to production instead of the local gen worker on 8788.

- Adds `genBaseUrl` to each env in `client/config.ts` (`http://localhost:8788` in dev, prod URL otherwise) and exports a `genDocsUrl(hash?)` helper.
- Swaps the four hardcoded sites to use it: sidebar `API Reference`, two `Read the guide` / `API` links in `api-key-dialog.tsx`, the dev-earnings call-out in `api-key-list.tsx`.
- Staging keeps the prod gen URL (no staging gen worker today) — matches current behavior.