### PR TITLE
model-monitor: 4h window + move per-model revenue to a private pipe

### DIFF
--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -80,6 +80,15 @@ function get2xxColor(ok2xx, total, excludedUserErrors = 0) {
     return "text-dark font-medium";
 }
 
+// Format a Pollen amount (1 Pollen ≈ $1) for the revenue/value columns.
+function formatPollen(value) {
+    if (!value || value <= 0) return null;
+    if (value < 0.01) return "<0.01";
+    if (value < 100) return value.toFixed(2);
+    if (value < 1000) return value.toFixed(0);
+    return `${(value / 1000).toFixed(1)}k`;
+}
+
 function getLatencyColor(latencySec) {
     if (latencySec < 2) return "text-secondary-strong";
     if (latencySec < 5) return "text-tertiary-strong";
@@ -321,6 +330,7 @@ function App() {
     const WINDOW_OPTIONS = [
         { key: "7d", label: "7d" },
         { key: "24h", label: "24h" },
+        { key: "4h", label: "4h" },
         { key: "60m", label: "1h" },
         { key: "5m", label: "5m" },
     ];
@@ -442,6 +452,17 @@ function App() {
                 const bPct = (b.stats?.errors_4xx || 0) / bTotal;
                 return dir * (aPct - bPct);
             }
+            case "paidRevenue":
+                return (
+                    dir *
+                    ((a.stats?.paid_revenue || 0) -
+                        (b.stats?.paid_revenue || 0))
+                );
+            case "tierValue":
+                return (
+                    dir *
+                    ((a.stats?.tier_value || 0) - (b.stats?.tier_value || 0))
+                );
             case "status":
                 return dir * (statusSeverity(a) - statusSeverity(b));
             case "provider":
@@ -675,6 +696,24 @@ function App() {
                                     onSort={handleSort}
                                     align="right"
                                 />
+                                {adminMode && (
+                                    <>
+                                        <SortableTh
+                                            label="Paid"
+                                            sortKey="paidRevenue"
+                                            currentSort={sort}
+                                            onSort={handleSort}
+                                            align="right"
+                                        />
+                                        <SortableTh
+                                            label="Tier"
+                                            sortKey="tierValue"
+                                            currentSort={sort}
+                                            onSort={handleSort}
+                                            align="right"
+                                        />
+                                    </>
+                                )}
                                 <SortableTh
                                     label="Success"
                                     sortKey="ok2xx"
@@ -716,7 +755,7 @@ function App() {
                             {filteredModels.length === 0 ? (
                                 <tr>
                                     <td
-                                        colSpan={adminMode ? 10 : 9}
+                                        colSpan={adminMode ? 12 : 9}
                                         className="p-8 text-center text-subtle"
                                     >
                                         {lastUpdated
@@ -812,6 +851,34 @@ function App() {
                                                     "—"
                                                 )}
                                             </td>
+                                            {adminMode && (
+                                                <>
+                                                    <td className="px-3 py-2 text-right tabular-nums">
+                                                        {formatPollen(
+                                                            stats?.paid_revenue,
+                                                        ) ? (
+                                                            <span className="text-dark font-medium">
+                                                                {formatPollen(
+                                                                    stats?.paid_revenue,
+                                                                )}
+                                                            </span>
+                                                        ) : (
+                                                            <span className="text-border">
+                                                                —
+                                                            </span>
+                                                        )}
+                                                    </td>
+                                                    <td className="px-3 py-2 text-right tabular-nums text-subtle">
+                                                        {formatPollen(
+                                                            stats?.tier_value,
+                                                        ) || (
+                                                            <span className="text-border">
+                                                                —
+                                                            </span>
+                                                        )}
+                                                    </td>
+                                                </>
+                                            )}
                                             <td
                                                 className={`px-3 py-2 text-right tabular-nums ${get2xxColor(
                                                     stats?.status_2xx || 0,

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -80,15 +80,6 @@ function get2xxColor(ok2xx, total, excludedUserErrors = 0) {
     return "text-dark font-medium";
 }
 
-// Format a Pollen amount (1 Pollen ≈ $1) for the revenue/value columns.
-function formatPollen(value) {
-    if (!value || value <= 0) return null;
-    if (value < 0.01) return "<0.01";
-    if (value < 100) return value.toFixed(2);
-    if (value < 1000) return value.toFixed(0);
-    return `${(value / 1000).toFixed(1)}k`;
-}
-
 function getLatencyColor(latencySec) {
     if (latencySec < 2) return "text-secondary-strong";
     if (latencySec < 5) return "text-tertiary-strong";
@@ -452,17 +443,6 @@ function App() {
                 const bPct = (b.stats?.errors_4xx || 0) / bTotal;
                 return dir * (aPct - bPct);
             }
-            case "paidRevenue":
-                return (
-                    dir *
-                    ((a.stats?.paid_revenue || 0) -
-                        (b.stats?.paid_revenue || 0))
-                );
-            case "tierValue":
-                return (
-                    dir *
-                    ((a.stats?.tier_value || 0) - (b.stats?.tier_value || 0))
-                );
             case "status":
                 return dir * (statusSeverity(a) - statusSeverity(b));
             case "provider":
@@ -696,24 +676,6 @@ function App() {
                                     onSort={handleSort}
                                     align="right"
                                 />
-                                {adminMode && (
-                                    <>
-                                        <SortableTh
-                                            label="Paid"
-                                            sortKey="paidRevenue"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label="Tier"
-                                            sortKey="tierValue"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                    </>
-                                )}
                                 <SortableTh
                                     label="Success"
                                     sortKey="ok2xx"
@@ -755,7 +717,7 @@ function App() {
                             {filteredModels.length === 0 ? (
                                 <tr>
                                     <td
-                                        colSpan={adminMode ? 12 : 9}
+                                        colSpan={adminMode ? 10 : 9}
                                         className="p-8 text-center text-subtle"
                                     >
                                         {lastUpdated
@@ -851,34 +813,6 @@ function App() {
                                                     "—"
                                                 )}
                                             </td>
-                                            {adminMode && (
-                                                <>
-                                                    <td className="px-3 py-2 text-right tabular-nums">
-                                                        {formatPollen(
-                                                            stats?.paid_revenue,
-                                                        ) ? (
-                                                            <span className="text-dark font-medium">
-                                                                {formatPollen(
-                                                                    stats?.paid_revenue,
-                                                                )}
-                                                            </span>
-                                                        ) : (
-                                                            <span className="text-border">
-                                                                —
-                                                            </span>
-                                                        )}
-                                                    </td>
-                                                    <td className="px-3 py-2 text-right tabular-nums text-subtle">
-                                                        {formatPollen(
-                                                            stats?.tier_value,
-                                                        ) || (
-                                                            <span className="text-border">
-                                                                —
-                                                            </span>
-                                                        )}
-                                                    </td>
-                                                </>
-                                            )}
                                             <td
                                                 className={`px-3 py-2 text-right tabular-nums ${get2xxColor(
                                                     stats?.status_2xx || 0,

--- a/apps/model-monitor/src/hooks/useModelMonitor.js
+++ b/apps/model-monitor/src/hooks/useModelMonitor.js
@@ -22,6 +22,7 @@ const MODEL_ENDPOINTS = {
 const WINDOW_MINUTES = {
     "7d": 10080,
     "24h": 1440,
+    "4h": 240,
     "60m": 60,
     "5m": 5,
 };
@@ -30,6 +31,7 @@ const WINDOW_MINUTES = {
 const POLL_INTERVALS = {
     "7d": 300000, // 5 minutes for 7-day view
     "24h": 120000, // 2 minutes for 24-hour view
+    "4h": 60000, // 1 minute for 4-hour view
     "60m": 60000, // 1 minute for stable 60m view
     "5m": 15000, // 15 seconds for live 5m view
 };

--- a/enter.pollinations.ai/observability/endpoints/model_health.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health.pipe
@@ -18,6 +18,8 @@ SQL >
         countIf(response_status >= 200 AND response_status < 300) as status_2xx,
         countIf(response_status >= 400 AND response_status < 500) as errors_4xx,
         countIf(response_status >= 500) as errors_5xx,
+        round(sumIf(total_price, selected_meter_slug = 'v1:meter:pack' AND response_status >= 200 AND response_status < 300), 4) as paid_revenue,
+        round(sumIf(total_price, selected_meter_slug = 'v1:meter:tier' AND response_status >= 200 AND response_status < 300), 4) as tier_value,
         maxIf(start_time, response_status >= 500) as last_error_at,
         round(quantileIf(0.5)(response_time, response_status >= 200 AND response_status < 300), 0) as latency_p50_ms,
         round(quantileIf(0.95)(response_time, response_status >= 200 AND response_status < 300), 0) as latency_p95_ms,

--- a/enter.pollinations.ai/observability/endpoints/model_health.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health.pipe
@@ -18,8 +18,6 @@ SQL >
         countIf(response_status >= 200 AND response_status < 300) as status_2xx,
         countIf(response_status >= 400 AND response_status < 500) as errors_4xx,
         countIf(response_status >= 500) as errors_5xx,
-        round(sumIf(total_price, selected_meter_slug = 'v1:meter:pack' AND response_status >= 200 AND response_status < 300), 4) as paid_revenue,
-        round(sumIf(total_price, selected_meter_slug = 'v1:meter:tier' AND response_status >= 200 AND response_status < 300), 4) as tier_value,
         maxIf(start_time, response_status >= 500) as last_error_at,
         round(quantileIf(0.5)(response_time, response_status >= 200 AND response_status < 300), 0) as latency_p50_ms,
         round(quantileIf(0.95)(response_time, response_status >= 200 AND response_status < 300), 0) as latency_p95_ms,

--- a/enter.pollinations.ai/observability/endpoints/model_revenue.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_revenue.pipe
@@ -1,0 +1,28 @@
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+Per-model revenue breakdown for successful requests, grouped by model and event type.
+Splits revenue by which balance bucket actually paid:
+  - paid_revenue: requests billed to a pack (paid top-up) meter
+  - tier_value:   requests billed to tier allowance
+Only successful (2xx) requests are summed.
+PRIVATE: uses `tinybird_read` only (not `tinybird_read_public`) — exposes monetization
+data per model, not suitable for the public model monitor token.
+Time window controlled by the `minutes` parameter (default 60).
+
+NODE model_revenue_stats
+SQL >
+    %
+    SELECT
+        resolved_model_requested as model,
+        event_type,
+        count() as total_requests,
+        countIf(response_status >= 200 AND response_status < 300) as status_2xx,
+        round(sumIf(total_price, selected_meter_slug = 'v1:meter:pack' AND response_status >= 200 AND response_status < 300), 4) as paid_revenue,
+        round(sumIf(total_price, selected_meter_slug = 'v1:meter:tier' AND response_status >= 200 AND response_status < 300), 4) as tier_value
+    FROM generation_event
+    WHERE start_time >= now() - interval {{Int32(minutes, 60)}} minute
+    GROUP BY resolved_model_requested, event_type
+    ORDER BY paid_revenue DESC
+
+TYPE endpoint


### PR DESCRIPTION
Two small unrelated changes:

**4h aggregation window** between `24h` and `1h`. Useful for catching multi-hour traffic dips that the 1h view misses and the 24h view smooths over.

**Per-model revenue moved off the public token.** An earlier commit on this branch added `paid_revenue` / `tier_value` to `model_health.pipe`, which is granted the public read token — that exposed per-model monetization data to anyone who can read the model monitor's bundle. Reverted on the public pipe; the same aggregates now live in a new `model_revenue.pipe` that is granted `tinybird_read` (private) only. The frontend columns are reverted along with this — they need a separate authenticated path before they can render private data, which is a follow-up.

Verification:
- public pipe response no longer contains the revenue fields
- public token → private pipe returns HTTP 403
- admin token → private pipe returns the data
- Tinybird deployments: #109 (initial — landed the leak) then #110 (revert + private pipe)