### PR TITLE
fix(gen): remove artificial fetch timeouts

### DIFF
--- a/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
+++ b/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
@@ -24,20 +24,6 @@ import {
 const logError = debug("pollinations:error");
 const logCloudflare = debug("pollinations:cloudflare");
 
-function withTimeout<T>(
-    promise: Promise<T>,
-    ms: number,
-    label: string,
-): Promise<T> {
-    const timeout = new Promise<never>((_, reject) => {
-        setTimeout(
-            () => reject(new Error(`${label} timeout after ${ms / 1000}s`)),
-            ms,
-        );
-    });
-    return Promise.race([promise, timeout]);
-}
-
 /**
  * Calls the Azure Flux Kontext API to generate or edit images
  * Supports both text-to-image generation and image-to-image editing
@@ -74,13 +60,8 @@ export async function callAzureFluxKontext(
         logCloudflare("Using Azure Flux Kontext in generation mode");
     }
 
-    // Check prompt safety with Azure Content Safety (with 30s timeout)
     logCloudflare("Checking prompt safety...");
-    const promptSafetyResult = await withTimeout(
-        analyzeTextSafety(prompt),
-        30000,
-        "Azure Content Safety check",
-    );
+    const promptSafetyResult = await analyzeTextSafety(prompt);
 
     // Log the prompt with safety analysis results
     await logGptImagePrompt(prompt, safeParams, userInfo, promptSafetyResult);
@@ -143,13 +124,8 @@ export async function callAzureFluxKontext(
 
             const { buffer, mimeType } = await downloadUserImage(imageUrl);
 
-            // Check safety of input image (with 30s timeout)
             logCloudflare("Checking safety of input image");
-            const imageSafetyResult = await withTimeout(
-                analyzeImageSafety(buffer),
-                30000,
-                "Azure Image Safety check",
-            );
+            const imageSafetyResult = await analyzeImageSafety(buffer);
 
             if (!imageSafetyResult.safe) {
                 const errorMessage = `Input image contains unsafe content: ${imageSafetyResult.formattedViolations}`;

--- a/gen.pollinations.ai/src/image/util.ts
+++ b/gen.pollinations.ai/src/image/util.ts
@@ -1,34 +1,3 @@
-/**
- * Wraps a promise factory with a timeout that creates and manages an AbortController internally.
- * The promise factory receives an AbortSignal that will be aborted when the timeout occurs.
- *
- * @param promiseFactory - Function that creates a promise and accepts an AbortSignal
- * @param timeoutMs - Timeout in milliseconds
- * @returns Promise that resolves/rejects with the original promise or timeout error
- *
- * @example
- * const response = await withTimeoutSignal(
- *   (signal) => fetch('/api/data', { signal }),
- *   30000
- * );
- */
-export function withTimeoutSignal<T>(
-    promiseFactory: (signal: AbortSignal) => Promise<T>,
-    timeoutMs: number,
-): Promise<T> {
-    const controller = new AbortController();
-
-    const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
-            controller.abort();
-            reject(new Error(`Operation timed out after ${timeoutMs}ms`));
-        }, timeoutMs);
-    });
-
-    const promise = promiseFactory(controller.signal);
-    return Promise.race([promise, timeoutPromise]);
-}
-
 export async function sleep(ms: number) {
     await new Promise<void>((resolve, _) => setTimeout(resolve, ms));
 }

--- a/gen.pollinations.ai/src/text/auth/googleCloudAuth.ts
+++ b/gen.pollinations.ai/src/text/auth/googleCloudAuth.ts
@@ -12,7 +12,6 @@ interface ServiceAccountKey {
 }
 
 const TOKEN_REFRESH_SKEW_MS = 60_000;
-const GOOGLE_TOKEN_TIMEOUT_MS = 10_000;
 
 let cachedToken: string | null = null;
 let tokenExpiration = 0;
@@ -78,7 +77,6 @@ async function exchangeJwtForAccessToken(
                 grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
                 assertion: jwt,
             }),
-            signal: AbortSignal.timeout(GOOGLE_TOKEN_TIMEOUT_MS),
         });
 
         if (!response.ok) {

--- a/gen.pollinations.ai/src/text/genericOpenAIClient.ts
+++ b/gen.pollinations.ai/src/text/genericOpenAIClient.ts
@@ -17,8 +17,6 @@ import { cleanNullAndUndefined } from "./utils/objectCleaners.js";
 const log = debug("pollinations:genericopenai");
 const errorLog = debug("pollinations:error");
 const DONE_EVENT_PATTERN = /data:\s*\[DONE\]/;
-const DEFAULT_UPSTREAM_TIMEOUT_MS = 90_000;
-const STREAM_UPSTREAM_TIMEOUT_MS = 300_000;
 
 function ensureOpenAISseDone(
     source: ReadableStream<Uint8Array> | null,
@@ -82,25 +80,6 @@ function createApiError(
     ) as ServiceError;
     error.status = response.status;
     error.details = details;
-    error.model = modelName;
-    return error;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-    return (
-        error instanceof DOMException &&
-        (error.name === "AbortError" || error.name === "TimeoutError")
-    );
-}
-
-function createTimeoutError(
-    modelName: string,
-    timeoutMs: number,
-): ServiceError {
-    const error = new Error(
-        `Upstream provider timed out after ${timeoutMs}ms`,
-    ) as ServiceError;
-    error.status = 504;
     error.model = modelName;
     return error;
 }
@@ -190,23 +169,11 @@ export async function genericOpenAIClient(
 
         log(`[${requestId}] Header keys:`, Object.keys(headers));
 
-        const timeoutMs = normalizedOptions.stream
-            ? STREAM_UPSTREAM_TIMEOUT_MS
-            : DEFAULT_UPSTREAM_TIMEOUT_MS;
-        let response: Response;
-        try {
-            response = await fetch(endpointUrl, {
-                method: "POST",
-                headers,
-                body: JSON.stringify(requestBody),
-                signal: AbortSignal.timeout(timeoutMs),
-            });
-        } catch (thrown: unknown) {
-            if (isAbortLikeError(thrown)) {
-                throw createTimeoutError(modelName, timeoutMs);
-            }
-            throw thrown;
-        }
+        const response = await fetch(endpointUrl, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(requestBody),
+        });
 
         if (!response.ok) {
             const errorText = await response.text();

--- a/gen.pollinations.ai/src/text/transforms/imageUrlToBase64Transform.ts
+++ b/gen.pollinations.ai/src/text/transforms/imageUrlToBase64Transform.ts
@@ -28,7 +28,6 @@ class ImageFetchError extends Error {
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024;
 const MAX_TOTAL_IMAGE_BYTES = MAX_IMAGE_SIZE;
 const MAX_IMAGES_PER_REQUEST = 8;
-const IMAGE_FETCH_TIMEOUT_MS = 30_000;
 
 const BLOCKED_HOSTNAMES = /^localhost$/i;
 
@@ -163,7 +162,6 @@ async function fetchImageAsBase64(
         log(`Fetching image: ${validatedUrl.origin}${validatedUrl.pathname}`);
         const response = await fetch(validatedUrl, {
             redirect: "manual",
-            signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
             headers: { "User-Agent": "Pollinations/1.0" },
         });
 
@@ -237,14 +235,11 @@ async function fetchImageAsBase64(
 
         const error = thrown as {
             message?: string;
-            name?: string;
         };
         const message = error.message || "Unknown error";
         let errorMessage = `Failed to fetch image from ${url}: ${message}`;
 
-        if (error.name === "AbortError") {
-            errorMessage = `Image fetch timeout for ${url}: The server took too long to respond (>30 seconds). Please try a faster image host.`;
-        } else if (error instanceof TypeError) {
+        if (error instanceof TypeError) {
             if (/dns|domain|not found|resolve/i.test(message)) {
                 errorMessage = `Invalid image URL ${url}: The domain could not be found. Please check the URL is correct.`;
             } else if (/connect|refused|unreachable/i.test(message)) {

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -12,6 +12,7 @@ describe("genericOpenAIClient", () => {
         vi.spyOn(globalThis, "fetch").mockImplementationOnce(
             async (input, init) => {
                 expect(String(input)).toBe("https://portkey.test/chat");
+                expect(init?.signal).toBeUndefined();
                 upstreamBody = JSON.parse(String(init?.body));
                 return Response.json({
                     id: "chatcmpl_test",

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -8,13 +8,11 @@ afterEach(() => {
 describe("genericOpenAIClient", () => {
     it("does not send internal gateway options in the upstream JSON body", async () => {
         let upstreamBody: Record<string, unknown> | undefined;
-        let upstreamSignal: AbortSignal | undefined;
 
         vi.spyOn(globalThis, "fetch").mockImplementationOnce(
             async (input, init) => {
                 expect(String(input)).toBe("https://portkey.test/chat");
                 upstreamBody = JSON.parse(String(init?.body));
-                upstreamSignal = init?.signal as AbortSignal;
                 return Response.json({
                     id: "chatcmpl_test",
                     object: "chat.completion",
@@ -73,7 +71,6 @@ describe("genericOpenAIClient", () => {
         expect(upstreamBody).not.toHaveProperty("requestedModel");
         expect(upstreamBody).not.toHaveProperty("userApiKey");
         expect(upstreamBody).not.toHaveProperty("userInfo");
-        expect(upstreamSignal).toBeInstanceOf(AbortSignal);
     });
 
     it("drops invalid optional message names before sending upstream", async () => {


### PR DESCRIPTION
## Summary
- Removes the 90s/300s timeout from generic OpenAI/Portkey fetches.
- Removes manual timeout caps from Google token exchange and text image inlining.
- Removes unused timeout helper code and Azure Content Safety Promise.race wrappers.
- Keeps Tinybird ingest timeout and explicit async polling budgets.

## Tests
- npx biome check --write <changed files>
- npx tsc --noEmit
- npx vitest run test/text/genericOpenAIClient.test.ts test/text/transforms/imageUrlToBase64Transform.test.ts