### PR TITLE
fix(gen): surface upstream error codes instead of generic 500s

### DIFF
--- a/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
@@ -24,11 +24,38 @@ const logError = debug("pollinations:seedance2:error");
 const MODEL = "bytedance/seedance-2.0";
 const TRACKING_LABEL = "seedance-2.0";
 
+// Replicate's Seedance 2.0 accepts a narrower set than our shared aspectRatio
+// enum (which also allows 9:21). Validate at the boundary so users get a clear
+// 400 instead of a Replicate 422 round-trip.
+const SEEDANCE_V2_ASPECT_RATIOS = [
+    "16:9",
+    "4:3",
+    "1:1",
+    "3:4",
+    "9:16",
+    "21:9",
+    "adaptive",
+] as const;
+type SeedanceV2AspectRatio = (typeof SEEDANCE_V2_ASPECT_RATIOS)[number];
+
+export function resolveSeedanceV2AspectRatio(
+    requested: ImageParams["aspectRatio"] | undefined,
+): SeedanceV2AspectRatio {
+    if (!requested) return "16:9";
+    if ((SEEDANCE_V2_ASPECT_RATIOS as readonly string[]).includes(requested)) {
+        return requested as SeedanceV2AspectRatio;
+    }
+    throw new HttpError(
+        `aspectRatio "${requested}" is not supported by Seedance 2.0. Supported: ${SEEDANCE_V2_ASPECT_RATIOS.join(", ")}.`,
+        400,
+    );
+}
+
 interface SeedanceV2Input {
     prompt: string;
     duration: number;
     resolution: "720p";
-    aspect_ratio: NonNullable<ImageParams["aspectRatio"]>;
+    aspect_ratio: SeedanceV2AspectRatio;
     generate_audio: boolean;
     seed?: number;
     image?: string;
@@ -76,7 +103,7 @@ export async function callSeedanceV2API(
         prompt,
         duration,
         resolution: "720p",
-        aspect_ratio: safeParams.aspectRatio ?? "16:9",
+        aspect_ratio: resolveSeedanceV2AspectRatio(safeParams.aspectRatio),
         generate_audio: safeParams.audio,
     };
     if (safeParams.seed !== undefined && safeParams.seed !== -1) {

--- a/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
@@ -121,8 +121,12 @@ export async function callSeedanceV2API(
             video_output_duration: actualDurationSeconds,
         });
     } catch (err) {
+        logError("Seedance 2.0 prediction call failed:", err);
         if (err instanceof ReplicateError) {
-            logError("Replicate error:", err.message);
+            logError("Replicate raw error details:", {
+                message: err.message,
+                status: err.status,
+            });
             throw new HttpError(
                 `Seedance 2.0 generation failed: ${err.message}`,
                 err.status ?? 500,

--- a/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
@@ -239,10 +239,6 @@ async function generateSeedanceVideo(
 
     const generateEndpoint =
         "https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks";
-    logOps(
-        `${config.displayName} request body:`,
-        JSON.stringify(requestBody, null, 2),
-    );
     const generateResponse = await fetchUpstream(generateEndpoint, {
         method: "POST",
         headers: {

--- a/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
@@ -21,6 +21,34 @@ const SEEDANCE_LITE_I2V = "seedance-1-0-lite-i2v-250428";
 // Pro-Fast uses single model for both T2V and I2V
 const SEEDANCE_PRO_FAST = "seedance-1-0-pro-fast-251015";
 
+/**
+ * Map a BytePlus error to an HTTP status. Patterns observed in prod logs:
+ * - "output ... may contain sensitive information" — content filter (400)
+ * - "Failed to process/fetch (reference) image" — unfetchable input URL (422)
+ * - numeric `code` already in 400..599 — provider-supplied status
+ * Default 500 keeps unknown failure modes loud.
+ */
+export function classifyByteplusError(
+    err: { code?: number | string; message?: string } | undefined,
+): number {
+    const message = err?.message ?? "";
+    if (/may contain sensitive|content (filter|policy)/i.test(message)) {
+        return 400;
+    }
+    if (
+        /failed to (process|fetch) (reference )?image|failed to fetch image/i.test(
+            message,
+        )
+    ) {
+        return 422;
+    }
+    const code = err?.code;
+    if (typeof code === "number" && code >= 400 && code < 600) {
+        return code;
+    }
+    return 500;
+}
+
 interface SeedanceTaskResponse {
     id?: string;
     task_id?: string;
@@ -404,14 +432,8 @@ async function pollSeedanceTask(
         if (status === "failed" || status === "error") {
             const errorMsg =
                 pollData.error?.message || "Video generation failed";
-            const errorCode = pollData.error?.code;
-            const httpStatus =
-                typeof errorCode === "number" &&
-                errorCode >= 400 &&
-                errorCode < 600
-                    ? errorCode
-                    : 500;
             logError("Seedance generation error:", pollData.error);
+            const httpStatus = classifyByteplusError(pollData.error);
             throw new HttpError(errorMsg, httpStatus, undefined, pollUrl);
         }
 

--- a/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceVideoModel.ts
@@ -26,7 +26,7 @@ interface SeedanceTaskResponse {
     task_id?: string;
     status?: string;
     error?: {
-        code: string;
+        code: number | string;
         message: string;
     };
 }
@@ -38,7 +38,7 @@ interface SeedanceTaskResult {
         video_url?: string;
     };
     error?: {
-        code: string;
+        code: number | string;
         message: string;
     };
     usage?: {
@@ -211,6 +211,10 @@ async function generateSeedanceVideo(
 
     const generateEndpoint =
         "https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks";
+    logOps(
+        `${config.displayName} request body:`,
+        JSON.stringify(requestBody, null, 2),
+    );
     const generateResponse = await fetchUpstream(generateEndpoint, {
         method: "POST",
         headers: {
@@ -400,8 +404,15 @@ async function pollSeedanceTask(
         if (status === "failed" || status === "error") {
             const errorMsg =
                 pollData.error?.message || "Video generation failed";
+            const errorCode = pollData.error?.code;
+            const httpStatus =
+                typeof errorCode === "number" &&
+                errorCode >= 400 &&
+                errorCode < 600
+                    ? errorCode
+                    : 500;
             logError("Seedance generation error:", pollData.error);
-            throw new HttpError(errorMsg, 500, undefined, pollUrl);
+            throw new HttpError(errorMsg, httpStatus, undefined, pollUrl);
         }
 
         // Status is still pending/queued/generating - wait and try again

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -52,6 +52,22 @@ const WAN_22_CONFIG: WanModelConfig = {
 const POLL_MAX_ATTEMPTS = 60; // 5 minutes max
 const POLL_DELAY_MS = 5000; // 5 second intervals
 
+function getDashScopeErrorStatus(message: string): number {
+    const lower = message.toLowerCase();
+    if (
+        lower.includes("content filter") ||
+        lower.includes("invalid") ||
+        lower.includes("validation") ||
+        lower.includes("not support")
+    ) {
+        return 400;
+    }
+    if (lower.includes("rate limit") || lower.includes("throttl")) {
+        return 429;
+    }
+    return 500;
+}
+
 interface WanTaskResponse {
     output?: {
         task_id: string;
@@ -432,7 +448,12 @@ async function pollWanTask(
         }
 
         if (pollResult.status === "failed") {
-            throw new HttpError(pollResult.error, 500, undefined, pollUrl);
+            throw new HttpError(
+                pollResult.error,
+                getDashScopeErrorStatus(pollResult.error),
+                undefined,
+                pollUrl,
+            );
         }
 
         await sleep(POLL_DELAY_MS);

--- a/gen.pollinations.ai/src/image/models/xaiVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/xaiVideoModel.ts
@@ -200,7 +200,7 @@ async function pollXaiVideoStatus(
         if (pollData.status === "failed") {
             throw new HttpError(
                 `xAI video generation failed: ${pollData.error ?? "unknown error"}`,
-                500,
+                502,
                 undefined,
                 pollUrl,
             );

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -14,6 +14,10 @@ import { sleep } from "../util.ts";
 const API_BASE = "https://api.replicate.com/v1";
 const PREFER_WAIT_SECONDS = 60;
 const POLL_INTERVAL_MS = 5000;
+// Cap total poll time so a stuck prediction surfaces as a controlled 504
+// instead of consuming Worker time until the runtime kills the request.
+// Seedance 2.0 typical wall time is 40-90s; 5min covers slow runs + queueing.
+const POLL_MAX_ATTEMPTS = 60;
 
 export class ReplicateError extends Error {
     constructor(
@@ -27,7 +31,13 @@ export class ReplicateError extends Error {
 
 interface ReplicatePrediction<TOutput> {
     id: string;
-    status: "starting" | "processing" | "succeeded" | "failed" | "canceled";
+    status:
+        | "starting"
+        | "processing"
+        | "succeeded"
+        | "failed"
+        | "canceled"
+        | "aborted";
     output?: TOutput;
     error?: string | null;
     urls?: { get?: string };
@@ -77,18 +87,30 @@ export async function runReplicatePrediction<TInput, TOutput>(
     const pollUrl =
         prediction.urls?.get || `${API_BASE}/predictions/${prediction.id}`;
 
+    let pollAttempts = 0;
     while (
         prediction.status === "starting" ||
         prediction.status === "processing"
     ) {
+        if (pollAttempts >= POLL_MAX_ATTEMPTS) {
+            throw new ReplicateError(
+                `Replicate prediction ${prediction.id} timed out after ${(POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s (status=${prediction.status})`,
+                504,
+            );
+        }
         await sleep(POLL_INTERVAL_MS);
         prediction = await replicateFetch<ReplicatePrediction<TOutput>>(token, {
             method: "GET",
             url: pollUrl,
         });
+        pollAttempts++;
     }
 
-    if (prediction.status === "failed" || prediction.status === "canceled") {
+    if (
+        prediction.status === "failed" ||
+        prediction.status === "canceled" ||
+        prediction.status === "aborted"
+    ) {
         const message = prediction.error || `Prediction ${prediction.status}`;
         throw new ReplicateError(
             message,

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -143,7 +143,13 @@ async function replicateFetch<T>(
 }
 
 export function classifyReplicateHttpStatus(httpStatus: number): number {
+    // 429 → 429 so clients can back off.
+    // 400/422 → pass through; Replicate uses these for input validation
+    // (bad model params, invalid image url, etc.) — surfacing them lets
+    // the user fix their request instead of seeing a generic 502.
+    // Other 4xx (401/403/404) and all 5xx → 502 (our config / upstream outage).
     if (httpStatus === 429) return 429;
+    if (httpStatus === 400 || httpStatus === 422) return httpStatus;
     return 502;
 }
 

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -136,12 +136,18 @@ async function replicateFetch<T>(
 
     if (!response.ok) {
         const text = await response.text().catch(() => "<no body>");
-        // No status set — HTTP-level Replicate errors (401 bad token, 429
-        // our rate limit, 5xx Replicate down) are infra issues on our side,
-        // never user input. Caller defaults to 500.
+        // 429 passes through so clients can back off. Everything else upstream
+        // (auth, validation of our request, Replicate outages) maps to 502 —
+        // the failure is on our side of the boundary, not the user's input.
         throw new ReplicateError(
             `Replicate ${args.method} ${args.url} failed (HTTP ${response.status}): ${text.slice(0, 300)}`,
+            classifyReplicateHttpStatus(response.status),
         );
     }
     return (await response.json()) as T;
+}
+
+export function classifyReplicateHttpStatus(httpStatus: number): number {
+    if (httpStatus === 429) return 429;
+    return 502;
 }

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -90,15 +90,10 @@ export async function runReplicatePrediction<TInput, TOutput>(
 
     if (prediction.status === "failed" || prediction.status === "canceled") {
         const message = prediction.error || `Prediction ${prediction.status}`;
-        // Replicate returns failures as HTTP 200 + error string with no
-        // structured code field (verified in API docs). Patterns observed
-        // in our prod logs: E005 + "flagged as sensitive" are Seedance's
-        // content filter; "Input validation error:" is Replicate's input
-        // URL fetcher. Default stays 500 so new failure modes stay loud.
-        const isUserInput =
-            /\bE005\b|flagged as sensitive/i.test(message) ||
-            /^Input validation error:/i.test(message);
-        throw new ReplicateError(message, isUserInput ? 400 : 500);
+        throw new ReplicateError(
+            message,
+            classifyReplicatePredictionError(message),
+        );
     }
     if (prediction.output === undefined || prediction.output === null) {
         throw new ReplicateError("Prediction succeeded but output is missing");
@@ -150,4 +145,17 @@ async function replicateFetch<T>(
 export function classifyReplicateHttpStatus(httpStatus: number): number {
     if (httpStatus === 429) return 429;
     return 502;
+}
+
+/**
+ * Replicate returns prediction failures as HTTP 200 + error string with no
+ * structured code field. Patterns observed in our prod logs:
+ * - E005 / "flagged as sensitive" — Seedance content filter (400)
+ * - "Input validation error:" — Replicate's input URL fetcher (400)
+ * Default 500 keeps new failure modes loud.
+ */
+export function classifyReplicatePredictionError(message: string): number {
+    if (/\bE005\b|flagged as sensitive/i.test(message)) return 400;
+    if (/^Input validation error:/i.test(message)) return 400;
+    return 500;
 }

--- a/gen.pollinations.ai/test/image/replicateClient.test.ts
+++ b/gen.pollinations.ai/test/image/replicateClient.test.ts
@@ -137,6 +137,59 @@ describe("runReplicatePrediction", () => {
         });
     });
 
+    it("treats aborted predictions as terminal failures", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    id: "pred_aborted",
+                    status: "aborted",
+                    error: "Prediction aborted before starting",
+                }),
+                { status: 201 },
+            ),
+        );
+
+        await expect(
+            runReplicatePrediction({ model: MODEL, input: { prompt: "x" } }),
+        ).rejects.toMatchObject({
+            name: "ReplicateError",
+            status: 500,
+        });
+    });
+
+    it("times out with 504 when prediction stays processing past poll budget", async () => {
+        vi.useFakeTimers();
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+            async () =>
+                new Response(
+                    JSON.stringify({
+                        id: "pred_stuck",
+                        status: "processing",
+                        urls: {
+                            get: "https://api.replicate.com/v1/predictions/pred_stuck",
+                        },
+                    }),
+                    { status: 201 },
+                ),
+        );
+
+        const promise = runReplicatePrediction({
+            model: MODEL,
+            input: { prompt: "x" },
+        });
+        // Attach rejection handler before advancing timers so the rejection
+        // is observed (avoids Vitest "unhandled rejection" complaint).
+        const assertion = expect(promise).rejects.toMatchObject({
+            name: "ReplicateError",
+            status: 504,
+        });
+        await vi.advanceTimersByTimeAsync(60 * 5_000 + 1_000);
+        await assertion;
+        // 1 POST + up to 60 GET polls
+        expect(fetchSpy.mock.calls.length).toBeLessThanOrEqual(61);
+        vi.useRealTimers();
+    });
+
     it("classifies generic prediction failures as 500 (upstream error)", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
             new Response(

--- a/gen.pollinations.ai/test/image/replicateClient.test.ts
+++ b/gen.pollinations.ai/test/image/replicateClient.test.ts
@@ -207,9 +207,7 @@ describe("runReplicatePrediction", () => {
         vi.useRealTimers();
     });
 
-    it("throws ReplicateError without status on HTTP-level errors (handler defaults to 500)", async () => {
-        // 401 (bad token), 429 (our rate limit), 5xx (Replicate down) are all
-        // infra issues on our side, never user input — caller maps to 500.
+    it("maps Replicate auth/infra HTTP errors to 502", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
             new Response(JSON.stringify({ detail: "Invalid token" }), {
                 status: 401,
@@ -220,7 +218,38 @@ describe("runReplicatePrediction", () => {
             runReplicatePrediction({ model: MODEL, input: { prompt: "x" } }),
         ).rejects.toMatchObject({
             name: "ReplicateError",
-            status: undefined,
+            status: 502,
+        });
+    });
+
+    it("passes through Replicate 422 input validation errors", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(
+                JSON.stringify({ detail: "Invalid aspect_ratio: 9:21" }),
+                { status: 422 },
+            ),
+        );
+
+        await expect(
+            runReplicatePrediction({ model: MODEL, input: { prompt: "x" } }),
+        ).rejects.toMatchObject({
+            name: "ReplicateError",
+            status: 422,
+        });
+    });
+
+    it("passes through Replicate 429 rate-limit errors", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({ detail: "Rate limited" }), {
+                status: 429,
+            }),
+        );
+
+        await expect(
+            runReplicatePrediction({ model: MODEL, input: { prompt: "x" } }),
+        ).rejects.toMatchObject({
+            name: "ReplicateError",
+            status: 429,
         });
     });
 });

--- a/gen.pollinations.ai/test/video-error-classification.test.ts
+++ b/gen.pollinations.ai/test/video-error-classification.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolveSeedanceV2AspectRatio } from "@/image/models/seedanceV2VideoModel.ts";
 import { classifyByteplusError } from "@/image/models/seedanceVideoModel.ts";
 import {
     classifyReplicateHttpStatus,
@@ -138,5 +139,29 @@ describe("classifyByteplusError", () => {
                 message: "output may contain sensitive information",
             }),
         ).toBe(400);
+    });
+});
+
+describe("resolveSeedanceV2AspectRatio", () => {
+    it("defaults to 16:9 when not provided", () => {
+        expect(resolveSeedanceV2AspectRatio(undefined)).toBe("16:9");
+    });
+
+    it.each([
+        "16:9",
+        "4:3",
+        "1:1",
+        "3:4",
+        "9:16",
+        "21:9",
+        "adaptive",
+    ] as const)("passes through supported ratio %s", (ratio) => {
+        expect(resolveSeedanceV2AspectRatio(ratio)).toBe(ratio);
+    });
+
+    it("rejects 9:21 (allowed by global schema, unsupported by Replicate Seedance 2.0)", () => {
+        expect(() => resolveSeedanceV2AspectRatio("9:21")).toThrow(
+            /not supported by Seedance 2\.0/,
+        );
     });
 });

--- a/gen.pollinations.ai/test/video-error-classification.test.ts
+++ b/gen.pollinations.ai/test/video-error-classification.test.ts
@@ -16,10 +16,15 @@ describe("classifyReplicateHttpStatus", () => {
         expect(classifyReplicateHttpStatus(503)).toBe(502);
     });
 
-    it("maps infra-side 4xx to 502 (our config, not user input)", () => {
+    it("maps auth/lookup 4xx to 502 (our config, not user input)", () => {
         expect(classifyReplicateHttpStatus(401)).toBe(502);
         expect(classifyReplicateHttpStatus(403)).toBe(502);
-        expect(classifyReplicateHttpStatus(422)).toBe(502);
+        expect(classifyReplicateHttpStatus(404)).toBe(502);
+    });
+
+    it("passes through input-validation 4xx (400, 422) so users can fix requests", () => {
+        expect(classifyReplicateHttpStatus(400)).toBe(400);
+        expect(classifyReplicateHttpStatus(422)).toBe(422);
     });
 });
 

--- a/gen.pollinations.ai/test/video-error-classification.test.ts
+++ b/gen.pollinations.ai/test/video-error-classification.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { classifyByteplusError } from "@/image/models/seedanceVideoModel.ts";
+import {
+    classifyReplicateHttpStatus,
+    classifyReplicatePredictionError,
+} from "@/image/utils/replicateClient.ts";
+
+describe("classifyReplicateHttpStatus", () => {
+    it("passes through 429 so clients can back off", () => {
+        expect(classifyReplicateHttpStatus(429)).toBe(429);
+    });
+
+    it("maps 5xx to 502 (upstream failure)", () => {
+        expect(classifyReplicateHttpStatus(500)).toBe(502);
+        expect(classifyReplicateHttpStatus(502)).toBe(502);
+        expect(classifyReplicateHttpStatus(503)).toBe(502);
+    });
+
+    it("maps infra-side 4xx to 502 (our config, not user input)", () => {
+        expect(classifyReplicateHttpStatus(401)).toBe(502);
+        expect(classifyReplicateHttpStatus(403)).toBe(502);
+        expect(classifyReplicateHttpStatus(422)).toBe(502);
+    });
+});
+
+describe("classifyReplicatePredictionError", () => {
+    it("maps Seedance E005 sensitive content to 400", () => {
+        expect(
+            classifyReplicatePredictionError(
+                "ModelError: The input or output was flagged as sensitive. Please try again with different inputs. (E005) (uIJ6l3ruRD)",
+            ),
+        ).toBe(400);
+    });
+
+    it("maps 'flagged as sensitive' (no E005) to 400", () => {
+        expect(
+            classifyReplicatePredictionError(
+                "Output was flagged as sensitive content",
+            ),
+        ).toBe(400);
+    });
+
+    it("maps Replicate input-fetch failures to 400", () => {
+        expect(
+            classifyReplicatePredictionError(
+                "Input validation error: 403 Client Error: Forbidden for url: https://wsrv.nl/?url=...",
+            ),
+        ).toBe(400);
+    });
+
+    it("defaults unknown failures to 500", () => {
+        expect(classifyReplicatePredictionError("CUDA out of memory")).toBe(
+            500,
+        );
+        expect(classifyReplicatePredictionError("Prediction failed")).toBe(500);
+    });
+});
+
+describe("classifyByteplusError", () => {
+    it("maps NSFW output rejection to 400", () => {
+        expect(
+            classifyByteplusError({
+                code: "OutputAudit",
+                message:
+                    "The request failed because the output video may contain sensitive information. Request id: 02177...",
+            }),
+        ).toBe(400);
+    });
+
+    it("maps content filter mentions to 400", () => {
+        expect(
+            classifyByteplusError({
+                message: "Blocked by content filter",
+            }),
+        ).toBe(400);
+        expect(
+            classifyByteplusError({
+                message: "Rejected: violates content policy",
+            }),
+        ).toBe(400);
+    });
+
+    it("maps unfetchable reference image to 422", () => {
+        expect(
+            classifyByteplusError({
+                message:
+                    "Failed to process reference image: Failed to fetch image: 522 <none>",
+            }),
+        ).toBe(422);
+        expect(
+            classifyByteplusError({
+                message:
+                    "Failed to process reference image: Failed to fetch image: 403 Forbidden",
+            }),
+        ).toBe(422);
+    });
+
+    it("uses numeric error.code as fallback when in HTTP range", () => {
+        expect(
+            classifyByteplusError({ code: 429, message: "rate limited" }),
+        ).toBe(429);
+        expect(classifyByteplusError({ code: 503, message: "down" })).toBe(503);
+    });
+
+    it("ignores numeric error.code outside HTTP range (BytePlus's own scheme)", () => {
+        expect(classifyByteplusError({ code: 1709, message: "unknown" })).toBe(
+            500,
+        );
+        expect(classifyByteplusError({ code: 100, message: "unknown" })).toBe(
+            500,
+        );
+    });
+
+    it("ignores string error.code", () => {
+        expect(
+            classifyByteplusError({
+                code: "InvalidParameter",
+                message: "unknown",
+            }),
+        ).toBe(500);
+    });
+
+    it("defaults unknown failures to 500", () => {
+        expect(classifyByteplusError({ message: "unknown error" })).toBe(500);
+        expect(classifyByteplusError(undefined)).toBe(500);
+        expect(classifyByteplusError({})).toBe(500);
+    });
+
+    it("prioritizes content filter over numeric code", () => {
+        expect(
+            classifyByteplusError({
+                code: 500,
+                message: "output may contain sensitive information",
+            }),
+        ).toBe(400);
+    });
+});


### PR DESCRIPTION
stops video model handlers from masking upstream errors as generic 500s

the error path in several video models was hardcoding 500 for any upstream failure, making it impossible to distinguish a content policy rejection (400) from a rate limit (429) or an actual server crash. this surfaces the real status codes downstream.

\- seedance v1: extract BytePlus `error.code` and use it as HTTP status when it's a valid 4xx/5xx
\- seedance v2: richer Replicate error logging - logs full error object and structured `{ message, status }` before rethrowing
\- wan: add `getDashScopeErrorStatus()` classifier that maps error messages to 400 (content filter, validation) or 429 (rate limit) instead of blanket 500
\- xai video: poll failures now return 502 (bad gateway) since it's an upstream provider failure and not a pollinations server error
