### PR TITLE
add gemini-3.5-flash via vertex

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -114,6 +114,13 @@ source _local/.env
 
 > **There are no "free" vs "paid" keys.** A key is a key. The `paidOnly` gate checks the user's `packBalance` (purchased Pollen pack balance), not the key prefix. To exercise the gate, use a token whose **owning user has `packBalance == 0`** — typically a freshly minted key (signup grants free Pollen, no pack) or one whose pack has been depleted. Don't confuse "free Pollen remaining" (signup grant, doesn't unlock paidOnly) with "pack balance" (purchased, does unlock).
 
+> **`_local/.env` token labels are not guaranteed to match where they actually validate.** Before assuming a 401 means "wrong/expired token," verify the token against gen's local D1 — only keys seeded in *gen's* `apikey` table validate there (enter's D1 is a separate sqlite, not shared with gen in local). Quick lookup (no secrets printed):
+> ```bash
+> GEN_DB=gen.pollinations.ai/.wrangler/state/v3/d1/miniflare-D1DatabaseObject/*.sqlite
+> sqlite3 $GEN_DB "SELECT name, start, prefix FROM apikey;"
+> ```
+> Match each `POLLINATIONS_TOKEN_*` env var's first 6 chars against the `start` column — the env var named `_LOCAL` is not necessarily the one seeded locally. Pick whichever env var matches a row whose `name` looks like a local test key (e.g., `local-battle-test`, `local-e2e-test-key`).
+
 Provider/runtime secrets (Azure, OpenAI, OpenRouter API keys, etc.) belong in `gen.pollinations.ai/secrets/{dev,staging,prod}.vars.json` via SOPS — never in `_local/.env`. See §11.
 
 ---
@@ -527,6 +534,25 @@ sops set gen.pollinations.ai/secrets/prod.vars.json '["KEY_NAME"]' '"value"'
 ```
 
 > Never put Pollinations test tokens (`POLLINATIONS_TOKEN_*`) or admin/operator tokens in SOPS — recipient list is too broad. SOPS is for provider/runtime keys only.
+
+### When decrypt-vars fails with "no identity matched any of the recipients"
+
+The convention on this team is to keep the Pollinations age private key in **macOS Keychain** under service name `sops-age-key` (account = your local `$USER`). If `~/.config/sops/age/keys.txt` exists but contains an unrelated key, decrypt fails with all `.sops.yaml` recipients listed as `FAILED`. Restore from keychain — don't ask the user to paste secrets:
+
+```bash
+SOPS_KEY=$(security find-generic-password -s "sops-age-key" -a "$USER" -w 2>/dev/null) \
+  || { echo "Not in keychain — ask the user where their age key lives"; exit 1; }
+for KF in ~/.config/sops/age/keys.txt ~/Library/Application\ Support/sops/age/keys.txt; do
+  mkdir -p "$(dirname "$KF")"
+  grep -qF "$SOPS_KEY" "$KF" 2>/dev/null || {
+    printf '\n# pollinations (restored from keychain svce=sops-age-key)\n%s\n' "$SOPS_KEY" >> "$KF"
+    chmod 600 "$KF"
+  }
+done
+sops --decrypt gen.pollinations.ai/secrets/dev.vars.json >/dev/null && echo "decrypt OK"
+```
+
+If `-a "$USER"` doesn't match, try without `-a` (`security find-generic-password -s "sops-age-key" -w`) and let keychain pick the only one. Recipients can rotate — read the current expected public keys from `.sops.yaml` rather than hard-coding them here.
 
 ## 11.2 Description style
 

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -142,6 +142,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptVideoTokens": 0.000018,
     },
   },
+  "gemini-3.5-flash": {
+    "cost": {
+      "completionTextTokens": 0.000009,
+      "promptAudioTokens": 0.0000015,
+      "promptCachedTokens": 1.5e-7,
+      "promptTextTokens": 0.0000015,
+    },
+    "price": {
+      "completionTextTokens": 0.0000135,
+      "promptAudioTokens": 0.00000225,
+      "promptCachedTokens": 2.25e-7,
+      "promptTextTokens": 0.00000225,
+    },
+  },
   "gemini-fast": {
     "cost": {
       "completionTextTokens": 4e-7,

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -1,10 +1,14 @@
 import { expect, test } from "vitest";
+import { AUDIO_SERVICES } from "../../shared/registry/audio.ts";
+import { EMBEDDING_SERVICES } from "../../shared/registry/embeddings.ts";
+import { IMAGE_SERVICES } from "../../shared/registry/image.ts";
 import {
     calculateCost,
     calculatePrice,
     getModelDefinition,
     getPriceDefinition,
 } from "../../shared/registry/registry.ts";
+import { TEXT_SERVICES } from "../../shared/registry/text.ts";
 import { getModelPrices } from "../src/client/components/models/data.ts";
 
 test("pricing data applies the per-model price multiplier uniformly", () => {
@@ -121,4 +125,31 @@ test("Grok 4.20 registry metadata covers verified modalities and costs", () => {
         16.2,
         8,
     );
+});
+
+test("registry cost blocks contain no sentinel/placeholder negative values", () => {
+    const registries = [
+        ["text", TEXT_SERVICES],
+        ["image", IMAGE_SERVICES],
+        ["audio", AUDIO_SERVICES],
+        ["embeddings", EMBEDDING_SERVICES],
+    ] as const;
+
+    const offenders: string[] = [];
+    for (const [kind, services] of registries) {
+        for (const [name, def] of Object.entries(services)) {
+            const cost = (def as { cost?: Record<string, number> }).cost;
+            if (!cost) continue;
+            for (const [field, value] of Object.entries(cost)) {
+                if (typeof value === "number" && value < 0) {
+                    offenders.push(`${kind}/${name}.cost.${field}=${value}`);
+                }
+            }
+        }
+    }
+
+    expect(
+        offenders,
+        `Models with placeholder/sentinel pricing — fill in real rates before merging:\n${offenders.join("\n")}`,
+    ).toEqual([]);
 });

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -126,6 +126,16 @@ const models: ModelDefinition[] = [
         ),
     },
     {
+        name: "gemini-3.5-flash",
+        config: portkeyConfig["gemini-3.5-flash"],
+        transform: pipe(
+            sanitizeToolSchemas(),
+            createGeminiToolsTransform(["code_execution"]),
+            removeToolsForJsonResponse,
+            createGeminiThinkingTransform("v3-flash"),
+        ),
+    },
+    {
         name: "gemini-flash-lite-3.1",
         config: portkeyConfig["gemini-3.1-flash-lite-preview"],
         transform: pipe(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -196,6 +196,7 @@ export const portkeyConfig: PortkeyConfigMap = {
         "gemini-3.1-flash-lite-preview",
         "global",
     ),
+    "gemini-3.5-flash": createVertexGeminiConfig("gemini-3.5-flash", "global"),
 
     // -- Perplexity -----------------------------------------------------------
     "sonar": () => createPerplexityModelConfig({ model: "sonar" }),

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -273,6 +273,32 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "gemini-3.5-flash": {
+        aliases: ["gemini-3.5-flash"],
+        modelId: "gemini-3.5-flash",
+        provider: "google",
+        brand: "Google",
+        category: "text",
+        addedDate: new Date("2026-05-19").getTime(),
+        priceMultiplier: 1.5,
+        paidOnly: true,
+        // Rates per https://ai.google.dev/gemini-api/docs/pricing (global region).
+        // Non-global regions add ~10%; we route through global.
+        cost: {
+            promptTextTokens: perMillion(1.5),
+            promptCachedTokens: perMillion(0.15),
+            promptAudioTokens: perMillion(1.5), // Audio billed at same rate as text
+            completionTextTokens: perMillion(9.0),
+        },
+        description: "Gemini 3.5 Flash - Next-Gen Reasoning at Flash Speed",
+        inputModalities: ["text", "image", "audio", "video"],
+        outputModalities: ["text"],
+        tools: true,
+        search: true,
+        codeExecution: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "gemini-flash-lite-3.1": {
         aliases: [
             "gemini-3.1-flash-lite",


### PR DESCRIPTION
New paid text model wired through the existing `createVertexGeminiConfig("global")` helper. Same transform pipeline as `gemini` (3-flash): tool sanitizer + `code_execution` + JSON-strip + `v3-flash` thinking.

Pricing pulled from https://ai.google.dev/gemini-api/docs/pricing (global region): $1.50 / $9.00 / $0.15 in / out / cached per 1M tokens, audio-in mirrored to text-in rate per existing 3-flash precedent. `priceMultiplier: 1.5` applied. Verified end-to-end against local gen: Tinybird `generation_event` row shows `token_price_completion_text = 1.35e-5` and `total_price = total_cost * 1.5`. Reasoning tokens correctly fall back to the completion-text rate per `registry.ts:118`. Wrangler log clean of `[registry] Missing conversion rate`.

Test matrix passed: basic, streaming, max_tokens edge, image input, tools, reasoning, all five 4xx error paths, 5-way burst. Prompt cache returned `cached_tokens=0` on the second call — matches existing `gemini` (3-flash) behaviour; Vertex Gemini context caching wants an explicit `cachedContent` resource, not implicit prefix. `promptCachedTokens` kept in the cost block so it bills correctly once that path is wired.

Also:
- `pricing-data.test.ts`: guard test fails on any negative cost value across all four registries (catches placeholder pricing left behind).
- model-management skill: added a `_local/.env` token-verification step (token names don't always match where they validate) and a SOPS keychain restore recipe for when `decrypt-vars` fails.