### PR TITLE
ci: set CLOUDFLARE_ACCOUNT_ID for wrangler in production deploys

### DIFF
--- a/.github/workflows/deploy-enter-cloudflare.yml
+++ b/.github/workflows/deploy-enter-cloudflare.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: efdcb0933eaac64f27c0b295039b28f2
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: efdcb0933eaac64f27c0b295039b28f2
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Production Cloudflare deploys have been failing all day (since ~14:55 UTC) at the wrangler migrate step:

```
ERROR: More than one account available but unable to select one in non-interactive mode.
```

The CLOUDFLARE_API_TOKEN GitHub secret now has access to two CF accounts, so wrangler can't auto-pick. No top-level account_id is set in either wrangler.toml (only in [vars], which is worker-runtime, not wrangler-CLI).

Setting CLOUDFLARE_ACCOUNT_ID at the job level in both deploy workflows so every wrangler step (migrate, push-secrets, apply-lifecycle, deploy) targets the right account.

Account ID is not a secret — it's already hardcoded in [vars] of both wrangler.toml files and bundled into the deployed worker.

Unblocks #10972 (mistral-small-3.2 + mistral-4) which is on production branch but hasn't deployed.