### PR TITLE
fix(error-handler): avoid c.var.log dependency

### DIFF
--- a/enter.pollinations.ai/src/error.ts
+++ b/enter.pollinations.ai/src/error.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "@logtape/logtape";
+import { getLogger, type Logger } from "@logtape/logtape";
 import { ValidationError } from "@shared/http/validation-error.ts";
 import {
     collectRequestInputs,
@@ -178,7 +178,10 @@ export async function handleError<TEnv extends ErrorHandlerEnv>(
     err: Error,
     c: Context<TEnv>,
 ) {
-    const log = c.get("log");
+    // Use getLogger directly instead of c.get("log"). The error handler must
+    // never depend on logger middleware having run successfully — getLogger is
+    // idempotent (returns the same singleton for the same category).
+    const log = getLogger(["hono"]);
     const timestamp = new Date().toISOString();
 
     // Set the error on the context for it to be tracked

--- a/gen.pollinations.ai/src/error.ts
+++ b/gen.pollinations.ai/src/error.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "@logtape/logtape";
+import { getLogger, type Logger } from "@logtape/logtape";
 import { ValidationError } from "@shared/http/validation-error.ts";
 import {
     collectRequestInputs,
@@ -178,7 +178,10 @@ export async function handleError<TEnv extends ErrorHandlerEnv>(
     err: Error,
     c: Context<TEnv>,
 ) {
-    const log = c.get("log");
+    // Use getLogger directly instead of c.get("log"). The error handler must
+    // never depend on logger middleware having run successfully — getLogger is
+    // idempotent (returns the same singleton for the same category).
+    const log = getLogger(["hono"]);
     const timestamp = new Date().toISOString();
 
     c.set("error", err);

--- a/gen.pollinations.ai/test/error-observability.test.ts
+++ b/gen.pollinations.ai/test/error-observability.test.ts
@@ -241,4 +241,57 @@ describe("error observability", () => {
             request_inputs: JSON.stringify({ query: { x: "1" } }),
         });
     });
+
+    it("does not require logger middleware state for 5xx errors", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+
+        const app = new Hono<Env>();
+        app.get("/before-logger", () => {
+            throw new Error("pre-logger failure");
+        });
+        app.onError(handleError);
+
+        const ctx = createExecutionContext();
+        const response = await app.fetch(
+            new Request("https://gen.pollinations.ai/before-logger"),
+            {
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toMatchObject({
+            success: false,
+            error: {
+                code: "INTERNAL_ERROR",
+                message: "pre-logger failure",
+            },
+        });
+
+        expect(tinybirdRequests).toHaveLength(1);
+        const tinybirdPayload = (await tinybirdRequests[0].json()) as Record<
+            string,
+            unknown
+        >;
+        expect(tinybirdPayload).toMatchObject({
+            kind: "server_error",
+            route_path: "/before-logger",
+            status: 500,
+            error_class: "Error",
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Stops `handleError` from reading the logger through `c.get("log")` before calling `log.error(...)`.
- Uses `getLogger(["hono"])` directly in both workers; LogTape returns the same logger singleton for that category.
- Adds a regression test proving 5xx error handling still works when logger middleware never populated `c.var.log`.

## Root cause

`c.var.log` is middleware state, not an error-handler invariant. In Hono, `onError` can be called for failures that happen before later middleware runs. Since `cors` and `requestId` are registered before `logger`, any pre-logger failure reaches `handleError` with `c.get("log") === undefined`. The old code then crashed inside the error handler and masked the original error.

The fix makes the error handler self-contained instead of depending on request middleware having completed.

## Test plan

- [x] `node node_modules/.bin/biome check --write gen.pollinations.ai/test/error-observability.test.ts`
- [x] `/Users/thomash/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ../node_modules/.bin/vitest run test/error-observability.test.ts`
- [x] Gen typecheck passed locally before this test-only follow-up
- [ ] Post-deploy: tail enter prod and confirm the masking exception is gone