### PR TITLE
Mark paid provider models as paid-only

### DIFF
--- a/gen.pollinations.ai/test/billing-deduction.test.ts
+++ b/gen.pollinations.ai/test/billing-deduction.test.ts
@@ -131,4 +131,9 @@ describe("billing deduction", () => {
         expect(balance.tierBalance).toBeCloseTo(0.01, 10);
         expect(balance.packBalance).toBeCloseTo(-0.01, 10);
     });
+    it("treats paid provider models as paid-only by default", () => {
+        const model = getModelDefinition("openai");
+        expect(model.provider).toBe("azure");
+        expect(model.paidOnly).toBe(true);
+    });
 });

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -141,6 +141,24 @@ function derivePrice(svc: ModelDefinition): PriceDefinition {
     ) as PriceDefinition;
 }
 
+
+// Providers whose upstream usage costs must be paid from purchased pack balance,
+// not free/tier credits.
+export const PAID_ONLY_PROVIDERS = new Set([
+    "azure",
+    "bedrock",
+    "fireworks",
+    "google",
+    "openai",
+    "openrouter",
+    "perplexity",
+    "replicate",
+]);
+
+export function isPaidOnlyProvider(provider: string): boolean {
+    return PAID_ONLY_PROVIDERS.has(provider);
+}
+
 const MODEL_REGISTRY = {
     ...TEXT_SERVICES,
     ...IMAGE_SERVICES,
@@ -230,7 +248,11 @@ export function getModelDefinition(model: ModelName): ModelDefinition {
     if (!definition) {
         throw new Error(`Invalid model: "${model}"`);
     }
-    return definition;
+    return {
+        ...definition,
+        paidOnly:
+            definition.paidOnly ?? isPaidOnlyProvider(definition.provider),
+    };
 }
 
 /**


### PR DESCRIPTION
Fixes #11104.\n\n## Summary\n- add a registry-level paid-provider allowlist\n- default models from paid upstream providers to paid-only unless explicitly configured\n- add coverage for an Azure model inheriting paid-only behavior\n\n## Verification\n- npm test --workspace pollinations-gen -- billing-deduction.test.ts\n- npm run typecheck --workspace pollinations-gen