### PR TITLE
fix(nunchaku): install from prebuilt wheel + recovery doc fixes

### DIFF
--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -171,13 +171,26 @@ curl -s --connect-timeout 5 --max-time 10 https://gen.pollinations.ai/register
 ```
 Expected: 4 workers with 0% error rate, all `hsl3ksl31lvrcc-*.proxy.runpod.net`. The registry is Cloudflare KV-backed (`image:server:<env>:<type>:<hash>`, 240s TTL); workers heartbeat to `gen.pollinations.ai/register`.
 
-**Restart a worker:**
+**Restart a worker** (fresh containers don't have `screen`; use `nohup`):
 ```bash
-ssh -i <SOPS:SSH_RUNPOD_FLUX_ZIMAGE> -p 19489 root@38.65.239.17
-screen -S flux-gpu0 -X quit
-screen -dmS flux-gpu0 bash -c 'source /opt/pollinations/image.pollinations.ai/nunchaku/venv/bin/activate && \
+ssh -i <SOPS:SSH_RUNPOD_FLUX_ZIMAGE> -p <runtime-port> root@<runtime-ip>
+pkill -f 'nunchaku/server.py'  # or pkill -f 'z-image/server.py'
+mkdir -p /workspace/logs
+cd /opt/pollinations/pollinations/image.pollinations.ai/nunchaku
+nohup bash -c "source venv/bin/activate && \
   CUDA_VISIBLE_DEVICES=0 PORT=8765 PUBLIC_IP=hsl3ksl31lvrcc-8765.proxy.runpod.net PUBLIC_PORT=443 \
-  SERVICE_TYPE=flux python /opt/pollinations/image.pollinations.ai/nunchaku/server.py 2>&1 | tee /tmp/flux-gpu0.log'
+  SERVICE_TYPE=flux HF_TOKEN=<SOPS:HF_TOKEN or .testingtokens> PLN_GPU_TOKEN=<SOPS> \
+  python server.py" > /workspace/logs/flux-gpu0.log 2>&1 &
+```
+
+**Pod stop/start wipes the container overlay disk** — `/opt/pollinations/` is gone after every restart. Only `/workspace/` persists. Full rebuild = clone repo → `bash setup.sh` (~5 min: prebuilt nunchaku wheel + HF model download).
+
+**SSH port rotates on stop/start.** Get current host/port via the RunPod GraphQL API:
+```bash
+RUNPOD_TOKEN=$(cat ~/.runpod/config.toml | grep apikey | cut -d\' -f2)
+curl -s -X POST "https://api.runpod.io/graphql?api_key=$RUNPOD_TOKEN" -H "Content-Type: application/json" \
+  -d '{"query":"{pod(input:{podId:\"hsl3ksl31lvrcc\"}){runtime{ports{ip privatePort publicPort type}}}}"}' \
+  | python3 -c "import sys,json;[print(p) for p in json.load(sys.stdin)['data']['pod']['runtime']['ports'] if p['privatePort']==22]"
 ```
 
 ---

--- a/image.pollinations.ai/nunchaku/requirements.txt
+++ b/image.pollinations.ai/nunchaku/requirements.txt
@@ -1,7 +1,7 @@
 # Flux Schnell Server Dependencies
-# Note: PyTorch is installed separately with CUDA support
-# Note: nunchaku must be built from source for RTX 5090 (Blackwell/sm_120)
-#       See VASTAI_INSTANCES.md for instructions
+# Note: PyTorch is installed separately with CUDA support (see setup.sh)
+# Note: nunchaku is installed from a prebuilt wheel in setup.sh —
+#       wheel bundles kernels for SM 7.5/8.0/8.6/8.9/120, no source build needed.
 
 # Core ML
 accelerate>=1.9

--- a/image.pollinations.ai/nunchaku/setup.sh
+++ b/image.pollinations.ai/nunchaku/setup.sh
@@ -124,48 +124,32 @@ setup_python_env() {
     pip install --upgrade pip
     
     log_info "Installing PyTorch with CUDA 12.8..."
-    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
-    
+    # Pin torch 2.9.1: matches prebuilt nunchaku wheel (cu12.8torch2.9) and
+    # works with driver 570.x / CUDA 12.8. Newer torch (2.11+) requires CUDA 13.
+    pip install torch==2.9.1 torchvision==0.24.1 --index-url https://download.pytorch.org/whl/cu128
+
     log_info "Installing other requirements..."
     pip install -r requirements.txt
     
     log_info "Python environment ready"
 }
 
-# Build and install nunchaku
-build_nunchaku() {
-    log_step "📦 Step 4: Building nunchaku (this takes 10-15 minutes)"
-    
-    # Set CUDA environment for build
-    export PATH=/usr/local/cuda-12.8/bin:$PATH
-    export CUDA_HOME=/usr/local/cuda-12.8
-    export LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
-    
-    # Clone nunchaku if not exists
-    if [ ! -d "$HOME/nunchaku" ]; then
-        log_info "Cloning nunchaku..."
-        cd $HOME
-        git clone --recursive https://github.com/mit-han-lab/nunchaku.git
-    else
-        log_info "Updating nunchaku..."
-        cd $HOME/nunchaku
-        git pull
-        git submodule update --init --recursive
-    fi
-    
-    cd $HOME/nunchaku
+# Install nunchaku from prebuilt wheel
+install_nunchaku() {
+    log_step "📦 Step 4: Installing prebuilt nunchaku wheel"
+
     source $HOME/pollinations/image.pollinations.ai/nunchaku/venv/bin/activate
-    
-    # Clean previous build
-    rm -rf build/ dist/ *.egg-info
-    
-    log_info "Building nunchaku for RTX 4090 (SM 8.9)..."
-    TORCH_CUDA_ARCH_LIST="8.9" pip install -e .
-    
-    # Verify installation
+
+    # Prebuilt wheel bundles CUDA kernels for SM 7.5/8.0/8.6/8.9/120 — no
+    # source build, no CUDA toolkit, no 10-15 min compile. Must match the
+    # pinned torch (cu12.8torch2.9) and Python (cp312) in setup_python_env.
+    local wheel_url="https://github.com/nunchaku-ai/nunchaku/releases/download/v1.2.1/nunchaku-1.2.1+cu12.8torch2.9-cp312-cp312-linux_x86_64.whl"
+    log_info "Downloading wheel..."
+    pip install --no-cache-dir --no-deps "$wheel_url"
+
     python -c "from nunchaku.models import NunchakuFluxTransformer2dModel; print('✅ nunchaku installed successfully')"
-    
-    log_info "Nunchaku build complete"
+
+    log_info "Nunchaku install complete"
 }
 
 # Create .env file
@@ -298,7 +282,7 @@ main() {
     install_system_deps
     setup_repo
     setup_python_env
-    build_nunchaku
+    install_nunchaku
     create_env_file
     create_services
     start_services


### PR DESCRIPTION
## Summary

- Switch `image.pollinations.ai/nunchaku/setup.sh` from a 10-15 min from-source build to a 30-second prebuilt wheel install (`nunchaku-1.2.1+cu12.8torch2.9-cp312`, bundles kernels for SM 7.5/8.0/8.6/8.9/120 — no CUDA toolkit needed).
- Pin `torch==2.9.1` / `torchvision==0.24.1` in `setup.sh` to match the wheel and to stay compatible with NVIDIA driver 570.x (the latest torch 2.11+ requires CUDA 13, which RunPod RTX 4090 pods don't have yet).
- Update `.claude/skills/monitor-services/SKILL.md`: replace the `screen`-based restart snippet (screen isn't installed in fresh containers), document that pod stop/start wipes the container overlay disk (only `/workspace/` persists), and add the GraphQL query for resolving the rotated SSH port.

Validated live during the 2026-05-12 Flux/Z-Image recovery on pod `hsl3ksl31lvrcc`. Wheel install + worker boot took ~5 min vs the failing 15+ min source build (which was also unbuildable on the overloaded host).

## Test plan

- [ ] Next time pod `hsl3ksl31lvrcc` needs rebuilt, run `bash setup.sh` and verify it completes in <10 min total.
- [ ] On rebuild, confirm `python -c "from nunchaku.models import NunchakuFluxTransformer2dModel"` succeeds.
- [ ] Confirm Flux workers heartbeat to `gen.pollinations.ai/register` and EXIF `manufacturer=flux` returns on a generated image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)