### PR TITLE
fix(gen): throttle image server registry KV writes (1×/30s per key)

### DIFF
--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -13,9 +13,11 @@ type ServerEntry = {
 
 const SERVER_TIMEOUT = 180000;
 const REGISTRY_TTL_SECONDS = 240;
+const REGISTRY_WRITE_THROTTLE_MS = 30_000;
 
 let serverRegistry: KVNamespace | null = null;
 let registryEnvironment = "development";
+const recentWrites = new Map<string, number>();
 
 export function setServerRegistryBinding(
     binding: KVNamespace,
@@ -57,10 +59,20 @@ export const registerServer = async (
 ): Promise<void> => {
     const kv = getServerRegistry();
     const key = prefix(type) + (await urlHash(url));
-    const entry: ServerEntry = { url, lastHeartbeat: Date.now() };
+    const now = Date.now();
+    const lastWrite = recentWrites.get(key);
+    if (
+        lastWrite !== undefined &&
+        now - lastWrite < REGISTRY_WRITE_THROTTLE_MS
+    ) {
+        logServer(`Skipped throttled write for ${type} server ${url}`);
+        return;
+    }
+    const entry: ServerEntry = { url, lastHeartbeat: now };
     await kv.put(key, JSON.stringify(entry), {
         expirationTtl: REGISTRY_TTL_SECONDS,
     });
+    recentWrites.set(key, now);
     logServer(`Registered ${type} server ${url}`);
 };
 


### PR DESCRIPTION
## Summary
- Throttle \`registerServer\` KV writes to once-per-30s per key (in-memory Map, per-isolate)
- Eliminates ~100 daily \`KV PUT failed: 429 Too Many Requests\` errors on \`POST /register\` caused by GPU servers heartbeat-registering faster than Cloudflare KV's 1-write/sec/key cap

## Why this is safe
- Previous write already sets \`expirationTtl=240s\`, so the registry entry stays fresh well past the 30s throttle
- Per-isolate Map → different isolates each get one write; bounded by KV key count (a few dozen image GPU servers)
- Throttled writes are logged but don't error out

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` (220/220 pass)