### PR TITLE
add gpt-5.4-mini

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -32,6 +32,10 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["gpt-5.4"],
     },
     {
+        name: "gpt-5.4-mini",
+        config: portkeyConfig["gpt-5.4-mini"],
+    },
+    {
         name: "gpt-5.5",
         config: portkeyConfig["gpt-5.5"],
     },

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -58,6 +58,12 @@ export const portkeyConfig: PortkeyConfigMap = {
             "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/deployments/gpt-5.4/chat/completions?api-version=2024-12-01-preview",
             "gpt-5.4",
         ),
+    "gpt-5.4-mini": () =>
+        createAzureModelConfig(
+            process.env.AZURE_MYCELI_PROD_API_KEY,
+            "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/deployments/gpt-5.4-mini/chat/completions?api-version=2024-12-01-preview",
+            "gpt-5.4-mini",
+        ),
 
     // -- Azure (Myceli Prod — swedencentral, GPT-5.5) -------------------------
     "gpt-5.5": () =>

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -109,7 +109,7 @@ export const TEXT_SERVICES = {
                 completionTextTokens: perMillion(4.5),
             },
         ],
-        description: "GPT-5.4 Mini - Balanced",
+        description: "GPT-5.4 Mini - Balanced Speed & Cost",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -26,7 +26,7 @@ export type TextModelId = (typeof TEXT_SERVICES)[TextModelName]["modelId"];
 
 export const TEXT_SERVICES = {
     "openai": {
-        aliases: ["gpt-5.4-nano", "gpt-5-mini"],
+        aliases: ["gpt-5.4-nano"],
         modelId: "gpt-5.4-nano",
         provider: "azure",
         brand: "OpenAI",
@@ -92,6 +92,27 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
+        contextLength: 400000,
+        isSpecialized: false,
+    },
+    "gpt-5.4-mini": {
+        aliases: ["gpt-5-mini", "openai-mini"],
+        modelId: "gpt-5.4-mini",
+        provider: "azure",
+        brand: "OpenAI",
+        category: "text",
+        cost: [
+            {
+                date: COST_START_DATE,
+                promptTextTokens: perMillion(0.75),
+                promptCachedTokens: perMillion(0.075),
+                completionTextTokens: perMillion(4.5),
+            },
+        ],
+        description: "GPT-5.4 Mini - Balanced",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        tools: true,
         contextLength: 400000,
         isSpecialized: false,
     },


### PR DESCRIPTION
- adds `gpt-5.4-mini` as a new text model (free tier, not paid-only)
- pricing matches OpenAI: $0.75 / $0.075 / $4.50 per 1M (in / cached / out), 400k ctx
- routes through Azure eastus deployment `gpt-5.4-mini` at 15000 TPM (just created)
- moves `gpt-5-mini` alias from `openai` (nano) to the new mini — fixes misleading routing where "mini" callers landed on nano
- adds `openai-mini` alias to the new mini

gpt-5.5-pro was considered but isn't available on Azure OpenAI in any region yet, so it's not included.

battle-tested locally: text/image/tools/streaming all 200, error matrix returns clean 400s, burst at n=30 had 0 failures with p95 ~1.2s, alias routing verified, `enter` aliases.test.ts 187/187 pass.