### PR TITLE
(patch): Migrate the quest payout transaction based on the GITHUB ID of the user (assignee / creator) 

### DIFF
--- a/.github/scripts/quest-reward-payout.js
+++ b/.github/scripts/quest-reward-payout.js
@@ -84,7 +84,10 @@ async function resolveLinkedQuest({ github, context, core }) {
         quests.push({
             number: issueNumber,
             node_id: issue.node_id,
-            assignees: (issue.assignees || []).map((a) => a.login),
+            assignees: (issue.assignees || []).map((a) => ({
+                login: a.login,
+                id: a.id,
+            })),
             body: issue.body || "",
         });
     }
@@ -148,7 +151,7 @@ async function computePayout({ github, context, core }) {
                 `@${process.env.PAYOUT_FALLBACK} — quest payout could not be auto-processed.`,
                 "",
                 `**Missing:** ${missing.join(", ")}`,
-                `- assignees: ${quest.assignees.length ? quest.assignees.join(", ") : "(none)"}`,
+                `- assignees: ${quest.assignees.length ? quest.assignees.map((a) => a.login).join(", ") : "(none)"}`,
                 `- parsed reward: ${reward ?? "(unparsed)"}`,
                 "",
                 `Triggered by merge of #${context.payload.pull_request.number}. Please review and back-fill manually.`,
@@ -157,11 +160,13 @@ async function computePayout({ github, context, core }) {
         return;
     }
 
+    const assignee = quest.assignees[0];
     core.setOutput(
         "payout",
         JSON.stringify({
             issue: quest.number,
-            recipient: quest.assignees[0],
+            recipient: assignee.login,
+            recipientId: assignee.id,
             amount: reward,
             role: "assignee",
         }),
@@ -282,6 +287,8 @@ function runGrant(enterDir, payout) {
             "tsx",
             "src/tier-progression/shared/quest-grant-pollen.ts",
             "grant",
+            "--githubId",
+            String(payout.recipientId),
             "--githubUsername",
             payout.recipient,
             "--amount",

--- a/.github/workflows/issue-quest-gate.yml
+++ b/.github/workflows/issue-quest-gate.yml
@@ -22,11 +22,17 @@ env:
   QUEST_PROJECT_ID: PVT_kwDOBS76fs4BW8uW
   QUEST_STATUS_DESCRIPTIONS: |
     {
-      "Open": "Quest filed, awaiting a dev to claim it",
+      "Todo": "Quest filed, awaiting a dev to claim it",
       "In Progress": "Assignee is working on it",
       "In Review": "Linked PR is open",
       "Reward Ready": "PR merged, payout pending D1 grant",
       "Paid Out": "Pollen credited to author and assignee"
+    }
+  QUEST_TYPE_DESCRIPTIONS: |
+    {
+      "Bug": "Fix for broken behavior (DEV-BUG)",
+      "Feature": "New functionality or enhancement (DEV-FEATURE)",
+      "Task": "Docs / infra / chores / research (other DEV-*)"
     }
 
 jobs:

--- a/.github/workflows/issue-quest-gate.yml
+++ b/.github/workflows/issue-quest-gate.yml
@@ -52,41 +52,61 @@ jobs:
           github-token: ${{ steps.token.outputs.token }}
           script: |
             const QUEST_PROJECT_ID = process.env.QUEST_PROJECT_ID;
-            const descriptions = JSON.parse(process.env.QUEST_STATUS_DESCRIPTIONS);
-            const wanted = Object.keys(descriptions);
+            const statusDescs = JSON.parse(process.env.QUEST_STATUS_DESCRIPTIONS);
+            const typeDescs   = JSON.parse(process.env.QUEST_TYPE_DESCRIPTIONS);
 
             const r = await github.graphql(`
               query($id: ID!) {
                 node(id: $id) { ... on ProjectV2 {
-                  field(name: "Status") { ... on ProjectV2SingleSelectField {
-                    id options { id name color description }
+                  fields(first: 50) { nodes {
+                    ... on ProjectV2SingleSelectField {
+                      id name options { id name color description }
+                    }
                   }}
                 }}
               }`, { id: QUEST_PROJECT_ID });
-            const field = r.node.field;
+            const fields = r.node.fields.nodes.filter(f => f && f.id);
 
-            const existing = new Map(field.options.map(o => [o.name, o]));
-            const merged = wanted.map(name => {
-                const e = existing.get(name);
-                return {
-                    ...(e ? { id: e.id } : {}),
-                    name,
-                    color: e?.color ?? 'GRAY',
-                    description: descriptions[name],
-                };
-            });
+            async function ensureField(fieldName, descMap) {
+                const wanted = Object.keys(descMap);
+                const existing = fields.find(f => f.name === fieldName);
 
-            await github.graphql(`
-              mutation($id: ID!, $opts: [ProjectV2SingleSelectFieldOptionInput!]!) {
-                updateProjectV2Field(input: { fieldId: $id, singleSelectOptions: $opts }) {
-                  projectV2Field { ... on ProjectV2SingleSelectField { options { id name } } }
+                if (existing) {
+                    const existingOpts = new Map(existing.options.map(o => [o.name, o]));
+                    const merged = wanted.map(name => {
+                        const e = existingOpts.get(name);
+                        return {
+                            ...(e ? { id: e.id } : {}),
+                            name,
+                            color: e?.color ?? 'GRAY',
+                            description: descMap[name],
+                        };
+                    });
+                    await github.graphql(`
+                      mutation($id: ID!, $opts: [ProjectV2SingleSelectFieldOptionInput!]!) {
+                        updateProjectV2Field(input: { fieldId: $id, singleSelectOptions: $opts }) {
+                          projectV2Field { ... on ProjectV2SingleSelectField { options { id name } } }
+                        }
+                      }`, { id: existing.id, opts: merged });
+                    core.notice(`${fieldName} field updated: ${wanted.join(', ')}`);
+                } else {
+                    const opts = wanted.map(name => ({ name, color: 'GRAY', description: descMap[name] }));
+                    await github.graphql(`
+                      mutation($pid: ID!, $name: String!, $opts: [ProjectV2SingleSelectFieldOptionInput!]!) {
+                        createProjectV2Field(input: { projectId: $pid, dataType: SINGLE_SELECT, name: $name, singleSelectOptions: $opts }) {
+                          projectV2Field { ... on ProjectV2SingleSelectField { id name } }
+                        }
+                      }`, { pid: QUEST_PROJECT_ID, name: fieldName, opts });
+                    core.notice(`${fieldName} field created: ${wanted.join(', ')}`);
                 }
-              }`, { id: field.id, opts: merged });
+            }
 
-            core.notice(`Quest Status field set to: ${wanted.join(', ')}`);
+            await ensureField("Status", statusDescs);
+            await ensureField("Type", typeDescs);
         env:
           QUEST_PROJECT_ID: ${{ env.QUEST_PROJECT_ID }}
           QUEST_STATUS_DESCRIPTIONS: ${{ env.QUEST_STATUS_DESCRIPTIONS }}
+          QUEST_TYPE_DESCRIPTIONS: ${{ env.QUEST_TYPE_DESCRIPTIONS }}
 
   backfill:
     if: github.event_name == 'workflow_dispatch' && inputs.backfill_existing

--- a/.github/workflows/issue-quest-gate.yml
+++ b/.github/workflows/issue-quest-gate.yml
@@ -297,6 +297,40 @@ jobs:
                 });
             }
 
+            // POLLEN-QUEST takes priority over Dev/Support/News/Tier.
+            // If the issue was already routed into one of those projects (e.g. it
+            // was an open Dev issue later promoted via the POLLEN-QUEST label),
+            // remove those cards so the issue lives in the Quest project only.
+            const OTHER_PROJECT_IDS = new Set([
+                'PVT_kwDOBS76fs4AwCAM',  // Dev
+                'PVT_kwDOBS76fs4BLr1H',  // Support
+                'PVT_kwDOBS76fs4BLtD8',  // News
+                'PVT_kwDOBS76fs4BLtE_',  // Tier
+            ]);
+            try {
+                const pi = await github.graphql(`
+                    query($id: ID!) {
+                      node(id: $id) {
+                        ... on Issue {
+                          projectItems(first: 30) {
+                            nodes { id project { id } }
+                          }
+                        }
+                      }
+                    }`, { id: issue.node_id });
+                const items = pi.node?.projectItems?.nodes ?? [];
+                for (const it of items) {
+                    if (it.project?.id && OTHER_PROJECT_IDS.has(it.project.id)) {
+                        await github.graphql(`
+                            mutation($p:ID!,$i:ID!){deleteProjectV2Item(input:{projectId:$p,itemId:$i}){deletedItemId}}`,
+                            { p: it.project.id, i: it.id });
+                        core.info(`Purged #${issue.number} from project ${it.project.id}`);
+                    }
+                }
+            } catch (e) {
+                core.warning(`Project purge failed for #${issue.number}: ${e.message}`);
+            }
+
             // Resolve project item ID once (idempotent add).
             const addQ = await github.graphql(`
                 mutation($p: ID!, $c: ID!) {

--- a/.github/workflows/issue-quest-gate.yml
+++ b/.github/workflows/issue-quest-gate.yml
@@ -127,16 +127,20 @@ jobs:
           script: |
             const QUEST_PROJECT_ID = process.env.QUEST_PROJECT_ID;
 
-            const fieldQ = await github.graphql(`
+            const fieldsQ = await github.graphql(`
               query($id: ID!) {
                 node(id: $id) { ... on ProjectV2 {
-                  field(name: "Status") { ... on ProjectV2SingleSelectField {
-                    id options { id name }
+                  fields(first: 50) { nodes {
+                    ... on ProjectV2SingleSelectField {
+                      id name options { id name }
+                    }
                   }}
                 }}
               }`, { id: QUEST_PROJECT_ID });
-            const field = fieldQ.node.field;
-            const optionId = (name) => field.options.find(o => o.name === name)?.id;
+            const allFields = fieldsQ.node.fields.nodes.filter(f => f && f.id);
+            const statusField = allFields.find(f => f.name === 'Status');
+            const typeField   = allFields.find(f => f.name === 'Type');
+            const optionId = (field, name) => field?.options.find(o => o.name === name)?.id;
 
             const issues = await github.paginate(github.rest.issues.listForRepo, {
                 owner: context.repo.owner, repo: context.repo.repo,
@@ -166,19 +170,28 @@ jobs:
                 } else if ((issue.assignees || []).length > 0) {
                     status = 'In Progress';
                 } else {
-                    status = 'Open';
+                    status = 'Todo';
                 }
 
-                const oid = optionId(status);
-                if (!oid) {
-                    core.warning(`#${issue.number}: status "${status}" not in field — run setup_status_field=true first`);
-                    continue;
+                const issueLabels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+                const questType = issueLabels.includes('DEV-BUG') ? 'Bug'
+                    : issueLabels.includes('DEV-FEATURE') ? 'Feature'
+                    : 'Task';
+
+                async function setField(field, optionName) {
+                    const oid = optionId(field, optionName);
+                    if (!field || !oid) {
+                        core.warning(`#${issue.number}: option "${optionName}" not found — run setup_status_field=true first`);
+                        return;
+                    }
+                    await github.graphql(`
+                      mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
+                      { p: QUEST_PROJECT_ID, i: itemId, f: field.id, o: oid });
                 }
 
-                await github.graphql(`
-                  mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
-                  { p: QUEST_PROJECT_ID, i: itemId, f: field.id, o: oid });
-                core.info(`#${issue.number} → ${status}`);
+                await setField(statusField, status);
+                await setField(typeField, questType);
+                core.info(`#${issue.number} → Status=${status}, Type=${questType}`);
                 added++;
             }
 
@@ -309,34 +322,53 @@ jobs:
 
             let target = null;
             if (action === 'opened' || (action === 'labeled' && labelEvent === 'POLLEN-QUEST')) {
-                target = 'Open';
+                target = 'Todo';
             } else if (action === 'assigned') {
                 target = 'In Progress';
             } else if (action === 'unassigned' && (issue.assignees || []).length === 0) {
-                target = 'Open';
+                target = 'Todo';
             } else if (action === 'reopened') {
-                target = (issue.assignees || []).length > 0 ? 'In Progress' : 'Open';
+                target = (issue.assignees || []).length > 0 ? 'In Progress' : 'Todo';
             }
             if (!target) return;
 
-            const fieldQ = await github.graphql(`
+            // Resolve Status + Type fields together.
+            const fieldsQ = await github.graphql(`
                 query($id: ID!) {
                   node(id: $id) { ... on ProjectV2 {
-                    field(name: "Status") { ... on ProjectV2SingleSelectField {
-                      id options { id name }
+                    fields(first: 50) { nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id name options { id name }
+                      }
                     }}
                   }}
                 }`, { id: QUEST_PROJECT_ID });
-            const field = fieldQ.node.field;
-            const opt = field.options.find(o => o.name === target);
-            if (!opt) {
-                core.warning(`Quest Status option "${target}" not found. Run the workflow_dispatch with setup_status_field=true once to create the lifecycle options.`);
-                return;
+            const allFields = fieldsQ.node.fields.nodes.filter(f => f && f.id);
+            const statusField = allFields.find(f => f.name === 'Status');
+            const typeField   = allFields.find(f => f.name === 'Type');
+
+            async function setSingleSelect(field, optionName) {
+                if (!field) {
+                    core.warning(`Field missing — run workflow_dispatch with setup_status_field=true once.`);
+                    return;
+                }
+                const opt = field.options.find(o => o.name === optionName);
+                if (!opt) {
+                    core.warning(`Option "${optionName}" not found in field "${field.name}".`);
+                    return;
+                }
+                await github.graphql(`
+                    mutation($p:ID!,$i:ID!,$f:ID!,$o:String!) {
+                      updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}) { projectV2Item { id } }
+                    }`, { p: QUEST_PROJECT_ID, i: itemId, f: field.id, o: opt.id });
             }
 
-            await github.graphql(`
-                mutation($p:ID!,$i:ID!,$f:ID!,$o:String!) {
-                  updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}) { projectV2Item { id } }
-                }`, { p: QUEST_PROJECT_ID, i: itemId, f: field.id, o: opt.id });
+            await setSingleSelect(statusField, target);
 
-            core.info(`Set #${issue.number} → ${target}`);
+            // Type auto-population from DEV-* labels.
+            const questType = labels.includes('DEV-BUG') ? 'Bug'
+                : labels.includes('DEV-FEATURE') ? 'Feature'
+                : 'Task';
+            await setSingleSelect(typeField, questType);
+
+            core.info(`Set #${issue.number} → Status=${target}, Type=${questType}`);

--- a/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
+++ b/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
@@ -3,14 +3,6 @@ import { command, number, run, string } from "@drizzle-team/brocli";
 
 type Environment = "staging" | "production";
 
-function sanitizeGitHubUsername(username: string): string {
-    const sanitized = username.replace(/[^a-zA-Z0-9-]/g, "");
-    if (sanitized.length === 0 || sanitized.length > 39) {
-        throw new Error(`Invalid GitHub username: "${username}"`);
-    }
-    return sanitized;
-}
-
 function sqlString(value: string): string {
     return `'${value.replaceAll("'", "''")}'`;
 }
@@ -89,8 +81,6 @@ const grantCommand = command({
             console.error(`❌ githubId must be a positive integer, got: ${githubId}`);
             process.exit(1);
         }
-        const safeGithubUsername = sanitizeGitHubUsername(opts.githubUsername);
-
         const user = getUserByGithubId(env, githubId);
         if (!user) {
             console.log(`NOT_FOUND github_id=${githubId} github_username=${opts.githubUsername}`);

--- a/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
+++ b/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
@@ -40,12 +40,16 @@ function queryD1(env: Environment, sql: string): string {
 
 interface D1User {
     id: string;
+    github_id: number | null;
     github_username: string;
     pack_balance: number | null;
 }
 
-function getUser(env: Environment, safeGithubUsername: string): D1User | null {
-    const sql = `SELECT id, github_username, pack_balance FROM user WHERE LOWER(github_username) = LOWER(${sqlString(safeGithubUsername)}) LIMIT 1;`;
+function getUserByGithubId(
+    env: Environment,
+    githubId: number,
+): D1User | null {
+    const sql = `SELECT id, github_id, github_username, pack_balance FROM user WHERE github_id = ${githubId} LIMIT 1;`;
     const raw = queryD1(env, sql);
     const parsed = JSON.parse(raw);
     const results = parsed[0]?.results || parsed.results || [];
@@ -56,9 +60,12 @@ const grantCommand = command({
     name: "grant",
     desc: "Add Pollen to a user's pack_balance once for a quest payout",
     options: {
+        githubId: number()
+            .required()
+            .desc("Immutable numeric GitHub user ID of the recipient"),
         githubUsername: string()
             .required()
-            .desc("GitHub username of the recipient"),
+            .desc("GitHub username (for logging and payout_key — not used for D1 lookup)"),
         amount: number()
             .required()
             .desc("Pollen amount to add (positive number)"),
@@ -68,7 +75,7 @@ const grantCommand = command({
         env: string().enum("staging", "production").default("production"),
     },
     handler: async (opts) => {
-        const { amount, questIssue, prNumber, role } = opts;
+        const { amount, questIssue, prNumber, role, githubId } = opts;
         const env = opts.env as Environment;
 
         const MAX_AMOUNT = 10000;
@@ -78,15 +85,20 @@ const grantCommand = command({
             );
             process.exit(1);
         }
+        if (!Number.isInteger(githubId) || githubId <= 0) {
+            console.error(`❌ githubId must be a positive integer, got: ${githubId}`);
+            process.exit(1);
+        }
         const safeGithubUsername = sanitizeGitHubUsername(opts.githubUsername);
 
-        const user = getUser(env, safeGithubUsername);
+        const user = getUserByGithubId(env, githubId);
         if (!user) {
-            console.log(`NOT_FOUND github_username=${opts.githubUsername}`);
+            console.log(`NOT_FOUND github_id=${githubId} github_username=${opts.githubUsername}`);
             process.exit(2);
         }
 
-        const payoutKey = `quest:${questIssue}:pr:${prNumber}:user:${safeGithubUsername.toLowerCase()}:role:${role}`;
+        // Idempotency key uses the immutable github_id, not the mutable username.
+        const payoutKey = `quest:${questIssue}:pr:${prNumber}:gh:${githubId}:role:${role}`;
         const sql = `
             BEGIN;
             INSERT INTO quest_payout_credits (

--- a/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
+++ b/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
@@ -37,10 +37,7 @@ interface D1User {
     pack_balance: number | null;
 }
 
-function getUserByGithubId(
-    env: Environment,
-    githubId: number,
-): D1User | null {
+function getUserByGithubId(env: Environment, githubId: number): D1User | null {
     const sql = `SELECT id, github_id, github_username, pack_balance FROM user WHERE github_id = ${githubId} LIMIT 1;`;
     const raw = queryD1(env, sql);
     const parsed = JSON.parse(raw);
@@ -57,7 +54,9 @@ const grantCommand = command({
             .desc("Immutable numeric GitHub user ID of the recipient"),
         githubUsername: string()
             .required()
-            .desc("GitHub username (for logging and payout_key — not used for D1 lookup)"),
+            .desc(
+                "GitHub username (for logging and payout_key — not used for D1 lookup)",
+            ),
         amount: number()
             .required()
             .desc("Pollen amount to add (positive number)"),
@@ -78,12 +77,16 @@ const grantCommand = command({
             process.exit(1);
         }
         if (!Number.isInteger(githubId) || githubId <= 0) {
-            console.error(`❌ githubId must be a positive integer, got: ${githubId}`);
+            console.error(
+                `❌ githubId must be a positive integer, got: ${githubId}`,
+            );
             process.exit(1);
         }
         const user = getUserByGithubId(env, githubId);
         if (!user) {
-            console.log(`NOT_FOUND github_id=${githubId} github_username=${opts.githubUsername}`);
+            console.log(
+                `NOT_FOUND github_id=${githubId} github_username=${opts.githubUsername}`,
+            );
             process.exit(2);
         }
 


### PR DESCRIPTION
## Changes Made:- 



- New required --githubId arg (numeric, validated as positive integer)
- getUserByGithubId queries WHERE github_id = N (immutable)
--githubUsername kept for logging only — D1 lookup no longer touches it
- Idempotency payout_key is now quest:N:pr:M:gh:<github_id>:role:R — survives username renames
- Dropped unused sanitizeGitHubUsername
- assignees now collected as { login, id } objects (not just strings)
- payout output includes recipientId (the immutable GitHub user ID)
- Grant invocation passes both --githubId and --githubUsername
- Missing-assignee comment unchanged (still uses .login for display)

> The quest_payout_credits row still records github_username as a snapshot of the name at payout time, which is good for human auditing — but the user_id (the better-auth row) is the actual link, and the payout_key uniqueness is now keyed on github_id, so a username rename mid-quest can no longer cause double-payouts or false NOT_FOUND.