### PR TITLE
[codex] fix replicate token secrets

### DIFF
--- a/gen.pollinations.ai/secrets/prod.vars.json
+++ b/gen.pollinations.ai/secrets/prod.vars.json
@@ -30,7 +30,7 @@
 	"XAI_API_KEY": "ENC[AES256_GCM,data:T92SCl4ZXH+5N/sz2v7qgUfhvqduGspZcD7YzzKreG73aliHcN431yVGI4PgSP7MFf+wd8RZqGdkIzmichek//Rlj8Nri+eQk3DHWvi2H7OGGqC8,iv:yxLq8OG4qwVrOiieWSLZtYW2myQpuO59lUeRNjK+Al8=,tag:CwjJnlFV3u+KiS43+jJtrA==,type:str]",
 	"LTX2_BASE_URL": "ENC[AES256_GCM,data:6S1x646UMLfDhbmsgznteB52DGoHG4aYL25ZUKJwjYtqOR0f,iv:Jo8me6Hpf6QWPWfawCh8U6MsV0Ad8JxfKx716+xV/Hc=,tag:5/ao+DcNms8PFz059ljYYw==,type:str]",
 	"OPENROUTER_API_KEY": "ENC[AES256_GCM,data:7ayEmHy6S41vD6BXx7XS96ZcijOvcrq07Q7ZADhQiIiqGyBhRnVjhMQzTYJCiAngIiTf4Yz+7YWAwuijC7GxdXUvUApG75xkDg==,iv:rJzx4exzX+43K2Qn/dDQMTTFf2f/U1GAoLBvp2ahfVo=,tag:fgfiB6VdVUHsBtlMZvjCVw==,type:str]",
-	"REPLICATE_API_TOKEN": "ENC[AES256_GCM,data:LOSnOZ/maNaLgMtYMSQdrFbGIl5QRr3UBe+fo6dcNQI=,iv:RWkwATQKLpOeviQH5zqO9W1SHeyxBxc06s7xAo8IE44=,tag:aqMpWkJpGEhpnK6DS4+9MA==,type:str]",
+	"REPLICATE_API_TOKEN": "ENC[AES256_GCM,data:zDlPwDZN5aceIPall5hgT7P7+1fguYf9q0/qS18NDkiaTLBVyAFd7w==,iv:i94dUlJNx4iW5vwxqqOsSFL6xStPqHDVRnMgOb9ZUCg=,tag:ZVuVmcTvLOHBn4aUNWmaAg==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -46,8 +46,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlZjY1M2N2aGN0UVNsVnla\nRDlGbk5pN3RIeXJwdmhkbWZCSzEzcVBNcmljClRueWVDRXRJTkx3TjBMS296cGRK\nUTg2eHNmZzNOS3E5SFdRNjdtRHdoYkEKLS0tIGRrL2JvTDRTaDNJWmkwcHFKbitV\nTjNxYTVIOUNLZFUvUnFYaTNkSWVyS1UKRm6mMBuSa2oprj+4kkEY8OiRtbzKofdr\nlFzyZgIOOU8/UlZUIzmLrj1A7qqBGd4ReHnGuYEkrmLfwXdeZolWdg==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-05-07T01:25:00Z",
-		"mac": "ENC[AES256_GCM,data:rG5UtH2R7dt3Y3UvVlMZhRaJ4zL3pSQIfL7UtosvTXZShTEHjJ1gpqR/owSXsgukmsdATwWzPZ57byDp6vm2xXGldS5LH7Cu40tgsCbHLyysDtgngZjAjBE2PzAOxZM/gQ4Iv+F3Q1i7pCJ9cCfJjzQxom3vq11U8vMNRkahyOI=,iv:jryLyMc+LQeqEZtzJCEMgmji15wC8XyyX9IZxB58E1A=,tag:DP2f9ION1xXVLmrCulNgrA==,type:str]",
+		"lastmodified": "2026-05-08T12:54:02Z",
+		"mac": "ENC[AES256_GCM,data:nABMILnsBt30ciS2LqVfinWCL2tb0fquH6U4rXJVi97BUec+ZHC9i9CbbkztYQdZiN0fQad0uO2w9BBLPLRHrh5AKxayOpk5ABZcq/2x6ndJeqlKZCj+xENJOJZDRTYu64ZzbE5vp1ztofbMdERZB17OriUNXLBcudr3UYInuBE=,iv:j2GyImRt/lqseku8stXxrMyzETOxlJ5iQn+8h6NE78Q=,tag:VtoDZLRAT4vudE1mI+9S3Q==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/gen.pollinations.ai/secrets/staging.vars.json
+++ b/gen.pollinations.ai/secrets/staging.vars.json
@@ -30,7 +30,7 @@
 	"XAI_API_KEY": "ENC[AES256_GCM,data:0PatVf4AxBluVg112Ts/DEsW2ecBF3th0474KPClDoM/X/j9iLJF2FdnspU8FJjOqz/cgF4V/fmpyNwf3mKCWA0jSnAAFVHpn81J9Tfps+Sbr/dW,iv:EeM8wLmVv0kD9Ttvqcu8j5iINOUaMuFcv+oeUQ8azQ8=,tag:EjoNzkmNHH4igjpChQ2tCw==,type:str]",
 	"LTX2_BASE_URL": "ENC[AES256_GCM,data:NRynjYPSY1g6x4e/xHyFOd8wtzR6gWfTXaR72V0pkLUP3w3Z,iv:kODnN5MuudpyiSaimvm65Unl/x9HuurGAfHwmZerUMo=,tag:RpYdld7bXMIgHxKPpIJFXg==,type:str]",
 	"OPENROUTER_API_KEY": "ENC[AES256_GCM,data:kvwTwj1UhJJXn8f3AcsGVWzNHd+k0sWJeqJeaKRY6oveBGbA8UZnq74EfcDOxx5OdkFoS52pE8yiuQcLAMKTeWBK3unAhyqjJw==,iv:GKZHBxRpztRa5ba2wi0fPokreuAtDLVYYgh0ezeFj7I=,tag:SR1T0ajW/B1c6k1rwtugtw==,type:str]",
-	"REPLICATE_API_TOKEN": "ENC[AES256_GCM,data:DIONgARf1KutF0Ge8TSrQUSvnU0r2/0twLcHt04pnEo=,iv:s/qF9NNsDtY+GK6fVWz40lJs4cWQ33KXh1+PJBnkk5s=,tag:94VJRx8YxjZD8mpVIGdouw==,type:str]",
+	"REPLICATE_API_TOKEN": "ENC[AES256_GCM,data:V2SdmOFFsPbRp5E+J8g3/RdKAJ2Ni3vzzVk0EWrRJXqWAr4lzhbXRg==,iv:ImU2ODKRRnuHUmA+C6gY1zsifSRMPIgJMagh37yojTM=,tag:BUiPHbIQRm9q5/9fUi/v0Q==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -46,8 +46,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFeld5czFJemNLNW9hOWt3\nczYzcFhWWUxyQi9vQ00rSVlUQnA2WStrbjNzCkpHT0FrM0xWeFJYalpDSUljUFdJ\ndWtoLzQ3YnJmYWcyalhjNVg2c3BCcTgKLS0tIEpDY2t0dWZMN2hOc1dWQjhPWlZo\nY1paeWpra3UySmRnc1JPdmdRMElDWkkKl0H6E4hIn8EeCPr5kQdEciBNN0EhNC5M\nghVFGNVGZn0OGJy4dvzGPhlBfizNeX+XSxmuJs3Hv8jmUKL/lRJ+0A==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-05-07T17:19:45Z",
-		"mac": "ENC[AES256_GCM,data:iTYYlyQrOPiXUHQT5c/rPxo5tLdEtsSU2uZg9JztuOOi0IHMaBEKGVvGfKRFm3snHYJJa0xxV9qE9t/y+RvpCS/S7O198QW6DnRN53u4zFQytOgz26p4lW/J+nB1kly8qg8Fx0MYiPRSYr96Bcm1MoJeOcwHpZMSmDAMtyOohb0=,iv:HfoWh1rJzTpEQLqhB6JqzjTuUZQu2X9dgdHElsXjYSU=,tag:6wdUVal6KT9jnc+CFGlEBg==,type:str]",
+		"lastmodified": "2026-05-08T12:54:25Z",
+		"mac": "ENC[AES256_GCM,data:KP1+m1eCqeZlpbbe6c+chZjGyuv+S+3/LkgvvMCmjvItk9yCg2tuqx23eOySdVz+vxsJq8S710vCo9nZ8IiytCzr3P5++2y9VfKxh2adHPsNVLaPPT0qYKPxzut1AfimqSRR+phjBy+aFMsDt9OQU0sI6LTcOa9Ygf3FMhQcTMk=,iv:slf83GxRrYGnmlOM13rv0lHJaPJCqQKhHAdCP/7o/Ao=,tag:Y6hEST9jkWQOqVNhP0qL/w==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
- Updates encrypted `REPLICATE_API_TOKEN` values in `gen.pollinations.ai/secrets/prod.vars.json` and `gen.pollinations.ai/secrets/staging.vars.json`.
- Leaves the existing dev token unchanged because it was already token-shaped and not a placeholder.
- Root cause: staging and prod SOPS secrets still contained placeholder values for Replicate.

Validation:
- `sops -d` metadata check confirmed dev/staging/prod tokens are token-shaped and not placeholders.
- `npx biome check --write gen.pollinations.ai/secrets/prod.vars.json gen.pollinations.ai/secrets/staging.vars.json`
- `git diff --check`