### PR TITLE
fix(registry): suppress polly empty-cost warnings

### DIFF
--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -881,7 +881,10 @@ export const TEXT_SERVICES = {
         brand: "Pollinations",
         category: "text",
         addedDate: new Date("2026-02-24").getTime(),
-        cost: {},
+        cost: {
+            promptTextTokens: perMillion(0),
+            completionTextTokens: perMillion(0),
+        },
         description:
             "Polly by @Itachi-1824 - Pollinations AI Assistant with GitHub, Code Search & Web Tools (Alpha)",
         inputModalities: ["text", "image"],


### PR DESCRIPTION
## Summary

- Polly's registry entry had `cost: {}` (free community model by @Itachi-1824)
- Every request triggered `[registry] Missing conversion rate: model=polly usageType=promptTextTokens ...` warnings in production logs
- Replaced with explicit `perMillion(0)` for the two usage types Polly actually returns

## Why this is benign

- Behavior unchanged: still bills 0 (warnings already returned 0 for missing rates)
- Just silences log noise; clarifies intent in the registry

## Verification

After the deploy from PR #11147, only `mistral` (fixed in PR #11148) and `polly` were emitting these warnings. Mistral was a genuine billing leak; polly is intentionally free.

## Test plan
- [ ] Merge to main, sync to production
- [ ] Verify `[registry] Missing conversion rate: model=polly` warnings stop appearing in wrangler tail