### PR TITLE
fix(image): concatenate all Gemini text parts in Vertex response

### DIFF
--- a/gen.pollinations.ai/src/image/vertexAIClient.ts
+++ b/gen.pollinations.ai/src/image/vertexAIClient.ts
@@ -357,13 +357,17 @@ export async function generateImageWithVertexAI(
             // Check if content and parts exist before iterating
             // When safety blocks content, candidate.content or parts may be undefined
             if (candidate.content?.parts) {
+                const textParts: string[] = [];
                 for (const part of candidate.content.parts) {
                     if (part.inlineData) {
                         imageData = part.inlineData.data;
                         mimeType = part.inlineData.mimeType;
                     } else if (part.text) {
-                        textResponse = part.text;
+                        textParts.push(part.text);
                     }
+                }
+                if (textParts.length > 0) {
+                    textResponse = textParts.join("\n");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Gemini 3 (`nanobanana-2`, `nanobanana-pro`) emits multiple text parts in `candidate.content.parts` — typically a thinking block followed by the final answer.
- `vertexAIClient.ts:365` was reassigning `textResponse = part.text` on each iteration, so only the **last** text part survived.
- After yesterday's error-surface fix (#11001), user-visible refusals therefore started mid-sentence (e.g. `"Gemini: realism of the provided image. Resources..."`, `"Gemini: generation process, not a disease."`).

## Fix
Collect all `text` parts into an array and join with `\n`.

## Test plan
- [x] `npx vitest run test/generation-vcr.test.ts` — 13/13 pass
- [ ] After deploy, verify refusals start at the beginning of Gemini's reply