### PR TITLE
fix(image): surface real error on upstream 400 instead of "{}"

### DIFF
--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -252,7 +252,9 @@ function classifyImageHttpError(error: HttpError): {
         const text = parsed.text || error.message;
         return {
             status: remapUpstreamStatus(error.status),
-            message: text ? `Image provider error: ${text}` : "Image provider error",
+            message: text
+                ? `Image provider error: ${text}`
+                : "Image provider error",
         };
     }
 

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -186,7 +186,7 @@ function throwImageError(error: unknown, c: ImageContext): never {
             requestUrl:
                 safeUpstreamUrl(error.upstreamUrl) ?? new URL(c.req.url),
             upstreamStatus: error.status,
-            responseBody: JSON.stringify(error.details || {}),
+            responseBody: imageResponseBody(error),
             cause: error,
         });
     }
@@ -202,6 +202,23 @@ type ParsedUpstreamBody = {
     kind: "validation" | "message" | "none";
     text: string | null;
 };
+
+/**
+ * Build the responseBody to thread through UpstreamError so clients see a real
+ * error message instead of `"{}"`. Prefer the upstream provider's raw body
+ * (already in details.body), then the HttpError message, then a JSON-encoded
+ * details bag as last resort.
+ */
+function imageResponseBody(error: HttpError): string {
+    const detailsBody = error.details?.body;
+    if (typeof detailsBody === "string" && detailsBody.length > 0) {
+        return detailsBody;
+    }
+    if (error.message) {
+        return JSON.stringify({ message: error.message });
+    }
+    return JSON.stringify(error.details || {});
+}
 
 function classifyImageHttpError(error: HttpError): {
     status: ContentfulStatusCode;
@@ -232,11 +249,10 @@ function classifyImageHttpError(error: HttpError): {
     }
 
     if (error.status >= 400 && error.status < 500) {
+        const text = parsed.text || error.message;
         return {
             status: remapUpstreamStatus(error.status),
-            message: parsed.text
-                ? `Image provider error: ${parsed.text}`
-                : "Image provider error",
+            message: text ? `Image provider error: ${text}` : "Image provider error",
         };
     }
 

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -86,6 +86,9 @@ async function fakeImageBackendResponse(request: Request) {
             { status: 400 },
         );
     }
+    if (prompt.includes("empty body 400")) {
+        return new Response("", { status: 400 });
+    }
 
     if (body.height && body.height < 256) {
         return Response.json(
@@ -707,6 +710,27 @@ test("image backend validation errors return client-facing 400", async ({
         modelRequested: "zimage",
         responseStatus: 400,
     });
+
+    // Upstream 400 with empty body must still surface a useful message via
+    // HttpError.message, not collapse to a generic "Image provider error".
+    const { response: emptyBody400Response, wait: waitEmptyBody400 } =
+        await fetchWorker(
+            "/image/empty%20body%20400?model=zimage&width=280&height=280&seed=42",
+            {
+                headers: { authorization: `Bearer ${paidApiKey}` },
+            },
+        );
+
+    expect(emptyBody400Response.status).toBe(400);
+    await expect(emptyBody400Response.json()).resolves.toMatchObject({
+        success: false,
+        error: {
+            code: "BAD_REQUEST",
+            message:
+                "Image provider error: Image backend rejected request with status 400",
+        },
+    });
+    await waitEmptyBody400();
 });
 
 test("malformed image edit multipart bodies return tracked 400", async ({


### PR DESCRIPTION
## Summary
- `/v1/images/edits` (and `/image/*`) was returning `upstreamBody: "{}"` and a generic `"Image provider error"` whenever an `HttpError` was thrown without a `details.body` (e.g. `nanobanana-2` failing in `vertexAIImageGenerator.buildNoImageDataError`).
- Now the real `HttpError.message` is preserved on both `responseBody` and the user-facing `message`, so clients see something like `"Image provider error: Gemini: <reason>"` instead of an empty `{}`.
- Existing tracked-400 flow (provider body with `message`/`detail`) is unchanged — covered by the existing tests.

## Why
While debugging a `nanobanana-2` image-edit failure, the only signal from the gateway was `upstreamBody: "{}"`. That's not actionable — the underlying Gemini text/finish-reason was already being attached to the `HttpError` but discarded by `throwImageError` and `classifyImageHttpError`.

## Changes
- `gen.pollinations.ai/src/image/handler.ts`
  - `throwImageError` now uses `imageResponseBody(error)` which prefers `details.body`, then `error.message`, then a JSON details fallback — never raw `"{}"` when a message exists.
  - `classifyImageHttpError` falls back to `error.message` when the upstream body can't be parsed for 4xx errors.
- `gen.pollinations.ai/test/generation-vcr.test.ts`
  - Adds a regression case: upstream 400 with empty body now surfaces `"Image provider error: Image backend rejected request with status 400"` rather than `"Image provider error"`.

## Test plan
- [x] `npx vitest run test/generation-vcr.test.ts` — 13/13 pass
- [x] `npx vitest run test/error-observability.test.ts` — 1/1 pass
- [x] `npx biome check` clean on touched files
- [ ] After deploy, verify a failing `nanobanana-2` edit returns the underlying Gemini reason (currently masked as `"{}"`).