### PR TITLE
add sync-production skill

### DIFF
--- a/.claude/skills/sync-production/SKILL.md
+++ b/.claude/skills/sync-production/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: sync-production
+description: Sync the main branch into production via the GitHub merges API. Pre-checks for merge conflicts and bails out with a clear reason if the merge isn't clean. Use when asked to merge main into production, deploy main to production, or sync production.
+---
+
+# Sync Production
+
+Server-side merge of `main` → `production` using the GitHub merges API. No local checkout, no working tree changes.
+
+## Quick Usage
+
+```bash
+.claude/skills/sync-production/scripts/sync-production.sh
+```
+
+## What It Does
+
+1. Fetches `origin/main` and `origin/production`
+2. Lists the commits that would be merged
+3. Pre-checks for conflicts with `git merge-tree` (no working tree touched)
+4. **If conflicts** → stops with the conflicting paths and exits non-zero. Resolve manually, then re-run.
+5. **If clean** → calls `POST /repos/pollinations/pollinations/merges` to create the merge commit on `production` server-side
+
+## Exit Codes
+
+- `0` — merge succeeded, or nothing to merge
+- `2` — merge would conflict (paths printed)
+- `3` — GitHub merges API rejected the request (branch protection, missing branches, etc.)
+
+## On Conflict
+
+The skill stops and reports the conflicting files. Don't try to force it — surface the reason in chat and resolve manually:
+
+```bash
+git checkout production && git pull
+git merge main           # resolve conflicts in editor
+git push origin production
+```
+
+## Overrides
+
+```bash
+SYNC_REPO=owner/repo SYNC_BASE=staging SYNC_HEAD=main \
+  .claude/skills/sync-production/scripts/sync-production.sh
+```
+
+## Notes
+
+- Run from repo root
+- Requires `gh` (authenticated, push access to `production`) and `jq`
+- Branch protection on `production` that requires PRs will cause exit code `3` — open a PR manually with `gh pr create --base production --head main` in that case

--- a/.claude/skills/sync-production/scripts/sync-production.sh
+++ b/.claude/skills/sync-production/scripts/sync-production.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Merge main into production via the GitHub merges API.
+# Pre-checks for conflicts with git merge-tree before attempting the merge.
+# Exits non-zero with a clear reason if the merge would conflict.
+
+set -euo pipefail
+
+REPO="${SYNC_REPO:-pollinations/pollinations}"
+BASE="${SYNC_BASE:-production}"
+HEAD="${SYNC_HEAD:-main}"
+
+echo "→ Fetching origin/$BASE and origin/$HEAD..."
+git fetch --quiet origin "$BASE" "$HEAD"
+
+ahead=$(git rev-list --count "origin/$BASE..origin/$HEAD")
+if [ "$ahead" -eq 0 ]; then
+  echo "✓ origin/$BASE is already up to date with origin/$HEAD. Nothing to merge."
+  exit 0
+fi
+
+echo "→ $ahead commit(s) to merge from $HEAD into $BASE:"
+git log --oneline "origin/$BASE..origin/$HEAD" | sed 's/^/    /'
+
+echo ""
+echo "→ Pre-checking for merge conflicts (git merge-tree, no working tree)..."
+set +e
+conflict_output=$(git merge-tree --write-tree --name-only "origin/$BASE" "origin/$HEAD" 2>&1)
+merge_ec=$?
+set -e
+
+if [ "$merge_ec" -ne 0 ]; then
+  echo ""
+  echo "✗ Merge would conflict. Refusing to merge."
+  echo ""
+  echo "Conflicting paths:"
+  # First line of output is the conflicted tree OID; the rest are paths.
+  echo "$conflict_output" | tail -n +2 | sed 's/^/    /'
+  echo ""
+  echo "Resolve manually:"
+  echo "  git checkout $BASE && git pull"
+  echo "  git merge $HEAD     # resolve in editor"
+  echo "  git push origin $BASE"
+  exit 2
+fi
+
+echo "✓ Clean merge."
+echo ""
+echo "→ Calling GitHub merges API for $REPO ($HEAD → $BASE)..."
+
+set +e
+response=$(gh api -X POST "repos/$REPO/merges" \
+  -f base="$BASE" \
+  -f head="$HEAD" \
+  -f commit_message="Merge branch '$HEAD' into $BASE" 2>&1)
+api_ec=$?
+set -e
+
+if [ "$api_ec" -ne 0 ]; then
+  echo "✗ GitHub merges API call failed:"
+  echo "$response" | sed 's/^/    /'
+  exit 3
+fi
+
+sha=$(echo "$response" | jq -r '.sha // empty' 2>/dev/null || true)
+if [ -n "$sha" ]; then
+  echo "✓ Merged. New commit on $BASE: $sha"
+  echo "  https://github.com/$REPO/commit/$sha"
+else
+  echo "$response"
+fi

--- a/.claude/skills/sync-production/scripts/sync-production.sh
+++ b/.claude/skills/sync-production/scripts/sync-production.sh
@@ -12,19 +12,24 @@ HEAD="${SYNC_HEAD:-main}"
 echo "→ Fetching origin/$BASE and origin/$HEAD..."
 git fetch --quiet origin "$BASE" "$HEAD"
 
-ahead=$(git rev-list --count "origin/$BASE..origin/$HEAD")
+# Pin to the SHAs we fetched so the pre-check and the API call agree
+# even if origin/$HEAD advances between them.
+HEAD_SHA=$(git rev-parse "origin/$HEAD")
+BASE_SHA=$(git rev-parse "origin/$BASE")
+
+ahead=$(git rev-list --count "$BASE_SHA..$HEAD_SHA")
 if [ "$ahead" -eq 0 ]; then
   echo "✓ origin/$BASE is already up to date with origin/$HEAD. Nothing to merge."
   exit 0
 fi
 
-echo "→ $ahead commit(s) to merge from $HEAD into $BASE:"
-git log --oneline "origin/$BASE..origin/$HEAD" | sed 's/^/    /'
+echo "→ $ahead commit(s) to merge from $HEAD ($HEAD_SHA) into $BASE:"
+git log --oneline "$BASE_SHA..$HEAD_SHA" | sed 's/^/    /'
 
 echo ""
 echo "→ Pre-checking for merge conflicts (git merge-tree, no working tree)..."
 set +e
-conflict_output=$(git merge-tree --write-tree --name-only "origin/$BASE" "origin/$HEAD" 2>&1)
+conflict_output=$(git merge-tree --write-tree --name-only --no-messages "$BASE_SHA" "$HEAD_SHA" 2>&1)
 merge_ec=$?
 set -e
 
@@ -33,7 +38,8 @@ if [ "$merge_ec" -ne 0 ]; then
   echo "✗ Merge would conflict. Refusing to merge."
   echo ""
   echo "Conflicting paths:"
-  # First line of output is the conflicted tree OID; the rest are paths.
+  # First line of output is the conflicted tree OID; the rest are paths
+  # (--no-messages suppresses the trailing "Auto-merging"/"CONFLICT" notices).
   echo "$conflict_output" | tail -n +2 | sed 's/^/    /'
   echo ""
   echo "Resolve manually:"
@@ -45,12 +51,12 @@ fi
 
 echo "✓ Clean merge."
 echo ""
-echo "→ Calling GitHub merges API for $REPO ($HEAD → $BASE)..."
+echo "→ Calling GitHub merges API for $REPO ($HEAD_SHA → $BASE)..."
 
 set +e
 response=$(gh api -X POST "repos/$REPO/merges" \
   -f base="$BASE" \
-  -f head="$HEAD" \
+  -f head="$HEAD_SHA" \
   -f commit_message="Merge branch '$HEAD' into $BASE" 2>&1)
 api_ec=$?
 set -e


### PR DESCRIPTION
Adds `.claude/skills/sync-production/` for merging `main` into `production` via the GitHub merges API — no local checkout, no working tree changes.

Pre-checks for conflicts with `git merge-tree` before calling the API. If the merge would conflict, the script lists the conflicting paths and exits non-zero so the agent can surface the reason in chat instead of forcing it through.

Run with:
```
.claude/skills/sync-production/scripts/sync-production.sh
```

Exit codes: `0` success/no-op, `2` would-conflict, `3` API rejected.