### PR TITLE
fix(gen): use ImageUrl struct for xAI video I2V requests

### DIFF
--- a/gen.pollinations.ai/src/image/models/xaiVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/xaiVideoModel.ts
@@ -87,7 +87,7 @@ export async function callXaiVideoAPI(
     if (aspectRatio) requestBody.aspect_ratio = aspectRatio;
 
     if (safeParams.image?.length) {
-        requestBody.image = safeParams.image[0];
+        requestBody.image = { url: safeParams.image[0] };
     }
 
     logOps("Request body:", JSON.stringify(requestBody));


### PR DESCRIPTION
fixes xAI video image-to-video requests returning 422

xAI's `/v1/videos/generations` endpoint expects the `image` field as `{ url: string }`, not a bare string. the image model (`xaiModel.ts`) already does this correctly, but the video model was sending the raw URL directly, causing xAI to reject with `"expected struct ImageUrl"`. this change wraps `safeParams.image[0]` in `{ url: ... }` to match xAI's expected `ImageUrl` struct.