### PR TITLE
fix(enter): restore prod GitHub OAuth app creds

### DIFF
--- a/enter.pollinations.ai/secrets/prod.vars.json
+++ b/enter.pollinations.ai/secrets/prod.vars.json
@@ -1,8 +1,8 @@
 {
 	"BETTER_AUTH_SECRET": "ENC[AES256_GCM,data:0VNoPFqwsmh5hrHM72Cuw431vNOu1jReITj1XUv6mPxp4sFD9ZGu1EY2ffYofmo3,iv:yLYswOEw0P+FXvQ9yXx5ER9g95u/lJlb701Cq5Fbrvs=,tag:o30FFibHsXCoxma0jRiqfA==,type:str]",
 	"ELEVENLABS_API_KEY": "ENC[AES256_GCM,data:eSbmMRcis8cLCKar+mVpvusOPuOcmiD21Gc27llFKJ1fa3WmaG9sV5vu4nn9uChT1rLZ,iv:q+FceKMTLwPjowvdAFOmZm42kRlwAVs2dC37ugdR+m8=,tag:rTGvFaBpymkoSrPBrLWv5w==,type:str]",
-	"GITHUB_CLIENT_ID": "ENC[AES256_GCM,data:m7MNbFCv1x5JGfe3C4DUC1DCgjA=,iv:W0yaiJYLn0S4rzibLaEJ7L54yh3Y93w7ePoNCPlb2Qs=,tag:GVp69stlNyd4ikKYs5wOPw==,type:str]",
-	"GITHUB_CLIENT_SECRET": "ENC[AES256_GCM,data:Za/obAqtea70QE6uyQY62EXvS1BJ7wg+RDcWg8K3wj9z1FBIuDtyYw==,iv:t8NJFQHDkWZkGisgFtWf+GyZiEMhTt0VPtXld/i2d1g=,tag:AjcITQiJoYW5DiikYr07RA==,type:str]",
+	"GITHUB_CLIENT_ID": "ENC[AES256_GCM,data:CBXWfkW32xvzfnnwakudg+ftJ4c=,iv:HTzwqwGrrinFFuhxYKqG6dreJDRb2emLImgZ4YACbzg=,tag:9sHnbaDD2zhH7y7bc/V2ww==,type:str]",
+	"GITHUB_CLIENT_SECRET": "ENC[AES256_GCM,data:+fXrtNOb10Q9UMvCFLmG+PeerkKuDcKWw2UCLz6nQoa3kSCalou+bg==,iv:GUgZJJOFQXYFJ/waMefEwZ2T4J+r0YYClv3U83lUGdQ=,tag:pyF2CIUzxvFasTroy37yrA==,type:str]",
 	"OVHCLOUD_API_KEY": "ENC[AES256_GCM,data:GiiFHsFbEbZB2kuHtjnGkN0f+TolvtX29r6xNO+ffuoqLm4uAO+0Zm5BjOCis197LlMSUiohc7QuWrBlqbClqAmccwsIr7vviktcfPuhbaBD7JpqF1amk5v1OYfpvtbSygaNu83wB8oaWdbwzlIGmW+hqI3roI3SovJ7WA+2rIIfXAwHzU3T8rqdPIsdOv8pBXweVv/cvK5dHMr/w+kHBEdB+YnR3ox5rx7uoBEgtgv9sdKa3LPEUm/aQbnFko5VX9SvPPj6qUFnMOpcDIYB1DvyLfoc7SXbC0SZNSnDYhaznWSCE2yKzA8zm6408n9hieM4aNkdeB5W76vrZqDS9tlcJ+dwykwlTV/HT/gGhy5TIKS5KepFzI3p,iv:qeDcnpkUCo/RX6igtWIw/lcXHgDLMpBGl8ZYOzCKIkk=,tag:etnLTl0chlBmGGKldXpypg==,type:str]",
 	"PLN_ENTER_TOKEN": "ENC[AES256_GCM,data:kocaRe2LdgoqNibwdtffkWCMA+37wQwlu60dXDsKAPgPTPRwmyTEVu1zi6X2Z2Mz5c8RDBtudBfc1MrqrPnvYg==,iv:rMuQSoBJPkcUNpeUeEeQwozu+ws/CzF3UYuoPwAG7OU=,tag:tFmZrFWQ1ftVwVuUH5xaSw==,type:str]",
 	"STRIPE_SECRET_KEY": "ENC[AES256_GCM,data:iwvuPERtI6T0pIRkEwOKKmX0//E6KmTr30PpDJcg3Kydo3Oi9pBPN0Xf2XjutCV0USouSzzzKNTJS7mxlNUlyYeUAQ/8VoIOP6oSFBUm0Cgtycc8HbR0GWNISabiWJd83kMwhyV6dX+ZAAw=,iv:WlQuquB+Bd5aEpDnGIaf+eMbIDliIozPwmrHO1OMR50=,tag:eJGa3y5CMdDiy/4p+7xWHA==,type:str]",
@@ -17,10 +17,6 @@
 	"TINYBIRD_SYNC_TOKEN": "ENC[AES256_GCM,data:N6ZDBWJy3MkmPUe9/u1cwWjDgS22oNXjk2EDPD0jgyuxPHCo+/qw7IViNt7x9uIcXi0qgs/LSNzjpdXV/M5dEoej/ACGdVdVxs7sNRIWvSq7IphsO1ihDz1qdIEevGJe4jfgwxOniwE7sFLtItYYAO1hbdELmsZl0Kuh8gEYY3pjZxICw3xavRZFEn0uBfhBAGJkDq/WJHBZLweOMaqYiHT25SDkHV+KQGmX317XBMicZHOZwaEXbpKxVncWripn0Mp03uLUOrU4rriayg==,iv:wKkN4beEq6tH3s8D3IADkI8EVnbIIZj/uQhf33orF5o=,tag:BIsvSukIDr1tBrY7cNFfaA==,type:str]",
 	"DASHSCOPE_API_KEY": "ENC[AES256_GCM,data:nDH7wk4TXlTQqqAF4GCorNJKtLPAtl3BMliqhUkKWUT7MkU=,iv:A9dLFRs6PtQYaZtmjQDgk5NrLzYxUcvkVf2dJbgpx4I=,tag:csXQyZH9OwXMcfr+zQcDBA==,type:str]",
 	"sops": {
-		"kms": null,
-		"gcp_kms": null,
-		"azure_kv": null,
-		"hc_vault": null,
 		"age": [
 			{
 				"recipient": "age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd",
@@ -35,9 +31,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwakRvSmkwRnZFb3l3dGMz\nYnhneTFGM3ZkSUhGcnB0a2tEVmU5RDdKYjBFCkpueFVJNVpvTkdtNGgya2tUY3ha\ncG9yZXhzTkVwTVU0S2hBWFhJcnRsWWsKLS0tIGEwNEU2WW4yOFYrWGlrZVN0Qi9z\nSHVXYWd2TldHZHB0eVl0N0M5bmgvbEUKmZc5jsObbFT7jQ2hawKbZHyJ+QRVpWn5\nH4rn1pTTLMgEQP3ngO/c9HXvjGeHSBphejrxSPiAt2SL++KM+6xTfA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-05-15T21:00:31Z",
-		"mac": "ENC[AES256_GCM,data:UtaXmjjPLwnYWoxVhqzDhM2a3eWUUmC0EvyTq3FvRK7wx44oJDfm5ZpGG8a2+W8XM/L1yffKEi4TeC3T0cRN3N19wEN/k9VY5IeKwIX+SiVOPmysXnW4cX8dBjIgQcYvozCZdjdE7xWdGLic0K8NHpiaK7tqpiJUooRv0GXUAo0=,iv:QqDlYMqWcTr23fZ2GRLeEIbkqhih6jHtq43h4k3sC3U=,tag:Q17Y21SGlR+z3yimWhCpGQ==,type:str]",
-		"pgp": null,
+		"lastmodified": "2026-05-21T16:19:46Z",
+		"mac": "ENC[AES256_GCM,data:cau4pj9chGsBeCU77QMhw5lbEgACo6AtShfejEbZ9lqetVkqlgSD9bmjWfjvE5s34XCcLV2Lhh7Ac+MMuTUK/sT/621DOKW4ZsC6vVi73HxWyNlJHpzdzboClZyKr3xbAFQzUCTubJtfqyZAqyQNostx4ZsICMiITUfGxpKgCh8=,iv:r0yWnfTemXImKFtGZ1c9Ew0qsw7KdIA9NORtds+hyZU=,tag:Vsbcfu8rh5SCHu2jMX+vSA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
## Summary
- Myceli cutover deployed temporary GitHub OAuth app creds to prod whose only allowed callback URL is `enter.myceli.ai`
- Login broken since 14:00 UTC: users hitting `enter.pollinations.ai` get GitHub's "The redirect_uri is not associated with this application" screen
- Revert `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` in `secrets/prod.vars.json` to the original pollinations app
- Dev/staging keep the myceli app for direct `enter.myceli.ai` testing

## Test plan
- [ ] Merge → squash merge to main
- [ ] Sync main → production to trigger `Deploy enter.pollinations.ai` CI
- [ ] CI's `push-secrets:production` step rolls the new GitHub creds onto the live Myceli worker
- [ ] Open `https://enter.pollinations.ai` in a private window and sign in with GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)