### PR TITLE
feat(authorize): catgpt app_key + flexible redirect_uri match

### DIFF
--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -7,6 +7,7 @@ const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/a84b58d293d69f35";
 const AUTH_KEY = "catgpt_api_key";
+const APP_KEY = "pk_uWjreBEkxFAhjDHo";
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -35,6 +36,7 @@ export function getAuthorizeUrl() {
     const redirect = window.location.href.split("#")[0];
     return `${ENTER}/authorize?${new URLSearchParams({
         redirect_url: redirect,
+        app_key: APP_KEY,
         budget: "5",
         models: "gptimage,nanobanana,claude-fast",
         permissions: "profile,usage",

--- a/enter.pollinations.ai/src/routes/url-utils.ts
+++ b/enter.pollinations.ai/src/routes/url-utils.ts
@@ -1,85 +1,16 @@
+import { isLoopbackHostname } from "@shared/auth/redirect-uri.ts";
+
+export { redirectUriMatchesAllowlist } from "@shared/auth/redirect-uri.ts";
+
 /**
  * Returns true if the URL's hostname is a loopback/local address.
  * Kept for the consent UI to recognize localhost dev servers and word the
  * "unrecognized app" warning appropriately. Not used for identity inference.
  */
 export function isLoopbackUrl(url: string): boolean {
-    const parsed = safeParse(url);
-    return parsed ? isLoopbackHostname(parsed.hostname) : false;
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-    const h = normalizeHostname(hostname);
-    if (h === "localhost" || h === "0.0.0.0" || h === "::1") return true;
-    if (/^127\.\d+\.\d+\.\d+$/.test(h)) return true;
-    return false;
-}
-
-function normalizeHostname(hostname: string): string {
-    return hostname
-        .toLowerCase()
-        .replace(/^\[(.*)\]$/, "$1")
-        .replace(/\.$/, "");
-}
-
-function safeParse(url: string): URL | null {
     try {
-        return new URL(url);
+        return isLoopbackHostname(new URL(url).hostname);
     } catch {
-        return null;
-    }
-}
-
-/**
- * Match an incoming `redirect_uri` against a registered allowlist for a `pk_`.
- *
- * Comparison rules:
- * - Scheme + hostname + path are matched exactly (after lowercasing host).
- * - Trailing slash on the path is insignificant: `/cb` and `/cb/` match.
- * - Query strings are ignored: apps round-trip state (e.g. `?prompt=...`) and
- *   the auth code/token rides the URL fragment, not the query. Pinning host
- *   and path is what blocks confused-deputy attacks; matching the query adds
- *   no security and breaks legitimate apps. Mirrors GitHub's behavior.
- * - For loopback entries (RFC 8252 §7.3): port is ignored — any port matches.
- *   This covers native/CLI apps that bind to ephemeral ports each run.
- * - For non-loopback entries: port must match (default ports normalized).
- * - Fragments are rejected; redirect URIs must not contain them.
- *
- * Returns false on any parse error or empty allowlist.
- */
-export function redirectUriMatchesAllowlist(
-    uri: string,
-    allowlist: readonly string[] | null | undefined,
-): boolean {
-    if (!allowlist?.length) return false;
-    const incoming = safeParse(uri);
-    if (!incoming) return false;
-    return allowlist.some((entry) => matchesEntry(incoming, entry));
-}
-
-function normalizePathname(pathname: string): string {
-    return pathname.length > 1 && pathname.endsWith("/")
-        ? pathname.slice(0, -1)
-        : pathname;
-}
-
-function matchesEntry(incoming: URL, entryUrl: string): boolean {
-    const entry = safeParse(entryUrl);
-    if (!entry) return false;
-    if (incoming.hash || entry.hash) return false;
-    if (incoming.protocol !== entry.protocol) return false;
-    if (
-        normalizeHostname(incoming.hostname) !==
-        normalizeHostname(entry.hostname)
-    ) {
         return false;
     }
-    if (
-        normalizePathname(incoming.pathname) !==
-        normalizePathname(entry.pathname)
-    ) {
-        return false;
-    }
-    if (isLoopbackHostname(entry.hostname)) return true;
-    return incoming.port === entry.port;
 }

--- a/enter.pollinations.ai/src/routes/url-utils.ts
+++ b/enter.pollinations.ai/src/routes/url-utils.ts
@@ -34,8 +34,12 @@ function safeParse(url: string): URL | null {
  * Match an incoming `redirect_uri` against a registered allowlist for a `pk_`.
  *
  * Comparison rules:
- * - Scheme + hostname + path + query are matched exactly (after lowercasing
- *   host).
+ * - Scheme + hostname + path are matched exactly (after lowercasing host).
+ * - Trailing slash on the path is insignificant: `/cb` and `/cb/` match.
+ * - Query strings are ignored: apps round-trip state (e.g. `?prompt=...`) and
+ *   the auth code/token rides the URL fragment, not the query. Pinning host
+ *   and path is what blocks confused-deputy attacks; matching the query adds
+ *   no security and breaks legitimate apps. Mirrors GitHub's behavior.
  * - For loopback entries (RFC 8252 §7.3): port is ignored — any port matches.
  *   This covers native/CLI apps that bind to ephemeral ports each run.
  * - For non-loopback entries: port must match (default ports normalized).
@@ -53,6 +57,12 @@ export function redirectUriMatchesAllowlist(
     return allowlist.some((entry) => matchesEntry(incoming, entry));
 }
 
+function normalizePathname(pathname: string): string {
+    return pathname.length > 1 && pathname.endsWith("/")
+        ? pathname.slice(0, -1)
+        : pathname;
+}
+
 function matchesEntry(incoming: URL, entryUrl: string): boolean {
     const entry = safeParse(entryUrl);
     if (!entry) return false;
@@ -64,8 +74,12 @@ function matchesEntry(incoming: URL, entryUrl: string): boolean {
     ) {
         return false;
     }
-    if (incoming.pathname !== entry.pathname) return false;
-    if (incoming.search !== entry.search) return false;
+    if (
+        normalizePathname(incoming.pathname) !==
+        normalizePathname(entry.pathname)
+    ) {
+        return false;
+    }
     if (isLoopbackHostname(entry.hostname)) return true;
     return incoming.port === entry.port;
 }

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -562,7 +562,7 @@ describe("API Key Management", () => {
             });
         });
 
-        test("matches app lookup redirect_uri exactly", async ({
+        test("ignores query string differences but rejects path mismatches", async ({
             sessionToken,
         }) => {
             const appResponse = await SELF.fetch(
@@ -577,9 +577,7 @@ describe("API Key Management", () => {
                         name: "query-bound-app",
                         type: "publishable",
                         metadata: {
-                            redirectUris: [
-                                "https://app.example/callback?flow=byop",
-                            ],
+                            redirectUris: ["https://app.example/callback"],
                         },
                     }),
                 },
@@ -587,20 +585,99 @@ describe("API Key Management", () => {
             expect(appResponse.status).toBe(200);
             const appKey = await appResponse.json();
 
-            const matching = await SELF.fetch(
-                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}&redirect_uri=${encodeURIComponent("https://app.example/callback?flow=byop")}`,
+            // Extra query params on the incoming URL are allowed — apps
+            // round-trip state (e.g. ?prompt=, ?next=) through the redirect.
+            const withQuery = await SELF.fetch(
+                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}&redirect_uri=${encodeURIComponent("https://app.example/callback?prompt=hi&model=x")}`,
             );
-            expect(matching.status).toBe(200);
-            expect(await matching.json()).toMatchObject({ found: true });
+            expect(withQuery.status).toBe(200);
+            expect(await withQuery.json()).toMatchObject({ found: true });
 
-            const mismatch = await SELF.fetch(
-                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}&redirect_uri=${encodeURIComponent("https://app.example/callback")}`,
+            // Trailing slash on path is also insignificant.
+            const trailingSlash = await SELF.fetch(
+                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}&redirect_uri=${encodeURIComponent("https://app.example/callback/")}`,
             );
-            expect(mismatch.status).toBe(200);
-            expect(await mismatch.json()).toMatchObject({
+            expect(trailingSlash.status).toBe(200);
+            expect(await trailingSlash.json()).toMatchObject({ found: true });
+
+            // But a different path still mismatches.
+            const wrongPath = await SELF.fetch(
+                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}&redirect_uri=${encodeURIComponent("https://app.example/other")}`,
+            );
+            expect(wrongPath.status).toBe(200);
+            expect(await wrongPath.json()).toMatchObject({
                 found: false,
                 error: "redirect_uri_mismatch",
             });
+        });
+
+        test("createApiKey enforces same flexible redirect_uri rules", async ({
+            sessionToken,
+        }) => {
+            // Mint a publishable key with one registered URI.
+            const appResponse = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "minting-app",
+                        type: "publishable",
+                        metadata: {
+                            redirectUris: ["https://mint.example/cb"],
+                        },
+                    }),
+                },
+            );
+            expect(appResponse.status).toBe(200);
+            const appKey = await appResponse.json();
+
+            // sk_ minting must accept query + trailing slash on the redirect
+            // (matches what /authorize forwards from a browser address bar).
+            const mint = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "minted-sk",
+                        type: "secret",
+                        metadata: {
+                            requestedClientId: appKey.key,
+                            redirectUri:
+                                "https://mint.example/cb/?prompt=hi&model=x",
+                        },
+                    }),
+                },
+            );
+            expect(mint.status).toBe(200);
+
+            // But mismatching host still fails.
+            const evil = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "evil-sk",
+                        type: "secret",
+                        metadata: {
+                            requestedClientId: appKey.key,
+                            redirectUri: "https://attacker.example/cb",
+                        },
+                    }),
+                },
+            );
+            expect(evil.status).toBe(400);
         });
     });
 

--- a/enter.pollinations.ai/test/url-utils.test.ts
+++ b/enter.pollinations.ai/test/url-utils.test.ts
@@ -49,11 +49,24 @@ describe("redirectUriMatchesAllowlist", () => {
                 ["https://app.com/cb"],
             ),
         ).toBe(true);
+    });
+
+    test("preserves query-bound allowlist entries", () => {
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb?env=prod", [
+                "https://app.com/cb?env=prod",
+            ]),
+        ).toBe(true);
         expect(
             redirectUriMatchesAllowlist("https://app.com/cb", [
                 "https://app.com/cb?env=prod",
             ]),
-        ).toBe(true);
+        ).toBe(false);
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb?env=dev", [
+                "https://app.com/cb?env=prod",
+            ]),
+        ).toBe(false);
     });
 
     test("treats trailing slash on path as insignificant", () => {

--- a/enter.pollinations.ai/test/url-utils.test.ts
+++ b/enter.pollinations.ai/test/url-utils.test.ts
@@ -37,20 +37,57 @@ describe("redirectUriMatchesAllowlist", () => {
         ).toBe(true);
     });
 
-    test("matches query strings exactly and rejects fragments", () => {
+    test("ignores query strings (host + path is what's pinned)", () => {
         expect(
             redirectUriMatchesAllowlist("https://app.com/cb?flow=byop", [
-                "https://app.com/cb?flow=byop",
+                "https://app.com/cb",
             ]),
         ).toBe(true);
         expect(
-            redirectUriMatchesAllowlist("https://app.com/cb?next=/admin", [
+            redirectUriMatchesAllowlist(
+                "https://app.com/cb?prompt=hi&model=x",
+                ["https://app.com/cb"],
+            ),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb", [
+                "https://app.com/cb?env=prod",
+            ]),
+        ).toBe(true);
+    });
+
+    test("treats trailing slash on path as insignificant", () => {
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb/", [
+                "https://app.com/cb",
+            ]),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb", [
+                "https://app.com/cb/",
+            ]),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/", [
+                "https://app.com",
+            ]),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb/x", [
+                "https://app.com/cb",
+            ]),
+        ).toBe(false);
+    });
+
+    test("rejects fragments on either side", () => {
+        expect(
+            redirectUriMatchesAllowlist("https://app.com/cb#token", [
                 "https://app.com/cb",
             ]),
         ).toBe(false);
         expect(
-            redirectUriMatchesAllowlist("https://app.com/cb#token", [
-                "https://app.com/cb#token",
+            redirectUriMatchesAllowlist("https://app.com/cb", [
+                "https://app.com/cb#frag",
             ]),
         ).toBe(false);
     });

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import * as schema from "../db/better-auth.ts";
 import { sanitizeAuthorizeAccountPermissions } from "./authorize-config.ts";
+import { redirectUriMatchesAllowlist } from "./redirect-uri.ts";
 
 export type ApiKeyType = "secret" | "publishable";
 
@@ -113,55 +114,6 @@ function rejectInvalidClientId(): never {
     throw new HTTPException(400, {
         message: "Invalid client_id",
     });
-}
-
-function redirectUriMatchesAllowlist(
-    uri: string,
-    allowlist: readonly string[] | null | undefined,
-): boolean {
-    if (!allowlist?.length) return false;
-    const incoming = safeParse(uri);
-    if (!incoming) return false;
-    return allowlist.some((entry) => matchesRedirectEntry(incoming, entry));
-}
-
-function matchesRedirectEntry(incoming: URL, entryUrl: string): boolean {
-    const entry = safeParse(entryUrl);
-    if (!entry) return false;
-    if (incoming.hash || entry.hash) return false;
-    if (incoming.protocol !== entry.protocol) return false;
-    if (
-        normalizeHostname(incoming.hostname) !==
-        normalizeHostname(entry.hostname)
-    ) {
-        return false;
-    }
-    if (incoming.pathname !== entry.pathname) return false;
-    if (incoming.search !== entry.search) return false;
-    if (isLoopbackHostname(entry.hostname)) return true;
-    return incoming.port === entry.port;
-}
-
-function safeParse(url: string): URL | null {
-    try {
-        return new URL(url);
-    } catch {
-        return null;
-    }
-}
-
-function normalizeHostname(hostname: string): string {
-    return hostname
-        .toLowerCase()
-        .replace(/^\[(.*)\]$/, "$1")
-        .replace(/\.$/, "");
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-    const h = normalizeHostname(hostname);
-    if (h === "localhost" || h === "0.0.0.0" || h === "::1") return true;
-    if (/^127\.\d+\.\d+\.\d+$/.test(h)) return true;
-    return false;
 }
 
 // Caller-provided metadata is restricted to a typed allowlist. Server-controlled

--- a/shared/auth/redirect-uri.ts
+++ b/shared/auth/redirect-uri.ts
@@ -1,0 +1,78 @@
+/**
+ * Match an incoming `redirect_uri` against a registered allowlist for a `pk_`.
+ *
+ * Comparison rules:
+ * - Scheme + hostname + path are matched exactly (after lowercasing host).
+ * - Trailing slash on the path is insignificant: `/cb` and `/cb/` match.
+ * - Query strings are ignored: apps round-trip state (e.g. `?prompt=...`) and
+ *   the auth code/token rides the URL fragment, not the query. Pinning host
+ *   and path is what blocks confused-deputy attacks; matching the query adds
+ *   no security and breaks legitimate apps. Mirrors GitHub's behavior.
+ * - For loopback entries (RFC 8252 §7.3): port is ignored — any port matches.
+ *   This covers native/CLI apps that bind to ephemeral ports each run.
+ * - For non-loopback entries: port must match (default ports normalized).
+ * - Fragments are rejected; redirect URIs must not contain them.
+ *
+ * Returns false on any parse error or empty allowlist.
+ *
+ * Single source of truth for both /api/app-lookup (consent screen attribution)
+ * and createApiKeyForUser (sk_ minting). Keep them aligned.
+ */
+export function redirectUriMatchesAllowlist(
+    uri: string,
+    allowlist: readonly string[] | null | undefined,
+): boolean {
+    if (!allowlist?.length) return false;
+    const incoming = safeParse(uri);
+    if (!incoming) return false;
+    return allowlist.some((entry) => matchesEntry(incoming, entry));
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+    const h = normalizeHostname(hostname);
+    if (h === "localhost" || h === "0.0.0.0" || h === "::1") return true;
+    if (/^127\.\d+\.\d+\.\d+$/.test(h)) return true;
+    return false;
+}
+
+function safeParse(url: string): URL | null {
+    try {
+        return new URL(url);
+    } catch {
+        return null;
+    }
+}
+
+function normalizeHostname(hostname: string): string {
+    return hostname
+        .toLowerCase()
+        .replace(/^\[(.*)\]$/, "$1")
+        .replace(/\.$/, "");
+}
+
+function normalizePathname(pathname: string): string {
+    return pathname.length > 1 && pathname.endsWith("/")
+        ? pathname.slice(0, -1)
+        : pathname;
+}
+
+function matchesEntry(incoming: URL, entryUrl: string): boolean {
+    const entry = safeParse(entryUrl);
+    if (!entry) return false;
+    if (incoming.hash || entry.hash) return false;
+    if (incoming.protocol !== entry.protocol) return false;
+    if (
+        normalizeHostname(incoming.hostname) !==
+        normalizeHostname(entry.hostname)
+    ) {
+        return false;
+    }
+    if (
+        normalizePathname(incoming.pathname) !==
+        normalizePathname(entry.pathname)
+    ) {
+        return false;
+    }
+    if (isLoopbackHostname(entry.hostname)) return true;
+    return incoming.port === entry.port;
+}

--- a/shared/auth/redirect-uri.ts
+++ b/shared/auth/redirect-uri.ts
@@ -4,10 +4,10 @@
  * Comparison rules:
  * - Scheme + hostname + path are matched exactly (after lowercasing host).
  * - Trailing slash on the path is insignificant: `/cb` and `/cb/` match.
- * - Query strings are ignored: apps round-trip state (e.g. `?prompt=...`) and
- *   the auth code/token rides the URL fragment, not the query. Pinning host
- *   and path is what blocks confused-deputy attacks; matching the query adds
- *   no security and breaks legitimate apps. Mirrors GitHub's behavior.
+ * - Query strings are ignored when the registered URI has no query: apps
+ *   round-trip state (e.g. `?prompt=...`) and the auth code/token rides the URL
+ *   fragment, not the query. If the registered URI includes a query, it must
+ *   match exactly so existing query-bound allowlist entries are not broadened.
  * - For loopback entries (RFC 8252 §7.3): port is ignored — any port matches.
  *   This covers native/CLI apps that bind to ephemeral ports each run.
  * - For non-loopback entries: port must match (default ports normalized).
@@ -73,6 +73,7 @@ function matchesEntry(incoming: URL, entryUrl: string): boolean {
     ) {
         return false;
     }
+    if (entry.search && incoming.search !== entry.search) return false;
     if (isLoopbackHostname(entry.hostname)) return true;
     return incoming.port === entry.port;
 }


### PR DESCRIPTION
## Summary
- CatGPT passes `app_key=pk_uWjreBEkxFAhjDHo` so the consent screen shows attribution.
- Redirect URI matching is shared between app lookup and `sk_` minting.
- Bare registered redirect URIs allow app query state and one trailing slash difference; query-bound allowlist entries still require exact query match.
- Scheme, host, port, and path stay pinned; loopback ports remain port-agnostic.

## Test plan
- [x] `npx vitest run test/url-utils.test.ts` (covers query state, query-bound exact matching, trailing slash, and loopback ports)
- [ ] After deploy: visit catgpt.pollinations.ai with `?prompt=hi`, confirm authorize → consent → redirect succeeds.