### PR TITLE
simplify project manager routing

### DIFF
--- a/.github/docs/TRIAGE.md
+++ b/.github/docs/TRIAGE.md
@@ -77,10 +77,9 @@ flowchart TD
     AB --> AC[Done - skip AI]
     AA -->|No| AN{Has NEWS label?}
     AN -->|Yes| AX[Skip - social pipeline only]
-    AN -->|No| B{Check Author}
-    B --> C[is_org_member?]
-    D -->|Yes| F[INTERNAL]
-    D -->|No| G[EXTERNAL]
+    AN -->|No| B[is_org_member?]
+    B -->|Yes| F[INTERNAL]
+    B -->|No| G[EXTERNAL]
 
     F --> H[AI Classification]
     G --> H

--- a/.github/docs/TRIAGE.md
+++ b/.github/docs/TRIAGE.md
@@ -41,7 +41,7 @@ flowchart TD
 
 ## Project Management
 
-- **project-manager.yml** - AI-powered auto-kanban. Classifies issues/PRs and routes to Dev/Support/News/Tier projects with priority.
+- **project-manager.yml** - AI-powered auto-kanban. Classifies issues/PRs and routes to Dev/Support/Apps projects with priority.
 - **issue-close-discarded.yml** - Auto-closes issues marked "Discarded" in project (hourly).
 - **pr-update-project-status.yml** - Updates PR status in project (In Progress/In Review/Done/Discarded).
 
@@ -53,17 +53,16 @@ Routes issues and PRs to the appropriate project board using AI classification:
 | ------- | --- | ------------- | ----------------------------------- |
 | Dev     | 20  | Internal only | Features, refactors, infrastructure |
 | Support | 21  | Everyone      | User help, bugs, API questions      |
-| News    | 22  | Everyone      | Releases, announcements             |
-| Tier    | 23  | External      | App submissions, code contributions |
+| Apps    | 23  | External      | App submissions                     |
 
 **Features:**
 
-- **TIER-\* bypass**: Items with `TIER-*` labels skip AI classification and route directly to Tier project
+- **TIER-\* bypass**: Items with `TIER-*` labels skip AI classification and route directly to Apps project
+- **NEWS skip**: Items with `NEWS` label are skipped entirely (label is used by the social pipeline, not project routing)
 - AI classification via `gen.pollinations.ai` with retry + random seed
 - Sets Priority field (Urgent/High/Medium/Low) in project
-- Sets Status field (Backlog/In Progress/Review/Todo/Done/Discarded)
-- Adds labels (DEV-_ for dev, SUPPORT-_ for support, none for news)
-- Enforces internal-only rule for Dev project
+- Adds labels (`DEV-*` for dev, `.TYPE` + `SERVICE` for support)
+- Enforces internal-only rule for Dev project (external authors classified as dev get reassigned to support)
 - Fallback classification if AI fails
 
 ## Flow Diagrams
@@ -74,16 +73,14 @@ Routes issues and PRs to the appropriate project board using AI classification:
 %%{init: {'theme': 'dark'}}%%
 flowchart TD
     A[Issue/PR Opened] --> AA{Has TIER-* label?}
-    AA -->|Yes| AB[Add to Tier #23]
+    AA -->|Yes| AB[Add to Apps #23]
     AB --> AC[Done - skip AI]
-    AA -->|No| B{Check Author}
+    AA -->|No| AN{Has NEWS label?}
+    AN -->|Yes| AX[Skip - social pipeline only]
+    AN -->|No| B{Check Author}
     B --> C[is_org_member?]
-    C -->|Config list| D{In list?}
-    C -->|API fallback| E{/orgs/members/}
     D -->|Yes| F[INTERNAL]
-    D -->|No| E
-    E -->|204| F
-    E -->|404| G[EXTERNAL]
+    D -->|No| G[EXTERNAL]
 
     F --> H[AI Classification]
     G --> H
@@ -94,22 +91,16 @@ flowchart TD
     J --> L[project, priority, labels]
     K --> L
 
-    L --> M{Internal + Dev?}
+    L --> IAS{is_app_submission?}
+    IAS -->|Yes| AP[Add to Apps #23]
+    IAS -->|No| M{project=dev + internal?}
     M -->|Yes| N[Add to Dev #20]
-    M -->|No, External| O{News content?}
-    O -->|Yes| P[Add to News #22]
-    O -->|No| Q[Add to Support #21]
-    L -->|Internal + Support| Q
-    L -->|Internal + News| P
+    M -->|No| Q[Add to Support #21]
 
-    N --> R[Set Status: Backlog]
-    Q --> S[Set Status: Review]
-    P --> T[Set Status: Todo]
-
-    R --> U[Set Priority Field]
-    S --> U
-    T --> V[Done]
-    U --> V
+    Q --> U[Set Priority Field]
+    U --> V[Done]
+    N --> V
+    AP --> V
 ```
 
 ### PR Assignment
@@ -120,7 +111,7 @@ flowchart TD
     A[PR opened] --> B[pr-assign-author.yml]
     B --> C[Author assigned]
     C --> D[project-manager.yml]
-    D --> E[Routed to Dev/Support/News/Tier]
+    D --> E[Routed to Dev/Support/Apps]
 ```
 
 ### AI Assistant (Polly)
@@ -158,17 +149,17 @@ flowchart TD
 
 ## Label System
 
-### Tier Labels (App Submissions)
+### Apps Project Labels (App Submissions)
 
-| Label                 | Purpose                           | Applied by                  |
-| --------------------- | --------------------------------- | --------------------------- |
-| `TIER-APP`            | New app submission                | Issue template              |
-| `TIER-APP-INCOMPLETE` | Needs user action (info/register) | `app-review-submission.yml` |
-| `TIER-APP-REVIEW`     | Issue awaiting maintainer review  | `app-review-submission.yml` |
-| `TIER-APP-APPROVED`   | Maintainer approved, PR created   | Maintainer (manual)         |
-| `TIER-APP-REJECTED`   | Submission rejected               | `app-review-submission.yml` |
+Any `TIER-*` labeled issue routes to the Apps project (#23). The state machine:
 
-**Code Contributions** _(future)_: `TIER-CODE`, `TIER-CODE-REVIEW-PR`, `TIER-CODE-COMPLETE`, `TIER-CODE-REJECTED` planned.
+| Label                 | Purpose                           | Applied by                                         |
+| --------------------- | --------------------------------- | -------------------------------------------------- |
+| `TIER-APP`            | New app submission                | Issue template                                     |
+| `TIER-APP-INCOMPLETE` | Needs user action (info/register) | `app-review-submission.yml`                        |
+| `TIER-APP-REVIEW`     | Issue awaiting maintainer review  | `app-review-submission.yml` (stripped on approval) |
+| `TIER-APP-APPROVED`   | Maintainer approved, PR created   | Maintainer (manual)                                |
+| `TIER-APP-REJECTED`   | Submission rejected               | `app-review-submission.yml`                        |
 
 ### Dev Labels
 
@@ -211,6 +202,8 @@ flowchart TD
 
 ### News Labels
 
-| Label  | Purpose                | Applied by                 |
-| ------ | ---------------------- | -------------------------- |
-| `NEWS` | News/social content PR | News & Instagram workflows |
+The `NEWS` label is used by the social pipeline (`social/` workflows), not by Project Manager routing. Issues/PRs carrying it are skipped by `project-manager.py` and don't land on any project board.
+
+| Label  | Purpose                | Applied by                                          |
+| ------ | ---------------------- | --------------------------------------------------- |
+| `NEWS` | News/social content PR | `readme-daily-update.yml`, `NEWS_summary.yml`, etc. |

--- a/.github/prompts/project-manager.md
+++ b/.github/prompts/project-manager.md
@@ -5,7 +5,7 @@ Classify this GitHub issue/PR. Return JSON only.
 ```json
 {
   "is_app_submission": true | false,
-  "project": "dev" | "support" | "news",
+  "project": "dev" | "support",
   "priority": "Urgent" | "High" | "Medium" | "Low" | null,
   "labels": ["LABEL"],
   "reasoning": "brief explanation"
@@ -16,7 +16,6 @@ Classify this GitHub issue/PR. Return JSON only.
 
 - `dev`: Internal team only. Infrastructure, CI/CD, refactors, features, internal tooling.
 - `support`: External users. API help, bugs, billing, integration questions.
-- `news`: Announcements, releases, social media content, blog posts.
 
 ## Labels
 
@@ -52,18 +51,12 @@ Classify this GitHub issue/PR. Return JSON only.
 - `BILLING`: Payments, invoices, pricing
 - `ACCOUNT`: Account access, API keys, login issues
 
-### news
-
-No labels needed.
-
 ## Priority (dev and support)
 
 - `Urgent`: Service outage, security issue, data loss, critical blocker
 - `High`: Bugs breaking functionality, blocking issues, billing problems
 - `Medium`: Features, enhancements, bugs with workarounds, integration help
 - `Low`: Minor issues, cosmetic bugs, general questions, documentation
-
-For `news`: set priority to `null`
 
 **Note for dev:** DEV-TRACKING and DEV-VOTING issues can have priority `null` as they are meta/tracking items.
 

--- a/.github/scripts/project-backfill-labels.py
+++ b/.github/scripts/project-backfill-labels.py
@@ -20,7 +20,7 @@ Usage:
     python project-backfill-labels.py --project dev --prs-only
 
 Options:
-    --project        Required. Project to process: dev, support, news, tier
+    --project        Required. Project to process: dev, support, apps
     --dry-run        Preview changes without applying
     --with-priority  Also update priority field (dev/support only)
     --only-missing   Only fill missing fields, don't replace existing values
@@ -314,7 +314,7 @@ def get_real_author(author: str, body: str) -> str:
 
 def main():
     parser = argparse.ArgumentParser(description="Backfill labels for project issues")
-    parser.add_argument("--project", required=True, choices=["dev", "support", "news", "tier"],
+    parser.add_argument("--project", required=True, choices=["dev", "support", "apps"],
                         help="Project to process")
     parser.add_argument("--dry-run", action="store_true", help="Preview without applying")
     parser.add_argument("--with-priority", action="store_true", help="Also update priority (dev/support)")

--- a/.github/scripts/project-manager.py
+++ b/.github/scripts/project-manager.py
@@ -84,14 +84,9 @@ CONFIG = {
             },
             "opened_field_id": "PVTF_lADOBS76fs4BLr1Hzg7WCHY",
         },
-        "news": {
-            "id": "PVT_kwDOBS76fs4BLtD8",
-            "name": "News",
-            "internal_only": False,
-        },
-        "tier": {
+        "apps": {
             "id": "PVT_kwDOBS76fs4BLtE_",
-            "name": "Tier",
+            "name": "Apps",
             "internal_only": False,
         },
     },
@@ -150,7 +145,6 @@ VALID_LABELS = {
         ".BUG", ".OUTAGE", ".QUESTION", ".REQUEST", ".DOCS", ".INTEGRATION",
         "IMAGE", "TEXT", "AUDIO", "VIDEO", "API", "WEB", "CREDITS", "BILLING", "ACCOUNT",
     },
-    "news": set()
 }
 
 SUPPORT_TYPE_LABELS = {".BUG", ".OUTAGE", ".QUESTION", ".REQUEST", ".DOCS", ".INTEGRATION"}
@@ -262,7 +256,7 @@ Body: {ISSUE_BODY[:2000]}
             is_app_submission = raw.get("is_app_submission", False)
 
             project = raw.get("project", "").lower()
-            if project not in ["dev", "support", "news"]:
+            if project not in ["dev", "support"]:
                 log_error(f"AI returned invalid project: {project}")
                 return get_fallback_classification(is_internal)
 
@@ -453,32 +447,24 @@ def main():
     existing_labels = get_existing_labels()
     tier_labels = [l for l in existing_labels if l.startswith("TIER-")]
     if tier_labels:
-        log_debug(f"Found TIER labels: {tier_labels}, routing to Tier project")
-        project = CONFIG["projects"].get("tier")
+        log_debug(f"Found TIER labels: {tier_labels}, routing to Apps project")
+        project = CONFIG["projects"].get("apps")
         if project:
             item_id = add_to_project(project["id"])
             if item_id:
-                log_debug(f"Added to Tier project successfully")
+                log_debug(f"Added to Apps project successfully")
             return
         else:
-            log_error("Tier project not configured")
+            log_error("Apps project not configured")
             return
     if "POLLEN-QUEST" in existing_labels or "DRAFT-QUEST" in existing_labels:
         log_debug("Found quest label; Quest project auto-add owns routing")
         return
 
     if "NEWS" in existing_labels:
-        log_debug("Found NEWS label, routing to News project (skipping AI)")
-        project = CONFIG["projects"].get("news")
-        if project:
-            item_id = add_to_project(project["id"])
-            if item_id:
-                log_debug("Added to News project successfully")
-            return
-        else:
-            log_error("News project not configured")
-            return
-    
+        log_debug("Found NEWS label, skipping (used by social pipeline, no project routing)")
+        return
+
     real_author = get_real_author()
     is_internal = is_org_member(real_author)
     log_debug(f"Author {ISSUE_AUTHOR} (real: {real_author}) is internal: {is_internal}")
@@ -489,17 +475,17 @@ def main():
     classification = classify_with_ai(is_internal)
     
     if classification.get("is_app_submission"):
-        log_debug("AI detected app submission, routing to Tier project")
-        project = CONFIG["projects"].get("tier")
+        log_debug("AI detected app submission, routing to Apps project")
+        project = CONFIG["projects"].get("apps")
         if project:
             item_id = add_to_project(project["id"])
             if item_id:
-                log_debug("Added to Tier project successfully")
+                log_debug("Added to Apps project successfully")
             else:
-                log_error("Failed to add app submission to Tier project")
+                log_error("Failed to add app submission to Apps project")
             return
         else:
-            log_error("Tier project not configured")
+            log_error("Apps project not configured")
             return
 
     if not classification.get("project"):

--- a/.github/workflows/app-review-submission.yml
+++ b/.github/workflows/app-review-submission.yml
@@ -205,6 +205,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
 
+      - name: Remove TIER-APP-REVIEW label
+        if: contains(github.event.issue.labels.*.name, 'TIER-APP-REVIEW')
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${ISSUE_NUMBER}/labels/TIER-APP-REVIEW" || true
+
       - uses: actions/checkout@v4
         with:
           ref: main


### PR DESCRIPTION
- drop News project routing; NEWS-labeled items now skip the manager (label stays for social pipeline use)
- rename `tier` → `apps` in project-manager config (project ID unchanged)
- strip TIER-APP-REVIEW when approving to avoid stacked labels with TIER-APP-APPROVED
- update TRIAGE.md to match

Out-of-band follow-ups (not in this PR): rename ProjectV2 #23 title `Tier` → `Apps`, delete the unused `TIER-APP-REVIEW-PR` label.