### PR TITLE
fix(gen): bump AssemblyAI transcription poll timeout 120s → 240s

### DIFF
--- a/gen.pollinations.ai/src/routes/assemblyai-transcription.ts
+++ b/gen.pollinations.ai/src/routes/assemblyai-transcription.ts
@@ -8,7 +8,7 @@ import { ensureUpstreamOk, UpstreamError } from "@/error.ts";
 
 const ASSEMBLYAI_API_BASE = "https://api.assemblyai.com";
 const ASSEMBLYAI_POLL_INTERVAL_MS = 2_000;
-const ASSEMBLYAI_TRANSCRIPTION_TIMEOUT_MS = 120_000;
+const ASSEMBLYAI_TRANSCRIPTION_TIMEOUT_MS = 240_000;
 const ASSEMBLYAI_MODELS: Record<string, string[]> = {
     "universal-2": ["universal-2"],
     "universal-3-pro": ["universal-3-pro", "universal-2"],


### PR DESCRIPTION
## Summary
- Real-world traffic shows ~7 daily transcription jobs timing out at exactly the 120s cap (measured durations 121-124s)
- Doubling to 240s — same bounded-polling shape, more realistic room for longer audio files

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] transcription tests pass (5/5)