### PR TITLE
fix: keep API publishable keys in API section

### DIFF
--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -15,6 +15,23 @@ import { LimitsBadge, shortLocale } from "./limits-badge.tsx";
 import { ModelsBadge } from "./models-badge.tsx";
 import type { ApiKey, ApiKeyManagerProps } from "./types.ts";
 
+function isPublishableKey(apiKey: ApiKey): boolean {
+    return apiKey.metadata?.keyType === "publishable";
+}
+
+function isAppKey(apiKey: ApiKey): boolean {
+    if (!isPublishableKey(apiKey)) return false;
+
+    const redirectUris = apiKey.metadata?.redirectUris;
+    const hasRedirectUris =
+        Array.isArray(redirectUris) &&
+        redirectUris.some(
+            (uri) => typeof uri === "string" && uri.trim().length > 0,
+        );
+
+    return hasRedirectUris || apiKey.metadata?.earningsEnabled === true;
+}
+
 export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     apiKeys,
     onCreate,
@@ -42,12 +59,9 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     const sortedApiKeys = sortedKeys.filter((apiKey) => !isAppKey(apiKey));
     const sortedAppKeys = sortedKeys.filter(isAppKey);
 
-    function isAppKey(apiKey: ApiKey): boolean {
-        return apiKey.metadata?.keyType === "publishable";
-    }
-
     function renderKeyCard(apiKey: ApiKey) {
-        const isPublishable = apiKey.metadata?.keyType === "publishable";
+        const isPublishable = isPublishableKey(apiKey);
+        const isApp = isAppKey(apiKey);
         const plaintextKey = apiKey.metadata?.plaintextKey as
             | string
             | undefined;
@@ -56,7 +70,6 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
             : [];
         const primaryRedirectUri = redirectUrisMeta[0] || "";
         const extraRedirectUriCount = Math.max(0, redirectUrisMeta.length - 1);
-        const isApp = isPublishable;
         const earningsEnabled = apiKey.metadata?.earningsEnabled === true;
 
         return (
@@ -67,7 +80,11 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
             >
                 <div className="flex items-center gap-2 mb-2">
                     <Tag color="blue" size="sm">
-                        {isPublishable ? "🖥️ App" : "🔒 Secret"}
+                        {isApp
+                            ? "🖥️ App"
+                            : isPublishable
+                              ? "🌐 Publishable"
+                              : "🔒 Secret"}
                     </Tag>
                     <span className="text-sm font-medium truncate">
                         {apiKey.name}

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -242,7 +242,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                                 />
                             )}
 
-                            {!appKey && (
+                            {!isPublishable && (
                                 <KeyPermissionsInputs
                                     value={keyPermissions}
                                     disabled={isSubmitting}

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -37,6 +37,18 @@ function cleanRedirectUris(uris: string[]): string[] {
     return uris.map((v) => v.trim()).filter((v) => v !== "");
 }
 
+function isPublishableKey(apiKey: ApiKey): boolean {
+    return apiKey.metadata?.keyType === "publishable";
+}
+
+function isAppKey(apiKey: ApiKey): boolean {
+    return (
+        isPublishableKey(apiKey) &&
+        (readInitialRedirectUris(apiKey.metadata).length > 0 ||
+            apiKey.metadata?.earningsEnabled === true)
+    );
+}
+
 export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     apiKey,
     onUpdate,
@@ -47,12 +59,12 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     const [error, setError] = useState<string | null>(null);
     const [copied, setCopied] = useState(false);
 
-    const isPublishable = apiKey.metadata?.keyType === "publishable";
+    const isPublishable = isPublishableKey(apiKey);
+    const appKey = isAppKey(apiKey);
     const plaintextKey = apiKey.metadata?.plaintextKey as string | undefined;
 
     const initialRedirectUris = readInitialRedirectUris(apiKey.metadata);
     const initialEarningsEnabled = apiKey.metadata?.earningsEnabled === true;
-    const isAppKey = isPublishable;
     const [redirectUris, setRedirectUris] =
         useState<string[]>(initialRedirectUris);
     const [earningsEnabled, setEarningsEnabled] = useState(
@@ -97,8 +109,8 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                     : null,
             });
 
-            // Save app settings for publishable keys
-            if (isPublishable) {
+            // Save app settings only for keys that belong in the App section.
+            if (appKey) {
                 const cleaned = cleanRedirectUris(redirectUris);
                 if (
                     sameRedirectUris(cleaned, initialRedirectUris) &&
@@ -154,12 +166,12 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                 >
                     <div className="shrink-0 p-6 pb-4">
                         <Dialog.Title className="text-xl font-bold mb-4">
-                            {isAppKey ? "Edit App Key" : "Edit API Key"}
+                            {appKey ? "Edit App Key" : "Edit API Key"}
                         </Dialog.Title>
 
                         <div className="flex items-center gap-3">
                             <Tag color="blue">
-                                {isAppKey
+                                {appKey
                                     ? "🖥️ App"
                                     : isPublishable
                                       ? "🌐 Publishable"
@@ -220,7 +232,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                                 />
                             </Field.Root>
 
-                            {isPublishable && (
+                            {appKey && (
                                 <PublishableKeySettings
                                     redirectUris={redirectUris}
                                     onRedirectUrisChange={setRedirectUris}
@@ -230,7 +242,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                                 />
                             )}
 
-                            {!isAppKey && (
+                            {!appKey && (
                                 <KeyPermissionsInputs
                                     value={keyPermissions}
                                     disabled={isSubmitting}


### PR DESCRIPTION
- Keeps plain publishable `pk_` API keys in the dashboard API section
- Classifies App keys only when app metadata is present (`redirectUris` or earnings enabled)
- Hides app redirect/earnings controls for legacy/API publishable keys

Verification:
- `npx biome check --write enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx`
- `npm run typecheck` in `enter.pollinations.ai`