### PR TITLE
fix(ci): clean working tree before switching to apidocs-sync branch

### DIFF
--- a/.github/workflows/docs-regenerate-apidocs.yml
+++ b/.github/workflows/docs-regenerate-apidocs.yml
@@ -107,6 +107,9 @@ jobs:
 
           # Save the regenerated file so we can re-apply it after switching branches
           cp APIDOCS.md /tmp/APIDOCS.md.new
+          # Discard the working-tree change so `git checkout` to the sync branch
+          # doesn't bail with "local changes would be overwritten"
+          git checkout -- APIDOCS.md
 
           git fetch origin "$BRANCH" || true
 


### PR DESCRIPTION
The `Regenerate API Docs` workflow has been failing at the `Create or update docs PR` step with:

```
error: Your local changes to the following files would be overwritten by checkout:
	APIDOCS.md
```

The step regenerates `APIDOCS.md` on the `main` checkout, copies it to `/tmp/APIDOCS.md.new`, then runs `git checkout -B docs/apidocs-sync origin/docs/apidocs-sync`. When the remote sync branch's `APIDOCS.md` differs from `main`'s, git refuses the checkout to avoid clobbering the uncommitted regeneration.

Fix: `git checkout -- APIDOCS.md` right after the `/tmp` copy, so the working tree is clean before the branch switch. The freshly generated content is re-applied from `/tmp/APIDOCS.md.new` after checkout, as before.

Failing run: https://github.com/pollinations/pollinations/actions/runs/25961789713