### PR TITLE
fix(authorize): keep mismatched deny redirects local

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -371,7 +371,7 @@ Create a new API key. Requires `account:keys` permission and a secret key (sk\_)
 
 - **`redirectUris`**
 
-  `array` — Allowed OAuth redirect URIs for publishable app keys. Loopback ports are matched port-agnostically.
+  `array` — Allowed OAuth redirect URIs for publishable app keys. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; query-bearing entries must match exactly. Loopback ports are port-agnostic.
 
   **Items:**
 

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -145,6 +145,9 @@ function AuthorizeComponent() {
     const { isSigningIn, error: signInError, signIn } = useGitHubSignIn();
     const [error, setError] = useState<string | null>(null);
     const [attribution, setAttribution] = useState<Attribution | null>(null);
+    const [redirectValidationState, setRedirectValidationState] = useState<
+        "unchecked" | "valid" | "invalid"
+    >("unchecked");
     const [deviceOutcome, setDeviceOutcome] = useState<
         "pending" | "approved" | "denied"
     >("pending");
@@ -178,10 +181,14 @@ function AuthorizeComponent() {
     const isAttributionPending = !!app_key && !attribution;
     const canAuthorize =
         (isDeviceMode || parsedRedirectUrl !== null) && !isAttributionPending;
+    const canRedirectOnDeny =
+        parsedRedirectUrl !== null &&
+        (!app_key || redirectValidationState === "valid");
 
     useScrollLock();
 
     useEffect(() => {
+        setRedirectValidationState("unchecked");
         if (isDeviceMode) {
             // device.tsx forwards the server-stored scope as `scope=` in the
             // URL, which flows into `urlScope` and preselects the
@@ -244,7 +251,10 @@ function AuthorizeComponent() {
 
             // Attribution is identified by client_id only. Without one, the
             // consent screen falls back to the hostname display.
-            if (!app_key) return;
+            if (!app_key) {
+                setRedirectValidationState("valid");
+                return;
+            }
 
             const lookupParams = new URLSearchParams({ client_id: app_key });
             if (!isDeviceMode && redirect_url) {
@@ -256,16 +266,21 @@ function AuthorizeComponent() {
                     const attr = data as Attribution;
                     setAttribution(attr);
                     if (attr.error === "redirect_uri_mismatch") {
+                        setRedirectValidationState("invalid");
                         setError(
                             "This redirect URL is not registered for this app. Authorization blocked.",
                         );
                     } else if (!attr.found) {
+                        setRedirectValidationState("invalid");
                         setError(
                             "This app key could not be verified. Authorization blocked.",
                         );
+                    } else {
+                        setRedirectValidationState("valid");
                     }
                 })
                 .catch(() => {
+                    setRedirectValidationState("invalid");
                     setError(
                         "Could not verify this app key. Authorization blocked.",
                     );
@@ -386,7 +401,7 @@ function AuthorizeComponent() {
                 // Best-effort deny
             }
             setDeviceOutcome("denied");
-        } else if (parsedRedirectUrl) {
+        } else if (canRedirectOnDeny && parsedRedirectUrl) {
             const url = new URL(parsedRedirectUrl.href);
             const hash = new URLSearchParams({ error: "access_denied" });
             if (state) hash.set("state", state);

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -137,7 +137,7 @@ const CreateKeySchema = z.object({
         .array(z.string())
         .optional()
         .describe(
-            "Allowed OAuth redirect URIs for publishable app keys. Required for OAuth app flows. Loopback ports are matched port-agnostically.",
+            "Allowed OAuth redirect URIs for publishable app keys. Required for OAuth app flows. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; if it has a query, the query must match exactly. Loopback ports are matched port-agnostically.",
         ),
     earningsEnabled: z
         .boolean()

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -405,7 +405,7 @@ function generateLLMDoc(): string {
         '- accountPermissions (string[], optional): e.g. ["profile","usage"]. "keys" is auto-stripped',
     );
     lines.push(
-        "- redirectUris (string[], optional): OAuth redirect URIs for publishable app keys",
+        "- redirectUris (string[], optional): OAuth redirect URIs for publishable app keys. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; query-bearing entries must match exactly. Loopback ports are port-agnostic.",
     );
     lines.push(
         "- earningsEnabled (boolean, optional): Developer earnings for publishable app keys; true opts in",


### PR DESCRIPTION
## Summary
- Keeps Deny local after app-key redirect validation fails.
- Documents redirect URI matching rules in API docs surfaces.

## Checks
- `biome check --write` on touched TS/TSX files
- `git diff --check`