### PR TITLE
fix(image): normalize whitespace + case in model param

### DIFF
--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -40,6 +40,27 @@ test.for(
     expect(resolved).toBe(shouldResolveTo);
 });
 
+test("resolveModelName tolerates surrounding whitespace", () => {
+    for (const raw of ["zimage ", "  zimage", " zimage\n", "\tzimage\t"]) {
+        expect(resolveModelName(raw)).toBe("zimage");
+    }
+});
+
+test("resolveModelName lower-cases the input", () => {
+    expect(resolveModelName("ZIMAGE")).toBe("zimage");
+    expect(resolveModelName("Flux")).toBe("flux");
+});
+
+test("resolveModelName normalizes aliases too", () => {
+    expect(resolveModelName(" Z-Image ")).toBe("zimage");
+});
+
+test("resolveModelName still throws on unknown models", () => {
+    expect(() => resolveModelName("definitely-not-a-real-model")).toThrow(
+        /Invalid model or alias/,
+    );
+});
+
 test("cost lookup uses the public model name instead of collapsing shared provider ids", () => {
     const usage = {
         promptTextTokens: 1_000_000,

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -20,7 +20,11 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     // Image model params
     model: z
         .preprocess(
-            (val) => (val === "" ? undefined : val),
+            (val) => {
+                if (typeof val !== "string") return val;
+                const normalized = val.trim().toLowerCase();
+                return normalized === "" ? undefined : normalized;
+            },
             z
                 .enum(VALID_IMAGE_MODELS as unknown as [string, ...string[]])
                 .optional()

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -193,11 +193,17 @@ const MODEL_REGISTRY = Object.fromEntries(
  * @throws Error if model is not found
  */
 export function resolveModelName(model: string): ModelName {
-    if (MODEL_REGISTRY[model as ModelName]) {
-        return model as ModelName;
+    // Normalize whitespace and case so callers can pass e.g. " ZIMAGE\n" —
+    // registry keys and aliases are all lowercase, so this is a no-op for
+    // already-canonical input but tolerates common client-side template
+    // artifacts (trailing newlines from n8n/Make, uppercased UI strings).
+    const normalized =
+        typeof model === "string" ? model.trim().toLowerCase() : model;
+    if (MODEL_REGISTRY[normalized as ModelName]) {
+        return normalized as ModelName;
     }
     for (const [modelName, service] of Object.entries(MODEL_REGISTRY)) {
-        if (service.aliases.includes(model)) {
+        if (service.aliases.includes(normalized)) {
             return modelName as ModelName;
         }
     }


### PR DESCRIPTION
n8n templates often inject trailing newlines or uppercased strings into the `model` query param. The current image route then 400s with `"Invalid option: expected one of ... zimage ..."` — listing `zimage` as valid while rejecting `"zimage "` or `ZIMAGE`. Reported by users hitting this from n8n at night (time-of-day was a red herring — it's whatever workflow runs at that hour that introduces the whitespace).

- `gen.pollinations.ai/src/schemas/image.ts` — preprocess the model param to trim + lowercase before the enum check. The query validator runs ahead of the `resolveModel` middleware, so this layer needs the fix on its own.
- `shared/registry/registry.ts` — apply the same normalization in `resolveModelName` so JSON POST paths (`/v1/images/generations` etc.) and other categories benefit too.
- New unit tests on `resolveModelName` for whitespace, casing, aliases, and the still-rejects-unknown case.

**Out of scope:** literal surrounding quotes (e.g. `model="zimage"`). Trim/lowercase covers the reported failure modes; quote-stripping would start swallowing user-side template errors and isn't requested.

Verified locally with `wrangler dev`:
- `model=zimage%20`, `model=%0Azimage`, `model=ZIMAGE` now pass query validation (401 = auth, not 400 = validation)
- `model=not-a-real-model` still 400s as expected

213/213 gen tests pass, 191/191 enter alias tests pass.

Fixes #9468