### PR TITLE
drop TIER-APP-COMPLETE from kpi worker

### DIFF
--- a/apps/operation/kpi/src/worker/index.ts
+++ b/apps/operation/kpi/src/worker/index.ts
@@ -587,18 +587,17 @@ app.get("/api/kpi/app-submissions", async (c) => {
     };
     if (token) headers.Authorization = `token ${token}`;
 
-    // Fetch all TIER-APP issues (submissions) and TIER-APP-COMPLETE issues (approved)
-    // GitHub Search API lets us get created/closed dates with labels in one call
+    // Fetch all TIER-APP issues (submissions) across the full app-review state machine.
+    // GitHub Search API lets us get created/closed dates with labels in one call.
     const repo = c.env.GITHUB_REPO;
     const since = DATA_START_DATE;
 
-    // TIER-APP label gets replaced as issues progress, so search each label separately
-    // GitHub Search API treats comma-separated labels as AND, not OR
+    // TIER-APP label gets replaced as issues progress, so search each label separately.
+    // GitHub Search API treats comma-separated labels as AND, not OR.
     const labels = [
         "TIER-APP",
         "TIER-APP-REVIEW",
         "TIER-APP-APPROVED",
-        "TIER-APP-COMPLETE",
         "TIER-APP-REJECTED",
         "TIER-APP-INCOMPLETE",
     ];


### PR DESCRIPTION
- legacy app-submission completion label is being retired
- all ~270 historical `TIER-APP-COMPLETE` issues have been migrated to `TIER-APP-APPROVED` so the KPI worker still finds them via the existing `TIER-APP-APPROVED` query
- remove `TIER-APP-COMPLETE` from the query list in [apps/operation/kpi/src/worker/index.ts](apps/operation/kpi/src/worker/index.ts)
- the label itself will be deleted from the repo after this merges