### PR TITLE
speed up d1->tinybird sync to every 15min

### DIFF
--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -85,7 +85,7 @@ POLLEN_REFILL_PER_HOUR = 1
 [env.production]
 
 [env.production.triggers]
-crons = ["0 * * * *"]
+crons = ["*/15 * * * *"]
 
 [env.production.observability]
 enabled = true
@@ -142,7 +142,7 @@ STRIPE_SUCCESS_URL = "https://enter.pollinations.ai"
 [env.staging]
 
 [env.staging.triggers]
-crons = ["0 * * * *"]
+crons = ["*/15 * * * *"]
 
 [[env.staging.routes]]
 pattern = "staging.enter.pollinations.ai"


### PR DESCRIPTION
- changes the d1->tinybird sync cron from `0 * * * *` (hourly) to `*/15 * * * *` (every 15 min) on prod and staging
- gives devs/support a fresher snapshot in the restricted tinybird pipes (no emails, no balances, no oauth tokens) without exposing live d1
- 15 min is the safe lower bound: low compaction churn, no overlapping-run risk, fresh enough for support workflows

context: we'd rather not hand out live d1 access since we don't have a backup, so we're improving the existing tinybird mirror instead.