### PR TITLE
fix(nova-reel): use FetchHttpHandler for Bedrock + S3 in Workers

### DIFF
--- a/gen.pollinations.ai/src/image/models/novaReelModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaReelModel.ts
@@ -149,10 +149,12 @@ export async function callNovaReelAPI(
         StartAsyncInvokeCommand,
         GetAsyncInvokeCommand,
     } = await import("@aws-sdk/client-bedrock-runtime");
+    const { FetchHttpHandler } = await import("@smithy/fetch-http-handler");
 
     const bedrockClient = new BedrockRuntimeClient({
         region,
         credentials: { accessKeyId, secretAccessKey },
+        requestHandler: new FetchHttpHandler(),
     });
 
     // Build request body
@@ -348,6 +350,7 @@ async function downloadFromS3(
     secretAccessKey: string,
 ): Promise<Buffer> {
     const { S3Client, GetObjectCommand } = await import("@aws-sdk/client-s3");
+    const { FetchHttpHandler } = await import("@smithy/fetch-http-handler");
 
     // Parse s3://bucket/key format
     const match = s3Uri.match(/^s3:\/\/([^/]+)\/(.+)$/);
@@ -363,6 +366,7 @@ async function downloadFromS3(
     const s3Client = new S3Client({
         region,
         credentials: { accessKeyId, secretAccessKey },
+        requestHandler: new FetchHttpHandler(),
     });
 
     const getCommand = new GetObjectCommand({ Bucket: bucket, Key: key });


### PR DESCRIPTION
## Summary

Nova Reel is currently 100% failing on prod — **88 requests in last 24h, 78% returning 5xx** — with:

> `Nova Reel video generation failed to start: The http2.connect method is not implemented`

The default Smithy HTTP handler used by `@aws-sdk/client-bedrock-runtime` and `@aws-sdk/client-s3` tries to use HTTP/2, which the Cloudflare Workers runtime doesn't implement.

`novaCanvasModel.ts` and `bedrock-guardrail.ts` already work around this by injecting `FetchHttpHandler` from `@smithy/fetch-http-handler` (already a dep). This PR applies the same fix to `novaReelModel.ts`:
- `BedrockRuntimeClient` (used for `StartAsyncInvoke` + polling `GetAsyncInvoke`)
- `S3Client` (used to download the finished video)

## Test plan
- [ ] Hit `gen.pollinations.ai/image/{prompt}?model=nova-reel` after deploy and confirm 200 + MP4
- [ ] Watch nova-reel error rate in Tinybird drop from ~78% to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)