### PR TITLE
fix(seedance-2.0): map Replicate content-filter errors to 4xx

### DIFF
--- a/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
@@ -125,7 +125,7 @@ export async function callSeedanceV2API(
             logError("Replicate error:", err.message);
             throw new HttpError(
                 `Seedance 2.0 generation failed: ${err.message}`,
-                500,
+                err.status ?? 500,
             );
         }
         throw err;

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -89,9 +89,8 @@ export async function runReplicatePrediction<TInput, TOutput>(
     }
 
     if (prediction.status === "failed" || prediction.status === "canceled") {
-        throw new ReplicateError(
-            prediction.error || `Prediction ${prediction.status}`,
-        );
+        const message = prediction.error || `Prediction ${prediction.status}`;
+        throw new ReplicateError(message, classifyPredictionError(message));
     }
     if (prediction.output === undefined || prediction.output === null) {
         throw new ReplicateError("Prediction succeeded but output is missing");
@@ -104,6 +103,18 @@ export async function runReplicatePrediction<TInput, TOutput>(
         videoOutputDurationSeconds:
             prediction.metrics?.video_output_duration_seconds,
     };
+}
+
+// Replicate prediction failures are returned with HTTP 200 and an error
+// string. Default to 500 (upstream/model failure) and only opt explicit
+// user-input patterns up to 400 — this keeps unfamiliar failures loud in
+// monitoring instead of silently classified as client errors.
+function classifyPredictionError(message: string): number {
+    const isUserInputError =
+        /\bE005\b/.test(message) ||
+        /flagged as sensitive/i.test(message) ||
+        /^Input validation error:/i.test(message);
+    return isUserInputError ? 400 : 500;
 }
 
 async function replicateFetch<T>(

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -90,7 +90,15 @@ export async function runReplicatePrediction<TInput, TOutput>(
 
     if (prediction.status === "failed" || prediction.status === "canceled") {
         const message = prediction.error || `Prediction ${prediction.status}`;
-        throw new ReplicateError(message, classifyPredictionError(message));
+        // Replicate returns failures as HTTP 200 + error string with no
+        // structured code field (verified in API docs). Patterns observed
+        // in our prod logs: E005 + "flagged as sensitive" are Seedance's
+        // content filter; "Input validation error:" is Replicate's input
+        // URL fetcher. Default stays 500 so new failure modes stay loud.
+        const isUserInput =
+            /\bE005\b|flagged as sensitive/i.test(message) ||
+            /^Input validation error:/i.test(message);
+        throw new ReplicateError(message, isUserInput ? 400 : 500);
     }
     if (prediction.output === undefined || prediction.output === null) {
         throw new ReplicateError("Prediction succeeded but output is missing");
@@ -103,18 +111,6 @@ export async function runReplicatePrediction<TInput, TOutput>(
         videoOutputDurationSeconds:
             prediction.metrics?.video_output_duration_seconds,
     };
-}
-
-// Replicate prediction failures are returned with HTTP 200 and an error
-// string. Default to 500 (upstream/model failure) and only opt explicit
-// user-input patterns up to 400 — this keeps unfamiliar failures loud in
-// monitoring instead of silently classified as client errors.
-function classifyPredictionError(message: string): number {
-    const isUserInputError =
-        /\bE005\b/.test(message) ||
-        /flagged as sensitive/i.test(message) ||
-        /^Input validation error:/i.test(message);
-    return isUserInputError ? 400 : 500;
 }
 
 async function replicateFetch<T>(
@@ -140,9 +136,11 @@ async function replicateFetch<T>(
 
     if (!response.ok) {
         const text = await response.text().catch(() => "<no body>");
+        // No status set — HTTP-level Replicate errors (401 bad token, 429
+        // our rate limit, 5xx Replicate down) are infra issues on our side,
+        // never user input. Caller defaults to 500.
         throw new ReplicateError(
             `Replicate ${args.method} ${args.url} failed (HTTP ${response.status}): ${text.slice(0, 300)}`,
-            response.status,
         );
     }
     return (await response.json()) as T;

--- a/gen.pollinations.ai/test/image/replicateClient.test.ts
+++ b/gen.pollinations.ai/test/image/replicateClient.test.ts
@@ -105,6 +105,58 @@ describe("runReplicatePrediction", () => {
         ).rejects.toThrowError(ReplicateError);
     });
 
+    it.each([
+        [
+            "content filter rejection (E005)",
+            "ModelError: The input or output was flagged as sensitive. Please try again with different inputs. (E005)",
+        ],
+        [
+            "input validation error (e.g. expired image URL)",
+            "Input validation error: 403 Client Error: Forbidden for url: https://example.com/img.jpg",
+        ],
+    ])("classifies %s as 400 (user input error)", async (_, errorMessage) => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    id: "pred_user_err",
+                    status: "failed",
+                    error: errorMessage,
+                }),
+                { status: 201 },
+            ),
+        );
+
+        await expect(
+            runReplicatePrediction({
+                model: MODEL,
+                input: { prompt: "x" },
+            }),
+        ).rejects.toMatchObject({
+            name: "ReplicateError",
+            status: 400,
+        });
+    });
+
+    it("classifies generic prediction failures as 500 (upstream error)", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    id: "pred_upstream_err",
+                    status: "failed",
+                    error: "CUDA out of memory",
+                }),
+                { status: 201 },
+            ),
+        );
+
+        await expect(
+            runReplicatePrediction({ model: MODEL, input: { prompt: "x" } }),
+        ).rejects.toMatchObject({
+            name: "ReplicateError",
+            status: 500,
+        });
+    });
+
     it("polls /predictions/{id} when initial response is processing", async () => {
         vi.useFakeTimers();
         const fetchSpy = vi.spyOn(globalThis, "fetch");

--- a/gen.pollinations.ai/test/image/replicateClient.test.ts
+++ b/gen.pollinations.ai/test/image/replicateClient.test.ts
@@ -207,7 +207,9 @@ describe("runReplicatePrediction", () => {
         vi.useRealTimers();
     });
 
-    it("throws ReplicateError with status on non-2xx response (401, 429, 5xx)", async () => {
+    it("throws ReplicateError without status on HTTP-level errors (handler defaults to 500)", async () => {
+        // 401 (bad token), 429 (our rate limit), 5xx (Replicate down) are all
+        // infra issues on our side, never user input — caller maps to 500.
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
             new Response(JSON.stringify({ detail: "Invalid token" }), {
                 status: 401,
@@ -218,7 +220,7 @@ describe("runReplicatePrediction", () => {
             runReplicatePrediction({ model: MODEL, input: { prompt: "x" } }),
         ).rejects.toMatchObject({
             name: "ReplicateError",
-            status: 401,
+            status: undefined,
         });
     });
 });


### PR DESCRIPTION
## Summary

- Seedance 2.0 prediction failures (Replicate content filter, expired image URLs) were surfaced as 500, masking client-side issues as backend outages.
- `replicateClient` now classifies prediction-status failures: `E005` / `flagged as sensitive` (Seedance content filter) and `^Input validation error:` (Replicate input URL fetcher) → 400. Everything else stays 500 so unfamiliar failure modes stay loud in monitoring.
- HTTP-level errors from `replicateFetch` (401 bad token, 429 our rate limit, 5xx Replicate down) no longer propagate their upstream status — they're infra issues on our side, never user input. Caller defaults to 500.
- `seedanceV2VideoModel` propagates `ReplicateError.status` instead of hardcoding 500.

## Why

A user reported "seedance-2 goes down after a single generation" in #dev-models. Investigation showed all recent 500s were either Replicate's content filter (same prediction ID `uIJ6l3ruRD` repeated) or expired Discord ephemeral attachment URLs (`?ex=…&hm=…` signed params expire ~24h). Both are user-input issues that should return 4xx.

## Verified online

- Replicate's `error` field is a plain string with no structured code field ([docs](https://replicate.com/docs/reference/http)).
- Documented Replicate platform error codes are E1000+; `E005` is **Seedance-model-specific**, not platform-wide. String matching is the only available signal — patterns are scoped to what we've actually seen in our prod logs.

## Verified live

```
$ curl '.../image/test?model=seedance-2.0&image=https://example.invalid/notfound.jpg' -H 'Authorization: Bearer $TOKEN'
HTTP: 500  (current behavior — bug)
"Input validation error: HTTPSConnectionPool... Failed to resolve 'example.invalid'..."
```
After this PR: same call returns 400 with the same error message.

## Test plan
- [x] `npx vitest run test/image/replicateClient.test.ts` — 8 tests pass (3 new: E005/input-validation classification, generic 500 default, HTTP-level error has no status)
- [x] Manually verified bug reproduces on current prod (Input validation error → 500)
- [ ] Re-run after deploy: same call → 400

## Follow-ups (not in this PR)
Same hardcoded-500 pattern exists in `seedanceVideoModel.ts:404`, `wanVideoModel.ts:435`, `novaCanvasModel.ts:203`. Worth a follow-up if we see misclassified errors there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)