### PR TITLE
fix: correct gemini-3-Flash audio input rate $0.50/M → $1.00/M

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -117,13 +117,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "gemini": {
     "cost": {
       "completionTextTokens": 0.000003,
-      "promptAudioTokens": 5e-7,
+      "promptAudioTokens": 0.000001,
       "promptCachedTokens": 5e-8,
       "promptTextTokens": 5e-7,
     },
     "price": {
       "completionTextTokens": 0.0000045,
-      "promptAudioTokens": 7.5e-7,
+      "promptAudioTokens": 0.0000015,
       "promptCachedTokens": 7.5e-8,
       "promptTextTokens": 7.5e-7,
     },

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -261,7 +261,7 @@ export const TEXT_SERVICES = {
         cost: {
             promptTextTokens: perMillion(0.5),
             promptCachedTokens: perMillion(0.05),
-            promptAudioTokens: perMillion(0.5), // Audio billed at same rate as text
+            promptAudioTokens: perMillion(1.0),
             completionTextTokens: perMillion(3.0),
         },
         description: "Gemini 3 Flash - Pro-Grade Reasoning at Flash Speed",


### PR DESCRIPTION
## What

The `promptAudioTokens` rate on `gemini` (Gemini 3 Flash, `gemini-3-flash-preview`) was $0.50/M, but Vertex's published rate is **$1.00/M**. Verified against the live Vertex Serverless pricing page.

Audio input fires non-zero on this model in production (~66 audio-input calls per week), so getting the rate right is a real billing accuracy fix.

## Why this PR is small

It started bigger — originally plumbed `promptCachedAudioTokens` through registry + Tinybird schema to handle a theoretical cached-audio leak. Empirical verification of 7 days of production traffic showed:

- **0 cache hits on Gemini calls with audio input** across all 4 Gemini models
- **0 calls anywhere with `audio_tokens > 0` AND `cached_tokens > 0` simultaneously** (across every provider)

So the leak the PR was solving doesn't manifest under current upstream behavior. Following the principle "don't add columns/code for scenarios that never fire":

- Tinybird columns `token_price_prompt_cached_audio` + `token_count_prompt_cached_audio` dropped from staging (deploy #10) and prod (deploy #117)
- Registry rates, schema fields, proportional-split logic, and the `Math.max` defensive guard all removed

Left with the one fix that has measurable impact today: the audio rate correction.

## Tests

`effective-prices.snapshot.test.ts` snapshot regenerated, shows only the audio rate change.