### PR TITLE
fix new label on dashboard with dedicated addedDate field

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -7,10 +7,12 @@ description: "Add, update, or remove text/image/video models. Handles any provid
 
 1. Update `.env` and `secrets/env.json` (sops) with credentials
 2. Update config/handler with model routing
-3. Update registry with **pricing** and **provider**
+3. Update registry with **pricing**, **provider**, and **`addedDate`**
 4. Run tests (see [Testing](#testing) below)
 
 > ⚠️ **Pricing depends on BOTH model AND provider.** Always verify pricing on the provider's website.
+
+> ⚠️ **`addedDate` is set once and NEVER updated.** It drives the NEW chip on the dashboard (7-day window). Use `new Date("YYYY-MM-DD").getTime()` with today's date. Do not touch it when changing pricing, endpoint, or provider later — only the cost array gets new entries.
 
 ---
 

--- a/enter.pollinations.ai/src/client/components/models/model-info.ts
+++ b/enter.pollinations.ai/src/client/components/models/model-info.ts
@@ -156,13 +156,14 @@ export const isPersona = (modelName: string): boolean => {
 };
 
 /**
- * Check if a model is "new" (added within the last 30 days)
+ * Check if a model is "new" (added within the last 7 days).
+ * Uses the `addedDate` field, which is set once on creation and never updated.
  */
 export const isNewModel = (modelName: string): boolean => {
     const service = getModelDefinition(modelName as ModelName);
-    if (!service?.cost?.[0]?.date) return false;
-    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-    return service.cost[0].date > thirtyDaysAgo;
+    if (!service?.addedDate) return false;
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    return service.addedDate > sevenDaysAgo;
 };
 
 /**

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -56,6 +56,7 @@ export const AUDIO_SERVICES = {
         provider: "elevenlabs",
         brand: "ElevenLabs",
         category: "audio",
+        addedDate: new Date("2026-02-07").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -93,6 +94,7 @@ export const AUDIO_SERVICES = {
         brand: "ElevenLabs",
         category: "audio",
         paidOnly: true,
+        addedDate: new Date("2026-05-14").getTime(),
         cost: [
             {
                 date: new Date("2026-05-13").getTime(),
@@ -119,6 +121,7 @@ export const AUDIO_SERVICES = {
         provider: "elevenlabs",
         brand: "ElevenLabs",
         category: "audio",
+        addedDate: new Date("2026-02-08").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -146,6 +149,7 @@ export const AUDIO_SERVICES = {
         provider: "ovhcloud",
         brand: "OpenAI",
         category: "audio",
+        addedDate: new Date("2026-02-08").getTime(),
         cost: [
             {
                 date: new Date("2026-02-08").getTime(),
@@ -164,6 +168,7 @@ export const AUDIO_SERVICES = {
         provider: "elevenlabs",
         brand: "ElevenLabs",
         category: "audio",
+        addedDate: new Date("2026-02-13").getTime(),
         cost: [
             {
                 date: new Date("2026-02-13").getTime(),
@@ -193,6 +198,7 @@ export const AUDIO_SERVICES = {
         provider: "assemblyai",
         brand: "AssemblyAI",
         category: "audio",
+        addedDate: new Date("2026-05-02").getTime(),
         cost: [
             {
                 date: new Date("2026-05-02").getTime(),
@@ -215,6 +221,7 @@ export const AUDIO_SERVICES = {
         provider: "assemblyai",
         brand: "AssemblyAI",
         category: "audio",
+        addedDate: new Date("2026-05-02").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -234,6 +241,7 @@ export const AUDIO_SERVICES = {
         provider: "lambda",
         brand: "ACE-Step",
         category: "audio",
+        addedDate: new Date("2026-04-03").getTime(),
         cost: [
             {
                 date: new Date("2026-04-02").getTime(),
@@ -252,6 +260,7 @@ export const AUDIO_SERVICES = {
         provider: "alibaba",
         brand: "Qwen",
         category: "audio",
+        addedDate: new Date("2026-04-22").getTime(),
         cost: [
             {
                 date: new Date("2026-04-19").getTime(),
@@ -275,6 +284,7 @@ export const AUDIO_SERVICES = {
         provider: "alibaba",
         brand: "Qwen",
         category: "audio",
+        addedDate: new Date("2026-04-22").getTime(),
         paidOnly: true,
         cost: [
             {

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -21,6 +21,7 @@ export const EMBEDDING_SERVICES: EmbeddingModelDefinitions = {
         provider: "google",
         brand: "Google",
         category: "embedding",
+        addedDate: new Date("2026-05-08").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -52,6 +53,7 @@ export const EMBEDDING_SERVICES: EmbeddingModelDefinitions = {
         provider: "openai",
         brand: "OpenAI",
         category: "embedding",
+        addedDate: new Date("2026-05-08").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -76,6 +78,7 @@ export const EMBEDDING_SERVICES: EmbeddingModelDefinitions = {
         provider: "openai",
         brand: "OpenAI",
         category: "embedding",
+        addedDate: new Date("2026-05-08").getTime(),
         cost: [
             {
                 date: COST_START_DATE,

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -13,6 +13,7 @@ export const IMAGE_SERVICES = {
         provider: "azure",
         brand: "Black Forest Labs",
         category: "image",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -29,6 +30,7 @@ export const IMAGE_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "image",
+        addedDate: new Date("2025-10-07").getTime(),
         paidOnly: true,
         cost: [
             // Gemini 2.5 Flash Image via Vertex AI
@@ -49,6 +51,7 @@ export const IMAGE_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "image",
+        addedDate: new Date("2026-02-27").getTime(),
         paidOnly: true,
         cost: [
             // Gemini 3.1 Flash Image via Vertex AI
@@ -71,6 +74,7 @@ export const IMAGE_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "image",
+        addedDate: new Date("2025-12-01").getTime(),
         paidOnly: true,
         cost: [
             // Gemini 3 Pro Image via Vertex AI
@@ -94,6 +98,7 @@ export const IMAGE_SERVICES = {
         provider: "bytedance",
         brand: "ByteDance",
         category: "image",
+        addedDate: new Date("2026-02-27").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -118,6 +123,7 @@ export const IMAGE_SERVICES = {
         provider: "bytedance",
         brand: "ByteDance",
         category: "image",
+        addedDate: new Date("2025-10-07").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -141,6 +147,7 @@ export const IMAGE_SERVICES = {
         provider: "bytedance",
         brand: "ByteDance",
         category: "image",
+        addedDate: new Date("2025-12-04").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -165,6 +172,7 @@ export const IMAGE_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "image",
+        addedDate: new Date("2025-10-10").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -184,6 +192,7 @@ export const IMAGE_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "image",
+        addedDate: new Date("2025-12-23").getTime(),
         cost: [
             // Official pricing: https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-openai%E2%80%99s-gpt-image-1-5-in-microsoft-foundry/4478139
             {
@@ -205,6 +214,7 @@ export const IMAGE_SERVICES = {
         provider: "openai",
         brand: "OpenAI",
         category: "image",
+        addedDate: new Date("2026-04-22").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -226,6 +236,7 @@ export const IMAGE_SERVICES = {
         provider: "runpod",
         brand: "Black Forest Labs",
         category: "image",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -242,6 +253,7 @@ export const IMAGE_SERVICES = {
         provider: "runpod",
         brand: "Alibaba",
         category: "image",
+        addedDate: new Date("2025-12-08").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -258,6 +270,7 @@ export const IMAGE_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "video",
+        addedDate: new Date("2025-11-27").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -275,6 +288,7 @@ export const IMAGE_SERVICES = {
         provider: "bytedance",
         brand: "ByteDance",
         category: "video",
+        addedDate: new Date("2025-12-01").getTime(),
         paidOnly: true,
         cost: [
             // Token formula: (height × width × FPS × duration) / 1024
@@ -300,6 +314,7 @@ export const IMAGE_SERVICES = {
         provider: "bytedance",
         brand: "ByteDance",
         category: "video",
+        addedDate: new Date("2025-12-04").getTime(),
         paidOnly: true,
         cost: [
             // Token formula: (height × width × FPS × duration) / 1024
@@ -325,6 +340,7 @@ export const IMAGE_SERVICES = {
         provider: "replicate",
         brand: "ByteDance",
         category: "video",
+        addedDate: new Date("2026-05-07").getTime(),
         paidOnly: true,
         // non_video_in tier @ 720p; see provider-billing/providers/replicate.md
         cost: [
@@ -350,6 +366,7 @@ export const IMAGE_SERVICES = {
         provider: "alibaba",
         brand: "Alibaba",
         category: "video",
+        addedDate: new Date("2026-01-21").getTime(),
         paidOnly: true,
         cost: [
             // Using I2V+audio rate as base since T2V also generates audio; audio cost split out separately for tracking
@@ -377,6 +394,7 @@ export const IMAGE_SERVICES = {
         provider: "alibaba",
         brand: "Alibaba",
         category: "video",
+        addedDate: new Date("2026-03-23").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -403,6 +421,7 @@ export const IMAGE_SERVICES = {
         provider: "alibaba",
         brand: "Alibaba",
         category: "image",
+        addedDate: new Date("2026-04-02").getTime(),
         cost: [
             {
                 date: new Date("2026-04-02").getTime(),
@@ -426,6 +445,7 @@ export const IMAGE_SERVICES = {
         provider: "alibaba",
         brand: "Alibaba",
         category: "image",
+        addedDate: new Date("2026-04-02").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -455,6 +475,7 @@ export const IMAGE_SERVICES = {
         provider: "alibaba",
         brand: "Qwen",
         category: "image",
+        addedDate: new Date("2026-03-23").getTime(),
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),
@@ -478,6 +499,7 @@ export const IMAGE_SERVICES = {
         provider: "xai",
         brand: "xAI",
         category: "image",
+        addedDate: new Date("2026-02-25").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -501,6 +523,7 @@ export const IMAGE_SERVICES = {
         provider: "xai",
         brand: "xAI",
         category: "image",
+        addedDate: new Date("2026-03-23").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -525,6 +548,7 @@ export const IMAGE_SERVICES = {
         provider: "xai",
         brand: "xAI",
         category: "video",
+        addedDate: new Date("2026-03-23").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -549,6 +573,7 @@ export const IMAGE_SERVICES = {
         provider: "runpod",
         brand: "Black Forest Labs",
         category: "image",
+        addedDate: new Date("2026-01-17").getTime(),
         alpha: true,
         cost: [
             {
@@ -566,6 +591,7 @@ export const IMAGE_SERVICES = {
         provider: "lambda",
         brand: "Lightricks",
         category: "video",
+        addedDate: new Date("2026-02-06").getTime(),
         alpha: true,
         cost: [
             {
@@ -583,6 +609,7 @@ export const IMAGE_SERVICES = {
         provider: "pruna",
         brand: "Pruna",
         category: "image",
+        addedDate: new Date("2026-03-14").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -606,6 +633,7 @@ export const IMAGE_SERVICES = {
         provider: "pruna",
         brand: "Pruna",
         category: "image",
+        addedDate: new Date("2026-03-14").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -629,6 +657,7 @@ export const IMAGE_SERVICES = {
         provider: "pruna",
         brand: "Pruna",
         category: "video",
+        addedDate: new Date("2026-03-14").getTime(),
         paidOnly: true,
         cost: [
             // $0.12 per run / 5s default = $0.024/sec
@@ -654,6 +683,7 @@ export const IMAGE_SERVICES = {
         provider: "aws",
         brand: "Amazon",
         category: "image",
+        addedDate: new Date("2026-03-23").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -671,6 +701,7 @@ export const IMAGE_SERVICES = {
         provider: "aws",
         brand: "Amazon",
         category: "video",
+        addedDate: new Date("2026-03-23").getTime(),
         cost: [
             {
                 date: COST_START_DATE,

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -76,6 +76,8 @@ export type ModelDefinition<TModelId extends string = ModelId> = {
     category: Category;
     cost: CostDefinition[];
     price?: PriceDefinition[];
+    // Date the model was added to the registry (ms epoch). Set once, never updated.
+    addedDate: number;
     // User-facing metadata
     description?: string;
     inputModalities?: string[];

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -31,6 +31,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -52,6 +53,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -79,6 +81,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -101,6 +104,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2026-05-15").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -122,6 +126,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2026-05-02").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -145,6 +150,7 @@ export const TEXT_SERVICES = {
         provider: "ovhcloud",
         brand: "Qwen",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: new Date("2026-01-05").getTime(),
@@ -171,6 +177,7 @@ export const TEXT_SERVICES = {
         provider: "openrouter",
         brand: "Mistral",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -192,6 +199,7 @@ export const TEXT_SERVICES = {
         provider: "openrouter",
         brand: "Mistral",
         category: "text",
+        addedDate: new Date("2026-05-15").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -217,6 +225,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -240,6 +249,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "OpenAI",
         category: "text",
+        addedDate: new Date("2026-04-02").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -263,6 +273,7 @@ export const TEXT_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -301,6 +312,7 @@ export const TEXT_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "text",
+        addedDate: new Date("2026-04-03").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -335,6 +347,7 @@ export const TEXT_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "text",
+        addedDate: new Date("2025-12-18").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -374,6 +387,7 @@ export const TEXT_SERVICES = {
         provider: "openrouter",
         brand: "DeepSeek",
         category: "text",
+        addedDate: new Date("2025-10-10").getTime(),
         cost: [
             {
                 date: new Date("2026-05-15").getTime(),
@@ -399,6 +413,7 @@ export const TEXT_SERVICES = {
         ],
         modelId: "google/gemma-4-26B-A4B-it",
         provider: "deepinfra",
+        addedDate: new Date("2026-05-08").getTime(),
         brand: "Google",
         category: "text",
         cost: [
@@ -424,6 +439,7 @@ export const TEXT_SERVICES = {
         provider: "fireworks",
         brand: "DeepSeek",
         category: "text",
+        addedDate: new Date("2026-04-24").getTime(),
         cost: [
             {
                 date: new Date("2026-04-24").getTime(),
@@ -456,6 +472,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "xAI",
         category: "text",
+        addedDate: new Date("2025-11-10").getTime(),
         cost: [
             {
                 date: new Date("2026-04-27").getTime(),
@@ -483,6 +500,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "xAI",
         category: "text",
+        addedDate: new Date("2026-04-09").getTime(),
         cost: [
             {
                 date: new Date("2026-04-27").getTime(),
@@ -508,6 +526,7 @@ export const TEXT_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "text",
+        addedDate: new Date("2025-10-10").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -542,6 +561,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Pollinations",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -562,6 +582,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Pollinations",
         category: "text",
+        addedDate: new Date("2026-03-23").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -583,6 +604,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Anthropic",
         category: "text",
+        addedDate: new Date("2025-12-01").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -604,6 +626,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Anthropic",
         category: "text",
+        addedDate: new Date("2025-11-05").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -626,6 +649,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Anthropic",
         category: "text",
+        addedDate: new Date("2025-11-10").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -648,6 +672,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Anthropic",
         category: "text",
+        addedDate: new Date("2026-04-22").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -670,6 +695,7 @@ export const TEXT_SERVICES = {
         provider: "perplexity",
         brand: "Perplexity",
         category: "text",
+        addedDate: new Date("2025-11-04").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -691,6 +717,7 @@ export const TEXT_SERVICES = {
         provider: "perplexity",
         brand: "Perplexity",
         category: "text",
+        addedDate: new Date("2025-11-04").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -721,6 +748,7 @@ export const TEXT_SERVICES = {
         provider: "fireworks",
         brand: "Moonshot AI",
         category: "text",
+        addedDate: new Date("2026-01-10").getTime(),
         cost: [
             {
                 date: new Date("2026-04-12").getTime(),
@@ -744,6 +772,7 @@ export const TEXT_SERVICES = {
         provider: "fireworks",
         brand: "Moonshot AI",
         category: "text",
+        addedDate: new Date("2026-04-22").getTime(),
         cost: [
             {
                 date: new Date("2026-04-21").getTime(),
@@ -767,6 +796,7 @@ export const TEXT_SERVICES = {
         provider: "google",
         brand: "Google",
         category: "text",
+        addedDate: new Date("2025-11-19").getTime(),
         paidOnly: true,
         cost: [
             {
@@ -801,6 +831,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Amazon",
         category: "text",
+        addedDate: new Date("2025-10-07").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -821,6 +852,7 @@ export const TEXT_SERVICES = {
         provider: "bedrock",
         brand: "Amazon",
         category: "text",
+        addedDate: new Date("2026-03-23").getTime(),
         cost: [
             {
                 date: COST_START_DATE,
@@ -842,6 +874,7 @@ export const TEXT_SERVICES = {
         provider: "fireworks",
         brand: "Z.ai",
         category: "text",
+        addedDate: new Date("2026-01-06").getTime(),
         cost: [
             {
                 date: new Date("2026-04-12").getTime(),
@@ -865,6 +898,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "Meta",
         category: "text",
+        addedDate: new Date("2026-05-01").getTime(),
         cost: [
             {
                 date: new Date("2026-01-01").getTime(),
@@ -891,6 +925,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "Meta",
         category: "text",
+        addedDate: new Date("2026-05-04").getTime(),
         cost: [
             {
                 date: new Date("2025-06-01").getTime(),
@@ -917,6 +952,7 @@ export const TEXT_SERVICES = {
         provider: "openrouter",
         brand: "Meta",
         category: "text",
+        addedDate: new Date("2026-05-04").getTime(),
         cost: [
             {
                 date: new Date("2025-04-01").getTime(),
@@ -943,6 +979,7 @@ export const TEXT_SERVICES = {
         provider: "fireworks",
         brand: "MiniMax",
         category: "text",
+        addedDate: new Date("2026-01-06").getTime(),
         cost: [
             {
                 date: new Date("2026-04-19").getTime(),
@@ -965,6 +1002,7 @@ export const TEXT_SERVICES = {
         provider: "azure",
         brand: "Mistral",
         category: "text",
+        addedDate: new Date("2026-04-09").getTime(),
         cost: [
             {
                 date: new Date("2026-04-08").getTime(),
@@ -987,6 +1025,7 @@ export const TEXT_SERVICES = {
         provider: "community",
         brand: "Pollinations",
         category: "text",
+        addedDate: new Date("2026-02-24").getTime(),
         cost: [
             {
                 date: new Date("2026-02-23").getTime(),
@@ -1009,6 +1048,7 @@ export const TEXT_SERVICES = {
         provider: "alibaba",
         brand: "Qwen",
         category: "text",
+        addedDate: new Date("2026-03-22").getTime(),
         cost: [
             {
                 date: new Date("2026-03-22").getTime(),
@@ -1037,6 +1077,7 @@ export const TEXT_SERVICES = {
         provider: "fireworks",
         brand: "Qwen",
         category: "text",
+        addedDate: new Date("2026-03-22").getTime(),
         cost: [
             {
                 date: new Date("2026-04-12").getTime(),
@@ -1066,6 +1107,7 @@ export const TEXT_SERVICES = {
         provider: "openrouter",
         brand: "Qwen",
         category: "text",
+        addedDate: new Date("2026-03-22").getTime(),
         cost: [
             {
                 date: new Date("2026-05-15").getTime(),
@@ -1073,7 +1115,7 @@ export const TEXT_SERVICES = {
                 completionTextTokens: perMillion(0.52),
             },
         ],
-        description: "Fast vision-language model for image understanding",
+        description: "Qwen3 VL 30B A3B Instruct - Fast vision-language model",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,
@@ -1091,6 +1133,7 @@ export const TEXT_SERVICES = {
         modelId: "qwen/qwen3-vl-235b-a22b-thinking",
         provider: "openrouter",
         brand: "Qwen",
+        addedDate: new Date("2026-05-15").getTime(),
         category: "text",
         cost: [
             {
@@ -1113,6 +1156,7 @@ export const TEXT_SERVICES = {
         provider: "ovhcloud",
         brand: "Qwen",
         category: "text",
+        addedDate: new Date("2026-02-15").getTime(),
         cost: [
             {
                 date: new Date("2026-02-15").getTime(),


### PR DESCRIPTION
The NEW chip on the model list wasn't firing because `isNewModel` was reading `cost[0].date`, which nearly every model sets to `COST_START_DATE` (2025-08-01) — the global cost-tracking epoch, not when the model was added. So new additions like GPT-5.4 Mini never lit up.

- Added required `addedDate: number` on `ModelDefinition`. Set once when a model is added, never updated.
- `isNewModel` now reads `addedDate` with a 7-day window.
- Backfilled `addedDate` on all 88 models using each entry's git first-appearance date.
- Also fixed `qwen-vision` description ("Fast vision-language model for image understanding") — no `" - "` separator meant `getModelDisplayName` returned the whole string and the description disappeared. Audited all other models, none had the same issue.
- Updated the model-management skill so future additions set `addedDate` and never touch it on price/provider changes.