### PR TITLE
fix(audio): preserve filename + accept usage.seconds for OVH Whisper

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1092,15 +1092,14 @@ export const audioRoutes = new Hono<Env>()
         },
     );
 
-// OVH returns usage as either {type:"duration", duration:N} or {type:"duration", seconds:N}.
 function extractWhisperUsage(responseBody: string, log: Logger): number {
     const json = JSON.parse(responseBody);
-    const duration = json.usage?.duration ?? json.usage?.seconds;
-    if (typeof duration !== "number" || duration <= 0) {
+    const seconds = json.usage?.seconds;
+    if (typeof seconds !== "number" || seconds <= 0) {
         throw new Error(
-            `Whisper response missing usage duration: ${JSON.stringify(json.usage)}`,
+            `Whisper response missing usage.seconds: ${JSON.stringify(json.usage)}`,
         );
     }
-    log.debug("Whisper usage: {duration}s", { duration });
-    return duration;
+    log.debug("Whisper usage: {seconds}s", { seconds });
+    return seconds;
 }

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1048,9 +1048,12 @@ export const audioRoutes = new Hono<Env>()
                 });
             }
 
-            // Re-build formData for Whisper (Hono consumed the original body stream)
+            // Re-build formData for Whisper (Hono consumed the original body stream).
+            // Preserve filename — OVH needs the extension to detect format/duration.
             const whisperFormData = new FormData();
-            whisperFormData.append("file", file);
+            const filename =
+                file.name && file.name !== "blob" ? file.name : "audio.mp3";
+            whisperFormData.append("file", file, filename);
             if (language) whisperFormData.append("language", language);
             if (responseFormat)
                 whisperFormData.append("response_format", responseFormat);
@@ -1089,16 +1092,13 @@ export const audioRoutes = new Hono<Env>()
         },
     );
 
-/**
- * Extract usage from Whisper response body and build tracking headers.
- * OVH returns: {"usage": {"type": "duration", "duration": 21.0}, ...}
- */
+// OVH returns usage as either {type:"duration", duration:N} or {type:"duration", seconds:N}.
 function extractWhisperUsage(responseBody: string, log: Logger): number {
     const json = JSON.parse(responseBody);
-    const duration = json.usage?.duration;
+    const duration = json.usage?.duration ?? json.usage?.seconds;
     if (typeof duration !== "number" || duration <= 0) {
         throw new Error(
-            `Whisper response missing usage.duration: ${JSON.stringify(json.usage)}`,
+            `Whisper response missing usage duration: ${JSON.stringify(json.usage)}`,
         );
     }
     log.debug("Whisper usage: {duration}s", { duration });


### PR DESCRIPTION
- Pass filename when re-appending file to FormData (without an extension OVH can't probe duration → 500 / phantom 10800s)
- Accept `usage.seconds` alongside `usage.duration` (OVH renamed the field; previously every successful transcription crashed with `missing usage.duration`)
- Verified live against gen.pollinations.ai with three curl variants (proper filename, `filename=blob`, empty filename) — first now succeeds end-to-end with the schema fix

Fixes #10931