### PR TITLE
fix(tracking): preserve model used on cache hits

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -392,12 +392,22 @@ async function trackResponse(
     const log = getLogger(["hono", "track", "response"]);
     const { resolvedModelRequested } = requestTracking;
     const cacheInfo = extractCacheHeaders(response);
-    if (!response.ok || cacheInfo.cacheHit) {
+    if (!response.ok) {
         return {
             responseOk: response.ok,
             responseStatus: response.status,
             cacheData: cacheInfo,
             isBilledUsage: false,
+        };
+    }
+    if (cacheInfo.cacheHit) {
+        return {
+            responseOk: response.ok,
+            responseStatus: response.status,
+            cacheData: cacheInfo,
+            isBilledUsage: false,
+            modelUsed:
+                extractModelUsedHeader(response) ?? resolvedModelRequested,
         };
     }
 
@@ -418,6 +428,7 @@ async function trackResponse(
                 responseStatus: response.status,
                 cacheData: cacheInfo,
                 isBilledUsage: false,
+                modelUsed: extractModelUsedHeader(response),
             };
         }
     }
@@ -435,6 +446,7 @@ async function trackResponse(
                 responseStatus: response.status,
                 cacheData: cacheInfo,
                 isBilledUsage: false,
+                modelUsed: extractModelUsedHeader(response),
             };
         }
     }
@@ -457,6 +469,7 @@ async function trackResponse(
                 responseStatus: response.status,
                 cacheData: cacheInfo,
                 isBilledUsage: false,
+                modelUsed: extractModelUsedHeader(response),
             };
         }
     }
@@ -475,6 +488,7 @@ async function trackResponse(
             responseStatus: response.status,
             cacheData: cacheInfo,
             isBilledUsage: false,
+            modelUsed: extractModelUsedHeader(response),
             contentFilterResults,
         };
     }
@@ -656,8 +670,13 @@ async function extractStreamRequested(request: HonoRequest): Promise<boolean> {
     return false;
 }
 
-function extractUsageHeaders(response: Response): ModelUsage {
+function extractModelUsedHeader(response: Response): string | undefined {
     const modelUsed = response.headers.get("x-model-used");
+    return modelUsed || undefined;
+}
+
+function extractUsageHeaders(response: Response): ModelUsage {
+    const modelUsed = extractModelUsedHeader(response);
     if (!modelUsed) {
         throw new Error(
             "Failed to determine model: x-model-used header was missing",

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -11,6 +11,7 @@ import { removeUnset } from "@/util.ts";
 
 const EXCLUDED_PARAMS = ["nofeed", "no-cache", "key"];
 const SAFETY_CACHE_VERSION = "bedrock-input-v1";
+const CACHED_HEADER_NAMES = new Set(["x-model-used"]);
 const CACHED_HEADER_PREFIXES = ["x-safety-"];
 
 function hasActiveSafety(value: string | null | undefined): boolean {
@@ -87,6 +88,7 @@ function prepareCustomMetadata(response: Response): Record<string, string> {
     for (const [name, value] of response.headers.entries()) {
         const lowerName = name.toLowerCase();
         if (
+            CACHED_HEADER_NAMES.has(lowerName) ||
             CACHED_HEADER_PREFIXES.some((prefix) =>
                 lowerName.startsWith(prefix),
             )

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -21,6 +21,28 @@ afterEach(() => {
 function createTestApp(
     consumePollen: (amount: number) => Promise<void>,
     user?: AuthUser,
+    responseFactory: () => Response = () =>
+        new Response(
+            JSON.stringify({
+                id: "chatcmpl_test",
+                object: "chat.completion",
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: "assistant", content: "ok" },
+                        finish_reason: "stop",
+                    },
+                ],
+            }),
+            {
+                headers: {
+                    "content-type": "application/json",
+                    "x-model-used": "gpt-5-nano-2025-08-07",
+                    "x-usage-prompt-text-tokens": "1000",
+                    "x-usage-completion-text-tokens": "500",
+                },
+            },
+        ),
 ) {
     const app = new Hono<Env>();
 
@@ -51,32 +73,7 @@ function createTestApp(
         });
         await next();
     });
-    app.post(
-        "/v1/chat/completions",
-        track("generate.text"),
-        () =>
-            new Response(
-                JSON.stringify({
-                    id: "chatcmpl_test",
-                    object: "chat.completion",
-                    choices: [
-                        {
-                            index: 0,
-                            message: { role: "assistant", content: "ok" },
-                            finish_reason: "stop",
-                        },
-                    ],
-                }),
-                {
-                    headers: {
-                        "content-type": "application/json",
-                        "x-model-used": "gpt-5-nano-2025-08-07",
-                        "x-usage-prompt-text-tokens": "1000",
-                        "x-usage-completion-text-tokens": "500",
-                    },
-                },
-            ),
-    );
+    app.post("/v1/chat/completions", track("generate.text"), responseFactory);
 
     return app;
 }
@@ -149,6 +146,81 @@ describe("tracking observability", () => {
         });
         expect(consumePollen).toHaveBeenCalledWith(expect.any(Number));
         expect(consumePollen.mock.calls[0]?.[0]).toBeGreaterThan(0);
+    });
+
+    it("preserves modelUsed for cached responses without billing usage", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+
+        const ctx = createExecutionContext();
+        const response = await createTestApp(
+            consumePollen,
+            undefined,
+            () =>
+                new Response(
+                    JSON.stringify({
+                        id: "chatcmpl_cached",
+                        object: "chat.completion",
+                        choices: [],
+                    }),
+                    {
+                        headers: {
+                            "content-type": "application/json",
+                            "x-cache": "HIT",
+                            "x-cache-key": "cached-key",
+                            "x-model-used": "gpt-5-nano-2025-08-07",
+                            "x-usage-prompt-text-tokens": "1000",
+                            "x-usage-completion-text-tokens": "500",
+                        },
+                    },
+                ),
+        ).fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "cf-connecting-ip": "203.0.113.42",
+                },
+                body: JSON.stringify({
+                    model: "openai",
+                    stream: false,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            }),
+            {
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(tinybirdRequests).toHaveLength(1);
+        await expect(tinybirdRequests[0].json()).resolves.toMatchObject({
+            responseStatus: 200,
+            cacheHit: true,
+            cacheKey: "cached-key",
+            modelUsed: "gpt-5-nano-2025-08-07",
+            isBilledUsage: false,
+            tokenCountPromptText: 0,
+            tokenCountCompletionText: 0,
+        });
+        expect(consumePollen).toHaveBeenCalledWith(0);
     });
 
     it("does not trigger auto top-up while post-deduction pack balance is above threshold", async () => {


### PR DESCRIPTION
## Summary
- Preserves `modelUsed` for cache-hit tracking events without billing cached usage.
- Stores `x-model-used` in media cache metadata for future cached image/audio/video responses.
- Adds regression coverage for cached Tinybird events.

## Impact
- Minimal request impact: cached responses still skip usage parsing, cost, and price calculation.
- The added cache-hit work is a single `x-model-used` header read in async tracking.

## Test
- `./node_modules/.bin/biome check --write gen.pollinations.ai/src/middleware/track.ts gen.pollinations.ai/src/utils/media-cache.ts gen.pollinations.ai/test/tracking-observability.test.ts`
- `PATH=/Users/thomash/.nvm/versions/node/v22.20.0/bin:$PATH ../node_modules/.bin/vitest run test/tracking-observability.test.ts`