### PR TITLE
feat(ltx-2): add image-to-video input

### DIFF
--- a/apps/apps.json
+++ b/apps/apps.json
@@ -87,6 +87,13 @@
         "title": "Pollinations × OpenClaw",
         "description": "Use 25+ AI models as your OpenClaw brain through Pollinations' unified API"
     },
+    "voice-edit": {
+        "subdomain": "voice-edit",
+        "buildCommand": null,
+        "outputDir": ".",
+        "title": "Voice Edit",
+        "description": "Point at an image, speak or type an edit, and apply it with Pollinations"
+    },
     "slidepainter": {
         "subdomain": "slidepainter",
         "buildCommand": "npm run build",

--- a/apps/voice-edit-image/README.md
+++ b/apps/voice-edit-image/README.md
@@ -1,0 +1,54 @@
+# voice-edit-image
+
+Minimal image-only voice editor. Draw on an image, speak or type the edit, release. No video mode.
+
+## stack
+
+| layer | choice | notes |
+|---|---|---|
+| app | single `index.html` | no build step, no React |
+| UI | vanilla HTML/CSS/JS | modern browsers only |
+| auth | Pollinations OAuth | `api_key` URL fragment -> `localStorage["voice-edit:user-key"]` |
+| balance | `GET /account/balance` | shown in header, refreshed after successful edit |
+| STT | `POST /v1/audio/transcriptions`, `model=scribe` | ElevenLabs Scribe v2 |
+| edit | `POST /v1/images/edits` | OpenAI-compatible `{ prompt, image, model, response_format: "url" }` |
+| upload | `POST media.pollinations.ai/upload` | uploads composed PNG snapshot |
+| starter | detailed human-cell render | `media.pollinations.ai/10efdd0c1cfc65fa` |
+
+## interaction
+
+- One gesture: pointerdown -> draw/speak -> pointerup -> transcribe -> edit.
+- Drag path >= `3% * min(width,height)` = marked edit.
+- Marker is a pure opaque stroke in selected `markerColor`: red, black, or white.
+- No-drag click = no marker; prompt is sent as a global instruction.
+- Type mode uses the same gesture: draw first, release, type prompt.
+- Completed gestures enqueue as FIFO jobs.
+- Queued jobs store a transparent marker-overlay PNG; `runQueue()` composites that overlay onto the latest image just before upload, so queued edits chain from prior results.
+- Undo/redo is a linear image history. Editing from an older frame truncates later frames.
+
+## prompt
+
+- Marked: `The {color} markings indicate the area the prompt is referring to. Prompt: {text}. Output without {color} markings.`
+- Unmarked: `{text}`
+
+## architecture
+
+- `imageCanvas`: clean current image.
+- `markCanvas`: live freehand drawing only.
+- `pinLayer`: DOM label anchored to click point or rightmost mark edge.
+- `composeSnapshot(marker)`: offscreen PNG composition; draws marker overlay only when present.
+- `mediaHistory`: linear image history (`add`, `go`, `set`, `canUndo`, `canRedo`).
+- `app`: single state object for image, history, auth account data, mic stream, active gesture, FIFO queue, current job, marker color.
+
+## local
+
+```bash
+cd apps/voice-edit-image
+python3 -m http.server 8766
+# http://localhost:8766/
+```
+
+## sibling
+
+- `apps/voice-edit`: richer version with video experiments.
+- `apps/voice-edit-image`: minimal image-only version. Keep it boring.

--- a/apps/voice-edit-image/index.html
+++ b/apps/voice-edit-image/index.html
@@ -1,0 +1,1047 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --card: #fffaf2;
+    --line: #110518;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --primary: #c9a9e4;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  button, input, select { font: inherit; color: inherit; }
+  button { touch-action: manipulation; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .btn, .select {
+    min-height: 38px;
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    border-radius: 0;
+    font-weight: 700;
+  }
+  .btn {
+    padding: 0 12px;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); border-right-width: 3px; border-bottom-width: 3px; }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); border-right-width: 2px; border-bottom-width: 2px; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; max-width: min(100%, 20rem); }
+
+  .type-mode {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    user-select: none;
+  }
+  .history { margin-left: auto; }
+
+  .swatches {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .swatch {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 2px solid var(--line);
+    border-radius: 0;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    cursor: pointer;
+  }
+  .swatch.active { outline-color: var(--accent); }
+  .swatch[data-color="white"] { background: #fff; }
+  .swatch[data-color="black"] { background: #000; }
+  .swatch[data-color="red"] { background: red; }
+
+  .frame {
+    position: relative;
+    min-height: 280px;
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    overflow: auto;
+    display: grid;
+    place-items: center;
+  }
+  .frame.drop { outline: 4px dashed var(--accent); outline-offset: -10px; }
+  .stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    max-height: calc(100vh - 210px);
+    touch-action: none;
+  }
+  .stage canvas {
+    display: block;
+    max-width: 100%;
+    max-height: calc(100vh - 210px);
+    width: auto;
+    height: auto;
+  }
+  #markCanvas, #pinLayer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  #pinLayer { z-index: 3; pointer-events: none; }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(243, 235, 222, 0.88);
+    backdrop-filter: blur(2px);
+  }
+  .frame.locked .overlay { display: flex; }
+  .overlay-panel {
+    width: min(22rem, calc(100% - 32px));
+    padding: 18px;
+    text-align: center;
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+  }
+  .overlay-panel p { margin: 0 0 12px; font-size: 0.9rem; }
+
+  .pin {
+    position: absolute;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    max-width: min(16rem, 48vw);
+    width: max-content;
+    padding: 5px 9px;
+    transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    font-size: 0.75rem;
+    line-height: 1.25;
+    overflow-wrap: break-word;
+  }
+  .pin.processing { background: var(--accent); }
+  .pin .dot {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    background: var(--line);
+    border: 1.5px solid var(--line);
+  }
+  .pin span:last-child { min-width: 0; }
+
+  .pill {
+    position: fixed;
+    z-index: 20;
+    display: none;
+    align-items: center;
+    gap: 9px;
+    max-width: min(18rem, calc(100vw - 24px));
+    padding: 8px 12px 8px 8px;
+    transform: translate(18px, -50%);
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    pointer-events: none;
+    overflow-wrap: anywhere;
+  }
+  .pill.visible { display: inline-flex; }
+  .pill .mic {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: var(--accent);
+    border: 2px solid var(--line);
+  }
+  .pill .bar {
+    width: 3px;
+    background: var(--line);
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  .pill .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  .pill .bar:nth-child(2) { height: 10px; animation-delay: 0.15s; }
+  .pill .bar:nth-child(3) { height: 6px; animation-delay: 0.3s; }
+  .pill .placeholder { opacity: 0.55; font-style: italic; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+
+  @media (max-width: 720px) {
+    .app { width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .topbar { gap: 6px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .history { margin-left: 0; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .frame { min-height: 240px; }
+    .stage, .stage canvas { max-height: calc(100vh - 260px); }
+    .pin { max-width: 62vw; }
+  }
+  .frame.locked .stage { filter: grayscale(0.35) opacity(0.55); }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit</h1>
+      <span class="tagline">draw. talk. release.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="tools">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="uploadBtn" class="btn">image</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="image model">
+        <option value="nanobanana">nanobanana</option>
+      </select>
+      <div id="colorPicker" class="swatches" aria-label="marker color">
+        <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
+        <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
+        <button type="button" class="swatch" data-color="white" aria-label="white marker"></button>
+      </div>
+      <label class="type-mode"><input id="typeMode" type="checkbox"> type instead</label>
+      <button id="undoBtn" class="btn history" disabled title="undo">undo</button>
+      <button id="redoBtn" class="btn" disabled title="redo">redo</button>
+      <button id="downloadBtn" class="btn" title="download">save</button>
+    </section>
+
+    <section id="frame" class="frame">
+      <div id="stage" class="stage">
+        <canvas id="imageCanvas" width="1024" height="768"></canvas>
+        <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <div id="pinLayer"></div>
+      </div>
+      <div class="overlay">
+        <div class="overlay-panel">
+          <p>connect to pollinations to start editing</p>
+          <button id="connectOverlayBtn" class="btn accent">connect</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div id="cursorPill" class="pill" aria-hidden="true">
+    <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
+    <span id="pillText" class="placeholder">listening...</span>
+  </div>
+
+<script>
+const KEY_STORAGE = "voice-edit:user-key";
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const STARTER = "https://media.pollinations.ai/10efdd0c1cfc65fa";
+const STT_MODEL = "scribe";
+const STT_LANG = (navigator.language || "en").slice(0, 2);
+const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+  .find((m) => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+const DRAG_THRESHOLD = 0.03;
+const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+
+const els = {
+  account: document.getElementById("account"),
+  status: document.getElementById("status"),
+  error: document.getElementById("error"),
+  frame: document.getElementById("frame"),
+  stage: document.getElementById("stage"),
+  imageCanvas: document.getElementById("imageCanvas"),
+  markCanvas: document.getElementById("markCanvas"),
+  pinLayer: document.getElementById("pinLayer"),
+  connect: document.getElementById("connectBtn"),
+  connectOverlay: document.getElementById("connectOverlayBtn"),
+  upload: document.getElementById("uploadBtn"),
+  file: document.getElementById("fileInput"),
+  model: document.getElementById("modelSel"),
+  typeMode: document.getElementById("typeMode"),
+  undo: document.getElementById("undoBtn"),
+  redo: document.getElementById("redoBtn"),
+  download: document.getElementById("downloadBtn"),
+  colorPicker: document.getElementById("colorPicker"),
+  pill: document.getElementById("cursorPill"),
+  pillText: document.getElementById("pillText"),
+};
+const imageCtx = els.imageCanvas.getContext("2d");
+const markCtx = els.markCanvas.getContext("2d");
+
+const app = {
+  image: null,
+  imageURL: "",
+  current: null,
+  history: [],
+  historyIndex: -1,
+  micStream: null,
+  active: null,
+  busy: false,
+  queue: [],
+  currentJob: null,
+  markerColor: "red",
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+function render() {
+  const locked = app.busy || Boolean(app.active);
+  els.undo.disabled = !mediaHistory.canUndo() || locked;
+  els.redo.disabled = !mediaHistory.canRedo() || locked;
+  els.upload.disabled = locked;
+  els.model.disabled = locked;
+  els.typeMode.disabled = locked;
+  renderPins();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function renderPins() {
+  els.pinLayer.innerHTML = "";
+  const jobs = [app.currentJob, ...app.queue].filter(Boolean);
+  const layerBox = els.pinLayer.getBoundingClientRect();
+  for (const job of jobs) {
+    const pin = document.createElement("div");
+    pin.className = `pin ${job === app.currentJob ? "processing" : "queued"}`;
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    const text = document.createElement("span");
+    text.textContent = job.text;
+    pin.append(dot, text);
+    pin.style.left = `${job.xPct}%`;
+    pin.style.top = `${job.yPct}%`;
+    els.pinLayer.append(pin);
+    const anchorX = layerBox.left + (layerBox.width * job.xPct / 100);
+    const available = window.innerWidth - anchorX - 12;
+    pin.style.maxWidth = `${Math.min(256, Math.max(28, available))}px`;
+  }
+}
+
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) els.pill.style.left = `${x}px`;
+  if (y != null) els.pill.style.top = `${y}px`;
+  if (text !== undefined) {
+    els.pillText.textContent = text;
+    els.pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) els.pill.classList.toggle("visible", visible);
+}
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (apiKey) {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    history.replaceState(null, "", location.pathname + location.search);
+  } else if (params.get("error")) {
+    showError(`Authorization failed: ${params.get("error")}`);
+  }
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  els.frame.classList.toggle("locked", !connected);
+  if (!connected) {
+    app.accountUser = "";
+    app.accountBalance = null;
+    renderAccount();
+    setStatus("not connected");
+    return;
+  }
+  renderAccount();
+  warmMic();
+  loadUser();
+  loadBalance();
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  stopMic();
+  refreshConnectionUI();
+}
+
+async function loadUser() {
+  try {
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${key()}` } });
+    if (!res.ok) return;
+    const user = await res.json();
+    app.accountUser = user?.preferred_username || "";
+    renderAccount();
+  } catch {}
+}
+
+async function loadBalance() {
+  try {
+    const res = await fetch(`${BASE}/account/balance`, { headers: { Authorization: `Bearer ${key()}` } });
+    if (!res.ok) return;
+    const { balance } = await res.json();
+    app.accountBalance = Number(balance);
+    renderAccount();
+  } catch {}
+}
+
+async function warmMic() {
+  if (app.micStream || !navigator.mediaDevices?.getUserMedia) return;
+  try {
+    app.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+  } catch (err) {
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use type instead.`);
+  }
+}
+
+function stopMic() {
+  if (!app.micStream) return;
+  for (const track of app.micStream.getTracks()) track.stop();
+  app.micStream = null;
+}
+
+const mediaHistory = {
+  canUndo: () => app.historyIndex > 0,
+  canRedo: () => app.historyIndex >= 0 && app.historyIndex < app.history.length - 1,
+  add(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    app.current = frame;
+    render();
+  },
+  async go(index) {
+    const frame = app.history[index];
+    if (!frame) return;
+    await renderFrame(frame);
+    app.historyIndex = index;
+    app.current = frame;
+    render();
+  },
+  async set(frame, { add = false } = {}) {
+    await renderFrame(frame);
+    if (add) mediaHistory.add(frame);
+    else {
+      app.current = frame;
+      render();
+    }
+  },
+};
+
+async function loadModels() {
+  try {
+    const res = await fetch(`${BASE}/image/models`);
+    if (!res.ok) return;
+    const models = await res.json();
+    const editModels = models
+      .filter((m) => m.input_modalities?.includes("image") && m.output_modalities?.includes("image"))
+      .sort((a, b) => {
+        const ra = RECOMMENDED_MODELS.has(a.name) ? 0 : 1;
+        const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
+        return ra - rb || a.name.localeCompare(b.name);
+      });
+    els.model.innerHTML = "";
+    for (const m of editModels) {
+      const option = document.createElement("option");
+      option.value = m.name;
+      const tags = [];
+      if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
+      if (m.paid_only) tags.push("paid");
+      option.textContent = tags.length ? `${m.name} (${tags.join(", ")})` : m.name;
+      els.model.append(option);
+    }
+    if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+  } catch {}
+}
+
+async function loadImage(src, { addToHistory = false } = {}) {
+  clearError();
+  if (src instanceof File) src = await readImageFile(src);
+  await mediaHistory.set({ url: src }, { add: addToHistory });
+}
+
+async function renderFrame(frame) {
+  clearError();
+  await drawImage(frame.url);
+  clearMarks();
+  setStatus("ready");
+}
+
+async function drawImage(src) {
+  setStatus("loading image...");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = () => reject(new Error("could not load image"));
+    img.src = src;
+  });
+  app.image = img;
+  app.imageURL = src;
+  resizeCanvases(img.naturalWidth, img.naturalHeight);
+  imageCtx.drawImage(img, 0, 0);
+}
+
+function readImageFile(file) {
+  if (!file?.type?.startsWith("image/")) throw new Error("Drop or pick an image file.");
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("Could not read file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+function resizeCanvases(width, height) {
+  for (const canvas of [els.imageCanvas, els.markCanvas]) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function clearMarks() {
+  markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function pointerPoint(event) {
+  const rect = els.markCanvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
+  const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
+  return {
+    x: Math.max(0, Math.min(els.markCanvas.width, Math.round(x))),
+    y: Math.max(0, Math.min(els.markCanvas.height, Math.round(y))),
+  };
+}
+
+function strokeWidth() {
+  return Math.max(6, Math.round(Math.min(els.markCanvas.width, els.markCanvas.height) * 0.015));
+}
+
+function drawSegment(from, to) {
+  markCtx.save();
+  markCtx.strokeStyle = app.markerColor;
+  markCtx.lineWidth = strokeWidth();
+  markCtx.lineCap = "round";
+  markCtx.lineJoin = "round";
+  markCtx.beginPath();
+  markCtx.moveTo(from.x, from.y);
+  markCtx.lineTo(to.x, to.y);
+  markCtx.stroke();
+  markCtx.restore();
+}
+
+function pathLength(points) {
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    total += Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
+  }
+  return total;
+}
+
+function pathBounds(points) {
+  const bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity };
+  for (const point of points) {
+    bounds.minX = Math.min(bounds.minX, point.x);
+    bounds.maxX = Math.max(bounds.maxX, point.x);
+    bounds.minY = Math.min(bounds.minY, point.y);
+    bounds.maxY = Math.max(bounds.maxY, point.y);
+  }
+  return bounds;
+}
+
+function markerFromGesture(gesture) {
+  const marked = pathLength(gesture.points) >= Math.min(els.markCanvas.width, els.markCanvas.height) * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const marker = marked ? els.markCanvas.toDataURL("image/png") : "";
+  const bounds = marked ? pathBounds(gesture.points) : null;
+  const pinPoint = marked
+    ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 }
+    : gesture.points[0];
+  return { marked, marker, pinPoint };
+}
+
+async function composeSnapshot(marker = "") {
+  const out = document.createElement("canvas");
+  out.width = els.imageCanvas.width;
+  out.height = els.imageCanvas.height;
+  const outCtx = out.getContext("2d");
+  outCtx.drawImage(els.imageCanvas, 0, 0);
+  if (marker) {
+    const markerImage = await loadImageElement(marker);
+    outCtx.drawImage(markerImage, 0, 0, out.width, out.height);
+  }
+  return out.toDataURL("image/png");
+}
+
+function buildPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
+}
+
+function pinPct(point) {
+  return {
+    xPct: (point.x / els.markCanvas.width) * 100,
+    yPct: (point.y / els.markCanvas.height) * 100,
+  };
+}
+
+function loadImageElement(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load marker"));
+    img.src = src;
+  });
+}
+
+function enqueueJob({ text, marked = false, marker = "", pinPoint, color }) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  const pin = pinPct(pinPoint);
+  app.queue.push({
+    text,
+    marked,
+    marker,
+    color,
+    model: els.model.value,
+    xPct: pin.xPct,
+    yPct: pin.yPct,
+  });
+  render();
+  runQueue();
+}
+
+function beginRecording(clientX, clientY) {
+  clearError();
+  if (!window.MediaRecorder) return { error: "Voice input is not available in this browser. Use type instead." };
+  if (!app.micStream) {
+    warmMic();
+    return { error: "microphone not ready - click once, allow access, then try again" };
+  }
+  const capture = { chunks: [], recorder: null, error: "" };
+  try {
+    capture.recorder = new MediaRecorder(app.micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (event) => {
+      if (event.data?.size) capture.chunks.push(event.data);
+    };
+    capture.recorder.start();
+  } catch (err) {
+    capture.error = err?.message || "could not start recording";
+    return capture;
+  }
+  pill({ x: clientX, y: clientY, text: "listening...", placeholder: true, visible: true });
+  setStatus("listening...");
+  return capture;
+}
+
+async function stopAndTranscribe(capture) {
+  if (capture.error || !capture.recorder) return { text: "", error: capture.error };
+  setStatus("transcribing...");
+  pill({ text: "transcribing...", placeholder: true });
+  const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
+  capture.recorder.stop();
+  await stopped;
+  const type = capture.recorder.mimeType || "audio/webm";
+  const ext = type.includes("mp4") ? "mp4" : "webm";
+  const blob = new Blob(capture.chunks, { type });
+  if (blob.size < 1000) return { text: "", error: "no audio captured - hold and speak" };
+  const form = new FormData();
+  form.append("file", blob, `voice.${ext}`);
+  form.append("model", STT_MODEL);
+  form.append("language", STT_LANG);
+  form.append("response_format", "json");
+  try {
+    const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key()}` },
+      body: form,
+    });
+    if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
+    const json = await res.json();
+    return { text: (json.text || "").trim(), error: "" };
+  } catch (err) {
+    return { text: "", error: err?.message || "transcription failed" };
+  }
+}
+
+async function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  els.pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing...");
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (text) => {
+      if (done) return;
+      done = true;
+      input.replaceWith(els.pillText);
+      pill({ visible: false });
+      resolve(text.trim());
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") { event.preventDefault(); finish(input.value); }
+      if (event.key === "Escape") { event.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value));
+  });
+}
+
+async function uploadDataURL(dataURL, filename = "annot.png") {
+  setStatus("uploading...");
+  const blob = await (await fetch(dataURL)).blob();
+  const form = new FormData();
+  form.append("file", blob, filename);
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key()}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+async function runEdit(imageURL, prompt, model) {
+  const res = await fetch(`${BASE}/v1/images/edits`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key()}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
+  const json = await res.json();
+  const item = json.data?.[0];
+  if (!item) throw new Error("no image in response");
+  if (item.url) return item.url;
+  if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
+  throw new Error("no url or b64_json in response");
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+async function runQueue() {
+  if (app.busy) return;
+  app.busy = true;
+  render();
+  try {
+    while (app.queue.length) {
+      const job = app.queue.shift();
+      app.currentJob = job;
+      render();
+      setStatus(`editing... (${app.queue.length + 1} in queue)`);
+      try {
+        const snapshot = await composeSnapshot(job.marker);
+        const uploaded = await uploadDataURL(snapshot, "annot.png");
+        const prompt = buildPrompt(job.text, job.marked, job.color);
+        const result = await runEdit(uploaded, prompt, job.model);
+        await mediaHistory.set({ url: result }, { add: true });
+        await loadBalance();
+      } catch (err) {
+        showError(err.message);
+      } finally {
+        app.currentJob = null;
+        render();
+      }
+    }
+    setStatus("done");
+  } finally {
+    app.busy = false;
+    app.currentJob = null;
+    render();
+  }
+}
+
+function cancelGesture() {
+  if (app.active?.capture?.recorder?.state === "recording") {
+    try { app.active.capture.recorder.stop(); } catch {}
+  }
+  app.active = null;
+  clearMarks();
+  pill({ visible: false });
+  setStatus(app.busy ? "editing..." : "ready");
+  render();
+}
+
+els.markCanvas.addEventListener("pointerdown", async (event) => {
+  if (!app.image) { showError("Load an image first."); return; }
+  if (app.active) return;
+  event.preventDefault();
+  clearError();
+  clearMarks();
+  const start = pointerPoint(event);
+
+  if (els.typeMode.checked) {
+    app.active = { pointerId: event.pointerId, points: [start], typing: true, color: app.markerColor };
+    render();
+    try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+    return;
+  }
+
+  const capture = beginRecording(event.clientX, event.clientY);
+  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+});
+
+els.markCanvas.addEventListener("pointermove", (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  pill({ x: event.clientX, y: event.clientY });
+  const point = pointerPoint(event);
+  const prev = gesture.points[gesture.points.length - 1];
+  drawSegment(prev, point);
+  gesture.points.push(point);
+});
+
+els.markCanvas.addEventListener("pointerup", async (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  app.active = null;
+  if (gesture.typing) {
+    const annotation = markerFromGesture(gesture);
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    if (!text) {
+      clearMarks();
+      setStatus(app.busy ? "editing..." : "ready");
+      return;
+    }
+    try {
+      enqueueJob({ text, ...annotation, color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+      clearMarks();
+    }
+    return;
+  }
+  const annotation = markerFromGesture(gesture);
+  try {
+    const { text, error } = await stopAndTranscribe(gesture.capture);
+    pill({ visible: false });
+    if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    enqueueJob({ text, ...annotation, color: gesture.color });
+  } catch (err) {
+    showError(err.message);
+    clearMarks();
+  }
+});
+
+els.markCanvas.addEventListener("pointercancel", cancelGesture);
+
+els.connect.addEventListener("click", startConnect);
+els.connectOverlay.addEventListener("click", startConnect);
+els.upload.addEventListener("click", () => els.file.click());
+els.file.addEventListener("change", () => {
+  const file = els.file.files?.[0];
+  if (file) loadImage(file, { addToHistory: true }).catch((err) => showError(err.message));
+});
+
+els.colorPicker.addEventListener("click", (event) => {
+  const swatch = event.target.closest(".swatch");
+  if (!swatch) return;
+  app.markerColor = swatch.dataset.color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button === swatch);
+  }
+});
+
+for (const eventName of ["dragenter", "dragover"]) {
+  els.frame.addEventListener(eventName, (event) => {
+    event.preventDefault();
+    els.frame.classList.add("drop");
+  });
+}
+for (const eventName of ["dragleave", "drop"]) {
+  els.frame.addEventListener(eventName, (event) => {
+    event.preventDefault();
+    els.frame.classList.remove("drop");
+  });
+}
+els.frame.addEventListener("drop", (event) => {
+  const file = event.dataTransfer?.files?.[0];
+  if (file) loadImage(file, { addToHistory: true }).catch((err) => showError(err.message));
+});
+
+els.undo.addEventListener("click", () => {
+  if (!mediaHistory.canUndo() || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex - 1).then(() => setStatus("undone")).catch((err) => showError(err.message));
+});
+els.redo.addEventListener("click", () => {
+  if (!mediaHistory.canRedo() || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + 1).then(() => setStatus("redone")).catch((err) => showError(err.message));
+});
+els.download.addEventListener("click", () => {
+  try {
+    const link = document.createElement("a");
+    link.href = els.imageCanvas.toDataURL("image/png");
+    link.download = "voice-edit-image.png";
+    link.click();
+  } catch {
+    if (app.imageURL) window.open(app.imageURL, "_blank", "noopener");
+  }
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadModels();
+loadImage(STARTER, { addToHistory: true }).catch((err) => showError(err.message));
+for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+  button.classList.toggle("active", button.dataset.color === app.markerColor);
+}
+</script>
+</body>
+</html>

--- a/apps/voice-edit-image/index.html
+++ b/apps/voice-edit-image/index.html
@@ -338,35 +338,39 @@ const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
 const DRAG_THRESHOLD = 0.03;
 const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
 
-const els = {
-  account: document.getElementById("account"),
-  status: document.getElementById("status"),
-  error: document.getElementById("error"),
-  frame: document.getElementById("frame"),
-  stage: document.getElementById("stage"),
-  imageCanvas: document.getElementById("imageCanvas"),
-  markCanvas: document.getElementById("markCanvas"),
-  pinLayer: document.getElementById("pinLayer"),
-  connect: document.getElementById("connectBtn"),
-  connectOverlay: document.getElementById("connectOverlayBtn"),
-  upload: document.getElementById("uploadBtn"),
-  file: document.getElementById("fileInput"),
-  model: document.getElementById("modelSel"),
-  typeMode: document.getElementById("typeMode"),
-  undo: document.getElementById("undoBtn"),
-  redo: document.getElementById("redoBtn"),
-  download: document.getElementById("downloadBtn"),
-  colorPicker: document.getElementById("colorPicker"),
-  pill: document.getElementById("cursorPill"),
-  pillText: document.getElementById("pillText"),
-};
+const $ = (id) => document.getElementById(id);
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const pairs = (items) => items.slice(1).map((item, i) => [items[i], item]);
+const distance = (a, b) => Math.hypot(b.x - a.x, b.y - a.y);
+const minCanvasSide = () => Math.min(els.markCanvas.width, els.markCanvas.height);
+
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  frame: "frame",
+  imageCanvas: "imageCanvas",
+  markCanvas: "markCanvas",
+  pinLayer: "pinLayer",
+  connect: "connectBtn",
+  connectOverlay: "connectOverlayBtn",
+  upload: "uploadBtn",
+  file: "fileInput",
+  model: "modelSel",
+  typeMode: "typeMode",
+  undo: "undoBtn",
+  redo: "redoBtn",
+  download: "downloadBtn",
+  colorPicker: "colorPicker",
+  pill: "cursorPill",
+  pillText: "pillText",
+}).map(([key, id]) => [key, $(id)]));
 const imageCtx = els.imageCanvas.getContext("2d");
 const markCtx = els.markCanvas.getContext("2d");
 
 const app = {
   image: null,
   imageURL: "",
-  current: null,
   history: [],
   historyIndex: -1,
   micStream: null,
@@ -399,13 +403,13 @@ function key() {
   return token;
 }
 
+const authHeaders = (extra = {}) => ({ Authorization: `Bearer ${key()}`, ...extra });
+
 function render() {
   const locked = app.busy || Boolean(app.active);
   els.undo.disabled = !mediaHistory.canUndo() || locked;
   els.redo.disabled = !mediaHistory.canRedo() || locked;
-  els.upload.disabled = locked;
-  els.model.disabled = locked;
-  els.typeMode.disabled = locked;
+  [els.upload, els.model, els.typeMode].forEach((el) => { el.disabled = locked; });
   renderPins();
 }
 
@@ -424,11 +428,17 @@ function renderAccount() {
   els.account.append(button);
 }
 
+function setMarkerColor(color) {
+  app.markerColor = color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button.dataset.color === color);
+  }
+}
+
 function renderPins() {
-  els.pinLayer.innerHTML = "";
   const jobs = [app.currentJob, ...app.queue].filter(Boolean);
   const layerBox = els.pinLayer.getBoundingClientRect();
-  for (const job of jobs) {
+  els.pinLayer.replaceChildren(...jobs.map((job) => {
     const pin = document.createElement("div");
     pin.className = `pin ${job === app.currentJob ? "processing" : "queued"}`;
     const dot = document.createElement("span");
@@ -438,11 +448,11 @@ function renderPins() {
     pin.append(dot, text);
     pin.style.left = `${job.xPct}%`;
     pin.style.top = `${job.yPct}%`;
-    els.pinLayer.append(pin);
     const anchorX = layerBox.left + (layerBox.width * job.xPct / 100);
     const available = window.innerWidth - anchorX - 12;
-    pin.style.maxWidth = `${Math.min(256, Math.max(28, available))}px`;
-  }
+    pin.style.maxWidth = `${clamp(available, 28, 256)}px`;
+    return pin;
+  }));
 }
 
 function pill({ x, y, text, placeholder, visible }) {
@@ -501,7 +511,7 @@ function disconnect() {
 
 async function loadUser() {
   try {
-    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${key()}` } });
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
     if (!res.ok) return;
     const user = await res.json();
     app.accountUser = user?.preferred_username || "";
@@ -511,7 +521,7 @@ async function loadUser() {
 
 async function loadBalance() {
   try {
-    const res = await fetch(`${BASE}/account/balance`, { headers: { Authorization: `Bearer ${key()}` } });
+    const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
     if (!res.ok) return;
     const { balance } = await res.json();
     app.accountBalance = Number(balance);
@@ -543,7 +553,6 @@ const mediaHistory = {
     app.history = app.history.slice(0, app.historyIndex + 1);
     app.history.push(frame);
     app.historyIndex = app.history.length - 1;
-    app.current = frame;
     render();
   },
   async go(index) {
@@ -551,16 +560,12 @@ const mediaHistory = {
     if (!frame) return;
     await renderFrame(frame);
     app.historyIndex = index;
-    app.current = frame;
     render();
   },
   async set(frame, { add = false } = {}) {
     await renderFrame(frame);
     if (add) mediaHistory.add(frame);
-    else {
-      app.current = frame;
-      render();
-    }
+    else render();
   },
 };
 
@@ -576,16 +581,12 @@ async function loadModels() {
         const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
         return ra - rb || a.name.localeCompare(b.name);
       });
-    els.model.innerHTML = "";
-    for (const m of editModels) {
-      const option = document.createElement("option");
-      option.value = m.name;
+    els.model.replaceChildren(...editModels.map((m) => {
       const tags = [];
       if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
       if (m.paid_only) tags.push("paid");
-      option.textContent = tags.length ? `${m.name} (${tags.join(", ")})` : m.name;
-      els.model.append(option);
-    }
+      return new Option(tags.length ? `${m.name} (${tags.join(", ")})` : m.name, m.name);
+    }));
     if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
   } catch {}
 }
@@ -644,13 +645,13 @@ function pointerPoint(event) {
   const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
   const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
   return {
-    x: Math.max(0, Math.min(els.markCanvas.width, Math.round(x))),
-    y: Math.max(0, Math.min(els.markCanvas.height, Math.round(y))),
+    x: clamp(Math.round(x), 0, els.markCanvas.width),
+    y: clamp(Math.round(y), 0, els.markCanvas.height),
   };
 }
 
 function strokeWidth() {
-  return Math.max(6, Math.round(Math.min(els.markCanvas.width, els.markCanvas.height) * 0.015));
+  return Math.max(6, Math.round(minCanvasSide() * 0.015));
 }
 
 function drawSegment(from, to) {
@@ -667,33 +668,27 @@ function drawSegment(from, to) {
 }
 
 function pathLength(points) {
-  let total = 0;
-  for (let i = 1; i < points.length; i++) {
-    total += Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
-  }
-  return total;
+  return pairs(points).reduce((total, [a, b]) => total + distance(a, b), 0);
 }
 
 function pathBounds(points) {
-  const bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity };
-  for (const point of points) {
-    bounds.minX = Math.min(bounds.minX, point.x);
-    bounds.maxX = Math.max(bounds.maxX, point.x);
-    bounds.minY = Math.min(bounds.minY, point.y);
-    bounds.maxY = Math.max(bounds.maxY, point.y);
-  }
-  return bounds;
+  return points.reduce((bounds, point) => ({
+    minX: Math.min(bounds.minX, point.x),
+    maxX: Math.max(bounds.maxX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    maxY: Math.max(bounds.maxY, point.y),
+  }), { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity });
 }
 
-function markerFromGesture(gesture) {
-  const marked = pathLength(gesture.points) >= Math.min(els.markCanvas.width, els.markCanvas.height) * DRAG_THRESHOLD;
+function markerFromGesture({ points }) {
+  const marked = pathLength(points) >= minCanvasSide() * DRAG_THRESHOLD;
   if (!marked) clearMarks();
-  const marker = marked ? els.markCanvas.toDataURL("image/png") : "";
-  const bounds = marked ? pathBounds(gesture.points) : null;
-  const pinPoint = marked
-    ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 }
-    : gesture.points[0];
-  return { marked, marker, pinPoint };
+  const bounds = marked ? pathBounds(points) : null;
+  return {
+    marked,
+    marker: marked ? els.markCanvas.toDataURL("image/png") : "",
+    pinPoint: marked ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 } : points[0],
+  };
 }
 
 async function composeSnapshot(marker = "") {
@@ -788,7 +783,7 @@ async function stopAndTranscribe(capture) {
   try {
     const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${key()}` },
+      headers: authHeaders(),
       body: form,
     });
     if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
@@ -832,7 +827,7 @@ async function uploadDataURL(dataURL, filename = "annot.png") {
   form.append("file", blob, filename);
   const res = await fetch("https://media.pollinations.ai/upload", {
     method: "POST",
-    headers: { Authorization: `Bearer ${key()}` },
+    headers: authHeaders(),
     body: form,
   });
   if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
@@ -843,7 +838,7 @@ async function uploadDataURL(dataURL, filename = "annot.png") {
 async function runEdit(imageURL, prompt, model) {
   const res = await fetch(`${BASE}/v1/images/edits`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${key()}`, "Content-Type": "application/json" },
+    headers: authHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
   });
   if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
@@ -993,37 +988,31 @@ els.file.addEventListener("change", () => {
 els.colorPicker.addEventListener("click", (event) => {
   const swatch = event.target.closest(".swatch");
   if (!swatch) return;
-  app.markerColor = swatch.dataset.color;
-  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
-    button.classList.toggle("active", button === swatch);
-  }
+  setMarkerColor(swatch.dataset.color);
 });
 
-for (const eventName of ["dragenter", "dragover"]) {
-  els.frame.addEventListener(eventName, (event) => {
-    event.preventDefault();
-    els.frame.classList.add("drop");
-  });
-}
-for (const eventName of ["dragleave", "drop"]) {
-  els.frame.addEventListener(eventName, (event) => {
-    event.preventDefault();
-    els.frame.classList.remove("drop");
-  });
-}
+const setDrop = (drop) => (event) => {
+  event.preventDefault();
+  els.frame.classList.toggle("drop", drop);
+};
+["dragenter", "dragover"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(true));
+});
+["dragleave", "drop"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(false));
+});
 els.frame.addEventListener("drop", (event) => {
   const file = event.dataTransfer?.files?.[0];
   if (file) loadImage(file, { addToHistory: true }).catch((err) => showError(err.message));
 });
 
-els.undo.addEventListener("click", () => {
-  if (!mediaHistory.canUndo() || app.busy || app.active) return;
-  mediaHistory.go(app.historyIndex - 1).then(() => setStatus("undone")).catch((err) => showError(err.message));
-});
-els.redo.addEventListener("click", () => {
-  if (!mediaHistory.canRedo() || app.busy || app.active) return;
-  mediaHistory.go(app.historyIndex + 1).then(() => setStatus("redone")).catch((err) => showError(err.message));
-});
+const goHistory = (delta, label) => () => {
+  const canGo = delta < 0 ? mediaHistory.canUndo() : mediaHistory.canRedo();
+  if (!canGo || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + delta).then(() => setStatus(label)).catch((err) => showError(err.message));
+};
+els.undo.addEventListener("click", goHistory(-1, "undone"));
+els.redo.addEventListener("click", goHistory(1, "redone"));
 els.download.addEventListener("click", () => {
   try {
     const link = document.createElement("a");
@@ -1039,9 +1028,7 @@ captureKeyFromFragment();
 refreshConnectionUI();
 loadModels();
 loadImage(STARTER, { addToHistory: true }).catch((err) => showError(err.message));
-for (const button of els.colorPicker.querySelectorAll(".swatch")) {
-  button.classList.toggle("active", button.dataset.color === app.markerColor);
-}
+setMarkerColor(app.markerColor);
 </script>
 </body>
 </html>

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -1,0 +1,54 @@
+# Voice Edit
+
+> Click-and-hold on an image, speak your edit, release. The clicked spot is edited.
+
+A minimal clone of Google AI Studio's AI Pointer / Magic Pointer demo, built on Pollinations.
+
+## How to Use
+
+1. Open `index.html` in a browser (mic + clipboard permissions required)
+2. Click "Load starter image" or paste a URL
+3. Press-and-hold on the part you want to change
+4. While holding, say what you want — e.g. "make this a tabby cat" or "add a lamp here"
+5. Release — transcript appears, then the edited image swaps in (~7s)
+
+## How It Works
+
+```
+click+hold ── MediaRecorder ──┐
+                              │
+release ──┐                   │
+          ▼                   ▼
+ POST /v1/audio/transcriptions (whisper)
+          │
+          ▼
+ annotate canvas (red circle at click pt)
+          │
+          ▼
+ upload to media.pollinations.ai
+          │
+          ▼
+ POST /v1/images/edits (kontext)
+          │
+          ▼
+ swap canvas → result
+```
+
+The red circle burned into the pixels at the click point IS the spatial grounding signal — no bbox call needed. Kontext (FLUX.1 Kontext) respects the annotation reliably.
+
+## Models
+
+- **Edit**: `kontext` (fast, obeys the red-circle marker). Fallback: `nanobanana-2`.
+- **STT**: `whisper`. Fallback: `universal-2`.
+
+## API
+
+- `POST https://gen.pollinations.ai/v1/audio/transcriptions` — multipart, `file` + `model`
+- `POST https://media.pollinations.ai/upload` — multipart `file`
+- `POST https://gen.pollinations.ai/v1/images/edits` — JSON `{prompt, image, model}`
+
+Auth: `Authorization: Bearer <app-key>` (create one at https://enter.pollinations.ai). The key is stored in your browser's `localStorage` — never bundled in source.
+
+---
+
+Made with pollinations.ai

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -1,60 +1,119 @@
-# Voice Edit
+# voice-edit
 
-> Click-and-hold on an image, speak your edit, release. The clicked spot is edited.
+Voice-driven image editor. Click-and-hold on image, speak edit, release. Red ring burned at click point → uploaded → `/v1/images/edits` → canvas swap.
 
-A minimal clone of Google AI Studio's AI Pointer / Magic Pointer demo, built on Pollinations.
+- Single self-contained `index.html`. No build step.
+- Vanilla JS + Tailwind CDN.
+- BYOP auth via Pollinations OAuth (`enter.pollinations.ai`).
 
-## How to Use
+## stack
 
-1. Open `index.html` in a browser (mic + clipboard permissions required)
-2. Click "Load starter image" or paste a URL
-3. Press-and-hold on the part you want to change
-4. While holding, say what you want — e.g. "make this a tabby cat" or "add a lamp here"
-5. Release — transcript appears, then the edited image swaps in (~7s)
+| layer | choice | notes |
+|---|---|---|
+| auth | `enter.pollinations.ai/authorize` device flow | `api_key` in URL fragment → `localStorage["voice-edit:user-key"]` |
+| edit | `POST /v1/images/edits` (OpenAI-compat) | `{prompt, image: url, model, response_format: "url"}` |
+| STT | `POST /v1/audio/transcriptions`, model=`whisper` | OVH Whisper-large-v3. Tried `universal-2` (AssemblyAI) — worse on short utterances. |
+| upload | `POST media.pollinations.ai/upload` | annotated PNG before /edits |
+| default edit model | `nanobanana` | Gemini 2.5 Flash Image. Recommended: `nanobanana`, `p-image-edit`, `kontext`, `gpt-image-2`. |
+| starter image | Merian banana flower (PD) | `media.pollinations.ai/051ed82a46f5f85d` |
 
-## How It Works
+## marker
 
+Single gesture chooses shape by path length on `pointerup`:
+
+- **Click (path < 3% min(w,h))** → thin red outline ring at click point. Radius ~5% of min(w,h), stroke ~18% of radius, alpha 0.55.
+- **Drag (path ≥ 3% min(w,h))** → freehand red stroke live-painted during pointermove. Width ~1.5% of min(w,h), alpha 0.35, round caps/joins. Pin position = path centroid.
+- Canvas reset to source image immediately after snapshotting the annotation, so a stray stroke from gesture N never leaks into the snapshot for gesture N+1.
+- No fill, no text label, no multi-stroke aggregation. One pointerdown→up = one edit. Pointerdown is blocked while a previous edit is still running.
+- Speech and drawing run concurrently; pointerup ends both.
+- Prompt: `The red markings indicate the area the prompt is referring to. Prompt: {text}. Output without red markings.` Marker is deictic, `Prompt:` label disambiguates which part is the instruction, suppression suffix prevents bleed-through. Model decides whether instruction is local-edit / replace / reframe / reference. See `buildEditPrompt(text)`.
+
+## STT config (whisper, working)
+
+- **Pre-warm `getUserMedia` on connect**, keep mic stream alive. Without this, first 200-500ms cut off.
+- **Force MIME**: `audio/webm;codecs=opus` (Chrome) / `audio/mp4` (Safari). File extension must match codec.
+- **Pass `language` = `navigator.language.slice(0,2)`**. Whisper hallucinates language on short clips without it.
+- **Audio constraints**: `echoCancellation`, `noiseSuppression`, `autoGainControl` all true.
+- Latency ~1-2s post-release. Acceptable for this UX.
+
+## known issues / todos
+
+priority order:
+
+1. **[DONE 2026-05-15] Click + freehand region.** Click → auto-ring, drag → freehand stroke. Live-painted during pointermove, snapshotted at pointerup, canvas reset before transcription.
+2. **[DONE 2026-05-15] Pin positions stored as `{xPct, yPct}` fractions** of canvas at click time. Fixes drift when edit result returns at a different resolution. Still imperfect if model reframes the image content — true fix is to pass `size` to `/v1/images/edits` (gateway issue #10944).
+3. **[FEAT] Two-image pattern.** Send clean original + annotated copy, prompt "Image 2 marks edit region in Image 1." Research suggests biggest mitigation for marker bleed-through. Blocked: need to verify `/v1/images/edits` accepts multiple images. Deferred.
+4. **[FEAT] Multi-region labelling.** SoM-style numeric labels (1/2/3) on multiple strokes so user can say "make 1 a hat, 2 sunglasses". Speculative — SoM is proven on understanding models, not editing. Deferred.
+5. **[ENH] Mobile.** iOS Safari pointer events untested. Pinch-zoom + canvas interaction likely fragile.
+6. **[ENH] STT model selector.** UI dropdown to A/B `whisper` / `scribe` / `universal-2` / `universal-3-pro`.
+7. **[ENH] Deployment.** Not deployed. Currently localhost-only via `python3 -m http.server 8765`.
+
+## architecture
+
+- ~770 lines, single file, flat module scope.
+- State (module-level): `currentImage`, `currentImageURL`, `activeCapture`, `undoStack`, `redoStack`, `editQueue`, `queueRunning`, `micStream`.
+- `render()` — single function, called after every state mutation. Redraws pins + history button enabled state. Don't add ad-hoc DOM updates from mutation sites.
+- `pill({x, y, text, placeholder, visible})` — partial-state setter for cursor-anchored speech indicator.
+- `resetCanvas()` — synchronously redraws `currentImage` onto the canvas. Called at the *start* of each pointerdown so a stale marker from a prior gesture never leaks into the new gesture's snapshot. Async `loadImageFromURL` is not safe for this because the next pointerdown can fire before it resolves.
+- Pointer flow: down → block if `queueRunning || editQueue.length` → `resetCanvas()` → `startIntentCapture` (MediaRecorder) + show pill + init `capture.stroke = [point]` → move → live-paint stroke segment + push to `capture.stroke` → up → classify (click vs drag) → if click: `drawRing` → snapshot annotated canvas to dataURL → `stopIntentCapture` → `enqueueEdit({point, text, annotated})` → `runQueue` (upload snapshot → /v1/images/edits → swap canvas). Marker stays visible on-screen from pointerup through edit completion.
+
+## intentional non-changes
+
+Things that look redundant but are load-bearing. Don't simplify:
+
+- `pointercancel` handler — iOS fires on scroll interrupt; leaks `activeCapture` without it.
+- `setPointerCapture` on pointerdown — lets `pointerup` fire on canvas after dragging off (wrapped in try/catch for Playwright synth events).
+- `try { recorder.start() } catch` — MediaRecorder throws synchronously on permission issues.
+- `resetCanvas()` at pointerdown (not pointerup) — keeps marker visible during edit but still wipes before next snapshot.
+
+## research provenance
+
+| claim | source | strength |
+|---|---|---|
+| Red beats blue/purple/green | RedCircle, Shtedritski et al., ICCV 2023 (arxiv:2304.06712) Table 2 | **CLIP only**, not edit models |
+| Outline ring optimal at radius 12px / stroke 4px @ 224px | RedCircle Table 10, Fig 10 | CLIP only |
+| Labels improve grounding (84.4 → 89.2 adding boxes to num+mask) | Set-of-Marks, Yang et al., arxiv:2310.11441 Table 3 | **GPT-4V only**, understanding |
+| Scribbles/arrows/ellipses as visual prompts | ViP-LLaVA, Cai et al., CVPR 2024 (arxiv:2312.00784) | trained model, understanding |
+| FLUX Kontext "supports intuitive editing through visual cues, responding to geometric markers like red ellipses" | FLUX.1 Kontext §4.4 (arxiv:2506.15742) | **edit model**, no shape ablation |
+| Gemini app: freehand pen, single annotated image, no mask, multi-stroke OK | 9to5Google + Tom's Guide Dec 2025 teardowns | product, no paper |
+| Bleed-through is dominant failure | our May 13 empirical session ("HERE" labels bled through) | observation |
+
+No academic paper exists for DeepMind's "AI Pointer" (the inspiration). Product principles essay by Adrien Baranes + Rob Marchant; no arxiv.
+
+## refactor history
+
+5 simplifications applied 2026-05-14:
+
+- 4 pill helpers → 1 `pill(state)` setter
+- 2 annotate helpers + offscreen canvas → 1 `annotateAndCapture`
+- Module `clickPoint` baton → stored on capture object
+- 6 scattered render-calls → 1 `render()`
+- `loadLocalFile` + `loadImageFromURL` → unified `loadImage(File|URL)`
+
+## deploy
+
+Not deployed. Local:
+
+```bash
+cd apps/voice-edit
+python3 -m http.server 8765
+# http://localhost:8765/
 ```
-click+hold ── browser speech recognition or typed prompt
-          │
-          ▼
- annotate canvas (red circle at click pt)
-          │
-          ▼
- upload to media.pollinations.ai
-          │
-          ▼
- POST /v1/images/edits (kontext)
-          │
-          ▼
- swap canvas → result
-```
 
-The red circle burned into the pixels at the click point IS the spatial grounding signal — no bbox call needed. Kontext (FLUX.1 Kontext) respects the annotation reliably.
-
-## Models
-
-- **Edit**: `kontext` (fast, obeys the red-circle marker). Fallback: `nanobanana-2`.
-- **Voice input**: browser-native speech recognition, with typed prompt fallback. No server STT call is required.
-
-## API
-
-- `POST https://media.pollinations.ai/upload` — multipart `file`
-- `POST https://gen.pollinations.ai/v1/images/edits` — JSON `{prompt, image, model}`
-
-Auth: **BYOP** (Bring Your Own Pollen). On first use, the app redirects to `enter.pollinations.ai/authorize?client_id=pk_<voice_edit_app_key>` — the user approves and returns with a scoped `sk_user_*` key in the URL fragment. The key spends the user's Pollen, not ours. The `pk_` App Key in source is just an identifier; only the user's returned `sk_` is sensitive (stored in their browser's `localStorage`).
-
-### App key registration (one-time, by the app owner)
+OAuth `redirect_uri` = `location.origin + location.pathname`. Works on `localhost:*` and any origin registered with enter.pollinations.ai. To register an App Key set `CLIENT_ID` constant at top of script:
 
 ```bash
 curl -X POST https://gen.pollinations.ai/account/keys \
   -H 'Authorization: Bearer <your_sk_>' \
   -H 'Content-Type: application/json' \
-  -d '{"name":"Voice Edit","type":"publishable","redirectUris":["https://voice-edit.pollinations.ai/"],"earningsEnabled":true,"models":["kontext","nanobanana-2"]}'
+  -d '{"name":"Voice Edit","type":"publishable","redirectUris":["https://voice-edit.pollinations.ai/"],"earningsEnabled":true,"models":["nanobanana","kontext"]}'
 ```
 
-Paste the returned `pk_…` into `CLIENT_ID` in `index.html`. With `earningsEnabled:true`, the app owner earns 25% of each user's spend in the app.
+`earningsEnabled:true` → app owner earns 25% of users' Pollen spend.
 
----
+## dev rules
 
-Made with pollinations.ai
+- No build step. Tailwind via CDN only.
+- Single file. Splitting → build step → no.
+- Test in browser before claiming a fix works.
+- Run `npx biome check --write index.html` before commit (repo AGENTS.md).

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -15,11 +15,7 @@ A minimal clone of Google AI Studio's AI Pointer / Magic Pointer demo, built on 
 ## How It Works
 
 ```
-click+hold ── MediaRecorder ──┐
-                              │
-release ──┐                   │
-          ▼                   ▼
- POST /v1/audio/transcriptions (whisper)
+click+hold ── browser speech recognition or typed prompt
           │
           ▼
  annotate canvas (red circle at click pt)
@@ -39,11 +35,10 @@ The red circle burned into the pixels at the click point IS the spatial groundin
 ## Models
 
 - **Edit**: `kontext` (fast, obeys the red-circle marker). Fallback: `nanobanana-2`.
-- **STT**: `whisper`. Fallback: `universal-2`.
+- **Voice input**: browser-native speech recognition, with typed prompt fallback. No server STT call is required.
 
 ## API
 
-- `POST https://gen.pollinations.ai/v1/audio/transcriptions` — multipart, `file` + `model`
 - `POST https://media.pollinations.ai/upload` — multipart `file`
 - `POST https://gen.pollinations.ai/v1/images/edits` — JSON `{prompt, image, model}`
 
@@ -55,7 +50,7 @@ Auth: **BYOP** (Bring Your Own Pollen). On first use, the app redirects to `ente
 curl -X POST https://gen.pollinations.ai/account/keys \
   -H 'Authorization: Bearer <your_sk_>' \
   -H 'Content-Type: application/json' \
-  -d '{"name":"Voice Edit","type":"publishable","redirectUris":["https://pollinations.github.io/.../voice-edit/"],"earningsEnabled":true,"models":["kontext","nanobanana-2","whisper","universal-2"]}'
+  -d '{"name":"Voice Edit","type":"publishable","redirectUris":["https://voice-edit.pollinations.ai/"],"earningsEnabled":true,"models":["kontext","nanobanana-2"]}'
 ```
 
 Paste the returned `pk_…` into `CLIENT_ID` in `index.html`. With `earningsEnabled:true`, the app owner earns 25% of each user's spend in the app.

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -1,6 +1,6 @@
 # voice-edit
 
-Voice-driven image editor. Draw on an image, speak the edit, release. A marked drag uploads `image + marker` to `/v1/images/edits`; a no-drag click sends a clean/global edit.
+Voice-driven image/video editor. Draw on an image, speak the edit, release. Marked image edits upload `image + marker`; animate mode sends the clean current image to `/video/{prompt}`.
 
 ## stack
 
@@ -12,6 +12,7 @@ Voice-driven image editor. Draw on an image, speak the edit, release. A marked d
 | balance | `GET /account/balance` | shown in header, refreshed after successful edit |
 | STT | `POST /v1/audio/transcriptions`, `model=scribe` | ElevenLabs Scribe v2; replaced Whisper after short-utterance/silence issues |
 | edit | `POST /v1/images/edits` | OpenAI-compatible `{ prompt, image, model, response_format: "url" }` |
+| video | `GET /video/{prompt}`, `model=wan-fast` | clean current image as `image=`, blocking MP4 response |
 | upload | `POST media.pollinations.ai/upload` | uploads composed PNG snapshot |
 | starter | detailed human-cell render | `media.pollinations.ai/10efdd0c1cfc65fa` |
 
@@ -24,6 +25,9 @@ Voice-driven image editor. Draw on an image, speak the edit, release. A marked d
 - Type mode = typed global prompt, no marker.
 - Completed gestures enqueue as FIFO jobs. Marked jobs store a transparent marker-overlay PNG; the front job composites that overlay onto the latest image offscreen before upload, so queued edits chain from prior results.
 - The visible marker layer is only for the live/current gesture; queued jobs use their stored overlay image.
+- Animate mode is global-only: no marker, clean current image -> MP4. The video replaces the canvas visually.
+- Switch back to edit mode and draw on a paused video to commit that frame into image history, then continue editing it as a normal image.
+- Undo/redo stores image and video states. Full authored-playback UI is deferred; the state shape keeps prompts/results needed for it.
 
 ## prompt
 
@@ -34,9 +38,10 @@ Voice-driven image editor. Draw on an image, speak the edit, release. A marked d
 
 - `imageCanvas`: clean current image.
 - `markCanvas`: live freehand drawing only.
+- `stageVideo`: generated MP4 result, shown in the same stage as the canvas.
 - `pinLayer`: DOM label anchored to click point or rightmost mark edge.
-- `composeSnapshot(marked)`: offscreen PNG composition; draws marker layer only for marked edits.
-- `app`: single state object for image, auth account data, mic stream, active gesture, FIFO queue, current job, undo/redo, marker color.
+- `composeSnapshot(marker)`: offscreen PNG composition; draws a transparent marker overlay when present.
+- `app`: single state object for image/video, auth account data, mic stream, active gesture, FIFO queue, current job, undo/redo, marker color.
 - Queue jobs store marker overlay image, prompt text, color, model, and normalized pin position. `runQueue()` composites each overlay with the current image just before upload.
 
 ## local
@@ -52,4 +57,5 @@ python3 -m http.server 8765
 - Verify Scribe latency/accuracy on mobile microphones.
 - Test iOS Safari pointer capture + `touch-action: none`.
 - Consider a model selector for STT only if Scribe underperforms.
+- Add optional fast authored playback: prompts + marks + video clips + selected frames, using stored history states and no API wait times.
 - Two-image pattern remains deferred: clean image + marked image may reduce marker bleed-through if `/v1/images/edits` supports multiple images.

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -19,14 +19,14 @@ Voice-driven image editor. Click-and-hold on image, speak edit, release. Red rin
 
 ## marker
 
-Single gesture chooses shape by path length on `pointerup`:
+Single gesture, freehand only. No ring fallback — if the user doesn't move the mouse the edit is **global** (no marker on the image, plain prompt).
 
-- **Click (path < 3% min(w,h))** → thin red outline ring at click point. Radius ~5% of min(w,h), stroke ~18% of radius, alpha 0.35.
-- **Drag (path ≥ 3% min(w,h))** → freehand red stroke live-painted during pointermove. Width ~1.5% of min(w,h), alpha 0.20, round caps/joins. Pin position = path centroid.
-- Canvas reset to source image immediately after snapshotting the annotation, so a stray stroke from gesture N never leaks into the snapshot for gesture N+1.
+- **No movement (path < 3% min(w,h))** → no marker painted; prompt is sent as-is, model interprets the text as a global instruction. Pin sits at the click point.
+- **Drag (path ≥ 3% min(w,h))** → freehand pure stroke in current `markerColor` (red / black / white, switchable via swatch picker in the toolbar). Width ~1.5% of min(w,h), fully opaque, `lineCap: round`, `lineJoin: round`. Pin position = path bbox `(maxX, midY)` so the label sits just past the rightmost mark point.
+- Canvas reset to source image at the *start* of each pointerdown so stray strokes from gesture N never leak into the snapshot for gesture N+1. Marker stays visible from pointerup through edit completion.
 - No fill, no text label, no multi-stroke aggregation. One pointerdown→up = one edit. Pointerdown is blocked while a previous edit is still running.
 - Speech and drawing run concurrently; pointerup ends both.
-- Prompt: `The red markings indicate the area the prompt is referring to. Prompt: {text}. Output without red markings.` Marker is deictic, `Prompt:` label disambiguates which part is the instruction, suppression suffix prevents bleed-through. Model decides whether instruction is local-edit / replace / reframe / reference. See `buildEditPrompt(text)`.
+- Prompts: marked → `"The {color} markings indicate the area the prompt is referring to. Prompt: {text}. Output without {color} markings."`; unmarked → bare `{text}`. See `buildEditPrompt(text, marked, color)`.
 
 ## STT config (scribe, working)
 

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -12,7 +12,7 @@ Voice-driven image/video editor. Draw on an image, speak the edit, release. Mark
 | balance | `GET /account/balance` | shown in header, refreshed after successful edit |
 | STT | `POST /v1/audio/transcriptions`, `model=scribe` | ElevenLabs Scribe v2; replaced Whisper after short-utterance/silence issues |
 | edit | `POST /v1/images/edits` | OpenAI-compatible `{ prompt, image, model, response_format: "url" }` |
-| video | `GET /video/{prompt}`, `model=wan-fast` | clean current image as `image=`, blocking MP4 response |
+| video | `GET /video/{prompt}`, `model=wan-fast` | clean current image as `image=`; authenticated fetch fills cache, token-free URL is stored/rendered |
 | upload | `POST media.pollinations.ai/upload` | uploads composed PNG snapshot |
 | starter | detailed human-cell render | `media.pollinations.ai/10efdd0c1cfc65fa` |
 

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -41,6 +41,8 @@ Voice-driven image/video editor. Draw on an image, speak the edit, release. Mark
 - `stageVideo`: generated MP4 result, shown in the same stage as the canvas.
 - `pinLayer`: DOM label anchored to click point or rightmost mark edge.
 - `composeSnapshot(marker)`: offscreen PNG composition; draws a transparent marker overlay when present.
+- `media`: tiny frame factory/predicate (`image`, `video`, `isVideo`) so image/video shape stays centralized.
+- `mediaHistory`: linear frame history (`add`, `go`, `set`, `canUndo`, `canRedo`). Editing from an older frame truncates later frames here, not in gesture code.
 - `app`: single state object for current media, linear history, auth account data, mic stream, active gesture, FIFO queue, current job, marker color.
 - Queue jobs store marker overlay image, prompt text, color, model, and normalized pin position. `runQueue()` composites each overlay with the current image just before upload.
 

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -22,12 +22,12 @@ Voice-driven image/video editor. Draw on an image, speak the edit, release. Mark
 - Drag path >= `3% * min(width,height)` = marked edit.
 - Drag marker is a pure opaque stroke in selected `markerColor`: red, black, or white.
 - No-drag click = no marker; prompt is sent as a global instruction.
-- Type mode = typed global prompt, no marker.
+- Type mode uses the same gesture: draw first, release, type prompt. No-drag remains global.
 - Completed gestures enqueue as FIFO jobs. Marked jobs store a transparent marker-overlay PNG; the front job composites that overlay onto the latest image offscreen before upload, so queued edits chain from prior results.
 - The visible marker layer is only for the live/current gesture; queued jobs use their stored overlay image.
 - Animate mode is global-only: no marker, clean current image -> MP4. The video replaces the canvas visually.
 - Switch back to edit mode and draw on a paused video to commit that frame into image history, then continue editing it as a normal image.
-- Undo/redo stores image and video states. Full authored-playback UI is deferred; the state shape keeps prompts/results needed for it.
+- Undo/redo is a linear media history of image/video frames. Editing from an older frame truncates later frames.
 
 ## prompt
 
@@ -41,7 +41,7 @@ Voice-driven image/video editor. Draw on an image, speak the edit, release. Mark
 - `stageVideo`: generated MP4 result, shown in the same stage as the canvas.
 - `pinLayer`: DOM label anchored to click point or rightmost mark edge.
 - `composeSnapshot(marker)`: offscreen PNG composition; draws a transparent marker overlay when present.
-- `app`: single state object for image/video, auth account data, mic stream, active gesture, FIFO queue, current job, undo/redo, marker color.
+- `app`: single state object for current media, linear history, auth account data, mic stream, active gesture, FIFO queue, current job, marker color.
 - Queue jobs store marker overlay image, prompt text, color, model, and normalized pin position. `runQueue()` composites each overlay with the current image just before upload.
 
 ## local

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -47,7 +47,18 @@ The red circle burned into the pixels at the click point IS the spatial groundin
 - `POST https://media.pollinations.ai/upload` — multipart `file`
 - `POST https://gen.pollinations.ai/v1/images/edits` — JSON `{prompt, image, model}`
 
-Auth: `Authorization: Bearer <app-key>` (create one at https://enter.pollinations.ai). The key is stored in your browser's `localStorage` — never bundled in source.
+Auth: **BYOP** (Bring Your Own Pollen). On first use, the app redirects to `enter.pollinations.ai/authorize?client_id=pk_<voice_edit_app_key>` — the user approves and returns with a scoped `sk_user_*` key in the URL fragment. The key spends the user's Pollen, not ours. The `pk_` App Key in source is just an identifier; only the user's returned `sk_` is sensitive (stored in their browser's `localStorage`).
+
+### App key registration (one-time, by the app owner)
+
+```bash
+curl -X POST https://gen.pollinations.ai/account/keys \
+  -H 'Authorization: Bearer <your_sk_>' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Voice Edit","type":"publishable","redirectUris":["https://pollinations.github.io/.../voice-edit/"],"earningsEnabled":true,"models":["kontext","nanobanana-2","whisper","universal-2"]}'
+```
+
+Paste the returned `pk_…` into `CLIENT_ID` in `index.html`. With `earningsEnabled:true`, the app owner earns 25% of each user's spend in the app.
 
 ---
 

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -15,7 +15,7 @@ Voice-driven image editor. Click-and-hold on image, speak edit, release. Red rin
 | STT | `POST /v1/audio/transcriptions`, model=`scribe` | ElevenLabs Scribe v2. 1.6% WER on Artificial Analysis AA-AgentTalk (short voice-agent clips) vs ~2.3% Universal-3 Pro; Whisper-large-v3 ranks well below and hallucinates "Thank you / Thanks for watching" on silent or sub-second audio (documented YouTube-training-data artifact, arXiv:2501.11378). Tried `universal-2` earlier — worse on short clips. |
 | upload | `POST media.pollinations.ai/upload` | annotated PNG before /edits |
 | default edit model | `nanobanana` | Gemini 2.5 Flash Image. Recommended: `nanobanana`, `p-image-edit`, `kontext`, `gpt-image-2`. |
-| starter image | Merian banana flower (PD) | `media.pollinations.ai/051ed82a46f5f85d` |
+| starter image | "Most detailed view of a human cell" (Evan Ingersoll & Gael McGill, Digizyme) | `media.pollinations.ai/10efdd0c1cfc65fa` |
 
 ## marker
 

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -12,7 +12,7 @@ Voice-driven image editor. Click-and-hold on image, speak edit, release. Red rin
 |---|---|---|
 | auth | `enter.pollinations.ai/authorize` device flow | `api_key` in URL fragment → `localStorage["voice-edit:user-key"]` |
 | edit | `POST /v1/images/edits` (OpenAI-compat) | `{prompt, image: url, model, response_format: "url"}` |
-| STT | `POST /v1/audio/transcriptions`, model=`whisper` | OVH Whisper-large-v3. Tried `universal-2` (AssemblyAI) — worse on short utterances. |
+| STT | `POST /v1/audio/transcriptions`, model=`scribe` | ElevenLabs Scribe v2. 1.6% WER on Artificial Analysis AA-AgentTalk (short voice-agent clips) vs ~2.3% Universal-3 Pro; Whisper-large-v3 ranks well below and hallucinates "Thank you / Thanks for watching" on silent or sub-second audio (documented YouTube-training-data artifact, arXiv:2501.11378). Tried `universal-2` earlier — worse on short clips. |
 | upload | `POST media.pollinations.ai/upload` | annotated PNG before /edits |
 | default edit model | `nanobanana` | Gemini 2.5 Flash Image. Recommended: `nanobanana`, `p-image-edit`, `kontext`, `gpt-image-2`. |
 | starter image | Merian banana flower (PD) | `media.pollinations.ai/051ed82a46f5f85d` |
@@ -21,20 +21,20 @@ Voice-driven image editor. Click-and-hold on image, speak edit, release. Red rin
 
 Single gesture chooses shape by path length on `pointerup`:
 
-- **Click (path < 3% min(w,h))** → thin red outline ring at click point. Radius ~5% of min(w,h), stroke ~18% of radius, alpha 0.55.
-- **Drag (path ≥ 3% min(w,h))** → freehand red stroke live-painted during pointermove. Width ~1.5% of min(w,h), alpha 0.35, round caps/joins. Pin position = path centroid.
+- **Click (path < 3% min(w,h))** → thin red outline ring at click point. Radius ~5% of min(w,h), stroke ~18% of radius, alpha 0.35.
+- **Drag (path ≥ 3% min(w,h))** → freehand red stroke live-painted during pointermove. Width ~1.5% of min(w,h), alpha 0.20, round caps/joins. Pin position = path centroid.
 - Canvas reset to source image immediately after snapshotting the annotation, so a stray stroke from gesture N never leaks into the snapshot for gesture N+1.
 - No fill, no text label, no multi-stroke aggregation. One pointerdown→up = one edit. Pointerdown is blocked while a previous edit is still running.
 - Speech and drawing run concurrently; pointerup ends both.
 - Prompt: `The red markings indicate the area the prompt is referring to. Prompt: {text}. Output without red markings.` Marker is deictic, `Prompt:` label disambiguates which part is the instruction, suppression suffix prevents bleed-through. Model decides whether instruction is local-edit / replace / reframe / reference. See `buildEditPrompt(text)`.
 
-## STT config (whisper, working)
+## STT config (scribe, working)
 
 - **Pre-warm `getUserMedia` on connect**, keep mic stream alive. Without this, first 200-500ms cut off.
 - **Force MIME**: `audio/webm;codecs=opus` (Chrome) / `audio/mp4` (Safari). File extension must match codec.
-- **Pass `language` = `navigator.language.slice(0,2)`**. Whisper hallucinates language on short clips without it.
+- **Pass `language` = `navigator.language.slice(0,2)`**.
 - **Audio constraints**: `echoCancellation`, `noiseSuppression`, `autoGainControl` all true.
-- Latency ~1-2s post-release. Acceptable for this UX.
+- Latency: Scribe v2 ~150ms p50 streaming; non-streaming call on a 1–3s clip lands ~1s post-release.
 
 ## known issues / todos
 

--- a/apps/voice-edit/README.md
+++ b/apps/voice-edit/README.md
@@ -1,98 +1,45 @@
 # voice-edit
 
-Voice-driven image editor. Click-and-hold on image, speak edit, release. Red ring burned at click point → uploaded → `/v1/images/edits` → canvas swap.
-
-- Single self-contained `index.html`. No build step.
-- Vanilla JS + Tailwind CDN.
-- BYOP auth via Pollinations OAuth (`enter.pollinations.ai`).
+Voice-driven image editor. Draw on an image, speak the edit, release. A marked drag uploads `image + marker` to `/v1/images/edits`; a no-drag click sends a clean/global edit.
 
 ## stack
 
 | layer | choice | notes |
 |---|---|---|
-| auth | `enter.pollinations.ai/authorize` device flow | `api_key` in URL fragment → `localStorage["voice-edit:user-key"]` |
-| edit | `POST /v1/images/edits` (OpenAI-compat) | `{prompt, image: url, model, response_format: "url"}` |
-| STT | `POST /v1/audio/transcriptions`, model=`scribe` | ElevenLabs Scribe v2. 1.6% WER on Artificial Analysis AA-AgentTalk (short voice-agent clips) vs ~2.3% Universal-3 Pro; Whisper-large-v3 ranks well below and hallucinates "Thank you / Thanks for watching" on silent or sub-second audio (documented YouTube-training-data artifact, arXiv:2501.11378). Tried `universal-2` earlier — worse on short clips. |
-| upload | `POST media.pollinations.ai/upload` | annotated PNG before /edits |
-| default edit model | `nanobanana` | Gemini 2.5 Flash Image. Recommended: `nanobanana`, `p-image-edit`, `kontext`, `gpt-image-2`. |
-| starter image | "Most detailed view of a human cell" (Evan Ingersoll & Gael McGill, Digizyme) | `media.pollinations.ai/10efdd0c1cfc65fa` |
+| app | single `index.html` | no build step, no React, no Tailwind runtime |
+| UI | vanilla HTML/CSS/JS | modern browsers only |
+| auth | Pollinations OAuth | `api_key` URL fragment -> `localStorage["voice-edit:user-key"]` |
+| balance | `GET /account/balance` | shown in header, refreshed after successful edit |
+| STT | `POST /v1/audio/transcriptions`, `model=scribe` | ElevenLabs Scribe v2; replaced Whisper after short-utterance/silence issues |
+| edit | `POST /v1/images/edits` | OpenAI-compatible `{ prompt, image, model, response_format: "url" }` |
+| upload | `POST media.pollinations.ai/upload` | uploads composed PNG snapshot |
+| starter | detailed human-cell render | `media.pollinations.ai/10efdd0c1cfc65fa` |
 
-## marker
+## interaction
 
-Single gesture, freehand only. No ring fallback — if the user doesn't move the mouse the edit is **global** (no marker on the image, plain prompt).
+- One gesture only. Pointerdown -> draw/speak -> pointerup -> transcribe -> edit.
+- Drag path >= `3% * min(width,height)` = marked edit.
+- Drag marker is a pure opaque stroke in selected `markerColor`: red, black, or white.
+- No-drag click = no marker; prompt is sent as a global instruction.
+- Type mode = typed global prompt, no marker.
+- Completed gestures enqueue as FIFO jobs. Marked jobs store a transparent marker-overlay PNG; the front job composites that overlay onto the latest image offscreen before upload, so queued edits chain from prior results.
+- The visible marker layer is only for the live/current gesture; queued jobs use their stored overlay image.
 
-- **No movement (path < 3% min(w,h))** → no marker painted; prompt is sent as-is, model interprets the text as a global instruction. Pin sits at the click point.
-- **Drag (path ≥ 3% min(w,h))** → freehand pure stroke in current `markerColor` (red / black / white, switchable via swatch picker in the toolbar). Width ~1.5% of min(w,h), fully opaque, `lineCap: round`, `lineJoin: round`. Pin position = path bbox `(maxX, midY)` so the label sits just past the rightmost mark point.
-- Canvas reset to source image at the *start* of each pointerdown so stray strokes from gesture N never leak into the snapshot for gesture N+1. Marker stays visible from pointerup through edit completion.
-- No fill, no text label, no multi-stroke aggregation. One pointerdown→up = one edit. Pointerdown is blocked while a previous edit is still running.
-- Speech and drawing run concurrently; pointerup ends both.
-- Prompts: marked → `"The {color} markings indicate the area the prompt is referring to. Prompt: {text}. Output without {color} markings."`; unmarked → bare `{text}`. See `buildEditPrompt(text, marked, color)`.
+## prompt
 
-## STT config (scribe, working)
-
-- **Pre-warm `getUserMedia` on connect**, keep mic stream alive. Without this, first 200-500ms cut off.
-- **Force MIME**: `audio/webm;codecs=opus` (Chrome) / `audio/mp4` (Safari). File extension must match codec.
-- **Pass `language` = `navigator.language.slice(0,2)`**.
-- **Audio constraints**: `echoCancellation`, `noiseSuppression`, `autoGainControl` all true.
-- Latency: Scribe v2 ~150ms p50 streaming; non-streaming call on a 1–3s clip lands ~1s post-release.
-
-## known issues / todos
-
-priority order:
-
-1. **[DONE 2026-05-15] Click + freehand region.** Click → auto-ring, drag → freehand stroke. Live-painted during pointermove, snapshotted at pointerup, canvas reset before transcription.
-2. **[DONE 2026-05-15] Pin positions stored as `{xPct, yPct}` fractions** of canvas at click time. Fixes drift when edit result returns at a different resolution. Still imperfect if model reframes the image content — true fix is to pass `size` to `/v1/images/edits` (gateway issue #10944).
-3. **[FEAT] Two-image pattern.** Send clean original + annotated copy, prompt "Image 2 marks edit region in Image 1." Research suggests biggest mitigation for marker bleed-through. Blocked: need to verify `/v1/images/edits` accepts multiple images. Deferred.
-4. **[FEAT] Multi-region labelling.** SoM-style numeric labels (1/2/3) on multiple strokes so user can say "make 1 a hat, 2 sunglasses". Speculative — SoM is proven on understanding models, not editing. Deferred.
-5. **[ENH] Mobile.** iOS Safari pointer events untested. Pinch-zoom + canvas interaction likely fragile.
-6. **[ENH] STT model selector.** UI dropdown to A/B `whisper` / `scribe` / `universal-2` / `universal-3-pro`.
-7. **[ENH] Deployment.** Not deployed. Currently localhost-only via `python3 -m http.server 8765`.
+- Marked: `The {color} markings indicate the area the prompt is referring to. Prompt: {text}. Output without {color} markings.`
+- Unmarked: `{text}`
 
 ## architecture
 
-- ~770 lines, single file, flat module scope.
-- State (module-level): `currentImage`, `currentImageURL`, `activeCapture`, `undoStack`, `redoStack`, `editQueue`, `queueRunning`, `micStream`.
-- `render()` — single function, called after every state mutation. Redraws pins + history button enabled state. Don't add ad-hoc DOM updates from mutation sites.
-- `pill({x, y, text, placeholder, visible})` — partial-state setter for cursor-anchored speech indicator.
-- `resetCanvas()` — synchronously redraws `currentImage` onto the canvas. Called at the *start* of each pointerdown so a stale marker from a prior gesture never leaks into the new gesture's snapshot. Async `loadImageFromURL` is not safe for this because the next pointerdown can fire before it resolves.
-- Pointer flow: down → block if `queueRunning || editQueue.length` → `resetCanvas()` → `startIntentCapture` (MediaRecorder) + show pill + init `capture.stroke = [point]` → move → live-paint stroke segment + push to `capture.stroke` → up → classify (click vs drag) → if click: `drawRing` → snapshot annotated canvas to dataURL → `stopIntentCapture` → `enqueueEdit({point, text, annotated})` → `runQueue` (upload snapshot → /v1/images/edits → swap canvas). Marker stays visible on-screen from pointerup through edit completion.
+- `imageCanvas`: clean current image.
+- `markCanvas`: live freehand drawing only.
+- `pinLayer`: DOM label anchored to click point or rightmost mark edge.
+- `composeSnapshot(marked)`: offscreen PNG composition; draws marker layer only for marked edits.
+- `app`: single state object for image, auth account data, mic stream, active gesture, FIFO queue, current job, undo/redo, marker color.
+- Queue jobs store marker overlay image, prompt text, color, model, and normalized pin position. `runQueue()` composites each overlay with the current image just before upload.
 
-## intentional non-changes
-
-Things that look redundant but are load-bearing. Don't simplify:
-
-- `pointercancel` handler — iOS fires on scroll interrupt; leaks `activeCapture` without it.
-- `setPointerCapture` on pointerdown — lets `pointerup` fire on canvas after dragging off (wrapped in try/catch for Playwright synth events).
-- `try { recorder.start() } catch` — MediaRecorder throws synchronously on permission issues.
-- `resetCanvas()` at pointerdown (not pointerup) — keeps marker visible during edit but still wipes before next snapshot.
-
-## research provenance
-
-| claim | source | strength |
-|---|---|---|
-| Red beats blue/purple/green | RedCircle, Shtedritski et al., ICCV 2023 (arxiv:2304.06712) Table 2 | **CLIP only**, not edit models |
-| Outline ring optimal at radius 12px / stroke 4px @ 224px | RedCircle Table 10, Fig 10 | CLIP only |
-| Labels improve grounding (84.4 → 89.2 adding boxes to num+mask) | Set-of-Marks, Yang et al., arxiv:2310.11441 Table 3 | **GPT-4V only**, understanding |
-| Scribbles/arrows/ellipses as visual prompts | ViP-LLaVA, Cai et al., CVPR 2024 (arxiv:2312.00784) | trained model, understanding |
-| FLUX Kontext "supports intuitive editing through visual cues, responding to geometric markers like red ellipses" | FLUX.1 Kontext §4.4 (arxiv:2506.15742) | **edit model**, no shape ablation |
-| Gemini app: freehand pen, single annotated image, no mask, multi-stroke OK | 9to5Google + Tom's Guide Dec 2025 teardowns | product, no paper |
-| Bleed-through is dominant failure | our May 13 empirical session ("HERE" labels bled through) | observation |
-
-No academic paper exists for DeepMind's "AI Pointer" (the inspiration). Product principles essay by Adrien Baranes + Rob Marchant; no arxiv.
-
-## refactor history
-
-5 simplifications applied 2026-05-14:
-
-- 4 pill helpers → 1 `pill(state)` setter
-- 2 annotate helpers + offscreen canvas → 1 `annotateAndCapture`
-- Module `clickPoint` baton → stored on capture object
-- 6 scattered render-calls → 1 `render()`
-- `loadLocalFile` + `loadImageFromURL` → unified `loadImage(File|URL)`
-
-## deploy
-
-Not deployed. Local:
+## local
 
 ```bash
 cd apps/voice-edit
@@ -100,20 +47,9 @@ python3 -m http.server 8765
 # http://localhost:8765/
 ```
 
-OAuth `redirect_uri` = `location.origin + location.pathname`. Works on `localhost:*` and any origin registered with enter.pollinations.ai. To register an App Key set `CLIENT_ID` constant at top of script:
+## todos
 
-```bash
-curl -X POST https://gen.pollinations.ai/account/keys \
-  -H 'Authorization: Bearer <your_sk_>' \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"Voice Edit","type":"publishable","redirectUris":["https://voice-edit.pollinations.ai/"],"earningsEnabled":true,"models":["nanobanana","kontext"]}'
-```
-
-`earningsEnabled:true` → app owner earns 25% of users' Pollen spend.
-
-## dev rules
-
-- No build step. Tailwind via CDN only.
-- Single file. Splitting → build step → no.
-- Test in browser before claiming a fix works.
-- Run `npx biome check --write index.html` before commit (repo AGENTS.md).
+- Verify Scribe latency/accuracy on mobile microphones.
+- Test iOS Safari pointer capture + `touch-action: none`.
+- Consider a model selector for STT only if Scribe underperforms.
+- Two-image pattern remains deferred: clean image + marked image may reduce marker bleed-through if `/v1/images/edits` supports multiple images.

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -102,6 +102,36 @@
   }
   .history { margin-left: auto; }
 
+  .mode {
+    display: inline-flex;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    background: #fff;
+  }
+  .mode button {
+    min-height: 34px;
+    padding: 0 10px;
+    border: 0;
+    background: transparent;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .mode button.active { background: var(--accent); }
+  .mode button + button { border-left: 2px solid var(--line); }
+  .video-model {
+    min-height: 38px;
+    display: inline-flex;
+    align-items: center;
+    padding: 0 10px;
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
   .swatches {
     display: inline-flex;
     align-items: center;
@@ -141,13 +171,19 @@
     max-height: calc(100vh - 210px);
     touch-action: none;
   }
-  .stage canvas {
+  .stage canvas, .stage video {
     display: block;
     max-width: 100%;
     max-height: calc(100vh - 210px);
     width: auto;
     height: auto;
   }
+  .stage video {
+    background: #000;
+    max-width: 100%;
+  }
+  .stage.video #imageCanvas { display: none; }
+  #stageVideo[hidden] { display: none; }
   #markCanvas, #pinLayer {
     position: absolute;
     inset: 0;
@@ -155,6 +191,10 @@
     height: 100%;
   }
   #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  .stage.video.animate #markCanvas {
+    pointer-events: none;
+    cursor: default;
+  }
   #pinLayer { z-index: 3; pointer-events: none; }
 
   .overlay {
@@ -281,9 +321,14 @@
       <button id="disconnectBtn" class="btn" hidden>disconnect</button>
       <button id="uploadBtn" class="btn">image</button>
       <input id="fileInput" type="file" accept="image/*" hidden>
+      <div id="modePicker" class="mode" aria-label="mode">
+        <button type="button" data-mode="edit" class="active">edit</button>
+        <button type="button" data-mode="animate">animate</button>
+      </div>
       <select id="modelSel" class="select" aria-label="image model">
         <option value="nanobanana">nanobanana</option>
       </select>
+      <span id="videoModelLabel" class="video-model" hidden>wan-fast video</span>
       <div id="colorPicker" class="swatches" aria-label="marker color">
         <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
         <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
@@ -299,6 +344,7 @@
       <div id="stage" class="stage">
         <canvas id="imageCanvas" width="1024" height="768"></canvas>
         <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <video id="stageVideo" hidden controls autoplay loop muted playsinline></video>
         <div id="pinLayer"></div>
       </div>
       <div class="overlay">
@@ -308,6 +354,7 @@
         </div>
       </div>
     </section>
+
   </main>
 
   <div id="cursorPill" class="pill" aria-hidden="true">
@@ -321,6 +368,8 @@ const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
 const STARTER = "https://media.pollinations.ai/10efdd0c1cfc65fa";
+const VIDEO_MODEL = "wan-fast";
+const VIDEO_DURATION = "5";
 const STT_MODEL = "scribe";
 const STT_LANG = (navigator.language || "en").slice(0, 2);
 const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
@@ -336,12 +385,15 @@ const els = {
   stage: document.getElementById("stage"),
   imageCanvas: document.getElementById("imageCanvas"),
   markCanvas: document.getElementById("markCanvas"),
+  stageVideo: document.getElementById("stageVideo"),
   pinLayer: document.getElementById("pinLayer"),
   connect: document.getElementById("connectBtn"),
   disconnect: document.getElementById("disconnectBtn"),
   connectOverlay: document.getElementById("connectOverlayBtn"),
   upload: document.getElementById("uploadBtn"),
   file: document.getElementById("fileInput"),
+  modePicker: document.getElementById("modePicker"),
+  videoModel: document.getElementById("videoModelLabel"),
   model: document.getElementById("modelSel"),
   typeMode: document.getElementById("typeMode"),
   undo: document.getElementById("undoBtn"),
@@ -357,6 +409,9 @@ const markCtx = els.markCanvas.getContext("2d");
 const app = {
   image: null,
   imageURL: "",
+  videoURL: "",
+  videoPrompt: "",
+  mode: "edit",
   micStream: null,
   active: null,
   busy: false,
@@ -391,11 +446,22 @@ function key() {
 
 function render() {
   const locked = app.busy || Boolean(app.active);
-  els.undo.disabled = app.undo.length === 0 || locked;
+  els.undo.disabled = (app.undo.length === 0 && !app.videoURL) || locked;
   els.redo.disabled = app.redo.length === 0 || locked;
   els.upload.disabled = locked;
-  els.model.disabled = locked;
+  els.model.disabled = locked || app.mode === "animate";
+  els.model.hidden = app.mode === "animate";
+  els.videoModel.hidden = app.mode !== "animate";
+  els.colorPicker.hidden = app.mode === "animate";
   els.typeMode.disabled = locked;
+  els.stage.classList.toggle("video", !!app.videoURL);
+  els.stage.classList.toggle("edit", app.mode === "edit");
+  els.stage.classList.toggle("animate", app.mode === "animate");
+  els.stageVideo.hidden = !app.videoURL;
+  for (const button of els.modePicker.querySelectorAll("button")) {
+    button.disabled = locked;
+    button.classList.toggle("active", button.dataset.mode === app.mode);
+  }
   renderPins();
 }
 
@@ -419,7 +485,7 @@ function renderPins() {
     const dot = document.createElement("span");
     dot.className = "dot";
     const text = document.createElement("span");
-    text.textContent = job.text;
+    text.textContent = job.kind === "video" ? `animate: ${job.text}` : job.text;
     pin.append(dot, text);
     pin.style.left = `${job.xPct}%`;
     pin.style.top = `${job.yPct}%`;
@@ -428,6 +494,14 @@ function renderPins() {
     const available = window.innerWidth - anchorX - 12;
     pin.style.maxWidth = `${Math.min(256, Math.max(28, available))}px`;
   }
+}
+
+function setMode(mode) {
+  app.mode = mode;
+  clearError();
+  clearMarks();
+  setStatus(mode === "animate" ? "animate mode" : "ready");
+  render();
 }
 
 function pill({ x, y, text, placeholder, visible }) {
@@ -522,6 +596,22 @@ function stopMic() {
   app.micStream = null;
 }
 
+function currentState() {
+  if (app.videoURL) return { kind: "video", url: app.videoURL, prompt: app.videoPrompt, imageURL: app.imageURL };
+  if (app.imageURL) return { kind: "image", url: app.imageURL };
+  return null;
+}
+
+async function restoreState(state) {
+  if (!state) return;
+  if (state.kind === "video") {
+    await loadImage(state.imageURL);
+    showVideo(state.url, state.prompt);
+  } else {
+    await loadImage(state.url);
+  }
+}
+
 async function loadModels() {
   try {
     const res = await fetch(`${BASE}/image/models`);
@@ -549,8 +639,9 @@ async function loadModels() {
 }
 
 function pushUndo() {
-  if (!app.imageURL) return;
-  app.undo.push(app.imageURL);
+  const state = currentState();
+  if (!state) return;
+  app.undo.push(state);
   app.redo = [];
   render();
 }
@@ -559,6 +650,7 @@ async function loadImage(src, { pushHistory = false } = {}) {
   clearError();
   if (src instanceof File) src = await readImageFile(src);
   if (pushHistory) pushUndo();
+  hideVideo();
   setStatus("loading image...");
   const img = new Image();
   img.crossOrigin = "anonymous";
@@ -595,6 +687,40 @@ function resizeCanvases(width, height) {
 
 function clearMarks() {
   markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function showVideo(url, prompt = "") {
+  hideVideo();
+  clearMarks();
+  app.videoURL = url;
+  app.videoPrompt = prompt;
+  els.stageVideo.src = url;
+  els.stageVideo.play().catch(() => {});
+  render();
+}
+
+function hideVideo() {
+  if (!app.videoURL) return;
+  app.videoURL = "";
+  app.videoPrompt = "";
+  els.stageVideo.pause();
+  els.stageVideo.removeAttribute("src");
+  els.stageVideo.load();
+  render();
+}
+
+async function commitVideoFrame() {
+  if (!app.videoURL) return;
+  const video = els.stageVideo;
+  if (!video.videoWidth || !video.videoHeight) throw new Error("video frame is not ready yet");
+  const frame = document.createElement("canvas");
+  frame.width = video.videoWidth;
+  frame.height = video.videoHeight;
+  frame.getContext("2d").drawImage(video, 0, 0);
+  const dataURL = frame.toDataURL("image/png");
+  pushUndo();
+  hideVideo();
+  await loadImage(dataURL);
 }
 
 function pointerPoint(event) {
@@ -677,15 +803,16 @@ function loadImageElement(src) {
   });
 }
 
-function enqueueEdit({ text, marked, marker, pinPoint, color }) {
+function enqueueJob({ kind, text, marked = false, marker = "", pinPoint, color }) {
   if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
   const pin = pinPct(pinPoint);
   app.queue.push({
+    kind,
     text,
     marked,
     marker,
     color,
-    model: els.model.value,
+    model: kind === "video" ? VIDEO_MODEL : els.model.value,
     xPct: pin.xPct,
     yPct: pin.yPct,
   });
@@ -769,11 +896,11 @@ async function promptTypedEdit(clientX, clientY) {
   });
 }
 
-async function uploadDataURL(dataURL) {
+async function uploadDataURL(dataURL, filename = "annot.png") {
   setStatus("uploading...");
   const blob = await (await fetch(dataURL)).blob();
   const form = new FormData();
-  form.append("file", blob, "annot.png");
+  form.append("file", blob, filename);
   const res = await fetch("https://media.pollinations.ai/upload", {
     method: "POST",
     headers: { Authorization: `Bearer ${key()}` },
@@ -797,6 +924,20 @@ async function runEdit(imageURL, prompt, model) {
   if (item.url) return item.url;
   if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
   throw new Error("no url or b64_json in response");
+}
+
+async function runVideo(imageURL, prompt, model) {
+  const params = new URLSearchParams({
+    model,
+    duration: VIDEO_DURATION,
+    image: imageURL,
+  });
+  const res = await fetch(`${BASE}/video/${encodeURIComponent(prompt)}?${params}`, {
+    headers: { Authorization: `Bearer ${key()}` },
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Video failed"));
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
 }
 
 async function friendlyError(response, label) {
@@ -825,14 +966,20 @@ async function runQueue() {
       const job = app.queue.shift();
       app.currentJob = job;
       render();
-      setStatus(`editing... (${app.queue.length + 1} in queue)`);
+      setStatus(`${job.kind === "video" ? "animating" : "editing"}... (${app.queue.length + 1} in queue)`);
       try {
-        const snapshot = await composeSnapshot(job.marker);
-        const uploaded = await uploadDataURL(snapshot);
-        const prompt = buildPrompt(job.text, job.marked, job.color);
-        const result = await runEdit(uploaded, prompt, job.model);
-        pushUndo();
-        await loadImage(result);
+        const snapshot = await composeSnapshot(job.kind === "video" ? "" : job.marker);
+        const uploaded = await uploadDataURL(snapshot, job.kind === "video" ? "source.png" : "annot.png");
+        if (job.kind === "video") {
+          const videoURL = await runVideo(uploaded, job.text, job.model);
+          pushUndo();
+          showVideo(videoURL, job.text);
+        } else {
+          const prompt = buildPrompt(job.text, job.marked, job.color);
+          const result = await runEdit(uploaded, prompt, job.model);
+          pushUndo();
+          await loadImage(result);
+        }
         await loadBalance();
       } catch (err) {
         showError(err.message);
@@ -865,8 +1012,17 @@ els.markCanvas.addEventListener("pointerdown", async (event) => {
   if (app.active) return;
   event.preventDefault();
   clearError();
+  if (app.videoURL && app.mode === "edit") {
+    try {
+      await commitVideoFrame();
+    } catch (err) {
+      showError(err.message);
+      return;
+    }
+  }
   clearMarks();
   const start = pointerPoint(event);
+  const kind = app.mode === "animate" ? "video" : "edit";
 
   if (els.typeMode.checked) {
     app.active = { typing: true };
@@ -876,7 +1032,7 @@ els.markCanvas.addEventListener("pointerdown", async (event) => {
     render();
     if (!text) { setStatus(app.busy ? "editing..." : "ready"); return; }
     try {
-      enqueueEdit({ text, marked: false, marker: "", pinPoint: start, color: app.markerColor });
+      enqueueJob({ kind, text, pinPoint: start, color: app.markerColor });
     } catch (err) {
       showError(err.message);
     }
@@ -884,7 +1040,7 @@ els.markCanvas.addEventListener("pointerdown", async (event) => {
   }
 
   const capture = beginRecording(event.clientX, event.clientY);
-  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  app.active = { kind, pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
   try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
 });
 
@@ -893,6 +1049,7 @@ els.markCanvas.addEventListener("pointermove", (event) => {
   if (!gesture) return;
   event.preventDefault();
   pill({ x: event.clientX, y: event.clientY });
+  if (gesture.kind === "video") return;
   const point = pointerPoint(event);
   const prev = gesture.points[gesture.points.length - 1];
   drawSegment(prev, point);
@@ -904,6 +1061,17 @@ els.markCanvas.addEventListener("pointerup", async (event) => {
   if (!gesture) return;
   event.preventDefault();
   app.active = null;
+  if (gesture.kind === "video") {
+    try {
+      const { text, error } = await stopAndTranscribe(gesture.capture);
+      pill({ visible: false });
+      if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+      enqueueJob({ kind: "video", text, pinPoint: gesture.points[0], color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+    }
+    return;
+  }
   const length = pathLength(gesture.points);
   const marked = length >= Math.min(els.markCanvas.width, els.markCanvas.height) * DRAG_THRESHOLD;
   if (!marked) clearMarks();
@@ -916,7 +1084,7 @@ els.markCanvas.addEventListener("pointerup", async (event) => {
     const { text, error } = await stopAndTranscribe(gesture.capture);
     pill({ visible: false });
     if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
-    enqueueEdit({ text, marked, marker, pinPoint, color: gesture.color });
+    enqueueJob({ kind: "edit", text, marked, marker, pinPoint, color: gesture.color });
   } catch (err) {
     showError(err.message);
     clearMarks();
@@ -932,6 +1100,12 @@ els.upload.addEventListener("click", () => els.file.click());
 els.file.addEventListener("change", () => {
   const file = els.file.files?.[0];
   if (file) loadImage(file, { pushHistory: true }).catch((err) => showError(err.message));
+});
+
+els.modePicker.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-mode]");
+  if (!button || button.disabled) return;
+  setMode(button.dataset.mode);
 });
 
 els.colorPicker.addEventListener("click", (event) => {
@@ -961,20 +1135,23 @@ els.frame.addEventListener("drop", (event) => {
 });
 
 els.undo.addEventListener("click", () => {
-  if (!app.undo.length || app.busy || app.active) return;
-  app.redo.push(app.imageURL);
-  loadImage(app.undo.pop()).then(() => setStatus("undone")).catch((err) => showError(err.message));
+  if ((!app.undo.length && !app.videoURL) || app.busy || app.active) return;
+  const current = currentState();
+  if (current) app.redo.push(current);
+  const previous = app.videoURL && !app.undo.length ? { kind: "image", url: app.imageURL } : app.undo.pop();
+  restoreState(previous).then(() => setStatus("undone")).catch((err) => showError(err.message));
 });
 els.redo.addEventListener("click", () => {
   if (!app.redo.length || app.busy || app.active) return;
-  app.undo.push(app.imageURL);
-  loadImage(app.redo.pop()).then(() => setStatus("redone")).catch((err) => showError(err.message));
+  const current = currentState();
+  if (current) app.undo.push(current);
+  restoreState(app.redo.pop()).then(() => setStatus("redone")).catch((err) => showError(err.message));
 });
 els.download.addEventListener("click", () => {
   try {
     const link = document.createElement("a");
-    link.href = els.imageCanvas.toDataURL("image/png");
-    link.download = "voice-edit.png";
+    link.href = app.videoURL || els.imageCanvas.toDataURL("image/png");
+    link.download = app.videoURL ? "voice-edit.mp4" : "voice-edit.png";
     link.click();
   } catch {
     if (app.imageURL) window.open(app.imageURL, "_blank", "noopener");

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -63,8 +63,10 @@
     letter-spacing: -0.02em;
     line-height: 1.3;
   }
-  canvas { cursor: crosshair; touch-action: none; display: block; }
-  .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; }
+  canvas { cursor: crosshair; touch-action: none; display: block; max-width: 100%; height: auto; }
+  .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; position: relative; display: inline-block; width: 100%; }
+  .canvas-stage { position: relative; display: inline-block; width: 100%; }
+  .canvas-wrap.drop { outline: 4px dashed var(--accent); outline-offset: -8px; }
 
   /* Cursor-anchored speech pill */
   #cursorPill {
@@ -112,6 +114,39 @@
   @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
   #cursorPill .text { min-width: 1ch; }
   #cursorPill .text.placeholder { opacity: .55; font-style: italic; }
+
+  /* Per-job pins anchored at the click point — sits over the canvas, same box */
+  #pinLayer { position: absolute; inset: 0; z-index: 5; pointer-events: none; }
+  #pinLayer .pin { position: absolute; }
+  .pin {
+    position: absolute;
+    transform: translate(8px, -50%);
+    background: #fff;
+    border: 2px solid var(--dark);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    padding: 0.35rem 0.55rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    max-width: 14rem;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .pin.processing { background: var(--accent); }
+  .pin.queued { background: #fff; opacity: 0.85; }
+  .pin .dot {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    background: var(--dark);
+    border: 1.5px solid var(--dark);
+  }
+  .pin.processing .dot { background: var(--dark); animation: pulse 1s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
 </style>
 <body class="min-h-screen p-4 md:p-6 flex flex-col items-center gap-4">
   <div class="w-full max-w-5xl flex items-end justify-between gap-4">
@@ -132,10 +167,12 @@
 
   <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
     <button id="loadBtn" class="pollen-btn">load starter</button>
-    <input id="urlInput" placeholder="or paste image URL" class="pollen-input min-w-52 flex-1 text-sm">
+    <button id="uploadBtn" class="pollen-btn">upload</button>
+    <input id="fileInput" type="file" accept="image/*" class="hidden">
+    <input id="urlInput" placeholder="or paste image URL / drop image on canvas" class="pollen-input min-w-52 flex-1 text-sm">
     <button id="useUrl" class="pollen-btn">use</button>
     <select id="modelSel" class="pollen-select text-sm">
-      <option value="p-image-edit">p-image-edit</option>
+      <option value="nanobanana">nanobanana</option>
     </select>
     <button id="undoBtn" class="pollen-btn" disabled>undo</button>
     <button id="redoBtn" class="pollen-btn" disabled>redo</button>
@@ -152,7 +189,10 @@
   </div>
 
   <div class="relative w-full max-w-5xl canvas-wrap">
-    <canvas id="canvas" width="1024" height="768" class="bg-white max-w-full"></canvas>
+    <div class="canvas-stage">
+      <canvas id="canvas" width="1024" height="768" class="bg-white"></canvas>
+      <div id="pinLayer"></div>
+    </div>
   </div>
 
   <div id="cursorPill" aria-hidden="true">
@@ -180,6 +220,22 @@ const undoBtn = document.getElementById("undoBtn");
 const redoBtn = document.getElementById("redoBtn");
 const pillEl = document.getElementById("cursorPill");
 const pillText = pillEl.querySelector(".text");
+const pinLayer = document.getElementById("pinLayer");
+
+function renderPins() {
+  pinLayer.innerHTML = "";
+  for (let i = 0; i < editQueue.length; i++) {
+    const job = editQueue[i];
+    const pin = document.createElement("div");
+    pin.className = "pin " + (i === 0 && queueRunning ? "processing" : "queued");
+    const dot = document.createElement("span"); dot.className = "dot";
+    const text = document.createElement("span"); text.textContent = job.intent;
+    pin.append(dot, text);
+    pin.style.left = `${(job.point.x / canvas.width) * 100}%`;
+    pin.style.top = `${(job.point.y / canvas.height) * 100}%`;
+    pinLayer.append(pin);
+  }
+}
 
 function showPill(x, y, text, isPlaceholder = false) {
   pillEl.style.left = `${x}px`;
@@ -204,9 +260,10 @@ let currentImage = null;
 let currentImageURL = "";
 let clickPoint = null;
 let activeCapture = null;
-let isBusy = false;
 const undoStack = [];
 let redoStack = [];
+const editQueue = [];
+let queueRunning = false;
 const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 
 function setStatus(s) { statusEl.textContent = s; }
@@ -217,18 +274,9 @@ function showError(message) {
 }
 function clearError() { errorEl.classList.add("hidden"); }
 
-function setBusy(value) {
-  isBusy = value;
-  for (const el of document.querySelectorAll("button, input, select")) {
-    if (el.id === "disconnectBtn") continue;
-    el.disabled = value;
-  }
-  updateHistoryButtons();
-}
-
 function updateHistoryButtons() {
-  undoBtn.disabled = isBusy || undoStack.length === 0;
-  redoBtn.disabled = isBusy || redoStack.length === 0;
+  undoBtn.disabled = undoStack.length === 0;
+  redoBtn.disabled = redoStack.length === 0;
 }
 
 function pushUndo() {
@@ -289,7 +337,7 @@ refreshConnectionUI();
 
 (async function loadEditModels() {
   const modelSel = document.getElementById("modelSel");
-  const DEFAULT_MODEL = "p-image-edit";
+  const DEFAULT_MODEL = "nanobanana";
   // Models known to obey the burned-in red-circle annotation well
   const RECOMMENDED = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
   try {
@@ -337,6 +385,7 @@ async function loadImageFromURL(url, opts = {}) {
   currentImage = img;
   currentImageURL = url;
   updateHistoryButtons();
+  renderPins();
   setStatus("ready");
 }
 
@@ -345,6 +394,28 @@ document.getElementById("useUrl").onclick = () => {
   const u = document.getElementById("urlInput").value.trim();
   if (u) loadImageFromURL(u, { pushHistory: true }).catch(err => showError(err.message));
 };
+
+function loadLocalFile(file) {
+  if (!file || !file.type.startsWith("image/")) { showError("Drop or pick an image file."); return; }
+  const reader = new FileReader();
+  reader.onload = () => loadImageFromURL(reader.result, { pushHistory: true }).catch(err => showError(err.message));
+  reader.onerror = () => showError("Could not read file.");
+  reader.readAsDataURL(file);
+}
+document.getElementById("uploadBtn").onclick = () => document.getElementById("fileInput").click();
+document.getElementById("fileInput").onchange = (e) => loadLocalFile(e.target.files?.[0]);
+
+const dropZone = document.querySelector(".canvas-wrap");
+["dragenter", "dragover"].forEach(ev => dropZone.addEventListener(ev, (e) => {
+  e.preventDefault(); dropZone.classList.add("drop");
+}));
+["dragleave", "drop"].forEach(ev => dropZone.addEventListener(ev, (e) => {
+  e.preventDefault(); dropZone.classList.remove("drop");
+}));
+dropZone.addEventListener("drop", (e) => {
+  const file = e.dataTransfer?.files?.[0];
+  if (file) loadLocalFile(file);
+});
 document.getElementById("clearIntent").onclick = () => {
   intentInput.value = "";
 };
@@ -425,20 +496,34 @@ async function stopIntentCapture(capture) {
   return Promise.race([capture.done, timeout]);
 }
 
+function drawAnnotation(targetCtx, p, w, h) {
+  // ~4% of image diagonal — empirically optimal for Gemini Flash Image (r2clickthrough)
+  // Thin stroke + no text: avoids the text-glyph prior that re-renders "HERE" in outputs.
+  const r = Math.max(28, Math.round(Math.min(w, h) * 0.05));
+  const stroke = Math.max(4, Math.round(r * 0.18));
+  targetCtx.save();
+  // Semi-transparent ring — lets the model still see the pixels underneath.
+  targetCtx.globalAlpha = 0.7;
+  targetCtx.strokeStyle = "red";
+  targetCtx.lineWidth = stroke;
+  targetCtx.beginPath(); targetCtx.arc(p.x, p.y, r, 0, Math.PI * 2); targetCtx.stroke();
+  // Solid center dot anchors the exact click point.
+  targetCtx.globalAlpha = 1;
+  targetCtx.fillStyle = "red";
+  targetCtx.beginPath(); targetCtx.arc(p.x, p.y, Math.max(3, Math.round(r * 0.12)), 0, Math.PI * 2); targetCtx.fill();
+  targetCtx.restore();
+}
 function annotatedDataURL(p) {
   const c = document.createElement("canvas");
   c.width = canvas.width;
   c.height = canvas.height;
   const cc = c.getContext("2d");
   cc.drawImage(canvas, 0, 0);
-  const r = Math.max(60, Math.round(Math.min(c.width, c.height) * 0.08));
-  cc.strokeStyle = "red";
-  cc.lineWidth = Math.max(6, Math.round(r * 0.12));
-  cc.beginPath(); cc.arc(p.x, p.y, r, 0, Math.PI * 2); cc.stroke();
-  cc.font = `bold ${Math.round(r * 0.5)}px sans-serif`;
-  cc.fillStyle = "red";
-  cc.fillText("HERE", p.x + r + 10, p.y);
+  drawAnnotation(cc, p, c.width, c.height);
   return c.toDataURL("image/png");
+}
+function paintAnnotationOnCanvas(p) {
+  drawAnnotation(ctx, p, canvas.width, canvas.height);
 }
 
 async function friendlyError(response, label) {
@@ -475,9 +560,8 @@ async function uploadDataURL(dataURL) {
   return j.url || `https://media.pollinations.ai/${j.id}`;
 }
 
-async function runEdit(refURL, prompt) {
-  setStatus("editing…");
-  const model = document.getElementById("modelSel").value;
+async function runEdit(refURL, prompt, model) {
+  if (!model) model = document.getElementById("modelSel").value;
   const r = await fetch(`${BASE}/v1/images/edits`, {
     method: "POST",
     headers: { Authorization: `Bearer ${getKey()}`, "Content-Type": "application/json" },
@@ -494,28 +578,51 @@ async function runEdit(refURL, prompt) {
 
 function buildEditPrompt(text) {
   return [
-    "Use the red circle and HERE label only as edit instructions, not final content.",
-    `Modify the object or region inside the red circle: ${text}.`,
-    "Remove the red circle and HERE label in the final image. Keep unmarked areas unchanged."
+    `Modify the area marked by the red ring and dot: ${text}.`,
+    "Do not render the red ring or dot in the output.",
+    "Keep everything else unchanged.",
   ].join(" ");
 }
 
-async function applyEditAtPoint(point, text) {
+function enqueueEdit(point, text) {
   if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
-  setBusy(true);
+  const prompt = buildEditPrompt(text);
+  const model = document.getElementById("modelSel").value;
+  editQueue.push({ point, intent: text, prompt, model });
+  renderPins();
+  runQueue();
+}
+
+async function runQueue() {
+  if (queueRunning) return;
+  queueRunning = true;
   try {
-    const annotURL = await uploadDataURL(annotatedDataURL(point));
-    const resultURL = await runEdit(annotURL, buildEditPrompt(text));
-    pushUndo();
-    await loadImageFromURL(resultURL);
+    while (editQueue.length) {
+      const job = editQueue[0];
+      const annotated = annotatedDataURL(job.point);
+      paintAnnotationOnCanvas(job.point);
+      renderPins();
+      setStatus(`editing… (${editQueue.length} in queue)`);
+      try {
+        const annotURL = await uploadDataURL(annotated);
+        const resultURL = await runEdit(annotURL, job.prompt, job.model);
+        pushUndo();
+        await loadImageFromURL(resultURL);
+      } catch (err) {
+        showError(err.message);
+        if (currentImageURL) await loadImageFromURL(currentImageURL).catch(() => {});
+      }
+      editQueue.shift();
+      renderPins();
+    }
     setStatus("done");
   } finally {
-    setBusy(false);
+    queueRunning = false;
+    renderPins();
   }
 }
 
 canvas.addEventListener("pointerdown", async (e) => {
-  if (isBusy) return;
   if (!currentImage) { showError("Load an image first."); return; }
   e.preventDefault();
   canvas.setPointerCapture(e.pointerId);
@@ -532,12 +639,13 @@ canvas.addEventListener("pointerup", async (e) => {
   if (!activeCapture) return;
   e.preventDefault();
   const capture = activeCapture;
+  const point = clickPoint;
   activeCapture = null;
   try {
     const { text, error } = await stopIntentCapture(capture);
     hidePill();
     if (!text.trim() && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
-    await applyEditAtPoint(clickPoint, text);
+    enqueueEdit(point, text);
   } catch (err) {
     showError(err.message);
   }
@@ -553,7 +661,7 @@ canvas.addEventListener("pointercancel", () => {
 });
 
 undoBtn.onclick = () => {
-  if (!undoStack.length || isBusy) return;
+  if (!undoStack.length) return;
   redoStack.push(currentImageURL);
   loadImageFromURL(undoStack.pop()).then(() => {
     setStatus("undone");
@@ -562,7 +670,7 @@ undoBtn.onclick = () => {
 };
 
 redoBtn.onclick = () => {
-  if (!redoStack.length || isBusy) return;
+  if (!redoStack.length) return;
   undoStack.push(currentImageURL);
   loadImageFromURL(redoStack.pop()).then(() => {
     setStatus("redone");

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -60,6 +60,16 @@
     color: var(--muted);
   }
   .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
   .status { min-width: 8ch; text-align: right; }
 
   .error {
@@ -318,7 +328,6 @@
 
     <section class="toolbar" aria-label="tools">
       <button id="connectBtn" class="btn accent">connect</button>
-      <button id="disconnectBtn" class="btn" hidden>disconnect</button>
       <button id="uploadBtn" class="btn">image</button>
       <input id="fileInput" type="file" accept="image/*" hidden>
       <div id="modePicker" class="mode" aria-label="mode">
@@ -388,7 +397,6 @@ const els = {
   stageVideo: document.getElementById("stageVideo"),
   pinLayer: document.getElementById("pinLayer"),
   connect: document.getElementById("connectBtn"),
-  disconnect: document.getElementById("disconnectBtn"),
   connectOverlay: document.getElementById("connectOverlayBtn"),
   upload: document.getElementById("uploadBtn"),
   file: document.getElementById("fileInput"),
@@ -472,7 +480,12 @@ function renderAccount() {
   }
   const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
   const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
-  els.account.textContent = user + balance;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
 }
 
 function renderPins() {
@@ -529,7 +542,6 @@ function captureKeyFromFragment() {
 function refreshConnectionUI() {
   const connected = !!localStorage.getItem(KEY_STORAGE);
   els.connect.hidden = connected;
-  els.disconnect.hidden = !connected;
   els.frame.classList.toggle("locked", !connected);
   if (!connected) {
     app.accountUser = "";
@@ -1124,7 +1136,6 @@ els.markCanvas.addEventListener("pointercancel", cancelGesture);
 
 els.connect.addEventListener("click", startConnect);
 els.connectOverlay.addEventListener("click", startConnect);
-els.disconnect.addEventListener("click", disconnect);
 els.upload.addEventListener("click", () => els.file.click());
 els.file.addEventListener("change", () => {
   const file = els.file.files?.[0];

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -224,7 +224,7 @@ const KEY_STORAGE = "voice-edit:user-key";
 const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
-const STARTER = "https://media.pollinations.ai/051ed82a46f5f85d";
+const STARTER = "https://media.pollinations.ai/10efdd0c1cfc65fa";
 
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -44,7 +44,8 @@
 
 <script>
 const KEY_STORAGE = "voice-edit:user-key";
-const CLIENT_ID = "pk_VOICE_EDIT_APP_KEY"; // TODO: replace with real App Key from enter.pollinations.ai
+// Optional App Key — register at enter.pollinations.ai → /authorize will fall back to hostname if blank
+const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
 const STARTER = "https://media.pollinations.ai/649d0f9cf10b5e48";
@@ -104,9 +105,9 @@ function refreshConnectionUI() {
 connectBtn.onclick = () => {
   const params = new URLSearchParams({
     redirect_uri: location.origin + location.pathname,
-    client_id: CLIENT_ID,
     scope: "generate",
   });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
   location.href = `${ENTER}/authorize?${params}`;
 };
 disconnectBtn.onclick = () => {

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -960,12 +960,13 @@ async function runVideo(imageURL, prompt, model) {
     duration: VIDEO_DURATION,
     image: imageURL,
   });
-  const res = await fetch(`${BASE}/video/${encodeURIComponent(prompt)}?${params}`, {
+  const url = `${BASE}/video/${encodeURIComponent(prompt)}?${params}`;
+  const res = await fetch(url, {
     headers: { Authorization: `Bearer ${key()}` },
   });
   if (!res.ok) throw new Error(await friendlyError(res, "Video failed"));
-  const blob = await res.blob();
-  return URL.createObjectURL(blob);
+  await res.arrayBuffer();
+  return url;
 }
 
 async function friendlyError(response, label) {

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -1,308 +1,446 @@
 <!doctype html>
+<html lang="en">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Voice Edit | Pollinations</title>
+<link rel="icon" href="data:,">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
-<script src="https://cdn.tailwindcss.com"></script>
 <style>
   :root {
     --dark: #110518;
-    --cream: #F3EBDE;
-    --tan: #e8e2d8;
-    --border: #cfc8b8;
-    --accent: #E8F372;
-    --primary: #C9A9E4;
-    --secondary: #A4B4DE;
-    --muted: #4a3f5c;
+    --paper: #f3ebde;
+    --card: #fffaf2;
+    --line: #110518;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --primary: #c9a9e4;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
   }
+
+  * { box-sizing: border-box; }
   body {
-    background: var(--cream);
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
     color: var(--dark);
-    font-family: 'IBM Plex Mono', monospace;
+    font-family: "IBM Plex Mono", monospace;
   }
-  .pollen-card {
-    background: #fff;
-    border: 2px solid var(--dark);
-    border-right-width: 4px;
-    border-bottom-width: 4px;
-    border-radius: 0;
+
+  button, input, select { font: inherit; color: inherit; }
+  button { touch-action: manipulation; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
   }
-  .pollen-btn {
-    font-family: 'IBM Plex Mono', monospace;
-    font-weight: 700;
-    background: #fff;
-    color: var(--dark);
-    border: 2px solid var(--dark);
-    border-right-width: 4px;
-    border-bottom-width: 4px;
-    padding: 0.45rem 0.9rem;
-    cursor: pointer;
-    transition: all 0.1s;
-    text-transform: lowercase;
-    letter-spacing: 0.02em;
+
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
   }
-  .pollen-btn:hover:not(:disabled) { transform: translate(1px, 1px); border-right-width: 3px; border-bottom-width: 3px; }
-  .pollen-btn:active:not(:disabled) { transform: translate(2px, 2px); border-right-width: 2px; border-bottom-width: 2px; }
-  .pollen-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-  .pollen-btn-accent { background: var(--accent); }
-  .pollen-btn-primary { background: var(--primary); }
-  .pollen-input, .pollen-select {
-    font-family: 'IBM Plex Mono', monospace;
-    background: #fff;
-    color: var(--dark);
-    border: 2px solid var(--dark);
-    border-right-width: 4px;
-    border-bottom-width: 4px;
-    border-radius: 0;
-    padding: 0.45rem 0.7rem;
-  }
-  .pollen-title {
-    font-family: 'Press Start 2P', monospace;
-    letter-spacing: -0.02em;
+
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
     line-height: 1.3;
+    letter-spacing: 0;
   }
-  canvas { cursor: crosshair; touch-action: none; display: block; max-width: 100%; max-height: calc(100vh - 200px); width: auto; height: auto; margin: 0 auto; }
-  .swatch { width: 1.4rem; height: 1.4rem; border: 2px solid var(--dark); cursor: pointer; padding: 0; outline: 2px solid transparent; outline-offset: 1px; }
+
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .status { min-width: 8ch; text-align: right; }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .btn, .select {
+    min-height: 38px;
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    border-radius: 0;
+    font-weight: 700;
+  }
+  .btn {
+    padding: 0 12px;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); border-right-width: 3px; border-bottom-width: 3px; }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); border-right-width: 2px; border-bottom-width: 2px; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; max-width: min(100%, 20rem); }
+
+  .type-mode {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    user-select: none;
+  }
+  .history { margin-left: auto; }
+
+  .swatches {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .swatch {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 2px solid var(--line);
+    border-radius: 0;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    cursor: pointer;
+  }
   .swatch.active { outline-color: var(--accent); }
-  .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; position: relative; display: flex; align-items: center; justify-content: center; width: 100%; }
-  .canvas-stage { position: relative; display: inline-block; max-width: 100%; }
-  .canvas-wrap.drop { outline: 4px dashed var(--accent); outline-offset: -8px; }
-  .canvas-wrap.locked canvas { cursor: not-allowed; filter: grayscale(0.4) opacity(0.55); }
-  #connectOverlay {
-    position: absolute; inset: 0; z-index: 20;
-    display: none; align-items: center; justify-content: center;
+  .swatch[data-color="white"] { background: #fff; }
+  .swatch[data-color="black"] { background: #000; }
+  .swatch[data-color="red"] { background: red; }
+
+  .frame {
+    position: relative;
+    min-height: 280px;
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    overflow: auto;
+    display: grid;
+    place-items: center;
+  }
+  .frame.drop { outline: 4px dashed var(--accent); outline-offset: -10px; }
+  .stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    max-height: calc(100vh - 210px);
+    touch-action: none;
+  }
+  .stage canvas {
+    display: block;
+    max-width: 100%;
+    max-height: calc(100vh - 210px);
+    width: auto;
+    height: auto;
+  }
+  #markCanvas, #pinLayer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  #pinLayer { z-index: 3; pointer-events: none; }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: none;
+    align-items: center;
+    justify-content: center;
     background: rgba(243, 235, 222, 0.88);
     backdrop-filter: blur(2px);
   }
-  .canvas-wrap.locked #connectOverlay { display: flex; }
-  #connectOverlay .panel {
-    background: #fff;
-    border: 2px solid var(--dark);
-    border-right-width: 4px;
-    border-bottom-width: 4px;
-    padding: 1.2rem 1.4rem;
+  .frame.locked .overlay { display: flex; }
+  .overlay-panel {
+    width: min(22rem, calc(100% - 32px));
+    padding: 18px;
     text-align: center;
-    max-width: 22rem;
-  }
-  #connectOverlay .panel p { font-size: 0.9rem; margin-bottom: 0.9rem; }
-
-  /* Cursor-anchored speech pill */
-  #cursorPill {
-    position: fixed;
-    z-index: 50;
-    transform: translate(18px, -50%);
     background: #fff;
-    color: var(--dark);
-    border: 2px solid var(--dark);
+    border: 2px solid var(--line);
     border-right-width: 4px;
     border-bottom-width: 4px;
-    border-radius: 0;
-    padding: 0.5rem 0.8rem 0.5rem 0.5rem;
-    font-family: 'IBM Plex Mono', monospace;
-    font-weight: 700;
-    font-size: 0.95rem;
-    max-width: 18rem;
-    display: none;
-    align-items: center;
-    gap: 0.55rem;
-    pointer-events: none;
-    white-space: normal;
-    overflow-wrap: anywhere;
   }
-  #cursorPill.visible { display: inline-flex; }
-  #cursorPill .mic {
-    flex: 0 0 auto;
-    width: 1.5rem;
-    height: 1.5rem;
-    background: var(--accent);
-    border: 2px solid var(--dark);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-  #cursorPill .mic .bar {
-    width: 3px;
-    background: var(--dark);
-    margin: 0 1px;
-    animation: micbar 0.9s ease-in-out infinite;
-  }
-  #cursorPill .mic .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
-  #cursorPill .mic .bar:nth-child(2) { height: 10px; animation-delay: .15s; }
-  #cursorPill .mic .bar:nth-child(3) { height: 6px; animation-delay: .3s; }
-  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
-  #cursorPill .text { min-width: 1ch; }
-  #cursorPill .text.placeholder { opacity: .55; font-style: italic; }
+  .overlay-panel p { margin: 0 0 12px; font-size: 0.9rem; }
 
-  /* Per-job pins anchored at the click point — sits over the canvas, same box */
-  #pinLayer { position: absolute; inset: 0; z-index: 5; pointer-events: none; }
-  #pinLayer .pin { position: absolute; }
   .pin {
     position: absolute;
-    /* Anchor point is the dot center. Default: pin extends to the right.
-       Subtract: half-dot (≈0.275rem) + dot-border (1.5px) + padding (0.55rem) + small gap so the dot sits exactly on (xPct, yPct). */
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    max-width: min(16rem, 48vw);
+    width: max-content;
+    padding: 5px 9px;
     transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
     background: #fff;
-    border: 2px solid var(--dark);
+    border: 2px solid var(--line);
     border-right-width: 4px;
     border-bottom-width: 4px;
-    padding: 0.35rem 0.55rem;
-    font-family: 'IBM Plex Mono', monospace;
     font-size: 0.75rem;
-    line-height: 1.3;
-    min-width: 6rem;
-    max-width: 16rem;
-    width: max-content;
-    white-space: normal;
-    word-break: normal;
+    line-height: 1.25;
     overflow-wrap: break-word;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
   }
   .pin.processing { background: var(--accent); }
-  .pin.queued { background: #fff; opacity: 0.85; }
   .pin .dot {
     flex: 0 0 auto;
     width: 0.55rem;
     height: 0.55rem;
-    background: var(--dark);
-    border: 1.5px solid var(--dark);
+    background: var(--line);
+    border: 1.5px solid var(--line);
   }
-  .pin.processing .dot { background: var(--dark); animation: pulse 1s ease-in-out infinite; }
-  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+  .pin span:last-child { min-width: 0; }
+
+  .pill {
+    position: fixed;
+    z-index: 20;
+    display: none;
+    align-items: center;
+    gap: 9px;
+    max-width: min(18rem, calc(100vw - 24px));
+    padding: 8px 12px 8px 8px;
+    transform: translate(18px, -50%);
+    background: #fff;
+    border: 2px solid var(--line);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    pointer-events: none;
+    overflow-wrap: anywhere;
+  }
+  .pill.visible { display: inline-flex; }
+  .pill .mic {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: var(--accent);
+    border: 2px solid var(--line);
+  }
+  .pill .bar {
+    width: 3px;
+    background: var(--line);
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  .pill .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  .pill .bar:nth-child(2) { height: 10px; animation-delay: 0.15s; }
+  .pill .bar:nth-child(3) { height: 6px; animation-delay: 0.3s; }
+  .pill .placeholder { opacity: 0.55; font-style: italic; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+
+  @media (max-width: 720px) {
+    .app { width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .topbar { gap: 6px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .history { margin-left: 0; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .frame { min-height: 240px; }
+    .stage, .stage canvas { max-height: calc(100vh - 260px); }
+    .pin { max-width: 62vw; }
+  }
+  .frame.locked .stage { filter: grayscale(0.35) opacity(0.55); }
 </style>
-<body class="min-h-screen p-4 md:p-6 flex flex-col items-center gap-4">
-  <div class="w-full max-w-5xl flex items-baseline gap-3">
-    <h1 class="pollen-title text-xl md:text-2xl">voice·edit</h1>
-    <span class="text-xs text-[var(--muted)]">point. talk. release.</span>
-    <span class="text-xs text-[var(--muted)] ml-auto" id="account"></span>
-    <span class="text-xs text-[var(--muted)]" id="status">ready</span>
-  </div>
 
-  <div id="error" class="hidden w-full max-w-5xl pollen-card px-4 py-3 text-sm" style="background:#ffe1e1;border-color:#a02020"></div>
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit</h1>
+      <span class="tagline">draw. talk. release.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
 
-  <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <button id="connectBtn" class="pollen-btn pollen-btn-accent">connect</button>
-    <button id="disconnectBtn" class="hidden pollen-btn">disconnect</button>
-    <button id="uploadBtn" class="pollen-btn">image</button>
-    <input id="fileInput" type="file" accept="image/*" class="hidden">
-    <select id="modelSel" class="pollen-select text-sm">
-      <option value="nanobanana">nanobanana</option>
-    </select>
-    <div id="colorPicker" class="flex items-center gap-1 ml-1">
-      <button type="button" class="swatch" data-color="red" style="background:red"></button>
-      <button type="button" class="swatch" data-color="black" style="background:black"></button>
-      <button type="button" class="swatch" data-color="white" style="background:white"></button>
-    </div>
-    <label class="ml-2 text-xs flex items-center gap-1 select-none">
-      <input id="typeMode" type="checkbox"> type instead
-    </label>
-    <button id="undoBtn" class="pollen-btn ml-auto" disabled title="undo">↶</button>
-    <button id="redoBtn" class="pollen-btn" disabled title="redo">↷</button>
-    <button id="downloadBtn" class="pollen-btn" title="download">↓</button>
-  </div>
+    <div id="error" class="error"></div>
 
-  <div class="relative w-full max-w-5xl canvas-wrap">
-    <div class="canvas-stage">
-      <canvas id="canvas" width="1024" height="768" class="bg-white"></canvas>
-      <div id="pinLayer"></div>
-    </div>
-    <div id="connectOverlay">
-      <div class="panel">
-        <p>connect to pollinations to start editing</p>
-        <button id="connectOverlayBtn" class="pollen-btn pollen-btn-accent">connect</button>
+    <section class="toolbar" aria-label="tools">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="disconnectBtn" class="btn" hidden>disconnect</button>
+      <button id="uploadBtn" class="btn">image</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="image model">
+        <option value="nanobanana">nanobanana</option>
+      </select>
+      <div id="colorPicker" class="swatches" aria-label="marker color">
+        <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
+        <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
+        <button type="button" class="swatch" data-color="white" aria-label="white marker"></button>
       </div>
-    </div>
-  </div>
+      <label class="type-mode"><input id="typeMode" type="checkbox"> type instead</label>
+      <button id="undoBtn" class="btn history" disabled title="undo">undo</button>
+      <button id="redoBtn" class="btn" disabled title="redo">redo</button>
+      <button id="downloadBtn" class="btn" title="download">save</button>
+    </section>
 
-  <div id="cursorPill" aria-hidden="true">
+    <section id="frame" class="frame">
+      <div id="stage" class="stage">
+        <canvas id="imageCanvas" width="1024" height="768"></canvas>
+        <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <div id="pinLayer"></div>
+      </div>
+      <div class="overlay">
+        <div class="overlay-panel">
+          <p>connect to pollinations to start editing</p>
+          <button id="connectOverlayBtn" class="btn accent">connect</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div id="cursorPill" class="pill" aria-hidden="true">
     <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
-    <span class="text placeholder">listening…</span>
+    <span id="pillText" class="placeholder">listening...</span>
   </div>
 
 <script>
 const KEY_STORAGE = "voice-edit:user-key";
-// Optional App Key — register at enter.pollinations.ai → /authorize will fall back to hostname if blank
 const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
 const STARTER = "https://media.pollinations.ai/10efdd0c1cfc65fa";
-
-const canvas = document.getElementById("canvas");
-const ctx = canvas.getContext("2d");
-const statusEl = document.getElementById("status");
-const errorEl = document.getElementById("error");
-const connectBtn = document.getElementById("connectBtn");
-const disconnectBtn = document.getElementById("disconnectBtn");
-const accountEl = document.getElementById("account");
-const undoBtn = document.getElementById("undoBtn");
-const redoBtn = document.getElementById("redoBtn");
-const pillEl = document.getElementById("cursorPill");
-const pillText = pillEl.querySelector(".text");
-const pinLayer = document.getElementById("pinLayer");
-
-function renderPins() {
-  pinLayer.innerHTML = "";
-  for (let i = 0; i < editQueue.length; i++) {
-    const job = editQueue[i];
-    const pin = document.createElement("div");
-    pin.className = `pin ${i === 0 && queueRunning ? "processing" : "queued"}`;
-    const dot = document.createElement("span"); dot.className = "dot";
-    const text = document.createElement("span"); text.textContent = job.intent;
-    pin.append(dot, text);
-    pin.style.left = `${job.xPct}%`;
-    pin.style.top = `${job.yPct}%`;
-    pinLayer.append(pin);
-  }
-}
-function render() {
-  renderPins();
-  undoBtn.disabled = undoStack.length === 0;
-  redoBtn.disabled = redoStack.length === 0;
-}
-
-function pill({ x, y, text, placeholder, visible }) {
-  if (x != null) pillEl.style.left = `${x}px`;
-  if (y != null) pillEl.style.top = `${y}px`;
-  if (text !== undefined) {
-    pillText.textContent = text;
-    pillText.classList.toggle("placeholder", !!placeholder);
-  }
-  if (visible !== undefined) pillEl.classList.toggle("visible", visible);
-}
-
-let currentImage = null;
-let currentImageURL = "";
-let activeCapture = null;
-const undoStack = [];
-let redoStack = [];
-const editQueue = [];
-let queueRunning = false;
 const STT_MODEL = "scribe";
 const STT_LANG = (navigator.language || "en").slice(0, 2);
 const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
-  .find(m => window.MediaRecorder?.isTypeSupported?.(m)) || "";
-let micStream = null; // pre-warmed mic to eliminate startup cut-off
-let markerColor = "red";
+  .find((m) => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+const DRAG_THRESHOLD = 0.03;
+const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
 
-function setStatus(s) { statusEl.textContent = s; }
+const els = {
+  account: document.getElementById("account"),
+  status: document.getElementById("status"),
+  error: document.getElementById("error"),
+  frame: document.getElementById("frame"),
+  stage: document.getElementById("stage"),
+  imageCanvas: document.getElementById("imageCanvas"),
+  markCanvas: document.getElementById("markCanvas"),
+  pinLayer: document.getElementById("pinLayer"),
+  connect: document.getElementById("connectBtn"),
+  disconnect: document.getElementById("disconnectBtn"),
+  connectOverlay: document.getElementById("connectOverlayBtn"),
+  upload: document.getElementById("uploadBtn"),
+  file: document.getElementById("fileInput"),
+  model: document.getElementById("modelSel"),
+  typeMode: document.getElementById("typeMode"),
+  undo: document.getElementById("undoBtn"),
+  redo: document.getElementById("redoBtn"),
+  download: document.getElementById("downloadBtn"),
+  colorPicker: document.getElementById("colorPicker"),
+  pill: document.getElementById("cursorPill"),
+  pillText: document.getElementById("pillText"),
+};
+const imageCtx = els.imageCanvas.getContext("2d");
+const markCtx = els.markCanvas.getContext("2d");
+
+const app = {
+  image: null,
+  imageURL: "",
+  micStream: null,
+  active: null,
+  busy: false,
+  queue: [],
+  currentJob: null,
+  undo: [],
+  redo: [],
+  markerColor: "red",
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
 function showError(message) {
-  errorEl.textContent = message;
-  errorEl.classList.remove("hidden");
+  els.error.textContent = message;
+  els.error.classList.add("visible");
   setStatus("error");
 }
-function clearError() { errorEl.classList.add("hidden"); }
 
-function pushUndo() {
-  if (!currentImageURL) return;
-  undoStack.push(currentImageURL);
-  redoStack = [];
-  render();
+function clearError() {
+  els.error.classList.remove("visible");
 }
 
-(function captureKeyFromFragment() {
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+function render() {
+  const locked = app.busy || Boolean(app.active);
+  els.undo.disabled = app.undo.length === 0 || locked;
+  els.redo.disabled = app.redo.length === 0 || locked;
+  els.upload.disabled = locked;
+  els.model.disabled = locked;
+  els.typeMode.disabled = locked;
+  renderPins();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = user + balance;
+}
+
+function renderPins() {
+  els.pinLayer.innerHTML = "";
+  const jobs = [app.currentJob, ...app.queue].filter(Boolean);
+  const layerBox = els.pinLayer.getBoundingClientRect();
+  for (const job of jobs) {
+    const pin = document.createElement("div");
+    pin.className = `pin ${job === app.currentJob ? "processing" : "queued"}`;
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    const text = document.createElement("span");
+    text.textContent = job.text;
+    pin.append(dot, text);
+    pin.style.left = `${job.xPct}%`;
+    pin.style.top = `${job.yPct}%`;
+    els.pinLayer.append(pin);
+    const anchorX = layerBox.left + (layerBox.width * job.xPct / 100);
+    const available = window.innerWidth - anchorX - 12;
+    pin.style.maxWidth = `${Math.min(256, Math.max(28, available))}px`;
+  }
+}
+
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) els.pill.style.left = `${x}px`;
+  if (y != null) els.pill.style.top = `${y}px`;
+  if (text !== undefined) {
+    els.pillText.textContent = text;
+    els.pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) els.pill.classList.toggle("visible", visible);
+}
+
+function captureKeyFromFragment() {
   if (!location.hash) return;
   const params = new URLSearchParams(location.hash.slice(1));
   const apiKey = params.get("api_key");
@@ -312,59 +450,24 @@ function pushUndo() {
   } else if (params.get("error")) {
     showError(`Authorization failed: ${params.get("error")}`);
   }
-})();
-
-function getKey() {
-  const k = localStorage.getItem(KEY_STORAGE);
-  if (!k) throw new Error("not connected — click Connect Pollinations");
-  return k;
-}
-
-let accountUser = "";
-let accountBalance = null;
-function renderAccount() {
-  const base = accountUser ? `connected as ${accountUser}` : "connected";
-  const bal = accountBalance == null ? "" : ` · ${accountBalance.toFixed(2)} pollen`;
-  accountEl.textContent = base + bal;
-}
-
-async function loadBalance() {
-  const k = localStorage.getItem(KEY_STORAGE);
-  if (!k) return;
-  try {
-    const r = await fetch(`${BASE}/account/balance`, { headers: { Authorization: `Bearer ${k}` } });
-    if (!r.ok) return;
-    const { balance } = await r.json();
-    accountBalance = balance;
-    renderAccount();
-  } catch {}
 }
 
 function refreshConnectionUI() {
-  const k = localStorage.getItem(KEY_STORAGE);
-  const canvasWrap = document.querySelector(".canvas-wrap");
-  if (k) {
-    connectBtn.classList.add("hidden");
-    disconnectBtn.classList.remove("hidden");
-    accountUser = "";
-    accountBalance = null;
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  els.disconnect.hidden = !connected;
+  els.frame.classList.toggle("locked", !connected);
+  if (!connected) {
+    app.accountUser = "";
+    app.accountBalance = null;
     renderAccount();
-    canvasWrap.classList.remove("locked");
-    warmMic();
-    fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${k}` } })
-      .then(r => r.ok ? r.json() : null)
-      .then(u => { if (u?.preferred_username) { accountUser = u.preferred_username; renderAccount(); } })
-      .catch(() => {});
-    loadBalance();
-  } else {
-    connectBtn.classList.remove("hidden");
-    disconnectBtn.classList.add("hidden");
-    accountUser = "";
-    accountBalance = null;
-    accountEl.textContent = "not connected";
-    canvasWrap.classList.add("locked");
     setStatus("not connected");
+    return;
   }
+  renderAccount();
+  warmMic();
+  loadUser();
+  loadBalance();
 }
 
 function startConnect() {
@@ -375,440 +478,516 @@ function startConnect() {
   if (CLIENT_ID) params.set("client_id", CLIENT_ID);
   location.href = `${ENTER}/authorize?${params}`;
 }
-connectBtn.onclick = startConnect;
-document.getElementById("connectOverlayBtn").onclick = startConnect;
-disconnectBtn.onclick = () => {
+
+function disconnect() {
   localStorage.removeItem(KEY_STORAGE);
-  if (micStream) {
-    for (const t of micStream.getTracks()) t.stop();
-    micStream = null;
-  }
+  stopMic();
   refreshConnectionUI();
-};
-refreshConnectionUI();
+}
 
-(function setupColorPicker() {
-  const picker = document.getElementById("colorPicker");
-  const swatches = picker.querySelectorAll(".swatch");
-  const apply = () => {
-    for (const s of swatches) s.classList.toggle("active", s.dataset.color === markerColor);
-  };
-  for (const s of swatches) s.addEventListener("click", () => { markerColor = s.dataset.color; apply(); });
-  apply();
-})();
-
-(async function loadEditModels() {
-  const modelSel = document.getElementById("modelSel");
-  const DEFAULT_MODEL = "nanobanana";
-  // Models known to obey the burned-in red-circle annotation well
-  const RECOMMENDED = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+async function loadUser() {
   try {
-    const r = await fetch(`${BASE}/image/models`);
-    if (!r.ok) return;
-    const all = await r.json();
-    const edits = all.filter(m =>
-      m.input_modalities?.includes("image") && m.output_modalities?.includes("image"),
-    );
-    edits.sort((a, b) => {
-      const ra = RECOMMENDED.has(a.name) ? 0 : 1;
-      const rb = RECOMMENDED.has(b.name) ? 0 : 1;
-      return ra - rb || a.name.localeCompare(b.name);
-    });
-    modelSel.innerHTML = "";
-    for (const m of edits) {
-      const opt = document.createElement("option");
-      opt.value = m.name;
-      const tags = [];
-      if (RECOMMENDED.has(m.name)) tags.push("★");
-      if (m.paid_only) tags.push("paid");
-      opt.textContent = tags.length ? `${m.name} (${tags.join(" · ")})` : m.name;
-      modelSel.append(opt);
-    }
-    if ([...modelSel.options].some(o => o.value === DEFAULT_MODEL)) modelSel.value = DEFAULT_MODEL;
-  } catch {
-    // network blip — leave the hardcoded option in place
-  }
-})();
-
-async function loadImageFromURL(url, opts = {}) {
-  clearError();
-  if (opts.pushHistory) pushUndo();
-  setStatus("loading image…");
-  const img = new Image();
-  img.crossOrigin = "anonymous";
-  await new Promise((res, rej) => {
-    img.onload = res;
-    img.onerror = () => rej(new Error("could not load image; try another URL"));
-    img.src = url;
-  });
-  canvas.width = img.naturalWidth;
-  canvas.height = img.naturalHeight;
-  ctx.drawImage(img, 0, 0);
-  currentImage = img;
-  currentImageURL = url;
-  render();
-  setStatus("ready");
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${key()}` } });
+    if (!res.ok) return;
+    const user = await res.json();
+    app.accountUser = user?.preferred_username || "";
+    renderAccount();
+  } catch {}
 }
 
-async function loadImage(src, opts) {
-  if (src instanceof File) {
-    if (!src.type.startsWith("image/")) throw new Error("Drop or pick an image file.");
-    src = await new Promise((res, rej) => {
-      const r = new FileReader();
-      r.onload = () => res(r.result);
-      r.onerror = () => rej(new Error("Could not read file."));
-      r.readAsDataURL(src);
-    });
-  }
-  return loadImageFromURL(src, opts);
-}
-const safeLoad = (src) => loadImage(src, { pushHistory: true }).catch(err => showError(err.message));
-document.getElementById("uploadBtn").onclick = () => document.getElementById("fileInput").click();
-document.getElementById("fileInput").onchange = (e) => { const f = e.target.files?.[0]; if (f) safeLoad(f); };
-
-function promptTypedEdit(clientX, clientY) {
-  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
-  const input = document.createElement("input");
-  input.type = "text";
-  input.placeholder = "type edit, press enter";
-  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
-  pillText.replaceWith(input);
-  input.focus();
-  setStatus("typing…");
-  return new Promise((resolve) => {
-    const finish = (text) => {
-      input.replaceWith(pillText);
-      pill({ visible: false });
-      resolve(text);
-    };
-    input.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") { e.preventDefault(); finish(input.value.trim()); }
-      if (e.key === "Escape") { e.preventDefault(); finish(""); }
-    });
-    input.addEventListener("blur", () => finish(input.value.trim()));
-  });
-}
-
-const dropZone = document.querySelector(".canvas-wrap");
-["dragenter", "dragover"].forEach((ev) => {
-  dropZone.addEventListener(ev, (e) => {
-    e.preventDefault(); dropZone.classList.add("drop");
-  });
-});
-["dragleave", "drop"].forEach((ev) => {
-  dropZone.addEventListener(ev, (e) => {
-    e.preventDefault(); dropZone.classList.remove("drop");
-  });
-});
-dropZone.addEventListener("drop", (e) => {
-  const file = e.dataTransfer?.files?.[0];
-  if (file) safeLoad(file);
-});
-function canvasPointFromEvent(e) {
-  const rect = canvas.getBoundingClientRect();
-  const sx = canvas.width / rect.width;
-  const sy = canvas.height / rect.height;
-  return {
-    x: Math.round((e.clientX - rect.left) * sx),
-    y: Math.round((e.clientY - rect.top) * sy),
-    rectX: e.clientX - rect.left,
-    rectY: e.clientY - rect.top,
-  };
+async function loadBalance() {
+  try {
+    const res = await fetch(`${BASE}/account/balance`, { headers: { Authorization: `Bearer ${key()}` } });
+    if (!res.ok) return;
+    const { balance } = await res.json();
+    app.accountBalance = Number(balance);
+    renderAccount();
+  } catch {}
 }
 
 async function warmMic() {
-  if (micStream || !navigator.mediaDevices?.getUserMedia) return;
+  if (app.micStream || !navigator.mediaDevices?.getUserMedia) return;
   try {
-    micStream = await navigator.mediaDevices.getUserMedia({
+    app.micStream = await navigator.mediaDevices.getUserMedia({
       audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
     });
   } catch (err) {
-    showError(`Microphone unavailable (${err?.message || "denied"}). Use 'type instead'.`);
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use type instead.`);
   }
 }
 
-function startIntentCapture(clientX, clientY) {
-  clearError();
-  if (!window.MediaRecorder) {
-    showError("Voice input is not available in this browser. Use 'type instead'.");
-    return null;
-  }
-  const capture = { chunks: [], error: "", recorder: null };
-  if (!micStream) {
-    capture.error = "microphone not ready — click the page once, then try again";
-    warmMic();
-    return capture; // pointerup will surface the error
-  }
+function stopMic() {
+  if (!app.micStream) return;
+  for (const track of app.micStream.getTracks()) track.stop();
+  app.micStream = null;
+}
+
+async function loadModels() {
   try {
-    capture.recorder = new MediaRecorder(micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
-    capture.recorder.ondataavailable = (e) => { if (e.data?.size) capture.chunks.push(e.data); };
+    const res = await fetch(`${BASE}/image/models`);
+    if (!res.ok) return;
+    const models = await res.json();
+    const editModels = models
+      .filter((m) => m.input_modalities?.includes("image") && m.output_modalities?.includes("image"))
+      .sort((a, b) => {
+        const ra = RECOMMENDED_MODELS.has(a.name) ? 0 : 1;
+        const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
+        return ra - rb || a.name.localeCompare(b.name);
+      });
+    els.model.innerHTML = "";
+    for (const m of editModels) {
+      const option = document.createElement("option");
+      option.value = m.name;
+      const tags = [];
+      if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
+      if (m.paid_only) tags.push("paid");
+      option.textContent = tags.length ? `${m.name} (${tags.join(", ")})` : m.name;
+      els.model.append(option);
+    }
+    if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+  } catch {}
+}
+
+function pushUndo() {
+  if (!app.imageURL) return;
+  app.undo.push(app.imageURL);
+  app.redo = [];
+  render();
+}
+
+async function loadImage(src, { pushHistory = false } = {}) {
+  clearError();
+  if (src instanceof File) src = await readImageFile(src);
+  if (pushHistory) pushUndo();
+  setStatus("loading image...");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = () => reject(new Error("could not load image"));
+    img.src = src;
+  });
+  app.image = img;
+  app.imageURL = src;
+  resizeCanvases(img.naturalWidth, img.naturalHeight);
+  imageCtx.drawImage(img, 0, 0);
+  clearMarks();
+  setStatus("ready");
+  render();
+}
+
+function readImageFile(file) {
+  if (!file?.type?.startsWith("image/")) throw new Error("Drop or pick an image file.");
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("Could not read file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+function resizeCanvases(width, height) {
+  for (const canvas of [els.imageCanvas, els.markCanvas]) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function clearMarks() {
+  markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function pointerPoint(event) {
+  const rect = els.markCanvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
+  const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
+  return {
+    x: Math.max(0, Math.min(els.markCanvas.width, Math.round(x))),
+    y: Math.max(0, Math.min(els.markCanvas.height, Math.round(y))),
+  };
+}
+
+function strokeWidth() {
+  return Math.max(6, Math.round(Math.min(els.markCanvas.width, els.markCanvas.height) * 0.015));
+}
+
+function drawSegment(from, to) {
+  markCtx.save();
+  markCtx.strokeStyle = app.markerColor;
+  markCtx.lineWidth = strokeWidth();
+  markCtx.lineCap = "round";
+  markCtx.lineJoin = "round";
+  markCtx.beginPath();
+  markCtx.moveTo(from.x, from.y);
+  markCtx.lineTo(to.x, to.y);
+  markCtx.stroke();
+  markCtx.restore();
+}
+
+function pathLength(points) {
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    total += Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
+  }
+  return total;
+}
+
+function pathBounds(points) {
+  const bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity };
+  for (const point of points) {
+    bounds.minX = Math.min(bounds.minX, point.x);
+    bounds.maxX = Math.max(bounds.maxX, point.x);
+    bounds.minY = Math.min(bounds.minY, point.y);
+    bounds.maxY = Math.max(bounds.maxY, point.y);
+  }
+  return bounds;
+}
+
+async function composeSnapshot(marker = "") {
+  const out = document.createElement("canvas");
+  out.width = els.imageCanvas.width;
+  out.height = els.imageCanvas.height;
+  const outCtx = out.getContext("2d");
+  outCtx.drawImage(els.imageCanvas, 0, 0);
+  if (marker) {
+    const markerImage = await loadImageElement(marker);
+    outCtx.drawImage(markerImage, 0, 0, out.width, out.height);
+  }
+  return out.toDataURL("image/png");
+}
+
+function buildPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
+}
+
+function pinPct(point) {
+  return {
+    xPct: (point.x / els.markCanvas.width) * 100,
+    yPct: (point.y / els.markCanvas.height) * 100,
+  };
+}
+
+function loadImageElement(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load marker"));
+    img.src = src;
+  });
+}
+
+function enqueueEdit({ text, marked, marker, pinPoint, color }) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  const pin = pinPct(pinPoint);
+  app.queue.push({
+    text,
+    marked,
+    marker,
+    color,
+    model: els.model.value,
+    xPct: pin.xPct,
+    yPct: pin.yPct,
+  });
+  render();
+  runQueue();
+}
+
+function beginRecording(clientX, clientY) {
+  clearError();
+  if (!window.MediaRecorder) return { error: "Voice input is not available in this browser. Use type instead." };
+  if (!app.micStream) {
+    warmMic();
+    return { error: "microphone not ready - click once, allow access, then try again" };
+  }
+  const capture = { chunks: [], recorder: null, error: "" };
+  try {
+    capture.recorder = new MediaRecorder(app.micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (event) => {
+      if (event.data?.size) capture.chunks.push(event.data);
+    };
     capture.recorder.start();
   } catch (err) {
     capture.error = err?.message || "could not start recording";
     return capture;
   }
-  pill({ x: clientX, y: clientY, text: "listening…", placeholder: true, visible: true });
-  setStatus("listening…");
+  pill({ x: clientX, y: clientY, text: "listening...", placeholder: true, visible: true });
+  setStatus("listening...");
   return capture;
 }
 
-async function stopIntentCapture(capture) {
+async function stopAndTranscribe(capture) {
   if (capture.error || !capture.recorder) return { text: "", error: capture.error };
-  setStatus("transcribing…");
-  pill({ text: "transcribing…", placeholder: true });
+  setStatus("transcribing...");
+  pill({ text: "transcribing...", placeholder: true });
   const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
-  try { capture.recorder.stop(); } catch {}
+  capture.recorder.stop();
   await stopped;
   const type = capture.recorder.mimeType || "audio/webm";
   const ext = type.includes("mp4") ? "mp4" : "webm";
   const blob = new Blob(capture.chunks, { type });
-  if (blob.size < 1000) return { text: "", error: "no audio captured — hold and speak" };
-  const fd = new FormData();
-  fd.append("file", blob, `voice.${ext}`);
-  fd.append("model", STT_MODEL);
-  fd.append("language", STT_LANG);
-  fd.append("response_format", "json");
+  if (blob.size < 1000) return { text: "", error: "no audio captured - hold and speak" };
+  const form = new FormData();
+  form.append("file", blob, `voice.${ext}`);
+  form.append("model", STT_MODEL);
+  form.append("language", STT_LANG);
+  form.append("response_format", "json");
   try {
-    const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${getKey()}` },
-      body: fd,
+      headers: { Authorization: `Bearer ${key()}` },
+      body: form,
     });
-    if (!r.ok) return { text: "", error: await friendlyError(r, "Transcription failed") };
-    const j = await r.json();
-    return { text: (j.text || "").trim(), error: "" };
+    if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
+    const json = await res.json();
+    return { text: (json.text || "").trim(), error: "" };
   } catch (err) {
     return { text: "", error: err?.message || "transcription failed" };
   }
 }
 
-function strokeWidthFor(w, h) {
-  return Math.max(6, Math.round(Math.min(w, h) * 0.015));
-}
-function drawStrokeSegment(targetCtx, a, b, w, h) {
-  targetCtx.save();
-  targetCtx.strokeStyle = markerColor;
-  targetCtx.lineWidth = strokeWidthFor(w, h);
-  targetCtx.lineCap = "round";
-  targetCtx.lineJoin = "round";
-  targetCtx.beginPath(); targetCtx.moveTo(a.x, a.y); targetCtx.lineTo(b.x, b.y); targetCtx.stroke();
-  targetCtx.restore();
-}
-function pathLength(points) {
-  let total = 0;
-  for (let i = 1; i < points.length; i++) {
-    const dx = points[i].x - points[i - 1].x, dy = points[i].y - points[i - 1].y;
-    total += Math.hypot(dx, dy);
-  }
-  return total;
-}
-function pathBounds(points) {
-  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-  for (const p of points) {
-    if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
-    if (p.y < minY) minY = p.y; if (p.y > maxY) maxY = p.y;
-  }
-  return { minX, maxX, minY, maxY };
-}
-
-async function friendlyError(response, label) {
-  let details = "";
-  try {
-    const text = await response.text();
-    const json = JSON.parse(text);
-    details = json.error?.message || json.message || text;
-  } catch {
-    details = response.statusText || "request failed";
-  }
-  if (response.status === 401 || response.status === 403) {
-    localStorage.removeItem(KEY_STORAGE);
-    refreshConnectionUI();
-    return `${label}: authorization expired. Connect Pollinations again.`;
-  }
-  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
-  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
-  return `${label}: ${response.status} ${details}`;
+async function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  els.pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing...");
+  return new Promise((resolve) => {
+    const finish = (text) => {
+      input.replaceWith(els.pillText);
+      pill({ visible: false });
+      resolve(text.trim());
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") { event.preventDefault(); finish(input.value); }
+      if (event.key === "Escape") { event.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value));
+  });
 }
 
 async function uploadDataURL(dataURL) {
-  setStatus("uploading…");
+  setStatus("uploading...");
   const blob = await (await fetch(dataURL)).blob();
-  const fd = new FormData();
-  fd.append("file", blob, "annot.png");
-  const r = await fetch("https://media.pollinations.ai/upload", {
+  const form = new FormData();
+  form.append("file", blob, "annot.png");
+  const res = await fetch("https://media.pollinations.ai/upload", {
     method: "POST",
-    headers: { Authorization: `Bearer ${getKey()}` },
-    body: fd,
+    headers: { Authorization: `Bearer ${key()}` },
+    body: form,
   });
-  if (!r.ok) throw new Error(await friendlyError(r, "Upload failed"));
-  const j = await r.json();
-  return j.url || `https://media.pollinations.ai/${j.id}`;
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
 }
 
-async function runEdit(refURL, prompt, model) {
-  if (!model) model = document.getElementById("modelSel").value;
-  const r = await fetch(`${BASE}/v1/images/edits`, {
+async function runEdit(imageURL, prompt, model) {
+  const res = await fetch(`${BASE}/v1/images/edits`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${getKey()}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt, image: refURL, model, response_format: "url" }),
+    headers: { Authorization: `Bearer ${key()}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
   });
-  if (!r.ok) throw new Error(await friendlyError(r, "Edit failed"));
-  const j = await r.json();
-  const item = j.data?.[0];
+  if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
+  const json = await res.json();
+  const item = json.data?.[0];
   if (!item) throw new Error("no image in response");
   if (item.url) return item.url;
   if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
   throw new Error("no url or b64_json in response");
 }
 
-function buildEditPrompt(text, marked, color) {
-  if (!marked) return text;
-  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
-}
-
-function enqueueEdit({ point, text, annotated, marked }) {
-  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
-  const prompt = buildEditPrompt(text, marked, markerColor);
-  const model = document.getElementById("modelSel").value;
-  const xPct = (point.x / canvas.width) * 100;
-  const yPct = (point.y / canvas.height) * 100;
-  editQueue.push({ xPct, yPct, intent: text, prompt, model, annotated });
-  render();
-  runQueue();
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
 }
 
 async function runQueue() {
-  if (queueRunning) return;
-  queueRunning = true;
+  if (app.busy) return;
+  app.busy = true;
+  render();
   try {
-    while (editQueue.length) {
-      const job = editQueue[0];
+    while (app.queue.length) {
+      const job = app.queue.shift();
+      app.currentJob = job;
       render();
-      setStatus(`editing… (${editQueue.length} in queue)`);
+      setStatus(`editing... (${app.queue.length + 1} in queue)`);
       try {
-        const annotURL = await uploadDataURL(job.annotated);
-        const resultURL = await runEdit(annotURL, job.prompt, job.model);
+        const snapshot = await composeSnapshot(job.marker);
+        const uploaded = await uploadDataURL(snapshot);
+        const prompt = buildPrompt(job.text, job.marked, job.color);
+        const result = await runEdit(uploaded, prompt, job.model);
         pushUndo();
-        await loadImageFromURL(resultURL);
+        await loadImage(result);
+        await loadBalance();
       } catch (err) {
         showError(err.message);
-        if (currentImageURL) await loadImageFromURL(currentImageURL).catch(() => {});
+      } finally {
+        app.currentJob = null;
+        render();
       }
-      editQueue.shift();
-      render();
     }
     setStatus("done");
-    loadBalance();
   } finally {
-    queueRunning = false;
+    app.busy = false;
+    app.currentJob = null;
     render();
   }
 }
 
-function resetCanvas() {
-  if (!currentImage) return;
-  canvas.width = currentImage.naturalWidth;
-  canvas.height = currentImage.naturalHeight;
-  ctx.drawImage(currentImage, 0, 0);
+function cancelGesture() {
+  if (app.active?.capture?.recorder?.state === "recording") {
+    try { app.active.capture.recorder.stop(); } catch {}
+  }
+  app.active = null;
+  clearMarks();
+  pill({ visible: false });
+  setStatus(app.busy ? "editing..." : "ready");
+  render();
 }
 
-canvas.addEventListener("pointerdown", async (e) => {
-  if (!currentImage) { showError("Load an image first."); return; }
-  if (queueRunning || editQueue.length) { showError("Wait for the current edit to finish."); return; }
-  e.preventDefault();
-  resetCanvas(); // wipe any leftover markings from the prior gesture
-  const point = canvasPointFromEvent(e);
-  if (document.getElementById("typeMode").checked) {
-    const text = await promptTypedEdit(e.clientX, e.clientY);
-    if (text) {
-      const annotated = canvas.toDataURL("image/png");
-      try { enqueueEdit({ point, text, annotated, marked: false }); }
-      catch (err) { showError(err.message); }
-    } else {
-      setStatus("ready");
+els.markCanvas.addEventListener("pointerdown", async (event) => {
+  if (!app.image) { showError("Load an image first."); return; }
+  if (app.active) return;
+  event.preventDefault();
+  clearError();
+  clearMarks();
+  const start = pointerPoint(event);
+
+  if (els.typeMode.checked) {
+    app.active = { typing: true };
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    app.active = null;
+    render();
+    if (!text) { setStatus(app.busy ? "editing..." : "ready"); return; }
+    try {
+      enqueueEdit({ text, marked: false, marker: "", pinPoint: start, color: app.markerColor });
+    } catch (err) {
+      showError(err.message);
     }
     return;
   }
-  try { canvas.setPointerCapture(e.pointerId); } catch {}
-  activeCapture = startIntentCapture(e.clientX, e.clientY);
-  if (activeCapture) {
-    activeCapture.point = point;
-    activeCapture.stroke = [point];
-  }
+
+  const capture = beginRecording(event.clientX, event.clientY);
+  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
 });
 
-canvas.addEventListener("pointermove", (e) => {
-  if (!activeCapture) return;
-  pill({ x: e.clientX, y: e.clientY });
-  if (!activeCapture.stroke) return;
-  const p = canvasPointFromEvent(e);
-  const prev = activeCapture.stroke[activeCapture.stroke.length - 1];
-  drawStrokeSegment(ctx, prev, p, canvas.width, canvas.height);
-  activeCapture.stroke.push(p);
+els.markCanvas.addEventListener("pointermove", (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  pill({ x: event.clientX, y: event.clientY });
+  const point = pointerPoint(event);
+  const prev = gesture.points[gesture.points.length - 1];
+  drawSegment(prev, point);
+  gesture.points.push(point);
 });
 
-canvas.addEventListener("pointerup", async (e) => {
-  if (!activeCapture) return;
-  e.preventDefault();
-  const capture = activeCapture;
-  activeCapture = null;
-  const minLen = Math.min(canvas.width, canvas.height) * 0.03;
-  const stroke = capture.stroke || [capture.point];
-  const isDrag = pathLength(stroke) > minLen;
-  // No drag → wipe back to clean source so no faint live-paint trace persists in the snapshot.
-  if (!isDrag) resetCanvas();
-  const annotated = canvas.toDataURL("image/png");
-  let pinPoint;
-  if (isDrag) {
-    const b = pathBounds(stroke);
-    pinPoint = { x: b.maxX, y: (b.minY + b.maxY) / 2 };
-  } else {
-    pinPoint = capture.point;
-  }
+els.markCanvas.addEventListener("pointerup", async (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  app.active = null;
+  const length = pathLength(gesture.points);
+  const marked = length >= Math.min(els.markCanvas.width, els.markCanvas.height) * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const marker = marked ? els.markCanvas.toDataURL("image/png") : "";
+  const bounds = marked ? pathBounds(gesture.points) : null;
+  const pinPoint = marked
+    ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 }
+    : gesture.points[0];
   try {
-    const { text, error } = await stopIntentCapture(capture);
+    const { text, error } = await stopAndTranscribe(gesture.capture);
     pill({ visible: false });
-    if (!text.trim() && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
-    enqueueEdit({ point: pinPoint, text, annotated, marked: isDrag });
+    if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    enqueueEdit({ text, marked, marker, pinPoint, color: gesture.color });
   } catch (err) {
     showError(err.message);
-    resetCanvas();
+    clearMarks();
   }
 });
 
-canvas.addEventListener("pointercancel", () => {
-  if (activeCapture) {
-    try { activeCapture.recorder?.stop(); } catch {}
-  }
-  activeCapture = null;
-  pill({ visible: false });
-  resetCanvas();
-  setStatus("ready");
+els.markCanvas.addEventListener("pointercancel", cancelGesture);
+
+els.connect.addEventListener("click", startConnect);
+els.connectOverlay.addEventListener("click", startConnect);
+els.disconnect.addEventListener("click", disconnect);
+els.upload.addEventListener("click", () => els.file.click());
+els.file.addEventListener("change", () => {
+  const file = els.file.files?.[0];
+  if (file) loadImage(file, { pushHistory: true }).catch((err) => showError(err.message));
 });
 
-undoBtn.onclick = () => {
-  if (!undoStack.length) return;
-  redoStack.push(currentImageURL);
-  loadImageFromURL(undoStack.pop()).then(() => setStatus("undone")).catch(err => showError(err.message));
-};
+els.colorPicker.addEventListener("click", (event) => {
+  const swatch = event.target.closest(".swatch");
+  if (!swatch) return;
+  app.markerColor = swatch.dataset.color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button === swatch);
+  }
+});
 
-redoBtn.onclick = () => {
-  if (!redoStack.length) return;
-  undoStack.push(currentImageURL);
-  loadImageFromURL(redoStack.pop()).then(() => setStatus("redone")).catch(err => showError(err.message));
-};
+for (const eventName of ["dragenter", "dragover"]) {
+  els.frame.addEventListener(eventName, (event) => {
+    event.preventDefault();
+    els.frame.classList.add("drop");
+  });
+}
+for (const eventName of ["dragleave", "drop"]) {
+  els.frame.addEventListener(eventName, (event) => {
+    event.preventDefault();
+    els.frame.classList.remove("drop");
+  });
+}
+els.frame.addEventListener("drop", (event) => {
+  const file = event.dataTransfer?.files?.[0];
+  if (file) loadImage(file, { pushHistory: true }).catch((err) => showError(err.message));
+});
 
-document.getElementById("downloadBtn").onclick = () => {
+els.undo.addEventListener("click", () => {
+  if (!app.undo.length || app.busy || app.active) return;
+  app.redo.push(app.imageURL);
+  loadImage(app.undo.pop()).then(() => setStatus("undone")).catch((err) => showError(err.message));
+});
+els.redo.addEventListener("click", () => {
+  if (!app.redo.length || app.busy || app.active) return;
+  app.undo.push(app.imageURL);
+  loadImage(app.redo.pop()).then(() => setStatus("redone")).catch((err) => showError(err.message));
+});
+els.download.addEventListener("click", () => {
   try {
-    const a = document.createElement("a");
-    a.href = canvas.toDataURL("image/png");
-    a.download = "voice-edit.png";
-    a.click();
+    const link = document.createElement("a");
+    link.href = els.imageCanvas.toDataURL("image/png");
+    link.download = "voice-edit.png";
+    link.click();
   } catch {
-    if (currentImageURL) window.open(currentImageURL, "_blank", "noopener");
+    if (app.imageURL) window.open(app.imageURL, "_blank", "noopener");
   }
-};
+});
 
-loadImageFromURL(STARTER).catch(err => showError(err.message));
+captureKeyFromFragment();
+refreshConnectionUI();
+loadModels();
+loadImage(STARTER).catch((err) => showError(err.message));
+for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+  button.classList.toggle("active", button.dataset.color === app.markerColor);
+}
 </script>
 </body>
+</html>

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -2,54 +2,162 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Voice Edit | Pollinations</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
 <script src="https://cdn.tailwindcss.com"></script>
 <style>
-  body { background:#0a0a0a; color:#e5e5e5; }
-  canvas { cursor: crosshair; touch-action: none; }
-  button:disabled { opacity: .45; cursor: not-allowed; }
+  :root {
+    --dark: #110518;
+    --cream: #F3EBDE;
+    --tan: #e8e2d8;
+    --border: #cfc8b8;
+    --accent: #E8F372;
+    --primary: #C9A9E4;
+    --secondary: #A4B4DE;
+    --muted: #4a3f5c;
+  }
+  body {
+    background: var(--cream);
+    color: var(--dark);
+    font-family: 'IBM Plex Mono', monospace;
+  }
+  .pollen-card {
+    background: #fff;
+    border: 2px solid var(--dark);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    border-radius: 0;
+  }
+  .pollen-btn {
+    font-family: 'IBM Plex Mono', monospace;
+    font-weight: 700;
+    background: #fff;
+    color: var(--dark);
+    border: 2px solid var(--dark);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    padding: 0.45rem 0.9rem;
+    cursor: pointer;
+    transition: all 0.1s;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
+  }
+  .pollen-btn:hover:not(:disabled) { transform: translate(1px, 1px); border-right-width: 3px; border-bottom-width: 3px; }
+  .pollen-btn:active:not(:disabled) { transform: translate(2px, 2px); border-right-width: 2px; border-bottom-width: 2px; }
+  .pollen-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .pollen-btn-accent { background: var(--accent); }
+  .pollen-btn-primary { background: var(--primary); }
+  .pollen-input, .pollen-select {
+    font-family: 'IBM Plex Mono', monospace;
+    background: #fff;
+    color: var(--dark);
+    border: 2px solid var(--dark);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    border-radius: 0;
+    padding: 0.45rem 0.7rem;
+  }
+  .pollen-title {
+    font-family: 'Press Start 2P', monospace;
+    letter-spacing: -0.02em;
+    line-height: 1.3;
+  }
+  canvas { cursor: crosshair; touch-action: none; display: block; }
+  .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; }
+
+  /* Cursor-anchored speech pill */
+  #cursorPill {
+    position: fixed;
+    z-index: 50;
+    transform: translate(18px, -50%);
+    background: #fff;
+    color: var(--dark);
+    border: 2px solid var(--dark);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    border-radius: 0;
+    padding: 0.5rem 0.8rem 0.5rem 0.5rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-weight: 700;
+    font-size: 0.95rem;
+    max-width: 18rem;
+    display: none;
+    align-items: center;
+    gap: 0.55rem;
+    pointer-events: none;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  #cursorPill.visible { display: inline-flex; }
+  #cursorPill .mic {
+    flex: 0 0 auto;
+    width: 1.5rem;
+    height: 1.5rem;
+    background: var(--accent);
+    border: 2px solid var(--dark);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  #cursorPill .mic .bar {
+    width: 3px;
+    background: var(--dark);
+    margin: 0 1px;
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  #cursorPill .mic .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  #cursorPill .mic .bar:nth-child(2) { height: 10px; animation-delay: .15s; }
+  #cursorPill .mic .bar:nth-child(3) { height: 6px; animation-delay: .3s; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+  #cursorPill .text { min-width: 1ch; }
+  #cursorPill .text.placeholder { opacity: .55; font-style: italic; }
 </style>
 <body class="min-h-screen p-4 md:p-6 flex flex-col items-center gap-4">
-  <div class="w-full max-w-5xl flex items-center justify-between gap-4">
+  <div class="w-full max-w-5xl flex items-end justify-between gap-4">
     <div>
-      <h1 class="text-2xl font-semibold tracking-tight">Voice Edit</h1>
-      <p class="text-sm text-neutral-500">Point at an image, speak or type an edit, release to apply.</p>
+      <h1 class="pollen-title text-2xl md:text-3xl">voice<br>edit</h1>
+      <p class="text-sm text-[var(--muted)] mt-2">point. talk. release. it's edited.</p>
     </div>
-    <div class="text-xs text-neutral-500 shrink-0" id="status">ready</div>
+    <div class="text-xs text-[var(--muted)] shrink-0" id="status">ready</div>
   </div>
 
-  <div id="error" class="hidden w-full max-w-5xl rounded-lg border border-red-500/30 bg-red-950/40 px-4 py-3 text-sm text-red-100"></div>
+  <div id="error" class="hidden w-full max-w-5xl pollen-card px-4 py-3 text-sm" style="background:#ffe1e1;border-color:#a02020"></div>
 
   <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <button id="connectBtn" class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 rounded">Connect Pollinations</button>
-    <button id="disconnectBtn" class="hidden px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Disconnect</button>
-    <span id="account" class="text-neutral-400"></span>
+    <button id="connectBtn" class="pollen-btn pollen-btn-accent">connect pollinations</button>
+    <button id="disconnectBtn" class="hidden pollen-btn">disconnect</button>
+    <span id="account" class="text-[var(--muted)]"></span>
   </div>
 
   <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <button id="loadBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Load starter image</button>
-    <input id="urlInput" placeholder="or paste image URL" class="min-w-52 flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
-    <button id="useUrl" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Use</button>
-    <select id="modelSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
+    <button id="loadBtn" class="pollen-btn">load starter</button>
+    <input id="urlInput" placeholder="or paste image URL" class="pollen-input min-w-52 flex-1 text-sm">
+    <button id="useUrl" class="pollen-btn">use</button>
+    <select id="modelSel" class="pollen-select text-sm">
       <option value="p-image-edit">p-image-edit</option>
     </select>
-    <button id="undoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Undo</button>
-    <button id="redoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Redo</button>
-    <button id="downloadBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Download</button>
+    <button id="undoBtn" class="pollen-btn" disabled>undo</button>
+    <button id="redoBtn" class="pollen-btn" disabled>redo</button>
+    <button id="downloadBtn" class="pollen-btn">download</button>
   </div>
 
   <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <input id="intentInput" placeholder="Optional typed edit, e.g. make this a brass lamp" class="min-w-64 flex-1 px-3 py-2 bg-neutral-900 border border-neutral-800 rounded">
-    <button id="clearIntent" class="px-3 py-2 bg-neutral-800 hover:bg-neutral-700 rounded">Clear</button>
+    <input id="intentInput" placeholder="optional typed edit, e.g. make this a brass lamp" class="pollen-input min-w-64 flex-1">
+    <button id="clearIntent" class="pollen-btn">clear</button>
   </div>
 
-  <div class="w-full max-w-5xl text-sm text-neutral-400">
-    <div>Click and hold on the image. If the text field is empty, the browser listens for your voice; otherwise it applies the typed edit.</div>
-    <div id="transcript" class="mt-1 text-neutral-300 italic min-h-[1.5em]"></div>
+  <div class="w-full max-w-5xl text-xs text-[var(--muted)]">
+    click and hold on the image. talk into the pill that pops up — release to apply.
   </div>
 
-  <div class="relative w-full max-w-5xl overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950 shadow-2xl">
-    <canvas id="canvas" width="1024" height="768" class="rounded-lg bg-neutral-900 max-w-full"></canvas>
-    <div id="recDot" class="hidden absolute top-4 right-4 w-4 h-4 rounded-full bg-red-500 animate-pulse"></div>
+  <div class="relative w-full max-w-5xl canvas-wrap">
+    <canvas id="canvas" width="1024" height="768" class="bg-white max-w-full"></canvas>
+  </div>
+
+  <div id="cursorPill" aria-hidden="true">
+    <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
+    <span class="text placeholder">listening…</span>
   </div>
 
 <script>
@@ -63,15 +171,34 @@ const STARTER = "https://media.pollinations.ai/649d0f9cf10b5e48";
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 const statusEl = document.getElementById("status");
-const transcriptEl = document.getElementById("transcript");
 const errorEl = document.getElementById("error");
-const recDot = document.getElementById("recDot");
 const connectBtn = document.getElementById("connectBtn");
 const disconnectBtn = document.getElementById("disconnectBtn");
 const accountEl = document.getElementById("account");
 const intentInput = document.getElementById("intentInput");
 const undoBtn = document.getElementById("undoBtn");
 const redoBtn = document.getElementById("redoBtn");
+const pillEl = document.getElementById("cursorPill");
+const pillText = pillEl.querySelector(".text");
+
+function showPill(x, y, text, isPlaceholder = false) {
+  pillEl.style.left = `${x}px`;
+  pillEl.style.top = `${y}px`;
+  pillText.textContent = text;
+  pillText.classList.toggle("placeholder", isPlaceholder);
+  pillEl.classList.add("visible");
+}
+function movePill(x, y) {
+  pillEl.style.left = `${x}px`;
+  pillEl.style.top = `${y}px`;
+}
+function setPillText(text, isPlaceholder = false) {
+  pillText.textContent = text;
+  pillText.classList.toggle("placeholder", isPlaceholder);
+}
+function hidePill() {
+  pillEl.classList.remove("visible");
+}
 
 let currentImage = null;
 let currentImageURL = "";
@@ -220,7 +347,6 @@ document.getElementById("useUrl").onclick = () => {
 };
 document.getElementById("clearIntent").onclick = () => {
   intentInput.value = "";
-  transcriptEl.textContent = "";
 };
 
 function canvasPointFromEvent(e) {
@@ -235,11 +361,11 @@ function canvasPointFromEvent(e) {
   };
 }
 
-function startIntentCapture() {
+function startIntentCapture(clientX, clientY) {
   clearError();
   const typed = intentInput.value.trim();
   if (typed) {
-    transcriptEl.textContent = `→ ${typed}`;
+    showPill(clientX, clientY, typed, false);
     setStatus("release to edit…");
     return { mode: "typed", text: typed };
   }
@@ -262,26 +388,19 @@ function startIntentCapture() {
   recognition.interimResults = true;
   recognition.lang = navigator.language || "en-US";
 
-  capture.done = new Promise((resolve) => {
-    capture.resolve = resolve;
-  });
+  capture.done = new Promise((resolve) => { capture.resolve = resolve; });
   const finish = () => {
     if (capture.finished) return;
     capture.finished = true;
-    recDot.classList.add("hidden");
     capture.resolve({ text: capture.text.trim(), error: capture.error });
   };
   recognition.onresult = (event) => {
     let text = "";
-    for (let i = 0; i < event.results.length; i++) {
-      text += event.results[i][0].transcript;
-    }
+    for (let i = 0; i < event.results.length; i++) text += event.results[i][0].transcript;
     capture.text = text.trim();
-    transcriptEl.textContent = capture.text ? `→ ${capture.text}` : "listening…";
+    setPillText(capture.text || "listening…", !capture.text);
   };
-  recognition.onerror = (event) => {
-    capture.error = event.error || "speech recognition failed";
-  };
+  recognition.onerror = (event) => { capture.error = event.error || "speech recognition failed"; };
   recognition.onend = finish;
 
   try {
@@ -291,8 +410,7 @@ function startIntentCapture() {
     return null;
   }
 
-  recDot.classList.remove("hidden");
-  transcriptEl.textContent = "listening…";
+  showPill(clientX, clientY, "listening…", true);
   setStatus("listening…");
   return capture;
 }
@@ -302,7 +420,6 @@ async function stopIntentCapture(capture) {
   setStatus("processing…");
   try { capture.recognition.stop(); } catch {}
   const timeout = new Promise((resolve) => setTimeout(() => {
-    recDot.classList.add("hidden");
     resolve({ text: capture.text.trim(), error: capture.error });
   }, 1500));
   return Promise.race([capture.done, timeout]);
@@ -387,7 +504,6 @@ async function applyEditAtPoint(point, text) {
   if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
   setBusy(true);
   try {
-    transcriptEl.textContent = `→ ${text}`;
     const annotURL = await uploadDataURL(annotatedDataURL(point));
     const resultURL = await runEdit(annotURL, buildEditPrompt(text));
     pushUndo();
@@ -404,8 +520,12 @@ canvas.addEventListener("pointerdown", async (e) => {
   e.preventDefault();
   canvas.setPointerCapture(e.pointerId);
   clickPoint = canvasPointFromEvent(e);
-  transcriptEl.textContent = "";
-  activeCapture = startIntentCapture();
+  activeCapture = startIntentCapture(e.clientX, e.clientY);
+});
+
+canvas.addEventListener("pointermove", (e) => {
+  if (!activeCapture) return;
+  movePill(e.clientX, e.clientY);
 });
 
 canvas.addEventListener("pointerup", async (e) => {
@@ -415,6 +535,7 @@ canvas.addEventListener("pointerup", async (e) => {
   activeCapture = null;
   try {
     const { text, error } = await stopIntentCapture(capture);
+    hidePill();
     if (!text.trim() && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
     await applyEditAtPoint(clickPoint, text);
   } catch (err) {
@@ -427,7 +548,7 @@ canvas.addEventListener("pointercancel", () => {
     try { activeCapture.recognition.stop(); } catch {}
   }
   activeCapture = null;
-  recDot.classList.add("hidden");
+  hidePill();
   setStatus("ready");
 });
 

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -4,7 +4,6 @@
 <script src="https://cdn.tailwindcss.com"></script>
 <style>
   body { background:#0a0a0a; color:#e5e5e5; }
-  .ring { box-shadow: 0 0 0 4px rgba(239,68,68,.6), 0 0 30px rgba(239,68,68,.4); }
   canvas { cursor: crosshair; touch-action: none; }
 </style>
 <body class="min-h-screen p-6 flex flex-col items-center gap-4">
@@ -16,7 +15,6 @@
   <div class="relative">
     <canvas id="canvas" width="1024" height="768" class="rounded-lg bg-neutral-900 max-w-full"></canvas>
     <div id="recDot" class="hidden absolute top-4 right-4 w-4 h-4 rounded-full bg-red-500 animate-pulse"></div>
-    <div id="marker" class="hidden absolute pointer-events-none w-24 h-24 -ml-12 -mt-12 rounded-full border-4 border-red-500 ring"></div>
   </div>
 
   <div class="w-full max-w-4xl flex items-center gap-2 text-sm">
@@ -48,14 +46,13 @@
 <script>
 const KEY_STORAGE = "voice-edit:api-key";
 const BASE = "https://gen.pollinations.ai";
-const STARTER = "https://media.pollinations.ai/c5d89da41260fc5a";
+const STARTER = "https://media.pollinations.ai/649d0f9cf10b5e48";
 
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 const statusEl = document.getElementById("status");
 const transcriptEl = document.getElementById("transcript");
 const recDot = document.getElementById("recDot");
-const marker = document.getElementById("marker");
 const keyInput = document.getElementById("keyInput");
 
 let currentImage = null;
@@ -106,13 +103,6 @@ function canvasPointFromEvent(e) {
     rectY: e.clientY - rect.top,
   };
 }
-
-function showMarker(p) {
-  marker.style.left = (canvas.offsetLeft + p.rectX) + "px";
-  marker.style.top = (canvas.offsetTop + p.rectY) + "px";
-  marker.classList.remove("hidden");
-}
-function hideMarker() { marker.classList.add("hidden"); }
 
 async function startRecording() {
   try {
@@ -210,7 +200,6 @@ canvas.addEventListener("pointerdown", async (e) => {
   e.preventDefault();
   canvas.setPointerCapture(e.pointerId);
   clickPoint = canvasPointFromEvent(e);
-  showMarker(clickPoint);
   transcriptEl.textContent = "";
   await startRecording();
 });
@@ -219,19 +208,17 @@ canvas.addEventListener("pointerup", async (e) => {
   if (!mediaRecorder || mediaRecorder.state !== "recording") return;
   try {
     const blob = await stopRecordingAndGetBlob();
-    if (blob.size < 1000) { setStatus("too short"); hideMarker(); return; }
+    if (blob.size < 1000) { setStatus("too short"); return; }
     const text = await transcribe(blob);
     transcriptEl.textContent = "→ " + text;
-    if (!text.trim()) { setStatus("nothing heard"); hideMarker(); return; }
+    if (!text.trim()) { setStatus("nothing heard"); return; }
     const annotURL = await uploadDataURL(annotatedDataURL(clickPoint));
     const prompt = `Edit the area marked with the red circle (labeled HERE). ${text}. Remove the red circle and HERE text in the final image.`;
     const resultURL = await runEdit(annotURL, prompt);
     await loadImageFromURL(resultURL);
-    hideMarker();
     setStatus("done");
   } catch (err) {
     setStatus("error: " + err.message);
-    hideMarker();
   }
 });
 

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -445,9 +445,9 @@ function key() {
 
 function render() {
   const locked = app.busy || Boolean(app.active);
-  const video = app.current?.kind === "video";
-  els.undo.disabled = !canUndo() || locked;
-  els.redo.disabled = !canRedo() || locked;
+  const video = media.isVideo();
+  els.undo.disabled = !mediaHistory.canUndo() || locked;
+  els.redo.disabled = !mediaHistory.canRedo() || locked;
   els.upload.disabled = locked;
   els.model.disabled = locked || app.mode === "animate";
   els.model.hidden = app.mode === "animate";
@@ -596,40 +596,39 @@ function stopMic() {
   app.micStream = null;
 }
 
-function canUndo() {
-  return app.historyIndex > 0;
-}
+const media = {
+  image: (url) => ({ kind: "image", url }),
+  video: (url, prompt, imageURL = app.imageURL) => ({ kind: "video", url, prompt, imageURL }),
+  isVideo: (frame = app.current) => frame?.kind === "video",
+};
 
-function canRedo() {
-  return app.historyIndex >= 0 && app.historyIndex < app.history.length - 1;
-}
-
-function addFrame(frame) {
-  app.history = app.history.slice(0, app.historyIndex + 1);
-  app.history.push(frame);
-  app.historyIndex = app.history.length - 1;
-  app.current = frame;
-  render();
-}
-
-async function goToFrame(index) {
-  const frame = app.history[index];
-  if (!frame) return;
-  await renderFrame(frame);
-  app.historyIndex = index;
-  app.current = frame;
-  render();
-}
-
-async function setFrame(frame, { addToHistory = false } = {}) {
-  await renderFrame(frame);
-  if (addToHistory) {
-    addFrame(frame);
-  } else {
+const mediaHistory = {
+  canUndo: () => app.historyIndex > 0,
+  canRedo: () => app.historyIndex >= 0 && app.historyIndex < app.history.length - 1,
+  add(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
     app.current = frame;
     render();
-  }
-}
+  },
+  async go(index) {
+    const frame = app.history[index];
+    if (!frame) return;
+    await renderFrame(frame);
+    app.historyIndex = index;
+    app.current = frame;
+    render();
+  },
+  async set(frame, { add = false } = {}) {
+    await renderFrame(frame);
+    if (add) mediaHistory.add(frame);
+    else {
+      app.current = frame;
+      render();
+    }
+  },
+};
 
 async function loadModels() {
   try {
@@ -660,12 +659,12 @@ async function loadModels() {
 async function loadImage(src, { addToHistory = false } = {}) {
   clearError();
   if (src instanceof File) src = await readImageFile(src);
-  await setFrame({ kind: "image", url: src }, { addToHistory });
+  await mediaHistory.set(media.image(src), { add: addToHistory });
 }
 
 async function renderFrame(frame) {
   clearError();
-  if (frame.kind === "video") {
+  if (media.isVideo(frame)) {
     if (frame.imageURL) await drawImage(frame.imageURL);
     showVideoElement(frame.url);
   } else {
@@ -727,14 +726,14 @@ function hideVideoElement() {
 }
 
 async function commitVideoFrame() {
-  if (app.current?.kind !== "video") return;
+  if (!media.isVideo()) return;
   const video = els.stageVideo;
   if (!video.videoWidth || !video.videoHeight) throw new Error("video frame is not ready yet");
   const frame = document.createElement("canvas");
   frame.width = video.videoWidth;
   frame.height = video.videoHeight;
   frame.getContext("2d").drawImage(video, 0, 0);
-  await setFrame({ kind: "image", url: frame.toDataURL("image/png") }, { addToHistory: true });
+  await mediaHistory.set(media.image(frame.toDataURL("image/png")), { add: true });
 }
 
 function pointerPoint(event) {
@@ -1001,11 +1000,11 @@ async function runQueue() {
         const uploaded = await uploadDataURL(snapshot, job.kind === "video" ? "source.png" : "annot.png");
         if (job.kind === "video") {
           const videoURL = await runVideo(uploaded, job.text, job.model);
-          await setFrame({ kind: "video", url: videoURL, prompt: job.text, imageURL: app.imageURL }, { addToHistory: true });
+          await mediaHistory.set(media.video(videoURL, job.text), { add: true });
         } else {
           const prompt = buildPrompt(job.text, job.marked, job.color);
           const result = await runEdit(uploaded, prompt, job.model);
-          await setFrame({ kind: "image", url: result }, { addToHistory: true });
+          await mediaHistory.set(media.image(result), { add: true });
         }
         await loadBalance();
       } catch (err) {
@@ -1039,7 +1038,7 @@ els.markCanvas.addEventListener("pointerdown", async (event) => {
   if (app.active) return;
   event.preventDefault();
   clearError();
-  if (app.current?.kind === "video") {
+  if (media.isVideo()) {
     try {
       await commitVideoFrame();
     } catch (err) {
@@ -1164,17 +1163,17 @@ els.frame.addEventListener("drop", (event) => {
 });
 
 els.undo.addEventListener("click", () => {
-  if (!canUndo() || app.busy || app.active) return;
-  goToFrame(app.historyIndex - 1).then(() => setStatus("undone")).catch((err) => showError(err.message));
+  if (!mediaHistory.canUndo() || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex - 1).then(() => setStatus("undone")).catch((err) => showError(err.message));
 });
 els.redo.addEventListener("click", () => {
-  if (!canRedo() || app.busy || app.active) return;
-  goToFrame(app.historyIndex + 1).then(() => setStatus("redone")).catch((err) => showError(err.message));
+  if (!mediaHistory.canRedo() || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + 1).then(() => setStatus("redone")).catch((err) => showError(err.message));
 });
 els.download.addEventListener("click", () => {
   try {
     const link = document.createElement("a");
-    const video = app.current?.kind === "video";
+    const video = media.isVideo();
     link.href = video ? app.current.url : els.imageCanvas.toDataURL("image/png");
     link.download = video ? "voice-edit.mp4" : "voice-edit.png";
     link.click();

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -32,10 +32,9 @@
   </div>
 
   <div class="w-full max-w-4xl flex items-center gap-2 text-sm">
-    <input id="keyInput" type="password" placeholder="paste your Pollinations app key"
-      class="flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded font-mono">
-    <button id="saveKey" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Save</button>
-    <a href="https://enter.pollinations.ai" target="_blank" class="px-3 py-1.5 text-blue-400 hover:underline">get a key →</a>
+    <button id="connectBtn" class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 rounded">Connect Pollinations</button>
+    <button id="disconnectBtn" class="hidden px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Disconnect</button>
+    <span id="account" class="text-neutral-400"></span>
   </div>
 
   <div class="w-full max-w-4xl text-sm text-neutral-400">
@@ -44,7 +43,9 @@
   </div>
 
 <script>
-const KEY_STORAGE = "voice-edit:api-key";
+const KEY_STORAGE = "voice-edit:user-key";
+const CLIENT_ID = "pk_VOICE_EDIT_APP_KEY"; // TODO: replace with real App Key from enter.pollinations.ai
+const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
 const STARTER = "https://media.pollinations.ai/649d0f9cf10b5e48";
 
@@ -53,7 +54,9 @@ const ctx = canvas.getContext("2d");
 const statusEl = document.getElementById("status");
 const transcriptEl = document.getElementById("transcript");
 const recDot = document.getElementById("recDot");
-const keyInput = document.getElementById("keyInput");
+const connectBtn = document.getElementById("connectBtn");
+const disconnectBtn = document.getElementById("disconnectBtn");
+const accountEl = document.getElementById("account");
 
 let currentImage = null;
 let mediaRecorder = null;
@@ -63,16 +66,54 @@ let stream = null;
 
 function setStatus(s) { statusEl.textContent = s; }
 
-keyInput.value = localStorage.getItem(KEY_STORAGE) || "";
-document.getElementById("saveKey").onclick = () => {
-  localStorage.setItem(KEY_STORAGE, keyInput.value.trim());
-  setStatus("key saved");
-};
+(function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (apiKey) {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    history.replaceState(null, "", location.pathname + location.search);
+  } else if (params.get("error")) {
+    setStatus("auth: " + params.get("error"));
+  }
+})();
+
 function getKey() {
-  const k = (keyInput.value || localStorage.getItem(KEY_STORAGE) || "").trim();
-  if (!k) throw new Error("no API key — paste one above (get one at enter.pollinations.ai)");
+  const k = localStorage.getItem(KEY_STORAGE);
+  if (!k) throw new Error("not connected — click Connect Pollinations");
   return k;
 }
+
+function refreshConnectionUI() {
+  const k = localStorage.getItem(KEY_STORAGE);
+  if (k) {
+    connectBtn.classList.add("hidden");
+    disconnectBtn.classList.remove("hidden");
+    accountEl.textContent = "connected";
+    fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${k}` } })
+      .then(r => r.ok ? r.json() : null)
+      .then(u => { if (u?.preferred_username) accountEl.textContent = `connected as ${u.preferred_username}`; })
+      .catch(() => {});
+  } else {
+    connectBtn.classList.remove("hidden");
+    disconnectBtn.classList.add("hidden");
+    accountEl.textContent = "";
+  }
+}
+
+connectBtn.onclick = () => {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname,
+    client_id: CLIENT_ID,
+    scope: "generate",
+  });
+  location.href = `${ENTER}/authorize?${params}`;
+};
+disconnectBtn.onclick = () => {
+  localStorage.removeItem(KEY_STORAGE);
+  refreshConnectionUI();
+};
+refreshConnectionUI();
 
 async function loadImageFromURL(url) {
   setStatus("loading image…");

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -769,6 +769,18 @@ function pathBounds(points) {
   return bounds;
 }
 
+function markerFromGesture(gesture) {
+  const marked = gesture.kind === "edit" &&
+    pathLength(gesture.points) >= Math.min(els.markCanvas.width, els.markCanvas.height) * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const marker = marked ? els.markCanvas.toDataURL("image/png") : "";
+  const bounds = marked ? pathBounds(gesture.points) : null;
+  const pinPoint = marked
+    ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 }
+    : gesture.points[0];
+  return { marked, marker, pinPoint };
+}
+
 async function composeSnapshot(marker = "") {
   const out = document.createElement("canvas");
   out.width = els.imageCanvas.width;
@@ -883,7 +895,10 @@ async function promptTypedEdit(clientX, clientY) {
   input.focus();
   setStatus("typing...");
   return new Promise((resolve) => {
+    let done = false;
     const finish = (text) => {
+      if (done) return;
+      done = true;
       input.replaceWith(els.pillText);
       pill({ visible: false });
       resolve(text.trim());
@@ -1025,17 +1040,9 @@ els.markCanvas.addEventListener("pointerdown", async (event) => {
   const kind = app.mode === "animate" ? "video" : "edit";
 
   if (els.typeMode.checked) {
-    app.active = { typing: true };
+    app.active = { kind, pointerId: event.pointerId, points: [start], typing: true, color: app.markerColor };
     render();
-    const text = await promptTypedEdit(event.clientX, event.clientY);
-    app.active = null;
-    render();
-    if (!text) { setStatus(app.busy ? "editing..." : "ready"); return; }
-    try {
-      enqueueJob({ kind, text, pinPoint: start, color: app.markerColor });
-    } catch (err) {
-      showError(err.message);
-    }
+    try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
     return;
   }
 
@@ -1061,6 +1068,23 @@ els.markCanvas.addEventListener("pointerup", async (event) => {
   if (!gesture) return;
   event.preventDefault();
   app.active = null;
+  if (gesture.typing) {
+    const annotation = markerFromGesture(gesture);
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    if (!text) {
+      clearMarks();
+      setStatus(app.busy ? "editing..." : "ready");
+      return;
+    }
+    try {
+      enqueueJob({ kind: gesture.kind, text, ...annotation, color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+      clearMarks();
+    }
+    return;
+  }
   if (gesture.kind === "video") {
     try {
       const { text, error } = await stopAndTranscribe(gesture.capture);
@@ -1072,19 +1096,12 @@ els.markCanvas.addEventListener("pointerup", async (event) => {
     }
     return;
   }
-  const length = pathLength(gesture.points);
-  const marked = length >= Math.min(els.markCanvas.width, els.markCanvas.height) * DRAG_THRESHOLD;
-  if (!marked) clearMarks();
-  const marker = marked ? els.markCanvas.toDataURL("image/png") : "";
-  const bounds = marked ? pathBounds(gesture.points) : null;
-  const pinPoint = marked
-    ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 }
-    : gesture.points[0];
+  const annotation = markerFromGesture(gesture);
   try {
     const { text, error } = await stopAndTranscribe(gesture.capture);
     pill({ visible: false });
     if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
-    enqueueJob({ kind: "edit", text, marked, marker, pinPoint, color: gesture.color });
+    enqueueJob({ kind: "edit", text, ...annotation, color: gesture.color });
   } catch (err) {
     showError(err.message);
     clearMarks();

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Edit v0</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>
+  body { background:#0a0a0a; color:#e5e5e5; }
+  .ring { box-shadow: 0 0 0 4px rgba(239,68,68,.6), 0 0 30px rgba(239,68,68,.4); }
+  canvas { cursor: crosshair; touch-action: none; }
+</style>
+<body class="min-h-screen p-6 flex flex-col items-center gap-4">
+  <div class="w-full max-w-4xl flex items-center justify-between">
+    <h1 class="text-xl font-semibold">Voice Edit · v0</h1>
+    <div class="text-xs text-neutral-500" id="status">ready</div>
+  </div>
+
+  <div class="relative">
+    <canvas id="canvas" width="1024" height="768" class="rounded-lg bg-neutral-900 max-w-full"></canvas>
+    <div id="recDot" class="hidden absolute top-4 right-4 w-4 h-4 rounded-full bg-red-500 animate-pulse"></div>
+    <div id="marker" class="hidden absolute pointer-events-none w-24 h-24 -ml-12 -mt-12 rounded-full border-4 border-red-500 ring"></div>
+  </div>
+
+  <div class="w-full max-w-4xl flex items-center gap-2 text-sm">
+    <button id="loadBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Load starter image</button>
+    <input id="urlInput" placeholder="or paste image URL" class="flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
+    <button id="useUrl" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Use</button>
+    <select id="modelSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
+      <option value="kontext">kontext (fast)</option>
+      <option value="nanobanana-2">nanobanana-2 (quality)</option>
+    </select>
+    <select id="sttSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
+      <option value="whisper">whisper</option>
+      <option value="universal-2">universal-2</option>
+    </select>
+  </div>
+
+  <div class="w-full max-w-4xl flex items-center gap-2 text-sm">
+    <input id="keyInput" type="password" placeholder="paste your Pollinations app key"
+      class="flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded font-mono">
+    <button id="saveKey" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Save</button>
+    <a href="https://enter.pollinations.ai" target="_blank" class="px-3 py-1.5 text-blue-400 hover:underline">get a key →</a>
+  </div>
+
+  <div class="w-full max-w-4xl text-sm text-neutral-400">
+    <div>Click and hold on the image, speak your edit, release to apply.</div>
+    <div id="transcript" class="mt-1 text-neutral-300 italic min-h-[1.5em]"></div>
+  </div>
+
+<script>
+const KEY_STORAGE = "voice-edit:api-key";
+const BASE = "https://gen.pollinations.ai";
+const STARTER = "https://media.pollinations.ai/c5d89da41260fc5a";
+
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d");
+const statusEl = document.getElementById("status");
+const transcriptEl = document.getElementById("transcript");
+const recDot = document.getElementById("recDot");
+const marker = document.getElementById("marker");
+const keyInput = document.getElementById("keyInput");
+
+let currentImage = null;
+let mediaRecorder = null;
+let chunks = [];
+let clickPoint = null;
+let stream = null;
+
+function setStatus(s) { statusEl.textContent = s; }
+
+keyInput.value = localStorage.getItem(KEY_STORAGE) || "";
+document.getElementById("saveKey").onclick = () => {
+  localStorage.setItem(KEY_STORAGE, keyInput.value.trim());
+  setStatus("key saved");
+};
+function getKey() {
+  const k = (keyInput.value || localStorage.getItem(KEY_STORAGE) || "").trim();
+  if (!k) throw new Error("no API key — paste one above (get one at enter.pollinations.ai)");
+  return k;
+}
+
+async function loadImageFromURL(url) {
+  setStatus("loading image…");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = url; });
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  ctx.drawImage(img, 0, 0);
+  currentImage = img;
+  setStatus("ready");
+}
+
+document.getElementById("loadBtn").onclick = () => loadImageFromURL(STARTER);
+document.getElementById("useUrl").onclick = () => {
+  const u = document.getElementById("urlInput").value.trim();
+  if (u) loadImageFromURL(u);
+};
+
+function canvasPointFromEvent(e) {
+  const rect = canvas.getBoundingClientRect();
+  const sx = canvas.width / rect.width;
+  const sy = canvas.height / rect.height;
+  return {
+    x: Math.round((e.clientX - rect.left) * sx),
+    y: Math.round((e.clientY - rect.top) * sy),
+    rectX: e.clientX - rect.left,
+    rectY: e.clientY - rect.top,
+  };
+}
+
+function showMarker(p) {
+  marker.style.left = (canvas.offsetLeft + p.rectX) + "px";
+  marker.style.top = (canvas.offsetTop + p.rectY) + "px";
+  marker.classList.remove("hidden");
+}
+function hideMarker() { marker.classList.add("hidden"); }
+
+async function startRecording() {
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (err) {
+    setStatus("mic denied: " + err.message);
+    return false;
+  }
+  chunks = [];
+  const mime = MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : "";
+  mediaRecorder = new MediaRecorder(stream, mime ? { mimeType: mime } : undefined);
+  mediaRecorder.ondataavailable = (e) => e.data.size && chunks.push(e.data);
+  mediaRecorder.start();
+  recDot.classList.remove("hidden");
+  setStatus("recording…");
+  return true;
+}
+
+function stopRecordingAndGetBlob() {
+  return new Promise((res) => {
+    mediaRecorder.onstop = () => {
+      stream.getTracks().forEach(t => t.stop());
+      recDot.classList.add("hidden");
+      res(new Blob(chunks, { type: chunks[0]?.type || "audio/webm" }));
+    };
+    mediaRecorder.stop();
+  });
+}
+
+async function transcribe(blob) {
+  setStatus("transcribing…");
+  const fd = new FormData();
+  fd.append("file", blob, "rec.webm");
+  fd.append("model", document.getElementById("sttSel").value);
+  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${getKey()}` },
+    body: fd,
+  });
+  if (!r.ok) throw new Error("transcribe failed " + r.status + " " + await r.text());
+  const j = await r.json();
+  return j.text || j.transcription || "";
+}
+
+function annotatedDataURL(p) {
+  const c = document.createElement("canvas");
+  c.width = canvas.width;
+  c.height = canvas.height;
+  const cc = c.getContext("2d");
+  cc.drawImage(canvas, 0, 0);
+  const r = Math.max(60, Math.round(Math.min(c.width, c.height) * 0.08));
+  cc.strokeStyle = "red";
+  cc.lineWidth = Math.max(6, Math.round(r * 0.12));
+  cc.beginPath(); cc.arc(p.x, p.y, r, 0, Math.PI * 2); cc.stroke();
+  cc.font = `bold ${Math.round(r * 0.5)}px sans-serif`;
+  cc.fillStyle = "red";
+  cc.fillText("HERE", p.x + r + 10, p.y);
+  return c.toDataURL("image/png");
+}
+
+async function uploadDataURL(dataURL) {
+  setStatus("uploading…");
+  const blob = await (await fetch(dataURL)).blob();
+  const fd = new FormData();
+  fd.append("file", blob, "annot.png");
+  const r = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${getKey()}` },
+    body: fd,
+  });
+  if (!r.ok) throw new Error("upload failed " + r.status);
+  const j = await r.json();
+  return j.url || `https://media.pollinations.ai/${j.id}`;
+}
+
+async function runEdit(refURL, prompt) {
+  setStatus("editing…");
+  const model = document.getElementById("modelSel").value;
+  const r = await fetch(`${BASE}/v1/images/edits`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${getKey()}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, image: refURL, model, response_format: "url" }),
+  });
+  if (!r.ok) throw new Error("edit failed " + r.status + " " + await r.text());
+  const j = await r.json();
+  const item = j.data?.[0];
+  if (!item) throw new Error("no image in response");
+  if (item.url) return item.url;
+  if (item.b64_json) return "data:image/png;base64," + item.b64_json;
+  throw new Error("no url or b64_json in response");
+}
+
+canvas.addEventListener("pointerdown", async (e) => {
+  if (!currentImage) { setStatus("load an image first"); return; }
+  e.preventDefault();
+  canvas.setPointerCapture(e.pointerId);
+  clickPoint = canvasPointFromEvent(e);
+  showMarker(clickPoint);
+  transcriptEl.textContent = "";
+  await startRecording();
+});
+
+canvas.addEventListener("pointerup", async (e) => {
+  if (!mediaRecorder || mediaRecorder.state !== "recording") return;
+  try {
+    const blob = await stopRecordingAndGetBlob();
+    if (blob.size < 1000) { setStatus("too short"); hideMarker(); return; }
+    const text = await transcribe(blob);
+    transcriptEl.textContent = "→ " + text;
+    if (!text.trim()) { setStatus("nothing heard"); hideMarker(); return; }
+    const annotURL = await uploadDataURL(annotatedDataURL(clickPoint));
+    const prompt = `Edit the area marked with the red circle (labeled HERE). ${text}. Remove the red circle and HERE text in the final image.`;
+    const resultURL = await runEdit(annotURL, prompt);
+    await loadImageFromURL(resultURL);
+    hideMarker();
+    setStatus("done");
+  } catch (err) {
+    setStatus("error: " + err.message);
+    hideMarker();
+  }
+});
+
+loadImageFromURL(STARTER);
+</script>
+</body>
+</content>
+</invoke>

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -409,16 +409,15 @@ const markCtx = els.markCanvas.getContext("2d");
 const app = {
   image: null,
   imageURL: "",
-  videoURL: "",
-  videoPrompt: "",
+  current: null,
+  history: [],
+  historyIndex: -1,
   mode: "edit",
   micStream: null,
   active: null,
   busy: false,
   queue: [],
   currentJob: null,
-  undo: [],
-  redo: [],
   markerColor: "red",
   accountUser: "",
   accountBalance: null,
@@ -446,18 +445,19 @@ function key() {
 
 function render() {
   const locked = app.busy || Boolean(app.active);
-  els.undo.disabled = (app.undo.length === 0 && !app.videoURL) || locked;
-  els.redo.disabled = app.redo.length === 0 || locked;
+  const video = app.current?.kind === "video";
+  els.undo.disabled = !canUndo() || locked;
+  els.redo.disabled = !canRedo() || locked;
   els.upload.disabled = locked;
   els.model.disabled = locked || app.mode === "animate";
   els.model.hidden = app.mode === "animate";
   els.videoModel.hidden = app.mode !== "animate";
   els.colorPicker.hidden = app.mode === "animate";
   els.typeMode.disabled = locked;
-  els.stage.classList.toggle("video", !!app.videoURL);
+  els.stage.classList.toggle("video", video);
   els.stage.classList.toggle("edit", app.mode === "edit");
   els.stage.classList.toggle("animate", app.mode === "animate");
-  els.stageVideo.hidden = !app.videoURL;
+  els.stageVideo.hidden = !video;
   for (const button of els.modePicker.querySelectorAll("button")) {
     button.disabled = locked;
     button.classList.toggle("active", button.dataset.mode === app.mode);
@@ -596,19 +596,38 @@ function stopMic() {
   app.micStream = null;
 }
 
-function currentState() {
-  if (app.videoURL) return { kind: "video", url: app.videoURL, prompt: app.videoPrompt, imageURL: app.imageURL };
-  if (app.imageURL) return { kind: "image", url: app.imageURL };
-  return null;
+function canUndo() {
+  return app.historyIndex > 0;
 }
 
-async function restoreState(state) {
-  if (!state) return;
-  if (state.kind === "video") {
-    await loadImage(state.imageURL);
-    showVideo(state.url, state.prompt);
+function canRedo() {
+  return app.historyIndex >= 0 && app.historyIndex < app.history.length - 1;
+}
+
+function addFrame(frame) {
+  app.history = app.history.slice(0, app.historyIndex + 1);
+  app.history.push(frame);
+  app.historyIndex = app.history.length - 1;
+  app.current = frame;
+  render();
+}
+
+async function goToFrame(index) {
+  const frame = app.history[index];
+  if (!frame) return;
+  await renderFrame(frame);
+  app.historyIndex = index;
+  app.current = frame;
+  render();
+}
+
+async function setFrame(frame, { addToHistory = false } = {}) {
+  await renderFrame(frame);
+  if (addToHistory) {
+    addFrame(frame);
   } else {
-    await loadImage(state.url);
+    app.current = frame;
+    render();
   }
 }
 
@@ -638,19 +657,26 @@ async function loadModels() {
   } catch {}
 }
 
-function pushUndo() {
-  const state = currentState();
-  if (!state) return;
-  app.undo.push(state);
-  app.redo = [];
-  render();
-}
-
-async function loadImage(src, { pushHistory = false } = {}) {
+async function loadImage(src, { addToHistory = false } = {}) {
   clearError();
   if (src instanceof File) src = await readImageFile(src);
-  if (pushHistory) pushUndo();
-  hideVideo();
+  await setFrame({ kind: "image", url: src }, { addToHistory });
+}
+
+async function renderFrame(frame) {
+  clearError();
+  if (frame.kind === "video") {
+    if (frame.imageURL) await drawImage(frame.imageURL);
+    showVideoElement(frame.url);
+  } else {
+    hideVideoElement();
+    await drawImage(frame.url);
+  }
+  clearMarks();
+  setStatus("ready");
+}
+
+async function drawImage(src) {
   setStatus("loading image...");
   const img = new Image();
   img.crossOrigin = "anonymous";
@@ -663,9 +689,6 @@ async function loadImage(src, { pushHistory = false } = {}) {
   app.imageURL = src;
   resizeCanvases(img.naturalWidth, img.naturalHeight);
   imageCtx.drawImage(img, 0, 0);
-  clearMarks();
-  setStatus("ready");
-  render();
 }
 
 function readImageFile(file) {
@@ -689,38 +712,29 @@ function clearMarks() {
   markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
 }
 
-function showVideo(url, prompt = "") {
-  hideVideo();
-  clearMarks();
-  app.videoURL = url;
-  app.videoPrompt = prompt;
+function showVideoElement(url) {
+  hideVideoElement();
+  els.stageVideo.hidden = false;
   els.stageVideo.src = url;
   els.stageVideo.play().catch(() => {});
-  render();
 }
 
-function hideVideo() {
-  if (!app.videoURL) return;
-  app.videoURL = "";
-  app.videoPrompt = "";
+function hideVideoElement() {
+  els.stageVideo.hidden = true;
   els.stageVideo.pause();
   els.stageVideo.removeAttribute("src");
   els.stageVideo.load();
-  render();
 }
 
 async function commitVideoFrame() {
-  if (!app.videoURL) return;
+  if (app.current?.kind !== "video") return;
   const video = els.stageVideo;
   if (!video.videoWidth || !video.videoHeight) throw new Error("video frame is not ready yet");
   const frame = document.createElement("canvas");
   frame.width = video.videoWidth;
   frame.height = video.videoHeight;
   frame.getContext("2d").drawImage(video, 0, 0);
-  const dataURL = frame.toDataURL("image/png");
-  pushUndo();
-  hideVideo();
-  await loadImage(dataURL);
+  await setFrame({ kind: "image", url: frame.toDataURL("image/png") }, { addToHistory: true });
 }
 
 function pointerPoint(event) {
@@ -987,13 +1001,11 @@ async function runQueue() {
         const uploaded = await uploadDataURL(snapshot, job.kind === "video" ? "source.png" : "annot.png");
         if (job.kind === "video") {
           const videoURL = await runVideo(uploaded, job.text, job.model);
-          pushUndo();
-          showVideo(videoURL, job.text);
+          await setFrame({ kind: "video", url: videoURL, prompt: job.text, imageURL: app.imageURL }, { addToHistory: true });
         } else {
           const prompt = buildPrompt(job.text, job.marked, job.color);
           const result = await runEdit(uploaded, prompt, job.model);
-          pushUndo();
-          await loadImage(result);
+          await setFrame({ kind: "image", url: result }, { addToHistory: true });
         }
         await loadBalance();
       } catch (err) {
@@ -1027,7 +1039,7 @@ els.markCanvas.addEventListener("pointerdown", async (event) => {
   if (app.active) return;
   event.preventDefault();
   clearError();
-  if (app.videoURL && app.mode === "edit") {
+  if (app.current?.kind === "video") {
     try {
       await commitVideoFrame();
     } catch (err) {
@@ -1116,7 +1128,7 @@ els.disconnect.addEventListener("click", disconnect);
 els.upload.addEventListener("click", () => els.file.click());
 els.file.addEventListener("change", () => {
   const file = els.file.files?.[0];
-  if (file) loadImage(file, { pushHistory: true }).catch((err) => showError(err.message));
+  if (file) loadImage(file, { addToHistory: true }).catch((err) => showError(err.message));
 });
 
 els.modePicker.addEventListener("click", (event) => {
@@ -1148,27 +1160,23 @@ for (const eventName of ["dragleave", "drop"]) {
 }
 els.frame.addEventListener("drop", (event) => {
   const file = event.dataTransfer?.files?.[0];
-  if (file) loadImage(file, { pushHistory: true }).catch((err) => showError(err.message));
+  if (file) loadImage(file, { addToHistory: true }).catch((err) => showError(err.message));
 });
 
 els.undo.addEventListener("click", () => {
-  if ((!app.undo.length && !app.videoURL) || app.busy || app.active) return;
-  const current = currentState();
-  if (current) app.redo.push(current);
-  const previous = app.videoURL && !app.undo.length ? { kind: "image", url: app.imageURL } : app.undo.pop();
-  restoreState(previous).then(() => setStatus("undone")).catch((err) => showError(err.message));
+  if (!canUndo() || app.busy || app.active) return;
+  goToFrame(app.historyIndex - 1).then(() => setStatus("undone")).catch((err) => showError(err.message));
 });
 els.redo.addEventListener("click", () => {
-  if (!app.redo.length || app.busy || app.active) return;
-  const current = currentState();
-  if (current) app.undo.push(current);
-  restoreState(app.redo.pop()).then(() => setStatus("redone")).catch((err) => showError(err.message));
+  if (!canRedo() || app.busy || app.active) return;
+  goToFrame(app.historyIndex + 1).then(() => setStatus("redone")).catch((err) => showError(err.message));
 });
 els.download.addEventListener("click", () => {
   try {
     const link = document.createElement("a");
-    link.href = app.videoURL || els.imageCanvas.toDataURL("image/png");
-    link.download = app.videoURL ? "voice-edit.mp4" : "voice-edit.png";
+    const video = app.current?.kind === "video";
+    link.href = video ? app.current.url : els.imageCanvas.toDataURL("image/png");
+    link.download = video ? "voice-edit.mp4" : "voice-edit.png";
     link.click();
   } catch {
     if (app.imageURL) window.open(app.imageURL, "_blank", "noopener");
@@ -1178,7 +1186,7 @@ els.download.addEventListener("click", () => {
 captureKeyFromFragment();
 refreshConnectionUI();
 loadModels();
-loadImage(STARTER).catch((err) => showError(err.message));
+loadImage(STARTER, { addToHistory: true }).catch((err) => showError(err.message));
 for (const button of els.colorPicker.querySelectorAll(".swatch")) {
   button.classList.toggle("active", button.dataset.color === app.markerColor);
 }

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -129,19 +129,6 @@
   }
   .mode button.active { background: var(--accent); }
   .mode button + button { border-left: 2px solid var(--line); }
-  .video-model {
-    min-height: 38px;
-    display: inline-flex;
-    align-items: center;
-    padding: 0 10px;
-    background: #fff;
-    border: 2px solid var(--line);
-    border-right-width: 4px;
-    border-bottom-width: 4px;
-    font-size: 0.78rem;
-    font-weight: 700;
-  }
-
   .swatches {
     display: inline-flex;
     align-items: center;
@@ -337,7 +324,7 @@
       <select id="modelSel" class="select" aria-label="image model">
         <option value="nanobanana">nanobanana</option>
       </select>
-      <span id="videoModelLabel" class="video-model" hidden>wan-fast video</span>
+      <select id="videoModelSel" class="select" aria-label="video model" hidden></select>
       <div id="colorPicker" class="swatches" aria-label="marker color">
         <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
         <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
@@ -377,7 +364,7 @@ const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
 const STARTER = "https://media.pollinations.ai/10efdd0c1cfc65fa";
-const VIDEO_MODEL = "wan-fast";
+const DEFAULT_VIDEO_MODEL = "seedance-pro";
 const VIDEO_DURATION = "5";
 const STT_MODEL = "scribe";
 const STT_LANG = (navigator.language || "en").slice(0, 2);
@@ -401,7 +388,7 @@ const els = {
   upload: document.getElementById("uploadBtn"),
   file: document.getElementById("fileInput"),
   modePicker: document.getElementById("modePicker"),
-  videoModel: document.getElementById("videoModelLabel"),
+  videoModel: document.getElementById("videoModelSel"),
   model: document.getElementById("modelSel"),
   typeMode: document.getElementById("typeMode"),
   undo: document.getElementById("undoBtn"),
@@ -460,6 +447,7 @@ function render() {
   els.model.disabled = locked || app.mode === "animate";
   els.model.hidden = app.mode === "animate";
   els.videoModel.hidden = app.mode !== "animate";
+  els.videoModel.disabled = locked || app.mode !== "animate";
   els.colorPicker.hidden = app.mode === "animate";
   els.typeMode.disabled = locked;
   els.stage.classList.toggle("video", video);
@@ -665,6 +653,20 @@ async function loadModels() {
       els.model.append(option);
     }
     if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+
+    const videoModels = models
+      .filter((m) => m.output_modalities?.includes("video") && m.input_modalities?.includes("image"))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    els.videoModel.innerHTML = "";
+    for (const m of videoModels) {
+      const option = document.createElement("option");
+      option.value = m.name;
+      option.textContent = m.paid_only ? `${m.name} (paid)` : m.name;
+      els.videoModel.append(option);
+    }
+    if ([...els.videoModel.options].some((o) => o.value === DEFAULT_VIDEO_MODEL)) {
+      els.videoModel.value = DEFAULT_VIDEO_MODEL;
+    }
   } catch {}
 }
 
@@ -849,7 +851,7 @@ function enqueueJob({ kind, text, marked = false, marker = "", pinPoint, color }
     marked,
     marker,
     color,
-    model: kind === "video" ? VIDEO_MODEL : els.model.value,
+    model: kind === "video" ? els.videoModel.value : els.model.value,
     xPct: pin.xPct,
     yPct: pin.yPct,
   });

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -63,10 +63,28 @@
     letter-spacing: -0.02em;
     line-height: 1.3;
   }
-  canvas { cursor: crosshair; touch-action: none; display: block; max-width: 100%; height: auto; }
-  .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; position: relative; display: inline-block; width: 100%; }
-  .canvas-stage { position: relative; display: inline-block; width: 100%; }
+  canvas { cursor: crosshair; touch-action: none; display: block; max-width: 100%; max-height: calc(100vh - 200px); width: auto; height: auto; margin: 0 auto; }
+  .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; position: relative; display: flex; align-items: center; justify-content: center; width: 100%; }
+  .canvas-stage { position: relative; display: inline-block; max-width: 100%; }
   .canvas-wrap.drop { outline: 4px dashed var(--accent); outline-offset: -8px; }
+  .canvas-wrap.locked canvas { cursor: not-allowed; filter: grayscale(0.4) opacity(0.55); }
+  #connectOverlay {
+    position: absolute; inset: 0; z-index: 20;
+    display: none; align-items: center; justify-content: center;
+    background: rgba(243, 235, 222, 0.88);
+    backdrop-filter: blur(2px);
+  }
+  .canvas-wrap.locked #connectOverlay { display: flex; }
+  #connectOverlay .panel {
+    background: #fff;
+    border: 2px solid var(--dark);
+    border-right-width: 4px;
+    border-bottom-width: 4px;
+    padding: 1.2rem 1.4rem;
+    text-align: center;
+    max-width: 22rem;
+  }
+  #connectOverlay .panel p { font-size: 0.9rem; margin-bottom: 0.9rem; }
 
   /* Cursor-anchored speech pill */
   #cursorPill {
@@ -149,49 +167,41 @@
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
 </style>
 <body class="min-h-screen p-4 md:p-6 flex flex-col items-center gap-4">
-  <div class="w-full max-w-5xl flex items-end justify-between gap-4">
-    <div>
-      <h1 class="pollen-title text-2xl md:text-3xl">voice<br>edit</h1>
-      <p class="text-sm text-[var(--muted)] mt-2">point. talk. release. it's edited.</p>
-    </div>
-    <div class="text-xs text-[var(--muted)] shrink-0" id="status">ready</div>
+  <div class="w-full max-w-5xl flex items-baseline gap-3">
+    <h1 class="pollen-title text-xl md:text-2xl">voice·edit</h1>
+    <span class="text-xs text-[var(--muted)]">point. talk. release.</span>
+    <span class="text-xs text-[var(--muted)] ml-auto" id="account"></span>
+    <span class="text-xs text-[var(--muted)]" id="status">ready</span>
   </div>
 
   <div id="error" class="hidden w-full max-w-5xl pollen-card px-4 py-3 text-sm" style="background:#ffe1e1;border-color:#a02020"></div>
 
   <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <button id="connectBtn" class="pollen-btn pollen-btn-accent">connect pollinations</button>
+    <button id="connectBtn" class="pollen-btn pollen-btn-accent">connect</button>
     <button id="disconnectBtn" class="hidden pollen-btn">disconnect</button>
-    <span id="account" class="text-[var(--muted)]"></span>
-  </div>
-
-  <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <button id="loadBtn" class="pollen-btn">load starter</button>
-    <button id="uploadBtn" class="pollen-btn">upload</button>
+    <button id="uploadBtn" class="pollen-btn">image</button>
     <input id="fileInput" type="file" accept="image/*" class="hidden">
-    <input id="urlInput" placeholder="or paste image URL / drop image on canvas" class="pollen-input min-w-52 flex-1 text-sm">
-    <button id="useUrl" class="pollen-btn">use</button>
     <select id="modelSel" class="pollen-select text-sm">
       <option value="nanobanana">nanobanana</option>
     </select>
-    <button id="undoBtn" class="pollen-btn" disabled>undo</button>
-    <button id="redoBtn" class="pollen-btn" disabled>redo</button>
-    <button id="downloadBtn" class="pollen-btn">download</button>
-  </div>
-
-  <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
-    <input id="intentInput" placeholder="optional typed edit, e.g. make this a brass lamp" class="pollen-input min-w-64 flex-1">
-    <button id="clearIntent" class="pollen-btn">clear</button>
-  </div>
-
-  <div class="w-full max-w-5xl text-xs text-[var(--muted)]">
-    click and hold on the image. talk into the pill that pops up — release to apply.
+    <label class="ml-2 text-xs flex items-center gap-1 select-none">
+      <input id="typeMode" type="checkbox"> type instead
+    </label>
+    <button id="undoBtn" class="pollen-btn ml-auto" disabled title="undo">↶</button>
+    <button id="redoBtn" class="pollen-btn" disabled title="redo">↷</button>
+    <button id="downloadBtn" class="pollen-btn" title="download">↓</button>
   </div>
 
   <div class="relative w-full max-w-5xl canvas-wrap">
     <div class="canvas-stage">
       <canvas id="canvas" width="1024" height="768" class="bg-white"></canvas>
       <div id="pinLayer"></div>
+    </div>
+    <div id="connectOverlay">
+      <div class="panel">
+        <p>connect to pollinations to start editing</p>
+        <button id="connectOverlayBtn" class="pollen-btn pollen-btn-accent">connect</button>
+      </div>
     </div>
   </div>
 
@@ -206,7 +216,7 @@ const KEY_STORAGE = "voice-edit:user-key";
 const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
-const STARTER = "https://media.pollinations.ai/649d0f9cf10b5e48";
+const STARTER = "https://media.pollinations.ai/051ed82a46f5f85d";
 
 const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
@@ -215,7 +225,6 @@ const errorEl = document.getElementById("error");
 const connectBtn = document.getElementById("connectBtn");
 const disconnectBtn = document.getElementById("disconnectBtn");
 const accountEl = document.getElementById("account");
-const intentInput = document.getElementById("intentInput");
 const undoBtn = document.getElementById("undoBtn");
 const redoBtn = document.getElementById("redoBtn");
 const pillEl = document.getElementById("cursorPill");
@@ -306,10 +315,12 @@ function getKey() {
 
 function refreshConnectionUI() {
   const k = localStorage.getItem(KEY_STORAGE);
+  const canvasWrap = document.querySelector(".canvas-wrap");
   if (k) {
     connectBtn.classList.add("hidden");
     disconnectBtn.classList.remove("hidden");
     accountEl.textContent = "connected";
+    canvasWrap.classList.remove("locked");
     fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${k}` } })
       .then(r => r.ok ? r.json() : null)
       .then(u => { if (u?.preferred_username) accountEl.textContent = `connected as ${u.preferred_username}`; })
@@ -317,18 +328,22 @@ function refreshConnectionUI() {
   } else {
     connectBtn.classList.remove("hidden");
     disconnectBtn.classList.add("hidden");
-    accountEl.textContent = "";
+    accountEl.textContent = "not connected";
+    canvasWrap.classList.add("locked");
+    setStatus("not connected");
   }
 }
 
-connectBtn.onclick = () => {
+function startConnect() {
   const params = new URLSearchParams({
     redirect_uri: location.origin + location.pathname,
     scope: "generate",
   });
   if (CLIENT_ID) params.set("client_id", CLIENT_ID);
   location.href = `${ENTER}/authorize?${params}`;
-};
+}
+connectBtn.onclick = startConnect;
+document.getElementById("connectOverlayBtn").onclick = startConnect;
 disconnectBtn.onclick = () => {
   localStorage.removeItem(KEY_STORAGE);
   refreshConnectionUI();
@@ -389,12 +404,6 @@ async function loadImageFromURL(url, opts = {}) {
   setStatus("ready");
 }
 
-document.getElementById("loadBtn").onclick = () => loadImageFromURL(STARTER, { pushHistory: true }).catch(err => showError(err.message));
-document.getElementById("useUrl").onclick = () => {
-  const u = document.getElementById("urlInput").value.trim();
-  if (u) loadImageFromURL(u, { pushHistory: true }).catch(err => showError(err.message));
-};
-
 function loadLocalFile(file) {
   if (!file || !file.type.startsWith("image/")) { showError("Drop or pick an image file."); return; }
   const reader = new FileReader();
@@ -404,6 +413,29 @@ function loadLocalFile(file) {
 }
 document.getElementById("uploadBtn").onclick = () => document.getElementById("fileInput").click();
 document.getElementById("fileInput").onchange = (e) => loadLocalFile(e.target.files?.[0]);
+
+function promptTypedEdit(clientX, clientY, point) {
+  showPill(clientX, clientY, "", true);
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing…");
+  return new Promise((resolve) => {
+    const finish = (text) => {
+      input.replaceWith(pillText);
+      hidePill();
+      resolve(text);
+    };
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); finish(input.value.trim()); }
+      if (e.key === "Escape") { e.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value.trim()));
+  });
+}
 
 const dropZone = document.querySelector(".canvas-wrap");
 ["dragenter", "dragover"].forEach(ev => dropZone.addEventListener(ev, (e) => {
@@ -416,10 +448,6 @@ dropZone.addEventListener("drop", (e) => {
   const file = e.dataTransfer?.files?.[0];
   if (file) loadLocalFile(file);
 });
-document.getElementById("clearIntent").onclick = () => {
-  intentInput.value = "";
-};
-
 function canvasPointFromEvent(e) {
   const rect = canvas.getBoundingClientRect();
   const sx = canvas.width / rect.width;
@@ -434,20 +462,12 @@ function canvasPointFromEvent(e) {
 
 function startIntentCapture(clientX, clientY) {
   clearError();
-  const typed = intentInput.value.trim();
-  if (typed) {
-    showPill(clientX, clientY, typed, false);
-    setStatus("release to edit…");
-    return { mode: "typed", text: typed };
-  }
-
   if (!SpeechRecognition) {
-    showError("Voice input is not available in this browser. Type an edit, then click the target area.");
+    showError("Voice input is not available in this browser.");
     return null;
   }
 
   const capture = {
-    mode: "speech",
     text: "",
     error: "",
     finished: false,
@@ -487,7 +507,6 @@ function startIntentCapture(clientX, clientY) {
 }
 
 async function stopIntentCapture(capture) {
-  if (capture.mode === "typed") return { text: capture.text, error: "" };
   setStatus("processing…");
   try { capture.recognition.stop(); } catch {}
   const timeout = new Promise((resolve) => setTimeout(() => {
@@ -625,8 +644,19 @@ async function runQueue() {
 canvas.addEventListener("pointerdown", async (e) => {
   if (!currentImage) { showError("Load an image first."); return; }
   e.preventDefault();
-  canvas.setPointerCapture(e.pointerId);
+  const typeMode = document.getElementById("typeMode").checked;
   clickPoint = canvasPointFromEvent(e);
+  if (typeMode) {
+    const point = clickPoint;
+    const text = await promptTypedEdit(e.clientX, e.clientY, point);
+    if (text) {
+      try { enqueueEdit(point, text); } catch (err) { showError(err.message); }
+    } else {
+      setStatus("ready");
+    }
+    return;
+  }
+  canvas.setPointerCapture(e.pointerId);
   activeCapture = startIntentCapture(e.clientX, e.clientY);
 });
 

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -159,9 +159,6 @@
     align-items: center;
     gap: 0.4rem;
   }
-  /* Flipped: pin extends to the left of the dot; dot is the *last* visual child.
-     Translate so the dot center is on the anchor: full pin width minus (half-dot + dot-border + right-padding). */
-  .pin.flip { flex-direction: row-reverse; transform: translate(calc(-100% + 0.55rem + 0.275rem + 1.5px), -50%); }
   .pin.processing { background: var(--accent); }
   .pin.queued { background: #fff; opacity: 0.85; }
   .pin .dot {
@@ -251,9 +248,6 @@ function renderPins() {
     pin.style.left = `${job.xPct}%`;
     pin.style.top = `${job.yPct}%`;
     pinLayer.append(pin);
-    const pinBox = pin.getBoundingClientRect();
-    const layerBox = pinLayer.getBoundingClientRect();
-    pin.classList.toggle("flip", pinBox.right > layerBox.right);
   }
 }
 function render() {
@@ -573,8 +567,11 @@ async function stopIntentCapture(capture) {
 function strokeWidthFor(w, h) {
   return Math.max(6, Math.round(Math.min(w, h) * 0.015));
 }
+function ringRadius(w, h) {
+  return Math.max(28, Math.round(Math.min(w, h) * 0.05));
+}
 function drawRing(targetCtx, p, w, h) {
-  const r = Math.max(28, Math.round(Math.min(w, h) * 0.05));
+  const r = ringRadius(w, h);
   targetCtx.save();
   targetCtx.globalAlpha = 0.35;
   targetCtx.strokeStyle = "red";
@@ -600,10 +597,13 @@ function pathLength(points) {
   }
   return total;
 }
-function pathCentroid(points) {
-  let sx = 0, sy = 0;
-  for (const p of points) { sx += p.x; sy += p.y; }
-  return { x: sx / points.length, y: sy / points.length };
+function pathBounds(points) {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y; if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, maxX, minY, maxY };
 }
 
 async function friendlyError(response, label) {
@@ -717,7 +717,9 @@ canvas.addEventListener("pointerdown", async (e) => {
     if (text) {
       drawRing(ctx, point, canvas.width, canvas.height);
       const annotated = canvas.toDataURL("image/png");
-      try { enqueueEdit({ point, text, annotated }); }
+      const r = ringRadius(canvas.width, canvas.height);
+      const pinPoint = { x: point.x + r, y: point.y };
+      try { enqueueEdit({ point: pinPoint, text, annotated }); }
       catch (err) { showError(err.message); }
     } else {
       resetCanvas();
@@ -753,7 +755,15 @@ canvas.addEventListener("pointerup", async (e) => {
   const isDrag = pathLength(stroke) > minLen;
   if (!isDrag) drawRing(ctx, capture.point, canvas.width, canvas.height);
   const annotated = canvas.toDataURL("image/png");
-  const pinPoint = isDrag ? pathCentroid(stroke) : capture.point;
+  // Pin always anchors at the rightmost edge of the marking, vertically centered on it.
+  let pinPoint;
+  if (isDrag) {
+    const b = pathBounds(stroke);
+    pinPoint = { x: b.maxX, y: (b.minY + b.maxY) / 2 };
+  } else {
+    const r = ringRadius(canvas.width, canvas.height);
+    pinPoint = { x: capture.point.x + r, y: capture.point.y };
+  }
   try {
     const { text, error } = await stopIntentCapture(capture);
     pill({ visible: false });

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -318,22 +318,47 @@ function getKey() {
   return k;
 }
 
+let accountUser = "";
+let accountBalance = null;
+function renderAccount() {
+  const base = accountUser ? `connected as ${accountUser}` : "connected";
+  const bal = accountBalance == null ? "" : ` · ${accountBalance.toFixed(2)} pollen`;
+  accountEl.textContent = base + bal;
+}
+
+async function loadBalance() {
+  const k = localStorage.getItem(KEY_STORAGE);
+  if (!k) return;
+  try {
+    const r = await fetch(`${BASE}/account/balance`, { headers: { Authorization: `Bearer ${k}` } });
+    if (!r.ok) return;
+    const { balance } = await r.json();
+    accountBalance = balance;
+    renderAccount();
+  } catch {}
+}
+
 function refreshConnectionUI() {
   const k = localStorage.getItem(KEY_STORAGE);
   const canvasWrap = document.querySelector(".canvas-wrap");
   if (k) {
     connectBtn.classList.add("hidden");
     disconnectBtn.classList.remove("hidden");
-    accountEl.textContent = "connected";
+    accountUser = "";
+    accountBalance = null;
+    renderAccount();
     canvasWrap.classList.remove("locked");
     warmMic();
     fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${k}` } })
       .then(r => r.ok ? r.json() : null)
-      .then(u => { if (u?.preferred_username) accountEl.textContent = `connected as ${u.preferred_username}`; })
+      .then(u => { if (u?.preferred_username) { accountUser = u.preferred_username; renderAccount(); } })
       .catch(() => {});
+    loadBalance();
   } else {
     connectBtn.classList.remove("hidden");
     disconnectBtn.classList.add("hidden");
+    accountUser = "";
+    accountBalance = null;
     accountEl.textContent = "not connected";
     canvasWrap.classList.add("locked");
     setStatus("not connected");
@@ -667,6 +692,7 @@ async function runQueue() {
       render();
     }
     setStatus("done");
+    loadBalance();
   } finally {
     queueRunning = false;
     render();

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -147,13 +147,17 @@
     font-family: 'IBM Plex Mono', monospace;
     font-size: 0.75rem;
     line-height: 1.3;
-    max-width: 14rem;
+    min-width: 6rem;
+    max-width: 16rem;
+    width: max-content;
     white-space: normal;
-    overflow-wrap: anywhere;
+    word-break: normal;
+    overflow-wrap: break-word;
     display: flex;
     align-items: center;
     gap: 0.4rem;
   }
+  .pin.flip { transform: translate(-100%, -50%) translateX(-8px); }
   .pin.processing { background: var(--accent); }
   .pin.queued { background: #fff; opacity: 0.85; }
   .pin .dot {
@@ -236,44 +240,44 @@ function renderPins() {
   for (let i = 0; i < editQueue.length; i++) {
     const job = editQueue[i];
     const pin = document.createElement("div");
-    pin.className = "pin " + (i === 0 && queueRunning ? "processing" : "queued");
+    const flip = job.xPct > 55;
+    pin.className = "pin " + (i === 0 && queueRunning ? "processing" : "queued") + (flip ? " flip" : "");
     const dot = document.createElement("span"); dot.className = "dot";
     const text = document.createElement("span"); text.textContent = job.intent;
     pin.append(dot, text);
-    pin.style.left = `${(job.point.x / canvas.width) * 100}%`;
-    pin.style.top = `${(job.point.y / canvas.height) * 100}%`;
+    pin.style.left = `${job.xPct}%`;
+    pin.style.top = `${job.yPct}%`;
     pinLayer.append(pin);
   }
 }
+function render() {
+  renderPins();
+  undoBtn.disabled = undoStack.length === 0;
+  redoBtn.disabled = redoStack.length === 0;
+}
 
-function showPill(x, y, text, isPlaceholder = false) {
-  pillEl.style.left = `${x}px`;
-  pillEl.style.top = `${y}px`;
-  pillText.textContent = text;
-  pillText.classList.toggle("placeholder", isPlaceholder);
-  pillEl.classList.add("visible");
-}
-function movePill(x, y) {
-  pillEl.style.left = `${x}px`;
-  pillEl.style.top = `${y}px`;
-}
-function setPillText(text, isPlaceholder = false) {
-  pillText.textContent = text;
-  pillText.classList.toggle("placeholder", isPlaceholder);
-}
-function hidePill() {
-  pillEl.classList.remove("visible");
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) pillEl.style.left = `${x}px`;
+  if (y != null) pillEl.style.top = `${y}px`;
+  if (text !== undefined) {
+    pillText.textContent = text;
+    pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) pillEl.classList.toggle("visible", visible);
 }
 
 let currentImage = null;
 let currentImageURL = "";
-let clickPoint = null;
 let activeCapture = null;
 const undoStack = [];
 let redoStack = [];
 const editQueue = [];
 let queueRunning = false;
-const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+const STT_MODEL = "whisper";
+const STT_LANG = (navigator.language || "en").slice(0, 2);
+const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+  .find(m => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+let micStream = null; // pre-warmed mic to eliminate startup cut-off
 
 function setStatus(s) { statusEl.textContent = s; }
 function showError(message) {
@@ -283,16 +287,11 @@ function showError(message) {
 }
 function clearError() { errorEl.classList.add("hidden"); }
 
-function updateHistoryButtons() {
-  undoBtn.disabled = undoStack.length === 0;
-  redoBtn.disabled = redoStack.length === 0;
-}
-
 function pushUndo() {
   if (!currentImageURL) return;
   undoStack.push(currentImageURL);
   redoStack = [];
-  updateHistoryButtons();
+  render();
 }
 
 (function captureKeyFromFragment() {
@@ -321,6 +320,7 @@ function refreshConnectionUI() {
     disconnectBtn.classList.remove("hidden");
     accountEl.textContent = "connected";
     canvasWrap.classList.remove("locked");
+    warmMic();
     fetch(`${ENTER}/api/device/userinfo`, { headers: { Authorization: `Bearer ${k}` } })
       .then(r => r.ok ? r.json() : null)
       .then(u => { if (u?.preferred_username) accountEl.textContent = `connected as ${u.preferred_username}`; })
@@ -346,6 +346,10 @@ connectBtn.onclick = startConnect;
 document.getElementById("connectOverlayBtn").onclick = startConnect;
 disconnectBtn.onclick = () => {
   localStorage.removeItem(KEY_STORAGE);
+  if (micStream) {
+    for (const t of micStream.getTracks()) t.stop();
+    micStream = null;
+  }
   refreshConnectionUI();
 };
 refreshConnectionUI();
@@ -399,23 +403,28 @@ async function loadImageFromURL(url, opts = {}) {
   ctx.drawImage(img, 0, 0);
   currentImage = img;
   currentImageURL = url;
-  updateHistoryButtons();
-  renderPins();
+  render();
   setStatus("ready");
 }
 
-function loadLocalFile(file) {
-  if (!file || !file.type.startsWith("image/")) { showError("Drop or pick an image file."); return; }
-  const reader = new FileReader();
-  reader.onload = () => loadImageFromURL(reader.result, { pushHistory: true }).catch(err => showError(err.message));
-  reader.onerror = () => showError("Could not read file.");
-  reader.readAsDataURL(file);
+async function loadImage(src, opts) {
+  if (src instanceof File) {
+    if (!src.type.startsWith("image/")) throw new Error("Drop or pick an image file.");
+    src = await new Promise((res, rej) => {
+      const r = new FileReader();
+      r.onload = () => res(r.result);
+      r.onerror = () => rej(new Error("Could not read file."));
+      r.readAsDataURL(src);
+    });
+  }
+  return loadImageFromURL(src, opts);
 }
+const safeLoad = (src) => loadImage(src, { pushHistory: true }).catch(err => showError(err.message));
 document.getElementById("uploadBtn").onclick = () => document.getElementById("fileInput").click();
-document.getElementById("fileInput").onchange = (e) => loadLocalFile(e.target.files?.[0]);
+document.getElementById("fileInput").onchange = (e) => { const f = e.target.files?.[0]; if (f) safeLoad(f); };
 
-function promptTypedEdit(clientX, clientY, point) {
-  showPill(clientX, clientY, "", true);
+function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
   const input = document.createElement("input");
   input.type = "text";
   input.placeholder = "type edit, press enter";
@@ -426,7 +435,7 @@ function promptTypedEdit(clientX, clientY, point) {
   return new Promise((resolve) => {
     const finish = (text) => {
       input.replaceWith(pillText);
-      hidePill();
+      pill({ visible: false });
       resolve(text);
     };
     input.addEventListener("keydown", (e) => {
@@ -446,7 +455,7 @@ const dropZone = document.querySelector(".canvas-wrap");
 }));
 dropZone.addEventListener("drop", (e) => {
   const file = e.dataTransfer?.files?.[0];
-  if (file) loadLocalFile(file);
+  if (file) safeLoad(file);
 });
 function canvasPointFromEvent(e) {
   const rect = canvas.getBoundingClientRect();
@@ -460,89 +469,106 @@ function canvasPointFromEvent(e) {
   };
 }
 
+async function warmMic() {
+  if (micStream || !navigator.mediaDevices?.getUserMedia) return;
+  try {
+    micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+  } catch (err) {
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use 'type instead'.`);
+  }
+}
+
 function startIntentCapture(clientX, clientY) {
   clearError();
-  if (!SpeechRecognition) {
-    showError("Voice input is not available in this browser.");
+  if (!window.MediaRecorder) {
+    showError("Voice input is not available in this browser. Use 'type instead'.");
     return null;
   }
-
-  const capture = {
-    text: "",
-    error: "",
-    finished: false,
-    resolve: null,
-  };
-  const recognition = new SpeechRecognition();
-  capture.recognition = recognition;
-  recognition.continuous = true;
-  recognition.interimResults = true;
-  recognition.lang = navigator.language || "en-US";
-
-  capture.done = new Promise((resolve) => { capture.resolve = resolve; });
-  const finish = () => {
-    if (capture.finished) return;
-    capture.finished = true;
-    capture.resolve({ text: capture.text.trim(), error: capture.error });
-  };
-  recognition.onresult = (event) => {
-    let text = "";
-    for (let i = 0; i < event.results.length; i++) text += event.results[i][0].transcript;
-    capture.text = text.trim();
-    setPillText(capture.text || "listening…", !capture.text);
-  };
-  recognition.onerror = (event) => { capture.error = event.error || "speech recognition failed"; };
-  recognition.onend = finish;
-
+  const capture = { chunks: [], error: "", recorder: null };
+  if (!micStream) {
+    capture.error = "microphone not ready — click the page once, then try again";
+    warmMic();
+    return capture; // pointerup will surface the error
+  }
   try {
-    recognition.start();
-  } catch {
-    showError("Voice input could not start. Type an edit instead.");
-    return null;
+    capture.recorder = new MediaRecorder(micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (e) => { if (e.data?.size) capture.chunks.push(e.data); };
+    capture.recorder.start();
+  } catch (err) {
+    capture.error = err?.message || "could not start recording";
+    return capture;
   }
-
-  showPill(clientX, clientY, "listening…", true);
+  pill({ x: clientX, y: clientY, text: "listening…", placeholder: true, visible: true });
   setStatus("listening…");
   return capture;
 }
 
 async function stopIntentCapture(capture) {
-  setStatus("processing…");
-  try { capture.recognition.stop(); } catch {}
-  const timeout = new Promise((resolve) => setTimeout(() => {
-    resolve({ text: capture.text.trim(), error: capture.error });
-  }, 1500));
-  return Promise.race([capture.done, timeout]);
+  if (capture.error || !capture.recorder) return { text: "", error: capture.error };
+  setStatus("transcribing…");
+  pill({ text: "transcribing…", placeholder: true });
+  const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
+  try { capture.recorder.stop(); } catch {}
+  await stopped;
+  const type = capture.recorder.mimeType || "audio/webm";
+  const ext = type.includes("mp4") ? "mp4" : "webm";
+  const blob = new Blob(capture.chunks, { type });
+  if (blob.size < 1000) return { text: "", error: "no audio captured — hold and speak" };
+  const fd = new FormData();
+  fd.append("file", blob, `voice.${ext}`);
+  fd.append("model", STT_MODEL);
+  fd.append("language", STT_LANG);
+  fd.append("response_format", "json");
+  try {
+    const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${getKey()}` },
+      body: fd,
+    });
+    if (!r.ok) return { text: "", error: await friendlyError(r, "Transcription failed") };
+    const j = await r.json();
+    return { text: (j.text || "").trim(), error: "" };
+  } catch (err) {
+    return { text: "", error: err?.message || "transcription failed" };
+  }
 }
 
-function drawAnnotation(targetCtx, p, w, h) {
-  // ~4% of image diagonal — empirically optimal for Gemini Flash Image (r2clickthrough)
-  // Thin stroke + no text: avoids the text-glyph prior that re-renders "HERE" in outputs.
+function strokeWidthFor(w, h) {
+  return Math.max(6, Math.round(Math.min(w, h) * 0.015));
+}
+function drawRing(targetCtx, p, w, h) {
   const r = Math.max(28, Math.round(Math.min(w, h) * 0.05));
-  const stroke = Math.max(4, Math.round(r * 0.18));
   targetCtx.save();
-  // Semi-transparent ring — lets the model still see the pixels underneath.
-  targetCtx.globalAlpha = 0.7;
+  targetCtx.globalAlpha = 0.55;
   targetCtx.strokeStyle = "red";
-  targetCtx.lineWidth = stroke;
+  targetCtx.lineWidth = Math.max(4, Math.round(r * 0.18));
   targetCtx.beginPath(); targetCtx.arc(p.x, p.y, r, 0, Math.PI * 2); targetCtx.stroke();
-  // Solid center dot anchors the exact click point.
-  targetCtx.globalAlpha = 1;
-  targetCtx.fillStyle = "red";
-  targetCtx.beginPath(); targetCtx.arc(p.x, p.y, Math.max(3, Math.round(r * 0.12)), 0, Math.PI * 2); targetCtx.fill();
   targetCtx.restore();
 }
-function annotatedDataURL(p) {
-  const c = document.createElement("canvas");
-  c.width = canvas.width;
-  c.height = canvas.height;
-  const cc = c.getContext("2d");
-  cc.drawImage(canvas, 0, 0);
-  drawAnnotation(cc, p, c.width, c.height);
-  return c.toDataURL("image/png");
+function drawStrokeSegment(targetCtx, a, b, w, h) {
+  targetCtx.save();
+  targetCtx.globalAlpha = 0.35;
+  targetCtx.strokeStyle = "red";
+  targetCtx.lineWidth = strokeWidthFor(w, h);
+  targetCtx.lineCap = "round";
+  targetCtx.lineJoin = "round";
+  targetCtx.beginPath(); targetCtx.moveTo(a.x, a.y); targetCtx.lineTo(b.x, b.y); targetCtx.stroke();
+  targetCtx.restore();
 }
-function paintAnnotationOnCanvas(p) {
-  drawAnnotation(ctx, p, canvas.width, canvas.height);
+function pathLength(points) {
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x, dy = points[i].y - points[i - 1].y;
+    total += Math.hypot(dx, dy);
+  }
+  return total;
+}
+function pathCentroid(points) {
+  let sx = 0, sy = 0;
+  for (const p of points) { sx += p.x; sy += p.y; }
+  return { x: sx / points.length, y: sy / points.length };
 }
 
 async function friendlyError(response, label) {
@@ -596,19 +622,17 @@ async function runEdit(refURL, prompt, model) {
 }
 
 function buildEditPrompt(text) {
-  return [
-    `Modify the area marked by the red ring and dot: ${text}.`,
-    "Do not render the red ring or dot in the output.",
-    "Keep everything else unchanged.",
-  ].join(" ");
+  return `The red markings indicate the area the prompt is referring to. Prompt: ${text}. Output without red markings.`;
 }
 
-function enqueueEdit(point, text) {
+function enqueueEdit({ point, text, annotated }) {
   if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
   const prompt = buildEditPrompt(text);
   const model = document.getElementById("modelSel").value;
-  editQueue.push({ point, intent: text, prompt, model });
-  renderPins();
+  const xPct = (point.x / canvas.width) * 100;
+  const yPct = (point.y / canvas.height) * 100;
+  editQueue.push({ xPct, yPct, intent: text, prompt, model, annotated });
+  render();
   runQueue();
 }
 
@@ -618,12 +642,10 @@ async function runQueue() {
   try {
     while (editQueue.length) {
       const job = editQueue[0];
-      const annotated = annotatedDataURL(job.point);
-      paintAnnotationOnCanvas(job.point);
-      renderPins();
+      render();
       setStatus(`editing… (${editQueue.length} in queue)`);
       try {
-        const annotURL = await uploadDataURL(annotated);
+        const annotURL = await uploadDataURL(job.annotated);
         const resultURL = await runEdit(annotURL, job.prompt, job.model);
         pushUndo();
         await loadImageFromURL(resultURL);
@@ -632,80 +654,101 @@ async function runQueue() {
         if (currentImageURL) await loadImageFromURL(currentImageURL).catch(() => {});
       }
       editQueue.shift();
-      renderPins();
+      render();
     }
     setStatus("done");
   } finally {
     queueRunning = false;
-    renderPins();
+    render();
   }
+}
+
+function resetCanvas() {
+  if (!currentImage) return;
+  canvas.width = currentImage.naturalWidth;
+  canvas.height = currentImage.naturalHeight;
+  ctx.drawImage(currentImage, 0, 0);
 }
 
 canvas.addEventListener("pointerdown", async (e) => {
   if (!currentImage) { showError("Load an image first."); return; }
+  if (queueRunning || editQueue.length) { showError("Wait for the current edit to finish."); return; }
   e.preventDefault();
-  const typeMode = document.getElementById("typeMode").checked;
-  clickPoint = canvasPointFromEvent(e);
-  if (typeMode) {
-    const point = clickPoint;
-    const text = await promptTypedEdit(e.clientX, e.clientY, point);
+  resetCanvas(); // wipe any leftover markings from the prior gesture
+  const point = canvasPointFromEvent(e);
+  if (document.getElementById("typeMode").checked) {
+    const text = await promptTypedEdit(e.clientX, e.clientY);
     if (text) {
-      try { enqueueEdit(point, text); } catch (err) { showError(err.message); }
+      drawRing(ctx, point, canvas.width, canvas.height);
+      const annotated = canvas.toDataURL("image/png");
+      try { enqueueEdit({ point, text, annotated }); }
+      catch (err) { showError(err.message); }
     } else {
+      resetCanvas();
       setStatus("ready");
     }
     return;
   }
-  canvas.setPointerCapture(e.pointerId);
+  try { canvas.setPointerCapture(e.pointerId); } catch {}
   activeCapture = startIntentCapture(e.clientX, e.clientY);
+  if (activeCapture) {
+    activeCapture.point = point;
+    activeCapture.stroke = [point];
+  }
 });
 
 canvas.addEventListener("pointermove", (e) => {
   if (!activeCapture) return;
-  movePill(e.clientX, e.clientY);
+  pill({ x: e.clientX, y: e.clientY });
+  if (!activeCapture.stroke) return;
+  const p = canvasPointFromEvent(e);
+  const prev = activeCapture.stroke[activeCapture.stroke.length - 1];
+  drawStrokeSegment(ctx, prev, p, canvas.width, canvas.height);
+  activeCapture.stroke.push(p);
 });
 
 canvas.addEventListener("pointerup", async (e) => {
   if (!activeCapture) return;
   e.preventDefault();
   const capture = activeCapture;
-  const point = clickPoint;
   activeCapture = null;
+  const minLen = Math.min(canvas.width, canvas.height) * 0.03;
+  const stroke = capture.stroke || [capture.point];
+  const isDrag = pathLength(stroke) > minLen;
+  if (!isDrag) drawRing(ctx, capture.point, canvas.width, canvas.height);
+  const annotated = canvas.toDataURL("image/png");
+  const pinPoint = isDrag ? pathCentroid(stroke) : capture.point;
   try {
     const { text, error } = await stopIntentCapture(capture);
-    hidePill();
+    pill({ visible: false });
     if (!text.trim() && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
-    enqueueEdit(point, text);
+    enqueueEdit({ point: pinPoint, text, annotated });
   } catch (err) {
     showError(err.message);
+    resetCanvas();
   }
 });
 
 canvas.addEventListener("pointercancel", () => {
-  if (activeCapture?.recognition) {
-    try { activeCapture.recognition.stop(); } catch {}
+  if (activeCapture) {
+    try { activeCapture.recorder?.stop(); } catch {}
   }
   activeCapture = null;
-  hidePill();
+  pill({ visible: false });
+  resetCanvas();
   setStatus("ready");
 });
 
 undoBtn.onclick = () => {
   if (!undoStack.length) return;
   redoStack.push(currentImageURL);
-  loadImageFromURL(undoStack.pop()).then(() => {
-    setStatus("undone");
-    updateHistoryButtons();
-  }).catch(err => showError(err.message));
+  loadImageFromURL(undoStack.pop()).then(() => setStatus("undone")).catch(err => showError(err.message));
 };
 
 redoBtn.onclick = () => {
   if (!redoStack.length) return;
   undoStack.push(currentImageURL);
-  loadImageFromURL(redoStack.pop()).then(() => {
-    setStatus("redone");
-    updateHistoryButtons();
-  }).catch(err => showError(err.message));
+  loadImageFromURL(redoStack.pop()).then(() => setStatus("redone")).catch(err => showError(err.message));
 };
 
 document.getElementById("downloadBtn").onclick = () => {

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -138,7 +138,9 @@
   #pinLayer .pin { position: absolute; }
   .pin {
     position: absolute;
-    transform: translate(8px, -50%);
+    /* Anchor point is the dot center. Default: pin extends to the right.
+       Subtract: half-dot (≈0.275rem) + dot-border (1.5px) + padding (0.55rem) + small gap so the dot sits exactly on (xPct, yPct). */
+    transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
     background: #fff;
     border: 2px solid var(--dark);
     border-right-width: 4px;
@@ -157,7 +159,9 @@
     align-items: center;
     gap: 0.4rem;
   }
-  .pin.flip { transform: translate(-100%, -50%) translateX(-8px); }
+  /* Flipped: pin extends to the left of the dot; dot is the *last* visual child.
+     Translate so the dot center is on the anchor: full pin width minus (half-dot + dot-border + right-padding). */
+  .pin.flip { flex-direction: row-reverse; transform: translate(calc(-100% + 0.55rem + 0.275rem + 1.5px), -50%); }
   .pin.processing { background: var(--accent); }
   .pin.queued { background: #fff; opacity: 0.85; }
   .pin .dot {
@@ -240,14 +244,16 @@ function renderPins() {
   for (let i = 0; i < editQueue.length; i++) {
     const job = editQueue[i];
     const pin = document.createElement("div");
-    const flip = job.xPct > 55;
-    pin.className = "pin " + (i === 0 && queueRunning ? "processing" : "queued") + (flip ? " flip" : "");
+    pin.className = `pin ${i === 0 && queueRunning ? "processing" : "queued"}`;
     const dot = document.createElement("span"); dot.className = "dot";
     const text = document.createElement("span"); text.textContent = job.intent;
     pin.append(dot, text);
     pin.style.left = `${job.xPct}%`;
     pin.style.top = `${job.yPct}%`;
     pinLayer.append(pin);
+    const pinBox = pin.getBoundingClientRect();
+    const layerBox = pinLayer.getBoundingClientRect();
+    pin.classList.toggle("flip", pinBox.right > layerBox.right);
   }
 }
 function render() {
@@ -273,7 +279,7 @@ const undoStack = [];
 let redoStack = [];
 const editQueue = [];
 let queueRunning = false;
-const STT_MODEL = "whisper";
+const STT_MODEL = "scribe";
 const STT_LANG = (navigator.language || "en").slice(0, 2);
 const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
   .find(m => window.MediaRecorder?.isTypeSupported?.(m)) || "";
@@ -447,12 +453,16 @@ function promptTypedEdit(clientX, clientY) {
 }
 
 const dropZone = document.querySelector(".canvas-wrap");
-["dragenter", "dragover"].forEach(ev => dropZone.addEventListener(ev, (e) => {
-  e.preventDefault(); dropZone.classList.add("drop");
-}));
-["dragleave", "drop"].forEach(ev => dropZone.addEventListener(ev, (e) => {
-  e.preventDefault(); dropZone.classList.remove("drop");
-}));
+["dragenter", "dragover"].forEach((ev) => {
+  dropZone.addEventListener(ev, (e) => {
+    e.preventDefault(); dropZone.classList.add("drop");
+  });
+});
+["dragleave", "drop"].forEach((ev) => {
+  dropZone.addEventListener(ev, (e) => {
+    e.preventDefault(); dropZone.classList.remove("drop");
+  });
+});
 dropZone.addEventListener("drop", (e) => {
   const file = e.dataTransfer?.files?.[0];
   if (file) safeLoad(file);
@@ -541,7 +551,7 @@ function strokeWidthFor(w, h) {
 function drawRing(targetCtx, p, w, h) {
   const r = Math.max(28, Math.round(Math.min(w, h) * 0.05));
   targetCtx.save();
-  targetCtx.globalAlpha = 0.55;
+  targetCtx.globalAlpha = 0.35;
   targetCtx.strokeStyle = "red";
   targetCtx.lineWidth = Math.max(4, Math.round(r * 0.18));
   targetCtx.beginPath(); targetCtx.arc(p.x, p.y, r, 0, Math.PI * 2); targetCtx.stroke();
@@ -549,7 +559,7 @@ function drawRing(targetCtx, p, w, h) {
 }
 function drawStrokeSegment(targetCtx, a, b, w, h) {
   targetCtx.save();
-  targetCtx.globalAlpha = 0.35;
+  targetCtx.globalAlpha = 0.2;
   targetCtx.strokeStyle = "red";
   targetCtx.lineWidth = strokeWidthFor(w, h);
   targetCtx.lineCap = "round";

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -30,8 +30,7 @@
     <input id="urlInput" placeholder="or paste image URL" class="min-w-52 flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
     <button id="useUrl" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Use</button>
     <select id="modelSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
-      <option value="kontext">kontext (fast)</option>
-      <option value="nanobanana-2">nanobanana-2 (quality)</option>
+      <option value="nanobanana">nanobanana</option>
     </select>
     <button id="undoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Undo</button>
     <button id="redoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Redo</button>
@@ -160,6 +159,39 @@ disconnectBtn.onclick = () => {
   refreshConnectionUI();
 };
 refreshConnectionUI();
+
+(async function loadEditModels() {
+  const modelSel = document.getElementById("modelSel");
+  const DEFAULT_MODEL = "nanobanana";
+  // Models known to obey the burned-in red-circle annotation well
+  const RECOMMENDED = new Set(["nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+  try {
+    const r = await fetch(`${BASE}/image/models`);
+    if (!r.ok) return;
+    const all = await r.json();
+    const edits = all.filter(m =>
+      m.input_modalities?.includes("image") && m.output_modalities?.includes("image"),
+    );
+    edits.sort((a, b) => {
+      const ra = RECOMMENDED.has(a.name) ? 0 : 1;
+      const rb = RECOMMENDED.has(b.name) ? 0 : 1;
+      return ra - rb || a.name.localeCompare(b.name);
+    });
+    modelSel.innerHTML = "";
+    for (const m of edits) {
+      const opt = document.createElement("option");
+      opt.value = m.name;
+      const tags = [];
+      if (RECOMMENDED.has(m.name)) tags.push("★");
+      if (m.paid_only) tags.push("paid");
+      opt.textContent = tags.length ? `${m.name} (${tags.join(" · ")})` : m.name;
+      modelSel.append(opt);
+    }
+    if ([...modelSel.options].some(o => o.value === DEFAULT_MODEL)) modelSel.value = DEFAULT_MODEL;
+  } catch {
+    // network blip — leave the hardcoded option in place
+  }
+})();
 
 async function loadImageFromURL(url, opts = {}) {
   clearError();

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -1,45 +1,56 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>Voice Edit v0</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit | Pollinations</title>
 <script src="https://cdn.tailwindcss.com"></script>
 <style>
   body { background:#0a0a0a; color:#e5e5e5; }
   canvas { cursor: crosshair; touch-action: none; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
 </style>
-<body class="min-h-screen p-6 flex flex-col items-center gap-4">
-  <div class="w-full max-w-4xl flex items-center justify-between">
-    <h1 class="text-xl font-semibold">Voice Edit · v0</h1>
-    <div class="text-xs text-neutral-500" id="status">ready</div>
+<body class="min-h-screen p-4 md:p-6 flex flex-col items-center gap-4">
+  <div class="w-full max-w-5xl flex items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold tracking-tight">Voice Edit</h1>
+      <p class="text-sm text-neutral-500">Point at an image, speak or type an edit, release to apply.</p>
+    </div>
+    <div class="text-xs text-neutral-500 shrink-0" id="status">ready</div>
   </div>
 
-  <div class="relative">
-    <canvas id="canvas" width="1024" height="768" class="rounded-lg bg-neutral-900 max-w-full"></canvas>
-    <div id="recDot" class="hidden absolute top-4 right-4 w-4 h-4 rounded-full bg-red-500 animate-pulse"></div>
-  </div>
+  <div id="error" class="hidden w-full max-w-5xl rounded-lg border border-red-500/30 bg-red-950/40 px-4 py-3 text-sm text-red-100"></div>
 
-  <div class="w-full max-w-4xl flex items-center gap-2 text-sm">
-    <button id="loadBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Load starter image</button>
-    <input id="urlInput" placeholder="or paste image URL" class="flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
-    <button id="useUrl" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Use</button>
-    <select id="modelSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
-      <option value="kontext">kontext (fast)</option>
-      <option value="nanobanana-2">nanobanana-2 (quality)</option>
-    </select>
-    <select id="sttSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
-      <option value="whisper">whisper</option>
-      <option value="universal-2">universal-2</option>
-    </select>
-  </div>
-
-  <div class="w-full max-w-4xl flex items-center gap-2 text-sm">
+  <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
     <button id="connectBtn" class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 rounded">Connect Pollinations</button>
     <button id="disconnectBtn" class="hidden px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Disconnect</button>
     <span id="account" class="text-neutral-400"></span>
   </div>
 
-  <div class="w-full max-w-4xl text-sm text-neutral-400">
-    <div>Click and hold on the image, speak your edit, release to apply.</div>
+  <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
+    <button id="loadBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Load starter image</button>
+    <input id="urlInput" placeholder="or paste image URL" class="min-w-52 flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
+    <button id="useUrl" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Use</button>
+    <select id="modelSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
+      <option value="kontext">kontext (fast)</option>
+      <option value="nanobanana-2">nanobanana-2 (quality)</option>
+    </select>
+    <button id="undoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Undo</button>
+    <button id="redoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Redo</button>
+    <button id="downloadBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Download</button>
+  </div>
+
+  <div class="w-full max-w-5xl flex flex-wrap items-center gap-2 text-sm">
+    <input id="intentInput" placeholder="Optional typed edit, e.g. make this a brass lamp" class="min-w-64 flex-1 px-3 py-2 bg-neutral-900 border border-neutral-800 rounded">
+    <button id="clearIntent" class="px-3 py-2 bg-neutral-800 hover:bg-neutral-700 rounded">Clear</button>
+  </div>
+
+  <div class="w-full max-w-5xl text-sm text-neutral-400">
+    <div>Click and hold on the image. If the text field is empty, the browser listens for your voice; otherwise it applies the typed edit.</div>
     <div id="transcript" class="mt-1 text-neutral-300 italic min-h-[1.5em]"></div>
+  </div>
+
+  <div class="relative w-full max-w-5xl overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950 shadow-2xl">
+    <canvas id="canvas" width="1024" height="768" class="rounded-lg bg-neutral-900 max-w-full"></canvas>
+    <div id="recDot" class="hidden absolute top-4 right-4 w-4 h-4 rounded-full bg-red-500 animate-pulse"></div>
   </div>
 
 <script>
@@ -54,18 +65,52 @@ const canvas = document.getElementById("canvas");
 const ctx = canvas.getContext("2d");
 const statusEl = document.getElementById("status");
 const transcriptEl = document.getElementById("transcript");
+const errorEl = document.getElementById("error");
 const recDot = document.getElementById("recDot");
 const connectBtn = document.getElementById("connectBtn");
 const disconnectBtn = document.getElementById("disconnectBtn");
 const accountEl = document.getElementById("account");
+const intentInput = document.getElementById("intentInput");
+const undoBtn = document.getElementById("undoBtn");
+const redoBtn = document.getElementById("redoBtn");
 
 let currentImage = null;
-let mediaRecorder = null;
-let chunks = [];
+let currentImageURL = "";
 let clickPoint = null;
-let stream = null;
+let activeCapture = null;
+let isBusy = false;
+const undoStack = [];
+let redoStack = [];
+const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 
 function setStatus(s) { statusEl.textContent = s; }
+function showError(message) {
+  errorEl.textContent = message;
+  errorEl.classList.remove("hidden");
+  setStatus("error");
+}
+function clearError() { errorEl.classList.add("hidden"); }
+
+function setBusy(value) {
+  isBusy = value;
+  for (const el of document.querySelectorAll("button, input, select")) {
+    if (el.id === "disconnectBtn") continue;
+    el.disabled = value;
+  }
+  updateHistoryButtons();
+}
+
+function updateHistoryButtons() {
+  undoBtn.disabled = isBusy || undoStack.length === 0;
+  redoBtn.disabled = isBusy || redoStack.length === 0;
+}
+
+function pushUndo() {
+  if (!currentImageURL) return;
+  undoStack.push(currentImageURL);
+  redoStack = [];
+  updateHistoryButtons();
+}
 
 (function captureKeyFromFragment() {
   if (!location.hash) return;
@@ -75,7 +120,7 @@ function setStatus(s) { statusEl.textContent = s; }
     localStorage.setItem(KEY_STORAGE, apiKey);
     history.replaceState(null, "", location.pathname + location.search);
   } else if (params.get("error")) {
-    setStatus("auth: " + params.get("error"));
+    showError(`Authorization failed: ${params.get("error")}`);
   }
 })();
 
@@ -116,22 +161,34 @@ disconnectBtn.onclick = () => {
 };
 refreshConnectionUI();
 
-async function loadImageFromURL(url) {
+async function loadImageFromURL(url, opts = {}) {
+  clearError();
+  if (opts.pushHistory) pushUndo();
   setStatus("loading image…");
   const img = new Image();
   img.crossOrigin = "anonymous";
-  await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = url; });
+  await new Promise((res, rej) => {
+    img.onload = res;
+    img.onerror = () => rej(new Error("could not load image; try another URL"));
+    img.src = url;
+  });
   canvas.width = img.naturalWidth;
   canvas.height = img.naturalHeight;
   ctx.drawImage(img, 0, 0);
   currentImage = img;
+  currentImageURL = url;
+  updateHistoryButtons();
   setStatus("ready");
 }
 
-document.getElementById("loadBtn").onclick = () => loadImageFromURL(STARTER);
+document.getElementById("loadBtn").onclick = () => loadImageFromURL(STARTER, { pushHistory: true }).catch(err => showError(err.message));
 document.getElementById("useUrl").onclick = () => {
   const u = document.getElementById("urlInput").value.trim();
-  if (u) loadImageFromURL(u);
+  if (u) loadImageFromURL(u, { pushHistory: true }).catch(err => showError(err.message));
+};
+document.getElementById("clearIntent").onclick = () => {
+  intentInput.value = "";
+  transcriptEl.textContent = "";
 };
 
 function canvasPointFromEvent(e) {
@@ -146,47 +203,77 @@ function canvasPointFromEvent(e) {
   };
 }
 
-async function startRecording() {
-  try {
-    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-  } catch (err) {
-    setStatus("mic denied: " + err.message);
-    return false;
+function startIntentCapture() {
+  clearError();
+  const typed = intentInput.value.trim();
+  if (typed) {
+    transcriptEl.textContent = `→ ${typed}`;
+    setStatus("release to edit…");
+    return { mode: "typed", text: typed };
   }
-  chunks = [];
-  const mime = MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : "";
-  mediaRecorder = new MediaRecorder(stream, mime ? { mimeType: mime } : undefined);
-  mediaRecorder.ondataavailable = (e) => e.data.size && chunks.push(e.data);
-  mediaRecorder.start();
+
+  if (!SpeechRecognition) {
+    showError("Voice input is not available in this browser. Type an edit, then click the target area.");
+    return null;
+  }
+
+  const capture = {
+    mode: "speech",
+    text: "",
+    error: "",
+    finished: false,
+    resolve: null,
+  };
+  const recognition = new SpeechRecognition();
+  capture.recognition = recognition;
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.lang = navigator.language || "en-US";
+
+  capture.done = new Promise((resolve) => {
+    capture.resolve = resolve;
+  });
+  const finish = () => {
+    if (capture.finished) return;
+    capture.finished = true;
+    recDot.classList.add("hidden");
+    capture.resolve({ text: capture.text.trim(), error: capture.error });
+  };
+  recognition.onresult = (event) => {
+    let text = "";
+    for (let i = 0; i < event.results.length; i++) {
+      text += event.results[i][0].transcript;
+    }
+    capture.text = text.trim();
+    transcriptEl.textContent = capture.text ? `→ ${capture.text}` : "listening…";
+  };
+  recognition.onerror = (event) => {
+    capture.error = event.error || "speech recognition failed";
+  };
+  recognition.onend = finish;
+
+  try {
+    recognition.start();
+  } catch {
+    showError("Voice input could not start. Type an edit instead.");
+    return null;
+  }
+
   recDot.classList.remove("hidden");
-  setStatus("recording…");
-  return true;
+  transcriptEl.textContent = "listening…";
+  setStatus("listening…");
+  return capture;
 }
 
-function stopRecordingAndGetBlob() {
-  return new Promise((res) => {
-    mediaRecorder.onstop = () => {
-      stream.getTracks().forEach(t => t.stop());
-      recDot.classList.add("hidden");
-      res(new Blob(chunks, { type: chunks[0]?.type || "audio/webm" }));
-    };
-    mediaRecorder.stop();
-  });
-}
-
-async function transcribe(blob) {
-  setStatus("transcribing…");
-  const fd = new FormData();
-  fd.append("file", blob, "rec.webm");
-  fd.append("model", document.getElementById("sttSel").value);
-  const r = await fetch(`${BASE}/v1/audio/transcriptions`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${getKey()}` },
-    body: fd,
-  });
-  if (!r.ok) throw new Error("transcribe failed " + r.status + " " + await r.text());
-  const j = await r.json();
-  return j.text || j.transcription || "";
+async function stopIntentCapture(capture) {
+  if (capture.mode === "typed") return { text: capture.text, error: "" };
+  setStatus("processing…");
+  try { capture.recognition.stop(); } catch {}
+  const timeout = new Promise((resolve) => setTimeout(() => {
+    recDot.classList.add("hidden");
+    resolve({ text: capture.text.trim(), error: capture.error });
+  }, 1500));
+  return Promise.race([capture.done, timeout]);
 }
 
 function annotatedDataURL(p) {
@@ -205,6 +292,25 @@ function annotatedDataURL(p) {
   return c.toDataURL("image/png");
 }
 
+async function friendlyError(response, label) {
+  let details = "";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {
+    details = response.statusText || "request failed";
+  }
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect Pollinations again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
 async function uploadDataURL(dataURL) {
   setStatus("uploading…");
   const blob = await (await fetch(dataURL)).blob();
@@ -215,7 +321,7 @@ async function uploadDataURL(dataURL) {
     headers: { Authorization: `Bearer ${getKey()}` },
     body: fd,
   });
-  if (!r.ok) throw new Error("upload failed " + r.status);
+  if (!r.ok) throw new Error(await friendlyError(r, "Upload failed"));
   const j = await r.json();
   return j.url || `https://media.pollinations.ai/${j.id}`;
 }
@@ -228,44 +334,100 @@ async function runEdit(refURL, prompt) {
     headers: { Authorization: `Bearer ${getKey()}`, "Content-Type": "application/json" },
     body: JSON.stringify({ prompt, image: refURL, model, response_format: "url" }),
   });
-  if (!r.ok) throw new Error("edit failed " + r.status + " " + await r.text());
+  if (!r.ok) throw new Error(await friendlyError(r, "Edit failed"));
   const j = await r.json();
   const item = j.data?.[0];
   if (!item) throw new Error("no image in response");
   if (item.url) return item.url;
-  if (item.b64_json) return "data:image/png;base64," + item.b64_json;
+  if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
   throw new Error("no url or b64_json in response");
 }
 
+function buildEditPrompt(text) {
+  return [
+    "Use the red circle and HERE label only as edit instructions, not final content.",
+    `Modify the object or region inside the red circle: ${text}.`,
+    "Remove the red circle and HERE label in the final image. Keep unmarked areas unchanged."
+  ].join(" ");
+}
+
+async function applyEditAtPoint(point, text) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  setBusy(true);
+  try {
+    transcriptEl.textContent = `→ ${text}`;
+    const annotURL = await uploadDataURL(annotatedDataURL(point));
+    const resultURL = await runEdit(annotURL, buildEditPrompt(text));
+    pushUndo();
+    await loadImageFromURL(resultURL);
+    setStatus("done");
+  } finally {
+    setBusy(false);
+  }
+}
+
 canvas.addEventListener("pointerdown", async (e) => {
-  if (!currentImage) { setStatus("load an image first"); return; }
+  if (isBusy) return;
+  if (!currentImage) { showError("Load an image first."); return; }
   e.preventDefault();
   canvas.setPointerCapture(e.pointerId);
   clickPoint = canvasPointFromEvent(e);
   transcriptEl.textContent = "";
-  await startRecording();
+  activeCapture = startIntentCapture();
 });
 
 canvas.addEventListener("pointerup", async (e) => {
-  if (!mediaRecorder || mediaRecorder.state !== "recording") return;
+  if (!activeCapture) return;
+  e.preventDefault();
+  const capture = activeCapture;
+  activeCapture = null;
   try {
-    const blob = await stopRecordingAndGetBlob();
-    if (blob.size < 1000) { setStatus("too short"); return; }
-    const text = await transcribe(blob);
-    transcriptEl.textContent = "→ " + text;
-    if (!text.trim()) { setStatus("nothing heard"); return; }
-    const annotURL = await uploadDataURL(annotatedDataURL(clickPoint));
-    const prompt = `Edit the area marked with the red circle (labeled HERE). ${text}. Remove the red circle and HERE text in the final image.`;
-    const resultURL = await runEdit(annotURL, prompt);
-    await loadImageFromURL(resultURL);
-    setStatus("done");
+    const { text, error } = await stopIntentCapture(capture);
+    if (!text.trim() && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    await applyEditAtPoint(clickPoint, text);
   } catch (err) {
-    setStatus("error: " + err.message);
+    showError(err.message);
   }
 });
 
-loadImageFromURL(STARTER);
+canvas.addEventListener("pointercancel", () => {
+  if (activeCapture?.recognition) {
+    try { activeCapture.recognition.stop(); } catch {}
+  }
+  activeCapture = null;
+  recDot.classList.add("hidden");
+  setStatus("ready");
+});
+
+undoBtn.onclick = () => {
+  if (!undoStack.length || isBusy) return;
+  redoStack.push(currentImageURL);
+  loadImageFromURL(undoStack.pop()).then(() => {
+    setStatus("undone");
+    updateHistoryButtons();
+  }).catch(err => showError(err.message));
+};
+
+redoBtn.onclick = () => {
+  if (!redoStack.length || isBusy) return;
+  undoStack.push(currentImageURL);
+  loadImageFromURL(redoStack.pop()).then(() => {
+    setStatus("redone");
+    updateHistoryButtons();
+  }).catch(err => showError(err.message));
+};
+
+document.getElementById("downloadBtn").onclick = () => {
+  try {
+    const a = document.createElement("a");
+    a.href = canvas.toDataURL("image/png");
+    a.download = "voice-edit.png";
+    a.click();
+  } catch {
+    if (currentImageURL) window.open(currentImageURL, "_blank", "noopener");
+  }
+};
+
+loadImageFromURL(STARTER).catch(err => showError(err.message));
 </script>
 </body>
-</content>
-</invoke>

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -30,7 +30,7 @@
     <input id="urlInput" placeholder="or paste image URL" class="min-w-52 flex-1 px-3 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
     <button id="useUrl" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded">Use</button>
     <select id="modelSel" class="px-2 py-1.5 bg-neutral-900 border border-neutral-800 rounded">
-      <option value="nanobanana">nanobanana</option>
+      <option value="p-image-edit">p-image-edit</option>
     </select>
     <button id="undoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Undo</button>
     <button id="redoBtn" class="px-3 py-1.5 bg-neutral-800 hover:bg-neutral-700 rounded" disabled>Redo</button>
@@ -162,9 +162,9 @@ refreshConnectionUI();
 
 (async function loadEditModels() {
   const modelSel = document.getElementById("modelSel");
-  const DEFAULT_MODEL = "nanobanana";
+  const DEFAULT_MODEL = "p-image-edit";
   // Models known to obey the burned-in red-circle annotation well
-  const RECOMMENDED = new Set(["nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+  const RECOMMENDED = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
   try {
     const r = await fetch(`${BASE}/image/models`);
     if (!r.ok) return;

--- a/apps/voice-edit/index.html
+++ b/apps/voice-edit/index.html
@@ -64,6 +64,8 @@
     line-height: 1.3;
   }
   canvas { cursor: crosshair; touch-action: none; display: block; max-width: 100%; max-height: calc(100vh - 200px); width: auto; height: auto; margin: 0 auto; }
+  .swatch { width: 1.4rem; height: 1.4rem; border: 2px solid var(--dark); cursor: pointer; padding: 0; outline: 2px solid transparent; outline-offset: 1px; }
+  .swatch.active { outline-color: var(--accent); }
   .canvas-wrap { background: #fff; border: 2px solid var(--dark); border-right-width: 4px; border-bottom-width: 4px; padding: 0; overflow: hidden; position: relative; display: flex; align-items: center; justify-content: center; width: 100%; }
   .canvas-stage { position: relative; display: inline-block; max-width: 100%; }
   .canvas-wrap.drop { outline: 4px dashed var(--accent); outline-offset: -8px; }
@@ -189,6 +191,11 @@
     <select id="modelSel" class="pollen-select text-sm">
       <option value="nanobanana">nanobanana</option>
     </select>
+    <div id="colorPicker" class="flex items-center gap-1 ml-1">
+      <button type="button" class="swatch" data-color="red" style="background:red"></button>
+      <button type="button" class="swatch" data-color="black" style="background:black"></button>
+      <button type="button" class="swatch" data-color="white" style="background:white"></button>
+    </div>
     <label class="ml-2 text-xs flex items-center gap-1 select-none">
       <input id="typeMode" type="checkbox"> type instead
     </label>
@@ -278,6 +285,7 @@ const STT_LANG = (navigator.language || "en").slice(0, 2);
 const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
   .find(m => window.MediaRecorder?.isTypeSupported?.(m)) || "";
 let micStream = null; // pre-warmed mic to eliminate startup cut-off
+let markerColor = "red";
 
 function setStatus(s) { statusEl.textContent = s; }
 function showError(message) {
@@ -378,6 +386,16 @@ disconnectBtn.onclick = () => {
   refreshConnectionUI();
 };
 refreshConnectionUI();
+
+(function setupColorPicker() {
+  const picker = document.getElementById("colorPicker");
+  const swatches = picker.querySelectorAll(".swatch");
+  const apply = () => {
+    for (const s of swatches) s.classList.toggle("active", s.dataset.color === markerColor);
+  };
+  for (const s of swatches) s.addEventListener("click", () => { markerColor = s.dataset.color; apply(); });
+  apply();
+})();
 
 (async function loadEditModels() {
   const modelSel = document.getElementById("modelSel");
@@ -567,22 +585,9 @@ async function stopIntentCapture(capture) {
 function strokeWidthFor(w, h) {
   return Math.max(6, Math.round(Math.min(w, h) * 0.015));
 }
-function ringRadius(w, h) {
-  return Math.max(28, Math.round(Math.min(w, h) * 0.05));
-}
-function drawRing(targetCtx, p, w, h) {
-  const r = ringRadius(w, h);
-  targetCtx.save();
-  targetCtx.globalAlpha = 0.35;
-  targetCtx.strokeStyle = "red";
-  targetCtx.lineWidth = Math.max(4, Math.round(r * 0.18));
-  targetCtx.beginPath(); targetCtx.arc(p.x, p.y, r, 0, Math.PI * 2); targetCtx.stroke();
-  targetCtx.restore();
-}
 function drawStrokeSegment(targetCtx, a, b, w, h) {
   targetCtx.save();
-  targetCtx.globalAlpha = 0.2;
-  targetCtx.strokeStyle = "red";
+  targetCtx.strokeStyle = markerColor;
   targetCtx.lineWidth = strokeWidthFor(w, h);
   targetCtx.lineCap = "round";
   targetCtx.lineJoin = "round";
@@ -656,13 +661,14 @@ async function runEdit(refURL, prompt, model) {
   throw new Error("no url or b64_json in response");
 }
 
-function buildEditPrompt(text) {
-  return `The red markings indicate the area the prompt is referring to. Prompt: ${text}. Output without red markings.`;
+function buildEditPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
 }
 
-function enqueueEdit({ point, text, annotated }) {
+function enqueueEdit({ point, text, annotated, marked }) {
   if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
-  const prompt = buildEditPrompt(text);
+  const prompt = buildEditPrompt(text, marked, markerColor);
   const model = document.getElementById("modelSel").value;
   const xPct = (point.x / canvas.width) * 100;
   const yPct = (point.y / canvas.height) * 100;
@@ -715,14 +721,10 @@ canvas.addEventListener("pointerdown", async (e) => {
   if (document.getElementById("typeMode").checked) {
     const text = await promptTypedEdit(e.clientX, e.clientY);
     if (text) {
-      drawRing(ctx, point, canvas.width, canvas.height);
       const annotated = canvas.toDataURL("image/png");
-      const r = ringRadius(canvas.width, canvas.height);
-      const pinPoint = { x: point.x + r, y: point.y };
-      try { enqueueEdit({ point: pinPoint, text, annotated }); }
+      try { enqueueEdit({ point, text, annotated, marked: false }); }
       catch (err) { showError(err.message); }
     } else {
-      resetCanvas();
       setStatus("ready");
     }
     return;
@@ -753,22 +755,21 @@ canvas.addEventListener("pointerup", async (e) => {
   const minLen = Math.min(canvas.width, canvas.height) * 0.03;
   const stroke = capture.stroke || [capture.point];
   const isDrag = pathLength(stroke) > minLen;
-  if (!isDrag) drawRing(ctx, capture.point, canvas.width, canvas.height);
+  // No drag → wipe back to clean source so no faint live-paint trace persists in the snapshot.
+  if (!isDrag) resetCanvas();
   const annotated = canvas.toDataURL("image/png");
-  // Pin always anchors at the rightmost edge of the marking, vertically centered on it.
   let pinPoint;
   if (isDrag) {
     const b = pathBounds(stroke);
     pinPoint = { x: b.maxX, y: (b.minY + b.maxY) / 2 };
   } else {
-    const r = ringRadius(canvas.width, canvas.height);
-    pinPoint = { x: capture.point.x + r, y: capture.point.y };
+    pinPoint = capture.point;
   }
   try {
     const { text, error } = await stopIntentCapture(capture);
     pill({ visible: false });
     if (!text.trim() && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
-    enqueueEdit({ point: pinPoint, text, annotated });
+    enqueueEdit({ point: pinPoint, text, annotated, marked: isDrag });
   } catch (err) {
     showError(err.message);
     resetCanvas();

--- a/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
@@ -99,13 +99,15 @@ async function enqueueLtx2Job(
     width: number,
     height: number,
     frameCount: number,
+    imageUrl?: string,
 ): Promise<string> {
-    const requestBody = {
+    const requestBody: Record<string, unknown> = {
         prompt,
         width,
         height,
         frame_count: frameCount,
     };
+    if (imageUrl) requestBody.image_url = imageUrl;
 
     logOps("Enqueuing LTX-2 job:", requestBody);
 
@@ -286,22 +288,35 @@ export const callLtx2API = async (
         safeParams.aspectRatio,
     );
 
+    const imageUrl = Array.isArray(safeParams.image)
+        ? safeParams.image[0]
+        : safeParams.image;
+
     logOps("Video params:", {
         durationSeconds,
         frameCount,
         width,
         height,
         aspectRatio: safeParams.aspectRatio,
+        hasImage: Boolean(imageUrl),
     });
 
     progress.updateBar(
         requestId,
         40,
         "Processing",
-        "Enqueuing video generation job...",
+        imageUrl
+            ? "Enqueuing image-to-video job..."
+            : "Enqueuing video generation job...",
     );
 
-    const promptId = await enqueueLtx2Job(prompt, width, height, frameCount);
+    const promptId = await enqueueLtx2Job(
+        prompt,
+        width,
+        height,
+        frameCount,
+        imageUrl,
+    );
 
     progress.updateBar(requestId, 50, "Processing", "Generating video...");
 

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
@@ -3,8 +3,9 @@ LTX-2 ComfyUI wrapper server for GH200.
 Patched ComfyUI (model_management.py 1e32 fix) with two-stage upscaler.
 Includes watchdog that auto-restarts ComfyUI if it crashes.
 """
-import json, os, random, subprocess, threading, time, urllib.request, urllib.parse, logging
+import hashlib, json, os, random, subprocess, threading, time, urllib.request, urllib.parse, logging
 from pathlib import Path
+from typing import Optional
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
@@ -22,6 +23,14 @@ PROMPT_NODE = "177:109"
 WIDTH_HEIGHT_NODE = "177:131"
 FRAME_COUNT_NODE = "177:113"
 SEED_NODES = ["177:118", "177:123"]
+
+# I2V splice points (see workflow.json)
+EMPTY_LATENT_NODE = "177:116"            # EmptyLTXVLatentVideo, consumed by 177:132.video_latent
+CHECKPOINT_NODE = "177:100"              # CheckpointLoaderSimple — outputs [MODEL, CLIP, VAE]; VAE index = 2
+CONDITIONING_NODE = "177:103"            # LTXVConditioning — outputs [positive, negative]
+COMFY_INPUT_DIR = os.environ.get("COMFY_INPUT_DIR", "/home/ubuntu/comfy/ComfyUI/input")
+I2V_LOAD_NODE = "ltx_i2v_load_image"
+I2V_NODE = "ltx_i2v_img_to_video"
 
 REGISTER_URL = os.environ.get("REGISTER_URL", "https://gen.pollinations.ai/register")
 PUBLIC_IP = os.environ.get("PUBLIC_IP", "")
@@ -103,6 +112,72 @@ class EnqueueRequest(BaseModel):
     width: int = 720
     height: int = 720
     frame_count: int = 121
+    image_url: Optional[str] = None
+
+
+def _download_init_image(image_url: str) -> str:
+    """Download a public image URL into ComfyUI's input dir; return filename."""
+    parsed = urllib.parse.urlparse(image_url)
+    ext = Path(parsed.path).suffix.lower()
+    if ext not in {".png", ".jpg", ".jpeg", ".webp"}:
+        ext = ".png"
+    name = hashlib.sha256(image_url.encode()).hexdigest()[:24] + ext
+    Path(COMFY_INPUT_DIR).mkdir(parents=True, exist_ok=True)
+    dest = Path(COMFY_INPUT_DIR) / name
+    if not dest.exists():
+        req = urllib.request.Request(image_url, headers={"User-Agent": "pollinations-ltx2/1.0"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            dest.write_bytes(r.read())
+    return name
+
+
+def _patch_workflow_for_i2v(wf: dict, image_filename: str) -> None:
+    """Inject LoadImage + LTXVImgToVideo, rewire latent + conditioning consumers."""
+    empty = wf.get(EMPTY_LATENT_NODE)
+    if not empty:
+        return
+    width_in = empty["inputs"]["width"]
+    height_in = empty["inputs"]["height"]
+    length_in = empty["inputs"]["length"]
+
+    wf[I2V_LOAD_NODE] = {
+        "class_type": "LoadImage",
+        "inputs": {"image": image_filename},
+        "_meta": {"title": "Load Init Image (I2V)"},
+    }
+    wf[I2V_NODE] = {
+        "class_type": "LTXVImgToVideo",
+        "inputs": {
+            "positive": [CONDITIONING_NODE, 0],
+            "negative": [CONDITIONING_NODE, 1],
+            "vae": [CHECKPOINT_NODE, 2],
+            "image": [I2V_LOAD_NODE, 0],
+            "width": width_in,
+            "height": height_in,
+            "length": length_in,
+            "batch_size": 1,
+            "strength": 1.0,
+        },
+        "_meta": {"title": "LTXV Image to Video (I2V)"},
+    }
+    # Rewire: any consumer of (EMPTY_LATENT_NODE, *) -> (I2V_NODE, 2)  (latent output index)
+    # Rewire: any consumer of (CONDITIONING_NODE, 0) -> (I2V_NODE, 0)  (image-conditioned positive)
+    # Rewire: any consumer of (CONDITIONING_NODE, 1) -> (I2V_NODE, 1)  (image-conditioned negative)
+    for nid, node in wf.items():
+        if nid in (I2V_NODE, I2V_LOAD_NODE):
+            continue  # don't rewire the new nodes' own inputs
+        inputs = node.get("inputs", {})
+        for k, v in list(inputs.items()):
+            if not (isinstance(v, list) and len(v) == 2):
+                continue
+            src_id, src_idx = v
+            if src_id == EMPTY_LATENT_NODE:
+                inputs[k] = [I2V_NODE, 2]
+            elif src_id == CONDITIONING_NODE and src_idx == 0:
+                inputs[k] = [I2V_NODE, 0]
+            elif src_id == CONDITIONING_NODE and src_idx == 1:
+                inputs[k] = [I2V_NODE, 1]
+
 
 @app.post("/enqueue")
 def enqueue(req: EnqueueRequest):
@@ -111,6 +186,11 @@ def enqueue(req: EnqueueRequest):
     wf[WIDTH_HEIGHT_NODE]["inputs"]["width"] = req.width
     wf[WIDTH_HEIGHT_NODE]["inputs"]["height"] = req.height
     wf[FRAME_COUNT_NODE]["inputs"]["value"] = req.frame_count
+
+    if req.image_url:
+        image_filename = _download_init_image(req.image_url)
+        _patch_workflow_for_i2v(wf, image_filename)
+
     seed = random.randint(0, 2**32 - 1)
     for nid in SEED_NODES:
         if nid in wf:
@@ -121,7 +201,8 @@ def enqueue(req: EnqueueRequest):
     prompt_id = resp.get("prompt_id")
     if not prompt_id:
         raise HTTPException(500, "No prompt_id from ComfyUI")
-    log.info("Enqueued %s: %dx%d %d frames", prompt_id[:8], req.width, req.height, req.frame_count)
+    mode = "i2v" if req.image_url else "t2v"
+    log.info("Enqueued %s [%s]: %dx%d %d frames", prompt_id[:8], mode, req.width, req.height, req.frame_count)
     return {"prompt_id": prompt_id}
 
 @app.get("/status")

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -572,8 +572,9 @@ export const IMAGE_SERVICES = {
                 completionVideoSeconds: 0.005,
             },
         ],
-        description: "LTX-2.3 - Fast text-to-video generation with upscaler",
-        inputModalities: ["text"],
+        description:
+            "LTX-2.3 - Fast text/image-to-video generation with upscaler",
+        inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },
     "p-image": {


### PR DESCRIPTION
- gateway: pass `safeParams.image[0]` as `image_url` to Modal `/enqueue`
- modal: download image into ComfyUI input dir, splice `LoadImage` + `LTXVImgToVideoLatent` into workflow, replacing `EmptyLTXVLatentVideo` (node `177:116`)
- modal: install Lightricks/ComfyUI-LTXVideo custom node so `LTXVImgToVideoLatent` is available
- registry: ltx-2 inputModalities -> ["text", "image"]
- README: document `image_url` body field
- voice-edit bonus: replace static video label with a 9-model selectable dropdown (filtered from /image/models by output=video, input includes image); change default to seedance-pro (~3x faster than wan-fast in side-by-side bench)

Requires modal redeploy of `ltx2-comfyui-api-distilled` before the registry change takes effect end-to-end.

## Test plan
- [ ] modal deploy ltx2-t2v-distilled/comfyapp_ltx_distilled.py (this is the gating step — verify ComfyUI-LTXVideo nodes register)
- [ ] curl staging /image/models | jq '.[] | select(.name=="ltx-2") | .input_modalities' -> ["text","image"]
- [ ] curl staging /video/{prompt}?model=ltx-2&image=<url> -> mp4 conditioned on the init image
- [ ] curl staging /video/{prompt}?model=ltx-2 (no image) -> still works as pure T2V (back-compat)
- [ ] voice-edit animate mode dropdown shows ltx-2 once registry change deploys