### PR TITLE
embeddings: route openai-3-small/large to direct OpenAI API

### DIFF
--- a/gen.pollinations.ai/src/embeddings/handler.ts
+++ b/gen.pollinations.ai/src/embeddings/handler.ts
@@ -1,12 +1,12 @@
 import type { ModelDefinition, Usage } from "@shared/registry/registry.ts";
 import { buildUsageHeaders } from "@shared/registry/usage-headers.ts";
-import { callAzureEmbed, extractAzureUsage } from "./azure.ts";
 import {
     badRequest,
     inputToGeminiParts,
     inputToText,
     normalizeInputs,
 } from "./input.ts";
+import { callOpenAIEmbed, extractOpenAIUsage } from "./openai.ts";
 import type { EmbeddingRequest } from "./types.ts";
 import {
     callGeminiEmbed,
@@ -20,7 +20,7 @@ type EmbeddingData = {
     index: number;
 };
 
-const AZURE_MAX_DIMENSIONS: Record<string, number> = {
+const OPENAI_MAX_DIMENSIONS: Record<string, number> = {
     "text-embedding-3-small": 1536,
     "text-embedding-3-large": 3072,
 };
@@ -35,8 +35,8 @@ export async function generateEmbeddings(
         return await generateGeminiEmbeddings(env, request, responseModel);
     }
 
-    if (serviceDef.provider === "azure") {
-        return await generateAzureEmbeddings(env, request, responseModel);
+    if (serviceDef.provider === "openai") {
+        return await generateOpenAIEmbeddings(env, request, responseModel);
     }
 
     throw new Error(`Unsupported embeddings provider: ${serviceDef.provider}`);
@@ -78,7 +78,7 @@ async function generateGeminiEmbeddings(
     return embeddingsResponse(responseModel, data, aggregatedUsage);
 }
 
-async function generateAzureEmbeddings(
+async function generateOpenAIEmbeddings(
     env: CloudflareBindings,
     request: EmbeddingRequest,
     responseModel: string,
@@ -87,7 +87,7 @@ async function generateAzureEmbeddings(
         badRequest("task_type is only supported by Gemini embedding models");
     }
 
-    validateAzureDimensions(request, responseModel);
+    validateOpenAIDimensions(request, responseModel);
 
     const inputs = normalizeInputs(request.input);
     const textInputs = inputs.map(inputToText);
@@ -96,13 +96,13 @@ async function generateAzureEmbeddings(
         return embeddingsResponse(responseModel, [], { promptTextTokens: 0 });
     }
 
-    const result = await callAzureEmbed(
+    const result = await callOpenAIEmbed(
         env,
         request.model,
         textInputs,
         request.dimensions,
     );
-    const usage = extractAzureUsage(result);
+    const usage = extractOpenAIUsage(result);
 
     const data = [...result.data]
         .sort((a, b) => a.index - b.index)
@@ -115,13 +115,13 @@ async function generateAzureEmbeddings(
     return embeddingsResponse(responseModel, data, usage);
 }
 
-function validateAzureDimensions(
+function validateOpenAIDimensions(
     request: EmbeddingRequest,
     responseModel: string,
 ) {
     if (!request.dimensions) return;
 
-    const maxDimensions = AZURE_MAX_DIMENSIONS[request.model];
+    const maxDimensions = OPENAI_MAX_DIMENSIONS[request.model];
 
     if (maxDimensions && request.dimensions > maxDimensions) {
         badRequest(

--- a/gen.pollinations.ai/src/embeddings/openai.ts
+++ b/gen.pollinations.ai/src/embeddings/openai.ts
@@ -2,24 +2,23 @@ import type { Usage } from "@shared/registry/registry.ts";
 
 import { ensureUpstreamOk } from "@/error.ts";
 
-const AZURE_EMBEDDINGS_ENDPOINT =
-    "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/v1/embeddings";
+const OPENAI_EMBEDDINGS_ENDPOINT = "https://api.openai.com/v1/embeddings";
 
-type AzureEmbeddingRequest = {
+type OpenAIEmbeddingRequest = {
     model: string;
     input: string[];
     dimensions?: number;
 };
 
-type AzureEmbeddingData = {
+type OpenAIEmbeddingData = {
     object: "embedding";
     embedding: number[];
     index: number;
 };
 
-export type AzureEmbeddingResponse = {
+export type OpenAIEmbeddingResponse = {
     object: "list";
-    data: AzureEmbeddingData[];
+    data: OpenAIEmbeddingData[];
     model?: string;
     usage?: {
         prompt_tokens?: number;
@@ -27,42 +26,42 @@ export type AzureEmbeddingResponse = {
     };
 };
 
-export async function callAzureEmbed(
+export async function callOpenAIEmbed(
     env: CloudflareBindings,
     modelId: string,
     input: string[],
     dimensions?: number,
-): Promise<AzureEmbeddingResponse> {
-    const apiKey = env.AZURE_MYCELI_PROD_API_KEY;
+): Promise<OpenAIEmbeddingResponse> {
+    const apiKey = env.OPENAI_API_KEY;
 
     if (!apiKey) {
-        throw new Error("AZURE_MYCELI_PROD_API_KEY is not configured");
+        throw new Error("OPENAI_API_KEY is not configured");
     }
 
-    const body: AzureEmbeddingRequest = {
+    const body: OpenAIEmbeddingRequest = {
         model: modelId,
         input,
         ...(dimensions ? { dimensions } : {}),
     };
 
-    const response = await fetch(AZURE_EMBEDDINGS_ENDPOINT, {
+    const response = await fetch(OPENAI_EMBEDDINGS_ENDPOINT, {
         method: "POST",
         headers: {
             "content-type": "application/json",
-            "api-key": apiKey,
+            authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify(body),
     });
 
-    await ensureUpstreamOk(response, AZURE_EMBEDDINGS_ENDPOINT);
-    return response.json() as Promise<AzureEmbeddingResponse>;
+    await ensureUpstreamOk(response, OPENAI_EMBEDDINGS_ENDPOINT);
+    return response.json() as Promise<OpenAIEmbeddingResponse>;
 }
 
-export function extractAzureUsage(response: AzureEmbeddingResponse): Usage {
+export function extractOpenAIUsage(response: OpenAIEmbeddingResponse): Usage {
     const promptTextTokens = response.usage?.prompt_tokens;
 
     if (typeof promptTextTokens !== "number") {
-        throw new Error("Azure embedding response is missing prompt_tokens");
+        throw new Error("OpenAI embedding response is missing prompt_tokens");
     }
 
     return { promptTextTokens };

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -17,13 +17,13 @@ import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
 
 const TEST_EMBEDDING_MODEL = "gemini-2";
 const TEST_PROVIDER_MODEL = "gemini-embedding-2-preview";
-const TEST_AZURE_SMALL_MODEL = "openai-3-small";
-const TEST_AZURE_LARGE_MODEL = "openai-3-large";
-const TEST_AZURE_SMALL_PROVIDER_MODEL = "text-embedding-3-small";
-const TEST_AZURE_LARGE_PROVIDER_MODEL = "text-embedding-3-large";
+const TEST_OPENAI_SMALL_MODEL = "openai-3-small";
+const TEST_OPENAI_LARGE_MODEL = "openai-3-large";
+const TEST_OPENAI_SMALL_PROVIDER_MODEL = "text-embedding-3-small";
+const TEST_OPENAI_LARGE_PROVIDER_MODEL = "text-embedding-3-large";
 const TEST_EMBEDDING_INPUT = "Hello world";
 const VERTEX_HOST = "us-central1-aiplatform.googleapis.com";
-const AZURE_HOST = "myceli-prod-eastus.cognitiveservices.azure.com";
+const OPENAI_HOST = "api.openai.com";
 const TINYBIRD_STATS_HOST = "api.europe-west2.gcp.tinybird.co";
 
 beforeEach(() => {
@@ -57,7 +57,7 @@ function buildEmbeddingsBody(extra: Record<string, unknown> = {}) {
 
 function createEmbeddingMocks() {
     env.GOOGLE_PROJECT_ID = "test-project";
-    env.AZURE_MYCELI_PROD_API_KEY = "test-azure-api-key";
+    env.OPENAI_API_KEY = "test-openai-api-key";
     process.env.GOOGLE_PROJECT_ID = env.GOOGLE_PROJECT_ID;
 
     return createFetchMock({
@@ -69,7 +69,7 @@ function createEmbeddingMocks() {
             },
             reset: () => {},
         } satisfies MockAPI<Record<string, never>>,
-        azure: createAzureMock(),
+        openai: createOpenAIMock(),
         vertex: createVertexMock(),
     });
 }
@@ -126,7 +126,7 @@ function createVertexMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
     };
 }
 
-function createAzureMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
+function createOpenAIMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
     const state: { requests: unknown[]; urls: string[] } = {
         requests: [],
         urls: [],
@@ -134,7 +134,7 @@ function createAzureMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
     return {
         state,
         handlerMap: {
-            [AZURE_HOST]: async (request) => {
+            [OPENAI_HOST]: async (request) => {
                 const body = (await request.json()) as {
                     input?: string[];
                     dimensions?: number;
@@ -146,7 +146,9 @@ function createAzureMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
                 const inputs = body.input ?? [];
                 const dimensions =
                     body.dimensions ??
-                    (body.model === TEST_AZURE_LARGE_MODEL ? 3072 : 1536);
+                    (body.model === TEST_OPENAI_LARGE_PROVIDER_MODEL
+                        ? 3072
+                        : 1536);
 
                 return Response.json({
                     object: "list",
@@ -346,7 +348,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "azure");
+        await mocks.enable("tinybird", "tinybirdStats", "openai");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -354,7 +356,7 @@ describe("POST /v1/embeddings", () => {
                 authorization: `Bearer ${apiKey}`,
             },
             body: buildEmbeddingsBody({
-                model: TEST_AZURE_SMALL_MODEL,
+                model: TEST_OPENAI_SMALL_MODEL,
                 input: ["Hello", "World"],
                 dimensions: 512,
             }),
@@ -370,18 +372,18 @@ describe("POST /v1/embeddings", () => {
             model: string;
             usage: { prompt_tokens: number; total_tokens: number };
         };
-        expect(data.model).toBe(TEST_AZURE_SMALL_MODEL);
+        expect(data.model).toBe(TEST_OPENAI_SMALL_MODEL);
         expect(data.data).toHaveLength(2);
         expect(data.data[0].embedding).toHaveLength(512);
         expect(data.data.map(({ index }) => index)).toEqual([0, 1]);
         expect(data.usage).toEqual({ prompt_tokens: 8, total_tokens: 8 });
         expect(response.headers.get("x-model-used")).toBe(
-            TEST_AZURE_SMALL_MODEL,
+            TEST_OPENAI_SMALL_MODEL,
         );
         expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("8");
-        expect(mocks.azure.state.requests).toEqual([
+        expect(mocks.openai.state.requests).toEqual([
             {
-                model: TEST_AZURE_SMALL_PROVIDER_MODEL,
+                model: TEST_OPENAI_SMALL_PROVIDER_MODEL,
                 input: ["Hello", "World"],
                 dimensions: 512,
             },
@@ -393,9 +395,9 @@ describe("POST /v1/embeddings", () => {
         expect(events).toHaveLength(1);
         expect(events[0]).toMatchObject({
             eventType: "generate.embedding",
-            modelRequested: TEST_AZURE_SMALL_MODEL,
-            resolvedModelRequested: TEST_AZURE_SMALL_MODEL,
-            modelUsed: TEST_AZURE_SMALL_MODEL,
+            modelRequested: TEST_OPENAI_SMALL_MODEL,
+            resolvedModelRequested: TEST_OPENAI_SMALL_MODEL,
+            modelUsed: TEST_OPENAI_SMALL_MODEL,
             tokenCountPromptText: 8,
             isBilledUsage: true,
         });
@@ -405,7 +407,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "azure");
+        await mocks.enable("tinybird", "tinybirdStats", "openai");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -413,7 +415,7 @@ describe("POST /v1/embeddings", () => {
                 authorization: `Bearer ${apiKey}`,
             },
             body: buildEmbeddingsBody({
-                model: TEST_AZURE_LARGE_MODEL,
+                model: TEST_OPENAI_LARGE_MODEL,
                 input: TEST_EMBEDDING_INPUT,
                 dimensions: 256,
             }),
@@ -428,12 +430,12 @@ describe("POST /v1/embeddings", () => {
             data: { embedding: number[]; index: number }[];
             model: string;
         };
-        expect(data.model).toBe(TEST_AZURE_LARGE_MODEL);
+        expect(data.model).toBe(TEST_OPENAI_LARGE_MODEL);
         expect(data.data).toHaveLength(1);
         expect(data.data[0].embedding).toHaveLength(256);
-        expect(mocks.azure.state.requests).toEqual([
+        expect(mocks.openai.state.requests).toEqual([
             {
-                model: TEST_AZURE_LARGE_PROVIDER_MODEL,
+                model: TEST_OPENAI_LARGE_PROVIDER_MODEL,
                 input: [TEST_EMBEDDING_INPUT],
                 dimensions: 256,
             },
@@ -445,7 +447,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "azure");
+        await mocks.enable("tinybird", "tinybirdStats", "openai");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -453,7 +455,7 @@ describe("POST /v1/embeddings", () => {
                 authorization: `Bearer ${apiKey}`,
             },
             body: buildEmbeddingsBody({
-                model: TEST_AZURE_SMALL_MODEL,
+                model: TEST_OPENAI_SMALL_MODEL,
                 dimensions: 2048,
             }),
         });
@@ -461,7 +463,7 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("supports dimensions up to 1536");
-        expect(mocks.azure.state.requests).toHaveLength(0);
+        expect(mocks.openai.state.requests).toHaveLength(0);
         await wait();
     });
 
@@ -469,7 +471,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "azure");
+        await mocks.enable("tinybird", "tinybirdStats", "openai");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -477,7 +479,7 @@ describe("POST /v1/embeddings", () => {
                 authorization: `Bearer ${apiKey}`,
             },
             body: buildEmbeddingsBody({
-                model: TEST_AZURE_SMALL_MODEL,
+                model: TEST_OPENAI_SMALL_MODEL,
                 input: [
                     {
                         type: "image_url",
@@ -492,7 +494,7 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("text input only");
-        expect(mocks.azure.state.requests).toHaveLength(0);
+        expect(mocks.openai.state.requests).toHaveLength(0);
         await wait();
     });
 
@@ -500,7 +502,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "azure");
+        await mocks.enable("tinybird", "tinybirdStats", "openai");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -508,7 +510,7 @@ describe("POST /v1/embeddings", () => {
                 authorization: `Bearer ${apiKey}`,
             },
             body: buildEmbeddingsBody({
-                model: TEST_AZURE_SMALL_MODEL,
+                model: TEST_OPENAI_SMALL_MODEL,
                 task_type: "RETRIEVAL_QUERY",
             }),
         });
@@ -516,7 +518,7 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("task_type");
-        expect(mocks.azure.state.requests).toHaveLength(0);
+        expect(mocks.openai.state.requests).toHaveLength(0);
         await wait();
     });
 
@@ -639,11 +641,11 @@ describe("embedding models", () => {
                     output_modalities: ["embedding"],
                 }),
                 expect.objectContaining({
-                    name: TEST_AZURE_SMALL_MODEL,
+                    name: TEST_OPENAI_SMALL_MODEL,
                     output_modalities: ["embedding"],
                 }),
                 expect.objectContaining({
-                    name: TEST_AZURE_LARGE_MODEL,
+                    name: TEST_OPENAI_LARGE_MODEL,
                     output_modalities: ["embedding"],
                 }),
             ]),
@@ -666,11 +668,11 @@ describe("embedding models", () => {
                     supported_endpoints: ["/v1/embeddings"],
                 }),
                 expect.objectContaining({
-                    id: TEST_AZURE_SMALL_MODEL,
+                    id: TEST_OPENAI_SMALL_MODEL,
                     supported_endpoints: ["/v1/embeddings"],
                 }),
                 expect.objectContaining({
-                    id: TEST_AZURE_LARGE_MODEL,
+                    id: TEST_OPENAI_LARGE_MODEL,
                     supported_endpoints: ["/v1/embeddings"],
                 }),
             ]),

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -49,7 +49,7 @@ export const EMBEDDING_SERVICES: EmbeddingModelDefinitions = {
     "openai-3-small": {
         aliases: ["embedding-small"],
         modelId: "text-embedding-3-small",
-        provider: "azure",
+        provider: "openai",
         brand: "OpenAI",
         category: "embedding",
         cost: [
@@ -73,7 +73,7 @@ export const EMBEDDING_SERVICES: EmbeddingModelDefinitions = {
     "openai-3-large": {
         aliases: ["embedding-large"],
         modelId: "text-embedding-3-large",
-        provider: "azure",
+        provider: "openai",
         brand: "OpenAI",
         category: "embedding",
         cost: [


### PR DESCRIPTION
The Azure S0 deployment in East US has been the sole source of `openai-3-large` errors. In the last 24h: 479 of 502 errors (14% of total traffic) were Azure rate-limit messages (`exceeded the call rate limit for your current AIServices S0 pricing tier`) — surfaced to users as 502s by the upstream-429→502 remap.

Direct OpenAI has far higher rate-limit headroom and matches the existing per-token cost ($0.13/M for `text-embedding-3-large`, $0.02/M for `text-embedding-3-small`), so no registry pricing change.

- Adds `api.openai.com/v1/embeddings` client mirroring the prior Azure client (Bearer auth via `OPENAI_API_KEY`, already a worker binding used by `gpt-image-2`).
- Removes the Azure embeddings client — no other embedding model used it. `AZURE_MYCELI_PROD_API_KEY` is still consumed by text models, so the env var stays.
- Updates `provider: "azure"` → `"openai"` for both `openai-3-small` and `openai-3-large`.
- Updates the existing test suite to mock `api.openai.com` instead of the Azure host. All 16 embedding tests pass.