### PR TITLE
feat(ltx-2): i2v — gateway downloads image, backend takes base64

### DIFF
--- a/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/ltx2VideoModel.ts
@@ -5,6 +5,7 @@ import type { ImageParams } from "../params.ts";
 import type { ProgressManager } from "../progressBar.ts";
 import { sleep } from "../util.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
+import { downloadUserImage } from "../utils/imageDownload.ts";
 import type { VideoGenerationResult } from "./veoVideoModel.ts";
 
 // Logger
@@ -99,15 +100,23 @@ async function enqueueLtx2Job(
     width: number,
     height: number,
     frameCount: number,
+    initImage?: { base64: string; mimeType: string },
 ): Promise<string> {
-    const requestBody = {
+    const requestBody: Record<string, unknown> = {
         prompt,
         width,
         height,
         frame_count: frameCount,
     };
+    if (initImage) {
+        requestBody.image_b64 = initImage.base64;
+        requestBody.image_mime = initImage.mimeType;
+    }
 
-    logOps("Enqueuing LTX-2 job:", requestBody);
+    logOps("Enqueuing LTX-2 job:", {
+        ...requestBody,
+        image_b64: initImage ? `<${initImage.base64.length} chars>` : undefined,
+    });
 
     const enqueueUrl = `${getLtx2BaseUrl()}/enqueue`;
     const response = await fetchUpstream(enqueueUrl, {
@@ -286,22 +295,45 @@ export const callLtx2API = async (
         safeParams.aspectRatio,
     );
 
+    const imageUrl = safeParams.image?.[0];
+
     logOps("Video params:", {
         durationSeconds,
         frameCount,
         width,
         height,
         aspectRatio: safeParams.aspectRatio,
+        hasImage: Boolean(imageUrl),
     });
+
+    let initImage: { base64: string; mimeType: string } | undefined;
+    if (imageUrl) {
+        progress.updateBar(
+            requestId,
+            38,
+            "Processing",
+            "Downloading init image...",
+        );
+        const { buffer, mimeType } = await downloadUserImage(imageUrl);
+        initImage = { base64: buffer.toString("base64"), mimeType };
+    }
 
     progress.updateBar(
         requestId,
         40,
         "Processing",
-        "Enqueuing video generation job...",
+        imageUrl
+            ? "Enqueuing image-to-video job..."
+            : "Enqueuing video generation job...",
     );
 
-    const promptId = await enqueueLtx2Job(prompt, width, height, frameCount);
+    const promptId = await enqueueLtx2Job(
+        prompt,
+        width,
+        height,
+        frameCount,
+        initImage,
+    );
 
     progress.updateBar(requestId, 50, "Processing", "Generating video...");
 

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
@@ -82,7 +82,9 @@ def heartbeat_loop():
     url = "%s?port=%s&ip=%s&type=%s&token=%s" % (REGISTER_URL, port, PUBLIC_IP, SERVICE_TYPE, PLN_TOKEN)
     while True:
         try:
-            urllib.request.urlopen(url, timeout=5)
+            # Cloudflare blocks the default Python-urllib UA on gen.pollinations.ai.
+            req = urllib.request.Request(url, headers={"User-Agent": "pollinations-ltx2/1.0"})
+            urllib.request.urlopen(req, timeout=5)
             log.debug("Heartbeat sent")
         except Exception as e:
             log.warning("Heartbeat failed: %s", e)

--- a/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
+++ b/image.pollinations.ai/video_gen_ltx2modal/ltx2-vastai/server_comfyui.py
@@ -3,8 +3,9 @@ LTX-2 ComfyUI wrapper server for GH200.
 Patched ComfyUI (model_management.py 1e32 fix) with two-stage upscaler.
 Includes watchdog that auto-restarts ComfyUI if it crashes.
 """
-import json, os, random, subprocess, threading, time, urllib.request, urllib.parse, logging
+import base64, json, os, random, subprocess, threading, time, urllib.request, urllib.parse, uuid, logging
 from pathlib import Path
+from typing import Optional
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
@@ -22,6 +23,16 @@ PROMPT_NODE = "177:109"
 WIDTH_HEIGHT_NODE = "177:131"
 FRAME_COUNT_NODE = "177:113"
 SEED_NODES = ["177:118", "177:123"]
+
+# I2V splice points (see workflow.json)
+EMPTY_LATENT_NODE = "177:116"        # EmptyLTXVLatentVideo, consumed by 177:132.video_latent
+CHECKPOINT_NODE = "177:100"          # CheckpointLoaderSimple — VAE at output index 2
+CONDITIONING_NODE = "177:103"        # LTXVConditioning — [positive, negative]
+COMFY_INPUT_DIR = os.environ.get("COMFY_INPUT_DIR", "/home/ubuntu/comfy/ComfyUI/input")
+I2V_LOAD_NODE = "ltx_i2v_load_image"
+I2V_NODE = "ltx_i2v_img_to_video"
+
+MIME_EXT = {"image/png": ".png", "image/jpeg": ".jpg", "image/webp": ".webp", "image/gif": ".gif"}
 
 REGISTER_URL = os.environ.get("REGISTER_URL", "https://gen.pollinations.ai/register")
 PUBLIC_IP = os.environ.get("PUBLIC_IP", "")
@@ -103,6 +114,66 @@ class EnqueueRequest(BaseModel):
     width: int = 720
     height: int = 720
     frame_count: int = 121
+    image_b64: Optional[str] = None
+    image_mime: Optional[str] = None
+
+
+def _save_init_image_b64(image_b64: str, image_mime: Optional[str]) -> str:
+    """Decode a base64 init image into ComfyUI's input dir; return filename."""
+    ext = MIME_EXT.get((image_mime or "").lower(), ".png")
+    name = "i2v_%s%s" % (uuid.uuid4().hex, ext)
+    Path(COMFY_INPUT_DIR).mkdir(parents=True, exist_ok=True)
+    (Path(COMFY_INPUT_DIR) / name).write_bytes(base64.b64decode(image_b64))
+    return name
+
+
+def _patch_workflow_for_i2v(wf: dict, image_filename: str) -> None:
+    """Inject LoadImage + LTXVImgToVideo, rewire latent + conditioning consumers."""
+    empty = wf.get(EMPTY_LATENT_NODE)
+    if not empty:
+        return
+    width_in = empty["inputs"]["width"]
+    height_in = empty["inputs"]["height"]
+    length_in = empty["inputs"]["length"]
+
+    wf[I2V_LOAD_NODE] = {
+        "class_type": "LoadImage",
+        "inputs": {"image": image_filename},
+        "_meta": {"title": "Load Init Image (I2V)"},
+    }
+    wf[I2V_NODE] = {
+        "class_type": "LTXVImgToVideo",
+        "inputs": {
+            "positive": [CONDITIONING_NODE, 0],
+            "negative": [CONDITIONING_NODE, 1],
+            "vae": [CHECKPOINT_NODE, 2],
+            "image": [I2V_LOAD_NODE, 0],
+            "width": width_in,
+            "height": height_in,
+            "length": length_in,
+            "batch_size": 1,
+            "strength": 1.0,
+        },
+        "_meta": {"title": "LTXV Image to Video (I2V)"},
+    }
+    # Rewire downstream consumers:
+    #   EMPTY_LATENT_NODE.*   -> (I2V_NODE, 2)   latent output
+    #   CONDITIONING_NODE.0   -> (I2V_NODE, 0)   image-conditioned positive
+    #   CONDITIONING_NODE.1   -> (I2V_NODE, 1)   image-conditioned negative
+    for nid, node in wf.items():
+        if nid in (I2V_NODE, I2V_LOAD_NODE):
+            continue
+        for k, v in list(node.get("inputs", {}).items()):
+            if not (isinstance(v, list) and len(v) == 2):
+                continue
+            src_id, src_idx = v
+            if src_id == EMPTY_LATENT_NODE:
+                node["inputs"][k] = [I2V_NODE, 2]
+            elif src_id == CONDITIONING_NODE and src_idx == 0:
+                node["inputs"][k] = [I2V_NODE, 0]
+            elif src_id == CONDITIONING_NODE and src_idx == 1:
+                node["inputs"][k] = [I2V_NODE, 1]
+
 
 @app.post("/enqueue")
 def enqueue(req: EnqueueRequest):
@@ -111,6 +182,11 @@ def enqueue(req: EnqueueRequest):
     wf[WIDTH_HEIGHT_NODE]["inputs"]["width"] = req.width
     wf[WIDTH_HEIGHT_NODE]["inputs"]["height"] = req.height
     wf[FRAME_COUNT_NODE]["inputs"]["value"] = req.frame_count
+
+    if req.image_b64:
+        image_filename = _save_init_image_b64(req.image_b64, req.image_mime)
+        _patch_workflow_for_i2v(wf, image_filename)
+
     seed = random.randint(0, 2**32 - 1)
     for nid in SEED_NODES:
         if nid in wf:
@@ -121,7 +197,8 @@ def enqueue(req: EnqueueRequest):
     prompt_id = resp.get("prompt_id")
     if not prompt_id:
         raise HTTPException(500, "No prompt_id from ComfyUI")
-    log.info("Enqueued %s: %dx%d %d frames", prompt_id[:8], req.width, req.height, req.frame_count)
+    mode = "i2v" if req.image_b64 else "t2v"
+    log.info("Enqueued %s [%s]: %dx%d %d frames", prompt_id[:8], mode, req.width, req.height, req.frame_count)
     return {"prompt_id": prompt_id}
 
 @app.get("/status")

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -599,8 +599,9 @@ export const IMAGE_SERVICES = {
                 completionVideoSeconds: 0.005,
             },
         ],
-        description: "LTX-2.3 - Fast text-to-video generation with upscaler",
-        inputModalities: ["text"],
+        description:
+            "LTX-2.3 - Fast text/image-to-video generation with upscaler",
+        inputModalities: ["text", "image"],
         outputModalities: ["video"],
     },
     "p-image": {


### PR DESCRIPTION
Alternative to #10953 — same LTX-2 i2v capability, but image download stays on the gateway like every other model.

## Changes
- Gateway: download init image with shared `downloadUserImage` (used by klein/wan/qwen/seedance/veo), send `image_b64` + `image_mime` to `/enqueue`
- GH200 wrapper: accept base64, write to ComfyUI input dir, splice `LoadImage` + `LTXVImgToVideo` at the `EmptyLTXVLatentVideo` (177:116) seam, rewire latent + conditioning consumers
- Registry: `ltx-2` `inputModalities` → `["text", "image"]`

## Why
- Single image-fetch boundary on the gateway (auth, SSRF, future safety/tracking hooks)
- No new `urllib` download helper on the GPU box — reuses the existing convention
- Same splice logic as #10953, only the transport changed

## Test plan
- [ ] Deploy gateway + GH200 wrapper
- [ ] `gen.pollinations.ai/image/...?model=ltx-2&image=<url>` end-to-end
- [ ] Verify t2v path (no `image` param) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)