### PR TITLE
prioritize paid customers as urgent in support

### DIFF
--- a/.github/docs/TRIAGE.md
+++ b/.github/docs/TRIAGE.md
@@ -60,10 +60,22 @@ Routes issues and PRs to the appropriate project board using AI classification:
 - **TIER-\* bypass**: Items with `TIER-*` labels skip AI classification and route directly to Apps project
 - **NEWS skip**: Items with `NEWS` label are skipped entirely (label is used by the social pipeline, not project routing)
 - AI classification via `gen.pollinations.ai` with retry + random seed
-- Sets Priority field (Urgent/High/Medium/Low) in project
+- Sets Priority field on Support items (see [Priority Rules](#priority-rules))
 - Adds labels (`DEV-*` for dev, `.TYPE` + `SERVICE` for support)
 - Enforces internal-only rule for Dev project (external authors classified as dev get reassigned to support)
 - Fallback classification if AI fails
+
+### Priority Rules
+
+Priority is only set on Support items. The AI picks one of two values; `Urgent` is applied automatically when the author is a paid Stripe customer.
+
+| Priority | Who applies it | When |
+| -------- | -------------- | ---- |
+| `Urgent` | `project-manager.py` (override) | Issue author's GitHub ID matches a paid Stripe customer (`paid_customers.json` Tinybird endpoint) |
+| `High`   | AI | Bugs breaking functionality, blocking issues, billing problems, outages |
+| `Low`    | AI | Minor issues, cosmetic bugs, questions, docs, feature requests, integration help |
+
+`Medium` is no longer used. The paid-customer lookup joins `stripe_event.user_id → d1_user.id → d1_user.github_id` filtered to the latest `synced_at`. GitHub IDs are used instead of usernames so the flag survives username changes.
 
 ## Flow Diagrams
 

--- a/.github/prompts/project-manager.md
+++ b/.github/prompts/project-manager.md
@@ -6,7 +6,7 @@ Classify this GitHub issue/PR. Return JSON only.
 {
   "is_app_submission": true | false,
   "project": "dev" | "support",
-  "priority": "Urgent" | "High" | "Medium" | "Low" | null,
+  "priority": "High" | "Low" | null,
   "labels": ["LABEL"],
   "reasoning": "brief explanation"
 }
@@ -51,14 +51,16 @@ Classify this GitHub issue/PR. Return JSON only.
 - `BILLING`: Payments, invoices, pricing
 - `ACCOUNT`: Account access, API keys, login issues
 
-## Priority (dev and support)
+## Priority (support only)
 
-- `Urgent`: Service outage, security issue, data loss, critical blocker
-- `High`: Bugs breaking functionality, blocking issues, billing problems
-- `Medium`: Features, enhancements, bugs with workarounds, integration help
-- `Low`: Minor issues, cosmetic bugs, general questions, documentation
+Pick exactly one of `High` or `Low`. Do **not** return `Urgent` or `Medium`:
 
-**Note for dev:** DEV-TRACKING and DEV-VOTING issues can have priority `null` as they are meta/tracking items.
+- `High`: Bugs breaking functionality, blocking issues, billing problems, outages
+- `Low`: Minor issues, cosmetic bugs, general questions, documentation, feature requests, integration help
+
+`Urgent` is reserved for paid customers and is applied automatically downstream — never return it.
+
+**Note for dev:** Always return `null` for priority. Dev priority is set manually.
 
 ## Rules
 

--- a/.github/scripts/project-backfill-labels.py
+++ b/.github/scripts/project-backfill-labels.py
@@ -402,6 +402,9 @@ def main():
             
             if classification:
                 priority = classification.get("priority")
+                if project_key == "support" and priority not in {"High", "Low"}:
+                    log_debug(f"Backfill: AI returned non-{{High,Low}} priority '{priority}' for #{issue_number}; clamping to Low")
+                    priority = "Low"
                 author_id = (issue.get("author") or {}).get("databaseId")
                 if project_key == "support" and is_paid_customer(author_id):
                     log_debug(f"Author {author} (id={author_id}) is a paid customer; overriding priority to Urgent for #{issue_number}")

--- a/.github/scripts/project-backfill-labels.py
+++ b/.github/scripts/project-backfill-labels.py
@@ -68,6 +68,7 @@ normalize_labels = pm.normalize_labels
 graphql_request = pm.graphql_request
 set_project_field = pm.set_project_field
 set_date_field = pm.set_date_field
+is_paid_customer = pm.is_paid_customer
 
 POLLINATIONS_API = "https://gen.pollinations.ai/v1/chat/completions"
 POLLINATIONS_TOKEN = os.getenv("POLLINATIONS_TOKEN")
@@ -104,7 +105,7 @@ def get_project_issues(project_id: str, include_prs: bool = False, priority_fiel
                                 body
                                 state
                                 createdAt
-                                author { login }
+                                author { login ... on User { databaseId } }
                                 labels(first: 20) {
                                     nodes { name }
                                 }
@@ -117,7 +118,7 @@ def get_project_issues(project_id: str, include_prs: bool = False, priority_fiel
                                 body
                                 state
                                 createdAt
-                                author { login }
+                                author { login ... on User { databaseId } }
                                 labels(first: 20) {
                                     nodes { name }
                                 }
@@ -401,6 +402,10 @@ def main():
             
             if classification:
                 priority = classification.get("priority")
+                author_id = (issue.get("author") or {}).get("databaseId")
+                if project_key == "support" and is_paid_customer(author_id):
+                    log_debug(f"Author {author} (id={author_id}) is a paid customer; overriding priority to Urgent for #{issue_number}")
+                    priority = "Urgent"
                 priority_option = project.get("priority_options", {}).get(priority)
                 item_id = issue.get("_item_id")
                 if priority_option and project.get("priority_field_id") and item_id:

--- a/.github/scripts/project-manager.py
+++ b/.github/scripts/project-manager.py
@@ -9,6 +9,8 @@ from typing import Optional
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 POLLINATIONS_TOKEN = os.getenv("POLLINATIONS_TOKEN")
+TINYBIRD_READ_TOKEN = os.getenv("TINYBIRD_READ_TOKEN")
+TINYBIRD_API = "https://api.europe-west2.gcp.tinybird.co"
 GITHUB_EVENT_JSON = os.getenv("GITHUB_EVENT", "{}")
 try:
     GITHUB_EVENT = json.loads(GITHUB_EVENT_JSON)
@@ -27,6 +29,7 @@ ISSUE_NUMBER = ITEM_DATA.get("number")
 ISSUE_TITLE = ITEM_DATA.get("title", "")
 ISSUE_BODY = ITEM_DATA.get("body", "") or ""
 ISSUE_AUTHOR = ITEM_DATA.get("user", {}).get("login", "")
+ISSUE_AUTHOR_ID = ITEM_DATA.get("user", {}).get("id")
 ISSUE_NODE_ID = ITEM_DATA.get("node_id", "")
 ISSUE_CREATED_AT = ITEM_DATA.get("created_at", "")
 GITHUB_API = "https://api.github.com"
@@ -79,7 +82,6 @@ CONFIG = {
             "priority_options": {
                 "Urgent": "5b4c403c",
                 "High": "509f6cf1",
-                "Medium": "ce60ee16",
                 "Low": "ca5161be",
             },
             "opened_field_id": "PVTF_lADOBS76fs4BLr1Hzg7WCHY",
@@ -124,6 +126,45 @@ def is_org_member(username: str) -> bool:
     is_member = username.lower() in [m.lower() for m in CONFIG["org_members"]]
     log_debug(f"Checked {username} org membership: {is_member}")
     return is_member
+
+
+_PAID_CUSTOMER_IDS: Optional[set] = None
+
+
+def fetch_paid_customer_ids() -> set:
+    """Return the set of GitHub numeric user IDs that have ever completed a paid
+    Stripe checkout. Cached for the lifetime of the process."""
+    global _PAID_CUSTOMER_IDS
+    if _PAID_CUSTOMER_IDS is not None:
+        return _PAID_CUSTOMER_IDS
+    if not TINYBIRD_READ_TOKEN:
+        log_debug("TINYBIRD_READ_TOKEN not set; skipping paid-customer lookup")
+        _PAID_CUSTOMER_IDS = set()
+        return _PAID_CUSTOMER_IDS
+    try:
+        r = requests.get(
+            f"{TINYBIRD_API}/v0/pipes/paid_customers.json",
+            headers={"Authorization": f"Bearer {TINYBIRD_READ_TOKEN}"},
+            timeout=15,
+        )
+        if r.status_code != 200:
+            log_error(f"Tinybird paid_customers HTTP {r.status_code}: {r.text[:200]}")
+            _PAID_CUSTOMER_IDS = set()
+            return _PAID_CUSTOMER_IDS
+        rows = r.json().get("data", [])
+        _PAID_CUSTOMER_IDS = {row["github_id"] for row in rows if row.get("github_id") is not None}
+        log_debug(f"Loaded {len(_PAID_CUSTOMER_IDS)} paid-customer GitHub IDs from Tinybird")
+        return _PAID_CUSTOMER_IDS
+    except (requests.RequestException, ValueError) as e:
+        log_error(f"Failed to fetch paid customers: {e}")
+        _PAID_CUSTOMER_IDS = set()
+        return _PAID_CUSTOMER_IDS
+
+
+def is_paid_customer(github_id) -> bool:
+    if github_id is None:
+        return False
+    return github_id in fetch_paid_customer_ids()
 
 def get_script_dir() -> str:
     return os.path.dirname(os.path.abspath(__file__))
@@ -262,10 +303,10 @@ Body: {ISSUE_BODY[:2000]}
 
             priority = raw.get("priority")
             if project == "support":
-                valid_priorities = {"Urgent", "High", "Medium", "Low"}
+                valid_priorities = {"High", "Low"}
                 if priority not in valid_priorities:
                     log_error(f"AI returned invalid priority: {priority}")
-                    priority = "Medium"
+                    priority = "Low"
             else:
                 priority = None
 
@@ -498,7 +539,10 @@ def main():
         log_debug(f"Project 'dev' is internal-only, but author {ISSUE_AUTHOR} is external. Reassigning to support.")
         project_key = "support"
     
-    priority = classification.get("priority", "Medium")
+    priority = classification.get("priority", "Low")
+    if project_key == "support" and is_paid_customer(ISSUE_AUTHOR_ID):
+        log_debug(f"Author {ISSUE_AUTHOR} (id={ISSUE_AUTHOR_ID}) is a paid customer; overriding priority to Urgent")
+        priority = "Urgent"
     log_debug(f"Classified: project={project_key}, priority={priority}")
     project = CONFIG["projects"].get(project_key)
     if not project:

--- a/.github/workflows/project-manager.yml
+++ b/.github/workflows/project-manager.yml
@@ -42,4 +42,5 @@ jobs:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           GITHUB_EVENT: ${{ toJSON(github.event) }}
           POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
+          TINYBIRD_READ_TOKEN: ${{ secrets.TINYBIRD_READ_TOKEN }}
         run: python .github/scripts/project-manager.py

--- a/enter.pollinations.ai/observability/endpoints/paid_customers.pipe
+++ b/enter.pollinations.ai/observability/endpoints/paid_customers.pipe
@@ -1,0 +1,20 @@
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+    GitHub user IDs (numeric, stable across renames) of users who have ever
+    completed a paid Stripe checkout. Used by
+    .github/scripts/project-manager.py to flag support issues from paid
+    customers as Urgent priority.
+
+NODE paid_customers_node
+SQL >
+    SELECT DISTINCT u.github_id AS github_id
+    FROM stripe_event s
+    INNER JOIN d1_user u ON s.user_id = u.id
+    WHERE s.event_type = 'checkout.session.completed'
+        AND s.payment_status = 'paid'
+        AND s.livemode = 1
+        AND u.github_id IS NOT NULL
+        AND u.synced_at = (SELECT max(synced_at) FROM d1_user)
+
+TYPE endpoint


### PR DESCRIPTION
Routes support issues from paid Stripe customers to Urgent priority automatically. AI now picks between High/Low only; Urgent is owned by the paid-customer override; Medium is dropped.

## What
- New Tinybird endpoint `paid_customers.pipe` — `SELECT DISTINCT u.github_id FROM stripe_event s INNER JOIN d1_user u ON s.user_id = u.id WHERE event_type='checkout.session.completed' AND payment_status='paid' AND livemode=1 AND synced_at = max(synced_at)`. Uses `github_id` (numeric, stable) instead of username so the flag survives renames.
- `project-manager.py` — fetches paid IDs from Tinybird (cached for process lifetime), overrides support priority to Urgent when `issue.user.id` matches.
- `project-backfill-labels.py` — same override; GraphQL query now pulls `author.databaseId`.
- Prompt — schema is `"priority": "High" | "Low" | null`; explicit rule that AI must not return Urgent.
- Workflow — passes `TINYBIRD_READ_TOKEN` secret.
- TRIAGE.md — new Priority Rules table.

## Out-of-band after merge
- Deploy the Tinybird pipe: from `enter.pollinations.ai/observability/`, `tb --cloud deploy --wait`.
- Add `TINYBIRD_READ_TOKEN` repo secret if not already present.
- Delete the `Medium` option from the Support project Priority field in the GitHub Project UI.
- Optional: run the backfill against existing Support issues to apply Urgent to paid customers retroactively.

## Why github_id over username
GitHub usernames can change. Joining on the stable numeric `github_id` keeps the flag attached after a rename.