### PR TITLE
feat: add generic Replicate passthrough

### DIFF
--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -62,6 +62,7 @@ SCHEMA >
 `token_price_completion_image`     Float64  `json:$.tokenPriceCompletionImage` DEFAULT 0,
 `token_price_completion_video_seconds` Float64 `json:$.tokenPriceCompletionVideoSeconds` DEFAULT 0,
 `token_price_completion_video_tokens`  Float64 `json:$.tokenPriceCompletionVideoTokens` DEFAULT 0,
+`token_price_billing_dollars`      Float64  `json:$.tokenPriceBillingDollars` DEFAULT 0,
 
 -- Usage
 `token_count_prompt_text`          UInt32   `json:$.tokenCountPromptText` DEFAULT 0,
@@ -75,6 +76,7 @@ SCHEMA >
 `token_count_completion_image`     UInt32   `json:$.tokenCountCompletionImage` DEFAULT 0,
 `token_count_completion_video_seconds` UInt32 `json:$.tokenCountCompletionVideoSeconds` DEFAULT 0,
 `token_count_completion_video_tokens`  UInt32 `json:$.tokenCountCompletionVideoTokens` DEFAULT 0,
+`token_count_billing_dollars`      Float64  `json:$.tokenCountBillingDollars` DEFAULT 0,
 
 -- Totals
 `total_cost`    Float64 `json:$.totalCost` DEFAULT 0,

--- a/enter.pollinations.ai/test/events.test.ts
+++ b/enter.pollinations.ai/test/events.test.ts
@@ -39,6 +39,7 @@ test("sendToTinybird sends event to Tinybird API", async ({ log, mocks }) => {
         tokenPriceCompletionImage: 0,
         tokenPriceCompletionVideoSeconds: 0,
         tokenPriceCompletionVideoTokens: 0,
+        tokenPriceBillingDollars: 0,
         tokenCountPromptText: 100,
         tokenCountPromptCached: 0,
         tokenCountPromptAudio: 0,
@@ -49,6 +50,7 @@ test("sendToTinybird sends event to Tinybird API", async ({ log, mocks }) => {
         tokenCountCompletionImage: 0,
         tokenCountCompletionVideoSeconds: 0,
         tokenCountCompletionVideoTokens: 0,
+        tokenCountBillingDollars: 0,
         totalCost: 0.001,
         totalPrice: 0.002,
     };
@@ -94,6 +96,7 @@ test("sendToTinybird handles API errors gracefully", async ({ log, mocks }) => {
         tokenPriceCompletionImage: 0,
         tokenPriceCompletionVideoSeconds: 0,
         tokenPriceCompletionVideoTokens: 0,
+        tokenPriceBillingDollars: 0,
         tokenCountPromptText: 100,
         tokenCountPromptCached: 0,
         tokenCountPromptAudio: 0,
@@ -104,6 +107,7 @@ test("sendToTinybird handles API errors gracefully", async ({ log, mocks }) => {
         tokenCountCompletionImage: 0,
         tokenCountCompletionVideoSeconds: 0,
         tokenCountCompletionVideoTokens: 0,
+        tokenCountBillingDollars: 0,
         totalCost: 0.001,
         totalPrice: 0.002,
     };

--- a/enter.pollinations.ai/test/helpers/billing-assertions.ts
+++ b/enter.pollinations.ai/test/helpers/billing-assertions.ts
@@ -22,6 +22,7 @@ type BillingEvent = {
     tokenPriceCompletionImage: number;
     tokenPriceCompletionVideoSeconds?: number;
     tokenPriceCompletionVideoTokens?: number;
+    tokenPriceBillingDollars?: number;
     tokenCountPromptText: number;
     tokenCountPromptCached: number;
     tokenCountPromptAudio: number;
@@ -32,6 +33,7 @@ type BillingEvent = {
     tokenCountCompletionImage: number;
     tokenCountCompletionVideoSeconds?: number;
     tokenCountCompletionVideoTokens?: number;
+    tokenCountBillingDollars?: number;
     totalCost: number;
     totalPrice: number;
 };
@@ -48,6 +50,7 @@ function usageFromEvent(event: BillingEvent): Usage {
         completionImageTokens: event.tokenCountCompletionImage,
         completionVideoSeconds: event.tokenCountCompletionVideoSeconds || 0,
         completionVideoTokens: event.tokenCountCompletionVideoTokens || 0,
+        billingDollars: event.tokenCountBillingDollars || 0,
     };
 }
 
@@ -98,6 +101,9 @@ export function assertTrackedBillingEvent(
     );
     expect(event.tokenPriceCompletionVideoTokens || 0).toBe(
         priceDefinition?.completionVideoTokens || 0,
+    );
+    expect(event.tokenPriceBillingDollars || 0).toBe(
+        priceDefinition?.billingDollars || 0,
     );
 
     expect(event.totalCost).toBeCloseTo(expectedCost.totalCost, 8);

--- a/gen.pollinations.ai/src/index.ts
+++ b/gen.pollinations.ai/src/index.ts
@@ -13,7 +13,7 @@
  *   gen.pollinations.ai/text/*        -> text generation
  *   gen.pollinations.ai/audio/*       -> audio generation
  *   gen.pollinations.ai/video/*       -> video generation
- *   gen.pollinations.ai/v1/*          -> OpenAI-compatible generation
+ *   gen.pollinations.ai/v1/*          -> OpenAI-compatible and provider-native generation
  */
 
 import { type Context, Hono } from "hono";
@@ -26,6 +26,7 @@ import { logger } from "@/middleware/logger.ts";
 import { audioRoutes } from "./routes/audio.ts";
 import { createDocsRoutes } from "./routes/docs.ts";
 import { proxyRoutes } from "./routes/proxy.ts";
+import { replicateRoutes } from "./routes/replicate.ts";
 
 export { PollenRateLimiter } from "./durable-objects/PollenRateLimiter.ts";
 
@@ -122,6 +123,7 @@ app.use("*", cors(PERMISSIVE_CORS_OPTIONS))
     })
     .route("/docs", createDocsRoutes(app))
     .route("/v1/audio", audioRoutes)
+    .route("/v1/replicate", replicateRoutes)
     .route("/", proxyRoutes);
 
 app.notFound(async (c: Context<Env>) => {

--- a/gen.pollinations.ai/src/replicate/billing.ts
+++ b/gen.pollinations.ai/src/replicate/billing.ts
@@ -1,0 +1,160 @@
+import type { Logger } from "@logtape/logtape";
+import { cached } from "../cache.ts";
+
+const REPLICATE_PAGE_CACHE_TTL_SECONDS = 24 * 60 * 60;
+const REPLICATE_MODEL_RE =
+    /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const PER_SECOND_PRICE_RE = /"price"\s*:\s*"\$([0-9.]+)\s+per\s+second"/;
+
+export type ReplicateTimePricedConfig = {
+    slug: string;
+    version: string;
+    dollarsPerSecond: number;
+    priceLabel: string;
+    hardware?: string;
+};
+
+type ReplicateModelResponse = {
+    latest_version?: {
+        id?: string;
+    };
+};
+
+type ParsedReplicatePage = {
+    dollarsPerSecond: number;
+    priceLabel: string;
+    hardware?: string;
+} | null;
+
+export function isValidReplicateModelSlug(slug: string): boolean {
+    return REPLICATE_MODEL_RE.test(slug);
+}
+
+export async function getReplicateTimePricedConfig(opts: {
+    slug: string;
+    token: string;
+    kv: KVNamespace;
+    log: Logger;
+}): Promise<ReplicateTimePricedConfig | null> {
+    const fetchCached = cached(fetchReplicateTimePricedConfig, {
+        ttl: REPLICATE_PAGE_CACHE_TTL_SECONDS,
+        kv: opts.kv,
+        log: opts.log,
+        keyGenerator: (slug) => `replicate:time-priced:${slug}`,
+    });
+
+    return await fetchCached(opts.slug, opts.token);
+}
+
+async function fetchReplicateTimePricedConfig(
+    slug: string,
+    token: string,
+): Promise<ReplicateTimePricedConfig | null> {
+    const [pageResponse, modelResponse] = await Promise.all([
+        fetch(`https://replicate.com/${slug}`),
+        fetch(`https://api.replicate.com/v1/models/${slug}`, {
+            headers: { Authorization: `Bearer ${token}` },
+        }),
+    ]);
+
+    if (pageResponse.status === 404 || modelResponse.status === 404) {
+        return null;
+    }
+    if (!pageResponse.ok || !modelResponse.ok) {
+        throw new Error(
+            `Failed to fetch Replicate model pricing for ${slug}: page=${pageResponse.status} model=${modelResponse.status}`,
+        );
+    }
+
+    const [html, model] = await Promise.all([
+        pageResponse.text(),
+        modelResponse.json() as Promise<ReplicateModelResponse>,
+    ]);
+    const parsedPage = parseReplicateTimePricedPage(html);
+    const versionId = model.latest_version?.id;
+
+    if (!parsedPage || !versionId) return null;
+
+    return {
+        slug,
+        version: `${slug}:${versionId}`,
+        ...parsedPage,
+    };
+}
+
+export function parseReplicateTimePricedPage(
+    html: string,
+): ParsedReplicatePage {
+    const billingConfig = extractJsonField(html, "billingConfig");
+    if (billingConfig !== null) return null;
+
+    const priceMatch = html.match(PER_SECOND_PRICE_RE);
+    const dollarsPerSecond = priceMatch?.[1]
+        ? Number(priceMatch[1])
+        : Number.NaN;
+    if (!Number.isFinite(dollarsPerSecond) || dollarsPerSecond <= 0) {
+        return null;
+    }
+
+    return {
+        dollarsPerSecond,
+        priceLabel: `$${priceMatch?.[1]} per second`,
+        hardware: html.match(/"hardware"\s*:\s*"([^"]+)"/)?.[1],
+    };
+}
+
+export function calculateReplicateProviderBillingDollars(opts: {
+    predictTimeSeconds?: number;
+    dollarsPerSecond: number;
+}): number {
+    const predictTimeSeconds = opts.predictTimeSeconds ?? 0;
+    if (!Number.isFinite(predictTimeSeconds) || predictTimeSeconds <= 0) {
+        return 0;
+    }
+    return predictTimeSeconds * opts.dollarsPerSecond;
+}
+
+function extractJsonField(html: string, field: string): unknown {
+    const marker = `"${field}":`;
+    const start = html.indexOf(marker);
+    if (start === -1) return undefined;
+
+    let index = start + marker.length;
+    while (/\s/.test(html[index])) index++;
+
+    if (html.startsWith("null", index)) return null;
+
+    const open = html[index];
+    const close = open === "{" ? "}" : open === "[" ? "]" : null;
+    if (!close) return undefined;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let cursor = index; cursor < html.length; cursor++) {
+        const char = html[cursor];
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === "\\") {
+                escaped = true;
+            } else if (char === '"') {
+                inString = false;
+            }
+            continue;
+        }
+
+        if (char === '"') {
+            inString = true;
+        } else if (char === open) {
+            depth++;
+        } else if (char === close) {
+            depth--;
+            if (depth === 0) {
+                return JSON.parse(html.slice(index, cursor + 1));
+            }
+        }
+    }
+
+    return undefined;
+}

--- a/gen.pollinations.ai/src/routes/replicate.ts
+++ b/gen.pollinations.ai/src/routes/replicate.ts
@@ -1,0 +1,258 @@
+import { buildUsageHeaders } from "@shared/registry/usage-headers.ts";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { describeRoute } from "hono-openapi";
+import { z } from "zod";
+import type { Env } from "@/env.ts";
+import { auth } from "@/middleware/auth.ts";
+import { balance } from "@/middleware/balance.ts";
+import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
+import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
+import { track } from "@/middleware/track.ts";
+import { validator } from "@/middleware/validator.ts";
+import { errorResponseDescriptions } from "@/utils/api-docs.ts";
+import { generationAccess } from "@/utils/generation-access.ts";
+import {
+    calculateReplicateProviderBillingDollars,
+    getReplicateTimePricedConfig,
+    isValidReplicateModelSlug,
+} from "../replicate/billing.ts";
+
+const REPLICATE_GENERIC_MODEL = "replicate-generic";
+const REPLICATE_API_BASE = "https://api.replicate.com/v1";
+const PREFER_WAIT_SECONDS = 60;
+const POLL_INTERVAL_MS = 5000;
+const POLL_MAX_ATTEMPTS = 60;
+
+const ReplicatePredictionRequestSchema = z.object({
+    model: z.string().refine(isValidReplicateModelSlug, {
+        message: 'model must use "owner/name" format',
+    }),
+    input: z.record(z.string(), z.unknown()).default({}),
+});
+
+type ReplicatePredictionRequest = z.infer<
+    typeof ReplicatePredictionRequestSchema
+>;
+
+type ReplicatePrediction = {
+    id?: string;
+    status?:
+        | "starting"
+        | "processing"
+        | "succeeded"
+        | "failed"
+        | "canceled"
+        | "aborted";
+    urls?: {
+        get?: string;
+    };
+    metrics?: {
+        predict_time?: number;
+    };
+    error?: string | null;
+};
+
+const replicateBodyLimit = bodyLimit({
+    maxSize: 20 * 1024 * 1024,
+});
+
+const setReplicateGenericModel = createMiddleware<Env>(async (c, next) => {
+    const body = c.req.valid("json" as never) as ReplicatePredictionRequest;
+    c.set("model", {
+        requested: body.model,
+        resolved: REPLICATE_GENERIC_MODEL,
+    });
+    await next();
+});
+
+export const replicateRoutes = new Hono<Env>()
+    .use("*", edgeRateLimit)
+    .use("*", auth())
+    .use("*", frontendKeyRateLimit)
+    .use("*", balance)
+    .post(
+        "/predictions",
+        describeRoute({
+            tags: ["Provider APIs"],
+            summary: "Create Replicate Prediction",
+            description: [
+                "Runs a public Replicate model through Pollinations billing.",
+                "",
+                "Only time-priced models are supported. Models with Replicate `billingConfig` pricing are rejected and should use curated Pollinations endpoints.",
+                "",
+                'Request body: `{ "model": "owner/name", "input": { ... } }`. The response is the raw Replicate prediction JSON.',
+            ].join("\n"),
+            responses: {
+                200: {
+                    description:
+                        "Success - Returns the raw Replicate prediction",
+                },
+                ...errorResponseDescriptions(
+                    400,
+                    401,
+                    402,
+                    403,
+                    429,
+                    500,
+                    502,
+                    503,
+                ),
+            },
+        }),
+        replicateBodyLimit,
+        validator("json", ReplicatePredictionRequestSchema),
+        setReplicateGenericModel,
+        track("generate.text"),
+        generationAccess,
+        async (c) => {
+            const token = c.env.REPLICATE_API_TOKEN;
+            if (!token) {
+                throw new HTTPException(503, {
+                    message: "Replicate is not configured.",
+                });
+            }
+
+            const body = c.req.valid(
+                "json" as never,
+            ) as ReplicatePredictionRequest;
+            const billing = await getReplicateTimePricedConfig({
+                slug: body.model,
+                token,
+                kv: c.env.KV,
+                log: c.var.log.getChild("replicate"),
+            });
+
+            if (!billing) {
+                throw new HTTPException(400, {
+                    message:
+                        "This Replicate model is not available through the generic endpoint. Only time-priced models are supported.",
+                });
+            }
+
+            const createResult = await replicateFetch<ReplicatePrediction>(
+                token,
+                {
+                    method: "POST",
+                    url: `${REPLICATE_API_BASE}/predictions`,
+                    body: {
+                        version: billing.version,
+                        input: body.input,
+                    },
+                    headers: {
+                        Prefer: `wait=${PREFER_WAIT_SECONDS}`,
+                    },
+                },
+            );
+            if (!createResult.response.ok) {
+                return c.json(
+                    createResult.json,
+                    createResult.response.status as ContentfulStatusCode,
+                );
+            }
+
+            const prediction = await pollReplicatePrediction(
+                token,
+                createResult.json,
+            );
+
+            if (prediction.status !== "succeeded") {
+                c.var.track.overrideResponseTracking(
+                    new Response(null, { status: 502 }),
+                );
+                return c.json(prediction);
+            }
+
+            const providerBillingDollars =
+                calculateReplicateProviderBillingDollars({
+                    predictTimeSeconds: prediction.metrics?.predict_time,
+                    dollarsPerSecond: billing.dollarsPerSecond,
+                });
+            if (providerBillingDollars <= 0) {
+                c.var.log.warn(
+                    "Replicate prediction succeeded without billable runtime metrics.",
+                    {
+                        predictionId: prediction.id,
+                        replicateModel: billing.slug,
+                    },
+                );
+                c.var.track.overrideResponseTracking(
+                    new Response(null, { status: 502 }),
+                );
+                return c.json(prediction);
+            }
+            const usageHeaders = buildUsageHeaders(REPLICATE_GENERIC_MODEL, {
+                billingDollars: providerBillingDollars,
+            });
+
+            return c.json(prediction, 200, {
+                ...usageHeaders,
+                "x-replicate-model": billing.slug,
+                "x-replicate-price": billing.priceLabel,
+                ...(billing.hardware
+                    ? { "x-replicate-hardware": billing.hardware }
+                    : {}),
+                "x-replicate-provider-billing-dollars": String(
+                    providerBillingDollars,
+                ),
+            });
+        },
+    );
+
+async function pollReplicatePrediction(
+    token: string,
+    prediction: ReplicatePrediction,
+): Promise<ReplicatePrediction> {
+    let current = prediction;
+    const pollUrl =
+        current.urls?.get || `${REPLICATE_API_BASE}/predictions/${current.id}`;
+
+    for (
+        let attempts = 0;
+        current.status === "starting" || current.status === "processing";
+        attempts++
+    ) {
+        if (attempts >= POLL_MAX_ATTEMPTS) {
+            throw new HTTPException(504, {
+                message: `Replicate prediction ${current.id} timed out after ${(POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s.`,
+            });
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        const result = await replicateFetch<ReplicatePrediction>(token, {
+            method: "GET",
+            url: pollUrl,
+        });
+        if (!result.response.ok) return result.json;
+        current = result.json;
+    }
+
+    return current;
+}
+
+async function replicateFetch<T>(
+    token: string,
+    opts: {
+        method: "GET" | "POST";
+        url: string;
+        body?: Record<string, unknown>;
+        headers?: Record<string, string>;
+    },
+): Promise<{ response: Response; json: T }> {
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        ...opts.headers,
+    };
+    if (opts.body) headers["Content-Type"] = "application/json";
+
+    const response = await fetch(opts.url, {
+        method: opts.method,
+        headers,
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+    });
+    const json = (await response.json().catch(() => ({}))) as T;
+    return { response, json };
+}

--- a/gen.pollinations.ai/test/replicate-billing.test.ts
+++ b/gen.pollinations.ai/test/replicate-billing.test.ts
@@ -1,0 +1,246 @@
+import {
+    createExecutionContext,
+    env,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { test as fixtureTest } from "@shared/test/fixtures/index.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index.ts";
+import {
+    calculateReplicateProviderBillingDollars,
+    isValidReplicateModelSlug,
+    parseReplicateTimePricedPage,
+} from "../src/replicate/billing.ts";
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe("Replicate generic billing", () => {
+    it("parses time-priced model pages", () => {
+        const parsed = parseReplicateTimePricedPage(`
+            <script>{"billingConfig": null, "hardware": "L40S", "price": "$0.000975 per second", "p50price": "$0.0065"}</script>
+        `);
+
+        expect(parsed).toEqual({
+            dollarsPerSecond: 0.000975,
+            priceLabel: "$0.000975 per second",
+            hardware: "L40S",
+        });
+    });
+
+    it("rejects tiered billingConfig pages", () => {
+        const parsed = parseReplicateTimePricedPage(`
+            <script>{"billingConfig": {"current_tiers": [{"prices": [{"metric": "image_output_count", "price": "$3"}]}]}, "hardware": "H100", "price": "$3"}</script>
+        `);
+
+        expect(parsed).toBeNull();
+    });
+
+    it("requires a per-second price", () => {
+        const parsed = parseReplicateTimePricedPage(`
+            <script>{"billingConfig": null, "hardware": "H100", "price": "$3"}</script>
+        `);
+
+        expect(parsed).toBeNull();
+    });
+
+    it("calculates provider billing dollars", () => {
+        expect(
+            calculateReplicateProviderBillingDollars({
+                predictTimeSeconds: 0.47903636,
+                dollarsPerSecond: 0.000975,
+            }),
+        ).toBeCloseTo(0.000467060451);
+        expect(
+            calculateReplicateProviderBillingDollars({
+                predictTimeSeconds: 60,
+                dollarsPerSecond: 0.0061,
+            }),
+        ).toBeCloseTo(0.366);
+    });
+
+    it("validates owner/name slugs", () => {
+        expect(isValidReplicateModelSlug("stability-ai/sdxl")).toBe(true);
+        expect(
+            isValidReplicateModelSlug("black-forest-labs/flux-schnell"),
+        ).toBe(true);
+        expect(isValidReplicateModelSlug("stability-ai/sdxl:version")).toBe(
+            false,
+        );
+        expect(isValidReplicateModelSlug("https://replicate.com/foo/bar")).toBe(
+            false,
+        );
+    });
+});
+
+fixtureTest(
+    "generic Replicate route bills succeeded time-priced calls",
+    async ({ paidApiKey }) => {
+        const fetchMock = vi.fn(
+            async (input: string | URL | Request, init?: RequestInit) => {
+                const request =
+                    input instanceof Request ? input : new Request(input, init);
+                const url = new URL(request.url);
+
+                if (url.hostname === "replicate.com") {
+                    return new Response(
+                        '<script>{"billingConfig": null, "hardware": "L40S", "price": "$0.000975 per second"}</script>',
+                        { headers: { "content-type": "text/html" } },
+                    );
+                }
+
+                if (
+                    url.hostname === "api.replicate.com" &&
+                    url.pathname === "/v1/models/stability-ai/sdxl"
+                ) {
+                    return Response.json({
+                        latest_version: { id: "version-id" },
+                    });
+                }
+
+                if (
+                    url.hostname === "api.replicate.com" &&
+                    url.pathname === "/v1/predictions"
+                ) {
+                    await expect(request.json()).resolves.toEqual({
+                        version: "stability-ai/sdxl:version-id",
+                        input: { prompt: "red cube" },
+                    });
+                    return Response.json(
+                        {
+                            id: "prediction-id",
+                            status: "succeeded",
+                            output: ["https://example.com/output.png"],
+                            metrics: { predict_time: 0.47903636 },
+                        },
+                        { status: 201 },
+                    );
+                }
+
+                return Response.json({ data: [] });
+            },
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/v1/replicate/predictions",
+                {
+                    method: "POST",
+                    headers: {
+                        authorization: `Bearer ${paidApiKey}`,
+                        "content-type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: "stability-ai/sdxl",
+                        input: { prompt: "red cube" },
+                        webhook: "https://attacker.example/webhook",
+                    }),
+                },
+            ),
+            {
+                ...env,
+                REPLICATE_API_TOKEN: "r8_test",
+            } as CloudflareBindings,
+            ctx,
+        );
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-model-used")).toBe("replicate-generic");
+        expect(
+            Number(response.headers.get("x-usage-billing-dollars")),
+        ).toBeCloseTo(0.000467060451);
+        expect(
+            Number(
+                response.headers.get("x-replicate-provider-billing-dollars"),
+            ),
+        ).toBeCloseTo(0.000467060451);
+        await expect(response.json()).resolves.toMatchObject({
+            id: "prediction-id",
+            status: "succeeded",
+        });
+    },
+);
+
+fixtureTest(
+    "generic Replicate route returns failed predictions without billing",
+    async ({ paidApiKey }) => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+                const request =
+                    input instanceof Request ? input : new Request(input, init);
+                const url = new URL(request.url);
+
+                if (url.hostname === "replicate.com") {
+                    return new Response(
+                        '<script>{"billingConfig": null, "hardware": "L40S", "price": "$0.000975 per second"}</script>',
+                        { headers: { "content-type": "text/html" } },
+                    );
+                }
+
+                if (
+                    url.hostname === "api.replicate.com" &&
+                    url.pathname === "/v1/models/stability-ai/sdxl"
+                ) {
+                    return Response.json({
+                        latest_version: { id: "version-id" },
+                    });
+                }
+
+                if (
+                    url.hostname === "api.replicate.com" &&
+                    url.pathname === "/v1/predictions"
+                ) {
+                    return Response.json(
+                        {
+                            id: "prediction-id",
+                            status: "failed",
+                            error: "invalid input",
+                        },
+                        { status: 201 },
+                    );
+                }
+
+                return Response.json({ data: [] });
+            }),
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/v1/replicate/predictions",
+                {
+                    method: "POST",
+                    headers: {
+                        authorization: `Bearer ${paidApiKey}`,
+                        "content-type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: "stability-ai/sdxl",
+                        input: { prompt: "" },
+                    }),
+                },
+            ),
+            {
+                ...env,
+                REPLICATE_API_TOKEN: "r8_test",
+            } as CloudflareBindings,
+            ctx,
+        );
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-model-used")).toBeNull();
+        expect(response.headers.get("x-usage-billing-dollars")).toBeNull();
+        await expect(response.json()).resolves.toMatchObject({
+            id: "prediction-id",
+            status: "failed",
+            error: "invalid input",
+        });
+    },
+);

--- a/gen.pollinations.ai/test/usage-headers.test.ts
+++ b/gen.pollinations.ai/test/usage-headers.test.ts
@@ -76,12 +76,14 @@ describe("buildUsageHeaders", () => {
             promptAudioTokens: 500,
             completionAudioSeconds: 3.5,
             completionVideoSeconds: 10.2,
+            billingDollars: 0.000467060451,
         };
         const headers = buildUsageHeaders("gemini-large", usage);
 
         expect(headers["x-usage-prompt-audio-tokens"]).toBe("500");
         expect(headers["x-usage-completion-audio-seconds"]).toBe("3.5");
         expect(headers["x-usage-completion-video-seconds"]).toBe("10.2");
+        expect(headers["x-usage-billing-dollars"]).toBe("0.000467060451");
     });
 });
 
@@ -195,6 +197,7 @@ describe("parseUsageHeaders", () => {
             "x-usage-prompt-audio-seconds": "3.5",
             "x-usage-completion-audio-seconds": "10.25",
             "x-usage-completion-video-seconds": "15.75",
+            "x-usage-billing-dollars": "0.000467060451",
         };
 
         const usage = parseUsageHeaders(headers);
@@ -202,6 +205,7 @@ describe("parseUsageHeaders", () => {
         expect(usage.promptAudioSeconds).toBe(3.5);
         expect(usage.completionAudioSeconds).toBe(10.25);
         expect(usage.completionVideoSeconds).toBe(15.75);
+        expect(usage.billingDollars).toBe(0.000467060451);
     });
 
     it("should handle Headers object (from Response)", () => {
@@ -239,6 +243,7 @@ describe("buildUsageHeaders + parseUsageHeaders round-trip", () => {
             completionTextTokens: 75,
             completionReasoningTokens: 150,
             completionAudioSeconds: 5.5,
+            billingDollars: 0.000467060451,
         };
 
         const headers = buildUsageHeaders("test-model", originalUsage);
@@ -262,5 +267,6 @@ describe("buildUsageHeaders + parseUsageHeaders round-trip", () => {
         expect(parsedUsage.completionAudioSeconds).toBe(
             originalUsage.completionAudioSeconds,
         );
+        expect(parsedUsage.billingDollars).toBe(originalUsage.billingDollars);
     });
 });

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -12,7 +12,8 @@ import {
 // Pricing uses registry field names directly, filtering out zero/undefined values
 // Fields: promptTextTokens, promptCachedTokens, promptAudioTokens, promptAudioSeconds,
 //         promptImageTokens, completionTextTokens, completionReasoningTokens,
-//         completionAudioTokens, completionImageTokens, completionVideoSeconds, completionVideoTokens
+//         completionAudioTokens, completionImageTokens, completionVideoSeconds,
+//         completionVideoTokens, billingDollars
 export const ModelInfoSchema = z.object({
     name: z.string(),
     aliases: z.array(z.string()),

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -33,7 +33,8 @@ export type UsageType =
     | "completionAudioSeconds"
     | "completionImageTokens"
     | "completionVideoSeconds"
-    | "completionVideoTokens";
+    | "completionVideoTokens"
+    | "billingDollars";
 
 // Usage represents raw usage metrics (tokens, seconds, etc.)
 export type Usage = { [K in UsageType]?: number };

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1056,4 +1056,30 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         isSpecialized: true,
     },
+    "replicate-generic": {
+        aliases: [],
+        modelId: "replicate-generic",
+        provider: "replicate",
+        brand: "Replicate",
+        category: "text",
+        paidOnly: true,
+        hidden: true,
+        cost: [
+            {
+                date: COST_START_DATE,
+                // Generic Replicate passes through scraped provider cost directly.
+                billingDollars: 1,
+            },
+        ],
+        price: [
+            {
+                date: COST_START_DATE,
+                billingDollars: 1.5,
+            },
+        ],
+        description:
+            "Generic Replicate passthrough for time-priced public models",
+        inputModalities: ["text", "image", "audio", "video"],
+        outputModalities: ["text", "image", "audio", "video"],
+    },
 } as const satisfies Record<string, ModelDefinition<string>>;

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -17,6 +17,7 @@ export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
     completionImageTokens: "x-usage-completion-image-tokens",
     completionVideoSeconds: "x-usage-completion-video-seconds",
     completionVideoTokens: "x-usage-completion-video-tokens",
+    billingDollars: "x-usage-billing-dollars",
 };
 
 /**
@@ -107,6 +108,7 @@ export function parseUsageHeaders(
         "promptAudioSeconds",
         "completionAudioSeconds",
         "completionVideoSeconds",
+        "billingDollars",
     ]);
 
     for (const [usageType, headerName] of Object.entries(USAGE_TYPE_HEADERS)) {

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -69,6 +69,7 @@ export type TinybirdEvent = {
     tokenPriceCompletionImage: number;
     tokenPriceCompletionVideoSeconds: number;
     tokenPriceCompletionVideoTokens: number;
+    tokenPriceBillingDollars: number;
 
     // Usage
     tokenCountPromptText: number;
@@ -82,6 +83,7 @@ export type TinybirdEvent = {
     tokenCountCompletionImage: number;
     tokenCountCompletionVideoSeconds: number;
     tokenCountCompletionVideoTokens: number;
+    tokenCountBillingDollars: number;
 
     // Totals
     totalCost: number;
@@ -133,6 +135,7 @@ export type GenerationEventPriceParams = {
     tokenPriceCompletionImage: number;
     tokenPriceCompletionVideoSeconds: number;
     tokenPriceCompletionVideoTokens: number;
+    tokenPriceBillingDollars: number;
 };
 
 export type GenerationEventUsageParams = {
@@ -147,6 +150,7 @@ export type GenerationEventUsageParams = {
     tokenCountCompletionImage: number;
     tokenCountCompletionVideoSeconds: number;
     tokenCountCompletionVideoTokens: number;
+    tokenCountBillingDollars: number;
 };
 
 export function priceToEventParams(
@@ -179,6 +183,8 @@ export function priceToEventParams(
             priceDefinition?.completionVideoSeconds || 0,
         tokenPriceCompletionVideoTokens:
             priceDefinition?.completionVideoTokens || 0,
+        tokenPriceBillingDollars:
+            priceDefinition?.billingDollars || 0,
     };
 }
 
@@ -195,6 +201,7 @@ export function usageToEventParams(usage?: Usage): GenerationEventUsageParams {
         tokenCountCompletionImage: usage?.completionImageTokens || 0,
         tokenCountCompletionVideoSeconds: usage?.completionVideoSeconds || 0,
         tokenCountCompletionVideoTokens: usage?.completionVideoTokens || 0,
+        tokenCountBillingDollars: usage?.billingDollars || 0,
     };
 }
 


### PR DESCRIPTION
- Adds `/v1/replicate/predictions` for time-priced Replicate models.
- Bills runtime through `billingDollars` and hidden `replicate-generic`.
- Rejects tiered Replicate pricing; failed predictions pass through without billing.
- Validated focused tests, typechecks, routing test, and diff check.