### PR TITLE
add description tooltip next to model name in models list

### DIFF
--- a/enter.pollinations.ai/src/client/components/models/model-info.ts
+++ b/enter.pollinations.ai/src/client/components/models/model-info.ts
@@ -55,6 +55,17 @@ export const getModelDisplayName = (modelName: string): string | undefined => {
     return description.split(" - ")[0];
 };
 
+export const getModelDescriptionWithoutName = (
+    modelName: string,
+): string | undefined => {
+    const service = getModelDefinition(modelName as ModelName);
+    const description = service?.description;
+    if (!description) return undefined;
+    const parts = description.split(" - ");
+    if (parts.length < 2) return undefined;
+    return parts.slice(1).join(" - ").trim() || undefined;
+};
+
 export const getModelBrandLogoPath = (
     modelName: string,
 ): string | undefined => {

--- a/enter.pollinations.ai/src/client/components/models/model-row.tsx
+++ b/enter.pollinations.ai/src/client/components/models/model-row.tsx
@@ -1,6 +1,7 @@
 import { type FC, useState } from "react";
 import { cn } from "../../../util.ts";
 import { Chip } from "../ui/chip.tsx";
+import { InfoTip } from "../ui/info-tip.tsx";
 import { Tooltip } from "../ui/tooltip.tsx";
 import {
     calculatePerPollen,
@@ -11,6 +12,7 @@ import {
     getModelBrandLogoPath,
     getModelCapabilityIcons,
     getModelCapabilityLabel,
+    getModelDescriptionWithoutName,
     getModelDisplayName,
     getModelModalityIcons,
     getModelModalityLabel,
@@ -33,6 +35,7 @@ export const ModelRow: FC<ModelRowProps> = ({
     packBalance,
 }) => {
     const modelDisplayName = getModelDisplayName(model.name);
+    const modelDescription = getModelDescriptionWithoutName(model.name);
     const brandLogoPath = getModelBrandLogoPath(model.name);
     const modalityIcons = getModelModalityIcons(model.name);
     const modalityLabel = getModelModalityLabel(model.name);
@@ -172,8 +175,11 @@ export const ModelRow: FC<ModelRowProps> = ({
             {/* Model info — flexible width */}
             <div className="flex-1 min-w-0 pl-3">
                 <div className="flex min-w-0 flex-col gap-1.5">
-                    <span className="text-base font-medium leading-none">
+                    <span className="inline-flex items-center text-base font-medium leading-none">
                         <span>{publicModelName}</span>
+                        {modelDescription && (
+                            <InfoTip text={modelDescription} />
+                        )}
                     </span>
                     <button
                         type="button"


### PR DESCRIPTION
Adds a small "i" tooltip badge next to each model's display name in the models list. Hovering it shows the model's description with the leading name stripped (since the display name is already shown next to the badge).

- New `getModelDescriptionWithoutName` helper in `model-info.ts` — mirrors `getModelDisplayName` (which takes the part before `" - "`) by returning the part after.
- Reuses the existing `<InfoTip>` (`ui/info-tip.tsx`) and `<Tooltip>` primitives — no new components or styles.
- Badge only renders when a description exists for the model.