### PR TITLE
fix(gen): validate chat image model capabilities

### DIFF
--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -5,6 +5,7 @@ import { generateHeaders } from "./transforms/headerGenerator.js";
 import { createImageUrlToBase64Transform } from "./transforms/imageUrlToBase64Transform.js";
 import { sanitizeMessages } from "./transforms/messageSanitizer.js";
 import { processParameters } from "./transforms/parameterProcessor.js";
+import { validateInputModalities } from "./transforms/validateInputModalities.js";
 import type {
     ChatCompletion,
     ChatMessage,
@@ -51,6 +52,7 @@ export async function generateTextPortkey(
 
     if (state.options.model) {
         state = await resolveModelConfig(state.messages, state.options);
+        state = validateInputModalities(state.messages, state.options);
         state = await generateHeaders(state.messages, state.options);
         state = await createImageUrlToBase64Transform()(
             state.messages,

--- a/gen.pollinations.ai/src/text/transforms/validateInputModalities.ts
+++ b/gen.pollinations.ai/src/text/transforms/validateInputModalities.ts
@@ -1,0 +1,53 @@
+import {
+    getModelDefinition,
+    resolveModelName,
+} from "@shared/registry/registry.ts";
+import type {
+    ChatMessage,
+    ServiceError,
+    TransformOptions,
+    TransformResult,
+} from "../types.js";
+
+type ContentPart = {
+    type?: unknown;
+};
+
+function inputModalityError(message: string): ServiceError {
+    const error = new Error(message) as ServiceError;
+    error.name = "InputModalityError";
+    error.status = 400;
+    return error;
+}
+
+function hasImageInput(messages: ChatMessage[]): boolean {
+    return messages.some((message) => {
+        if (!Array.isArray(message.content)) return false;
+        return message.content.some(
+            (part): part is ContentPart =>
+                !!part &&
+                typeof part === "object" &&
+                (part as ContentPart).type === "image_url",
+        );
+    });
+}
+
+export function validateInputModalities(
+    messages: ChatMessage[],
+    options: TransformOptions,
+): TransformResult {
+    if (!hasImageInput(messages)) return { messages, options };
+
+    const requestedModel = options.requestedModel || options.model;
+    if (!requestedModel) return { messages, options };
+
+    const modelName = resolveModelName(requestedModel);
+    const definition = getModelDefinition(modelName);
+    if (definition.inputModalities?.includes("image")) {
+        return { messages, options };
+    }
+
+    throw inputModalityError(
+        `Model '${modelName}' does not support image input. Choose a model with image input support.`,
+    );
+}

--- a/gen.pollinations.ai/test/text/transforms/validateInputModalities.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/validateInputModalities.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { validateInputModalities } from "../../../src/text/transforms/validateInputModalities.js";
+import type { ChatMessage } from "../../../src/text/types.js";
+
+const imageMessage: ChatMessage[] = [
+    {
+        role: "user",
+        content: [
+            { type: "text", text: "What is in this image?" },
+            {
+                type: "image_url",
+                image_url: { url: "https://example.com/image.png" },
+            },
+        ],
+    },
+];
+
+describe("validateInputModalities", () => {
+    it("rejects image input for text-only models", () => {
+        expect(() =>
+            validateInputModalities(imageMessage, {
+                model: "deepseek/deepseek-v4-flash",
+                requestedModel: "deepseek",
+            }),
+        ).toThrow(
+            expect.objectContaining({
+                name: "InputModalityError",
+                status: 400,
+                message:
+                    "Model 'deepseek' does not support image input. Choose a model with image input support.",
+            }),
+        );
+    });
+
+    it("allows image input for vision-capable models", () => {
+        expect(
+            validateInputModalities(imageMessage, {
+                model: "mistralai/mistral-small-3.2-24b-instruct",
+                requestedModel: "mistral",
+            }).messages,
+        ).toBe(imageMessage);
+    });
+
+    it("allows text-only requests for text-only models", () => {
+        const textMessage: ChatMessage[] = [{ role: "user", content: "Hello" }];
+
+        expect(
+            validateInputModalities(textMessage, {
+                model: "deepseek/deepseek-v4-flash",
+                requestedModel: "deepseek",
+            }).messages,
+        ).toBe(textMessage);
+    });
+});


### PR DESCRIPTION
- Rejects chat requests with `image_url` parts when the requested model does not support image input
- Runs validation globally after model resolution, before image fetching or upstream calls
- Adds focused tests for text-only and vision-capable models

Validation:
- `./node_modules/.bin/biome check gen.pollinations.ai/src/text/generateTextPortkey.ts gen.pollinations.ai/src/text/transforms/validateInputModalities.ts gen.pollinations.ai/test/text/transforms/validateInputModalities.test.ts`
- `../node_modules/.bin/tsc --noEmit`
- `../node_modules/.bin/tsx --eval ...` smoke test

Note: local Vitest could not start because Rollup's native optional dependency is blocked by macOS code signing in this environment; CI should run the normal test path.