### PR TITLE
update pinned banner: pollen pack bonus reduction

### DIFF
--- a/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
+++ b/enter.pollinations.ai/src/client/components/layout/news-banner.tsx
@@ -22,11 +22,11 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
-        date: "2026-05-05",
+        date: "2026-05-13",
         emoji: "🌻",
-        title: "Developer earnings are live",
+        title: "Pollen pack bonuses are stepping down",
         description:
-            "Turn on Developer earnings on any App Key to receive a share of pollen users spend in your app.",
+            "As the service keeps improving, the bonus Pollen included with each pack is being reduced — new rates take effect on May 18.",
     },
 ];
 


### PR DESCRIPTION
Announces the pollen pack bonus reduction in the pinned news banner ahead of the May 18 rollout.

Replaces the "Developer earnings are live" pinned card with:

> 🌻 Pollen pack bonuses are stepping down — As the service keeps improving, the bonus Pollen included with each pack is being reduced — new rates take effect on May 18.

Merge this before #(reduce-bonuses PR) so users see the announcement before the actual reduction lands.