### PR TITLE
feat: split app clients from publishable keys

### DIFF
--- a/enter.pollinations.ai/drizzle/0024_oauth-client-app-keys.sql
+++ b/enter.pollinations.ai/drizzle/0024_oauth-client-app-keys.sql
@@ -1,0 +1,121 @@
+CREATE TABLE `oauthClient` (
+	`id` text PRIMARY KEY NOT NULL,
+	`client_id` text NOT NULL,
+	`client_secret` text,
+	`disabled` integer DEFAULT false,
+	`skip_consent` integer DEFAULT false,
+	`enable_end_session` integer DEFAULT false,
+	`subject_type` text,
+	`scopes` text,
+	`user_id` text,
+	`reference_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`name` text,
+	`uri` text,
+	`icon` text,
+	`contacts` text,
+	`tos` text,
+	`policy` text,
+	`software_id` text,
+	`software_version` text,
+	`software_statement` text,
+	`redirect_uris` text NOT NULL,
+	`post_logout_redirect_uris` text,
+	`token_endpoint_auth_method` text DEFAULT 'none',
+	`grant_types` text,
+	`response_types` text,
+	`public` integer DEFAULT true,
+	`type` text,
+	`require_pkce` integer DEFAULT true,
+	`metadata` text,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauthClient_client_id_unique` ON `oauthClient` (`client_id`);--> statement-breakpoint
+CREATE INDEX `idx_oauth_client_user_id` ON `oauthClient` (`user_id`);--> statement-breakpoint
+ALTER TABLE `apikey` ADD `oauth_client_id` text;--> statement-breakpoint
+CREATE INDEX `idx_apikey_oauth_client_id` ON `apikey` (`oauth_client_id`);--> statement-breakpoint
+INSERT INTO `oauthClient` (
+	`id`,
+	`client_id`,
+	`client_secret`,
+	`disabled`,
+	`skip_consent`,
+	`enable_end_session`,
+	`scopes`,
+	`user_id`,
+	`created_at`,
+	`updated_at`,
+	`name`,
+	`redirect_uris`,
+	`token_endpoint_auth_method`,
+	`grant_types`,
+	`response_types`,
+	`public`,
+	`type`,
+	`require_pkce`,
+	`metadata`
+)
+SELECT
+	'oauth_' || `id`,
+	json_extract(`metadata`, '$.plaintextKey'),
+	NULL,
+	COALESCE(`enabled`, 1) = 0,
+	false,
+	false,
+	'["profile","usage"]',
+	`user_id`,
+	`created_at`,
+	`updated_at`,
+	`name`,
+	CASE
+		WHEN json_type(`metadata`, '$.redirectUris') = 'array'
+			THEN json_extract(`metadata`, '$.redirectUris')
+		ELSE '[]'
+	END,
+	'none',
+	'["authorization_code"]',
+	'["code"]',
+	true,
+	'web',
+	true,
+	json_object(
+		'earningsEnabled', CASE
+			WHEN json_extract(`metadata`, '$.earningsEnabled') = 1 THEN json('true')
+			ELSE json('false')
+		END,
+		'description', json_extract(`metadata`, '$.description'),
+		'migratedFromApiKeyId', `id`,
+		'legacyClientId', json_extract(`metadata`, '$.plaintextKey')
+	)
+FROM `apikey`
+WHERE `prefix` = 'pk'
+  AND json_valid(`metadata`)
+  AND json_extract(`metadata`, '$.plaintextKey') IS NOT NULL
+  AND (
+	json_extract(`metadata`, '$.earningsEnabled') = 1
+	OR (
+		json_type(`metadata`, '$.redirectUris') = 'array'
+		AND json_array_length(`metadata`, '$.redirectUris') > 0
+	)
+  );
+--> statement-breakpoint
+UPDATE `apikey`
+SET `oauth_client_id` = 'oauth_' || `byop_client_key_id`
+WHERE `byop_client_key_id` IS NOT NULL
+  AND EXISTS (
+	SELECT 1
+	FROM `oauthClient`
+	WHERE `oauthClient`.`id` = 'oauth_' || `apikey`.`byop_client_key_id`
+  );
+--> statement-breakpoint
+DELETE FROM `apikey`
+WHERE `prefix` = 'pk'
+  AND json_valid(`metadata`)
+  AND json_extract(`metadata`, '$.plaintextKey') IS NOT NULL
+  AND EXISTS (
+	SELECT 1
+	FROM `oauthClient`
+	WHERE `oauthClient`.`id` = 'oauth_' || `apikey`.`id`
+  );

--- a/enter.pollinations.ai/drizzle/meta/0024_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1114 @@
+{
+  "id": "85d19750-70db-4d78-b225-dfcfd2fe456e",
+  "prevId": "0df2b212-b504-4a26-b01f-9c3fe22343f5",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_oauth_client_id": {
+          "name": "idx_apikey_oauth_client_id",
+          "columns": [
+            "oauth_client_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauthClient": {
+      "name": "oauthClient",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauthClient_client_id_unique": {
+          "name": "oauthClient_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_client_user_id": {
+          "name": "idx_oauth_client_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauthClient_user_id_user_id_fk": {
+          "name": "oauthClient_user_id_user_id_fk",
+          "tableFrom": "oauthClient",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1778063629187,
       "tag": "0023_byop-backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1778247024982,
+      "tag": "0024_oauth-client-app-keys",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/observability/datasources/d1_apikey.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_apikey.datasource
@@ -26,6 +26,7 @@ SCHEMA >
     `metadata` Nullable(String) `json:$.metadata`,
     `pollen_balance` Nullable(Float64) `json:$.pollen_balance`,
     `byop_client_key_id` Nullable(String) `json:$.byop_client_key_id`,
+    `oauth_client_id` Nullable(String) `json:$.oauth_client_id`,
     `synced_at` DateTime `json:$.synced_at`
 
 ENGINE "MergeTree"

--- a/enter.pollinations.ai/observability/datasources/d1_oauth_client.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_oauth_client.datasource
@@ -1,0 +1,40 @@
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+    Daily snapshot of D1 oauthClient table (public OAuth app client metadata)
+
+SCHEMA >
+    `id` String `json:$.id`,
+    `client_id` String `json:$.client_id`,
+    `disabled` UInt8 `json:$.disabled` DEFAULT 0,
+    `skip_consent` UInt8 `json:$.skip_consent` DEFAULT 0,
+    `enable_end_session` UInt8 `json:$.enable_end_session` DEFAULT 0,
+    `subject_type` Nullable(String) `json:$.subject_type`,
+    `scopes` Nullable(String) `json:$.scopes`,
+    `user_id` Nullable(String) `json:$.user_id`,
+    `reference_id` Nullable(String) `json:$.reference_id`,
+    `created_at` Int64 `json:$.created_at`,
+    `updated_at` Int64 `json:$.updated_at`,
+    `name` Nullable(String) `json:$.name`,
+    `uri` Nullable(String) `json:$.uri`,
+    `icon` Nullable(String) `json:$.icon`,
+    `contacts` Nullable(String) `json:$.contacts`,
+    `tos` Nullable(String) `json:$.tos`,
+    `policy` Nullable(String) `json:$.policy`,
+    `software_id` Nullable(String) `json:$.software_id`,
+    `software_version` Nullable(String) `json:$.software_version`,
+    `software_statement` Nullable(String) `json:$.software_statement`,
+    `redirect_uris` String `json:$.redirect_uris`,
+    `post_logout_redirect_uris` Nullable(String) `json:$.post_logout_redirect_uris`,
+    `token_endpoint_auth_method` Nullable(String) `json:$.token_endpoint_auth_method`,
+    `grant_types` Nullable(String) `json:$.grant_types`,
+    `response_types` Nullable(String) `json:$.response_types`,
+    `public` UInt8 `json:$.public` DEFAULT 1,
+    `type` Nullable(String) `json:$.type`,
+    `require_pkce` UInt8 `json:$.require_pkce` DEFAULT 1,
+    `metadata` Nullable(String) `json:$.metadata`,
+    `synced_at` DateTime `json:$.synced_at`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(synced_at)"
+ENGINE_SORTING_KEY "id"

--- a/enter.pollinations.ai/observability/endpoints/app_top_weekly.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_top_weekly.pipe
@@ -1,7 +1,7 @@
 DESCRIPTION >
     Top registered community apps by verified app-attributed request count
     over the last 7 days.
-    Source of truth is App Keys: publishable keys with a non-empty redirectUris allowlist.
+    Source of truth is OAuth app clients with a non-empty redirectUris allowlist.
     Current attribution only counts BYOP requests minted through redirect-auth
     for that registered app.
 
@@ -18,18 +18,18 @@ SQL >
 NODE registered_apps
 SQL >
     SELECT
-        id AS app_key_id,
+        id AS oauth_client_id,
+        client_id,
         user_id AS owner_user_id,
         name AS app_name,
-        JSONExtractString(metadata, 'redirectUris', 1) AS app_url
-    FROM d1_apikey
-    WHERE synced_at = (SELECT max(synced_at) FROM d1_apikey)
-      AND prefix = 'pk'
-      AND JSONExtractString(metadata, 'keyType') = 'publishable'
-      AND JSONExtractString(metadata, 'redirectUris', 1) != ''
-      AND positionCaseInsensitive(JSONExtractString(metadata, 'redirectUris', 1), 'localhost') = 0
-      AND positionCaseInsensitive(JSONExtractString(metadata, 'redirectUris', 1), '127.0.0.1') = 0
-      AND positionCaseInsensitive(JSONExtractString(metadata, 'redirectUris', 1), 'pollinations.ai') = 0
+        JSONExtractString(redirect_uris, 1) AS app_url
+    FROM d1_oauth_client
+    WHERE synced_at = (SELECT max(synced_at) FROM d1_oauth_client)
+      AND disabled = 0
+      AND JSONExtractString(redirect_uris, 1) != ''
+      AND positionCaseInsensitive(JSONExtractString(redirect_uris, 1), 'localhost') = 0
+      AND positionCaseInsensitive(JSONExtractString(redirect_uris, 1), '127.0.0.1') = 0
+      AND positionCaseInsensitive(JSONExtractString(redirect_uris, 1), 'pollinations.ai') = 0
 
 NODE byop_requests
 SQL >
@@ -41,7 +41,7 @@ SQL >
     FROM generation_event ge
     INNER JOIN registered_apps ra
         ON ge.api_key_created_via = 'redirect-auth'
-       AND ge.api_key_client_id = ra.app_key_id
+       AND ge.api_key_client_id = ra.client_id
     WHERE ge.start_time > now() - INTERVAL 7 DAY
       AND ge.environment = 'production'
       AND ge.response_status >= 200 AND ge.response_status < 300

--- a/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/api-key-list.tsx
@@ -20,6 +20,7 @@ function isPublishableKey(apiKey: ApiKey): boolean {
 }
 
 function isAppKey(apiKey: ApiKey): boolean {
+    if (apiKey.metadata?.recordType === "oauth_client") return true;
     if (!isPublishableKey(apiKey)) return false;
 
     const redirectUris = apiKey.metadata?.redirectUris;

--- a/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/src/client/components/api-keys/edit-api-key-dialog.tsx
@@ -42,6 +42,7 @@ function isPublishableKey(apiKey: ApiKey): boolean {
 }
 
 function isAppKey(apiKey: ApiKey): boolean {
+    if (apiKey.metadata?.recordType === "oauth_client") return true;
     return (
         isPublishableKey(apiKey) &&
         (readInitialRedirectUris(apiKey.metadata).length > 0 ||

--- a/enter.pollinations.ai/src/client/components/api-keys/types.ts
+++ b/enter.pollinations.ai/src/client/components/api-keys/types.ts
@@ -9,7 +9,7 @@ export interface ApiKey {
     permissions: Record<string, string[]> | null;
     metadata: Record<string, unknown> | null;
     pollenBalance?: number | null;
-    byopClientKeyId?: string | null;
+    oauthClientId?: string | null;
 }
 
 export interface ApiKeyUpdateParams {
@@ -39,9 +39,9 @@ export type CreateApiKey = {
     expiryDays?: number | null;
     /** Account permissions: ["profile", "usage", "keys"]. null = no permissions */
     accountPermissions?: string[] | null;
-    /** Allowed OAuth redirect URLs for publishable keys (RFC 8252 port-agnostic loopback) */
+    /** Allowed OAuth redirect URLs for app clients (RFC 8252 port-agnostic loopback) */
     redirectUris?: string[];
-    /** Enable BYOP developer earnings for publishable app keys */
+    /** Enable BYOP developer earnings for app clients */
     earningsEnabled?: boolean;
 };
 

--- a/enter.pollinations.ai/src/client/components/auth/app-attribution.tsx
+++ b/enter.pollinations.ai/src/client/components/auth/app-attribution.tsx
@@ -58,8 +58,8 @@ export function AppAttribution({
             )}
             {isDeviceMode && attribution?.appName && (
                 <p className="mt-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-                    Device app names are self-declared. Verify this is the app
-                    you started before approving access.
+                    Device apps use a public client ID. Only approve if you
+                    trust the device or CLI that showed this code.
                 </p>
             )}
             <p className="font-body text-xs font-semibold text-amber-800 tracking-wide mt-3">

--- a/enter.pollinations.ai/src/client/components/auth/app-attribution.tsx
+++ b/enter.pollinations.ai/src/client/components/auth/app-attribution.tsx
@@ -56,6 +56,12 @@ export function AppAttribution({
                     Code: {userCode}
                 </p>
             )}
+            {isDeviceMode && attribution?.appName && (
+                <p className="mt-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                    Device app names are self-declared. Verify this is the app
+                    you started before approving access.
+                </p>
+            )}
             <p className="font-body text-xs font-semibold text-amber-800 tracking-wide mt-3">
                 To access your Pollinations account{" "}
                 <InfoTip

--- a/enter.pollinations.ai/src/client/routes/authorize.tsx
+++ b/enter.pollinations.ai/src/client/routes/authorize.tsx
@@ -220,7 +220,9 @@ function AuthorizeComponent() {
                     })
                     .catch((e) => setError(e.message));
             }
-            // Fetch app attribution if device flow has an app_key
+            // Device clients are public, so this branding is informational,
+            // not proof of client identity. The minted key is not attributed
+            // to the app unless a future device proof is added.
             if (app_key) {
                 fetch(`/api/app-lookup?app_key=${encodeURIComponent(app_key)}`)
                     .then((r) => r.json())
@@ -327,8 +329,9 @@ function AuthorizeComponent() {
                 expiryDays: keyPermissions.permissions.expiryDays,
                 metadata: {
                     ...(isDeviceMode && { deviceUserCode: user_code }),
-                    ...(app_key &&
-                        (!isDeviceMode || attribution?.found) && {
+                    ...(!isDeviceMode &&
+                        app_key &&
+                        attribution?.found && {
                             requestedClientId: app_key,
                         }),
                     ...(!isDeviceMode &&

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -165,9 +165,16 @@ function RouteComponent() {
     }
 
     async function handleDeleteApiKey(id: string): Promise<void> {
-        const result = await authClient.apiKey.delete({ keyId: id });
-        if (result.error) {
-            console.error(result.error);
+        const response = await fetch(`/api/api-keys/${id}`, {
+            method: "DELETE",
+            credentials: "include",
+        });
+        if (!response.ok) {
+            const error = await response.json().catch(() => null);
+            throw new Error(
+                (error as { message?: string } | null)?.message ||
+                    "Delete failed",
+            );
         }
         router.invalidate();
     }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1,6 +1,11 @@
 import { createApiKeyForUser } from "@shared/auth/api-key-creation.ts";
 import {
+    normalizeOAuthClient,
+    oauthClientToListItem,
+} from "@shared/auth/oauth-client.ts";
+import {
     apikey as apikeyTable,
+    oauthClient as oauthClientTable,
     user as userTable,
 } from "@shared/db/better-auth.ts";
 import type { ApiKeyType } from "@shared/schemas/generation-event.ts";
@@ -107,7 +112,7 @@ const CreateKeySchema = z.object({
         .optional()
         .default("secret")
         .describe(
-            "Key type: secret (sk_) or publishable app key (pk_). Use publishable to create an app key.",
+            "Key type: secret (sk_) or publishable. Publishable requests with redirectUris or earnings enabled create OAuth app clients.",
         ),
     expiresIn: z
         .number()
@@ -137,13 +142,13 @@ const CreateKeySchema = z.object({
         .array(z.string())
         .optional()
         .describe(
-            "Allowed OAuth redirect URIs for publishable app keys. Required for OAuth app flows. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; if it has a query, the query must match exactly. Loopback ports are matched port-agnostically.",
+            "Allowed OAuth redirect URIs for app clients. Required for OAuth app flows. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; if it has a query, the query must match exactly. Loopback ports are matched port-agnostically.",
         ),
     earningsEnabled: z
         .boolean()
         .optional()
         .describe(
-            "Enable developer earnings for publishable app keys. Defaults to false; send true to opt in.",
+            "Enable developer earnings for app clients. Defaults to false; send true to opt in.",
         ),
 });
 
@@ -1055,30 +1060,40 @@ export const accountRoutes = new Hono<Env>()
                 .from(apikeyTable)
                 .where(eq(apikeyTable.userId, user.id))
                 .all();
+            const oauthClients = await db
+                .select()
+                .from(oauthClientTable)
+                .where(eq(oauthClientTable.userId, user.id))
+                .all();
 
             c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
-                data: keys.map((key) => ({
-                    id: key.id,
-                    name: key.name,
-                    start: key.start,
-                    prefix: key.prefix,
-                    createdAt: key.createdAt,
-                    expiresAt: key.expiresAt,
-                    lastRequest: key.lastRequest,
-                    permissions: key.permissions
-                        ? (() => {
-                              try {
-                                  return JSON.parse(key.permissions);
-                              } catch {
-                                  return null;
-                              }
-                          })()
-                        : null,
-                    metadata: parseMetadata(key.metadata),
-                    pollenBalance: key.pollenBalance,
-                    enabled: key.enabled,
-                })),
+                data: [
+                    ...keys.map((key) => ({
+                        id: key.id,
+                        name: key.name,
+                        start: key.start,
+                        prefix: key.prefix,
+                        createdAt: key.createdAt,
+                        expiresAt: key.expiresAt,
+                        lastRequest: key.lastRequest,
+                        permissions: key.permissions
+                            ? (() => {
+                                  try {
+                                      return JSON.parse(key.permissions);
+                                  } catch {
+                                      return null;
+                                  }
+                              })()
+                            : null,
+                        metadata: parseMetadata(key.metadata),
+                        pollenBalance: key.pollenBalance,
+                        enabled: key.enabled,
+                    })),
+                    ...oauthClients.map((client) =>
+                        oauthClientToListItem(normalizeOAuthClient(client)),
+                    ),
+                ],
             });
         },
     )
@@ -1088,7 +1103,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Create API Key",
             description:
-                'Create a new API key. To create an app key, use `type: "publishable"` with `redirectUris`. Publishable app keys default developer earnings off; send `earningsEnabled: true` to opt in. Requires `account:keys` permission and a secret key (sk_). The full key value is returned only once in the response. The `keys` account permission is automatically stripped from child keys to prevent escalation.',
+                'Create a new API key or OAuth app client. To create an app client, use `type: "publishable"` with `redirectUris` or `earningsEnabled: true`. App clients receive app_ client IDs; migrated legacy apps keep their pk_ client IDs. Requires `account:keys` permission and a secret key (sk_). The full key value is returned only once in the response. The `keys` account permission is automatically stripped from child keys to prevent escalation.',
             responses: {
                 200: { description: "Created API key with full secret" },
                 401: { description: "Unauthorized" },
@@ -1171,6 +1186,26 @@ export const accountRoutes = new Hono<Env>()
             }
 
             const db = drizzle(c.env.DB);
+            const oauthClient = await db
+                .select()
+                .from(oauthClientTable)
+                .where(
+                    and(
+                        eq(oauthClientTable.id, id),
+                        eq(oauthClientTable.userId, user.id),
+                    ),
+                )
+                .get();
+            if (oauthClient) {
+                await db
+                    .delete(apikeyTable)
+                    .where(eq(apikeyTable.oauthClientId, id));
+                await db
+                    .delete(oauthClientTable)
+                    .where(eq(oauthClientTable.id, id));
+                return c.json({ success: true });
+            }
+
             const key = await db
                 .select()
                 .from(apikeyTable)

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -3,6 +3,14 @@ import {
     validateRedirectUriFormat,
 } from "@shared/auth/api-key-creation.ts";
 import { sanitizeAuthorizeAccountPermissions } from "@shared/auth/authorize-config.ts";
+import {
+    deleteOwnedOAuthClientAndKeys,
+    findOwnedOAuthClient,
+    normalizeOAuthClient,
+    oauthClientKeyMetadata,
+    oauthClientToListItem,
+    updateOwnedOAuthClient,
+} from "@shared/auth/oauth-client.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -147,7 +155,9 @@ const CreateApiKeySchema = z.object({
         .enum(["secret", "publishable"])
         .optional()
         .default("secret")
-        .describe("Key type: secret (sk_) or publishable (pk_)"),
+        .describe(
+            "Key type: secret (sk_) or publishable. Publishable requests with app metadata create app_ OAuth clients.",
+        ),
     expiresIn: z
         .number()
         .int()
@@ -269,23 +279,59 @@ export const apiKeysRoutes = new Hono<Env>()
                 where: eq(schema.apikey.userId, user.id),
                 orderBy: (apikey, { desc }) => [desc(apikey.createdAt)],
             });
+            const oauthClients = await db.query.oauthClient.findMany({
+                where: eq(schema.oauthClient.userId, user.id),
+                orderBy: (oauthClient, { desc }) => [
+                    desc(oauthClient.createdAt),
+                ],
+            });
 
             return c.json({
-                data: keys.map((key) => ({
-                    id: key.id,
-                    name: key.name,
-                    start: key.start,
-                    createdAt: key.createdAt,
-                    lastRequest: key.lastRequest,
-                    expiresAt: key.expiresAt,
-                    permissions: key.permissions
-                        ? parsePermissions(key.permissions)
-                        : null,
-                    metadata: key.metadata ? parseMetadata(key.metadata) : null,
-                    pollenBalance: key.pollenBalance,
-                    byopClientKeyId: key.byopClientKeyId,
-                })),
+                data: [
+                    ...keys.map((key) => ({
+                        id: key.id,
+                        name: key.name,
+                        start: key.start,
+                        createdAt: key.createdAt,
+                        lastRequest: key.lastRequest,
+                        expiresAt: key.expiresAt,
+                        permissions: key.permissions
+                            ? parsePermissions(key.permissions)
+                            : null,
+                        metadata: key.metadata
+                            ? parseMetadata(key.metadata)
+                            : null,
+                        pollenBalance: key.pollenBalance,
+                        oauthClientId: key.oauthClientId,
+                    })),
+                    ...oauthClients.map((client) =>
+                        oauthClientToListItem(normalizeOAuthClient(client)),
+                    ),
+                ],
             });
+        },
+    )
+    .delete(
+        "/:id",
+        describeRoute({
+            tags: ["👤 Account"],
+            description: "Delete an API key or OAuth app client.",
+            hide: ({ c }) => c?.env.ENVIRONMENT !== "development",
+        }),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const { id } = c.req.param();
+            const db = drizzle(c.env.DB, { schema });
+
+            if (await deleteOwnedOAuthClientAndKeys(db, id, user.id)) {
+                return c.json({ success: true });
+            }
+
+            const existingKey = await requireOwnedKey(db, id, user.id);
+            await db
+                .delete(schema.apikey)
+                .where(eq(schema.apikey.id, existingKey.id));
+            return c.json({ success: true });
         },
     )
     /**
@@ -313,6 +359,23 @@ export const apiKeysRoutes = new Hono<Env>()
             } = c.req.valid("json");
 
             const db = drizzle(c.env.DB, { schema });
+            const oauthClient = await findOwnedOAuthClient(db, id, user.id);
+            if (oauthClient) {
+                const updated = await updateOwnedOAuthClient({
+                    db,
+                    id,
+                    userId: user.id,
+                    name,
+                });
+                return c.json({
+                    id: updated.id,
+                    name: updated.name,
+                    permissions: null,
+                    pollenBalance: null,
+                    expiresAt: null,
+                });
+            }
+
             const existingKey = await requireOwnedKey(db, id, user.id);
 
             const existingPermissions = existingKey.permissions
@@ -385,20 +448,36 @@ export const apiKeysRoutes = new Hono<Env>()
             const metadataUpdate = c.req.valid("json");
 
             const db = drizzle(c.env.DB, { schema });
-            const existingKey = await requireOwnedKey(db, id, user.id);
 
             if (metadataUpdate.redirectUris) {
                 for (const uri of metadataUpdate.redirectUris) {
                     validateRedirectUriFormat(uri);
                 }
             }
+            const oauthClient = await findOwnedOAuthClient(db, id, user.id);
+            if (oauthClient) {
+                const updated = await updateOwnedOAuthClient({
+                    db,
+                    id,
+                    userId: user.id,
+                    redirectUris: metadataUpdate.redirectUris,
+                    description: metadataUpdate.description,
+                    earningsEnabled: metadataUpdate.earningsEnabled,
+                });
+                return c.json({
+                    id,
+                    metadata: oauthClientKeyMetadata(updated),
+                });
+            }
+
+            const existingKey = await requireOwnedKey(db, id, user.id);
             if (
-                metadataUpdate.earningsEnabled !== undefined &&
-                existingKey.prefix !== "pk"
+                metadataUpdate.redirectUris !== undefined ||
+                metadataUpdate.earningsEnabled !== undefined
             ) {
                 throw new HTTPException(400, {
                     message:
-                        "BYOP earnings can only be enabled on publishable app keys",
+                        "App metadata can only be updated on OAuth app clients",
                 });
             }
             const metadata = await updateKeyMetadata(

--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -1,33 +1,34 @@
+import {
+    findOAuthClientByClientId,
+    type OAuthClientPublic,
+} from "@shared/auth/oauth-client.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { describeRoute } from "hono-openapi";
 import { z } from "zod";
-import { createAuth } from "../auth.ts";
 import type { Env } from "../env.ts";
 import { validator } from "../middleware/validator.ts";
-import { getRedirectUris, parseMetadata } from "./metadata-utils.ts";
 import { redirectUriMatchesAllowlist } from "./url-utils.ts";
 
 async function resolveAttribution(
     db: ReturnType<typeof drizzle<typeof schema>>,
-    keyRow: typeof schema.apikey.$inferSelect,
+    client: OAuthClientPublic,
 ) {
-    const meta = parseMetadata(keyRow.metadata);
     const user = await db.query.user.findFirst({
-        where: eq(schema.user.id, keyRow.userId),
+        where: eq(schema.user.id, client.userId ?? ""),
     });
-    const redirectUris = getRedirectUris(meta);
     return {
         found: true as const,
-        clientId: keyRow.id,
-        userId: keyRow.userId,
+        clientId: client.clientId,
+        oauthClientId: client.id,
+        userId: client.userId,
         userName: user?.name,
         githubUsername: user?.githubUsername || undefined,
-        appName: keyRow.name,
-        redirectUris,
-        earningsEnabled: meta.earningsEnabled === true,
+        appName: client.name,
+        redirectUris: client.redirectUris,
+        earningsEnabled: client.metadata.earningsEnabled === true,
     };
 }
 
@@ -42,14 +43,12 @@ async function resolveAttribution(
 const AppLookupQuerySchema = z.object({
     client_id: z
         .string()
-        .startsWith("pk_")
         .optional()
         .describe(
-            "Your publishable App Key (pk_...). When provided, the consent screen shows your app name and GitHub username. Canonical OAuth name.",
+            "Your OAuth app client_id (app_... for new apps; legacy pk_... values remain valid after migration). When provided, the consent screen shows your app name and GitHub username.",
         ),
     app_key: z
         .string()
-        .startsWith("pk_")
         .optional()
         .describe(
             "Legacy alias for `client_id`. Accepted for backwards compatibility.",
@@ -83,32 +82,27 @@ export const appLookupRoutes = new Hono<Env>().get(
         }
 
         const db = drizzle(c.env.DB, { schema });
-        const auth = createAuth(c.env);
-        const result = await auth.api.verifyApiKey({
-            body: { key: resolvedAppKey },
-        });
-        if (result.valid && result.key) {
-            const keyRow = await db.query.apikey.findFirst({
-                where: eq(schema.apikey.id, result.key.id),
-            });
-            if (keyRow) {
-                // Bind client_id to redirect_uri before delivering attribution.
-                // Without this, a stolen client_id could be paired with any
-                // redirect: the consent screen would brand the legitimate app
-                // (confused-deputy) and the minted sk_ would land at the
-                // attacker's URL. RFC 6749 §3.1.2 / RFC 8252 §7.3.
-                if (redirectUri) {
-                    const meta = parseMetadata(keyRow.metadata);
-                    const allowlist = getRedirectUris(meta);
-                    if (!redirectUriMatchesAllowlist(redirectUri, allowlist)) {
-                        return c.json({
-                            found: false as const,
-                            error: "redirect_uri_mismatch" as const,
-                        });
-                    }
+        const client = await findOAuthClientByClientId(db, resolvedAppKey);
+        if (client) {
+            // Bind client_id to redirect_uri before delivering attribution.
+            // Without this, a stolen client_id could be paired with any
+            // redirect: the consent screen would brand the legitimate app
+            // (confused-deputy) and the minted sk_ would land at the
+            // attacker's URL. RFC 6749 §3.1.2 / RFC 8252 §7.3.
+            if (redirectUri) {
+                if (
+                    !redirectUriMatchesAllowlist(
+                        redirectUri,
+                        client.redirectUris,
+                    )
+                ) {
+                    return c.json({
+                        found: false as const,
+                        error: "redirect_uri_mismatch" as const,
+                    });
                 }
-                return c.json(await resolveAttribution(db, keyRow));
             }
+            return c.json(await resolveAttribution(db, client));
         }
 
         return c.json({ found: false });

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -380,7 +380,7 @@ function generateLLMDoc(): string {
 
     lines.push("### GET /account/keys");
     lines.push(
-        "List all API keys for the current user. Requires secret key (sk_) with `account:keys` permission.",
+        "List all API keys and OAuth app clients for the current user. Requires secret key (sk_) with `account:keys` permission.",
     );
     lines.push("");
 
@@ -391,9 +391,11 @@ function generateLLMDoc(): string {
     lines.push("Body (JSON):");
     lines.push("- name (string, required): Display name");
     lines.push(
-        '- type ("secret"|"publishable", default "secret"): Key type (sk_ or pk_)',
+        '- type ("secret"|"publishable", default "secret"): `secret` creates an sk_ API key; `publishable` with app fields creates an app_ OAuth client',
     );
-    lines.push('- App keys: set type to "publishable" and pass redirectUris');
+    lines.push(
+        '- App clients: set type to "publishable" and pass redirectUris or earningsEnabled',
+    );
     lines.push("- expiresIn (int, optional): Seconds until expiry (max 365d)");
     lines.push(
         "- allowedModels (string[], optional): Restrict to specific models. null = all",
@@ -405,19 +407,19 @@ function generateLLMDoc(): string {
         '- accountPermissions (string[], optional): e.g. ["profile","usage"]. "keys" is auto-stripped',
     );
     lines.push(
-        "- redirectUris (string[], optional): OAuth redirect URIs for publishable app keys. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; query-bearing entries must match exactly. Loopback ports are port-agnostic.",
+        "- redirectUris (string[], optional): OAuth redirect URIs for app clients. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; query-bearing entries must match exactly. Loopback ports are port-agnostic.",
     );
     lines.push(
-        "- earningsEnabled (boolean, optional): Developer earnings for publishable app keys; true opts in",
+        "- earningsEnabled (boolean, optional): Developer earnings for app clients; true opts in",
     );
-    lines.push("Example app key body:");
+    lines.push("Example app client body:");
     lines.push("```json");
     lines.push(
         '{"name":"myapp","type":"publishable","redirectUris":["https://myapp.com/callback"],"earningsEnabled":true}',
     );
     lines.push("```");
     lines.push(
-        "Returns full key value once: { id, key, name, type, prefix, start, expiresAt, permissions, pollenBudget }",
+        "Returns full key/client_id value once: { id, key, name, type, prefix, start, expiresAt, permissions, pollenBudget }",
     );
     lines.push("");
 

--- a/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
+++ b/enter.pollinations.ai/src/scheduled/d1-tinybird-sync.ts
@@ -1,7 +1,7 @@
 /**
  * D1 → Tinybird sync.
  *
- * Snapshots the D1 auth tables (user, apikey, session, account) into Tinybird
+ * Snapshots the D1 auth tables (user, apikey, oauthClient, session, account) into Tinybird
  * datasources. Sensitive columns (tokens, keys, passwords, IPs) are excluded
  * at the SQL level — they never leave D1.
  *
@@ -37,8 +37,19 @@ const TABLES: TableConfig[] = [
                        last_refill_at, enabled, rate_limit_enabled, rate_limit_time_window,
                        rate_limit_max, request_count, remaining, last_request, expires_at,
                        created_at, updated_at, permissions, metadata, pollen_balance,
-                       byop_client_key_id
+                       byop_client_key_id, oauth_client_id
                 FROM apikey`,
+    },
+    {
+        datasource: "d1_oauth_client",
+        query: `SELECT id, client_id, disabled, skip_consent, enable_end_session,
+                       subject_type, scopes, user_id, reference_id, created_at,
+                       updated_at, name, uri, icon, contacts, tos, policy,
+                       software_id, software_version, software_statement,
+                       redirect_uris, post_logout_redirect_uris,
+                       token_endpoint_auth_method, grant_types, response_types,
+                       public, type, require_pkce, metadata
+                FROM oauthClient`,
     },
     {
         datasource: "d1_session",

--- a/enter.pollinations.ai/test/integration/account-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/account-keys.test.ts
@@ -51,7 +51,7 @@ describe("Account Key Management API", () => {
 
             expect(response.status).toBe(200);
             const data = await response.json();
-            expect(data.key.startsWith("pk_")).toBe(true);
+            expect(data.key.startsWith("app_")).toBe(true);
             expect(data.type).toBe("publishable");
             expect(data.metadata.redirectUris).toEqual([
                 "https://cli.example/callback",
@@ -81,7 +81,7 @@ describe("Account Key Management API", () => {
 
             expect(response.status).toBe(200);
             const data = await response.json();
-            expect(data.key.startsWith("pk_")).toBe(true);
+            expect(data.key.startsWith("app_")).toBe(true);
             expect(data.type).toBe("publishable");
             expect(data.metadata.redirectUris).toEqual([
                 "https://cli-earnings.example/callback",

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -51,7 +51,7 @@ describe("API Key Management", () => {
 
             expect(response.status).toBe(200);
             const created = await response.json();
-            expect(created.key.startsWith("pk_")).toBe(true);
+            expect(created.key.startsWith("app_")).toBe(true);
             expect(created.metadata).toMatchObject({
                 keyType: "publishable",
                 description: "created in one step",
@@ -146,9 +146,9 @@ describe("API Key Management", () => {
 
             expect(response.status).toBe(200);
             const created = await response.json();
-            expect(created.key.startsWith("pk_")).toBe(true);
+            expect(created.key.startsWith("app_")).toBe(true);
             expect(created.metadata.keyType).toBe("publishable");
-            expect(created.metadata.createdVia).toBe("dashboard");
+            expect(created.metadata.createdVia).toBeUndefined();
             expect(created.metadata.plaintextKey).toBe(created.key);
             expect(created.metadata.redirectUris).toEqual([
                 "https://legit.example/callback",
@@ -288,7 +288,7 @@ describe("API Key Management", () => {
             expect(matchingCreated.metadata.clientId).toBeUndefined();
             expect(matchingCreated.metadata.createdForApp).toBeUndefined();
             expect(matchingCreated.metadata.createdForUserId).toBeUndefined();
-            expect(matchingCreated.byopClientKeyId).toBe(appKey.id);
+            expect(matchingCreated.oauthClientId).toBe(appKey.id);
         });
 
         test("stores app attribution even when rewards are currently disabled", async ({
@@ -341,10 +341,10 @@ describe("API Key Management", () => {
             expect(response.status).toBe(200);
             const created = await response.json();
             expect(created.metadata.clientId).toBeUndefined();
-            expect(created.byopClientKeyId).toBe(appKey.id);
+            expect(created.oauthClientId).toBe(appKey.id);
         });
 
-        test("allows device-flow attribution without redirect_uri when client_id matches the device code", async ({
+        test("rejects device-flow attribution from public client_id", async ({
             sessionToken,
         }) => {
             const appResponse = await SELF.fetch(
@@ -403,14 +403,7 @@ describe("API Key Management", () => {
                 },
             );
 
-            expect(response.status).toBe(200);
-            const created = await response.json();
-            expect(created.metadata.createdVia).toBe("redirect-auth");
-            expect(created.metadata.deviceUserCode).toBe(userCode);
-            expect(created.metadata.clientId).toBeUndefined();
-            expect(created.metadata.createdForApp).toBeUndefined();
-            expect(created.metadata.createdForUserId).toBeUndefined();
-            expect(created.byopClientKeyId).toBe(appKey.id);
+            expect(response.status).toBe(400);
         });
 
         test("allows unbranded device-flow key creation without caller attribution", async ({
@@ -549,7 +542,7 @@ describe("API Key Management", () => {
             );
             expect(deviceStyleLookup.status).toBe(200);
             expect(await deviceStyleLookup.json()).toMatchObject({
-                found: true,
+                found: false,
             });
 
             const redirectLookup = await SELF.fetch(
@@ -558,7 +551,6 @@ describe("API Key Management", () => {
             expect(redirectLookup.status).toBe(200);
             expect(await redirectLookup.json()).toMatchObject({
                 found: false,
-                error: "redirect_uri_mismatch",
             });
         });
 
@@ -940,15 +932,13 @@ describe("API Key Management", () => {
                         Cookie: `better-auth.session_token=${sessionToken}`,
                     },
                     body: JSON.stringify({
-                        redirectUris: ["https://freshness.example/callback"],
+                        description: "updated metadata",
                     }),
                 },
             );
             expect(metadataResponse.status).toBe(200);
             const updated = await metadataResponse.json();
-            expect(updated.metadata.redirectUris).toEqual([
-                "https://freshness.example/callback",
-            ]);
+            expect(updated.metadata.description).toBe("updated metadata");
 
             const listResponse = await SELF.fetch(
                 "http://localhost:3000/api/api-keys",
@@ -960,12 +950,45 @@ describe("API Key Management", () => {
             );
             expect(listResponse.status).toBe(200);
             const list = (await listResponse.json()) as {
-                data: { id: string; metadata?: { redirectUris?: string[] } }[];
+                data: { id: string; metadata?: { description?: string } }[];
             };
             const refreshed = list.data.find((k) => k.id === createdKey.id);
-            expect(refreshed?.metadata?.redirectUris).toEqual([
-                "https://freshness.example/callback",
-            ]);
+            expect(refreshed?.metadata?.description).toBe("updated metadata");
+        });
+
+        test("rejects app metadata updates on plain API key rows", async ({
+            auth,
+            sessionToken,
+        }) => {
+            const createResponse = await auth.apiKey.create({
+                name: "plain-key-app-metadata-reject",
+                fetchOptions: {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            });
+            const createdKey = createResponse.data;
+            expect(createdKey).toBeTruthy();
+            if (!createdKey) {
+                throw new Error("Failed to create API key");
+            }
+
+            const metadataResponse = await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${createdKey.id}/metadata`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        redirectUris: ["https://freshness.example/callback"],
+                    }),
+                },
+            );
+
+            expect(metadataResponse.status).toBe(400);
         });
 
         test("allows enabling rewards from app key metadata", async ({

--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -9,7 +9,7 @@ import {
     resolveDevMarkup,
 } from "@shared/billing/track-helpers.ts";
 import {
-    apikey as apikeyTable,
+    oauthClient as oauthClientTable,
     user as userTable,
 } from "@shared/db/better-auth.ts";
 import { sql } from "drizzle-orm";
@@ -51,7 +51,7 @@ async function setupPayerAndDev({
     const suffix = crypto.randomUUID();
     const payerId = `payer-${suffix}`;
     const devId = `dev-${suffix}`;
-    const pkId = `pk_markup_${suffix}`;
+    const oauthClientId = `oauth_markup_${suffix}`;
 
     await db.insert(userTable).values([
         {
@@ -76,19 +76,24 @@ async function setupPayerAndDev({
         },
     ]);
 
-    await db.insert(apikeyTable).values({
-        id: pkId,
+    await db.insert(oauthClientTable).values({
+        id: oauthClientId,
+        clientId: `app_markup_${suffix}`,
         userId: devId,
         name: "markup-app",
-        prefix: "pk",
-        key: `hashed-${pkId}`,
-        enabled: true,
+        redirectUris: JSON.stringify(["https://markup.example/callback"]),
+        public: true,
+        tokenEndpointAuthMethod: "none",
+        grantTypes: JSON.stringify(["authorization_code"]),
+        responseTypes: JSON.stringify(["code"]),
+        requirePKCE: true,
+        disabled: false,
         metadata: JSON.stringify({ earningsEnabled: true }),
         createdAt: new Date(),
         updatedAt: new Date(),
     });
 
-    return { payerId, devId, pkId };
+    return { payerId, devId, oauthClientId };
 }
 
 describe("BYOP markup", () => {
@@ -99,30 +104,32 @@ describe("BYOP markup", () => {
     });
 
     it("resolves markup only for enabled publishable app keys with earnings enabled", async () => {
-        const { payerId, devId, pkId } = await setupPayerAndDev();
+        const { payerId, devId, oauthClientId } = await setupPayerAndDev();
 
-        const resolved = await resolveDevMarkup(db, pkId, 4, payerId);
+        const resolved = await resolveDevMarkup(db, oauthClientId, 4, payerId);
         expect(resolved).toEqual({
             devUserId: devId,
             devCredit: 4 * MARKUP_PCT,
             markupRate: MARKUP_PCT,
         });
 
-        expect(await resolveDevMarkup(db, pkId, 4, devId)).toBeNull();
+        expect(await resolveDevMarkup(db, oauthClientId, 4, devId)).toBeNull();
 
         await db
-            .update(apikeyTable)
+            .update(oauthClientTable)
             .set({ metadata: JSON.stringify({ earningsEnabled: false }) })
-            .where(sql`${apikeyTable.id} = ${pkId}`);
-        expect(await resolveDevMarkup(db, pkId, 4, payerId)).toBeNull();
+            .where(sql`${oauthClientTable.id} = ${oauthClientId}`);
+        expect(
+            await resolveDevMarkup(db, oauthClientId, 4, payerId),
+        ).toBeNull();
     });
 
     it("resolves markup for app owners on any tier", async () => {
-        const { payerId, devId, pkId } = await setupPayerAndDev({
+        const { payerId, devId, oauthClientId } = await setupPayerAndDev({
             devTier: "spore",
         });
 
-        expect(await resolveDevMarkup(db, pkId, 4, payerId)).toEqual({
+        expect(await resolveDevMarkup(db, oauthClientId, 4, payerId)).toEqual({
             devUserId: devId,
             devCredit: 4 * MARKUP_PCT,
             markupRate: MARKUP_PCT,
@@ -130,14 +137,14 @@ describe("BYOP markup", () => {
     });
 
     it("credits creator tier balance when payer spends tier balance", async () => {
-        const { payerId, devId, pkId } = await setupPayerAndDev();
+        const { payerId, devId, oauthClientId } = await setupPayerAndDev();
 
         const { markup } = await handleBalanceDeduction({
             db,
             isBilledUsage: true,
             totalPrice: 1,
             userId: payerId,
-            byopClientKeyId: pkId,
+            oauthClientId,
         });
 
         expect(markup?.devUserId).toBe(devId);
@@ -153,7 +160,7 @@ describe("BYOP markup", () => {
     });
 
     it("credits creator pack balance when payer spends pack balance", async () => {
-        const { payerId, devId, pkId } = await setupPayerAndDev();
+        const { payerId, devId, oauthClientId } = await setupPayerAndDev();
         await db
             .update(userTable)
             .set({ tierBalance: 0.5, packBalance: 2 })
@@ -164,7 +171,7 @@ describe("BYOP markup", () => {
             isBilledUsage: true,
             totalPrice: 1,
             userId: payerId,
-            byopClientKeyId: pkId,
+            oauthClientId,
         });
 
         expect(markup?.devUserId).toBe(devId);
@@ -180,7 +187,7 @@ describe("BYOP markup", () => {
     });
 
     it("bills baseline plus markup without a payer-tier gate", async () => {
-        const { payerId, devId, pkId } = await setupPayerAndDev({
+        const { payerId, devId, oauthClientId } = await setupPayerAndDev({
             payerTier: "flower",
         });
 
@@ -189,7 +196,7 @@ describe("BYOP markup", () => {
             isBilledUsage: true,
             totalPrice: 1,
             userId: payerId,
-            byopClientKeyId: pkId,
+            oauthClientId,
         });
 
         expect(markup?.devUserId).toBe(devId);
@@ -342,7 +349,7 @@ describe("BYOP markup", () => {
                 user: { id: "preflight-payer" },
                 apiKey: {
                     id: "sk-test",
-                    byopClientKeyId: "pk-test",
+                    oauthClientId: "oauth-test",
                     pollenBalance: 1.1,
                 },
             },
@@ -372,7 +379,7 @@ describe("BYOP markup", () => {
                 user: { id: "preflight-payer" },
                 apiKey: {
                     id: "sk-test",
-                    byopClientKeyId: "pk-test",
+                    oauthClientId: "oauth-test",
                     pollenBalance: 10,
                 },
             },
@@ -397,14 +404,14 @@ describe("BYOP markup", () => {
     });
 
     it("does not credit or deduct for unbilled requests", async () => {
-        const { payerId, devId, pkId } = await setupPayerAndDev();
+        const { payerId, devId, oauthClientId } = await setupPayerAndDev();
 
         const { markup } = await handleBalanceDeduction({
             db,
             isBilledUsage: false,
             totalPrice: 1,
             userId: payerId,
-            byopClientKeyId: pkId,
+            oauthClientId,
         });
 
         expect(markup).toBeNull();
@@ -413,7 +420,7 @@ describe("BYOP markup", () => {
     });
 
     it("reverts dev credit when payer deduction fails", async () => {
-        const { devId, pkId } = await setupPayerAndDev();
+        const { devId, oauthClientId } = await setupPayerAndDev();
 
         await expect(
             handleBalanceDeduction({
@@ -421,7 +428,7 @@ describe("BYOP markup", () => {
                 isBilledUsage: true,
                 totalPrice: 1,
                 userId: "missing-payer-row",
-                byopClientKeyId: pkId,
+                oauthClientId,
             }),
         ).rejects.toThrow(/affected 0 rows/);
 

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -3,7 +3,7 @@ import {
     handleBalanceDeduction,
     type MarkupResolution,
 } from "@shared/billing/track-helpers.ts";
-import { apikey as apikeyTable } from "@shared/db/better-auth.ts";
+import { oauthClient as oauthClientTable } from "@shared/db/better-auth.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 import {
     calculateCost,
@@ -127,7 +127,7 @@ export const track = (eventType: EventType) =>
         const apiKeyMetadata = c.var.auth.apiKey?.metadata as
             | Record<string, unknown>
             | undefined;
-        const byopClientKeyId = c.var.auth.apiKey?.byopClientKeyId;
+        const oauthClientId = c.var.auth.apiKey?.oauthClientId;
         const userTracking: UserData = {
             userId: c.var.auth.user?.id,
             userTier: c.var.auth.user?.tier,
@@ -138,13 +138,14 @@ export const track = (eventType: EventType) =>
             apiKeyId: c.var.auth.apiKey?.id,
             apiKeyType: apiKeyMetadata?.keyType as ApiKeyType,
             apiKeyName: c.var.auth.apiKey?.name,
-            apiKeyCreatedVia: byopClientKeyId
+            apiKeyCreatedVia: oauthClientId
                 ? "redirect-auth"
                 : (apiKeyMetadata?.createdVia as string | undefined),
-            apiKeyClientId: byopClientKeyId ?? undefined,
-            apiKeyCreatedForApp: c.var.auth.apiKey?.byopClientName ?? undefined,
+            apiKeyClientId: c.var.auth.apiKey?.oauthClientClientId ?? undefined,
+            apiKeyCreatedForApp:
+                c.var.auth.apiKey?.oauthClientName ?? undefined,
             apiKeyCreatedForUserId:
-                c.var.auth.apiKey?.byopClientUserId ?? undefined,
+                c.var.auth.apiKey?.oauthClientUserId ?? undefined,
         } satisfies UserData;
 
         let responseOverride = null;
@@ -181,9 +182,9 @@ export const track = (eventType: EventType) =>
                 } satisfies BalanceData;
 
                 const ipHash = await hashIp(clientIp, c.env.BETTER_AUTH_SECRET);
-                const byopClientTracking = await resolveByopClientTracking(
+                const oauthClientTracking = await resolveOAuthClientTracking(
                     db,
-                    byopClientKeyId,
+                    oauthClientId,
                 );
 
                 // Deduct payer + credit dev before emitting the event so billing
@@ -203,7 +204,7 @@ export const track = (eventType: EventType) =>
                         userId: userTracking.userId,
                         apiKeyId: c.var.auth?.apiKey?.id,
                         apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
-                        byopClientKeyId,
+                        oauthClientId,
                         modelResolved: c.var.model?.resolved,
                     });
                     markup = deduction.markup;
@@ -242,7 +243,7 @@ export const track = (eventType: EventType) =>
                     ipHash,
                     userTracking: {
                         ...userTracking,
-                        ...byopClientTracking,
+                        ...oauthClientTracking,
                     },
                     balanceTracking: committedBalanceTracking,
                     requestTracking,
@@ -871,26 +872,27 @@ type ErrorData = {
     // errorStack and errorDetails removed to reduce D1 memory usage
 };
 
-async function resolveByopClientTracking(
+async function resolveOAuthClientTracking(
     db: ReturnType<typeof drizzle>,
-    byopClientKeyId: string | null | undefined,
+    oauthClientId: string | null | undefined,
 ): Promise<Partial<UserData>> {
-    if (!byopClientKeyId) return {};
+    if (!oauthClientId) return {};
 
-    const [clientKey] = await db
+    const [client] = await db
         .select({
-            id: apikeyTable.id,
-            name: apikeyTable.name,
-            userId: apikeyTable.userId,
+            id: oauthClientTable.id,
+            clientId: oauthClientTable.clientId,
+            name: oauthClientTable.name,
+            userId: oauthClientTable.userId,
         })
-        .from(apikeyTable)
-        .where(eq(apikeyTable.id, byopClientKeyId))
+        .from(oauthClientTable)
+        .where(eq(oauthClientTable.id, oauthClientId))
         .limit(1);
 
     return {
-        apiKeyClientId: clientKey?.id ?? byopClientKeyId,
-        apiKeyCreatedForApp: clientKey?.name ?? undefined,
-        apiKeyCreatedForUserId: clientKey?.userId ?? undefined,
+        apiKeyClientId: client?.clientId ?? oauthClientId,
+        apiKeyCreatedForApp: client?.name ?? undefined,
+        apiKeyCreatedForUserId: client?.userId ?? undefined,
     };
 }
 

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -3,6 +3,11 @@ import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import * as schema from "../db/better-auth.ts";
 import { sanitizeAuthorizeAccountPermissions } from "./authorize-config.ts";
+import {
+    createOAuthClientForUser,
+    findOAuthClientByClientId,
+    isOAuthClientMetadata,
+} from "./oauth-client.ts";
 import { redirectUriMatchesAllowlist } from "./redirect-uri.ts";
 
 export type ApiKeyType = "secret" | "publishable";
@@ -58,7 +63,7 @@ type CreateApiKeyAuthClient = {
 };
 
 type VerifiedClientAttribution = {
-    clientId: string;
+    oauthClientId: string;
 };
 
 export function validateRedirectUriFormat(redirectUri: string): void {
@@ -80,28 +85,6 @@ export function validateRedirectUriFormat(redirectUri: string): void {
             message: "Redirect URI must not include a fragment",
         });
     }
-}
-
-function parseMetadata(
-    raw: string | null | undefined,
-): Record<string, unknown> {
-    if (!raw) return {};
-    try {
-        const parsed = JSON.parse(raw);
-        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-            ? parsed
-            : {};
-    } catch {
-        return {};
-    }
-}
-
-function getRedirectUris(meta: Record<string, unknown>): string[] {
-    const list = meta.redirectUris;
-    if (Array.isArray(list)) {
-        return list.filter((v): v is string => typeof v === "string" && !!v);
-    }
-    return [];
 }
 
 function cleanRedirectUris(redirectUris: string[]): string[] {
@@ -140,7 +123,6 @@ function pickCallerMetadata(
 }
 
 async function validateClientRedirectBinding(
-    authClient: CreateApiKeyAuthClient,
     db: ReturnType<typeof drizzle<typeof schema>>,
     metadata: CallerMetadata | undefined,
 ): Promise<VerifiedClientAttribution | null> {
@@ -155,47 +137,26 @@ async function validateClientRedirectBinding(
         return null;
     }
 
-    if (!requestedClientId.startsWith("pk_")) {
+    if (typeof metadata.deviceUserCode === "string") {
+        throw new HTTPException(400, {
+            message: "client_id is not supported for device authorization",
+        });
+    }
+
+    if (
+        !requestedClientId.startsWith("app_") &&
+        !requestedClientId.startsWith("pk_")
+    ) {
         rejectInvalidClientId();
     }
 
-    const result = await authClient.api.verifyApiKey({
-        body: { key: requestedClientId },
-    });
-    if (!result.valid || !result.key?.id) {
-        rejectInvalidClientId();
-    }
-    const clientKeyId = result.key.id;
-
-    const clientKey = await db.query.apikey.findFirst({
-        where: eq(schema.apikey.id, clientKeyId),
-    });
-    if (!clientKey || clientKey.prefix !== "pk") {
+    const oauthClient = await findOAuthClientByClientId(db, requestedClientId);
+    if (!oauthClient?.userId) {
         rejectInvalidClientId();
     }
     const attribution = {
-        clientId: clientKey.id,
+        oauthClientId: oauthClient.id,
     };
-
-    if (typeof metadata.deviceUserCode === "string") {
-        const device = await db.query.deviceCode.findFirst({
-            where: eq(
-                schema.deviceCode.userCode,
-                metadata.deviceUserCode.toUpperCase(),
-            ),
-        });
-        if (
-            !device ||
-            device.status !== "pending" ||
-            device.expiresAt < new Date() ||
-            device.clientId !== requestedClientId
-        ) {
-            throw new HTTPException(400, {
-                message: "client_id mismatch",
-            });
-        }
-        return attribution;
-    }
 
     if (typeof metadata.redirectUri !== "string") {
         throw new HTTPException(400, {
@@ -204,8 +165,12 @@ async function validateClientRedirectBinding(
     }
     validateRedirectUriFormat(metadata.redirectUri);
 
-    const allowlist = getRedirectUris(parseMetadata(clientKey.metadata));
-    if (!redirectUriMatchesAllowlist(metadata.redirectUri, allowlist)) {
+    if (
+        !redirectUriMatchesAllowlist(
+            metadata.redirectUri,
+            oauthClient.redirectUris,
+        )
+    ) {
         throw new HTTPException(400, {
             message: "redirect_uri not in allowlist for this client_id",
         });
@@ -228,11 +193,7 @@ export async function createApiKeyForUser({
     defaultCreatedVia,
 }: CreateApiKeyForUserInput) {
     const db = drizzle(dbBinding, { schema });
-    const attribution = await validateClientRedirectBinding(
-        authClient,
-        db,
-        metadata,
-    );
+    const attribution = await validateClientRedirectBinding(db, metadata);
 
     const isPublishable = type === "publishable";
     const callerMetadata = pickCallerMetadata(metadata, isPublishable);
@@ -240,6 +201,17 @@ export async function createApiKeyForUser({
         for (const uri of callerMetadata.redirectUris as string[]) {
             validateRedirectUriFormat(uri);
         }
+    }
+
+    if (isPublishable && isOAuthClientMetadata(callerMetadata)) {
+        return createOAuthClientForUser({
+            dbBinding,
+            userId,
+            name,
+            redirectUris: callerMetadata.redirectUris as string[] | undefined,
+            description: callerMetadata.description as string | undefined,
+            earningsEnabled: callerMetadata.earningsEnabled === true,
+        });
     }
 
     const sanitizedAccountPerms =
@@ -289,7 +261,7 @@ export async function createApiKeyForUser({
     };
     if (pollenBudget != null) d1Updates.pollenBalance = pollenBudget;
     if (!isPublishable && attribution) {
-        d1Updates.byopClientKeyId = attribution.clientId;
+        d1Updates.oauthClientId = attribution.oauthClientId;
     }
 
     await db
@@ -308,8 +280,8 @@ export async function createApiKeyForUser({
         expiresIn,
         permissions: Object.keys(permissions).length > 0 ? permissions : null,
         pollenBudget: pollenBudget ?? null,
-        byopClientKeyId:
-            !isPublishable && attribution ? attribution.clientId : null,
+        oauthClientId:
+            !isPublishable && attribution ? attribution.oauthClientId : null,
         metadata: finalMetadata,
     };
 }

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -3,7 +3,6 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { apiKey } from "better-auth/plugins";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { alias } from "drizzle-orm/sqlite-core";
 import * as schema from "../db/better-auth.ts";
 
 const PUBLISHABLE_KEY_PREFIX = "pk";
@@ -16,9 +15,10 @@ export interface AuthenticatedApiKey {
     permissions?: Record<string, string[]>;
     metadata?: Record<string, unknown>;
     pollenBalance?: number | null;
-    byopClientKeyId?: string | null;
-    byopClientName?: string | null;
-    byopClientUserId?: string | null;
+    oauthClientId?: string | null;
+    oauthClientClientId?: string | null;
+    oauthClientName?: string | null;
+    oauthClientUserId?: string | null;
     rawKey?: string;
 }
 
@@ -165,19 +165,19 @@ export async function authenticateApiKeyRequest(opts: {
 
     const db = drizzle(opts.env.DB, { schema });
     const userId = typeof key.userId === "string" ? key.userId : undefined;
-    const byopClientKey = alias(schema.apikey, "byop_client_key");
     const [apiKeyExtra, userData] = await Promise.all([
         db
             .select({
                 pollenBalance: schema.apikey.pollenBalance,
-                byopClientKeyId: schema.apikey.byopClientKeyId,
-                byopClientName: byopClientKey.name,
-                byopClientUserId: byopClientKey.userId,
+                oauthClientId: schema.apikey.oauthClientId,
+                oauthClientClientId: schema.oauthClient.clientId,
+                oauthClientName: schema.oauthClient.name,
+                oauthClientUserId: schema.oauthClient.userId,
             })
             .from(schema.apikey)
             .leftJoin(
-                byopClientKey,
-                eq(byopClientKey.id, schema.apikey.byopClientKeyId),
+                schema.oauthClient,
+                eq(schema.oauthClient.id, schema.apikey.oauthClientId),
             )
             .where(eq(schema.apikey.id, keyId))
             .get(),
@@ -202,9 +202,10 @@ export async function authenticateApiKeyRequest(opts: {
             permissions: normalizePermissions(key.permissions),
             metadata: normalizeMetadata(key.metadata),
             pollenBalance: apiKeyExtra?.pollenBalance ?? null,
-            byopClientKeyId: apiKeyExtra?.byopClientKeyId ?? null,
-            byopClientName: apiKeyExtra?.byopClientName ?? null,
-            byopClientUserId: apiKeyExtra?.byopClientUserId ?? null,
+            oauthClientId: apiKeyExtra?.oauthClientId ?? null,
+            oauthClientClientId: apiKeyExtra?.oauthClientClientId ?? null,
+            oauthClientName: apiKeyExtra?.oauthClientName ?? null,
+            oauthClientUserId: apiKeyExtra?.oauthClientUserId ?? null,
             rawKey: rawApiKey,
         },
         rawApiKey,

--- a/shared/auth/oauth-client.ts
+++ b/shared/auth/oauth-client.ts
@@ -1,0 +1,309 @@
+import { and, eq, isNull, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "../db/better-auth.ts";
+
+export type OAuthClientMetadata = {
+    description?: string;
+    earningsEnabled?: boolean;
+    migratedFromApiKeyId?: string;
+    legacyClientId?: string;
+};
+
+export type OAuthClientRow = typeof schema.oauthClient.$inferSelect;
+
+export type OAuthClientPublic = {
+    id: string;
+    clientId: string;
+    userId: string | null;
+    name: string | null;
+    disabled: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    redirectUris: string[];
+    metadata: OAuthClientMetadata;
+};
+
+type CreateOAuthClientInput = {
+    dbBinding: D1Database;
+    userId: string;
+    name: string;
+    redirectUris?: string[];
+    description?: string;
+    earningsEnabled?: boolean;
+    clientId?: string;
+    createdAt?: Date;
+};
+
+type UpdateOAuthClientInput = {
+    db: ReturnType<typeof drizzle<typeof schema>>;
+    id: string;
+    userId: string;
+    name?: string;
+    redirectUris?: string[];
+    description?: string;
+    earningsEnabled?: boolean;
+};
+
+const DEFAULT_SCOPES = ["profile", "usage"];
+const DEFAULT_GRANT_TYPES = ["authorization_code"];
+const DEFAULT_RESPONSE_TYPES = ["code"];
+
+export function isOAuthClientMetadata(metadata: unknown): boolean {
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+        return false;
+    }
+    const record = metadata as Record<string, unknown>;
+    const redirectUris = record.redirectUris;
+    const hasRedirectUris =
+        Array.isArray(redirectUris) &&
+        redirectUris.some(
+            (uri) => typeof uri === "string" && uri.trim().length > 0,
+        );
+    return hasRedirectUris || record.earningsEnabled === true;
+}
+
+export async function createOAuthClientForUser({
+    dbBinding,
+    userId,
+    name,
+    redirectUris = [],
+    description,
+    earningsEnabled = false,
+    clientId,
+    createdAt = new Date(),
+}: CreateOAuthClientInput) {
+    const db = drizzle(dbBinding, { schema });
+    const row = {
+        id: crypto.randomUUID(),
+        clientId: clientId ?? generateClientId(),
+        clientSecret: null,
+        disabled: false,
+        skipConsent: false,
+        enableEndSession: false,
+        scopes: JSON.stringify(DEFAULT_SCOPES),
+        userId,
+        createdAt,
+        updatedAt: createdAt,
+        name,
+        redirectUris: JSON.stringify(cleanRedirectUris(redirectUris)),
+        tokenEndpointAuthMethod: "none",
+        grantTypes: JSON.stringify(DEFAULT_GRANT_TYPES),
+        responseTypes: JSON.stringify(DEFAULT_RESPONSE_TYPES),
+        public: true,
+        type: "web",
+        requirePKCE: true,
+        metadata: JSON.stringify({
+            ...(description && { description }),
+            earningsEnabled,
+        }),
+    } satisfies typeof schema.oauthClient.$inferInsert;
+
+    await db.insert(schema.oauthClient).values(row);
+    return oauthClientToCreatedKey(row);
+}
+
+export async function findOAuthClientByClientId(
+    db: ReturnType<typeof drizzle<typeof schema>>,
+    clientId: string,
+): Promise<OAuthClientPublic | null> {
+    const row = await db.query.oauthClient.findFirst({
+        where: and(
+            eq(schema.oauthClient.clientId, clientId),
+            or(
+                isNull(schema.oauthClient.disabled),
+                eq(schema.oauthClient.disabled, false),
+            ),
+        ),
+    });
+    return row ? normalizeOAuthClient(row) : null;
+}
+
+export async function findOwnedOAuthClient(
+    db: ReturnType<typeof drizzle<typeof schema>>,
+    id: string,
+    userId: string,
+): Promise<OAuthClientPublic | null> {
+    const row = await db.query.oauthClient.findFirst({
+        where: and(
+            eq(schema.oauthClient.id, id),
+            eq(schema.oauthClient.userId, userId),
+        ),
+    });
+    return row ? normalizeOAuthClient(row) : null;
+}
+
+export async function updateOwnedOAuthClient({
+    db,
+    id,
+    userId,
+    name,
+    redirectUris,
+    description,
+    earningsEnabled,
+}: UpdateOAuthClientInput): Promise<OAuthClientPublic> {
+    const existing = await findOwnedOAuthClient(db, id, userId);
+    if (!existing) {
+        throw new Error("OAuth client not found");
+    }
+
+    const metadata = {
+        ...existing.metadata,
+        ...(description !== undefined && { description }),
+        ...(earningsEnabled !== undefined && { earningsEnabled }),
+    };
+    const update: Partial<typeof schema.oauthClient.$inferInsert> = {
+        updatedAt: new Date(),
+    };
+    if (name !== undefined) update.name = name;
+    if (redirectUris !== undefined) {
+        update.redirectUris = JSON.stringify(cleanRedirectUris(redirectUris));
+    }
+    if (description !== undefined || earningsEnabled !== undefined) {
+        update.metadata = JSON.stringify(metadata);
+    }
+
+    await db
+        .update(schema.oauthClient)
+        .set(update)
+        .where(eq(schema.oauthClient.id, id));
+
+    const updated = await findOwnedOAuthClient(db, id, userId);
+    if (!updated) {
+        throw new Error("OAuth client not found after update");
+    }
+    return updated;
+}
+
+export async function deleteOwnedOAuthClientAndKeys(
+    db: ReturnType<typeof drizzle<typeof schema>>,
+    id: string,
+    userId: string,
+): Promise<boolean> {
+    const existing = await findOwnedOAuthClient(db, id, userId);
+    if (!existing) return false;
+
+    await db.delete(schema.apikey).where(eq(schema.apikey.oauthClientId, id));
+    await db.delete(schema.oauthClient).where(eq(schema.oauthClient.id, id));
+    return true;
+}
+
+export function normalizeOAuthClient(row: OAuthClientRow): OAuthClientPublic {
+    return {
+        id: row.id,
+        clientId: row.clientId,
+        userId: row.userId ?? null,
+        name: row.name ?? null,
+        disabled: row.disabled === true,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        redirectUris: parseStringArray(row.redirectUris),
+        metadata: parseMetadata(row.metadata),
+    };
+}
+
+export function oauthClientKeyMetadata(client: {
+    clientId: string;
+    redirectUris?: string | string[];
+    metadata?: string | OAuthClientMetadata | null;
+}) {
+    const redirectUris =
+        typeof client.redirectUris === "string"
+            ? parseStringArray(client.redirectUris)
+            : (client.redirectUris ?? []);
+    const metadata =
+        typeof client.metadata === "string"
+            ? parseMetadata(client.metadata)
+            : (client.metadata ?? {});
+    return {
+        keyType: "publishable",
+        recordType: "oauth_client",
+        plaintextKey: client.clientId,
+        ...(metadata.description && { description: metadata.description }),
+        redirectUris,
+        earningsEnabled: metadata.earningsEnabled === true,
+    };
+}
+
+export function oauthClientToCreatedKey(client: {
+    id: string;
+    clientId: string;
+    name?: string | null;
+    createdAt?: Date;
+    redirectUris?: string | string[];
+    metadata?: string | OAuthClientMetadata | null;
+}) {
+    return {
+        id: client.id,
+        key: client.clientId,
+        name: client.name ?? null,
+        type: "publishable" as const,
+        prefix: "app" as const,
+        start: client.clientId.slice(0, 10),
+        expiresAt: null,
+        expiresIn: undefined,
+        permissions: null,
+        pollenBudget: null,
+        oauthClientId: client.id,
+        metadata: oauthClientKeyMetadata(client),
+        createdAt: client.createdAt,
+        lastRequest: null,
+    };
+}
+
+export function oauthClientToListItem(client: OAuthClientPublic) {
+    return {
+        id: client.id,
+        name: client.name,
+        start: client.clientId.slice(0, 10),
+        prefix: "app",
+        createdAt: client.createdAt,
+        updatedAt: client.updatedAt,
+        lastRequest: null,
+        expiresAt: null,
+        enabled: !client.disabled,
+        permissions: null,
+        metadata: oauthClientKeyMetadata(client),
+        pollenBalance: null,
+        oauthClientId: client.id,
+    };
+}
+
+function cleanRedirectUris(redirectUris: string[]): string[] {
+    return redirectUris
+        .map((uri) => uri.trim())
+        .filter((uri): uri is string => uri.length > 0);
+}
+
+function parseStringArray(raw: string | null | undefined): string[] {
+    if (!raw) return [];
+    try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed)
+            ? parsed.filter((v): v is string => typeof v === "string" && !!v)
+            : [];
+    } catch {
+        return [];
+    }
+}
+
+function parseMetadata(raw: string | null | undefined): OAuthClientMetadata {
+    if (!raw) return {};
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as OAuthClientMetadata)
+            : {};
+    } catch {
+        return {};
+    }
+}
+
+function generateClientId(): string {
+    const chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    const bytes = crypto.getRandomValues(new Uint8Array(24));
+    const suffix = Array.from(bytes, (byte) => chars[byte % chars.length]).join(
+        "",
+    );
+    return `app_${suffix}`;
+}

--- a/shared/auth/redirect-uri.ts
+++ b/shared/auth/redirect-uri.ts
@@ -1,5 +1,5 @@
 /**
- * Match an incoming `redirect_uri` against a registered allowlist for a `pk_`.
+ * Match an incoming `redirect_uri` against a registered OAuth client allowlist.
  *
  * Comparison rules:
  * - Scheme + hostname + path are matched exactly (after lowercasing host).

--- a/shared/billing/markup.ts
+++ b/shared/billing/markup.ts
@@ -1,6 +1,6 @@
 /**
  * BYOP markup applied to requests authenticated by a BYOP-issued sk_ token with
- * a trusted byop_client_key_id. The payer is billed baseline + markup; the
+ * a trusted oauth_client_id. The payer is billed baseline + markup; the
  * markup is credited to the app owner's matching tier or pack balance.
  */
 export const MARKUP_PCT = 0.25;

--- a/shared/billing/track-helpers.ts
+++ b/shared/billing/track-helpers.ts
@@ -1,7 +1,7 @@
 import { getLogger } from "@logtape/logtape";
-import { and, eq, gt, isNull, or } from "drizzle-orm";
+import { and, eq, isNull, or } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { apikey as apikeyTable } from "../db/better-auth.ts";
+import { oauthClient as oauthClientTable } from "../db/better-auth.ts";
 import type { ModelName } from "../registry/registry.ts";
 import { getModelDefinition } from "../registry/registry.ts";
 import {
@@ -27,7 +27,7 @@ interface DeductionParams {
     userId?: string;
     apiKeyId?: string;
     apiKeyPollenBalance?: number | null;
-    byopClientKeyId?: string | null;
+    oauthClientId?: string | null;
     modelResolved?: string;
 }
 
@@ -47,26 +47,27 @@ function parseMetadata(
 
 export async function resolveDevMarkup(
     db: DrizzleD1Database,
-    byopClientKeyId: string | null | undefined,
+    oauthClientId: string | null | undefined,
     baselinePrice: number,
     payerUserId: string | undefined,
 ): Promise<MarkupResolution | null> {
-    if (!byopClientKeyId || !payerUserId) return null;
+    if (!oauthClientId || !payerUserId) return null;
 
     const credit = computeDevCredit(baselinePrice);
     if (credit <= 0) return null;
 
     const [clientRow] = await db
-        .select({ userId: apikeyTable.userId, metadata: apikeyTable.metadata })
-        .from(apikeyTable)
+        .select({
+            userId: oauthClientTable.userId,
+            metadata: oauthClientTable.metadata,
+        })
+        .from(oauthClientTable)
         .where(
             and(
-                eq(apikeyTable.id, byopClientKeyId),
-                eq(apikeyTable.prefix, "pk"),
-                eq(apikeyTable.enabled, true),
+                eq(oauthClientTable.id, oauthClientId),
                 or(
-                    isNull(apikeyTable.expiresAt),
-                    gt(apikeyTable.expiresAt, new Date()),
+                    isNull(oauthClientTable.disabled),
+                    eq(oauthClientTable.disabled, false),
                 ),
             ),
         )
@@ -96,7 +97,7 @@ export async function handleBalanceDeduction(
         userId,
         apiKeyId,
         apiKeyPollenBalance,
-        byopClientKeyId,
+        oauthClientId,
         modelResolved,
     } = params;
 
@@ -106,7 +107,7 @@ export async function handleBalanceDeduction(
 
     const resolved = await resolveDevMarkup(
         db,
-        byopClientKeyId,
+        oauthClientId,
         totalPrice,
         userId,
     );

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -129,11 +129,48 @@ export const apikey = sqliteTable("apikey", {
   metadata: text("metadata"),
   pollenBalance: real("pollen_balance"),
   byopClientKeyId: text("byop_client_key_id"),
+  oauthClientId: text("oauth_client_id"),
 }, (table) => [
   index("idx_apikey_key").on(table.key),
   index('idx_apikey_expires_at').on(table.expiresAt),
   index("idx_apikey_user_id").on(table.userId),
   index("idx_apikey_byop_client_key_id").on(table.byopClientKeyId),
+  index("idx_apikey_oauth_client_id").on(table.oauthClientId),
+]);
+
+export const oauthClient = sqliteTable("oauthClient", {
+  id: text("id").primaryKey(),
+  clientId: text("client_id").notNull().unique(),
+  clientSecret: text("client_secret"),
+  disabled: integer("disabled", { mode: "boolean" }).default(false),
+  skipConsent: integer("skip_consent", { mode: "boolean" }).default(false),
+  enableEndSession: integer("enable_end_session", { mode: "boolean" }).default(false),
+  subjectType: text("subject_type"),
+  scopes: text("scopes"),
+  userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+  referenceId: text("reference_id"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  name: text("name"),
+  uri: text("uri"),
+  icon: text("icon"),
+  contacts: text("contacts"),
+  tos: text("tos"),
+  policy: text("policy"),
+  softwareId: text("software_id"),
+  softwareVersion: text("software_version"),
+  softwareStatement: text("software_statement"),
+  redirectUris: text("redirect_uris").notNull(),
+  postLogoutRedirectUris: text("post_logout_redirect_uris"),
+  tokenEndpointAuthMethod: text("token_endpoint_auth_method").default("none"),
+  grantTypes: text("grant_types"),
+  responseTypes: text("response_types"),
+  public: integer("public", { mode: "boolean" }).default(true),
+  type: text("type"),
+  requirePKCE: integer("require_pkce", { mode: "boolean" }).default(true),
+  metadata: text("metadata"),
+}, (table) => [
+  index("idx_oauth_client_user_id").on(table.userId),
 ]);
 
 // Drizzle relations for query builder joins
@@ -146,6 +183,17 @@ export const userRelations = relations(user, ({ many }) => ({
 export const apikeyRelations = relations(apikey, ({ one }) => ({
   user: one(user, {
     fields: [apikey.userId],
+    references: [user.id],
+  }),
+  oauthClient: one(oauthClient, {
+    fields: [apikey.oauthClientId],
+    references: [oauthClient.id],
+  }),
+}));
+
+export const oauthClientRelations = relations(oauthClient, ({ one }) => ({
+  user: one(user, {
+    fields: [oauthClient.userId],
     references: [user.id],
   }),
 }));


### PR DESCRIPTION
- Adds `oauthClient` storage for OAuth app client IDs while keeping API keys as bearer credentials.
- Migrates app-like `pk_` rows into `oauthClient` using `plaintextKey` as `client_id`, links minted `sk_` rows through `oauth_client_id`, then deletes migrated app rows.
- Updates app lookup, redirect-auth minting, BYOP attribution/billing, dashboard/account key APIs, Tinybird sync, and device branding with a warning disclaimer.
- Keeps stable `sk_` tokens; this does not add short-lived OAuth token endpoints.

Checks:
- `./node_modules/.bin/biome check --write ...` (passed with existing test lint warnings)
- `../node_modules/.bin/tsc --noEmit -p tsconfig.json` (enter, gen)
- `../node_modules/.bin/drizzle-kit check --config drizzle.config.ts`
- SQLite migration smoke test
- Vitest blocked locally by Rollup native optional dependency code-signature error under Codex Node