### PR TITLE
Fix negative usage text tokens

### DIFF
--- a/gen.pollinations.ai/test/usage-headers.test.ts
+++ b/gen.pollinations.ai/test/usage-headers.test.ts
@@ -174,6 +174,35 @@ describe("openaiUsageToUsage", () => {
         expect(usage.promptImageTokens).toBe(1);
         expect(usage.completionTextTokens).toBe(1);
     });
+
+    it("should floor text tokens at zero when detail tokens exceed headline totals", () => {
+        const openaiUsage = {
+            prompt_tokens: 100,
+            completion_tokens: 200,
+            total_tokens: 300,
+            prompt_tokens_details: {
+                cached_tokens: 80,
+                audio_tokens: 40,
+                image_tokens: 10,
+            },
+            completion_tokens_details: {
+                accepted_prediction_tokens: 20,
+                rejected_prediction_tokens: 30,
+                audio_tokens: 25,
+                reasoning_tokens: 300,
+            },
+        };
+
+        const usage = openaiUsageToUsage(openaiUsage);
+
+        expect(usage.promptTextTokens).toBe(0);
+        expect(usage.completionTextTokens).toBe(0);
+        expect(usage.promptCachedTokens).toBe(80);
+        expect(usage.promptAudioTokens).toBe(40);
+        expect(usage.promptImageTokens).toBe(10);
+        expect(usage.completionAudioTokens).toBe(25);
+        expect(usage.completionReasoningTokens).toBe(300);
+    });
 });
 
 describe("parseUsageHeaders", () => {

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -54,7 +54,7 @@ export function openaiUsageToUsage(openaiUsage: {
     // biome-ignore format: custom formatting
     return {
         promptTextTokens: 
-            openaiUsage.prompt_tokens - promptDetailTokens,
+            Math.max(0, openaiUsage.prompt_tokens - promptDetailTokens),
         promptCachedTokens:
             openaiUsage.prompt_tokens_details?.cached_tokens || 0,
         promptAudioTokens: 
@@ -62,7 +62,7 @@ export function openaiUsageToUsage(openaiUsage: {
         promptImageTokens:
             openaiUsage.prompt_tokens_details?.image_tokens || 0,
         completionTextTokens:
-            openaiUsage.completion_tokens - completionDetailTokens,
+            Math.max(0, openaiUsage.completion_tokens - completionDetailTokens),
         completionAudioTokens:
             openaiUsage.completion_tokens_details?.audio_tokens || 0,
         completionReasoningTokens:


### PR DESCRIPTION
Fixes #11183.\n\n## Summary\n- clamp prompt/completion text token derivation to zero when detail tokens exceed headline totals\n- add regression coverage for provider responses where prompt/completion details exceed headline token counts\n\n## Verification\n- npm test --workspace pollinations-gen -- usage-headers.test.ts\n- npm run typecheck --workspace pollinations-gen