### PR TITLE
fix(gen): return 400 when upstream rejects unsupported modality

### DIFF
--- a/gen.pollinations.ai/src/error.ts
+++ b/gen.pollinations.ai/src/error.ts
@@ -60,13 +60,26 @@ export async function ensureUpstreamOk(
     const rawMessage =
         extractUpstreamMessage(responseBody) ||
         getDefaultErrorMessage(response.status);
-    throw new UpstreamError(remapUpstreamStatus(response.status), {
+    const status = isUserInputModalityRejection(response.status, rawMessage)
+        ? 400
+        : remapUpstreamStatus(response.status);
+    throw new UpstreamError(status, {
         message: truncateString(rawMessage, MAX_ERROR_MESSAGE_LENGTH) ?? "",
         requestUrl:
             typeof requestUrl === "string" ? new URL(requestUrl) : requestUrl,
         upstreamStatus: response.status,
         responseBody,
     });
+}
+
+function isUserInputModalityRejection(
+    upstreamStatus: number,
+    message: string,
+): boolean {
+    return (
+        upstreamStatus === 404 &&
+        /no endpoints found that support image input/i.test(message)
+    );
 }
 
 function extractUpstreamMessage(body: string): string {


### PR DESCRIPTION
## Summary
- Before: clients sending \`image_url\` to text-only models (e.g. \`deepseek\`) got back a 502 because we remapped OpenRouter's 404 'no endpoints found that support image input' as a gateway error
- After: those user-input errors return 400 so the client sees them as their bug, not ours

## Detection
With \`request_inputs\` logging now in place, we can confirm 100+ daily errors of this shape, dominated by one user sending images to deepseek

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` (220/220 pass)