### PR TITLE
unhide seedream and seedream-pro

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -119,7 +119,6 @@ export const IMAGE_SERVICES = {
         brand: "ByteDance",
         category: "image",
         paidOnly: true,
-        hidden: true,
         cost: [
             {
                 date: COST_START_DATE,
@@ -143,7 +142,6 @@ export const IMAGE_SERVICES = {
         brand: "ByteDance",
         category: "image",
         paidOnly: true,
-        hidden: true,
         cost: [
             {
                 date: COST_START_DATE,


### PR DESCRIPTION
Removes `hidden: true` from `seedream` (v4.0) and `seedream-pro` (v4.5 Pro) in `shared/registry/image.ts`.

Both legacy models are still actively used by paying customers — `seedream-pro` did 1,186 successful calls in the past 7 days and `seedream` did 223, but neither appears in `/image/models` or the dashboard, so discovery is broken. Pricing/cost unchanged (50% margin on both). `paidOnly: true` stays.

`seedream5` (v5.0 Lite) remains the recommended current model; this just makes the legacy SKUs visible to users who want the older photoreal look.