### PR TITLE
feat(ltx-2): add image-to-video input

### DIFF
--- a/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
@@ -99,13 +99,15 @@ async function enqueueLtx2Job(
     width: number,
     height: number,
     frameCount: number,
+    imageUrl?: string,
 ): Promise<string> {
-    const requestBody = {
+    const requestBody: Record<string, unknown> = {
         prompt,
         width,
         height,
         frame_count: frameCount,
     };
+    if (imageUrl) requestBody.image_url = imageUrl;
 
     logOps("Enqueuing LTX-2 job:", requestBody);
 
@@ -286,22 +288,35 @@ export const callLtx2API = async (
         safeParams.aspectRatio,
     );
 
+    const imageUrl = Array.isArray(safeParams.image)
+        ? safeParams.image[0]
+        : safeParams.image;
+
     logOps("Video params:", {
         durationSeconds,
         frameCount,
         width,
         height,
         aspectRatio: safeParams.aspectRatio,
+        hasImage: Boolean(imageUrl),
     });
 
     progress.updateBar(
         requestId,
         40,
         "Processing",
-        "Enqueuing video generation job...",
+        imageUrl
+            ? "Enqueuing image-to-video job..."
+            : "Enqueuing video generation job...",
     );
 
-    const promptId = await enqueueLtx2Job(prompt, width, height, frameCount);
+    const promptId = await enqueueLtx2Job(
+        prompt,
+        width,
+        height,
+        frameCount,
+        imageUrl,
+    );
 
     progress.updateBar(requestId, 50, "Processing", "Generating video...");
 

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
@@ -3,8 +3,9 @@ LTX-2 ComfyUI wrapper server for GH200.
 Patched ComfyUI (model_management.py 1e32 fix) with two-stage upscaler.
 Includes watchdog that auto-restarts ComfyUI if it crashes.
 """
-import json, os, random, subprocess, threading, time, urllib.request, urllib.parse, logging
+import hashlib, json, os, random, subprocess, threading, time, urllib.request, urllib.parse, logging
 from pathlib import Path
+from typing import Optional
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
@@ -22,6 +23,14 @@ PROMPT_NODE = "177:109"
 WIDTH_HEIGHT_NODE = "177:131"
 FRAME_COUNT_NODE = "177:113"
 SEED_NODES = ["177:118", "177:123"]
+
+# I2V splice points (see workflow.json)
+EMPTY_LATENT_NODE = "177:116"            # EmptyLTXVLatentVideo, consumed by 177:132.video_latent
+CHECKPOINT_NODE = "177:100"              # CheckpointLoaderSimple — outputs [MODEL, CLIP, VAE]; VAE index = 2
+CONDITIONING_NODE = "177:103"            # LTXVConditioning — outputs [positive, negative]
+COMFY_INPUT_DIR = os.environ.get("COMFY_INPUT_DIR", "/home/ubuntu/comfy/ComfyUI/input")
+I2V_LOAD_NODE = "ltx_i2v_load_image"
+I2V_NODE = "ltx_i2v_img_to_video"
 
 REGISTER_URL = os.environ.get("REGISTER_URL", "https://gen.pollinations.ai/register")
 PUBLIC_IP = os.environ.get("PUBLIC_IP", "")
@@ -103,6 +112,72 @@ class EnqueueRequest(BaseModel):
     width: int = 720
     height: int = 720
     frame_count: int = 121
+    image_url: Optional[str] = None
+
+
+def _download_init_image(image_url: str) -> str:
+    """Download a public image URL into ComfyUI's input dir; return filename."""
+    parsed = urllib.parse.urlparse(image_url)
+    ext = Path(parsed.path).suffix.lower()
+    if ext not in {".png", ".jpg", ".jpeg", ".webp"}:
+        ext = ".png"
+    name = hashlib.sha256(image_url.encode()).hexdigest()[:24] + ext
+    Path(COMFY_INPUT_DIR).mkdir(parents=True, exist_ok=True)
+    dest = Path(COMFY_INPUT_DIR) / name
+    if not dest.exists():
+        req = urllib.request.Request(image_url, headers={"User-Agent": "pollinations-ltx2/1.0"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            dest.write_bytes(r.read())
+    return name
+
+
+def _patch_workflow_for_i2v(wf: dict, image_filename: str) -> None:
+    """Inject LoadImage + LTXVImgToVideo, rewire latent + conditioning consumers."""
+    empty = wf.get(EMPTY_LATENT_NODE)
+    if not empty:
+        return
+    width_in = empty["inputs"]["width"]
+    height_in = empty["inputs"]["height"]
+    length_in = empty["inputs"]["length"]
+
+    wf[I2V_LOAD_NODE] = {
+        "class_type": "LoadImage",
+        "inputs": {"image": image_filename},
+        "_meta": {"title": "Load Init Image (I2V)"},
+    }
+    wf[I2V_NODE] = {
+        "class_type": "LTXVImgToVideo",
+        "inputs": {
+            "positive": [CONDITIONING_NODE, 0],
+            "negative": [CONDITIONING_NODE, 1],
+            "vae": [CHECKPOINT_NODE, 2],
+            "image": [I2V_LOAD_NODE, 0],
+            "width": width_in,
+            "height": height_in,
+            "length": length_in,
+            "batch_size": 1,
+            "strength": 1.0,
+        },
+        "_meta": {"title": "LTXV Image to Video (I2V)"},
+    }
+    # Rewire: any consumer of (EMPTY_LATENT_NODE, *) -> (I2V_NODE, 2)  (latent output index)
+    # Rewire: any consumer of (CONDITIONING_NODE, 0) -> (I2V_NODE, 0)  (image-conditioned positive)
+    # Rewire: any consumer of (CONDITIONING_NODE, 1) -> (I2V_NODE, 1)  (image-conditioned negative)
+    for nid, node in wf.items():
+        if nid in (I2V_NODE, I2V_LOAD_NODE):
+            continue  # don't rewire the new nodes' own inputs
+        inputs = node.get("inputs", {})
+        for k, v in list(inputs.items()):
+            if not (isinstance(v, list) and len(v) == 2):
+                continue
+            src_id, src_idx = v
+            if src_id == EMPTY_LATENT_NODE:
+                inputs[k] = [I2V_NODE, 2]
+            elif src_id == CONDITIONING_NODE and src_idx == 0:
+                inputs[k] = [I2V_NODE, 0]
+            elif src_id == CONDITIONING_NODE and src_idx == 1:
+                inputs[k] = [I2V_NODE, 1]
+
 
 @app.post("/enqueue")
 def enqueue(req: EnqueueRequest):
@@ -111,6 +186,11 @@ def enqueue(req: EnqueueRequest):
     wf[WIDTH_HEIGHT_NODE]["inputs"]["width"] = req.width
     wf[WIDTH_HEIGHT_NODE]["inputs"]["height"] = req.height
     wf[FRAME_COUNT_NODE]["inputs"]["value"] = req.frame_count
+
+    if req.image_url:
+        image_filename = _download_init_image(req.image_url)
+        _patch_workflow_for_i2v(wf, image_filename)
+
     seed = random.randint(0, 2**32 - 1)
     for nid in SEED_NODES:
         if nid in wf:
@@ -121,7 +201,8 @@ def enqueue(req: EnqueueRequest):
     prompt_id = resp.get("prompt_id")
     if not prompt_id:
         raise HTTPException(500, "No prompt_id from ComfyUI")
-    log.info("Enqueued %s: %dx%d %d frames", prompt_id[:8], req.width, req.height, req.frame_count)
+    mode = "i2v" if req.image_url else "t2v"
+    log.info("Enqueued %s [%s]: %dx%d %d frames", prompt_id[:8], mode, req.width, req.height, req.frame_count)
     return {"prompt_id": prompt_id}
 
 @app.get("/status")

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -572,8 +572,9 @@ export const IMAGE_SERVICES = {
                 completionVideoSeconds: 0.005,
             },
         ],
-        description: "LTX-2.3 - Fast text-to-video generation with upscaler",
-        inputModalities: ["text"],
+        description:
+            "LTX-2.3 - Fast text/image-to-video generation with upscaler",
+        inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },
     "p-image": {


### PR DESCRIPTION
## Summary
- Gateway threads `image` param into LTX-2 `/enqueue` as `image_url`
- GH200 wrapper accepts optional `image_url`, downloads into ComfyUI input dir, splices `LoadImage` + `LTXVImgToVideo` into the workflow at the `EmptyLTXVLatentVideo` (177:116) seam, rewiring both base-stage latent and CFGGuider conditioning onto image-conditioned outputs
- Registry: `ltx-2` input modalities flipped to `["text", "image"]`

## Verification
Live-tested against production GH200 (192.222.51.105:8765) with Lightricks/ComfyUI-LTXVideo custom node preinstalled.

| Test | Result |
|---|---|
| 25 frames @ 512x512 | 17s gen, 558KB mp4 |
| 97 frames @ 768x512 | 20s gen, 1.9MB mp4 |

Init-image palette transfers into output. Full first-frame structural lock is weak at `cfg=1 strength=1.0` on the distilled checkpoint — matches LTX-2-distilled behavior documented by Lightricks. Stronger lock would require non-distilled weights or `LTXVAddGuide`.

## Test plan
- [ ] Merge → deploy gen worker (registry change takes effect)
- [ ] Probe via `gen.pollinations.ai/image/...?model=ltx-2&image=<url>` end-to-end
- [ ] Verify CF Workers proxy reaches the GH200 wrapper through cloudflared tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)