### PR TITLE
(fix): Resolved the missing steps in the workflow for the backfill to work in quest.

### DIFF
--- a/.github/workflows/issue-quest-gate.yml
+++ b/.github/workflows/issue-quest-gate.yml
@@ -9,6 +9,10 @@ on:
         description: "One-shot: ensure Quest project Status field has the quest-lifecycle options"
         type: boolean
         default: false
+      backfill_existing:
+        description: "One-shot: add every existing POLLEN-QUEST issue to the Quest project at the right status"
+        type: boolean
+        default: false
 
 permissions:
   issues: write
@@ -16,7 +20,14 @@ permissions:
 
 env:
   QUEST_PROJECT_ID: PVT_kwDOBS76fs4BW8uW
-  QUEST_STATUSES: '["Open","In Progress","In Review","Reward Ready","Paid Out"]'
+  QUEST_STATUS_DESCRIPTIONS: |
+    {
+      "Open": "Quest filed, awaiting a dev to claim it",
+      "In Progress": "Assignee is working on it",
+      "In Review": "Linked PR is open",
+      "Reward Ready": "PR merged, payout pending D1 grant",
+      "Paid Out": "Pollen credited to author and assignee"
+    }
 
 jobs:
   setup:
@@ -35,13 +46,14 @@ jobs:
           github-token: ${{ steps.token.outputs.token }}
           script: |
             const QUEST_PROJECT_ID = process.env.QUEST_PROJECT_ID;
-            const wanted = JSON.parse(process.env.QUEST_STATUSES);
+            const descriptions = JSON.parse(process.env.QUEST_STATUS_DESCRIPTIONS);
+            const wanted = Object.keys(descriptions);
 
             const r = await github.graphql(`
               query($id: ID!) {
                 node(id: $id) { ... on ProjectV2 {
                   field(name: "Status") { ... on ProjectV2SingleSelectField {
-                    id options { id name color }
+                    id options { id name color description }
                   }}
                 }}
               }`, { id: QUEST_PROJECT_ID });
@@ -50,7 +62,12 @@ jobs:
             const existing = new Map(field.options.map(o => [o.name, o]));
             const merged = wanted.map(name => {
                 const e = existing.get(name);
-                return e ? { id: e.id, name, color: e.color } : { name, color: 'GRAY' };
+                return {
+                    ...(e ? { id: e.id } : {}),
+                    name,
+                    color: e?.color ?? 'GRAY',
+                    description: descriptions[name],
+                };
             });
 
             await github.graphql(`
@@ -63,7 +80,7 @@ jobs:
             core.notice(`Quest Status field set to: ${wanted.join(', ')}`);
         env:
           QUEST_PROJECT_ID: ${{ env.QUEST_PROJECT_ID }}
-          QUEST_STATUSES: ${{ env.QUEST_STATUSES }}
+          QUEST_STATUS_DESCRIPTIONS: ${{ env.QUEST_STATUS_DESCRIPTIONS }}
 
   triage:
     if: github.event_name == 'issues'

--- a/.github/workflows/issue-quest-gate.yml
+++ b/.github/workflows/issue-quest-gate.yml
@@ -82,6 +82,82 @@ jobs:
           QUEST_PROJECT_ID: ${{ env.QUEST_PROJECT_ID }}
           QUEST_STATUS_DESCRIPTIONS: ${{ env.QUEST_STATUS_DESCRIPTIONS }}
 
+  backfill:
+    if: github.event_name == 'workflow_dispatch' && inputs.backfill_existing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Polly Bot token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.POLLY_BOT_APP_ID }}
+          private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
+          owner: pollinations
+      - uses: actions/github-script@v7
+        env:
+          QUEST_PROJECT_ID: ${{ env.QUEST_PROJECT_ID }}
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          script: |
+            const QUEST_PROJECT_ID = process.env.QUEST_PROJECT_ID;
+
+            const fieldQ = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) { ... on ProjectV2 {
+                  field(name: "Status") { ... on ProjectV2SingleSelectField {
+                    id options { id name }
+                  }}
+                }}
+              }`, { id: QUEST_PROJECT_ID });
+            const field = fieldQ.node.field;
+            const optionId = (name) => field.options.find(o => o.name === name)?.id;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner, repo: context.repo.repo,
+                state: 'all', labels: 'POLLEN-QUEST', per_page: 100,
+            });
+
+            let added = 0, archived = 0, skipped = 0;
+            for (const issue of issues) {
+                if (issue.pull_request) { skipped++; continue; }
+
+                const add = await github.graphql(`
+                  mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}`,
+                  { p: QUEST_PROJECT_ID, c: issue.node_id });
+                const itemId = add.addProjectV2ItemById.item.id;
+
+                if (issue.state === 'closed' && issue.state_reason !== 'completed') {
+                    await github.graphql(`
+                      mutation($p:ID!,$i:ID!){archiveProjectV2Item(input:{projectId:$p,itemId:$i}){item{id}}}`,
+                      { p: QUEST_PROJECT_ID, i: itemId });
+                    archived++;
+                    continue;
+                }
+
+                let status;
+                if (issue.state === 'closed' && issue.state_reason === 'completed') {
+                    status = 'Reward Ready';
+                } else if ((issue.assignees || []).length > 0) {
+                    status = 'In Progress';
+                } else {
+                    status = 'Open';
+                }
+
+                const oid = optionId(status);
+                if (!oid) {
+                    core.warning(`#${issue.number}: status "${status}" not in field — run setup_status_field=true first`);
+                    continue;
+                }
+
+                await github.graphql(`
+                  mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
+                  { p: QUEST_PROJECT_ID, i: itemId, f: field.id, o: oid });
+                core.info(`#${issue.number} → ${status}`);
+                added++;
+            }
+
+            core.notice(`Backfill done: ${added} carded, ${archived} archived, ${skipped} skipped`);
+
   triage:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes Make:- 

- Each option now includes a description (under env QUEST_STATUS_DESCRIPTIONS).
- New backfill_existing workflow_dispatch input added that walks every existing POLLEN-QUEST issue, adds it to the Quest project at the right status (closed-merged to Reward Ready, open+assigned to In Progress, open+unassigned to Open, closed-unmerged to archived).
 
