### PR TITLE
copy(community): tighten subtitle and unstyle pollen-beta link

### DIFF
--- a/pollinations.ai/src/copy/content/community.ts
+++ b/pollinations.ai/src/copy/content/community.ts
@@ -6,8 +6,7 @@ export const COMMUNITY_PAGE = {
         "Contribute to pollinations.ai — open source, open roadmap, open community",
     // Section 1 — Hero
     title: "Contribute",
-    subtitlePrefix:
-        "🌸 pollinations.ai is open source — the code, the roadmap, the conversations.",
+    subtitlePrefix: "🌸 pollinations.ai is open source.",
     subtitleBold: "Builders shape the platform directly.",
     subtitleSuffix:
         " Share what you need, meet the people using it, and help build what comes next. 🌿",

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -196,7 +196,7 @@ export default function CommunityPage() {
                                         href={LINKS.discordPollenBeta}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="font-headline text-xs font-black text-dark bg-accent-strong px-2 py-0.5 hover:underline"
+                                        className="font-bold hover:underline"
                                     >
                                         {pageCopy.discordDesc2Link}
                                     </a>


### PR DESCRIPTION
- Drops the "the code, the roadmap, the conversations" clause from the Community page subtitle
- Removes the yellow chip styling from the Discord `#pollen-beta` link — now just bold inline text with hover underline