### PR TITLE
fix(gen): capture upstream body when chat response fails schema validation

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -136,13 +136,23 @@ const chatCompletionHandlers = factory.createHandlers(
         // add content filter headers if not streaming
         let contentFilterHeaders = {};
         if (!c.var.track.streamRequested) {
-            const responseJson = await response.clone().json();
-            const parsedResponse = CreateChatCompletionResponseSchema.parse(
-                responseJson,
-                { reportInput: true },
-            );
-            contentFilterHeaders =
-                contentFilterResultsToHeaders(parsedResponse);
+            const responseText = await response.clone().text();
+            try {
+                const parsedResponse = CreateChatCompletionResponseSchema.parse(
+                    JSON.parse(responseText),
+                    { reportInput: true },
+                );
+                contentFilterHeaders =
+                    contentFilterResultsToHeaders(parsedResponse);
+            } catch (parseError) {
+                throw new UpstreamError(502, {
+                    message: `Upstream returned response that failed schema validation: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+                    requestUrl: new URL(c.req.url),
+                    upstreamStatus: response.status,
+                    responseBody: responseText,
+                    cause: parseError,
+                });
+            }
         }
 
         return withSafetyHeaders(


### PR DESCRIPTION
## Summary
- Wrap chat-completion response parse in try/catch and re-throw as `UpstreamError` so the raw upstream body is logged via `error_event.upstream_body` when validation fails
- Currently a plain `ZodError` is thrown and the malformed JSON is discarded — we get 22+ daily 500s on `mistral-large` with `usage:null` and no way to see what Portkey/Azure actually returned
- Schema NOT loosened: we still reject responses without proper usage (billing depends on it); this PR just gives us debug visibility into the root cause

## Background

Investigation of Mistral errors (#11039 logging) surfaced a pattern: `mistral-large` + `response_format: json_object` + non-streaming returns ZodError "usage: expected object, received null". Direct Azure + direct Portkey replays of the failing payload both return proper usage objects. Production fails with empty `upstream_body` because the Zod error path doesn't capture it.

## Test plan
- [x] `npx vitest run` (220/220 pass)
- [x] `npx tsc --noEmit` clean on gen + enter
- [ ] After deploy: confirm next `usage:null` 500 has populated `upstream_body` in Tinybird `error_event` so we can finally see what Portkey is returning

🤖 Generated with [Claude Code](https://claude.com/claude-code)