### PR TITLE
fix(quest): drop post-merge miss-comment from payout resolver

### DIFF
--- a/.github/scripts/quest-reward-payout.js
+++ b/.github/scripts/quest-reward-payout.js
@@ -43,11 +43,6 @@ async function resolveLinkedQuest({ github, context, core }) {
     if (!issue) {
         core.setOutput("quest", "");
         core.info("Linked POLLEN-QUEST issue: (none)");
-        await github.rest.issues.createComment({
-            ...repo(context),
-            issue_number: pr.number,
-            body: `@${process.env.QUEST_PAYOUT_FALLBACK} this PR merged with no linked \`POLLEN-QUEST\` issue. If it was a quest, link the issue via the PR sidebar or add \`Fixes #N\` to the body, then back-fill manually with \`enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts\`.`,
-        });
         return;
     }
 

--- a/.github/workflows/quest-reward-payout.yml
+++ b/.github/workflows/quest-reward-payout.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
+  pull-requests: read
   contents: read
 
 env:
@@ -30,8 +30,6 @@ jobs:
       - name: Resolve linked quest
         id: linked
         uses: actions/github-script@v7
-        env:
-          QUEST_PAYOUT_FALLBACK: ${{ env.QUEST_PAYOUT_FALLBACK }}
         with:
           github-token: ${{ steps.token.outputs.token }}
           script: |


### PR DESCRIPTION
## Summary
- Drop the post-merge \"no quest linked\" fallback ping from #10948.
- Revert workflow's \`pull-requests: write\` back to \`read\` (no longer needed).

## Why
Codex review on #10948 flagged it: the ping fires on every non-quest merge (it fired on #10948 itself). Post-merge nag is also closing the barn door after the horse — payout is gone, idempotency means no replay.

Prevention belongs pre-merge in the maintainer triage habit (glance at PR sidebar, click \"Link an issue\" if missing). Recovery stays the manual back-fill we just used for CloudCompile/#10920. Keeps everything simple.

## Test plan
- [x] Resolver still returns the linked quest when `Fixes #N` or sidebar link is present.
- [x] On miss, workflow ends green like it did before #10948.
- [x] \`npx biome check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)