### PR TITLE
fix(gen): pin worker placement to aws:eu-central-1

### DIFF
--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -54,13 +54,13 @@ port = 8788
 # Production routes
 [env.production]
 
-# Pin Worker isolate to EU (Frankfurt) so outbound fetch() egresses from a
-# stable, non-flagged IP pool. Mitigates Cloudflare anti-bot challenges from
-# CF-protected upstreams (e.g. api.elevenlabs.io) that flag traffic from
-# certain colos (notably RU/CIS).
+# Pin Worker isolate to a Frankfurt-area CF colo (aws:eu-central-1). Outbound
+# fetch() from that isolate egresses from that colo's IP pool, which reduces
+# per-region reputation variance with CF-protected upstreams. `mode = "smart"`
+# and `region` are mutually exclusive in the Wrangler parser; setting `region`
+# alone is explicit pinning, not heuristic Smart Placement.
 # https://developers.cloudflare.com/workers/configuration/smart-placement/
 [env.production.placement]
-mode = "smart"
 region = "aws:eu-central-1"
 
 [env.production.images]

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -54,6 +54,15 @@ port = 8788
 # Production routes
 [env.production]
 
+# Pin Worker isolate to EU (Frankfurt) so outbound fetch() egresses from a
+# stable, non-flagged IP pool. Mitigates Cloudflare anti-bot challenges from
+# CF-protected upstreams (e.g. api.elevenlabs.io) that flag traffic from
+# certain colos (notably RU/CIS).
+# https://developers.cloudflare.com/workers/configuration/smart-placement/
+[env.production.placement]
+mode = "smart"
+region = "aws:eu-central-1"
+
 [env.production.images]
 binding = "IMAGES"
 


### PR DESCRIPTION
## Summary

- Add `[env.production.placement]` block to `gen.pollinations.ai/wrangler.toml` pinning the Worker isolate to Frankfurt (`aws:eu-central-1`)
- Outbound `fetch()` from the gen Worker now egresses from a stable, non-flagged CF colo IP pool
- Mitigates 502s from `api.elevenlabs.io` returning Cloudflare anti-bot challenge HTML to users hitting RU/CIS CF colos

## Context

User `georgiyrudensky-png` (Saint Petersburg, RU) hit 100% 502 rate on all ElevenLabs models for 24h+ (~1900 events). Error body was a Cloudflare "Just a moment..." challenge page returned by ElevenLabs's CF layer, not our code. Other users on other CF colos succeed.

CF Workers `fetch()` egress IP depends on the colo the isolate runs in. Pinning placement forces all isolates to a single colo pool, eliminating per-region reputation variance.

## Test plan

- [ ] Validate `wrangler.toml` parses (`wrangler types` ran clean locally)
- [ ] Deploy to production
- [ ] Verify in Cloudflare dashboard that placement is active
- [ ] Watch Tinybird for elevenflash/elevenlabs 502 rate from `georgiyrudensky-png` — expect drop to ~0
- [ ] Verify no regression in p50 latency for non-EU users (worst case +50-100ms TTFB for US/Asia)

## Refs

- https://developers.cloudflare.com/workers/configuration/smart-placement/
- Explicit placement hints landed Jan 2026