### PR TITLE
fix: set Cloudflare account for frontend deploy

### DIFF
--- a/.github/workflows/deploy-pollinations-ai-cloudflare.yml
+++ b/.github/workflows/deploy-pollinations-ai-cloudflare.yml
@@ -30,5 +30,6 @@ jobs:
       - name: Build and deploy to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npm run deploy:production
         working-directory: ./pollinations.ai


### PR DESCRIPTION
- Adds `CLOUDFLARE_ACCOUNT_ID` to the `pollinations.ai` production deploy workflow.
- Fixes Wrangler failing in GitHub Actions when the token can access multiple Cloudflare accounts.
- Validated YAML parsing and `git diff --check`; Biome ignores workflow YAML in this repo.