### PR TITLE
fix(registry): reset gemini-search to base Vertex rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ temp/
 # Local-only design planning docs (kept out of the repo)
 /DESIGN_REFACTOR_PLAN.md
 /Design Audit.html
+/_local/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -495,11 +495,13 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2025-10-10").getTime(),
         paidOnly: true,
         priceMultiplier: 1.5,
+        // Vertex base rates for gemini-2.5-flash-lite. Grounding fee ($0.035/grounded
+        // prompt after 1,500 RPD free) is not yet modeled; absorbed by Pollinations.
         cost: {
-            promptTextTokens: perMillion(0.2), // per 1M tokens
-            promptCachedTokens: perMillion(0.02), // per 1M tokens
-            promptAudioTokens: perMillion(0.2), // per 1M tokens (audio billed at same rate as text)
-            completionTextTokens: perMillion(0.8), // per 1M tokens
+            promptTextTokens: perMillion(0.1),
+            promptCachedTokens: perMillion(0.01),
+            promptAudioTokens: perMillion(0.3),
+            completionTextTokens: perMillion(0.4),
         },
         description:
             "Google Gemini 2.5 Flash Lite Search - Web-grounded answers via Google Search",


### PR DESCRIPTION
Drop the artificial 2× token markup on `gemini-search`; charge users at the underlying `gemini-2.5-flash-lite` base rates. This also fixes the audio rate, which was below the text rate (inconsistent with everywhere else in the cost block).

Grounding fee (~$243/30d on the project) is now absorbed by Pollinations instead of being amortized through inflated token rates. Proper per-call grounding cost modeling will land in a follow-up PR.

User-facing effect for `gemini-search`:

| | Before (cost / price ×1.5) | After (cost / price ×1.5) |
|---|---:|---:|
| Text in | $0.20 / **$0.30**/M | $0.10 / **$0.15**/M |
| Cached | $0.02 / $0.03/M | $0.01 / $0.015/M |
| Audio in | $0.20 / $0.30/M | $0.30 / $0.45/M |
| Completion | $0.80 / $1.20/M | $0.40 / $0.60/M |

Most users see a ~50% price drop. Audio is +50% but volume is negligible (~300 tokens / 30d).

Also gitignores `/_local/` for local-only planning docs.