### PR TITLE
fix(observability): prevent error-handler crash on c.req.param()

### DIFF
--- a/gen.pollinations.ai/test/error-observability.test.ts
+++ b/gen.pollinations.ai/test/error-observability.test.ts
@@ -3,6 +3,7 @@ import {
     waitOnExecutionContext,
 } from "cloudflare:test";
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { requestId } from "hono/request-id";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
@@ -181,6 +182,63 @@ describe("error observability", () => {
                 max_tokens: 256,
                 temperature: 0.7,
             },
+        });
+    });
+
+    it("does not mask 5xx errors when no route matched", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const app = new Hono<Env>();
+        app.notFound((c) => {
+            c.set("log", {
+                error: vi.fn(),
+                trace: vi.fn(),
+                warn: vi.fn(),
+            } as never);
+            return handleError(new HTTPException(500), c);
+        });
+        app.onError(handleError);
+
+        const ctx = createExecutionContext();
+        const response = await app.fetch(
+            new Request("https://gen.pollinations.ai/unmatched?x=1"),
+            {
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toMatchObject({
+            success: false,
+            error: {
+                code: "INTERNAL_ERROR",
+            },
+        });
+
+        expect(tinybirdRequests).toHaveLength(1);
+        const tinybirdPayload = (await tinybirdRequests[0].json()) as Record<
+            string,
+            unknown
+        >;
+        expect(tinybirdPayload).toMatchObject({
+            kind: "server_error",
+            route_path: "/unmatched",
+            status: 500,
+            error_class: "Error",
+            request_inputs: JSON.stringify({ query: { x: "1" } }),
         });
     });
 });

--- a/shared/observability/request-inputs.ts
+++ b/shared/observability/request-inputs.ts
@@ -10,7 +10,7 @@ const BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 export async function collectRequestInputs(c: Context): Promise<RequestInputs> {
     const inputs: RequestInputs = {
-        params: removeEmptyRecord(c.req.param()),
+        params: removeEmptyRecord(safeParams(c)),
         query: removeEmptyRecord(queryParams(c)),
     };
 
@@ -20,6 +20,18 @@ export async function collectRequestInputs(c: Context): Promise<RequestInputs> {
     }
 
     return removeUndefined(inputs);
+}
+
+// Hono's c.req.param() throws TypeError when called on a request that didn't
+// match any route (e.g. when an error fires before routing completes, or in
+// the notFound/onError handlers). Since this helper exists to enrich error
+// envelopes, it must never crash the error handler.
+function safeParams(c: Context): Record<string, string> {
+    try {
+        return c.req.param();
+    } catch {
+        return {};
+    }
 }
 
 export function stringifyRequestInputs(inputs: RequestInputs | undefined) {


### PR DESCRIPTION
## Summary

- `collectRequestInputs` calls `c.req.param()` to enrich error envelopes, but Hono's `param()` throws `TypeError: Cannot read properties of undefined (reading '1')` when the request didn't match a route. When that fires inside the error handler, the original error gets masked and the user sees a generic 500.
- Wrap the call in `safeParams()` (try/catch returning `{}`) so the error handler can never crash.
- Adds a regression test for an unmatched-route 5xx error path to ensure request-input collection stays best-effort.

## Impact

Observed ~36 unhandled exceptions per hour on `enter.pollinations.ai` prod from a single bot pattern (~864/day), all the same stack:

```
TypeError: Cannot read properties of undefined (reading '1')
  at #getAllDecodedParams         (hono request.js:30)
  at HonoRequest.param
  at collectRequestInputs
  at createServerErrorEnvelope
  at emitServerError
  at Hono2.handleError
```

Module is shared, so both `enter.pollinations.ai` and `gen.pollinations.ai` are fixed.

## Test plan

- [x] TypeScript compile-check passes for both workers (`tsc --noEmit`)
- [x] Biome lint clean
- [x] `PATH=/Users/thomash/.nvm/versions/node/v22.20.0/bin:$PATH ../node_modules/.bin/vitest run test/error-observability.test.ts`
- [ ] CI vitest suite (local full Workers suite still deferred to GitHub Actions)
- [ ] Post-deploy: monitor enter prod wrangler tail for 10 min; `outcome=exception` count for this stack should drop to 0