### PR TITLE
Show quest rewards on wallet dashboard

### DIFF
--- a/enter.pollinations.ai/src/client/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/src/client/components/pollen/pollen-balance.tsx
@@ -14,6 +14,7 @@ type PollenBalanceProps = {
     tier?: string;
     paidWeek?: number;
     tierWeek?: number;
+    questReward?: number;
 };
 
 const BALANCE_DISPLAY_EPSILON = 0.0001;
@@ -107,6 +108,7 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
     tier = "spore",
     paidWeek = 0,
     tierWeek = 0,
+    questReward = 0,
 }) => {
     const displayTierBalance = normalizeDisplayBalance(tierBalance);
     const displayPaidBalance = normalizeDisplayBalance(packBalance);
@@ -259,6 +261,7 @@ type SidebarWalletProps = {
     tier?: string;
     paidWeek?: number;
     tierWeek?: number;
+    questReward?: number;
     onClick?: () => void;
 };
 
@@ -268,7 +271,9 @@ export const SidebarWallet: FC<SidebarWalletProps> = ({
     tier = "spore",
     paidWeek = 0,
     tierWeek = 0,
+    questReward = 0,
 }) => {
+    const displayQuestReward = normalizeDisplayBalance(questReward);
     const displayTierBalance = normalizeDisplayBalance(tierBalance);
     const displayPaidBalance = normalizeDisplayBalance(packBalance);
     const hideTierSegment = tier === "microbe" && displayTierBalance === 0;
@@ -294,6 +299,20 @@ export const SidebarWallet: FC<SidebarWalletProps> = ({
                     )}
                 </span>
             </div>
+            {displayQuestReward > 0 && (
+                <div className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-1.5 text-xs font-bold text-amber-900">
+                        <span
+                            className="h-2 w-2 rounded-full bg-green-600"
+                            aria-hidden="true"
+                        />
+                        Quest reward
+                    </span>
+                    <span className="text-micro font-bold tabular-nums text-amber-950 leading-none">
+                        {formatPollen(displayQuestReward)}
+                    </span>
+                </div>
+            )}
             {!hideTierSegment && (
                 <div className="flex items-center justify-between gap-2">
                     <span className="flex items-center gap-1.5 text-xs font-bold text-amber-900">

--- a/enter.pollinations.ai/src/client/routes/index.tsx
+++ b/enter.pollinations.ai/src/client/routes/index.tsx
@@ -121,6 +121,7 @@ export const Route = createFileRoute("/")({
         const apiKeys = (apiKeysResult.data || []) as ApiKey[];
         const tierBalance = d1BalanceResult?.tierBalance ?? 0;
         const packBalance = d1BalanceResult?.packBalance ?? 0;
+        const questReward = d1BalanceResult?.questReward ?? 0;
         const paidWeek = earningsTodayResult?.paidWeek ?? 0;
         const tierWeek = earningsTodayResult?.tierWeek ?? 0;
         // Prefer D1; session (KV-cached) may hold a stale username after relog.
@@ -137,6 +138,7 @@ export const Route = createFileRoute("/")({
             tierData,
             tierBalance,
             packBalance,
+            questReward,
             billingState,
             paidWeek,
             tierWeek,
@@ -153,6 +155,7 @@ function RouteComponent() {
         tierData,
         tierBalance,
         packBalance,
+        questReward,
         billingState,
         paidWeek,
         tierWeek,
@@ -306,6 +309,7 @@ function RouteComponent() {
                 <SidebarWallet
                     tierBalance={tierBalance}
                     packBalance={packBalance}
+                    questReward={questReward}
                     tier={tierData?.active?.tier}
                     paidWeek={paidWeek}
                     tierWeek={tierWeek}
@@ -319,6 +323,7 @@ function RouteComponent() {
                         <PollenBalance
                             tierBalance={tierBalance}
                             packBalance={packBalance}
+                            questReward={questReward}
                             tier={tierData?.active?.tier}
                             paidWeek={paidWeek}
                             tierWeek={tierWeek}

--- a/enter.pollinations.ai/src/routes/customer.ts
+++ b/enter.pollinations.ai/src/routes/customer.ts
@@ -1,5 +1,8 @@
-import { user as userTable } from "@shared/db/better-auth.ts";
-import { eq } from "drizzle-orm";
+import {
+    questPayoutCredits,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
+import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -35,18 +38,29 @@ export const customerRoutes = new Hono<Env>()
                 user.id,
             );
             const db = drizzle(c.env.DB);
-            const users = await db
-                .select({
-                    lastTierGrant: userTable.lastTierGrant,
-                })
-                .from(userTable)
-                .where(eq(userTable.id, user.id))
-                .limit(1);
+            const [users, questRewards] = await Promise.all([
+                db
+                    .select({
+                        lastTierGrant: userTable.lastTierGrant,
+                    })
+                    .from(userTable)
+                    .where(eq(userTable.id, user.id))
+                    .limit(1),
+                db
+                    .select({
+                        questReward:
+                            sql<number>`coalesce(sum(${questPayoutCredits.pollenCredited}), 0)`,
+                    })
+                    .from(questPayoutCredits)
+                    .where(eq(questPayoutCredits.userId, user.id)),
+            ]);
             const lastTierGrant = users[0]?.lastTierGrant ?? null;
+            const questReward = Number(questRewards[0]?.questReward) || 0;
 
             return c.json({
                 tierBalance,
                 packBalance,
+                questReward,
                 lastTierGrant,
             });
         },


### PR DESCRIPTION
Fixes #11109.\n\n## Summary\n- adds quest payout total to the customer balance payload\n- passes quest rewards through dashboard loader data\n- shows quest rewards in the sidebar wallet\n\n## Test\n- npm run typecheck --workspace pollinations-enter