### PR TITLE
fix(gen): point staging worker at pollinations_enter_staging tinybird workspace

### DIFF
--- a/gen.pollinations.ai/secrets/staging.vars.json
+++ b/gen.pollinations.ai/secrets/staging.vars.json
@@ -26,7 +26,7 @@
 	"PLN_GPU_TOKEN": "ENC[AES256_GCM,data:tKnv/Y9EtuRPr+th1rJLyc61O9Jx7ZOeU3O14KwT8rQgILu4YHIn,iv:nXAm5wO186PlENwfA48h1dgjnf5BUoP5zMVa1AI45Xk=,tag:2KhCt6eoG9AxG8bHFPWHPg==,type:str]",
 	"PORTKEY_GATEWAY_URL": "ENC[AES256_GCM,data:dsBl+Wwbh2DELqKsnouVRnWz7AdceM0lG3xcIjLdeg==,iv:6I6lOSCwwygp+MgDb4LyNgRk4EOx/e/YdjL94uDbUKY=,tag:iMQCrKDKTanSvS2uN6AO5Q==,type:str]",
 	"PRUNA_API_KEY": "ENC[AES256_GCM,data:++Uil6VRCasp+9ik+VLD9x7JzTxfffSLGDaRyrch4uitkVdS,iv:jG1cBw9d+8e7uSTRwDnicvOVlCaojr7lATOmB5/i2Qs=,tag:91KIa6eUFnX0h6Sk9s2NNQ==,type:str]",
-	"TINYBIRD_INGEST_TOKEN": "ENC[AES256_GCM,data:uR34vv4QBzYOhrxwnGDcCTRITvV5h56TyCjbHqCWKYEz4YYSx3mt63ZWrZPKCICT1BgPr7+VOZ+nJMEaik0QYN09BVSiekS6g5rH/UY/ThSXbKgrlGIWJ8EXp+aQYFczAWbHaraLLuiP11jqGKftKGmq0cPPgsNrFeluGBhPjun985QHpHGQldnrQveZ/JUjuSlFM3HEHTaquky1HikNro8LNm3TT2+Q1ViASFyesB4vgDiCtRrzHlgLWl6aOHO58AGc14gTsi3JFaP76g==,iv:JY/Vg92h6KM44NGn/LZ6Ia/Hd1nOiY2L2l5THhGY7cI=,tag:618Gvi+V3FWIiNCqNNmLHA==,type:str]",
+	"TINYBIRD_INGEST_TOKEN": "ENC[AES256_GCM,data:S+xdMFyEftIuckZlmRH/sTXHbl7ZJRhVIwjszHeoVezOdz5deXd6afAEO7Bh0UATMfZ0cUXA90WigTTxdNcaYjmflR9faCQzwb1otaktKZJc0kbtQ3ecbWOdBRtK9qZd9aZ914LriDjTd6k7SRAHGCLe5GwjX9T7H4e1uBV8yuoQ+B1LIr+Zwn3NGeYR3ouatpVB0+RGgOnXHiMdsrry8epxZWzlerCosOHlUiv4QNkstCPURP04JQKG6U7sifNhCOd4A/96aQpsjEjhWA==,iv:5zlkzAyzQIL82bgTCnjlMgS9TlrXeJzREO34ItmN+EY=,tag:RzzKPFtcIOK2mX8vSfoeEQ==,type:str]",
 	"XAI_API_KEY": "ENC[AES256_GCM,data:0PatVf4AxBluVg112Ts/DEsW2ecBF3th0474KPClDoM/X/j9iLJF2FdnspU8FJjOqz/cgF4V/fmpyNwf3mKCWA0jSnAAFVHpn81J9Tfps+Sbr/dW,iv:EeM8wLmVv0kD9Ttvqcu8j5iINOUaMuFcv+oeUQ8azQ8=,tag:EjoNzkmNHH4igjpChQ2tCw==,type:str]",
 	"LTX2_BASE_URL": "ENC[AES256_GCM,data:NRynjYPSY1g6x4e/xHyFOd8wtzR6gWfTXaR72V0pkLUP3w3Z,iv:kODnN5MuudpyiSaimvm65Unl/x9HuurGAfHwmZerUMo=,tag:RpYdld7bXMIgHxKPpIJFXg==,type:str]",
 	"OPENROUTER_API_KEY": "ENC[AES256_GCM,data:kvwTwj1UhJJXn8f3AcsGVWzNHd+k0sWJeqJeaKRY6oveBGbA8UZnq74EfcDOxx5OdkFoS52pE8yiuQcLAMKTeWBK3unAhyqjJw==,iv:GKZHBxRpztRa5ba2wi0fPokreuAtDLVYYgh0ezeFj7I=,tag:SR1T0ajW/B1c6k1rwtugtw==,type:str]",
@@ -47,8 +47,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFeld5czFJemNLNW9hOWt3\nczYzcFhWWUxyQi9vQ00rSVlUQnA2WStrbjNzCkpHT0FrM0xWeFJYalpDSUljUFdJ\ndWtoLzQ3YnJmYWcyalhjNVg2c3BCcTgKLS0tIEpDY2t0dWZMN2hOc1dWQjhPWlZo\nY1paeWpra3UySmRnc1JPdmdRMElDWkkKl0H6E4hIn8EeCPr5kQdEciBNN0EhNC5M\nghVFGNVGZn0OGJy4dvzGPhlBfizNeX+XSxmuJs3Hv8jmUKL/lRJ+0A==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-05-10T09:24:40Z",
-		"mac": "ENC[AES256_GCM,data:oH2MK50YBRgQ8WP/ZL/Bcv+nY3oUlXjKYMzfBcBpKfXWFz3CgIp9kSbX0cgnargLl8QPDqRI6k92Q9bMighky/RZK94kSFgLRP+vnOuhwALUAMc3jhsFOCJK152lIsMWixsbUTqPa+62uEJBIYZ40tDmF098kN1ngNZSSoQ6qRs=,iv:l3f9JQw9RZqucP+GA8rlOCZQF+a2321gy7zOkbocpms=,tag:WcND4JAz6z5opn7DuUqa5w==,type:str]",
+		"lastmodified": "2026-05-18T16:59:06Z",
+		"mac": "ENC[AES256_GCM,data:GibM0B3C9QhRNiO9pOCRy+HbdlmvCFX+A3opKoiLOG1vk+yhyfA2Hxo/5OaCtiMuaE76zMIEry6qdioTPukqrxZFwhX/DxQPcfkfn1IAtk0ZkDozdhq/b54OkEo67+c8NUmTp8NvPKoiVdeYPlYqBWqeDS0IAjB505kYailyBp4=,iv:WVVKGUBtW/Lzi3r+xlZRxriEy4TkuFgD4f1ewMXUEEI=,tag:K8Hn5+LxA0JTkf+XsA5ubQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
Complement to #11128. That PR swapped the enter staging worker's Tinybird token to write into the new `pollinations_enter_staging` workspace, but the gen staging worker still had its `TINYBIRD_INGEST_TOKEN` pointing at the prod workspace — so `generation_event` and `error_event` from `staging.gen.pollinations.ai` were still landing in prod.

- Swaps `TINYBIRD_INGEST_TOKEN` in `gen.pollinations.ai/secrets/staging.vars.json` to the staging workspace ingest token
- Pushed via `npm run push-secrets:staging`, worker auto-redeployed at 16:59
- Verified end-to-end: 3 test `generation_event`s from staging.gen.pollinations.ai now landing in the staging workspace; prod workspace shows only `production` rows in the same window

Related: #11127