### PR TITLE
feat(media): server-attested provenance + remix lineage

### DIFF
--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -183,3 +183,68 @@ export async function handleImageUpload(file, notify) {
         }
     }
 }
+
+// Re-upload a generated meme blob into the media catalog. Returns the public
+// media URL (no API key in the query string, unlike the gen URL). Stamps
+// app:catgpt server-side because the upload uses CatGPT's authorized key.
+// Returns null on failure; callers should fall back to the raw gen URL only
+// if they accept that the URL embeds the user's key.
+export async function uploadGeneratedMeme(blob, filename, parentHash = null) {
+    const key = getStoredApiKey();
+    if (!key) return null;
+    try {
+        const form = new FormData();
+        form.append("file", new File([blob], filename, { type: blob.type }));
+        if (parentHash) form.append("parent", parentHash);
+        const res = await fetch(MEDIA_UPLOAD, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${key}` },
+            body: form,
+        });
+        if (!res.ok) return null;
+        const data = await res.json();
+        return data.url || null;
+    } catch (err) {
+        console.error("Catalog upload failed:", err);
+        return null;
+    }
+}
+
+const MEDIA_HASH_RE = /^https:\/\/media\.pollinations\.ai\/([a-f0-9]{16})$/i;
+export function extractMediaHash(url) {
+    if (!url) return null;
+    const m = MEDIA_HASH_RE.exec(url);
+    return m ? m[1].toLowerCase() : null;
+}
+
+// ── Public catalogs ─────────────────────────────────────────────────────────
+
+const MEDIA_BASE = "https://media.pollinations.ai";
+
+export async function fetchMyMemes(limit = 8) {
+    const key = getStoredApiKey();
+    if (!key) return [];
+    try {
+        const res = await fetch(`${MEDIA_BASE}/me/media?limit=${limit}`, {
+            headers: { Authorization: `Bearer ${key}` },
+        });
+        if (!res.ok) return [];
+        const data = await res.json();
+        return Array.isArray(data.items) ? data.items : [];
+    } catch {
+        return [];
+    }
+}
+
+export async function fetchCatgptGallery(limit = 24) {
+    try {
+        const res = await fetch(
+            `${MEDIA_BASE}/apps/catgpt/media?limit=${limit}`,
+        );
+        if (!res.ok) return [];
+        const data = await res.json();
+        return Array.isArray(data.items) ? data.items : [];
+    } catch {
+        return [];
+    }
+}

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">Community Gallery 😼</h2>
+            <div class="examples-grid" id="galleryGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -5,7 +5,10 @@ import {
     createImageGenerationPrompt,
     EXAMPLE_PROMPTS,
     extractApiKeyFromFragment,
+    extractMediaHash,
     fetchBalance,
+    fetchCatgptGallery,
+    fetchMyMemes,
     fetchProfile,
     generateCatReply,
     generateImageURL,
@@ -14,6 +17,7 @@ import {
     handleImageUpload,
     pickModel,
     storeApiKey,
+    uploadGeneratedMeme,
 } from "./ai.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -75,6 +79,7 @@ const dom = {
     shareBtn: $("shareBtn"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
+    galleryGrid: $("galleryGrid"),
     imageUpload: $("imageUpload"),
     imageUploadContainer: $("imageUploadContainer"),
     imageThumbnailContainer: $("imageThumbnailContainer"),
@@ -159,15 +164,32 @@ function setActiveModel(model) {
 
 const STORAGE_KEY = "catgpt-generated";
 
+// A saved entry is safe to display/share only if it does NOT embed an API key.
+// Old localStorage entries from before the media-catalog rewrite stored the
+// gen URL with `?key=...` directly — those must never be re-rendered.
+function isShareableUrl(url) {
+    if (!url || typeof url !== "string") return false;
+    try {
+        const parsed = new URL(url, window.location.href);
+        if (parsed.searchParams.has("key")) return false;
+        if (parsed.searchParams.has("api_key")) return false;
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 function getSavedMemes() {
     try {
-        return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        const raw = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        return raw.filter((m) => isShareableUrl(m?.url));
     } catch {
         return [];
     }
 }
 
 function saveGeneratedMeme(prompt, url) {
+    if (!isShareableUrl(url)) return;
     const saved = getSavedMemes();
     const updated = [
         { prompt, url, model: activeModel },
@@ -333,23 +355,65 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
-    dom.yourMemesGrid.innerHTML = "";
-    const saved = getSavedMemes();
-
-    if (!saved.length) {
+function renderMemeList(grid, items, emptyMessage) {
+    grid.innerHTML = "";
+    if (!items.length) {
         const p = document.createElement("p");
-        p.textContent = "No memes yet! Generate one to see it here. 🎨";
+        p.textContent = emptyMessage;
         p.style.cssText =
             "grid-column: 1/-1; text-align: center; color: var(--color-muted); padding: 2rem; font-style: italic;";
-        dom.yourMemesGrid.appendChild(p);
+        grid.appendChild(p);
         return;
     }
-
-    saved.forEach((meme, i) => {
+    items.forEach((meme, i) => {
         const card = createMemeCard(meme.prompt, i, meme.url);
-        if (card) dom.yourMemesGrid.appendChild(card);
+        if (card) grid.appendChild(card);
     });
+}
+
+async function loadUserMemes() {
+    // Render localStorage first for instant feedback, then merge in catalog.
+    renderMemeList(
+        dom.yourMemesGrid,
+        getSavedMemes(),
+        "No memes yet! Generate one to see it here. 🎨",
+    );
+    if (!getStoredApiKey()) return;
+    const items = await fetchMyMemes(12);
+    if (!items.length) return;
+    // Use the original prompt where we have one (URL → prompt map from
+    // localStorage); otherwise show the first user tag or "(saved)".
+    const localByUrl = new Map(getSavedMemes().map((m) => [m.url, m.prompt]));
+    const merged = items
+        .filter((it) => it.app === "catgpt")
+        .map((it) => ({
+            url: it.url,
+            prompt:
+                localByUrl.get(it.url) ||
+                (Array.isArray(it.userTags) && it.userTags[0]) ||
+                "(saved)",
+        }));
+    if (merged.length) {
+        renderMemeList(
+            dom.yourMemesGrid,
+            merged,
+            "No memes yet! Generate one to see it here. 🎨",
+        );
+    }
+}
+
+async function loadPublicGallery() {
+    if (!dom.galleryGrid) return;
+    const items = await fetchCatgptGallery(12);
+    renderMemeList(
+        dom.galleryGrid,
+        items.map((it) => ({
+            url: it.url,
+            prompt:
+                (Array.isArray(it.userTags) && it.userTags[0]) || "community",
+        })),
+        "No public memes yet — be the first 😼",
+    );
 }
 
 function loadExamples() {
@@ -411,17 +475,32 @@ async function generateMeme() {
             throw new Error(text.slice(0, 200) || `Error ${response.status}`);
         }
 
-        // Use the pollinations URL directly (shareable, cacheable)
-        await response.blob(); // ensure the image is fully loaded
+        const blob = await response.blob();
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+
+        // Re-upload to media.pollinations.ai so the gallery URL has no API
+        // key in the query string and the meme is server-attested as
+        // app:catgpt for the public catalog.
+        const parentHash = extractMediaHash(uploadedImageUrl);
+        const catalogUrl = await uploadGeneratedMeme(
+            blob,
+            `catgpt-${Date.now()}.png`,
+            parentHash,
+        );
+        if (cancelled) return;
+        const displayUrl = catalogUrl || URL.createObjectURL(blob);
+        dom.generatedMeme.src = displayUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
-        loadUserMemes();
+        // Only persist URLs that don't embed the user's key. If the catalog
+        // upload failed we keep the meme in-session but skip saving.
+        if (catalogUrl) {
+            saveGeneratedMeme(question, catalogUrl);
+            loadUserMemes();
+        }
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +697,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadPublicGallery();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/pollicraft/README.md
+++ b/apps/pollicraft/README.md
@@ -1,0 +1,27 @@
+# pollicraft
+
+A tiny single-file paper-alchemy game. Drag two ingredients together; the
+combination is named by a small LLM, illustrated by an image model, and
+uploaded to the media catalog. Every player builds on the same shared tree.
+
+## How it uses the media catalog
+
+- Each newly crafted element is uploaded to `media.pollinations.ai` via the
+  authenticated upload endpoint. The upload carries:
+  - `parent=<alphabetically-first ingredient hash>` — the lineage edge
+  - `tag=element:<slug>` — element identity
+  - `tag=recipe:<a>+<b>` — deterministic recipe key (sorted)
+  - `tag=name:<slugified-name>` — display name
+- Server stamps `app:pollicraft` and `owner:<userId>` (these are server-attested,
+  not client-claimed).
+- Before crafting, the app checks `GET /apps/pollicraft/media` for an existing
+  element with the same `recipe:<a>+<b>` tag — that's the global recipe cache.
+- "mine" tab reads `GET /me/media?app=pollicraft`.
+- "community" tab reads `GET /apps/pollicraft/media`.
+
+No backend. No PocketBase. The catalog is the database.
+
+## Open
+
+Start a local static server and open `index.html`. You'll need a pollinations
+API key — click **connect** to run the OAuth flow.

--- a/apps/pollicraft/index.html
+++ b/apps/pollicraft/index.html
@@ -1,0 +1,515 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pollicraft — paper alchemy</title>
+<style>
+  :root {
+    --paper: #f6f1e3;
+    --ink: #1d1c18;
+    --ink-soft: #6f6a5a;
+    --accent: #b53a2c;
+    --shadow: 0 1px 0 rgba(29,28,24,.12), 0 8px 18px rgba(29,28,24,.08);
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; background: var(--paper); color: var(--ink);
+    font-family: "Iowan Old Style", "Book Antiqua", "Palatino Linotype", Georgia, serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .app { display: grid; grid-template-columns: 1fr 280px; gap: 18px; height: 100%; padding: 18px; }
+  @media (max-width: 720px) { .app { grid-template-columns: 1fr; padding: 10px; gap: 12px; } }
+
+  header {
+    grid-column: 1 / -1; display: flex; align-items: center; gap: 14px;
+    border-bottom: 1px solid var(--ink-soft); padding-bottom: 8px;
+  }
+  header h1 {
+    margin: 0; font-family: "Segoe Print", "Bradley Hand ITC", "Comic Sans MS", cursive;
+    font-size: 1.6rem; font-weight: 600;
+  }
+  header .tagline { color: var(--ink-soft); font-style: italic; }
+  header .account { margin-left: auto; display: flex; gap: 8px; align-items: center; font-size: 14px; }
+
+  .btn {
+    background: transparent; color: var(--ink); border: 1px solid var(--ink-soft);
+    border-radius: 6px; padding: 6px 10px; cursor: pointer; font: inherit;
+  }
+  .btn.accent { background: var(--accent); color: white; border-color: var(--accent); }
+  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .table {
+    position: relative; min-height: 320px; background: var(--paper);
+    border: 1px dashed var(--ink-soft); border-radius: 14px;
+    overflow: hidden; box-shadow: var(--shadow);
+  }
+  .placed {
+    position: absolute; width: 96px; height: 96px; cursor: grab;
+    border-radius: 10px; background: var(--paper);
+    box-shadow: var(--shadow); display: grid; place-items: center; padding: 6px;
+    text-align: center; font-size: 12px; touch-action: none; user-select: none;
+  }
+  .placed img { max-width: 100%; max-height: 64px; pointer-events: none; }
+  .placed .name { margin-top: 2px; font-weight: 600; }
+  .placed.dragging { cursor: grabbing; z-index: 5; }
+  .placed.crafting { outline: 2px dashed var(--accent); animation: pulse 1s infinite; }
+  @keyframes pulse { 0%,100% { transform: scale(1); } 50% { transform: scale(1.04); } }
+
+  .shelf {
+    background: var(--paper); border: 1px solid var(--ink-soft); border-radius: 14px;
+    padding: 10px; display: flex; flex-direction: column; gap: 10px; min-height: 0;
+    box-shadow: var(--shadow);
+  }
+  .shelf h2 { margin: 0; font-size: 1rem; font-weight: 600; }
+  .shelf .tabs { display: flex; gap: 6px; font-size: 13px; }
+  .shelf .tabs button { background: transparent; border: 0; cursor: pointer; padding: 4px 6px; border-bottom: 2px solid transparent; }
+  .shelf .tabs button.active { border-color: var(--accent); color: var(--accent); }
+  .inventory {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(82px, 1fr));
+    gap: 8px; overflow-y: auto; padding-right: 4px;
+  }
+  .inv-item {
+    border: 1px solid var(--ink-soft); border-radius: 8px; padding: 6px; text-align: center;
+    cursor: grab; background: var(--paper); touch-action: none; user-select: none;
+  }
+  .inv-item img { width: 56px; height: 56px; object-fit: contain; pointer-events: none; }
+  .inv-item .name { font-size: 11px; margin-top: 2px; font-weight: 600; }
+  .inv-item .meta { font-size: 10px; color: var(--ink-soft); }
+
+  .status { color: var(--ink-soft); font-size: 13px; padding: 4px 0; min-height: 18px; }
+  .error { color: var(--accent); font-weight: 600; }
+</style>
+
+<body>
+  <main class="app">
+    <header>
+      <h1>Pollicraft</h1>
+      <span class="tagline">paper alchemy · drag two to craft</span>
+      <div class="account">
+        <span id="status" class="status">ready</span>
+        <button id="connectBtn" class="btn accent">connect</button>
+      </div>
+    </header>
+
+    <section class="table" id="table"></section>
+
+    <aside class="shelf">
+      <h2>Inventory</h2>
+      <div class="tabs">
+        <button class="active" data-tab="mine">mine</button>
+        <button data-tab="community">community</button>
+      </div>
+      <div id="inventory" class="inventory"></div>
+    </aside>
+  </main>
+
+<script type="module">
+const GEN_BASE = "https://gen.pollinations.ai";
+const MEDIA_BASE = "https://media.pollinations.ai";
+const ENTER_BASE = "https://enter.pollinations.ai";
+const APP_KEY = "pk_pollicraft";  // replace with a real publishable key once minted
+const APP_ID = "pollicraft";
+const KEY_STORAGE = "pollicraft:apiKey";
+
+const SEEDS = [
+  { slug: "water", name: "Water" },
+  { slug: "fire", name: "Fire" },
+  { slug: "wind", name: "Wind" },
+  { slug: "earth", name: "Earth" },
+];
+
+const $ = (id) => document.getElementById(id);
+const els = {
+  table: $("table"),
+  inventory: $("inventory"),
+  status: $("status"),
+  connect: $("connectBtn"),
+};
+
+const state = {
+  // Inventory keyed by slug -> { slug, name, url, hash, parent }
+  // `mine` = personal discoveries; `community` = catalog reads
+  inventoryByTab: { mine: new Map(), community: new Map() },
+  activeTab: "mine",
+  placed: [],  // { uid, slug, x, y, el }
+  apiKey: localStorage.getItem(KEY_STORAGE) || null,
+};
+
+function setStatus(msg, isError = false) {
+  els.status.textContent = msg;
+  els.status.classList.toggle("error", isError);
+}
+
+function authHeaders(extra = {}) {
+  return state.apiKey
+    ? { Authorization: `Bearer ${state.apiKey}`, ...extra }
+    : { ...extra };
+}
+
+// ── Auth ────────────────────────────────────────────────────────────────────
+
+function extractKeyFromFragment() {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return null;
+  const k = new URLSearchParams(hash).get("api_key");
+  return k && /^(sk_|pk_|plln_)/.test(k) ? k : null;
+}
+
+function refreshConnectionUI() {
+  els.connect.textContent = state.apiKey ? "connected" : "connect";
+  els.connect.disabled = !!state.apiKey;
+}
+
+els.connect.addEventListener("click", () => {
+  const redirect = window.location.href.split("#")[0];
+  const url = `${ENTER_BASE}/authorize?${new URLSearchParams({
+    redirect_url: redirect,
+    app_key: APP_KEY,
+    budget: "5",
+    models: "flux,nanobanana",
+    permissions: "profile,usage",
+  })}`;
+  window.location.href = url;
+});
+
+(function captureKeyFromFragment() {
+  const k = extractKeyFromFragment();
+  if (k) {
+    state.apiKey = k;
+    localStorage.setItem(KEY_STORAGE, k);
+    history.replaceState(null, "", location.pathname + location.search);
+  }
+  refreshConnectionUI();
+})();
+
+// ── Element creation ────────────────────────────────────────────────────────
+
+function buildPrompt(name, leftName, rightName) {
+  return `small hand-painted ${name}, paper texture, indie game icon, made from ${leftName} and ${rightName}, white background`;
+}
+
+async function generateElementImage(name, leftName, rightName) {
+  const prompt = buildPrompt(name, leftName, rightName);
+  const url = `${GEN_BASE}/image/${encodeURIComponent(prompt)}?model=flux&width=512&height=512&nologo=true`;
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`image gen failed: ${res.status}`);
+  return res.blob();
+}
+
+// Ask a tiny LLM to name the combination.
+async function pickElementName(leftName, rightName) {
+  const res = await fetch(`${GEN_BASE}/v1/chat/completions`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      model: "openai-fast",
+      messages: [
+        {
+          role: "system",
+          content: "You play a craft naming game. Given two ingredients, reply with the most evocative one-word (or short two-word) name for what they make together. Lowercase. No punctuation, no quotes, no explanation. Just the name.",
+        },
+        { role: "user", content: `${leftName} + ${rightName} =` },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`naming failed: ${res.status}`);
+  const data = await res.json();
+  const raw = (data.choices?.[0]?.message?.content || "").trim().toLowerCase();
+  return raw.replace(/[^a-z0-9 ]/g, "").slice(0, 40) || `${leftName}-${rightName}`;
+}
+
+function slugify(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 32);
+}
+
+// ── Media catalog integration ───────────────────────────────────────────────
+
+async function uploadElement(blob, slug, name, leftHash, rightHash, recipeTag) {
+  const form = new FormData();
+  form.append("file", new File([blob], `${slug}.png`, { type: blob.type || "image/png" }));
+  // Pick one parent hash for the lineage edge — by convention the alphabetically
+  // first ingredient. The recipe tag below records both for community lookup.
+  const parent = [leftHash, rightHash].filter(Boolean).sort()[0];
+  if (parent) form.append("parent", parent);
+  form.append("tag", `element:${slug}`);
+  form.append("tag", recipeTag);
+  form.append("tag", `name:${slugify(name)}`);
+  const res = await fetch(`${MEDIA_BASE}/upload`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(`upload failed: ${res.status}`);
+  return res.json();
+}
+
+// Build the deterministic recipe tag from two slugs.
+function recipeTag(a, b) {
+  return `recipe:${[a, b].sort().join("+")}`;
+}
+
+// Look up an existing community discovery for a given recipe.
+async function lookupRecipe(a, b) {
+  const tag = recipeTag(a, b);
+  // tags/v1/<tag>/... is read-public; we hit the per-app catalog filtered
+  // client-side because there is no dedicated tag-read endpoint yet.
+  const res = await fetch(`${MEDIA_BASE}/apps/${APP_ID}/media?limit=200`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  for (const item of data.items || []) {
+    if (Array.isArray(item.userTags) && item.userTags.includes(tag)) {
+      return item;
+    }
+  }
+  return null;
+}
+
+async function fetchMyInventory() {
+  if (!state.apiKey) return [];
+  const res = await fetch(`${MEDIA_BASE}/me/media?limit=100`, { headers: authHeaders() });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.items || []).filter((it) => it.app === APP_ID);
+}
+
+async function fetchCommunityInventory() {
+  const res = await fetch(`${MEDIA_BASE}/apps/${APP_ID}/media?limit=100`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.items || [];
+}
+
+function itemToElement(item) {
+  const tags = Array.isArray(item.userTags) ? item.userTags : [];
+  const elementTag = tags.find((t) => t.startsWith("element:"));
+  const nameTag = tags.find((t) => t.startsWith("name:"));
+  const slug = elementTag ? elementTag.slice("element:".length) : item.hash;
+  const name = nameTag ? nameTag.slice("name:".length).replace(/-/g, " ") : slug;
+  return { slug, name, url: item.url, hash: item.hash, parent: item.parent };
+}
+
+// ── Inventory rendering ─────────────────────────────────────────────────────
+
+function ensureSeeds(tab) {
+  const map = state.inventoryByTab[tab];
+  for (const seed of SEEDS) {
+    if (!map.has(seed.slug)) {
+      // Seeds use placeholder icons (CSS-only) — no media hash yet, so they
+      // never produce a `parent` edge when used in a first-time combination.
+      map.set(seed.slug, { slug: seed.slug, name: seed.name, url: "", hash: null });
+    }
+  }
+}
+
+function renderInventory() {
+  const map = state.inventoryByTab[state.activeTab];
+  els.inventory.innerHTML = "";
+  const items = Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+  for (const item of items) {
+    const card = document.createElement("div");
+    card.className = "inv-item";
+    card.draggable = false;
+    card.dataset.slug = item.slug;
+    if (item.url) {
+      const img = document.createElement("img");
+      img.src = item.url;
+      img.alt = item.name;
+      img.loading = "lazy";
+      card.appendChild(img);
+    } else {
+      const placeholder = document.createElement("div");
+      placeholder.style.cssText = "width:56px;height:56px;display:grid;place-items:center;font-size:32px;";
+      placeholder.textContent = { water: "💧", fire: "🔥", wind: "🌬️", earth: "🪨" }[item.slug] || "🜍";
+      card.appendChild(placeholder);
+    }
+    const n = document.createElement("div");
+    n.className = "name";
+    n.textContent = item.name;
+    card.appendChild(n);
+    card.addEventListener("pointerdown", (e) => beginDragFromInventory(e, item));
+    els.inventory.appendChild(card);
+  }
+}
+
+for (const tabBtn of document.querySelectorAll(".tabs button")) {
+  tabBtn.addEventListener("click", async () => {
+    for (const b of document.querySelectorAll(".tabs button")) {
+      b.classList.toggle("active", b === tabBtn);
+    }
+    state.activeTab = tabBtn.dataset.tab;
+    if (state.activeTab === "community" && state.inventoryByTab.community.size === 0) {
+      setStatus("loading community discoveries...");
+      const items = await fetchCommunityInventory();
+      for (const it of items) {
+        const el = itemToElement(it);
+        state.inventoryByTab.community.set(el.slug, el);
+      }
+      setStatus(`${items.length} community discoveries`);
+    }
+    ensureSeeds(state.activeTab);
+    renderInventory();
+  });
+}
+
+// ── Table drag + craft ──────────────────────────────────────────────────────
+
+let dragState = null;
+
+function placeOnTable(item, x, y) {
+  const uid = Math.random().toString(36).slice(2, 9);
+  const el = document.createElement("div");
+  el.className = "placed";
+  el.style.left = `${x - 48}px`;
+  el.style.top = `${y - 48}px`;
+  if (item.url) {
+    const img = document.createElement("img");
+    img.src = item.url; img.alt = item.name; el.appendChild(img);
+  } else {
+    const ph = document.createElement("div");
+    ph.style.fontSize = "40px";
+    ph.textContent = { water: "💧", fire: "🔥", wind: "🌬️", earth: "🪨" }[item.slug] || "🜍";
+    el.appendChild(ph);
+  }
+  const n = document.createElement("div");
+  n.className = "name"; n.textContent = item.name; el.appendChild(n);
+  els.table.appendChild(el);
+  const placed = { uid, slug: item.slug, name: item.name, hash: item.hash, x, y, el };
+  el.addEventListener("pointerdown", (e) => beginDragPlaced(e, placed));
+  el.addEventListener("dblclick", () => removePlaced(placed));
+  state.placed.push(placed);
+  return placed;
+}
+
+function removePlaced(p) {
+  p.el.remove();
+  state.placed = state.placed.filter((q) => q !== p);
+}
+
+function beginDragFromInventory(e, item) {
+  e.preventDefault();
+  const tableRect = els.table.getBoundingClientRect();
+  const insideTable = e.clientX >= tableRect.left && e.clientX <= tableRect.right
+    && e.clientY >= tableRect.top && e.clientY <= tableRect.bottom;
+  let placed;
+  if (insideTable) {
+    placed = placeOnTable(item, e.clientX - tableRect.left, e.clientY - tableRect.top);
+  } else {
+    placed = placeOnTable(item, tableRect.width / 2, tableRect.height / 2);
+  }
+  beginDragPlaced(e, placed);
+}
+
+function beginDragPlaced(e, p) {
+  e.preventDefault();
+  const rect = p.el.getBoundingClientRect();
+  dragState = {
+    placed: p,
+    offsetX: e.clientX - rect.left,
+    offsetY: e.clientY - rect.top,
+  };
+  p.el.classList.add("dragging");
+  p.el.setPointerCapture(e.pointerId);
+  p.el.addEventListener("pointermove", onDragMove);
+  p.el.addEventListener("pointerup", onDragEnd, { once: true });
+  p.el.addEventListener("pointercancel", onDragEnd, { once: true });
+}
+
+function onDragMove(e) {
+  if (!dragState) return;
+  const tableRect = els.table.getBoundingClientRect();
+  const x = e.clientX - tableRect.left - dragState.offsetX + 48;
+  const y = e.clientY - tableRect.top - dragState.offsetY + 48;
+  dragState.placed.x = x;
+  dragState.placed.y = y;
+  dragState.placed.el.style.left = `${x - 48}px`;
+  dragState.placed.el.style.top = `${y - 48}px`;
+  highlightCollision(dragState.placed);
+}
+
+function distance(a, b) { return Math.hypot(a.x - b.x, a.y - b.y); }
+
+function highlightCollision(active) {
+  for (const p of state.placed) p.el.classList.remove("crafting");
+  const partner = findCollision(active);
+  if (partner) {
+    active.el.classList.add("crafting");
+    partner.el.classList.add("crafting");
+  }
+}
+
+function findCollision(active) {
+  return state.placed.find((p) => p !== active && distance(p, active) < 80) || null;
+}
+
+async function onDragEnd() {
+  if (!dragState) return;
+  const active = dragState.placed;
+  active.el.classList.remove("dragging");
+  active.el.removeEventListener("pointermove", onDragMove);
+  const partner = findCollision(active);
+  dragState = null;
+  for (const p of state.placed) p.el.classList.remove("crafting");
+  if (!partner) return;
+  if (active.slug === partner.slug) return;
+  await craftFromPlaced(active, partner);
+}
+
+async function craftFromPlaced(a, b) {
+  if (!state.apiKey) {
+    setStatus("connect first to craft new elements", true);
+    return;
+  }
+  setStatus(`crafting ${a.name} + ${b.name}...`);
+  try {
+    // First, check community catalog for a pre-existing recipe.
+    const existing = await lookupRecipe(a.slug, b.slug);
+    if (existing) {
+      const el = itemToElement(existing);
+      addToInventory("mine", el);
+      placeOnTable(el, (a.x + b.x) / 2, (a.y + b.y) / 2);
+      removePlaced(a); removePlaced(b);
+      setStatus(`discovered ${el.name} (from community)`);
+      renderInventory();
+      return;
+    }
+    const name = await pickElementName(a.name, b.name);
+    const slug = slugify(name) || `${a.slug}-${b.slug}`;
+    const blob = await generateElementImage(name, a.name, b.name);
+    const uploaded = await uploadElement(blob, slug, name, a.hash, b.hash, recipeTag(a.slug, b.slug));
+    const el = { slug, name, url: uploaded.url, hash: uploaded.id, parent: uploaded.parent };
+    addToInventory("mine", el);
+    placeOnTable(el, (a.x + b.x) / 2, (a.y + b.y) / 2);
+    removePlaced(a); removePlaced(b);
+    setStatus(`✨ discovered ${name}`);
+    renderInventory();
+  } catch (err) {
+    console.error(err);
+    setStatus(err.message || "craft failed", true);
+  }
+}
+
+function addToInventory(tab, el) {
+  state.inventoryByTab[tab].set(el.slug, el);
+}
+
+// ── Init ────────────────────────────────────────────────────────────────────
+
+(async function init() {
+  ensureSeeds("mine");
+  ensureSeeds("community");
+  renderInventory();
+  if (state.apiKey) {
+    setStatus("loading your inventory...");
+    const items = await fetchMyInventory();
+    for (const it of items) {
+      const el = itemToElement(it);
+      state.inventoryByTab.mine.set(el.slug, el);
+    }
+    setStatus(`${items.length} of your discoveries loaded`);
+    renderInventory();
+  }
+})();
+</script>
+</body>
+</html>

--- a/apps/voice-edit/REMIX.md
+++ b/apps/voice-edit/REMIX.md
@@ -1,0 +1,100 @@
+# voice-edit-remix
+
+Image-only voice editor where **the image IS the share unit**. Click save
+and you get a PNG with your full edit history embedded in a `tEXt` chunk.
+Drop that PNG back onto the app — or onto any other instance of the app —
+and the gallery rehydrates.
+
+## flow
+
+1. Open the app, edit images.
+2. Click **load** to load an image from disk, or **sample** to step through
+   copyright-friendly starter images: cell render,
+   public-domain octopus illustration, public-domain Grand Prismatic
+   Spring, NASA Cosmic Cliffs, NASA Mars rover, relativity stairs,
+   Da Vinci, Tomaselli, a mushroom with ladybug, or a surreal room.
+3. Each edit adds two history frames: the prompted/annotated input state,
+   then the generated result. Undo once from a result shows the prompt state.
+4. Each generated result is repacked as a PNG with current history metadata
+   and uploaded back to `media.pollinations.ai`; the current `#start=` URL
+   fragment points at that repacked image.
+5. Click **save** → downloads `voice-edit-<ts>.png`. The file is a normal
+   PNG of the current frame. It also carries the full history JSON in a
+   PNG `tEXt` chunk under keyword `pollinations:voice-edit:history`.
+6. Click **share** → uploads the same metadata PNG if needed and copies an
+   app link with `#start=<media-url>`.
+7. Share the PNG or link. Drop the PNG on the app (or open the link) — the
+   embedded chunk is read on drop, history restores, the latest frame
+   renders.
+
+Alternate entry: `#start=<image-url>` boots from that URL instead of the
+default starter; old `?start=<image-url>` links still work. If the URL
+points at a PNG with our `tEXt` chunk, that PNG is the source of truth:
+history is restored from it. If there is no chunk, the app starts a fresh
+one-frame history from that image. Undo/redo can use `index=<n>` in the
+fragment while keeping `start` pointed at the same metadata carrier.
+Load and sample use the same path: they first put a media URL into
+`#start=`, then the app initializes from that URL. Plain images become a
+one-frame history; remix PNGs restore their embedded history.
+
+## why this shape
+
+- The PNG is the canonical artifact — one file, not two.
+- Pollinations URLs are deterministic and server-cached, so embedding URL
+  strings (not bytes) keeps the overhead tiny. A session of 50 frames adds
+  ~3 KB to the PNG.
+- PNGs share natively everywhere (Discord, iMessage, AirDrop, Slack).
+  `media.pollinations.ai` preserves `tEXt` chunks on upload, so uploading
+  a saved PNG and sharing its URL is the same as sharing the file.
+- Generated results are repacked once, immediately after the edit returns,
+  so the live media URL already contains the remix metadata.
+- No HTML self-modification, no quine tricks, no source doubling. The app
+  HTML stays canonical at its hosted URL.
+
+## stack
+
+| layer | choice | notes |
+|---|---|---|
+| app | single `index.html` | no build step, no React |
+| state transport | PNG `tEXt` chunk | keyword `pollinations:voice-edit:history`, value is JSON `{v, history, historyIndex}` |
+| starter override | URL fragment `#start=<url>` | optional; default starter is the cell render |
+| auth | Pollinations OAuth, `localStorage["voice-edit:user-key"]` | not embedded in saved PNG |
+
+## tEXt chunk format
+
+PNG ancillary chunk per [PNG spec §11.3.4.3](https://www.w3.org/TR/PNG/#11tEXt).
+Inserted before `IEND`. Keyword and text are latin-1 / UTF-8 ASCII-safe.
+CRC32 over `type || data`. Pure JS, no deps.
+
+```js
+const payload = {
+  v: 1,
+  history: [{ url: "..." }, { url: "..." }],
+  historyIndex: 1,
+};
+```
+
+`v` is the schema version. Bump it if the payload shape changes.
+
+## auth
+
+Tokens never enter the PNG. They live only in `localStorage`. The
+recipient of a shared PNG opens it in their copy of the app and connects
+their own Pollinations account.
+
+The cached gallery (history URLs) loads without auth — generation URLs
+are public.
+
+## local
+
+```bash
+cd apps/voice-edit-remix
+python3 -m http.server 8767
+# http://localhost:8767/
+```
+
+## siblings
+
+- `apps/voice-edit` — richer version with video animate mode.
+- `apps/voice-edit-image` — minimal image-only base. This variant forks
+  from it.

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -1,0 +1,1590 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Remix | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --line: #110518;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--line);
+    --raise: 2px 2px 0 var(--line);
+    --stage-max: calc(100vh - 210px);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  button, input, select { font: inherit; color: inherit; }
+  button { touch-action: manipulation; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .btn, .select, .frame, .overlay-panel, .pin, .pill {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+    font-weight: 700;
+  }
+  .btn {
+    padding: 0 12px;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--line); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; max-width: min(100%, 20rem); }
+
+  .mode-toggle, .swatches {
+    display: inline-flex;
+    align-items: center;
+  }
+  .mode-toggle {
+    gap: 0;
+  }
+  .mode-toggle button {
+    width: 38px;
+    height: 38px;
+    border: var(--border);
+    background: var(--surface);
+    font: inherit;
+    font-size: 1.05rem;
+    cursor: pointer;
+  }
+  .mode-toggle button + button {
+    margin-left: -3px;
+  }
+  .mode-toggle button.active {
+    background: var(--accent);
+    z-index: 1;
+  }
+  .mode-toggle button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+  .history { margin-left: auto; }
+
+  .swatches {
+    gap: 5px;
+  }
+  .swatch {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: var(--border);
+    border-radius: 0;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    cursor: pointer;
+  }
+  .swatch.active { outline-color: var(--accent); }
+  .swatch[data-color="white"] { background: #fff; }
+  .swatch[data-color="black"] { background: #000; }
+  .swatch[data-color="red"] { background: red; }
+
+  .frame {
+    position: relative;
+    min-height: 280px;
+    overflow: visible;
+    display: grid;
+    place-items: center;
+  }
+  .frame.drop { outline: 4px dashed var(--accent); outline-offset: -10px; }
+  .stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    touch-action: none;
+  }
+  .stage canvas {
+    display: block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    width: auto;
+    height: auto;
+  }
+  #markCanvas, #pinLayer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  #pinLayer { z-index: 4; pointer-events: none; overflow: visible; }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(243, 235, 222, 0.88);
+    backdrop-filter: blur(2px);
+  }
+  .frame.locked .overlay { display: flex; }
+  .overlay-panel {
+    width: min(22rem, calc(100% - 32px));
+    padding: 18px;
+    text-align: center;
+  }
+  .overlay-panel p { margin: 0 0 12px; font-size: 0.9rem; }
+
+  .pin {
+    position: absolute;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    max-width: min(16rem, 48vw);
+    width: max-content;
+    padding: 5px 9px;
+    transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    overflow-wrap: break-word;
+  }
+  .pin.processing { background: var(--accent); }
+  .pin.history { background: var(--paper); opacity: 0.85; }
+  .pin.flip {
+    flex-direction: row-reverse;
+    transform: translate(calc(-100% + 0.55rem + 0.275rem + 1.5px), -50%);
+  }
+  .pin .dot {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    background: var(--line);
+    border: 1.5px solid var(--line);
+  }
+  .pin span:last-child { min-width: 0; }
+
+  .pill {
+    position: fixed;
+    z-index: 20;
+    display: none;
+    align-items: center;
+    gap: 9px;
+    max-width: min(18rem, calc(100vw - 24px));
+    padding: 8px 12px 8px 8px;
+    transform: translate(18px, -50%);
+    font-size: 0.9rem;
+    font-weight: 700;
+    pointer-events: none;
+    overflow-wrap: anywhere;
+  }
+  .pill.visible { display: inline-flex; }
+  .pill .mic {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: var(--accent);
+    border: var(--border);
+  }
+  .pill .bar {
+    width: 3px;
+    background: var(--line);
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  .pill .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  .pill .bar:nth-child(2) { height: 10px; animation-delay: 0.15s; }
+  .pill .bar:nth-child(3) { height: 6px; animation-delay: 0.3s; }
+  .pill .placeholder { opacity: 0.55; font-style: italic; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+
+  @media (max-width: 720px) {
+    .app { --stage-max: calc(100vh - 260px); width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .topbar { gap: 6px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .history { margin-left: 0; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .frame { min-height: 240px; }
+    .pin { max-width: 62vw; }
+  }
+  .frame.locked .stage { filter: grayscale(0.35) opacity(0.55); }
+
+  .remixes-panel {
+    background: var(--paper); border: 1px solid var(--ink-soft);
+    border-radius: 12px; padding: 12px 14px; display: flex; flex-direction: column;
+    gap: 10px;
+  }
+  .remixes-head { display: flex; align-items: center; gap: 8px; }
+  .remixes-head h2 { margin: 0; font-size: 1rem; font-weight: 600; }
+  .remixes-head .btn { margin-left: auto; }
+  .remixes-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px;
+  }
+  .remix-card {
+    border: 1px solid var(--ink-soft); border-radius: 8px; overflow: hidden;
+    cursor: pointer; background: var(--paper);
+  }
+  .remix-card img { display: block; width: 100%; aspect-ratio: 1; object-fit: cover; }
+  .remix-card .meta { padding: 6px 8px; font-size: 12px; color: var(--ink-soft); }
+  .remix-card .meta strong { color: var(--dark); display: block; font-weight: 600; }
+  .remixes-empty { color: var(--ink-soft); font-style: italic; margin: 0; }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / remix</h1>
+      <span class="tagline">draw. talk. release.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="tools">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="uploadBtn" class="btn" title="load an image from disk">load</button>
+      <button id="shuffleBtn" class="btn" title="next sample image">sample</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="image model">
+        <option value="nanobanana">nanobanana</option>
+      </select>
+      <div id="colorPicker" class="swatches" aria-label="marker color">
+        <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
+        <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
+        <button type="button" class="swatch" data-color="white" aria-label="white marker"></button>
+      </div>
+      <div id="inputMode" class="mode-toggle" aria-label="input mode">
+        <button type="button" data-mode="mic" aria-label="use microphone">🎙️</button>
+        <button type="button" data-mode="type" aria-label="type prompt">⌨️</button>
+      </div>
+      <button id="undoBtn" class="btn history" disabled title="undo">undo</button>
+      <button id="redoBtn" class="btn" disabled title="redo">redo</button>
+      <button id="downloadBtn" class="btn" title="download image with embedded history - drop it back onto the app to restore">save</button>
+      <button id="shareBtn" class="btn" title="upload PNG with embedded history and copy link">share</button>
+      <button id="remixesBtn" class="btn history" disabled title="see other remixes that branched from this image">remixes</button>
+      <button id="walkthroughBtn" class="btn" title="open this remix history as a video walkthrough">walkthrough</button>
+    </section>
+
+    <section id="remixesPanel" class="remixes-panel" hidden>
+      <header class="remixes-head">
+        <h2>community remixes</h2>
+        <button id="remixesCloseBtn" class="btn" type="button">close</button>
+      </header>
+      <div id="remixesGrid" class="remixes-grid"></div>
+      <p id="remixesEmpty" class="remixes-empty" hidden>no remixes yet — your share will start the tree</p>
+    </section>
+
+    <section id="frame" class="frame">
+      <div id="stage" class="stage">
+        <canvas id="imageCanvas" width="1024" height="768"></canvas>
+        <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <div id="pinLayer"></div>
+      </div>
+      <div class="overlay">
+        <div class="overlay-panel">
+          <p>connect to pollinations to start editing</p>
+          <button id="connectOverlayBtn" class="btn accent">connect</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div id="cursorPill" class="pill" aria-hidden="true">
+    <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
+    <span id="pillText" class="placeholder">listening...</span>
+  </div>
+
+<script>
+const KEY_STORAGE = "voice-edit:user-key";
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const STARTERS = [
+  { name: "cell", url: "https://media.pollinations.ai/10efdd0c1cfc65fa" },
+  { name: "octopus", url: "https://media.pollinations.ai/73775b7374f9b864" },
+  { name: "grand prismatic", url: "https://media.pollinations.ai/98280006f6099cb0" },
+  { name: "cosmic cliffs", url: "https://media.pollinations.ai/d05180b3bf21c01c" },
+  { name: "mars rover", url: "https://media.pollinations.ai/9a138c75c377d84a" },
+  { name: "relativity", url: "https://media.pollinations.ai/e7fc55d8a304edb3" },
+  { name: "da vinci", url: "https://media.pollinations.ai/31f553055c73b482" },
+  { name: "tomaselli", url: "https://media.pollinations.ai/9f450191ad9b8253" },
+  { name: "mushroom", url: "https://media.pollinations.ai/ad65acf0fd23ff85" },
+  { name: "surreal room", url: "https://media.pollinations.ai/fbc6c13d37c55f0b" },
+];
+const STARTER = STARTERS[0].url;
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const STT_MODEL = "scribe";
+const STT_LANG = (navigator.language || "en").slice(0, 2);
+const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+  .find((m) => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+const CAN_RECORD = Boolean(window.MediaRecorder && navigator.mediaDevices?.getUserMedia);
+const DRAG_THRESHOLD = 0.03;
+const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+
+const $ = (id) => document.getElementById(id);
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const pairs = (items) => items.slice(1).map((item, i) => [items[i], item]);
+const distance = (a, b) => Math.hypot(b.x - a.x, b.y - a.y);
+const minCanvasSide = () => Math.min(els.markCanvas.width, els.markCanvas.height);
+
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  frame: "frame",
+  imageCanvas: "imageCanvas",
+  markCanvas: "markCanvas",
+  pinLayer: "pinLayer",
+  connect: "connectBtn",
+  connectOverlay: "connectOverlayBtn",
+  upload: "uploadBtn",
+  shuffle: "shuffleBtn",
+  file: "fileInput",
+  model: "modelSel",
+  inputMode: "inputMode",
+  undo: "undoBtn",
+  redo: "redoBtn",
+  download: "downloadBtn",
+  share: "shareBtn",
+  remixes: "remixesBtn",
+  remixesClose: "remixesCloseBtn",
+  remixesPanel: "remixesPanel",
+  remixesGrid: "remixesGrid",
+  remixesEmpty: "remixesEmpty",
+  walkthrough: "walkthroughBtn",
+  colorPicker: "colorPicker",
+  pill: "cursorPill",
+  pillText: "pillText",
+}).map(([key, id]) => [key, $(id)]));
+const imageCtx = els.imageCanvas.getContext("2d");
+const markCtx = els.markCanvas.getContext("2d");
+
+const app = {
+  image: null,
+  imageURL: "",
+  stateURL: "",
+  history: [],
+  historyIndex: -1,
+  micStream: null,
+  active: null,
+  busy: false,
+  queue: [],
+  currentJob: null,
+  markerColor: "red",
+  inputMode: CAN_RECORD ? "mic" : "type",
+  micAvailable: CAN_RECORD,
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = (extra = {}) => ({ Authorization: `Bearer ${key()}`, ...extra });
+
+function render() {
+  const locked = app.busy || Boolean(app.active);
+  els.undo.disabled = !mediaHistory.canUndo() || locked;
+  els.redo.disabled = !mediaHistory.canRedo() || locked;
+  [els.upload, els.shuffle, els.model, els.share, els.walkthrough].forEach((el) => { el.disabled = locked; });
+  els.remixes.disabled = locked || !lineageParentHash();
+  renderInputMode(locked);
+  renderPins();
+}
+
+function renderInputMode(locked = false) {
+  for (const button of els.inputMode.querySelectorAll("button")) {
+    const mode = button.dataset.mode;
+    button.classList.toggle("active", app.inputMode === mode);
+    button.disabled = locked || (mode === "mic" && !app.micAvailable);
+  }
+}
+
+function setInputMode(mode) {
+  if (mode === "mic" && !app.micAvailable) return;
+  app.inputMode = mode;
+  render();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function setMarkerColor(color) {
+  app.markerColor = color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button.dataset.color === color);
+  }
+}
+
+function renderPins() {
+  const jobs = [app.currentJob, ...app.queue].filter(Boolean);
+  const items = jobs.length
+    ? jobs.map((job) => ({
+      cls: job === app.currentJob ? "processing" : "queued",
+      text: job.text,
+      xPct: job.xPct,
+      yPct: job.yPct,
+    }))
+    : pinForCurrentFrame();
+  const layerBox = els.pinLayer.getBoundingClientRect();
+  els.pinLayer.replaceChildren(...items.map((item) => {
+    const pin = document.createElement("div");
+    pin.className = `pin ${item.cls}`;
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    const text = document.createElement("span");
+    text.textContent = item.text;
+    pin.append(dot, text);
+    pin.style.left = `${item.xPct}%`;
+    pin.style.top = `${item.yPct}%`;
+    const anchorX = layerBox.left + (layerBox.width * item.xPct / 100);
+    const rightSpace = window.innerWidth - anchorX - 16;
+    const leftSpace = anchorX - 16;
+    const flip = rightSpace < 140 && leftSpace > rightSpace;
+    pin.classList.toggle("flip", flip);
+    pin.style.maxWidth = `${clamp(flip ? leftSpace : rightSpace, 40, 256)}px`;
+    return pin;
+  }));
+}
+
+function pinForCurrentFrame() {
+  const frame = app.history[app.historyIndex];
+  if (frame?.kind !== "prep" || frame.xPct == null || frame.yPct == null) return [];
+  return [{
+    cls: "history",
+    text: frame.promptText || "",
+    xPct: frame.xPct,
+    yPct: frame.yPct,
+  }];
+}
+
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) els.pill.style.left = `${x}px`;
+  if (y != null) els.pill.style.top = `${y}px`;
+  if (text !== undefined) {
+    els.pillText.textContent = text;
+    els.pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) els.pill.classList.toggle("visible", visible);
+}
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (apiKey) {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    history.replaceState(null, "", location.pathname + location.search);
+  } else if (params.get("error")) {
+    showError(`Authorization failed: ${params.get("error")}`);
+  }
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  els.frame.classList.toggle("locked", !connected);
+  if (!connected) {
+    app.accountUser = "";
+    app.accountBalance = null;
+    renderAccount();
+    setStatus("not connected");
+    return;
+  }
+  renderAccount();
+  warmMic();
+  loadUser();
+  loadBalance();
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname + location.search,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  stopMic();
+  refreshConnectionUI();
+}
+
+async function loadUser() {
+  try {
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const user = await res.json();
+    app.accountUser = user?.preferred_username || "";
+    renderAccount();
+  } catch {}
+}
+
+async function loadBalance() {
+  try {
+    const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const { balance } = await res.json();
+    app.accountBalance = Number(balance);
+    renderAccount();
+  } catch {}
+}
+
+async function warmMic() {
+  if (app.micStream || !app.micAvailable) return;
+  try {
+    app.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+  } catch (err) {
+    app.micAvailable = false;
+    app.inputMode = "type";
+    render();
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use type instead.`);
+  }
+}
+
+function stopMic() {
+  if (!app.micStream) return;
+  for (const track of app.micStream.getTracks()) track.stop();
+  app.micStream = null;
+}
+
+const mediaHistory = {
+  canUndo: () => app.historyIndex > 0,
+  canRedo: () => app.historyIndex >= 0 && app.historyIndex < app.history.length - 1,
+  add(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  addSilent(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  async go(index) {
+    const frame = app.history[index];
+    if (!frame) return;
+    await renderFrame(frame);
+    app.historyIndex = index;
+    syncStartToFrame(frame);
+    render();
+  },
+  async set(frame, { add = false } = {}) {
+    await renderFrame(frame);
+    if (add) mediaHistory.add(frame);
+    else {
+      syncStartToFrame(frame);
+      render();
+    }
+  },
+  async reset(frame, stateURL = frame.url) {
+    app.history = [frame];
+    app.historyIndex = 0;
+    app.stateURL = scrubURL(stateURL) || scrubURL(frame.url);
+    await renderFrame(frame);
+    syncStartToFrame(frame, { force: true });
+    render();
+  },
+};
+
+async function loadModels() {
+  try {
+    const res = await fetch(`${BASE}/image/models`);
+    if (!res.ok) return;
+    const models = await res.json();
+    const editModels = models
+      .filter((m) => m.input_modalities?.includes("image") && m.output_modalities?.includes("image"))
+      .sort((a, b) => {
+        const ra = RECOMMENDED_MODELS.has(a.name) ? 0 : 1;
+        const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
+        return ra - rb || a.name.localeCompare(b.name);
+      });
+    els.model.replaceChildren(...editModels.map((m) => {
+      const tags = [];
+      if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
+      if (m.paid_only) tags.push("paid");
+      return new Option(tags.length ? `${m.name} (${tags.join(", ")})` : m.name, m.name);
+    }));
+    if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+  } catch {}
+}
+
+async function renderFrame(frame) {
+  clearError();
+  await drawImage(frame.url);
+  clearMarks();
+  setStatus("ready");
+}
+
+async function drawImage(src) {
+  setStatus("loading image...");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = () => reject(new Error("could not load image"));
+    img.src = src;
+  });
+  app.image = img;
+  app.imageURL = src;
+  resizeCanvases(img.naturalWidth, img.naturalHeight);
+  imageCtx.drawImage(img, 0, 0);
+}
+
+function resizeCanvases(width, height) {
+  for (const canvas of [els.imageCanvas, els.markCanvas]) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function clearMarks() {
+  markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function pointerPoint(event) {
+  const rect = els.markCanvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
+  const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
+  return {
+    x: clamp(Math.round(x), 0, els.markCanvas.width),
+    y: clamp(Math.round(y), 0, els.markCanvas.height),
+  };
+}
+
+function strokeWidth() {
+  return Math.max(6, Math.round(minCanvasSide() * 0.015));
+}
+
+function drawSegment(from, to) {
+  markCtx.save();
+  markCtx.strokeStyle = app.markerColor;
+  markCtx.lineWidth = strokeWidth();
+  markCtx.lineCap = "round";
+  markCtx.lineJoin = "round";
+  markCtx.beginPath();
+  markCtx.moveTo(from.x, from.y);
+  markCtx.lineTo(to.x, to.y);
+  markCtx.stroke();
+  markCtx.restore();
+}
+
+function pathLength(points) {
+  return pairs(points).reduce((total, [a, b]) => total + distance(a, b), 0);
+}
+
+function pathBounds(points) {
+  return points.reduce((bounds, point) => ({
+    minX: Math.min(bounds.minX, point.x),
+    maxX: Math.max(bounds.maxX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    maxY: Math.max(bounds.maxY, point.y),
+  }), { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity });
+}
+
+function markerFromGesture({ points }) {
+  const marked = pathLength(points) >= minCanvasSide() * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const bounds = marked ? pathBounds(points) : null;
+  return {
+    marked,
+    marker: marked ? els.markCanvas.toDataURL("image/png") : "",
+    pinPoint: marked ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 } : points[0],
+  };
+}
+
+async function composeSnapshot(marker = "") {
+  const out = document.createElement("canvas");
+  out.width = els.imageCanvas.width;
+  out.height = els.imageCanvas.height;
+  const outCtx = out.getContext("2d");
+  outCtx.drawImage(els.imageCanvas, 0, 0);
+  if (marker) {
+    const markerImage = await loadImageElement(marker);
+    outCtx.drawImage(markerImage, 0, 0, out.width, out.height);
+  }
+  return out.toDataURL("image/png");
+}
+
+function buildPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
+}
+
+function pinPct(point) {
+  return {
+    xPct: (point.x / els.markCanvas.width) * 100,
+    yPct: (point.y / els.markCanvas.height) * 100,
+  };
+}
+
+function loadImageElement(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load marker"));
+    img.src = src;
+  });
+}
+
+function enqueueJob({ text, marked = false, marker = "", pinPoint, color }) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  const pin = pinPct(pinPoint);
+  app.queue.push({
+    text,
+    marked,
+    marker,
+    color,
+    model: els.model.value,
+    xPct: pin.xPct,
+    yPct: pin.yPct,
+  });
+  render();
+  runQueue();
+}
+
+function beginRecording(clientX, clientY) {
+  clearError();
+  if (!app.micAvailable) return { error: "Voice input is not available in this browser. Use type instead." };
+  if (!app.micStream) {
+    warmMic();
+    return { error: "microphone not ready - click once, allow access, then try again" };
+  }
+  const capture = { chunks: [], recorder: null, error: "" };
+  try {
+    capture.recorder = new MediaRecorder(app.micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (event) => {
+      if (event.data?.size) capture.chunks.push(event.data);
+    };
+    capture.recorder.start();
+  } catch (err) {
+    capture.error = err?.message || "could not start recording";
+    return capture;
+  }
+  pill({ x: clientX, y: clientY, text: "listening...", placeholder: true, visible: true });
+  setStatus("listening...");
+  return capture;
+}
+
+async function stopAndTranscribe(capture) {
+  if (capture.error || !capture.recorder) return { text: "", error: capture.error };
+  setStatus("transcribing...");
+  pill({ text: "transcribing...", placeholder: true });
+  const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
+  capture.recorder.stop();
+  await stopped;
+  const type = capture.recorder.mimeType || "audio/webm";
+  const ext = type.includes("mp4") ? "mp4" : "webm";
+  const blob = new Blob(capture.chunks, { type });
+  if (blob.size < 1000) return { text: "", error: "no audio captured - hold and speak" };
+  const form = new FormData();
+  form.append("file", blob, `voice.${ext}`);
+  form.append("model", STT_MODEL);
+  form.append("language", STT_LANG);
+  form.append("response_format", "json");
+  try {
+    const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    });
+    if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
+    const json = await res.json();
+    return { text: (json.text || "").trim(), error: "" };
+  } catch (err) {
+    return { text: "", error: err?.message || "transcription failed" };
+  }
+}
+
+async function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  els.pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing...");
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (text) => {
+      if (done) return;
+      done = true;
+      input.replaceWith(els.pillText);
+      pill({ visible: false });
+      resolve(text.trim());
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") { event.preventDefault(); finish(input.value); }
+      if (event.key === "Escape") { event.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value));
+  });
+}
+
+async function uploadDataURL(dataURL, filename = "annot.png", { parent } = {}) {
+  const blob = await (await fetch(dataURL)).blob();
+  return uploadBlob(blob, filename, { parent });
+}
+
+async function uploadBlob(blob, filename, { parent } = {}) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  if (parent && MEDIA_HASH_RE.test(parent)) form.append("parent", parent);
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+const MEDIA_HASH_RE = /^[a-f0-9]{16}$/i;
+const MEDIA_URL_RE = /^https:\/\/media\.pollinations\.ai\/([a-f0-9]{16})(?:[/?#].*)?$/i;
+function extractMediaHash(url) {
+  if (!url) return null;
+  const m = MEDIA_URL_RE.exec(String(url));
+  return m ? m[1].toLowerCase() : null;
+}
+
+function canvasBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("canvas toBlob failed"))), "image/png");
+  });
+}
+
+async function runEdit(imageURL, prompt, model) {
+  const res = await fetch(`${BASE}/v1/images/edits`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
+  const json = await res.json();
+  const item = json.data?.[0];
+  if (!item) throw new Error("no image in response");
+  if (item.url) return item.url;
+  if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
+  throw new Error("no url or b64_json in response");
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+async function runQueue() {
+  if (app.busy) return;
+  app.busy = true;
+  render();
+  try {
+    while (app.queue.length) {
+      const job = app.queue.shift();
+      app.currentJob = job;
+      render();
+      setStatus(`editing... (${app.queue.length + 1} in queue)`);
+      try {
+        const snapshot = await composeSnapshot(job.marker);
+        const uploaded = await uploadDataURL(snapshot, "annot.png");
+        mediaHistory.addSilent({
+          kind: "prep",
+          url: uploaded,
+          promptText: job.text,
+          marked: job.marked,
+          color: job.color,
+          xPct: job.xPct,
+          yPct: job.yPct,
+        });
+        const prompt = buildPrompt(job.text, job.marked, job.color);
+        const result = await runEdit(uploaded, prompt, job.model);
+        await mediaHistory.set({ url: result }, { add: true });
+        setStatus("packaging share link...");
+        const packaged = await packageCurrentFrameWithHistory();
+        const frame = app.history[app.historyIndex];
+        if (frame?.url === result) {
+          frame.url = packaged;
+          app.imageURL = packaged;
+          app.stateURL = packaged;
+          syncStartToCurrent({ force: true });
+          render();
+        }
+        await loadBalance();
+      } catch (err) {
+        showError(err.message);
+      } finally {
+        app.currentJob = null;
+        render();
+      }
+    }
+    setStatus("done");
+  } finally {
+    app.busy = false;
+    app.currentJob = null;
+    render();
+  }
+}
+
+function cancelGesture() {
+  if (app.active?.capture?.recorder?.state === "recording") {
+    try { app.active.capture.recorder.stop(); } catch {}
+  }
+  app.active = null;
+  clearMarks();
+  pill({ visible: false });
+  setStatus(app.busy ? "editing..." : "ready");
+  render();
+}
+
+els.markCanvas.addEventListener("pointerdown", async (event) => {
+  if (!app.image) { showError("Load an image first."); return; }
+  if (app.active) return;
+  event.preventDefault();
+  clearError();
+  clearMarks();
+  const start = pointerPoint(event);
+
+  if (app.inputMode === "type") {
+    app.active = { pointerId: event.pointerId, points: [start], typing: true, color: app.markerColor };
+    render();
+    try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+    return;
+  }
+
+  const capture = beginRecording(event.clientX, event.clientY);
+  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+});
+
+els.markCanvas.addEventListener("pointermove", (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  pill({ x: event.clientX, y: event.clientY });
+  const point = pointerPoint(event);
+  const prev = gesture.points[gesture.points.length - 1];
+  drawSegment(prev, point);
+  gesture.points.push(point);
+});
+
+els.markCanvas.addEventListener("pointerup", async (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  app.active = null;
+  if (gesture.typing) {
+    const annotation = markerFromGesture(gesture);
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    if (!text) {
+      clearMarks();
+      setStatus(app.busy ? "editing..." : "ready");
+      return;
+    }
+    try {
+      enqueueJob({ text, ...annotation, color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+      clearMarks();
+    }
+    return;
+  }
+  const annotation = markerFromGesture(gesture);
+  try {
+    const { text, error } = await stopAndTranscribe(gesture.capture);
+    pill({ visible: false });
+    if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    enqueueJob({ text, ...annotation, color: gesture.color });
+  } catch (err) {
+    showError(err.message);
+    clearMarks();
+  }
+});
+
+els.markCanvas.addEventListener("pointercancel", cancelGesture);
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape") return;
+  event.preventDefault();
+  cancelGesture();
+});
+
+els.connect.addEventListener("click", startConnect);
+els.connectOverlay.addEventListener("click", startConnect);
+els.upload.addEventListener("click", () => els.file.click());
+els.inputMode.addEventListener("click", (event) => {
+  const button = event.target.closest("button");
+  if (button) setInputMode(button.dataset.mode);
+});
+els.shuffle.addEventListener("click", () => {
+  const starter = nextStarter();
+  openStartURL(starter.url)
+    .then(() => setStatus(`loaded ${starter.name}`))
+    .catch((err) => showError(err.message));
+});
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image");
+    await openStartURL(mediaURL);
+    setStatus(`loaded ${file.name || "image"}`);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+
+els.colorPicker.addEventListener("click", (event) => {
+  const swatch = event.target.closest(".swatch");
+  if (!swatch) return;
+  setMarkerColor(swatch.dataset.color);
+});
+
+const setDrop = (drop) => (event) => {
+  event.preventDefault();
+  els.frame.classList.toggle("drop", drop);
+};
+["dragenter", "dragover"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(true));
+});
+["dragleave", "drop"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(false));
+});
+els.frame.addEventListener("drop", (event) => {
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+  uploadBlob(file, file.name || "image")
+    .then((mediaURL) => openStartURL(mediaURL))
+    .then(() => setStatus(`loaded ${file.name || "image"}`))
+    .catch((err) => showError(err.message));
+});
+
+// PNG tEXt chunk helpers — pure JS, no deps.
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c;
+  }
+  return t;
+})();
+function crc32(bytes) {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function writeUint32(view, offset, value) {
+  view.setUint32(offset, value >>> 0, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0) {
+        const k = dec.decode(data.subarray(0, sep));
+        if (k === keyword) return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+function injectTextChunk(bytes, keyword, text) {
+  if (!isValidPng(bytes)) throw new Error("not a PNG");
+  // Find IEND so we can insert before it.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let iendOffset = -1;
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    if (type === "IEND") { iendOffset = pos; break; }
+    pos = pos + 8 + length + 4;
+  }
+  if (iendOffset < 0) throw new Error("PNG missing IEND");
+  // Build tEXt chunk: <length:4><type:4>"tEXt"<keyword>\0<text><crc:4>
+  const enc = new TextEncoder();
+  const kw = enc.encode(keyword);
+  const tx = enc.encode(text);
+  const data = new Uint8Array(kw.length + 1 + tx.length);
+  data.set(kw, 0);
+  data[kw.length] = 0;
+  data.set(tx, kw.length + 1);
+  const chunk = new Uint8Array(4 + 4 + data.length + 4);
+  const chunkView = new DataView(chunk.buffer);
+  writeUint32(chunkView, 0, data.length);
+  chunk.set([0x74, 0x45, 0x58, 0x74], 4); // "tEXt"
+  chunk.set(data, 8);
+  const crcInput = chunk.subarray(4, 8 + data.length);
+  writeUint32(chunkView, 8 + data.length, crc32(crcInput));
+  // Splice into PNG before IEND.
+  const out = new Uint8Array(bytes.length + chunk.length);
+  out.set(bytes.subarray(0, iendOffset), 0);
+  out.set(chunk, iendOffset);
+  out.set(bytes.subarray(iendOffset), iendOffset + chunk.length);
+  return out;
+}
+async function bytesFromBlob(blob) {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+async function readRemixState(blob) {
+  const bytes = await bytesFromBlob(blob);
+  const text = isValidPng(bytes) ? readTextChunk(bytes, HISTORY_KEYWORD) : null;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed?.history) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function cleanHistoryFrames(frames) {
+  return frames
+    .map((frame) => cleanHistoryFrame(frame))
+    .filter((frame) => frame.url);
+}
+
+function cleanHistoryFrame(frame) {
+  const source = typeof frame === "string" ? { url: frame } : (frame || {});
+  const clean = { url: scrubURL(source.url) };
+  if (!clean.url) return clean;
+  if (source.kind === "prep") clean.kind = "prep";
+  if (source.promptText) clean.promptText = String(source.promptText);
+  if (source.marked != null) clean.marked = Boolean(source.marked);
+  if (source.color) clean.color = String(source.color);
+  if (Number.isFinite(source.xPct)) clean.xPct = source.xPct;
+  if (Number.isFinite(source.yPct)) clean.yPct = source.yPct;
+  return clean;
+}
+
+async function restoreRemix(state, fallbackURL, sourceURL = "") {
+  const frames = cleanHistoryFrames(state.history);
+  if (!frames.length) {
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    return;
+  }
+  const source = scrubURL(sourceURL);
+  const sourceIndex = clamp(state.historyIndex ?? frames.length - 1, 0, frames.length - 1);
+  const requestedIndex = startIndexFromLocation();
+  let currentIndex = sourceIndex;
+  if (source) {
+    if (frames[sourceIndex]?.kind === "prep") {
+      frames.splice(sourceIndex + 1, 0, { url: source });
+      currentIndex = sourceIndex + 1;
+    } else {
+      frames[sourceIndex].url = source;
+    }
+  }
+  const index = requestedIndex == null || (currentIndex !== sourceIndex && requestedIndex === sourceIndex)
+    ? currentIndex
+    : requestedIndex;
+  app.history = frames;
+  app.historyIndex = clamp(index, 0, frames.length - 1);
+  app.stateURL = source || scrubURL(fallbackURL);
+  try {
+    await mediaHistory.go(app.historyIndex);
+    setStatus(`restored ${frames.length} frames`);
+  } catch (err) {
+    app.history = [];
+    app.historyIndex = -1;
+    app.stateURL = "";
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    showError(`History URLs unavailable; loaded image only. ${err.message}`);
+  }
+}
+
+function remixPayload() {
+  const history = cleanHistoryFrames(app.history);
+  const current = scrubURL(app.history[app.historyIndex]?.url);
+  const found = history.findIndex((frame) => frame.url === current);
+  return JSON.stringify({
+    v: 1,
+    app: "voice-edit-remix",
+    history,
+    historyIndex: found >= 0 ? found : history.length - 1,
+  });
+}
+
+async function remixPNGBlob() {
+  const bytes = await bytesFromBlob(await canvasBlob(els.imageCanvas));
+  const png = injectTextChunk(bytes, HISTORY_KEYWORD, remixPayload());
+  return new Blob([png], { type: "image/png" });
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function loadStartImage(url) {
+  try {
+    const res = await fetch(url, { mode: "cors" });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const blob = await res.blob();
+    const remix = await readRemixState(blob);
+    if (remix) {
+      await restoreRemix(remix, url, url);
+      return;
+    }
+  } catch {
+    // Fall through to URL loading; the browser may still be able to render it.
+  }
+  await mediaHistory.reset({ url }, url);
+}
+
+function nextStarter() {
+  const current = scrubURL(app.stateURL || app.imageURL);
+  const index = STARTERS.findIndex((starter) => scrubURL(starter.url) === current);
+  return STARTERS[(index + 1) % STARTERS.length] || STARTERS[0];
+}
+
+function startLink(mediaURL, index = 0) {
+  const url = new URL(location.href);
+  url.searchParams.delete("start");
+  const params = new URLSearchParams({ start: mediaURL });
+  if (index > 0) params.set("index", String(index));
+  url.hash = params.toString();
+  return url;
+}
+
+function syncStartToFrame(frame, { force = false } = {}) {
+  if (app.busy && !force) return;
+  const url = app.stateURL || frame?.url || app.imageURL;
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return;
+  const index = app.stateURL && app.history.length > 1 ? app.historyIndex : 0;
+  window.history.replaceState(null, "", startLink(url, index));
+}
+
+function syncStartToCurrent(options = {}) {
+  syncStartToFrame(app.history[app.historyIndex] || { url: app.imageURL }, options);
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const params = new URLSearchParams(location.hash.slice(1));
+  const value = params.get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+async function loadFromLocation() {
+  const startURL = startURLFromLocation();
+  if (startURL) {
+    await loadStartImage(startURL);
+  } else {
+    await mediaHistory.reset({ url: STARTER }, STARTER);
+  }
+}
+
+async function followLocationStart() {
+  const startURL = startURLFromLocation();
+  const startIndex = startIndexFromLocation();
+  const currentURL = scrubURL(app.stateURL || app.history[app.historyIndex]?.url);
+  if (!startURL || (scrubURL(startURL) === currentURL && (startIndex == null || startIndex === app.historyIndex))) return;
+  if (app.busy || app.active) return;
+  await loadStartImage(startURL);
+}
+
+async function openStartURL(mediaURL) {
+  window.history.pushState(null, "", startLink(mediaURL));
+  await followLocationStart();
+}
+
+// Lineage parent: the media hash of the image the *first* frame in the
+// current history came from. This is the canonical ancestor for the
+// communal remix tree — every subsequent share declares it as `parent`.
+function lineageParentHash() {
+  const root = app.history[0];
+  const candidates = [root?.url, app.imageURL];
+  for (const url of candidates) {
+    const hash = extractMediaHash(url);
+    if (hash) return hash;
+  }
+  return null;
+}
+
+async function packageCurrentFrameWithHistory() {
+  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png", {
+    parent: lineageParentHash(),
+  });
+}
+
+const goHistory = (delta, label) => () => {
+  const canGo = delta < 0 ? mediaHistory.canUndo() : mediaHistory.canRedo();
+  if (!canGo || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + delta).then(() => setStatus(label)).catch((err) => showError(err.message));
+};
+els.undo.addEventListener("click", goHistory(-1, "undone"));
+els.redo.addEventListener("click", goHistory(1, "redone"));
+els.download.addEventListener("click", async () => {
+  try {
+    downloadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`);
+    setStatus(`saved with ${cleanHistoryFrames(app.history).length} frames`);
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.share.addEventListener("click", async () => {
+  try {
+    const mediaURL = await uploadBlob(
+      await remixPNGBlob(),
+      `voice-edit-${Date.now()}.png`,
+      { parent: lineageParentHash() },
+    );
+    const frame = app.history[app.historyIndex];
+    if (frame) {
+      frame.url = mediaURL;
+      app.imageURL = mediaURL;
+      app.stateURL = mediaURL;
+      syncStartToFrame(frame, { force: true });
+    }
+    const shareURL = startLink(mediaURL);
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(shareURL.href);
+      setStatus("share link copied");
+    } else {
+      window.prompt("share link", shareURL.href);
+      setStatus("share link ready");
+    }
+  } catch (err) {
+    showError(err.message);
+  }
+});
+async function loadRemixes() {
+  const parent = lineageParentHash();
+  if (!parent) {
+    els.remixesPanel.hidden = true;
+    return;
+  }
+  els.remixesPanel.hidden = false;
+  els.remixesEmpty.hidden = true;
+  els.remixesGrid.innerHTML = "";
+  setStatus("loading remixes...");
+  try {
+    const res = await fetch(`https://media.pollinations.ai/${parent}/children?limit=24`);
+    if (!res.ok) throw new Error(`remixes failed: ${res.status}`);
+    const data = await res.json();
+    const items = Array.isArray(data.items) ? data.items : [];
+    if (!items.length) {
+      els.remixesEmpty.hidden = false;
+      setStatus("no remixes yet");
+      return;
+    }
+    for (const item of items) {
+      const card = document.createElement("div");
+      card.className = "remix-card";
+      const img = document.createElement("img");
+      img.src = item.url;
+      img.alt = item.userTags?.[0] || "remix";
+      img.loading = "lazy";
+      const meta = document.createElement("div");
+      meta.className = "meta";
+      const tag = document.createElement("strong");
+      tag.textContent = item.app || item.appName || "remix";
+      meta.appendChild(tag);
+      meta.appendChild(document.createTextNode(new Date(item.createdAt).toLocaleDateString()));
+      card.appendChild(img);
+      card.appendChild(meta);
+      card.addEventListener("click", () => openStartURL(item.url));
+      els.remixesGrid.appendChild(card);
+    }
+    setStatus(`${items.length} remix${items.length === 1 ? "" : "es"}`);
+  } catch (err) {
+    showError(err.message);
+  }
+}
+
+els.remixes.addEventListener("click", () => {
+  if (els.remixesPanel.hidden) loadRemixes(); else els.remixesPanel.hidden = true;
+});
+els.remixesClose.addEventListener("click", () => { els.remixesPanel.hidden = true; });
+
+els.walkthrough.addEventListener("click", () => {
+  const url = app.stateURL || app.history[app.historyIndex]?.url || app.imageURL;
+  if (!url) return;
+  const params = new URLSearchParams({ start: url });
+  if (app.history.length > 1) params.set("index", String(app.historyIndex));
+  location.href = `walkthrough.html#${params}`;
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadModels();
+window.addEventListener("hashchange", () => followLocationStart().catch((err) => showError(err.message)));
+window.addEventListener("popstate", () => followLocationStart().catch((err) => showError(err.message)));
+loadFromLocation().catch((err) => showError(err.message));
+setMarkerColor(app.markerColor);
+</script>
+</body>
+</html>

--- a/apps/voice-edit/walkthrough.html
+++ b/apps/voice-edit/walkthrough.html
@@ -1,0 +1,1122 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Walkthrough | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--dark);
+    --raise: 2px 2px 0 var(--dark);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+  button, input, select { font: inherit; color: inherit; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .btn, .input, .select, .panel, .thumb, .clip {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+  }
+  .btn {
+    padding: 0 12px;
+    font-weight: 700;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--dark); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; }
+  .narrate {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+  }
+  .narrate input { margin: 0; }
+  .narrate-count { opacity: 0.7; font-variant-numeric: tabular-nums; }
+  .narrate input:disabled + .narrate-count,
+  .narrate input:disabled { opacity: 0.4; }
+  .prompt {
+    display: grid;
+    gap: 4px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .prompt textarea {
+    width: 100%;
+    min-height: 56px;
+    padding: 8px 10px;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    border-radius: 0;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    resize: vertical;
+  }
+  .prompt textarea:focus { outline: 2px solid var(--accent); outline-offset: 0; }
+  .prompt .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .prompt .row button {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .panel {
+    min-height: 320px;
+    padding: 12px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .panel img, .panel video {
+    display: block;
+    max-width: 100%;
+    max-height: calc(100vh - 290px);
+    background: #000;
+  }
+  .strip {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px 2px 6px;
+  }
+  .thumb, .clip {
+    flex: 0 0 auto;
+    width: 86px;
+    height: 64px;
+    padding: 0;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+  }
+  .thumb.active, .clip.active { outline: 3px solid var(--accent); outline-offset: 2px; }
+  .clip.pending { opacity: 0.55; cursor: wait; }
+  .clip.failed { opacity: 0.7; }
+  .clip-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--muted);
+    font-size: 1.4rem;
+    animation: clip-pulse 1.6s ease-in-out infinite;
+  }
+  .clip.failed .clip-placeholder {
+    animation: none;
+    color: #ff8888;
+    background: rgba(255, 80, 80, 0.18);
+  }
+  @keyframes clip-pulse {
+    0%, 100% { background: rgba(255, 255, 255, 0.05); }
+    50% { background: rgba(255, 255, 255, 0.15); }
+  }
+  .thumb img, .clip video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .thumb span, .clip span {
+    position: absolute;
+    left: 3px;
+    bottom: 2px;
+    background: var(--accent);
+    padding: 0 4px;
+    font-size: 0.65rem;
+    font-weight: 700;
+  }
+  .meta {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  @media (max-width: 720px) {
+    .app { width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .panel { min-height: 240px; }
+    .panel img, .panel video { max-height: calc(100vh - 340px); }
+  }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / walkthrough</h1>
+      <span class="tagline">history to video.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="walkthrough controls">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="loadBtn" class="btn" title="upload an image from disk">load</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="video model" disabled>
+        <option value="">loading models...</option>
+      </select>
+      <button id="makeBtn" class="btn accent">make</button>
+      <label class="narrate" title="insert a 2s card showing the marked-up image and prompt between video clips">
+        <input id="narrateToggle" type="checkbox"> narrate
+        <span id="narrateCount" class="narrate-count" aria-hidden="true"></span>
+      </label>
+      <button id="playAllBtn" class="btn" disabled title="play all clips in sequence">play all</button>
+      <button id="downloadAllBtn" class="btn" disabled title="download a single stitched .mp4 of all clips">download</button>
+    </section>
+
+    <label class="prompt">
+      <div class="row">
+        <span>video prompt</span>
+        <button type="button" id="promptReset" title="restore default prompt">reset</button>
+      </div>
+      <textarea id="promptInput" rows="2" spellcheck="false"></textarea>
+    </label>
+
+    <section id="viewer" class="panel"></section>
+    <div id="frameStrip" class="strip" aria-label="history frames"></div>
+    <div id="clipStrip" class="strip" aria-label="generated video clips"></div>
+    <div id="meta" class="meta"></div>
+  </main>
+
+<script type="module">
+import {ALL_FORMATS,BlobSource, BufferTarget, 
+  CanvasSource, Conversion, canEncodeVideo, EncodedAudioPacketSource,
+  EncodedPacketSink, EncodedVideoPacketSource, 
+  Input, Mp4OutputFormat,Output, 
+} from "https://esm.sh/mediabunny@1.45.3";
+
+const KEY_STORAGE = "voice-edit:user-key";
+const PROMPT_STORAGE = "voice-edit:walkthrough-prompt";
+const NARRATE_STORAGE = "voice-edit:walkthrough-narrate";
+const NARRATE_DURATION_SEC = 3.5;
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const DEFAULT_PROMPT = "Smooth visual transition from the first image to the second image. Preserve the subject, composition, and style. No text, labels, captions, or subtitles.";
+
+const $ = (id) => document.getElementById(id);
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  connect: "connectBtn",
+  load: "loadBtn",
+  file: "fileInput",
+  model: "modelSel",
+  make: "makeBtn",
+  playAll: "playAllBtn",
+  downloadAll: "downloadAllBtn",
+  prompt: "promptInput",
+  promptReset: "promptReset",
+  narrate: "narrateToggle",
+  narrateCount: "narrateCount",
+  viewer: "viewer",
+  frameStrip: "frameStrip",
+  clipStrip: "clipStrip",
+  meta: "meta",
+}).map(([key, id]) => [key, $(id)]));
+
+const app = {
+  sourceURL: "",
+  history: [],
+  currentFrame: 0,
+  clips: [],
+  currentClip: -1,
+  busy: false,
+  modelsReady: false,
+  playAll: false,
+  playAllIndex: 0,
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = () => ({ Authorization: `Bearer ${key()}` });
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (!apiKey) return;
+  localStorage.setItem(KEY_STORAGE, apiKey);
+  params.delete("api_key");
+  history.replaceState(null, "", params.toString() ? `${location.pathname}#${params}` : location.pathname);
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname + location.hash,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  refreshConnectionUI();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  renderAccount();
+  if (connected) {
+    loadUser();
+    loadBalance();
+  }
+  render();
+}
+
+async function loadUser() {
+  const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const user = await res.json();
+  app.accountUser = user?.preferred_username || "";
+  renderAccount();
+}
+
+async function loadBalance() {
+  const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const { balance } = await res.json();
+  app.accountBalance = Number(balance);
+  renderAccount();
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const value = new URLSearchParams(location.hash.slice(1)).get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function frameURL(frame) {
+  return scrubURL(typeof frame === "string" ? frame : frame?.url);
+}
+
+function cleanHistoryFrames(frames) {
+  return frames.map((frame) => {
+    const url = frameURL(frame);
+    if (!url) return null;
+    if (typeof frame === "string") return { url };
+    return {
+      url,
+      kind: frame?.kind,
+      promptText: frame?.promptText,
+      marked: frame?.marked,
+      color: frame?.color,
+    };
+  }).filter(Boolean);
+}
+
+function setHash(start, index = 0) {
+  const params = new URLSearchParams({ start });
+  if (index > 0) params.set("index", String(index));
+  history.replaceState(null, "", `${location.pathname}#${params}`);
+}
+
+async function loadSource(url) {
+  clearError();
+  const source = scrubURL(url);
+  if (!source) throw new Error("Enter a public image URL");
+  setStatus("loading...");
+  const res = await fetch(source, { mode: "cors" });
+  if (!res.ok) throw new Error(`Image load failed: ${res.status} ${res.statusText}`);
+  const blob = await res.blob();
+  const state = await readRemixState(blob);
+  const rawFrames = state ? cleanHistoryFrames(state.history) : [{ url: source }];
+  if (!rawFrames.length) throw new Error("No history frames found");
+  const sourceIndex = state ? Math.max(0, Math.min(state.historyIndex ?? rawFrames.length - 1, rawFrames.length - 1)) : 0;
+  if (state && rawFrames[sourceIndex]?.kind !== "prep") {
+    rawFrames[sourceIndex].url = source;
+  }
+  // Attach each prep frame's narration data (annotated URL + prompt text) to the
+  // clean frame it produced — that's the very next non-prep entry in the raw list.
+  let pendingPrep = null;
+  const frames = [];
+  for (const frame of rawFrames) {
+    if (frame.kind === "prep") {
+      pendingPrep = frame;
+      continue;
+    }
+    if (pendingPrep) {
+      frame.narration = {
+        annotatedURL: pendingPrep.url,
+        promptText: pendingPrep.promptText || "",
+      };
+      pendingPrep = null;
+    }
+    frames.push(frame);
+  }
+  if (!frames.length) throw new Error("No clean frames found (all entries are annotated previews)");
+  const targetURL = rawFrames[sourceIndex]?.kind === "prep" ? source : rawFrames[sourceIndex]?.url;
+  const sourceIndexClean = Math.max(
+    0,
+    frames.findIndex((frame) => frame.url === targetURL),
+  );
+  const requestedIndex = startIndexFromLocation();
+  const requestedIndexClean = requestedIndex == null
+    ? null
+    : Math.max(0, Math.min(requestedIndex, frames.length - 1));
+  const index = requestedIndexClean == null || requestedIndexClean === sourceIndex
+    ? sourceIndexClean
+    : requestedIndexClean;
+  app.sourceURL = source;
+  app.history = frames;
+  app.currentFrame = Math.max(0, Math.min(index, frames.length - 1));
+  app.clips = [];
+  app.currentClip = -1;
+  setHash(source, app.currentFrame);
+  render();
+  setStatus(state ? `loaded ${frames.length} clean frames` : "loaded image");
+}
+
+async function uploadBlob(blob, filename) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+function render() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const locked = app.busy || app.history.length < 2 || !connected || !app.modelsReady;
+  els.make.disabled = locked;
+  els.load.disabled = app.busy || !connected;
+  els.model.disabled = app.busy || !app.modelsReady;
+  const hasClips = app.clips.length > 0 && !app.busy;
+  els.playAll.disabled = !hasClips;
+  els.downloadAll.disabled = !hasClips;
+  els.playAll.textContent = app.playAll ? "stop" : "play all";
+  const narratable = app.history.filter((f) => f?.narration).length;
+  els.narrate.disabled = narratable === 0 || app.busy;
+  els.narrateCount.textContent = narratable ? `(${narratable})` : "(none)";
+  renderViewer();
+  renderFrames();
+  renderClips();
+  els.meta.textContent = app.history.length > 1
+    ? `${app.history.length} frames -> ${app.history.length - 1} transitions${narratable ? ` · ${narratable} narration card${narratable === 1 ? "" : "s"}` : ""}`
+    : "load a remix image with history to make a walkthrough";
+}
+
+function renderViewer() {
+  if (app.playAll && app.clips.length) {
+    const video = document.createElement("video");
+    video.src = app.clips[app.playAllIndex].src;
+    video.controls = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    video.addEventListener("ended", () => {
+      if (!app.playAll) return;
+      app.playAllIndex = (app.playAllIndex + 1) % app.clips.length;
+      app.currentClip = app.playAllIndex;
+      render();
+    });
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const clip = app.clips[app.currentClip];
+  if (clip && clip.src) {
+    const video = document.createElement("video");
+    video.src = clip.src;
+    video.controls = true;
+    video.loop = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const frame = app.history[app.currentFrame];
+  if (!frame) {
+    els.viewer.textContent = "load an image";
+    return;
+  }
+  const img = document.createElement("img");
+  img.src = frame.url;
+  img.alt = "";
+  els.viewer.replaceChildren(img);
+}
+
+function renderFrames() {
+  els.frameStrip.replaceChildren(...app.history.map((frame, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `thumb${index === app.currentFrame && app.currentClip < 0 ? " active" : ""}`;
+    button.addEventListener("click", () => {
+      app.currentFrame = index;
+      app.currentClip = -1;
+      setHash(app.sourceURL, index);
+      render();
+    });
+    const img = document.createElement("img");
+    img.src = frame.url;
+    img.alt = "";
+    const label = document.createElement("span");
+    label.textContent = String(index + 1);
+    button.append(img, label);
+    return button;
+  }));
+}
+
+function renderClips() {
+  let videoCount = 0;
+  els.clipStrip.replaceChildren(...app.clips.map((clip, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    const isReady = !!clip.src;
+    const cls = [
+      "clip",
+      index === app.currentClip ? "active" : "",
+      clip.pending ? "pending" : "",
+      clip.failed ? "failed" : "",
+    ].filter(Boolean).join(" ");
+    button.className = cls;
+    if (isReady) {
+      button.addEventListener("click", () => {
+        app.currentClip = index;
+        render();
+      });
+    } else {
+      button.disabled = true;
+    }
+    const media = document.createElement(isReady ? "video" : "div");
+    if (isReady) {
+      media.src = clip.src;
+      media.muted = true;
+      media.playsInline = true;
+    } else {
+      media.className = "clip-placeholder";
+      media.textContent = clip.failed ? "×" : "…";
+    }
+    const label = document.createElement("span");
+    if (clip.kind === "narration") {
+      // narration card intros the next video, so label it with that video's number
+      label.textContent = `intro ${videoCount + 1}`;
+    } else {
+      videoCount += 1;
+      label.textContent = `${videoCount}->${videoCount + 1}`;
+    }
+    button.append(media, label);
+    return button;
+  }));
+}
+
+async function loadVideoModels() {
+  try {
+    const res = await fetch(`${BASE}/models`);
+    if (!res.ok) throw new Error(`models fetch failed: ${res.status}`);
+    const all = await res.json();
+    const supported = all.filter((m) =>
+      Array.isArray(m.video_capabilities) && m.video_capabilities.includes("end_frame"),
+    );
+    if (!supported.length) throw new Error("no models advertise end_frame");
+    const preferred = ["veo", "seedance-2.0", "wan-fast"];
+    supported.sort((a, b) => {
+      const ai = preferred.indexOf(a.name);
+      const bi = preferred.indexOf(b.name);
+      if (ai === -1 && bi === -1) return a.name.localeCompare(b.name);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+    els.model.replaceChildren(...supported.map((m) => {
+      const opt = document.createElement("option");
+      opt.value = m.name;
+      opt.textContent = `${m.name} start+end`;
+      opt.title = m.description || "";
+      return opt;
+    }));
+  } catch (err) {
+    els.model.replaceChildren(
+      Object.assign(document.createElement("option"), { value: "veo", textContent: "veo start+end" }),
+      Object.assign(document.createElement("option"), { value: "seedance-2.0", textContent: "seedance-2.0 start+end" }),
+      Object.assign(document.createElement("option"), { value: "wan-fast", textContent: "wan-fast start+end" }),
+    );
+    console.warn("video model discovery failed, using fallback list:", err);
+  } finally {
+    app.modelsReady = true;
+    render();
+  }
+}
+
+function currentPrompt() {
+  const text = (els.prompt.value || "").trim();
+  return text || DEFAULT_PROMPT;
+}
+
+function videoRequestURL(start, end, model) {
+  const url = new URL(`${BASE}/video/${encodeURIComponent(currentPrompt())}`);
+  url.searchParams.set("model", model);
+  url.searchParams.set("duration", "4");
+  url.searchParams.set("audio", "false");
+  url.searchParams.set("image", `${start}|${end}`);
+  return url;
+}
+
+async function makeWalkthrough() {
+  if (app.history.length < 2 || app.busy) return;
+  app.busy = true;
+  for (const clip of app.clips) if (clip.src) URL.revokeObjectURL(clip.src);
+  app.clips = [];
+  app.currentClip = -1;
+
+  const narrate = els.narrate.checked;
+  const transitions = app.history.length - 1;
+  // Pre-populate placeholders in display order: (intro?, video) per transition.
+  const slots = []; // parallel array mapping transitionIndex -> { videoSlot, narrationSlot? }
+  for (let i = 0; i < transitions; i++) {
+    const target = app.history[i + 1];
+    const slot = {};
+    if (narrate && target?.narration) {
+      app.clips.push({ kind: "narration", pending: true });
+      slot.narrationSlot = app.clips.length - 1;
+    }
+    app.clips.push({ kind: "video", pending: true });
+    slot.videoSlot = app.clips.length - 1;
+    slots.push(slot);
+  }
+  render();
+
+  let videosDone = 0;
+  let firstError = null;
+  const setProgress = () => setStatus(`videos ${videosDone}/${transitions} ready...`);
+  setProgress();
+
+  await Promise.all(slots.map(async (slot, i) => {
+    const request = videoRequestURL(app.history[i].url, app.history[i + 1].url, els.model.value);
+    try {
+      const res = await fetch(request, { headers: authHeaders() });
+      if (!res.ok) throw new Error(await friendlyError(res, `Video ${i + 1} failed`));
+      const blob = await res.blob();
+
+      // Fill the video slot
+      const videoEntry = { url: request.href, src: URL.createObjectURL(blob), blob, kind: "video" };
+      app.clips[slot.videoSlot] = videoEntry;
+      if (app.currentClip < 0) app.currentClip = slot.videoSlot;
+
+      // Render the narration card for this transition (needs the just-finished clip as codec ref)
+      if (slot.narrationSlot != null) {
+        try {
+          const cardBlob = await renderNarrationClip(app.history[i + 1].narration, blob);
+          app.clips[slot.narrationSlot] = { src: URL.createObjectURL(cardBlob), blob: cardBlob, kind: "narration" };
+        } catch (err) {
+          console.warn(`narration card ${i + 1} failed`, err);
+          showError(`narration card ${i + 1} skipped: ${err.message}`);
+          // Remove the failed placeholder by marking it dropped; we'll compact at the end.
+          app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+        }
+      }
+
+      videosDone++;
+      setProgress();
+      render();
+    } catch (err) {
+      firstError = firstError || err;
+      app.clips[slot.videoSlot] = { kind: "video", failed: true, error: err.message };
+      if (slot.narrationSlot != null) app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+      videosDone++;
+      setProgress();
+      render();
+    }
+  }));
+
+  // Compact: drop slots that were never filled (failed videos / dropped cards)
+  app.clips = app.clips.filter((c) => !c.dropped && !c.failed);
+  if (app.currentClip >= app.clips.length) app.currentClip = app.clips.length - 1;
+
+  loadBalance().catch(() => {});
+  if (firstError) showError(firstError.message);
+  setStatus(firstError ? `done with errors` : "done");
+  app.busy = false;
+  render();
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) return `${label}: authorization expired. Connect again.`;
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const dec = new TextDecoder("latin1");
+  let pos = 8;
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0 && dec.decode(data.subarray(0, sep)) === keyword) {
+        return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+async function readRemixState(blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const text = readTextChunk(bytes, HISTORY_KEYWORD);
+  if (!text) return null;
+  const state = JSON.parse(text);
+  return Array.isArray(state?.history) ? state : null;
+}
+
+els.connect.addEventListener("click", startConnect);
+els.load.addEventListener("click", () => els.file.click());
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image");
+    setHash(mediaURL);
+    await loadSource(mediaURL);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+els.make.addEventListener("click", () => {
+  makeWalkthrough().catch((err) => {
+    app.busy = false;
+    showError(err.message);
+    render();
+  });
+});
+els.playAll.addEventListener("click", () => {
+  if (!app.clips.length) return;
+  app.playAll = !app.playAll;
+  if (app.playAll) {
+    app.playAllIndex = 0;
+    app.currentClip = 0;
+  }
+  render();
+});
+function loadImageBlob(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load narration image"));
+    img.src = url;
+  });
+}
+
+function wrapText(ctx, text, maxWidth) {
+  const lines = [];
+  for (const para of text.split(/\n/)) {
+    const words = para.split(/\s+/).filter(Boolean);
+    if (!words.length) { lines.push(""); continue; }
+    let line = words[0];
+    for (let i = 1; i < words.length; i++) {
+      const test = line + " " + words[i];
+      if (ctx.measureText(test).width > maxWidth) { lines.push(line); line = words[i]; }
+      else line = test;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+function drawNarrationCard(canvas, image, promptText) {
+  const ctx = canvas.getContext("2d");
+  const { width: W, height: H } = canvas;
+  ctx.fillStyle = "#110518";
+  ctx.fillRect(0, 0, W, H);
+  // contain-fit the annotated image
+  const s = Math.min(W / image.width, H / image.height);
+  const dw = image.width * s;
+  const dh = image.height * s;
+  ctx.drawImage(image, (W - dw) / 2, (H - dh) / 2, dw, dh);
+  // prompt text overlay at the bottom — subtitle-style
+  if (promptText) {
+    const fontPx = Math.min(26, Math.max(14, Math.round(H * 0.03)));
+    ctx.font = `500 ${fontPx}px "IBM Plex Mono", ui-monospace, Menlo, monospace`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    const lines = wrapText(ctx, promptText, W * 0.9);
+    const padY = Math.round(fontPx * 0.55);
+    const lineH = Math.round(fontPx * 1.3);
+    const bandH = lines.length * lineH + padY * 2;
+    ctx.fillStyle = "rgba(17, 5, 24, 0.75)";
+    ctx.fillRect(0, H - bandH, W, bandH);
+    ctx.fillStyle = "#fff";
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], W / 2, H - padY - (lines.length - 1 - i) * lineH);
+    }
+  }
+}
+
+async function probeVideoSpec(blob) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const track = await input.getPrimaryVideoTrack();
+  if (!track) throw new Error("reference clip has no video track");
+  const cfg = await track.getDecoderConfig();
+  return {
+    codec: track.codec,                    // e.g. "avc"
+    fullCodecString: cfg?.codec,           // e.g. "avc1.640028"
+    width: track.codedWidth,
+    height: track.codedHeight,
+  };
+}
+
+async function renderNarrationClip(narration, refBlob) {
+  const spec = await probeVideoSpec(refBlob);
+  // Force even dimensions (H.264 requires it).
+  const width = spec.width - (spec.width % 2);
+  const height = spec.height - (spec.height % 2);
+  const fps = 24;
+  const bitrate = 2_000_000;
+  if (typeof canEncodeVideo === "function") {
+    const ok = await canEncodeVideo(spec.codec, { width, height, bitrate });
+    if (!ok) throw new Error(`browser cannot encode ${spec.codec} ${width}x${height}`);
+  }
+
+  const image = await loadImageBlob(narration.annotatedURL);
+  const canvas = typeof OffscreenCanvas !== "undefined"
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement("canvas"), { width, height });
+  drawNarrationCard(canvas, image, narration.promptText);
+
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const sourceCfg = { codec: spec.codec, bitrate, keyFrameInterval: 1 };
+  if (spec.fullCodecString) sourceCfg.fullCodecString = spec.fullCodecString;
+  const source = new CanvasSource(canvas, sourceCfg);
+  output.addVideoTrack(source, { frameRate: fps });
+  await output.start();
+  const total = Math.max(1, Math.round(NARRATE_DURATION_SEC * fps));
+  const frameDur = 1 / fps;
+  for (let i = 0; i < total; i++) {
+    await source.add(i * frameDur, frameDur);
+  }
+  source.close();
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function remuxMp4Clips(blobs) {
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  let videoSrc = null;
+  let audioSrc = null;
+  let vOffset = 0;
+  let aOffset = 0;
+  let vMaxOut = 0;
+  let aMaxOut = 0;
+  let vCfgSent = false;
+  let aCfgSent = false;
+
+  for (let i = 0; i < blobs.length; i++) {
+    const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blobs[i]) });
+    const vTrack = await input.getPrimaryVideoTrack();
+    if (!vTrack) throw new Error(`clip ${i + 1} has no video track`);
+    const aTrack = await input.getPrimaryAudioTrack();
+
+    if (i === 0) {
+      videoSrc = new EncodedVideoPacketSource(vTrack.codec);
+      output.addVideoTrack(videoSrc);
+      if (aTrack) {
+        audioSrc = new EncodedAudioPacketSource(aTrack.codec);
+        output.addAudioTrack(audioSrc);
+      }
+      await output.start();
+    }
+
+    const vMeta = { decoderConfig: await vTrack.getDecoderConfig() };
+    const vSink = new EncodedPacketSink(vTrack);
+    let vClipMax = 0;
+    for (let p = await vSink.getFirstPacket(); p; p = await vSink.getNextPacket(p)) {
+      let ts = Math.max(0, p.timestamp + vOffset);
+      if (i > 0 && ts <= vMaxOut) ts = vMaxOut + 1e-6;
+      await videoSrc.add(p.clone({ timestamp: ts }), vCfgSent ? undefined : vMeta);
+      vCfgSent = true;
+      vMaxOut = Math.max(vMaxOut, ts);
+      vClipMax = Math.max(vClipMax, p.timestamp + p.duration);
+    }
+    vOffset += vClipMax;
+
+    if (aTrack && audioSrc) {
+      const aMeta = { decoderConfig: await aTrack.getDecoderConfig() };
+      const aSink = new EncodedPacketSink(aTrack);
+      let aClipMax = 0;
+      for (let p = await aSink.getFirstPacket(); p; p = await aSink.getNextPacket(p)) {
+        let ts = Math.max(0, p.timestamp + aOffset);
+        if (i > 0 && ts <= aMaxOut) ts = aMaxOut + 1e-6;
+        await audioSrc.add(p.clone({ timestamp: ts }), aCfgSent ? undefined : aMeta);
+        aCfgSent = true;
+        aMaxOut = Math.max(aMaxOut, ts);
+        aClipMax = Math.max(aClipMax, p.timestamp + p.duration);
+      }
+      aOffset += aClipMax;
+    } else if (audioSrc) {
+      // No audio in this clip but we have an audio track — keep the audio
+      // offset in lock-step with video so later audio packets land in the
+      // right spot. The merged audio track will just contain a silent gap.
+      aOffset += vClipMax;
+    }
+  }
+
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function normalizeMp4(blob, targetBitrate) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const conv = await Conversion.init({
+    input, output,
+    video: { codec: "avc", bitrate: targetBitrate },
+  });
+  await conv.execute();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+els.downloadAll.addEventListener("click", async () => {
+  if (!app.clips.length) return;
+  const originalLabel = els.downloadAll.textContent;
+  els.downloadAll.disabled = true;
+  els.downloadAll.textContent = "stitching…";
+  try {
+    const clips = app.clips.filter((c) => c.blob);
+    if (!clips.length) throw new Error("No video data to download");
+
+    // If we have any narration cards mixed in, the source clips and the cards
+    // will have different H.264 SPS/PPS — the player only honours the first
+    // avcC box, so naive remux silently drops the cards. Re-encode every clip
+    // to one uniform target so the final stream has a single decoder config.
+    let blobs = clips.map((c) => c.blob);
+    const mixed = clips.some((c) => c.kind === "narration");
+    if (mixed) {
+      const targetBitrate = 4_000_000;
+      const normalized = [];
+      for (let i = 0; i < clips.length; i++) {
+        els.downloadAll.textContent = `re-encoding ${i + 1}/${clips.length}…`;
+        normalized.push(await normalizeMp4(clips[i].blob, targetBitrate));
+      }
+      blobs = normalized;
+      els.downloadAll.textContent = "stitching…";
+    }
+
+    let merged;
+    let ext = "mp4";
+    try {
+      merged = await remuxMp4Clips(blobs);
+    } catch (remuxErr) {
+      console.warn("mediabunny remux failed, falling back to naive concat", remuxErr);
+      const type = blobs[0].type || "video/mp4";
+      merged = new Blob(blobs, { type });
+      ext = type.includes("webm") ? "webm" : "mp4";
+    }
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(merged);
+    a.download = `walkthrough-${Date.now()}.${ext}`;
+    document.body.append(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(a.href), 60_000);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.downloadAll.textContent = originalLabel;
+    els.downloadAll.disabled = !app.clips.length || app.busy;
+  }
+});
+window.addEventListener("hashchange", () => {
+  const start = startURLFromLocation();
+  if (start && scrubURL(start) !== app.sourceURL && !app.busy) loadSource(start).catch((err) => showError(err.message));
+});
+
+els.prompt.value = localStorage.getItem(PROMPT_STORAGE) ?? DEFAULT_PROMPT;
+els.prompt.placeholder = DEFAULT_PROMPT;
+els.prompt.addEventListener("input", () => {
+  localStorage.setItem(PROMPT_STORAGE, els.prompt.value);
+});
+els.promptReset.addEventListener("click", () => {
+  els.prompt.value = DEFAULT_PROMPT;
+  localStorage.setItem(PROMPT_STORAGE, DEFAULT_PROMPT);
+});
+
+els.narrate.checked = localStorage.getItem(NARRATE_STORAGE) === "1";
+els.narrate.addEventListener("change", () => {
+  localStorage.setItem(NARRATE_STORAGE, els.narrate.checked ? "1" : "0");
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadVideoModels();
+const start = startURLFromLocation();
+if (start) loadSource(start).catch((err) => showError(err.message));
+else render();
+</script>
+</body>
+</html>

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1440,6 +1440,24 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Display name of the API key",
                                         ),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Stable owner user id. Server-attested.",
+                                        ),
+                                    appId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Stable id of the publishable app that minted this key (BYOP), or null. Server-attested.",
+                                        ),
+                                    appName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Display name of the app that minted this key, or null.",
+                                        ),
                                     expiresAt: z
                                         .string()
                                         .nullable()
@@ -1546,10 +1564,19 @@ export const accountRoutes = new Hono<Env>()
                 account: apiKey.permissions?.account || null,
             };
 
+            // Stable user id and app attribution. Server-attested — services
+            // downstream (e.g. media.pollinations.ai) treat these as the
+            // owner/app identity for catalogs and lineage, never trusting
+            // client-supplied values for those facets.
+            const userId = c.var.auth.user?.id ?? null;
+
             return c.json({
                 valid: true, // If we got here, the key is valid
                 type: keyType,
                 name: apiKey.name || null,
+                userId,
+                appId: apiKey.byopClientKeyId ?? null,
+                appName: apiKey.byopClientName ?? null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -26,6 +26,65 @@ interface AuthResult {
     valid: boolean;
     type: string;
     name: string | null;
+    // Server-attested identity, added by enter.pollinations.ai/account/key.
+    // Both may be null on older tokens or non-BYOP keys; we treat them as
+    // anonymous-but-authenticated in that case.
+    userId?: string | null;
+    appId?: string | null;
+    appName?: string | null;
+}
+
+const TAG_NAMESPACE = "tags";
+const SAFE_FACET_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+const USER_TAG_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const MAX_USER_TAGS = 8;
+const LINEAGE_PREFIX = "lineage/v1/by-parent/";
+const CATALOG_ITEM_PREFIX = "catalog/v1/items/";
+const CATALOG_OWNER_PREFIX = "catalog/v1/by-owner/";
+const CATALOG_APP_PREFIX = "catalog/v1/by-app/";
+
+// R2 keys sort lexicographically. Using (Number.MAX_SAFE_INTEGER - ts) puts
+// newest-first under `list({prefix})` so pagination returns recent items
+// without a reverse pass.
+function revTs(ts: number = Date.now()): string {
+    return String(Number.MAX_SAFE_INTEGER - ts).padStart(16, "0");
+}
+
+function safeFacet(s: string | null | undefined): string | null {
+    if (!s) return null;
+    return SAFE_FACET_PATTERN.test(s) ? s : null;
+}
+
+function normalizeUserTags(raw: unknown): string[] {
+    if (!Array.isArray(raw) && typeof raw !== "string") return [];
+    const list = Array.isArray(raw)
+        ? raw
+        : String(raw)
+              .split(",")
+              .map((t) => t.trim());
+    const out: string[] = [];
+    for (const item of list) {
+        if (typeof item !== "string") continue;
+        const t = item.toLowerCase().trim();
+        if (USER_TAG_PATTERN.test(t) && !out.includes(t)) out.push(t);
+        if (out.length >= MAX_USER_TAGS) break;
+    }
+    return out;
+}
+
+interface CatalogItem {
+    hash: string;
+    url: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    owner: string | null;
+    app: string | null;
+    appName: string | null;
+    keyType: string;
+    parent: string | null;
+    userTags: string[];
+    duplicate: boolean;
 }
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
@@ -63,6 +122,47 @@ const UploadResponseSchema = z.object({
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    owner: z
+        .string()
+        .nullable()
+        .describe(
+            "Server-attested owner user id. Null if the API key has no user.",
+        ),
+    app: z
+        .string()
+        .nullable()
+        .describe(
+            "Server-attested app id (BYOP). Null if the key was not minted by a registered app. NEVER trusted from request params.",
+        ),
+    parent: z
+        .string()
+        .nullable()
+        .describe(
+            "Parent media hash if this upload was declared as a remix, else null.",
+        ),
+    userTags: z
+        .array(z.string())
+        .describe(
+            "Caller-supplied tags, lowercased and validated. Untrusted — anyone can write these.",
+        ),
+});
+
+const CatalogItemSchema = z.object({
+    hash: z.string(),
+    url: z.string(),
+    contentType: z.string(),
+    size: z.number(),
+    createdAt: z.string(),
+    owner: z.string().nullable(),
+    app: z.string().nullable(),
+    appName: z.string().nullable(),
+    parent: z.string().nullable(),
+    userTags: z.array(z.string()),
+});
+
+const ListResponseSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    nextCursor: z.string().nullable(),
 });
 
 const ErrorSchema = z.object({
@@ -142,6 +242,15 @@ api.post(
         let fileName: string | undefined;
 
         const requestContentType = c.req.header("content-type") || "";
+        const url = new URL(c.req.url);
+        // Provenance inputs can arrive either as query params or as form/JSON
+        // fields. We read query params unconditionally and let body fields
+        // override below.
+        let parentInput = url.searchParams.get("parent") || "";
+        let userTagsInput: unknown = url.searchParams.getAll("tag");
+        if (Array.isArray(userTagsInput) && userTagsInput.length === 0) {
+            userTagsInput = url.searchParams.get("tags");
+        }
 
         try {
             if (requestContentType.includes("multipart/form-data")) {
@@ -164,11 +273,17 @@ api.post(
                 fileBuffer = await file.arrayBuffer();
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
+                const parentField = formData.get("parent");
+                if (typeof parentField === "string") parentInput = parentField;
+                const tagsField = formData.getAll("tag");
+                if (tagsField.length > 0) userTagsInput = tagsField as string[];
             } else if (requestContentType.includes("application/json")) {
                 const body = await c.req.json<{
                     data: string;
                     contentType?: string;
                     name?: string;
+                    parent?: string;
+                    tags?: string[] | string;
                 }>();
 
                 if (!body.data) {
@@ -197,6 +312,8 @@ api.post(
 
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
+                if (typeof body.parent === "string") parentInput = body.parent;
+                if (body.tags !== undefined) userTagsInput = body.tags;
             } else {
                 fileBuffer = await c.req.arrayBuffer();
 
@@ -214,6 +331,20 @@ api.post(
 
             const existing = await c.env.MEDIA_BUCKET.head(hash);
 
+            // Server-attested provenance. We deliberately never read `app` or
+            // `owner` from request params — only from the verified /account/key
+            // response. Free-form user tags travel in a separate namespace.
+            const owner = safeFacet(authResult.userId ?? null);
+            const app = safeFacet(authResult.appId ?? null);
+            const appName = authResult.appName ?? null;
+            const parent =
+                parentInput && HASH_PATTERN.test(parentInput)
+                    ? parentInput.toLowerCase()
+                    : null;
+            const userTags = normalizeUserTags(userTagsInput);
+            const createdAt = new Date().toISOString();
+            const rev = revTs();
+
             // Always re-PUT to reset the R2 object timestamp (resets lifecycle TTL).
             await c.env.MEDIA_BUCKET.put(hash, fileBuffer, {
                 httpMetadata: {
@@ -221,12 +352,89 @@ api.post(
                     cacheControl: CACHE_CONTROL,
                 },
                 customMetadata: {
-                    uploadedAt: new Date().toISOString(),
+                    uploadedAt: createdAt,
                     originalName: fileName || "",
                     uploadedBy: authResult.name || "",
                     keyType: authResult.type,
+                    owner: owner || "",
+                    app: app || "",
+                    parent: parent || "",
                 },
             });
+
+            const item: CatalogItem = {
+                hash,
+                url: mediaUrl(hash),
+                contentType,
+                size: fileBuffer.byteLength,
+                createdAt,
+                owner,
+                app,
+                appName,
+                keyType: authResult.type,
+                parent,
+                userTags,
+                duplicate: !!existing,
+            };
+            const itemJson = JSON.stringify(item);
+
+            // Index writes are best-effort: failures here must not break the
+            // upload. We log but always return success once the blob is in R2.
+            // Order: item-by-hash, owner index, app index, lineage. We swallow
+            // individual rejections so partial failure leaves a valid blob and
+            // partial index — which the read endpoints already tolerate.
+            const writes: Promise<unknown>[] = [
+                c.env.MEDIA_BUCKET.put(
+                    `${CATALOG_ITEM_PREFIX}${hash}.json`,
+                    itemJson,
+                    { httpMetadata: { contentType: "application/json" } },
+                ),
+            ];
+            if (owner) {
+                writes.push(
+                    c.env.MEDIA_BUCKET.put(
+                        `${CATALOG_OWNER_PREFIX}${owner}/${rev}-${hash}.json`,
+                        itemJson,
+                        {
+                            httpMetadata: { contentType: "application/json" },
+                        },
+                    ),
+                );
+            }
+            if (app) {
+                writes.push(
+                    c.env.MEDIA_BUCKET.put(
+                        `${CATALOG_APP_PREFIX}${app}/${rev}-${hash}.json`,
+                        itemJson,
+                        {
+                            httpMetadata: { contentType: "application/json" },
+                        },
+                    ),
+                );
+            }
+            if (parent) {
+                writes.push(
+                    c.env.MEDIA_BUCKET.put(
+                        `${LINEAGE_PREFIX}${parent}/${rev}-${hash}.json`,
+                        itemJson,
+                        {
+                            httpMetadata: { contentType: "application/json" },
+                        },
+                    ),
+                );
+            }
+            for (const tag of userTags) {
+                writes.push(
+                    c.env.MEDIA_BUCKET.put(
+                        `${TAG_NAMESPACE}/v1/${tag}/${rev}-${hash}.json`,
+                        itemJson,
+                        {
+                            httpMetadata: { contentType: "application/json" },
+                        },
+                    ),
+                );
+            }
+            await Promise.allSettled(writes);
 
             console.log(
                 JSON.stringify({
@@ -236,16 +444,24 @@ api.post(
                     contentType,
                     keyType: authResult.type,
                     uploadedBy: authResult.name || "unknown",
+                    owner,
+                    app,
+                    parent,
+                    userTags,
                     duplicate: !!existing,
                 }),
             );
 
             return c.json({
                 id: hash,
-                url: mediaUrl(hash),
-                contentType,
-                size: fileBuffer.byteLength,
-                duplicate: !!existing,
+                url: item.url,
+                contentType: item.contentType,
+                size: item.size,
+                duplicate: item.duplicate,
+                owner: item.owner,
+                app: item.app,
+                parent: item.parent,
+                userTags: item.userTags,
             });
         } catch (error) {
             console.error("Upload error:", error);
@@ -431,6 +647,188 @@ api.on(
     },
 );
 
+async function readCatalogItems(
+    bucket: R2Bucket,
+    prefix: string,
+    limit: number,
+    cursor: string | undefined,
+): Promise<{ items: CatalogItem[]; nextCursor: string | null }> {
+    const listResult = await bucket.list({
+        prefix,
+        limit,
+        cursor: cursor || undefined,
+    });
+    const items: CatalogItem[] = [];
+    // Hydrate each listing entry to its full JSON record. Index entries that
+    // fail to parse or 404 mid-list are dropped — they may have been pruned
+    // by lifecycle or a future tombstone path.
+    const reads = await Promise.allSettled(
+        listResult.objects.map(async (obj) => {
+            const got = await bucket.get(obj.key);
+            if (!got) return null;
+            try {
+                return (await got.json()) as CatalogItem;
+            } catch {
+                return null;
+            }
+        }),
+    );
+    for (const r of reads) {
+        if (r.status === "fulfilled" && r.value) items.push(r.value);
+    }
+    const nextCursor =
+        listResult.truncated && "cursor" in listResult
+            ? (listResult.cursor as string | undefined) || null
+            : null;
+    return { items, nextCursor };
+}
+
+function clampLimit(raw: string | null): number {
+    const n = parseInt(raw || "50", 10);
+    if (Number.isNaN(n) || n <= 0) return 50;
+    return Math.min(n, 200);
+}
+
+api.get(
+    "/:hash/children",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List remixes derived from this hash",
+        description:
+            "Returns public remix children declared via `parent=<hash>` on upload. Newest first. No auth required.",
+        responses: {
+            200: {
+                description: "List of children",
+                content: {
+                    "application/json": {
+                        schema: resolver(ListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid hash format",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const hash = c.req.param("hash");
+        if (!HASH_PATTERN.test(hash)) {
+            return c.json({ error: "Invalid hash format" }, 400);
+        }
+        const url = new URL(c.req.url);
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const cursor = url.searchParams.get("cursor") || undefined;
+        const result = await readCatalogItems(
+            c.env.MEDIA_BUCKET,
+            `${LINEAGE_PREFIX}${hash.toLowerCase()}/`,
+            limit,
+            cursor,
+        );
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List uploads by the authenticated user",
+        description:
+            "Returns the caller's own uploads, newest first. The `app` query param optionally filters to a single app id (must match the verified app id of the calling key).",
+        responses: {
+            200: {
+                description: "List of items",
+                content: {
+                    "application/json": {
+                        schema: resolver(ListResponseSchema),
+                    },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) {
+            return c.json({ error: "API key required" }, 401);
+        }
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+        const owner = safeFacet(authResult.userId ?? null);
+        if (!owner) {
+            // Key is valid but has no resolvable user id (e.g. legacy key
+            // pre-dating /account/key exposing userId). Honest empty result.
+            return c.json({ items: [], nextCursor: null });
+        }
+        const url = new URL(c.req.url);
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const cursor = url.searchParams.get("cursor") || undefined;
+        const appFilter = safeFacet(url.searchParams.get("app"));
+        const result = await readCatalogItems(
+            c.env.MEDIA_BUCKET,
+            `${CATALOG_OWNER_PREFIX}${owner}/`,
+            limit,
+            cursor,
+        );
+        if (appFilter) {
+            result.items = result.items.filter((i) => i.app === appFilter);
+        }
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/apps/:app/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public uploads attributed to an app",
+        description:
+            "Returns uploads where the verified app id matches. Newest first. No auth required; `app` is server-attested at upload time so this listing is impersonation-resistant.",
+        responses: {
+            200: {
+                description: "List of items",
+                content: {
+                    "application/json": {
+                        schema: resolver(ListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid app id",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const app = safeFacet(c.req.param("app"));
+        if (!app) {
+            return c.json({ error: "Invalid app id" }, 400);
+        }
+        const url = new URL(c.req.url);
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const cursor = url.searchParams.get("cursor") || undefined;
+        const result = await readCatalogItems(
+            c.env.MEDIA_BUCKET,
+            `${CATALOG_APP_PREFIX}${app}/`,
+            limit,
+            cursor,
+        );
+        return c.json(result);
+    },
+);
+
 const app = new Hono<{ Bindings: Env }>();
 
 app.use(
@@ -446,10 +844,13 @@ app.use(
 app.get("/", (c) => {
     return c.json({
         service: DOMAIN,
-        version: "1.0.0",
+        version: "1.1.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
             retrieve: "GET /:hash",
+            children: "GET /:hash/children",
+            myMedia: "GET /me/media (requires API key)",
+            appMedia: "GET /apps/:app/media",
             docs: "GET /openapi.json",
         },
         limits: {

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -17,22 +17,86 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    owner: string | null;
+    app: string | null;
+    parent: string | null;
+    userTags: string[];
+}
+
+interface CatalogItem {
+    hash: string;
+    url: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    owner: string | null;
+    app: string | null;
+    appName: string | null;
+    parent: string | null;
+    userTags: string[];
+}
+
+interface ListResponse {
+    items: CatalogItem[];
+    nextCursor: string | null;
 }
 
 const VALID_KEY = "pk_test_key_123";
+const OTHER_KEY = "pk_other_key_456";
+const NO_USER_KEY = "pk_anon_key_789";
 
 function mockAuth() {
     fetchMock.activate();
     fetchMock.disableNetConnect();
-    fetchMock
-        .get("https://gen.pollinations.ai")
-        .intercept({ path: "/account/key" })
+    const pool = fetchMock.get("https://gen.pollinations.ai");
+
+    pool.intercept({
+        path: "/account/key",
+        headers: { authorization: `Bearer ${VALID_KEY}` },
+    })
         .reply(
             200,
             JSON.stringify({
                 valid: true,
                 type: "publishable",
                 name: "test-user",
+                userId: "user_alice",
+                appId: "catgpt",
+                appName: "CatGPT",
+            }),
+            { headers: { "content-type": "application/json" } },
+        )
+        .persist();
+
+    pool.intercept({
+        path: "/account/key",
+        headers: { authorization: `Bearer ${OTHER_KEY}` },
+    })
+        .reply(
+            200,
+            JSON.stringify({
+                valid: true,
+                type: "publishable",
+                name: "other-user",
+                userId: "user_bob",
+                appId: "voice-edit",
+                appName: "voice.edit",
+            }),
+            { headers: { "content-type": "application/json" } },
+        )
+        .persist();
+
+    pool.intercept({
+        path: "/account/key",
+        headers: { authorization: `Bearer ${NO_USER_KEY}` },
+    })
+        .reply(
+            200,
+            JSON.stringify({
+                valid: true,
+                type: "publishable",
+                name: "legacy-user",
+                // no userId / appId — legacy/anonymous key shape
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -166,5 +230,253 @@ describe("media.pollinations.ai", () => {
             "https://media.pollinations.ai/0000000000000000",
         );
         expect(res.status).toBe(404);
+    });
+
+    it("upload stamps server-attested owner and app from /account/key", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "stamped.png", { type: "image/png" }),
+        );
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        expect(res.status).toBe(200);
+        const upload = (await res.json()) as UploadResponse;
+        expect(upload.owner).toBe("user_alice");
+        expect(upload.app).toBe("catgpt");
+        expect(upload.parent).toBeNull();
+        expect(upload.userTags).toEqual([]);
+    });
+
+    it("request-supplied owner/app params do NOT override verified identity", async () => {
+        // Adversarial: client tries to claim a different app/owner via the
+        // request. These keys are reserved for the server. The upload
+        // succeeds but stamps the verified values from /account/key.
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([new Uint8Array([1, 2, 3, 4])], "adv.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        form.append("app", "voice-edit");
+        form.append("owner", "user_bob");
+
+        const res = await SELF.fetch(
+            "https://media.pollinations.ai/upload?app=voice-edit&owner=user_bob",
+            {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(res.status).toBe(200);
+        const upload = (await res.json()) as UploadResponse;
+        expect(upload.owner).toBe("user_alice");
+        expect(upload.app).toBe("catgpt");
+    });
+
+    it("lineage: child appears under parent's /children listing", async () => {
+        // Upload parent
+        const parentForm = new FormData();
+        parentForm.append(
+            "file",
+            new File([new Uint8Array([10, 20, 30])], "parent.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        const parentRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: parentForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        const parent = (await parentRes.json()) as UploadResponse;
+
+        // Upload child claiming parent
+        const childForm = new FormData();
+        childForm.append(
+            "file",
+            new File([new Uint8Array([40, 50, 60])], "child.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        childForm.append("parent", parent.id);
+        const childRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: childForm,
+                headers: { Authorization: `Bearer ${OTHER_KEY}` },
+            },
+        );
+        const child = (await childRes.json()) as UploadResponse;
+        expect(child.parent).toBe(parent.id);
+
+        const listRes = await SELF.fetch(
+            `https://media.pollinations.ai/${parent.id}/children`,
+        );
+        expect(listRes.status).toBe(200);
+        const list = (await listRes.json()) as ListResponse;
+        expect(list.items.length).toBe(1);
+        expect(list.items[0]!.hash).toBe(child.id);
+        expect(list.items[0]!.app).toBe("voice-edit");
+    });
+
+    it("invalid parent hash is ignored (not stored as lineage)", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([new Uint8Array([99, 99, 99])], "noparent.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        form.append("parent", "not-a-hash");
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        const upload = (await res.json()) as UploadResponse;
+        expect(upload.parent).toBeNull();
+    });
+
+    it("GET /me/media lists only the caller's uploads", async () => {
+        // Two uploads as alice, one as bob.
+        for (const name of ["alice-a.bin", "alice-b.bin"]) {
+            const form = new FormData();
+            form.append(
+                "file",
+                new File(
+                    [new Uint8Array([...name].map((c) => c.charCodeAt(0)))],
+                    name,
+                    {
+                        type: "application/octet-stream",
+                    },
+                ),
+            );
+            await SELF.fetch("https://media.pollinations.ai/upload", {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            });
+        }
+        const bobForm = new FormData();
+        bobForm.append(
+            "file",
+            new File([new Uint8Array([66, 79, 66])], "bob.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: bobForm,
+            headers: { Authorization: `Bearer ${OTHER_KEY}` },
+        });
+
+        const res = await SELF.fetch("https://media.pollinations.ai/me/media", {
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        expect(res.status).toBe(200);
+        const list = (await res.json()) as ListResponse;
+        expect(list.items.length).toBeGreaterThanOrEqual(2);
+        for (const item of list.items) {
+            expect(item.owner).toBe("user_alice");
+        }
+    });
+
+    it("GET /me/media without auth returns 401", async () => {
+        const res = await SELF.fetch("https://media.pollinations.ai/me/media");
+        expect(res.status).toBe(401);
+    });
+
+    it("GET /me/media with key lacking userId returns empty list", async () => {
+        const res = await SELF.fetch("https://media.pollinations.ai/me/media", {
+            headers: { Authorization: `Bearer ${NO_USER_KEY}` },
+        });
+        expect(res.status).toBe(200);
+        const list = (await res.json()) as ListResponse;
+        expect(list.items).toEqual([]);
+    });
+
+    it("GET /apps/:app/media lists only that app's uploads", async () => {
+        // Alice uploads under catgpt, bob under voice-edit.
+        const aForm = new FormData();
+        aForm.append(
+            "file",
+            new File([new Uint8Array([1, 1, 1])], "a.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: aForm,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        const bForm = new FormData();
+        bForm.append(
+            "file",
+            new File([new Uint8Array([2, 2, 2])], "b.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: bForm,
+            headers: { Authorization: `Bearer ${OTHER_KEY}` },
+        });
+
+        const res = await SELF.fetch(
+            "https://media.pollinations.ai/apps/catgpt/media",
+        );
+        expect(res.status).toBe(200);
+        const list = (await res.json()) as ListResponse;
+        for (const item of list.items) {
+            expect(item.app).toBe("catgpt");
+        }
+        expect(list.items.length).toBeGreaterThan(0);
+    });
+
+    it("user tags are lowercased, validated, and capped", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([new Uint8Array([7, 7, 7])], "tagged.bin", {
+                type: "application/octet-stream",
+            }),
+        );
+        form.append("tag", "Funny");
+        form.append("tag", "cats");
+        form.append("tag", "bad tag with spaces");
+        form.append("tag", "ok-2");
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        const upload = (await res.json()) as UploadResponse;
+        expect(upload.userTags).toContain("funny");
+        expect(upload.userTags).toContain("cats");
+        expect(upload.userTags).toContain("ok-2");
+        expect(upload.userTags).not.toContain("bad tag with spaces");
+    });
+
+    it("apps endpoint rejects invalid app id format", async () => {
+        const res = await SELF.fetch(
+            "https://media.pollinations.ai/apps/bad%20id/media",
+        );
+        expect(res.status).toBe(400);
+    });
+
+    it("children endpoint rejects invalid hash", async () => {
+        const res = await SELF.fetch(
+            "https://media.pollinations.ai/not-a-hash/children",
+        );
+        expect(res.status).toBe(400);
     });
 });


### PR DESCRIPTION
Smallest change that lets client-only apps (CatGPT, voice-edit) have a clean public gallery, a personal "my media" list, and a remix-lineage tree, without new infra.

Mechanism: media.pollinations.ai writes tiny JSON index entries under stable R2 prefixes on every upload. Three new read endpoints `list({prefix})` over those. Identity facets (`owner`, `app`) are stamped from the verified `/account/key` response and are not readable from request params.

Why R2 prefix, not D1/KV: only query needed is "list children of X" / "list by owner" / "list by app". No joins, no random tag lookup. Same shape works on S3 (ListObjectsV2) unchanged.

Changes:
- `enter.pollinations.ai/src/routes/account.ts` — `/account/key` now also returns `userId`, `appId`, `appName` (additive, backwards-compatible)
- `media.pollinations.ai/src/index.ts` — upload accepts optional `parent` + `tags`; writes index entries; new endpoints `GET /:hash/children`, `GET /me/media`, `GET /apps/:app/media`
- 11 new tests covering the trust boundary, lineage round-trip, listing isolation, tag normalization, and the legacy-key-without-userId case

Storage layout (R2):
```
catalog/v1/items/<hash>.json
catalog/v1/by-owner/<userId>/<revTs>-<hash>.json
catalog/v1/by-app/<appId>/<revTs>-<hash>.json
lineage/v1/by-parent/<parent>/<revTs>-<child>.json
tags/v1/<userTag>/<revTs>-<hash>.json
```

`revTs` is `MAX_SAFE_INTEGER - Date.now()` so lex-sort is newest-first.

Not in this PR:
- Frontend integration (voice-edit branch strip, CatGPT gallery) — separate
- Retention/billing for index entries — defer to #10832 work
- Closure tables, edit-verb classification, abuse pipelines — deferred until shape is in production
- Cross-app moderation/takedown — separate concern

Tests: 17/17 pass under cloudflare/vitest-pool-workers.