### PR TITLE
fix(social): preserve load-bearing specifics in PR-merge Discord posts

### DIFF
--- a/social/prompts/format.md
+++ b/social/prompts/format.md
@@ -126,7 +126,7 @@ PR body excerpt:
 - Start with a one-line summary of what changed
 - Bullet points with emojis if needed
 - Written for people who use the tools — skip internal details
-- **Quote concrete specifics from the PR body excerpt when they're the point of the change**: actual numbers (prices, pack sizes, rate limits, version bumps), model names, named features. Do not abstract them into vague phrases like "updated tiers" or "improved limits". If the PR is about changing values, the message must include the new values.
+- **Pick the load-bearing specifics out of the PR body and put them in the message**: names (models, endpoints, packages, providers, features), numbers (versions, defaults, prices, limits, sizes, timeouts), and before/after values when behavior changes. Don't substitute them with category labels ("updated plans", "new model added", "API improvements"). If the PR is about changing a value or naming a thing, the message must include that value or name.
 - Plain language, no hype
 
 Return ONLY the announcement text. No JSON, no markdown fences, no explanation.

--- a/social/prompts/format.md
+++ b/social/prompts/format.md
@@ -113,16 +113,20 @@ Return ONLY the JSON object. No markdown fences, no explanation.
 
 ## Realtime
 
-Given a PR's summary, impact, and keywords, write a short message announcing the change.
+Given a PR's summary, impact, keywords, and a verbatim excerpt of the PR body, write a short message announcing the change.
 
 Summary: {summary}
 Impact: {impact}
 Keywords: {keywords}
 
+PR body excerpt:
+{pr_excerpt}
+
 - 150-400 characters total
 - Start with a one-line summary of what changed
 - Bullet points with emojis if needed
 - Written for people who use the tools — skip internal details
+- **Quote concrete specifics from the PR body excerpt when they're the point of the change**: actual numbers (prices, pack sizes, rate limits, version bumps), model names, named features. Do not abstract them into vague phrases like "updated tiers" or "improved limits". If the PR is about changing values, the message must include the new values.
 - Plain language, no hype
 
 Return ONLY the announcement text. No JSON, no markdown fences, no explanation.

--- a/social/prompts/gist.md
+++ b/social/prompts/gist.md
@@ -95,8 +95,10 @@ Bee/nature metaphors fit the brand. Skip negativity — keep it celebratory.
 ### `summary`
 One clear sentence. Focus on WHAT changed and WHY. Written for a technical audience who follows the project.
 
+**Preserve concrete specifics** — when the PR centers on numbers, model names, prices, limits, version bumps, or named features, include them verbatim. Examples: `"$10 pack now grants 13 Pollen (was 20)"`, `"Llama 4 Maverick added via Fireworks"`, `"rate limit raised from 5 to 10 req/s"`. Abstracted summaries ("updated tier options") lose the information users actually need.
+
 ### `impact`
-One sentence about the practical effect. "Users will see...", "This means...", "Previously X, now Y."
+One sentence about the practical effect. "Users will see...", "This means...", "Previously X, now Y." Carry the concrete numbers from `summary` through into `impact` when they're load-bearing.
 
 ### `keywords`
 3-7 relevant keywords for clustering related PRs in the daily summary.
@@ -120,11 +122,13 @@ A short (1-2 sentence) pixel art scene description for generating the PR's annou
 All output fields (summary, impact) MUST frame changes positively — what users GAIN, not what they lose.
 
 ### Reframing Guide
-- Price increases → "new tier options" or "updated plans" — focus on what tiers unlock
-- Rate limiting / tighter quotas → "reliability improvements" or "fairer usage"
-- Feature removals → "streamlined experience" — focus on what remains or replaces it
-- Breaking API changes → "migration to better system" — focus on the improvement
-- Deprecations → "making way for [replacement]"
+Positive framing means tone, not abstraction. Always include the concrete change (numbers, names, before/after) — then frame it neutrally to positively.
+
+- Price / pack changes → state the new amounts AND the change (`"$10 pack now grants 13 Pollen (was 20)"`). Don't replace numbers with phrases like "updated plans".
+- Rate limiting / tighter quotas → state the new limit AND the reason (`"per-key limit dropped from 10 to 5 req/s to even out usage"`). Don't replace with "reliability improvements".
+- Feature removals → name what was removed and what replaces it (`"legacy 2x Checkout fallback removed; new packBonusPollen metadata is now the source of truth"`).
+- Breaking API changes → name the old and new shape; link migration notes when present.
+- Deprecations → name the deprecated thing and its replacement.
 
 ### Never surface in social content
 - Revenue or financial pressures

--- a/social/prompts/gist.md
+++ b/social/prompts/gist.md
@@ -95,10 +95,20 @@ Bee/nature metaphors fit the brand. Skip negativity — keep it celebratory.
 ### `summary`
 One clear sentence. Focus on WHAT changed and WHY. Written for a technical audience who follows the project.
 
-**Preserve concrete specifics** — when the PR centers on numbers, model names, prices, limits, version bumps, or named features, include them verbatim. Examples: `"$10 pack now grants 13 Pollen (was 20)"`, `"Llama 4 Maverick added via Fireworks"`, `"rate limit raised from 5 to 10 req/s"`. Abstracted summaries ("updated tier options") lose the information users actually need.
+**Preserve the load-bearing specifics from the PR body.** A summary that reads like a category label ("updated tier options", "new model added", "API improvements", "improved performance") is not useful — it forces readers to open the PR to learn anything. Identify the 1–3 concrete facts that make this PR distinct and put them in the sentence:
+- Names of models, endpoints, packages, fields, features, or providers being added/changed/removed
+- Numbers — version bumps, new defaults, prices, limits, sizes, timeouts, token counts
+- Before/after values when the PR changes existing behavior
+- The specific replacement when something is deprecated
+
+Examples — vague vs. specific:
+- ❌ "Added a new image model" → ✅ "Added Llama 4 Maverick via Fireworks, exposed at /v1/chat/completions"
+- ❌ "Updated tier options" → ✅ "Pollen pack bonuses reduced: $10 → 13 (was 20), $50 → 75 (was 110)"
+- ❌ "Improved checkout flow" → ✅ "Checkout metadata now uses packPollenGrant + packBonusPollen; the legacy 2x credit fallback is removed"
+- ❌ "Better rate limiting" → ✅ "Per-key rate limit dropped from 10 → 5 req/s for the free tier"
 
 ### `impact`
-One sentence about the practical effect. "Users will see...", "This means...", "Previously X, now Y." Carry the concrete numbers from `summary` through into `impact` when they're load-bearing.
+One sentence about the practical effect. "Users will see...", "This means...", "Previously X, now Y." Carry the same concrete specifics from `summary` through — never abstract them back into category language.
 
 ### `keywords`
 3-7 relevant keywords for clustering related PRs in the daily summary.
@@ -121,14 +131,10 @@ A short (1-2 sentence) pixel art scene description for generating the PR's annou
 
 All output fields (summary, impact) MUST frame changes positively — what users GAIN, not what they lose.
 
-### Reframing Guide
-Positive framing means tone, not abstraction. Always include the concrete change (numbers, names, before/after) — then frame it neutrally to positively.
+### Framing Principle
+Positive framing means tone, not abstraction. Always name the concrete change first — then frame it neutrally to positively. Abstracting a change into a category ("updated plans", "improvements", "new options") strips the information users actually came for, regardless of whether the underlying change is good news or bad news.
 
-- Price / pack changes → state the new amounts AND the change (`"$10 pack now grants 13 Pollen (was 20)"`). Don't replace numbers with phrases like "updated plans".
-- Rate limiting / tighter quotas → state the new limit AND the reason (`"per-key limit dropped from 10 to 5 req/s to even out usage"`). Don't replace with "reliability improvements".
-- Feature removals → name what was removed and what replaces it (`"legacy 2x Checkout fallback removed; new packBonusPollen metadata is now the source of truth"`).
-- Breaking API changes → name the old and new shape; link migration notes when present.
-- Deprecations → name the deprecated thing and its replacement.
+Apply this to every PR type — new features, deprecations, pricing changes, rate-limit changes, model additions, breaking API changes, performance improvements, infrastructure swaps, refactors. The specifics carry through to the user-facing sentence; the framing controls only the tone of how they're presented.
 
 ### Never surface in social content
 - Revenue or financial pressures

--- a/social/prompts/tone/discord.md
+++ b/social/prompts/tone/discord.md
@@ -27,7 +27,8 @@ Think: the person in the hackerspace who just deployed something and pops into t
 - Sound like a press release or a community manager following a playbook
 - Include PR numbers, author names, or internal jargon
 - Discuss bug fixes or maintenance unless they're significant
-- Editorialize about pricing or revenue (don't say "we had to raise prices because…"). Stating factual pricing/quota changes WITH the new numbers is fine and expected — abstracting them away ("updated plans") is not.
+- Strip out the concrete specifics — model names, endpoint paths, version bumps, prices, limits, before/after values, named features. If the PR is about changing or adding a specific thing, that thing must appear in the message. Don't replace it with a category label ("new model", "updated plans", "API improvements").
+- Editorialize about internal motivations (revenue, costs, abuse, complaints) — state factual changes neutrally
 - Add unnecessary length — if it can be said in 3 lines, don't use 10
 - Frame changes as losses — focus on what's new or better, but keep the concrete specifics
 

--- a/social/prompts/tone/discord.md
+++ b/social/prompts/tone/discord.md
@@ -27,9 +27,9 @@ Think: the person in the hackerspace who just deployed something and pops into t
 - Sound like a press release or a community manager following a playbook
 - Include PR numbers, author names, or internal jargon
 - Discuss bug fixes or maintenance unless they're significant
-- Mention pricing, rate limits, or billing
+- Editorialize about pricing or revenue (don't say "we had to raise prices because…"). Stating factual pricing/quota changes WITH the new numbers is fine and expected — abstracting them away ("updated plans") is not.
 - Add unnecessary length — if it can be said in 3 lines, don't use 10
-- Frame changes as losses — focus on what's new or better
+- Frame changes as losses — focus on what's new or better, but keep the concrete specifics
 
 ### Content Filtering:
 - Only include changes that matter to people using the tools

--- a/social/scripts/generate_realtime.py
+++ b/social/scripts/generate_realtime.py
@@ -166,6 +166,10 @@ def build_full_gist(pr_data: Dict, ai_analysis: Dict, changed_files: list) -> Di
     labels = [l["name"] for l in pr_data.get("labels", [])]
     author = pr_data.get("user", {}).get("login", "unknown")
 
+    # Preserve a PR body excerpt so downstream realtime/Discord generation can
+    # quote concrete numbers/names that the AI-distilled summary may abstract away.
+    pr_body_excerpt = (pr_data.get("body") or "")[:2000]
+
     gist = {
         "pr_number": pr_data["number"],
         "title": pr_data["title"],
@@ -173,6 +177,7 @@ def build_full_gist(pr_data: Dict, ai_analysis: Dict, changed_files: list) -> Di
         "url": pr_data["html_url"],
         "merged_at": pr_data.get("merged_at", datetime.now(timezone.utc).isoformat()),
         "labels": labels,
+        "pr_body_excerpt": pr_body_excerpt,
         "gist": ai_analysis,
         "image": {"url": None, "prompt": None},
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/social/scripts/publish_realtime.py
+++ b/social/scripts/publish_realtime.py
@@ -121,6 +121,10 @@ def main():
     summary = ai.get("summary", gist["title"])
     impact = ai.get("impact", "")
     keywords = ", ".join(ai.get("keywords", []))
+    # Trust boundary: PR body comes from merged PRs (requires repo write access),
+    # not arbitrary user input. Already truncated to 2000 chars upstream.
+    if "pr_body_excerpt" not in gist:
+        print("  WARN: gist has no pr_body_excerpt field — older gist format, specifics may be lost")
     pr_excerpt = gist.get("pr_body_excerpt") or "(no PR body)"
 
     # Voice = platform tone (system prompt), Task = format with data (user prompt)

--- a/social/scripts/publish_realtime.py
+++ b/social/scripts/publish_realtime.py
@@ -121,6 +121,7 @@ def main():
     summary = ai.get("summary", gist["title"])
     impact = ai.get("impact", "")
     keywords = ", ".join(ai.get("keywords", []))
+    pr_excerpt = gist.get("pr_body_excerpt") or "(no PR body)"
 
     # Voice = platform tone (system prompt), Task = format with data (user prompt)
     voice = load_prompt("tone/discord")
@@ -129,6 +130,7 @@ def main():
         .replace("{summary}", summary)
         .replace("{impact}", impact)
         .replace("{keywords}", keywords)
+        .replace("{pr_excerpt}", pr_excerpt)
     )
 
     snippet = call_pollinations_api(


### PR DESCRIPTION
## Changes Made

- The Discord PR-merge announcements were dropping the load-bearing details (numbers, model names, before/after values) and reading like category labels. Two root causes: the gist prompt actively abstracted specifics away, and the Discord-message stage never saw the original PR body.
- Rewrote the prompts so every PR type (model adds, refactors, pricing changes, rate limits, perf, infra) is required to preserve names + numbers + before/after values in the user-visible summary. Positive tone is preserved; the specifics carry through.
- Plumbed an excerpt of the PR body through to the Discord-message generation step so the model can quote concrete details directly.
- Relaxed the "don't mention pricing / rate limits" rule into "don't editorialize about internal motivations". Stating factual numbers is fine and expected.

## Checks

- [ ] Watch the next real PR-merge Discord post — specifics surfaced (numbers, names, before/after).
- [ ] Spot-check the gist JSON for that PR — summary / impact carry the concrete details, PR body excerpt is present.
- [ ] No regression on app-submission PRs (separate code path).
