### PR TITLE
fix(byop): revoke child keys when app key is deleted

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -1,4 +1,8 @@
 import { createApiKeyPlugin } from "@shared/auth/api-key.ts";
+import {
+    deleteByopChildKeysForAppKey,
+    deleteByopChildKeysForUserApps,
+} from "@shared/auth/byop-key-cleanup.ts";
 import * as betterAuthSchema from "@shared/db/better-auth.ts";
 import {
     account as accountTable,
@@ -13,7 +17,7 @@ import {
     type User as GenericUser,
 } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { APIError } from "better-auth/api";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { admin, openAPI } from "better-auth/plugins";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -93,6 +97,7 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
         },
         plugins: [
             adminPlugin,
+            byopKeyCleanupPlugin(env),
             apiKeyPlugin,
             tierPlugin(env, ctx),
             openAPIPlugin,
@@ -104,6 +109,97 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
 export type Auth = ReturnType<typeof createAuth>;
 export type Session = Auth["$Infer"]["Session"]["session"];
 export type User = Auth["$Infer"]["Session"]["user"];
+
+type ByopDeleteHookState = {
+    byopDeletedApiKey?: {
+        id: string;
+        prefix: string | null;
+    };
+};
+
+/**
+ * Better Auth owns the dashboard API-key delete endpoint. Keep Pollinations'
+ * BYOP references consistent when that endpoint deletes app keys, and when a
+ * user delete cascades app keys outside Better Auth's API-key delete route.
+ */
+function byopKeyCleanupPlugin(env: Cloudflare.Env): BetterAuthPlugin {
+    return {
+        id: "byop-key-cleanup",
+        init: () => {
+            const databaseHooks = {
+                user: {
+                    delete: {
+                        before: async (user: GenericUser) => {
+                            await deleteByopChildKeysForUserApps(
+                                drizzle(env.DB),
+                                user.id,
+                            );
+                        },
+                    },
+                },
+            } satisfies NonNullable<BetterAuthOptions["databaseHooks"]>;
+
+            return {
+                options: { databaseHooks } satisfies Partial<BetterAuthOptions>,
+            };
+        },
+        hooks: {
+            before: [
+                {
+                    matcher: (ctx) => ctx.path === "/api-key/delete",
+                    handler: createAuthMiddleware(async (ctx) => {
+                        const keyId = (
+                            ctx.body as { keyId?: unknown } | null | undefined
+                        )?.keyId;
+                        if (typeof keyId !== "string") return;
+
+                        const [apiKey] = await drizzle(env.DB)
+                            .select({
+                                id: betterAuthSchema.apikey.id,
+                                prefix: betterAuthSchema.apikey.prefix,
+                            })
+                            .from(betterAuthSchema.apikey)
+                            .where(eq(betterAuthSchema.apikey.id, keyId))
+                            .limit(1);
+
+                        if (!apiKey) return;
+
+                        return {
+                            context: {
+                                byopDeletedApiKey: {
+                                    id: apiKey.id,
+                                    prefix: apiKey.prefix,
+                                },
+                            } satisfies ByopDeleteHookState,
+                        };
+                    }),
+                },
+            ],
+            after: [
+                {
+                    matcher: (ctx) => ctx.path === "/api-key/delete",
+                    handler: createAuthMiddleware(async (ctx) => {
+                        const returned = ctx.context.returned as
+                            | { success?: unknown }
+                            | undefined;
+                        if (returned?.success !== true) return;
+
+                        // Better Auth merges before.context keys onto the
+                        // endpoint ctx before running the endpoint.
+                        const appKey = (ctx as typeof ctx & ByopDeleteHookState)
+                            .byopDeletedApiKey;
+                        if (!appKey) return;
+
+                        await deleteByopChildKeysForAppKey(
+                            drizzle(env.DB),
+                            appKey,
+                        );
+                    }),
+                },
+            ],
+        },
+    } satisfies BetterAuthPlugin;
+}
 
 /**
  * Plugin to initialize tier balance for new users in D1.

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -238,9 +238,18 @@ function RouteComponent() {
     }
 
     async function handleDeleteApiKey(id: string): Promise<void> {
-        const result = await authClient.apiKey.delete({ keyId: id });
-        if (result.error) {
-            console.error(result.error);
+        const response = await fetch(`/api/account/keys/${id}`, {
+            method: "DELETE",
+            credentials: "include",
+        });
+        if (!response.ok) {
+            const error = (await response.json().catch(() => null)) as {
+                message?: string;
+                error?: { message?: string };
+            } | null;
+            throw new Error(
+                error?.message || error?.error?.message || "Delete failed",
+            );
         }
         router.invalidate();
     }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1,4 +1,5 @@
 import { createApiKeyForUser } from "@shared/auth/api-key-creation.ts";
+import { deleteByopChildKeysForAppKey } from "@shared/auth/byop-key-cleanup.ts";
 import {
     apikey as apikeyTable,
     user as userTable,
@@ -1352,7 +1353,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Revoke API Key",
             description:
-                "Delete/revoke an API key. Requires `account:keys` permission and a secret key (sk_). Cannot revoke the key used to authenticate the request.",
+                "Delete/revoke an API key. Deleting an app key also revokes BYOP child keys issued for that app. Requires `account:keys` permission and a secret key (sk_). Cannot revoke the key used to authenticate the request.",
             responses: {
                 200: { description: "Key revoked" },
                 400: { description: "Cannot revoke self" },
@@ -1393,6 +1394,9 @@ export const accountRoutes = new Hono<Env>()
                 throw new HTTPException(404, { message: "API key not found" });
             }
 
+            // Revoke children before deleting the parent so a partial failure
+            // cannot leave active BYOP keys pointing at a deleted app key.
+            await deleteByopChildKeysForAppKey(db, key);
             await db.delete(apikeyTable).where(eq(apikeyTable.id, id));
 
             return c.json({ success: true });

--- a/enter.pollinations.ai/test/integration/account-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/account-keys.test.ts
@@ -1,6 +1,77 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
 import { describe, expect } from "vitest";
 import { test } from "../fixtures.ts";
+
+async function createByopAppAndChild(sessionToken: string, suffix: string) {
+    const redirectUri = `https://${suffix}.example/callback`;
+    const appResponse = await SELF.fetch("http://localhost:3000/api/api-keys", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        },
+        body: JSON.stringify({
+            name: `${suffix}-app`,
+            type: "publishable",
+            metadata: {
+                redirectUris: [redirectUri],
+                earningsEnabled: true,
+            },
+        }),
+    });
+    expect(appResponse.status).toBe(200);
+    const appKey = (await appResponse.json()) as { id: string; key: string };
+
+    const childResponse = await SELF.fetch(
+        "http://localhost:3000/api/api-keys",
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                name: `${suffix}-child`,
+                type: "secret",
+                metadata: {
+                    requestedClientId: appKey.key,
+                    redirectUri,
+                    redirectOrigin: `https://${suffix}.example`,
+                },
+            }),
+        },
+    );
+    expect(childResponse.status).toBe(200);
+    const childKey = (await childResponse.json()) as {
+        id: string;
+        key: string;
+        byopClientKeyId: string;
+    };
+    expect(childKey.byopClientKeyId).toBe(appKey.id);
+
+    return { appKey, childKey };
+}
+
+async function expectKeyDeleted(keyId: string, rawKey: string) {
+    const db = drizzle(env.DB, { schema });
+    const row = await db.query.apikey.findFirst({
+        where: eq(schema.apikey.id, keyId),
+    });
+    expect(row).toBeUndefined();
+
+    const verifyResp = await SELF.fetch(
+        "http://localhost:3000/api/account/key",
+        {
+            headers: {
+                Authorization: `Bearer ${rawKey}`,
+            },
+        },
+    );
+    expect(verifyResp.status).toBe(401);
+}
 
 describe("Account Key Management API", () => {
     describe("POST /api/account/keys (create)", () => {
@@ -352,6 +423,52 @@ describe("Account Key Management API", () => {
                 },
             );
             expect(verifyResp.status).toBe(401);
+        });
+
+        test("should revoke BYOP child keys when app key is deleted via account route", async ({
+            sessionToken,
+        }) => {
+            const { appKey, childKey } = await createByopAppAndChild(
+                sessionToken,
+                "account-delete-byop",
+            );
+
+            const response = await SELF.fetch(
+                `http://localhost:3000/api/account/keys/${appKey.id}`,
+                {
+                    method: "DELETE",
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            await expectKeyDeleted(childKey.id, childKey.key);
+        });
+
+        test("should revoke BYOP child keys when app key is deleted via auth route", async ({
+            sessionToken,
+        }) => {
+            const { appKey, childKey } = await createByopAppAndChild(
+                sessionToken,
+                "auth-delete-byop",
+            );
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/auth/api-key/delete",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({ keyId: appKey.id }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            await expectKeyDeleted(childKey.id, childKey.key);
         });
 
         test("should prevent self-revocation via API key", async ({

--- a/shared/auth/byop-key-cleanup.ts
+++ b/shared/auth/byop-key-cleanup.ts
@@ -1,0 +1,49 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { apikey as apikeyTable } from "../db/better-auth.ts";
+
+type AppKeyReference = {
+    id: string;
+    prefix?: string | null;
+};
+
+export async function deleteByopChildKeysForAppKey(
+    db: DrizzleD1Database,
+    appKey: AppKeyReference,
+): Promise<void> {
+    // Only publishable app keys can have BYOP children.
+    if (appKey.prefix !== "pk") return;
+
+    await db
+        .delete(apikeyTable)
+        .where(
+            and(
+                eq(apikeyTable.prefix, "sk"),
+                eq(apikeyTable.byopClientKeyId, appKey.id),
+            ),
+        );
+}
+
+export async function deleteByopChildKeysForUserApps(
+    db: DrizzleD1Database,
+    userId: string,
+): Promise<void> {
+    const appKeys = await db
+        .select({ id: apikeyTable.id })
+        .from(apikeyTable)
+        .where(
+            and(eq(apikeyTable.userId, userId), eq(apikeyTable.prefix, "pk")),
+        );
+
+    if (appKeys.length === 0) return;
+
+    await db.delete(apikeyTable).where(
+        and(
+            eq(apikeyTable.prefix, "sk"),
+            inArray(
+                apikeyTable.byopClientKeyId,
+                appKeys.map((key) => key.id),
+            ),
+        ),
+    );
+}


### PR DESCRIPTION
Cascade BYOP `sk` child keys when their parent `pk` app key is deleted.

- `/api/account/keys/:id`: delete children before parent so a partial failure never leaves active BYOP keys pointing at a deleted app.
- Better Auth `/api-key/delete`: new plugin captures the deleted key in a before-hook and cleans up children on success.
- `user.delete.before` cascade: drops BYOP children owned by other users that reference this user's app keys (FK cascade only handles same-user rows).
- Dashboard delete now goes through the account route so the cleanup always runs.
- Adds integration tests covering both delete paths.