### PR TITLE
fix(proxy): pass WebSocket 101 responses through unchanged

### DIFF
--- a/pollinations-myceli-proxy/src/index.ts
+++ b/pollinations-myceli-proxy/src/index.ts
@@ -37,6 +37,9 @@ export default {
         // Override Host so the upstream Worker's routing/SNI is correct.
         headers.set("Host", upstreamHost);
 
+        const isWebSocketUpgrade =
+            req.headers.get("Upgrade")?.toLowerCase() === "websocket";
+
         const hasBody = req.method !== "GET" && req.method !== "HEAD";
         let upstream: Response;
         try {
@@ -54,6 +57,13 @@ export default {
                     "Cache-Control": "no-store",
                 },
             });
+        }
+
+        // WebSocket upgrade responses carry a `webSocket` field that is lost
+        // if the response is rebuilt with `new Response(...)`. Pass it through
+        // unchanged so the client/upstream WS pair can hand-off.
+        if (isWebSocketUpgrade && upstream.status === 101) {
+            return upstream;
         }
 
         // Strip hop-by-hop and length headers so streaming bodies (SSE,


### PR DESCRIPTION
## Summary

- WebSocket upgrade responses through `*.pollinations.ai` were failing with HTTP 500 at the edge.
- Root cause: the proxy worker wraps the upstream response in `new Response(body, init)`, which drops Cloudflare's `webSocket` field — the handshake never completes.
- Fix: detect `Upgrade: websocket` requests and return the upstream response verbatim when the status is 101.

## Test plan
- [x] `npm run deploy:staging` from `pollinations-myceli-proxy/` (version `73bd8ff1`)
- [x] WS upgrade through `wss://staging.gen.pollinations.ai/v1/realtime?model=gpt-realtime-2` succeeds (HTTP 101, full round-trip to OpenAI realtime confirmed)
- [x] Non-WS traffic through the proxy unchanged

Unblocks `/v1/realtime` (and any future WS endpoint) through the public proxy.