### PR TITLE
feat: add media catalog

### DIFF
--- a/apps/ai-dungeon-master/src/App.tsx
+++ b/apps/ai-dungeon-master/src/App.tsx
@@ -12,6 +12,7 @@ const API_URL = {
     story: "https://gen.pollinations.ai/v1/chat/completions",
     image: "https://gen.pollinations.ai/image/",
 };
+const CATALOG_APP_TAG = "ai-dungeon-master";
 // Enhanced interfaces
 interface Character {
     name: string;
@@ -175,28 +176,70 @@ export default function App() {
             let uploadedSceneImage = gameState.currentScene.image;
 
             if (withUpload && apiKey) {
-                const sceneUpload = uploadToMedia(
-                    gameState.currentScene.image,
+                const originalLastStoryImage =
+                    gameState.storyHistory[gameState.storyHistory.length - 1]
+                        ?.image;
+                character.avatar = await uploadToMedia(
+                    character.avatar,
                     apiKey,
+                    {
+                        visibility: "private",
+                        tags: [CATALOG_APP_TAG, "ai-dungeon-avatar"],
+                        kind: "generation",
+                        prompt: `${character.name} the ${character.class}. ${character.backstory}`,
+                        model: "flux",
+                    },
                 );
-                await Promise.all([
-                    uploadToMedia(character.avatar, apiKey).then((url) => {
-                        character.avatar = url;
-                    }),
-                    sceneUpload.then((url) => {
-                        uploadedSceneImage = url;
-                    }),
-                    ...storyHistory.map((entry, idx) =>
-                        uploadToMedia(entry.image, apiKey).then((url) => {
-                            storyHistory[idx].image = url;
-                        }),
-                    ),
-                    ...inventory.map((item, idx) =>
-                        uploadToMedia(item.image, apiKey).then((url) => {
+
+                let previousStoryImage = character.avatar;
+                for (let idx = 0; idx < storyHistory.length; idx++) {
+                    const entry = storyHistory[idx];
+                    storyHistory[idx].image = await uploadToMedia(
+                        entry.image,
+                        apiKey,
+                        {
+                            visibility: "private",
+                            tags: [CATALOG_APP_TAG, "ai-dungeon-story"],
+                            parents: [previousStoryImage].filter(Boolean),
+                            kind: "generation",
+                            prompt: entry.description,
+                            model: "flux",
+                        },
+                    );
+                    previousStoryImage = storyHistory[idx].image;
+                }
+
+                if (originalLastStoryImage === gameState.currentScene.image) {
+                    uploadedSceneImage = previousStoryImage;
+                } else {
+                    uploadedSceneImage = await uploadToMedia(
+                        gameState.currentScene.image,
+                        apiKey,
+                        {
+                            visibility: "private",
+                            tags: [CATALOG_APP_TAG, "ai-dungeon-scene"],
+                            parents: [previousStoryImage].filter(Boolean),
+                            kind: "generation",
+                            prompt: gameState.currentScene.description,
+                            model: "flux",
+                        },
+                    );
+                }
+
+                await Promise.all(
+                    inventory.map((item, idx) =>
+                        uploadToMedia(item.image, apiKey, {
+                            visibility: "private",
+                            tags: [CATALOG_APP_TAG, "ai-dungeon-item"],
+                            parents: [uploadedSceneImage].filter(Boolean),
+                            kind: "generation",
+                            prompt: `${item.name}: ${item.description}`,
+                            model: "flux",
+                        }).then((url) => {
                             inventory[idx].image = url;
                         }),
                     ),
-                ]);
+                );
             }
 
             const currentScene = {

--- a/apps/ai-dungeon-master/src/utils/mediaUpload.ts
+++ b/apps/ai-dungeon-master/src/utils/mediaUpload.ts
@@ -1,5 +1,15 @@
-const MEDIA_URL = "https://gen.pollinations.ai";
+const MEDIA_URL = "https://media.pollinations.ai";
+const MEDIA_UPLOAD_URL = `${MEDIA_URL}/upload`;
 const MEDIA_HOST = "media.pollinations.ai";
+
+export interface MediaCatalogFields {
+    visibility?: "public" | "private";
+    tags?: string[];
+    parents?: string[];
+    kind?: "upload" | "generation" | "edit" | "saved_generation";
+    prompt?: string;
+    model?: string;
+}
 
 /** Check if a URL is already uploaded to media.pollinations.ai */
 function isMediaUrl(url: string): boolean {
@@ -10,6 +20,25 @@ function isMediaUrl(url: string): boolean {
     }
 }
 
+function appendCatalogFields(
+    formData: FormData,
+    {
+        visibility = "private",
+        tags = [],
+        parents = [],
+        kind = "generation",
+        prompt,
+        model,
+    }: MediaCatalogFields,
+) {
+    formData.append("visibility", visibility);
+    formData.append("kind", kind);
+    if (prompt) formData.append("prompt", prompt);
+    if (model) formData.append("model", model);
+    if (tags.length) formData.append("tags", JSON.stringify(tags));
+    if (parents.length) formData.append("parents", JSON.stringify(parents));
+}
+
 /**
  * Upload a gen.pollinations.ai image to media.pollinations.ai for permanent storage.
  * Returns the permanent media URL on success, or the original URL on any error.
@@ -18,6 +47,7 @@ function isMediaUrl(url: string): boolean {
 export async function uploadToMedia(
     genUrl: string,
     apiKey: string,
+    catalog: MediaCatalogFields = {},
 ): Promise<string> {
     if (!genUrl || isMediaUrl(genUrl)) return genUrl;
 
@@ -27,9 +57,10 @@ export async function uploadToMedia(
 
         const blob = await response.blob();
         const formData = new FormData();
-        formData.append("file", blob);
+        formData.append("file", blob, `ai-dungeon-${Date.now()}.png`);
+        appendCatalogFields(formData, catalog);
 
-        const uploadRes = await fetch(`${MEDIA_URL}/media`, {
+        const uploadRes = await fetch(MEDIA_UPLOAD_URL, {
             method: "POST",
             headers: { Authorization: `Bearer ${apiKey}` },
             body: formData,
@@ -38,7 +69,7 @@ export async function uploadToMedia(
         if (!uploadRes.ok) return genUrl;
 
         const data = await uploadRes.json();
-        return data.url || genUrl;
+        return data.url || (data.id ? `${MEDIA_URL}/${data.id}` : genUrl);
     } catch {
         return genUrl;
     }

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -3,11 +3,13 @@
 const API = "https://gen.pollinations.ai/image";
 const ENTER = "https://enter.pollinations.ai";
 const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA_API = "https://media.pollinations.ai";
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const AUTH_KEY = "catgpt_api_key";
 const APP_KEY = "pk_uWjreBEkxFAhjDHo";
+const CATGPT_TAGS = ["catgpt", "catgpt-generated"];
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -122,6 +124,73 @@ export function generateImageURL(prompt, model, imageUrl = null) {
     return url;
 }
 
+function appendMediaCatalogFields(form, fields = {}) {
+    const {
+        visibility = "public",
+        tags = [],
+        parentIds = [],
+        kind,
+        prompt,
+        model,
+    } = fields;
+    form.append("visibility", visibility);
+    if (kind) form.append("kind", kind);
+    if (prompt) form.append("prompt", prompt);
+    if (model) form.append("model", model);
+    if (tags.length) form.append("tags", JSON.stringify(tags));
+    if (parentIds.length) form.append("parents", JSON.stringify(parentIds));
+}
+
+async function uploadToMedia(blob, filename, fields) {
+    const key = getStoredApiKey();
+    const form = new FormData();
+    form.append("file", blob, filename);
+    appendMediaCatalogFields(form, fields);
+
+    const res = await fetch(MEDIA_UPLOAD, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${key}` },
+        body: form,
+    });
+    if (!res.ok) throw new Error("Media upload failed");
+    const json = await res.json();
+    return json.url || `${MEDIA_API}/${json.id}`;
+}
+
+export async function saveGeneratedMemeToMedia(
+    blob,
+    { question, model, parentUrls = [] },
+) {
+    return uploadToMedia(blob, "catgpt-meme.png", {
+        visibility: "public",
+        tags: CATGPT_TAGS,
+        parentIds: [SELFIE_CATGPT, ...parentUrls].filter(Boolean),
+        kind: "generation",
+        prompt: question,
+        model,
+    });
+}
+
+export async function fetchSavedCatGptMemes() {
+    const key = getStoredApiKey();
+    if (!key) return [];
+    const params = new URLSearchParams({
+        app_key: APP_KEY,
+        tag: "catgpt-generated",
+        limit: "12",
+    });
+    const res = await fetch(`${MEDIA_API}/me/media?${params}`, {
+        headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.items || []).map((item) => ({
+        prompt: item.prompt || "CatGPT meme",
+        url: item.url,
+        model: item.model,
+    }));
+}
+
 // ── Models ──────────────────────────────────────────────────────────────────
 
 const PREFERRED_MODEL = "nanobanana";
@@ -155,15 +224,11 @@ export async function handleImageUpload(file, notify) {
 
     try {
         notify("Uploading image...", "info");
-        const form = new FormData();
-        form.append("file", file);
-        const res = await fetch(MEDIA_UPLOAD, {
-            method: "POST",
-            headers: { Authorization: `Bearer ${getStoredApiKey()}` },
-            body: form,
+        return await uploadToMedia(file, file.name || "catgpt-source", {
+            visibility: "private",
+            tags: ["catgpt", "catgpt-source"],
+            kind: "upload",
         });
-        if (!res.ok) throw new Error("Upload failed");
-        return (await res.json()).url;
     } catch (err) {
         console.error("Media upload failed:", err);
         notify("Upload failed. Trying local fallback...", "warning");

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -7,12 +7,14 @@ import {
     extractApiKeyFromFragment,
     fetchBalance,
     fetchProfile,
+    fetchSavedCatGptMemes,
     generateCatReply,
     generateImageURL,
     getAuthorizeUrl,
     getStoredApiKey,
     handleImageUpload,
     pickModel,
+    saveGeneratedMemeToMedia,
     storeApiKey,
 } from "./ai.js";
 
@@ -333,9 +335,16 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
+async function loadUserMemes() {
     dom.yourMemesGrid.innerHTML = "";
-    const saved = getSavedMemes();
+    const localSaved = getSavedMemes();
+    const remoteSaved = await fetchSavedCatGptMemes().catch(() => []);
+    const saved = [
+        ...remoteSaved,
+        ...localSaved.filter(
+            (local) => !remoteSaved.some((remote) => remote.url === local.url),
+        ),
+    ].slice(0, 12);
 
     if (!saved.length) {
         const p = document.createElement("p");
@@ -396,8 +405,13 @@ async function generateMeme() {
     const catReply = await generateCatReply(question, uploadedImageUrl);
     if (cancelled) return;
 
+    const imagePrompt = createImageGenerationPrompt(
+        question,
+        catReply,
+        !!uploadedImageUrl,
+    );
     const imageUrl = generateImageURL(
-        createImageGenerationPrompt(question, catReply, !!uploadedImageUrl),
+        imagePrompt,
         activeModel,
         uploadedImageUrl,
     );
@@ -411,16 +425,26 @@ async function generateMeme() {
             throw new Error(text.slice(0, 200) || `Error ${response.status}`);
         }
 
-        // Use the pollinations URL directly (shareable, cacheable)
-        await response.blob(); // ensure the image is fully loaded
+        const blob = await response.blob();
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+        let savedUrl = imageUrl;
+        try {
+            savedUrl = await saveGeneratedMemeToMedia(blob, {
+                question,
+                model: activeModel,
+                parentUrls: [uploadedImageUrl],
+            });
+        } catch (err) {
+            console.warn("Generated meme catalog save failed:", err);
+        }
+        if (cancelled) return;
+        dom.generatedMeme.src = savedUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
+        saveGeneratedMeme(question, savedUrl);
         loadUserMemes();
     } catch (error) {
         if (cancelled) return;

--- a/apps/chat/src/utils/api.js
+++ b/apps/chat/src/utils/api.js
@@ -1,5 +1,7 @@
 // Pollinations API utilities — updated to match gen.pollinations.ai spec
 const BASE_URL = "https://gen.pollinations.ai";
+const MEDIA_API_URL = "https://media.pollinations.ai";
+const MEDIA_UPLOAD_URL = `${MEDIA_API_URL}/upload`;
 const ENV_API_TOKEN = import.meta.env.VITE_POLLINATIONS_API_KEY || "";
 export const BYOP_STORAGE_KEY = "pollinations_byop_api_key";
 
@@ -74,6 +76,62 @@ const parseApiError = async (response) => {
     }
     return buildClientError(response.status);
 };
+
+function appendCatalogFields(form, fields = {}) {
+    const {
+        visibility = "private",
+        tags = [],
+        parents = [],
+        kind = "generation",
+        prompt,
+        model,
+    } = fields;
+    form.append("visibility", visibility);
+    form.append("kind", kind);
+    if (prompt) form.append("prompt", prompt);
+    if (model) form.append("model", model);
+    if (tags.length) form.append("tags", JSON.stringify(tags));
+    if (parents.length) form.append("parents", JSON.stringify(parents));
+}
+
+async function uploadGeneratedMedia(blob, filename, fields) {
+    const token = getApiToken();
+    if (!token) throw new Error("No API key available for media upload");
+
+    const form = new FormData();
+    form.append("file", blob, filename);
+    appendCatalogFields(form, fields);
+
+    const response = await fetch(MEDIA_UPLOAD_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+    });
+    if (!response.ok) throw new Error("Media upload failed");
+
+    const data = await response.json();
+    if (data.url) return data.url;
+    if (data.id) return `${MEDIA_API_URL}/${data.id}`;
+    throw new Error("Media upload response missing URL");
+}
+
+function blobToDataUrl(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+async function catalogOrDataUrl(blob, filename, fields) {
+    try {
+        return await uploadGeneratedMedia(blob, filename, fields);
+    } catch (error) {
+        console.warn("Media catalog upload failed, using data URL:", error);
+        return blobToDataUrl(blob);
+    }
+}
 
 export const loadModels = async () => {
     if (
@@ -530,13 +588,18 @@ export const generateImage = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, width, height, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-image-${Date.now()}.png`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-image"],
+            kind: "generation",
+            prompt,
+            model,
+        },
+    );
+    return { url: mediaUrl, prompt, model, width, height, seed };
 };
 
 export const generateVideo = async (prompt, options = {}) => {
@@ -556,13 +619,18 @@ export const generateVideo = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-video-${Date.now()}.mp4`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-video"],
+            kind: "generation",
+            prompt,
+            model,
+        },
+    );
+    return { url: mediaUrl, prompt, model, seed };
 };
 
 // Generate speech/audio — GET /audio/{text}?voice=...
@@ -578,11 +646,21 @@ export const generateAudio = async (text, options = {}) => {
 
     const blob = await response.blob();
     const mimeType = blob.type || "audio/mpeg";
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, text, voice, model, mimeType });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const ext = mimeType.includes("wav")
+        ? "wav"
+        : mimeType.includes("ogg")
+          ? "ogg"
+          : "mp3";
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-audio-${Date.now()}.${ext}`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-audio"],
+            kind: "generation",
+            prompt: text,
+            model,
+        },
+    );
+    return { url: mediaUrl, text, voice, model, mimeType };
 };

--- a/apps/product-packaging-designer/src/App.tsx
+++ b/apps/product-packaging-designer/src/App.tsx
@@ -12,7 +12,8 @@ import {
     Sun,
     Upload,
 } from "lucide-react";
-import { type React, useEffect, useState } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 type StyleOption = {
     id: string;
@@ -27,6 +28,15 @@ type PackagingType = {
     label: string;
     icon: typeof Box;
     prompt: string;
+};
+
+type CatalogFields = {
+    visibility?: "public" | "private";
+    tags?: string[];
+    parents?: string[];
+    kind?: "upload" | "generation" | "edit" | "saved_generation";
+    prompt?: string;
+    model?: string;
 };
 
 const styleOptions: StyleOption[] = [
@@ -79,7 +89,8 @@ const packagingTypes: PackagingType[] = [
     { id: "can", label: "Can", icon: Package, prompt: "can packaging" },
 ];
 const POLLINATIONS_API = "https://gen.pollinations.ai/image";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
+const PACKAGING_TAGS = ["product-packaging-designer"];
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const MAX_DISPLAY_SIZE = 10 * 1024 * 1024;
@@ -236,18 +247,37 @@ function App() {
             setFile(null);
         }
     };
-    const uploadToPollinationsMedia = async (file: File): Promise<string> => {
-        const validation = validateFile(file, MAX_FILE_SIZE);
-        if (!validation.isValid) {
-            throw new Error(validation.error || "File validation failed");
-        }
+    const appendCatalogFields = (
+        formData: FormData,
+        {
+            visibility = "private",
+            tags = PACKAGING_TAGS,
+            parents = [],
+            kind = "generation",
+            prompt,
+            model,
+        }: CatalogFields = {},
+    ) => {
+        formData.append("visibility", visibility);
+        formData.append("kind", kind);
+        if (prompt) formData.append("prompt", prompt);
+        if (model) formData.append("model", model);
+        if (tags.length) formData.append("tags", JSON.stringify(tags));
+        if (parents.length) formData.append("parents", JSON.stringify(parents));
+    };
 
+    const uploadBlobToPollinationsMedia = async (
+        blob: Blob,
+        filename: string,
+        catalog: CatalogFields = {},
+    ): Promise<string> => {
         if (!apiKey) {
             throw new Error("No API key available for media upload");
         }
 
         const formData = new FormData();
-        formData.append("file", file);
+        formData.append("file", blob, filename);
+        appendCatalogFields(formData, catalog);
 
         try {
             const response = await fetch(POLLINATIONS_MEDIA_API, {
@@ -303,6 +333,23 @@ function App() {
 
             throw new Error("An unexpected error occurred during upload");
         }
+    };
+
+    const uploadToPollinationsMedia = async (file: File): Promise<string> => {
+        const validation = validateFile(file, MAX_FILE_SIZE);
+        if (!validation.isValid) {
+            throw new Error(validation.error || "File validation failed");
+        }
+
+        return uploadBlobToPollinationsMedia(
+            file,
+            file.name || "packaging-source.png",
+            {
+                visibility: "private",
+                tags: [...PACKAGING_TAGS, "packaging-source"],
+                kind: "upload",
+            },
+        );
     };
 
     const generatePackaging = async () => {
@@ -385,8 +432,32 @@ ${brandName.trim() ? ` Brand name: "${brandName}".` : ""}
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setGeneratedImage(blobUrl);
+            let resultUrl = URL.createObjectURL(blob);
+            try {
+                resultUrl = await uploadBlobToPollinationsMedia(
+                    blob,
+                    `packaging-mockup-${Date.now()}.png`,
+                    {
+                        visibility: "private",
+                        tags: [
+                            ...PACKAGING_TAGS,
+                            "packaging-result",
+                            packagingType,
+                            style,
+                        ],
+                        parents: [uploadedUrl],
+                        kind: "edit",
+                        prompt,
+                        model: "nanobanana",
+                    },
+                );
+            } catch (uploadError) {
+                console.warn(
+                    "Packaging result catalog upload failed:",
+                    uploadError,
+                );
+            }
+            setGeneratedImage(resultUrl);
             setImageLoaded(true);
         } catch (error) {
             console.error("Error in generatePackaging:", error);

--- a/apps/virtual-makeup/src/App.jsx
+++ b/apps/virtual-makeup/src/App.jsx
@@ -14,8 +14,9 @@ import { useEffect, useRef, useState } from "react";
 
 const APP_KEY = "pk_pollinations_virtual_makeup";
 const POLLINATIONS_AUTH_URL = "https://enter.pollinations.ai/authorize";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 const POLLINATIONS_IMAGE_API = "https://gen.pollinations.ai/image";
+const MAKEUP_TAGS = ["virtual-makeup"];
 
 const MAKEUP_STYLES = [
     {
@@ -117,9 +118,27 @@ function App() {
         }
     };
 
-    const uploadToPollinations = async (file) => {
+    const appendCatalogFields = (formData, fields = {}) => {
+        const {
+            visibility = "private",
+            tags = MAKEUP_TAGS,
+            parents = [],
+            kind = "generation",
+            prompt,
+            model,
+        } = fields;
+        formData.append("visibility", visibility);
+        formData.append("kind", kind);
+        if (prompt) formData.append("prompt", prompt);
+        if (model) formData.append("model", model);
+        if (tags.length) formData.append("tags", JSON.stringify(tags));
+        if (parents.length) formData.append("parents", JSON.stringify(parents));
+    };
+
+    const uploadBlobToPollinations = async (blob, filename, catalog = {}) => {
         const formData = new FormData();
-        formData.append("file", file);
+        formData.append("file", blob, filename);
+        appendCatalogFields(formData, catalog);
 
         const response = await fetch(POLLINATIONS_MEDIA_API, {
             method: "POST",
@@ -137,6 +156,18 @@ function App() {
 
         const data = await response.json();
         return data.url || data.secure_url || data.media_url;
+    };
+
+    const uploadToPollinations = async (file) => {
+        return uploadBlobToPollinations(
+            file,
+            file.name || "makeup-source.png",
+            {
+                visibility: "private",
+                tags: [...MAKEUP_TAGS, "virtual-makeup-source"],
+                kind: "upload",
+            },
+        );
     };
 
     const applyMakeup = async () => {
@@ -172,8 +203,31 @@ function App() {
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setMakeupImage(blobUrl);
+            let resultUrl = URL.createObjectURL(blob);
+            try {
+                resultUrl = await uploadBlobToPollinations(
+                    blob,
+                    `makeup-result-${Date.now()}.png`,
+                    {
+                        visibility: "private",
+                        tags: [
+                            ...MAKEUP_TAGS,
+                            "virtual-makeup-result",
+                            selectedStyle,
+                        ],
+                        parents: [pollinationsUrl],
+                        kind: "edit",
+                        prompt,
+                        model: "nanobanana",
+                    },
+                );
+            } catch (uploadError) {
+                console.warn(
+                    "Makeup result catalog upload failed:",
+                    uploadError,
+                );
+            }
+            setMakeupImage(resultUrl);
             setImageLoaded(true);
             setIsLoading(false);
         } catch (error) {

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -359,6 +359,7 @@ const STARTERS = [
 ];
 const STARTER = STARTERS[0].url;
 const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const REMIX_TAGS = ["voice-edit", "voice-edit-remix"];
 const STT_MODEL = "scribe";
 const STT_LANG = (navigator.language || "en").slice(0, 2);
 const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
@@ -899,15 +900,41 @@ async function promptTypedEdit(clientX, clientY) {
   });
 }
 
-async function uploadDataURL(dataURL, filename = "annot.png") {
-  const blob = await (await fetch(dataURL)).blob();
-  return uploadBlob(blob, filename);
+function catalogParents(...urls) {
+  return Array.from(new Set(urls.map(scrubURL).filter(Boolean)));
 }
 
-async function uploadBlob(blob, filename) {
+function appendCatalogFields(form, {
+  visibility = "public",
+  tags = REMIX_TAGS,
+  parents = [],
+  kind = "edit",
+  prompt = "",
+  model = "",
+} = {}) {
+  form.append("visibility", visibility);
+  form.append("kind", kind);
+  if (prompt) form.append("prompt", prompt);
+  if (model) form.append("model", model);
+  if (tags.length) form.append("tags", JSON.stringify(tags));
+  const parentIds = catalogParents(...parents);
+  if (parentIds.length) form.append("parents", JSON.stringify(parentIds));
+}
+
+function currentMediaURL() {
+  return app.history[app.historyIndex]?.url || app.imageURL || app.stateURL;
+}
+
+async function uploadDataURL(dataURL, filename = "annot.png", catalog = {}) {
+  const blob = await (await fetch(dataURL)).blob();
+  return uploadBlob(blob, filename, catalog);
+}
+
+async function uploadBlob(blob, filename, catalog = {}) {
   setStatus("uploading...");
   const form = new FormData();
   form.append("file", blob, filename);
+  appendCatalogFields(form, catalog);
   const res = await fetch("https://media.pollinations.ai/upload", {
     method: "POST",
     headers: authHeaders(),
@@ -967,8 +994,16 @@ async function runQueue() {
       render();
       setStatus(`editing... (${app.queue.length + 1} in queue)`);
       try {
+        const sourceURL = currentMediaURL();
         const snapshot = await composeSnapshot(job.marker);
-        const uploaded = await uploadDataURL(snapshot, "annot.png");
+        const uploaded = await uploadDataURL(snapshot, "annot.png", {
+          visibility: "private",
+          tags: [...REMIX_TAGS, "voice-edit-prep"],
+          parents: [sourceURL],
+          kind: "edit",
+          prompt: job.text,
+          model: job.model,
+        });
         mediaHistory.addSilent({
           kind: "prep",
           url: uploaded,
@@ -982,7 +1017,11 @@ async function runQueue() {
         const result = await runEdit(uploaded, prompt, job.model);
         await mediaHistory.set({ url: result }, { add: true });
         setStatus("packaging share link...");
-        const packaged = await packageCurrentFrameWithHistory();
+        const packaged = await packageCurrentFrameWithHistory({
+          parents: [sourceURL, uploaded, result],
+          prompt: job.text,
+          model: job.model,
+        });
         const frame = app.history[app.historyIndex];
         if (frame?.url === result) {
           frame.url = packaged;
@@ -1107,7 +1146,11 @@ els.file.addEventListener("change", async () => {
   const file = els.file.files?.[0];
   if (!file) return;
   try {
-    const mediaURL = await uploadBlob(file, file.name || "image");
+    const mediaURL = await uploadBlob(file, file.name || "image", {
+      visibility: "private",
+      tags: [...REMIX_TAGS, "voice-edit-source"],
+      kind: "upload",
+    });
     await openStartURL(mediaURL);
     setStatus(`loaded ${file.name || "image"}`);
   } catch (err) {
@@ -1136,7 +1179,11 @@ const setDrop = (drop) => (event) => {
 els.frame.addEventListener("drop", (event) => {
   const file = event.dataTransfer?.files?.[0];
   if (!file) return;
-  uploadBlob(file, file.name || "image")
+  uploadBlob(file, file.name || "image", {
+    visibility: "private",
+    tags: [...REMIX_TAGS, "voice-edit-source"],
+    kind: "upload",
+  })
     .then((mediaURL) => openStartURL(mediaURL))
     .then(() => setStatus(`loaded ${file.name || "image"}`))
     .catch((err) => showError(err.message));
@@ -1415,8 +1462,17 @@ async function openStartURL(mediaURL) {
   await followLocationStart();
 }
 
-async function packageCurrentFrameWithHistory() {
-  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png");
+async function packageCurrentFrameWithHistory(catalog = {}) {
+  const current = currentMediaURL();
+  const previous = app.history[app.historyIndex - 1]?.url;
+  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png", {
+    visibility: "public",
+    tags: [...REMIX_TAGS, "voice-edit-history"],
+    kind: "edit",
+    parents: catalog.parents || [previous, current],
+    prompt: catalog.prompt,
+    model: catalog.model,
+  });
 }
 
 const goHistory = (delta, label) => () => {
@@ -1436,7 +1492,12 @@ els.download.addEventListener("click", async () => {
 });
 els.share.addEventListener("click", async () => {
   try {
-    const mediaURL = await uploadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`);
+    const mediaURL = await uploadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`, {
+      visibility: "public",
+      tags: [...REMIX_TAGS, "voice-edit-share"],
+      parents: [currentMediaURL()],
+      kind: "edit",
+    });
     const frame = app.history[app.historyIndex];
     if (frame) {
       frame.url = mediaURL;

--- a/apps/voice-edit/walkthrough.html
+++ b/apps/voice-edit/walkthrough.html
@@ -283,6 +283,7 @@ const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
 const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const WALKTHROUGH_TAGS = ["voice-edit", "voice-edit-walkthrough"];
 const DEFAULT_PROMPT = "Smooth visual transition from the first image to the second image. Preserve the subject, composition, and style. No text, labels, captions, or subtitles.";
 
 const $ = (id) => document.getElementById(id);
@@ -513,10 +514,32 @@ async function loadSource(url) {
   setStatus(state ? `loaded ${frames.length} clean frames` : "loaded image");
 }
 
-async function uploadBlob(blob, filename) {
+function catalogParents(...urls) {
+  return Array.from(new Set(urls.map(scrubURL).filter(Boolean)));
+}
+
+function appendCatalogFields(form, {
+  visibility = "public",
+  tags = WALKTHROUGH_TAGS,
+  parents = [],
+  kind = "generation",
+  prompt = "",
+  model = "",
+} = {}) {
+  form.append("visibility", visibility);
+  form.append("kind", kind);
+  if (prompt) form.append("prompt", prompt);
+  if (model) form.append("model", model);
+  if (tags.length) form.append("tags", JSON.stringify(tags));
+  const parentIds = catalogParents(...parents);
+  if (parentIds.length) form.append("parents", JSON.stringify(parentIds));
+}
+
+async function uploadBlob(blob, filename, catalog = {}) {
   setStatus("uploading...");
   const form = new FormData();
   form.append("file", blob, filename);
+  appendCatalogFields(form, catalog);
   const res = await fetch("https://media.pollinations.ai/upload", {
     method: "POST",
     headers: authHeaders(),
@@ -525,6 +548,22 @@ async function uploadBlob(blob, filename) {
   if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
   const json = await res.json();
   return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+async function catalogVideoClip(blob, index) {
+  try {
+    return await uploadBlob(blob, `voice-edit-walkthrough-${Date.now()}-${index + 1}.mp4`, {
+      visibility: "public",
+      tags: [...WALKTHROUGH_TAGS, "voice-edit-transition"],
+      parents: [app.sourceURL, app.history[index]?.url, app.history[index + 1]?.url],
+      kind: "generation",
+      prompt: currentPrompt(),
+      model: els.model.value,
+    });
+  } catch (err) {
+    console.warn(`walkthrough clip ${index + 1} catalog upload failed`, err);
+    return "";
+  }
 }
 
 function render() {
@@ -737,9 +776,11 @@ async function makeWalkthrough() {
       const res = await fetch(request, { headers: authHeaders() });
       if (!res.ok) throw new Error(await friendlyError(res, `Video ${i + 1} failed`));
       const blob = await res.blob();
+      const mediaURL = await catalogVideoClip(blob, i);
+      setProgress();
 
       // Fill the video slot
-      const videoEntry = { url: request.href, src: URL.createObjectURL(blob), blob, kind: "video" };
+      const videoEntry = { url: mediaURL || request.href, src: URL.createObjectURL(blob), blob, kind: "video" };
       app.clips[slot.videoSlot] = videoEntry;
       if (app.currentClip < 0) app.currentClip = slot.videoSlot;
 
@@ -838,7 +879,11 @@ els.file.addEventListener("change", async () => {
   const file = els.file.files?.[0];
   if (!file) return;
   try {
-    const mediaURL = await uploadBlob(file, file.name || "image");
+    const mediaURL = await uploadBlob(file, file.name || "image", {
+      visibility: "private",
+      tags: [...WALKTHROUGH_TAGS, "voice-edit-source"],
+      kind: "upload",
+    });
     setHash(mediaURL);
     await loadSource(mediaURL);
   } catch (err) {

--- a/enter.pollinations.ai/drizzle/0026_media_catalog.sql
+++ b/enter.pollinations.ai/drizzle/0026_media_catalog.sql
@@ -1,0 +1,53 @@
+CREATE TABLE `media_asset` (
+	`id` text PRIMARY KEY NOT NULL,
+	`url` text NOT NULL,
+	`hash` text NOT NULL,
+	`content_type` text NOT NULL,
+	`size` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`expires_at` integer
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `media_asset_url_unique` ON `media_asset` (`url`);--> statement-breakpoint
+CREATE UNIQUE INDEX `media_asset_hash_unique` ON `media_asset` (`hash`);--> statement-breakpoint
+CREATE INDEX `idx_media_asset_expires_at` ON `media_asset` (`expires_at`);--> statement-breakpoint
+CREATE TABLE `media_event` (
+	`id` text PRIMARY KEY NOT NULL,
+	`media_id` text NOT NULL,
+	`user_id` text,
+	`api_key_id` text,
+	`app_key_id` text,
+	`app_name` text,
+	`attribution_source` text DEFAULT 'none' NOT NULL,
+	`creation_source` text DEFAULT 'upload' NOT NULL,
+	`visibility` text DEFAULT 'public' NOT NULL,
+	`prompt` text,
+	`model` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_media_event_user_created` ON `media_event` (`user_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_media_event_app_created` ON `media_event` (`app_key_id`,`visibility`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_media_event_media_created` ON `media_event` (`media_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `media_edge` (
+	`parent_media_id` text NOT NULL,
+	`child_media_id` text NOT NULL,
+	`event_id` text NOT NULL,
+	`relation` text DEFAULT 'derived_from' NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`parent_media_id`, `child_media_id`, `event_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_media_edge_parent_created` ON `media_edge` (`parent_media_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_media_edge_child` ON `media_edge` (`child_media_id`);--> statement-breakpoint
+CREATE TABLE `media_tag` (
+	`tag` text NOT NULL,
+	`media_id` text NOT NULL,
+	`event_id` text NOT NULL,
+	`source` text DEFAULT 'user' NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`tag`, `media_id`, `event_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_media_tag_tag_created` ON `media_tag` (`tag`,`created_at`);

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1778529206824,
       "tag": "0025_blue_banshee",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1779878400000,
+      "tag": "0026_media_catalog",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1434,11 +1434,40 @@ export const accountRoutes = new Hono<Env>()
                                     type: z
                                         .enum(["publishable", "secret"])
                                         .describe("Type of API key"),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for the API key",
+                                        ),
+                                    apiKeyId: z
+                                        .string()
+                                        .describe(
+                                            "Stable server-side API key id",
+                                        ),
                                     name: z
                                         .string()
                                         .nullable()
                                         .describe(
                                             "Display name of the API key",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "App key id that minted this key, when created through authorize",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "App key name that minted this key, when available",
+                                        ),
+                                    byopClientUserId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for the app key that minted this key",
                                         ),
                                     expiresAt: z
                                         .string()
@@ -1549,7 +1578,12 @@ export const accountRoutes = new Hono<Env>()
             return c.json({
                 valid: true, // If we got here, the key is valid
                 type: keyType,
+                userId: c.var.auth.user?.id ?? null,
+                apiKeyId: apiKey.id,
                 name: apiKey.name || null,
+                byopClientKeyId: apiKey.byopClientKeyId ?? null,
+                byopClientName: apiKey.byopClientName ?? null,
+                byopClientUserId: apiKey.byopClientUserId ?? null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -431,7 +431,7 @@ function generateLLMDoc(): string {
 
     lines.push("### GET /account/key");
     lines.push(
-        "Info about the current API key: { valid, type, name, expiresAt, expiresIn, permissions, pollenBudget, rateLimitEnabled }.",
+        "Info about the current API key: { valid, type, userId, apiKeyId, name, byopClientKeyId, byopClientName, byopClientUserId, expiresAt, expiresIn, permissions, pollenBudget, rateLimitEnabled }.",
     );
     lines.push("Requires API key authentication (any key type).");
     lines.push("");

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -40,6 +40,9 @@ test(
         const data = await response.json();
         expect(data.valid).toBe(true);
         expect(data.type).toBe("secret");
+        expect(typeof data.userId).toBe("string");
+        expect(typeof data.apiKeyId).toBe("string");
+        expect(data.byopClientKeyId).toBeNull();
         expect(data.name).toBeTruthy();
         expect(data).toHaveProperty("expiresAt");
         expect(data).toHaveProperty("expiresIn");

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -289,6 +289,20 @@ describe("API Key Management", () => {
             expect(matchingCreated.metadata.createdForApp).toBeUndefined();
             expect(matchingCreated.metadata.createdForUserId).toBeUndefined();
             expect(matchingCreated.byopClientKeyId).toBe(appKey.id);
+
+            const keyInfoResponse = await SELF.fetch(
+                "http://localhost:3000/api/account/key",
+                {
+                    headers: {
+                        Authorization: `Bearer ${matchingCreated.key}`,
+                    },
+                },
+            );
+            expect(keyInfoResponse.status).toBe(200);
+            const keyInfo = await keyInfoResponse.json();
+            expect(keyInfo.apiKeyId).toBe(matchingCreated.id);
+            expect(keyInfo.byopClientKeyId).toBe(appKey.id);
+            expect(keyInfo.byopClientName).toBe("registered-app");
         });
 
         test("stores app attribution even when rewards are currently disabled", async ({

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -104,7 +104,10 @@ function stringValue(value: unknown): string | undefined {
     return typeof value === "string" ? value : undefined;
 }
 
-function truncate(value: string | undefined, maxLength: number): string | undefined {
+function truncate(
+    value: string | undefined,
+    maxLength: number,
+): string | undefined {
     if (!value) return undefined;
     return value.length > maxLength ? value.slice(0, maxLength) : value;
 }
@@ -366,7 +369,9 @@ function catalogItem(row: CatalogRow) {
         visibility: row.visibility,
         creationSource: row.creation_source,
         createdAt: new Date(row.event_created_at).toISOString(),
-        expiresAt: row.expires_at ? new Date(row.expires_at).toISOString() : null,
+        expiresAt: row.expires_at
+            ? new Date(row.expires_at).toISOString()
+            : null,
         appKeyId: row.app_key_id,
         appName: row.app_name,
         attributionSource: row.attribution_source,
@@ -672,8 +677,46 @@ api.get(
         const url = new URL(c.req.url);
         const limit = parseLimit(url.searchParams.get("limit"));
         const cursor = parseCursor(url.searchParams.get("cursor"));
-        const cursorClause = cursor ? "AND e.created_at < ?" : "";
-        const binds = cursor ? [authResult.userId, cursor] : [authResult.userId];
+        const tag = parseTags(url.searchParams.get("tag"))[0];
+        const appKey = url.searchParams.get("app_key");
+        let appKeyId = url.searchParams.get("app_key_id");
+        if (!appKeyId && appKey) {
+            appKeyId = await resolveAppKeyId(appKey);
+            if (!appKeyId) return c.json({ items: [], nextCursor: null });
+        }
+
+        const clauses = ["e.user_id = ?"];
+        const binds: D1Bind[] = [authResult.userId];
+        if (appKeyId) {
+            clauses.push("e.app_key_id = ?");
+            binds.push(appKeyId);
+        }
+        if (cursor) {
+            clauses.push("e.created_at < ?");
+            binds.push(cursor);
+        }
+
+        if (tag) {
+            binds.unshift(tag);
+            return c.json(
+                await listCatalog(
+                    c.env.DB,
+                    `SELECT
+                        a.id, a.url, a.hash, a.content_type, a.size, a.expires_at,
+                        e.id AS event_id, e.created_at AS event_created_at,
+                        e.app_key_id, e.app_name, e.attribution_source,
+                        e.creation_source, e.visibility, e.prompt, e.model
+                     FROM media_tag t
+                     JOIN media_event e ON e.id = t.event_id
+                     JOIN media_asset a ON a.id = e.media_id
+                     WHERE t.tag = ? AND ${clauses.join(" AND ")}
+                     ORDER BY e.created_at DESC
+                     LIMIT ?`,
+                    binds,
+                    limit,
+                ),
+            );
+        }
 
         return c.json(
             await listCatalog(
@@ -685,7 +728,7 @@ api.get(
                     e.creation_source, e.visibility, e.prompt, e.model
                  FROM media_event e
                  JOIN media_asset a ON a.id = e.media_id
-                 WHERE e.user_id = ? ${cursorClause}
+                 WHERE ${clauses.join(" AND ")}
                  ORDER BY e.created_at DESC
                  LIMIT ?`,
                 binds,

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -16,9 +16,14 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const DEFAULT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_TAGS = 10;
+const MAX_PARENTS = 20;
+const MAX_PROMPT_LENGTH = 1000;
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
+    DB: D1Database;
     MAX_FILE_SIZE: string;
 }
 
@@ -26,6 +31,44 @@ interface AuthResult {
     valid: boolean;
     type: string;
     name: string | null;
+    userId?: string | null;
+    apiKeyId?: string | null;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    byopClientUserId?: string | null;
+}
+
+interface UploadOptions {
+    visibility: "public" | "private";
+    parentIds: string[];
+    tags: string[];
+    kind: "upload" | "generation" | "edit" | "saved_generation";
+    prompt?: string;
+    model?: string;
+}
+
+interface CatalogWriteResult {
+    recordId: string;
+    createdAt: string;
+    expiresAt: string;
+}
+
+interface CatalogRow {
+    id: string;
+    url: string;
+    hash: string;
+    content_type: string;
+    size: number;
+    expires_at: number | null;
+    event_id: string;
+    event_created_at: number;
+    app_key_id: string | null;
+    app_name: string | null;
+    attribution_source: string;
+    creation_source: string;
+    visibility: string;
+    prompt: string | null;
+    model: string | null;
 }
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
@@ -57,12 +100,143 @@ function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
 }
 
+function stringValue(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function truncate(value: string | undefined, maxLength: number): string | undefined {
+    if (!value) return undefined;
+    return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function parseList(value: unknown): string[] {
+    if (Array.isArray(value)) {
+        return value.filter((item): item is string => typeof item === "string");
+    }
+    if (typeof value !== "string" || value.trim() === "") return [];
+    const trimmed = value.trim();
+    if (trimmed.startsWith("[")) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) {
+                return parsed.filter(
+                    (item): item is string => typeof item === "string",
+                );
+            }
+        } catch {
+            return [];
+        }
+    }
+    return trimmed
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean);
+}
+
+function normalizeMediaId(value: string): string | null {
+    const trimmed = value.trim();
+    if (HASH_PATTERN.test(trimmed)) return trimmed.toLowerCase();
+    try {
+        const url = new URL(trimmed);
+        const [hash] = url.pathname.split("/").filter(Boolean);
+        if (hash && HASH_PATTERN.test(hash)) return hash.toLowerCase();
+    } catch {
+        return null;
+    }
+    return null;
+}
+
+function parseParentIds(value: unknown): string[] {
+    return Array.from(
+        new Set(
+            parseList(value)
+                .map(normalizeMediaId)
+                .filter((id): id is string => id !== null),
+        ),
+    ).slice(0, MAX_PARENTS);
+}
+
+function parseTags(value: unknown): string[] {
+    return Array.from(
+        new Set(
+            parseList(value)
+                .map((tag) =>
+                    tag
+                        .trim()
+                        .toLowerCase()
+                        .replace(/[^a-z0-9_.:-]/g, "-")
+                        .replace(/-+/g, "-")
+                        .slice(0, 64),
+                )
+                .filter(Boolean),
+        ),
+    ).slice(0, MAX_TAGS);
+}
+
+function parseVisibility(value: unknown): "public" | "private" {
+    return stringValue(value)?.toLowerCase() === "private"
+        ? "private"
+        : "public";
+}
+
+function parseKind(value: unknown): UploadOptions["kind"] {
+    const kind = stringValue(value)?.toLowerCase();
+    if (
+        kind === "generation" ||
+        kind === "edit" ||
+        kind === "saved_generation"
+    ) {
+        return kind;
+    }
+    return "upload";
+}
+
+function uploadOptionsFromValues(values: {
+    visibility?: unknown;
+    parents?: unknown;
+    parentIds?: unknown;
+    tags?: unknown;
+    kind?: unknown;
+    prompt?: unknown;
+    model?: unknown;
+}): UploadOptions {
+    return {
+        visibility: parseVisibility(values.visibility),
+        parentIds: parseParentIds(values.parentIds ?? values.parents),
+        tags: parseTags(values.tags),
+        kind: parseKind(values.kind),
+        prompt: truncate(stringValue(values.prompt), MAX_PROMPT_LENGTH),
+        model: truncate(stringValue(values.model), 100),
+    };
+}
+
+function uploadOptionsFromUrl(req: Request): UploadOptions {
+    const params = new URL(req.url).searchParams;
+    return uploadOptionsFromValues({
+        visibility: params.get("visibility"),
+        parentIds: params.get("parentIds"),
+        parents: params.get("parents"),
+        tags: params.get("tags"),
+        kind: params.get("kind"),
+        prompt: params.get("prompt"),
+        model: params.get("model"),
+    });
+}
+
 const UploadResponseSchema = z.object({
     id: z.string().describe("16-char hex content hash"),
     url: z.string().describe("Public retrieval URL"),
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    recordId: z.string().describe("Catalog event id for this upload"),
+    visibility: z.enum(["public", "private"]),
+    parentIds: z.array(z.string()),
+    tags: z.array(z.string()),
+    appKeyId: z.string().nullable(),
+    attributionSource: z.enum(["byop_key", "none"]),
+    createdAt: z.string(),
+    expiresAt: z.string(),
 });
 
 const ErrorSchema = z.object({
@@ -78,6 +252,193 @@ const MetadataResponseSchema = z.object({
         .optional()
         .describe("ISO-8601 upload timestamp, when recorded"),
 });
+
+const CatalogItemSchema = z.object({
+    id: z.string(),
+    url: z.string(),
+    contentType: z.string(),
+    size: z.number().int(),
+    recordId: z.string(),
+    visibility: z.string(),
+    creationSource: z.string(),
+    createdAt: z.string(),
+    expiresAt: z.string().nullable(),
+    appKeyId: z.string().nullable(),
+    appName: z.string().nullable(),
+    attributionSource: z.string(),
+    prompt: z.string().nullable(),
+    model: z.string().nullable(),
+});
+
+const CatalogListSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    nextCursor: z.string().nullable(),
+});
+
+function attributionSource(authResult: AuthResult): "byop_key" | "none" {
+    return authResult.byopClientKeyId ? "byop_key" : "none";
+}
+
+async function writeCatalogRecord(
+    env: Env,
+    hash: string,
+    contentType: string,
+    size: number,
+    authResult: AuthResult,
+    options: UploadOptions,
+): Promise<CatalogWriteResult> {
+    const now = Date.now();
+    const expiresAt = now + DEFAULT_RETENTION_MS;
+    const recordId = crypto.randomUUID();
+    const url = mediaUrl(hash);
+    const source = attributionSource(authResult);
+
+    const statements: D1PreparedStatement[] = [
+        env.DB.prepare(
+            `INSERT INTO media_asset
+                (id, url, hash, content_type, size, created_at, updated_at, expires_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                url = excluded.url,
+                content_type = excluded.content_type,
+                size = excluded.size,
+                updated_at = excluded.updated_at,
+                expires_at = excluded.expires_at`,
+        ).bind(hash, url, hash, contentType, size, now, now, expiresAt),
+        env.DB.prepare(
+            `INSERT INTO media_event
+                (id, media_id, user_id, api_key_id, app_key_id, app_name,
+                 attribution_source, creation_source, visibility, prompt, model, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).bind(
+            recordId,
+            hash,
+            authResult.userId ?? null,
+            authResult.apiKeyId ?? null,
+            authResult.byopClientKeyId ?? null,
+            authResult.byopClientName ?? null,
+            source,
+            options.kind,
+            options.visibility,
+            options.prompt ?? null,
+            options.model ?? null,
+            now,
+        ),
+    ];
+
+    for (const parentId of options.parentIds) {
+        if (parentId === hash) continue;
+        statements.push(
+            env.DB.prepare(
+                `INSERT OR IGNORE INTO media_edge
+                    (parent_media_id, child_media_id, event_id, relation, created_at)
+                 VALUES (?, ?, ?, 'derived_from', ?)`,
+            ).bind(parentId, hash, recordId, now),
+        );
+    }
+
+    for (const tag of options.tags) {
+        statements.push(
+            env.DB.prepare(
+                `INSERT OR IGNORE INTO media_tag
+                    (tag, media_id, event_id, source, created_at)
+                 VALUES (?, ?, ?, 'user', ?)`,
+            ).bind(tag, hash, recordId, now),
+        );
+    }
+
+    await env.DB.batch(statements);
+
+    return {
+        recordId,
+        createdAt: new Date(now).toISOString(),
+        expiresAt: new Date(expiresAt).toISOString(),
+    };
+}
+
+function catalogItem(row: CatalogRow) {
+    return {
+        id: row.id,
+        url: row.url,
+        contentType: row.content_type,
+        size: row.size,
+        recordId: row.event_id,
+        visibility: row.visibility,
+        creationSource: row.creation_source,
+        createdAt: new Date(row.event_created_at).toISOString(),
+        expiresAt: row.expires_at ? new Date(row.expires_at).toISOString() : null,
+        appKeyId: row.app_key_id,
+        appName: row.app_name,
+        attributionSource: row.attribution_source,
+        prompt: row.prompt,
+        model: row.model,
+    };
+}
+
+function parseLimit(value: string | null): number {
+    const parsed = Number.parseInt(value || "", 10);
+    if (!Number.isFinite(parsed)) return 50;
+    return Math.min(Math.max(parsed, 1), 100);
+}
+
+function parseCursor(value: string | null): number | null {
+    if (!value) return null;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function requireApiKey(request: Request): Promise<AuthResult | Response> {
+    const apiKey = extractApiKey(request);
+    if (!apiKey) {
+        return Response.json(
+            {
+                error: "API key required. Pass via Authorization: Bearer <key> or ?key=<key>",
+            },
+            { status: 401 },
+        );
+    }
+
+    const authResult = await verifyApiKey(apiKey);
+    if (!authResult) {
+        return Response.json(
+            { error: "Invalid or expired API key" },
+            { status: 401 },
+        );
+    }
+    return authResult;
+}
+
+function isResponse(value: AuthResult | Response): value is Response {
+    return value instanceof Response;
+}
+
+async function resolveAppKeyId(appKey: string): Promise<string | null> {
+    const appAuth = await verifyApiKey(appKey);
+    if (appAuth?.type === "publishable" && appAuth.apiKeyId) {
+        return appAuth.apiKeyId;
+    }
+    return null;
+}
+
+type D1Bind = string | number | null;
+
+async function listCatalog(
+    db: D1Database,
+    sql: string,
+    binds: D1Bind[],
+    limit: number,
+) {
+    const { results } = await db
+        .prepare(sql)
+        .bind(...binds, limit)
+        .all<CatalogRow>();
+    const items = (results || []).map(catalogItem);
+    const nextCursor =
+        results && results.length === limit
+            ? String(results[results.length - 1].event_created_at)
+            : null;
+    return { items, nextCursor };
+}
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -112,19 +473,8 @@ api.post(
         },
     }),
     async (c) => {
-        const apiKey = extractApiKey(c.req.raw);
-        if (!apiKey) {
-            return c.json(
-                {
-                    error: "API key required. Pass via Authorization: Bearer <key> or ?key=<key>",
-                },
-                401,
-            );
-        }
-        const authResult = await verifyApiKey(apiKey);
-        if (!authResult) {
-            return c.json({ error: "Invalid or expired API key" }, 401);
-        }
+        const authResult = await requireApiKey(c.req.raw);
+        if (isResponse(authResult)) return authResult;
 
         const maxSize = parseInt(c.env.MAX_FILE_SIZE, 10) || DEFAULT_MAX_SIZE;
 
@@ -140,6 +490,7 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        let options = uploadOptionsFromUrl(c.req.raw);
 
         const requestContentType = c.req.header("content-type") || "";
 
@@ -147,6 +498,15 @@ api.post(
             if (requestContentType.includes("multipart/form-data")) {
                 const formData = await c.req.formData();
                 const file = formData.get("file") as File | null;
+                options = uploadOptionsFromValues({
+                    visibility: formData.get("visibility"),
+                    parentIds: formData.get("parentIds"),
+                    parents: formData.get("parents"),
+                    tags: formData.get("tags"),
+                    kind: formData.get("kind"),
+                    prompt: formData.get("prompt"),
+                    model: formData.get("model"),
+                });
 
                 if (!(file instanceof File)) {
                     return c.json(
@@ -169,7 +529,15 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
+                    visibility?: string;
+                    parentIds?: string[] | string;
+                    parents?: string[] | string;
+                    tags?: string[] | string;
+                    kind?: string;
+                    prompt?: string;
+                    model?: string;
                 }>();
+                options = uploadOptionsFromValues(body);
 
                 if (!body.data) {
                     return c.json(
@@ -227,6 +595,14 @@ api.post(
                     keyType: authResult.type,
                 },
             });
+            const catalog = await writeCatalogRecord(
+                c.env,
+                hash,
+                contentType,
+                fileBuffer.byteLength,
+                authResult,
+                options,
+            );
 
             console.log(
                 JSON.stringify({
@@ -236,6 +612,10 @@ api.post(
                     contentType,
                     keyType: authResult.type,
                     uploadedBy: authResult.name || "unknown",
+                    userId: authResult.userId || "",
+                    apiKeyId: authResult.apiKeyId || "",
+                    appKeyId: authResult.byopClientKeyId || "",
+                    visibility: options.visibility,
                     duplicate: !!existing,
                 }),
             );
@@ -246,11 +626,250 @@ api.post(
                 contentType,
                 size: fileBuffer.byteLength,
                 duplicate: !!existing,
+                recordId: catalog.recordId,
+                visibility: options.visibility,
+                parentIds: options.parentIds,
+                tags: options.tags,
+                appKeyId: authResult.byopClientKeyId ?? null,
+                attributionSource: attributionSource(authResult),
+                createdAt: catalog.createdAt,
+                expiresAt: catalog.expiresAt,
             });
         } catch (error) {
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List authenticated user's media",
+        responses: {
+            200: {
+                description: "Cataloged media for the current API key owner",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const authResult = await requireApiKey(c.req.raw);
+        if (isResponse(authResult)) return authResult;
+        if (!authResult.userId) {
+            return c.json({ error: "Verified key has no user id" }, 401);
+        }
+
+        const url = new URL(c.req.url);
+        const limit = parseLimit(url.searchParams.get("limit"));
+        const cursor = parseCursor(url.searchParams.get("cursor"));
+        const cursorClause = cursor ? "AND e.created_at < ?" : "";
+        const binds = cursor ? [authResult.userId, cursor] : [authResult.userId];
+
+        return c.json(
+            await listCatalog(
+                c.env.DB,
+                `SELECT
+                    a.id, a.url, a.hash, a.content_type, a.size, a.expires_at,
+                    e.id AS event_id, e.created_at AS event_created_at,
+                    e.app_key_id, e.app_name, e.attribution_source,
+                    e.creation_source, e.visibility, e.prompt, e.model
+                 FROM media_event e
+                 JOIN media_asset a ON a.id = e.media_id
+                 WHERE e.user_id = ? ${cursorClause}
+                 ORDER BY e.created_at DESC
+                 LIMIT ?`,
+                binds,
+                limit,
+            ),
+        );
+    },
+);
+
+api.get(
+    "/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media catalog",
+        responses: {
+            200: {
+                description: "Public media catalog entries",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const limit = parseLimit(url.searchParams.get("limit"));
+        const cursor = parseCursor(url.searchParams.get("cursor"));
+        const tag = parseTags(url.searchParams.get("tag"))[0];
+        const appKey = url.searchParams.get("app_key");
+        let appKeyId = url.searchParams.get("app_key_id");
+        if (!appKeyId && appKey) {
+            appKeyId = await resolveAppKeyId(appKey);
+            if (!appKeyId) return c.json({ items: [], nextCursor: null });
+        }
+
+        const clauses = ["e.visibility = 'public'"];
+        const binds: (string | number)[] = [];
+        if (appKeyId) {
+            clauses.push("e.app_key_id = ?");
+            binds.push(appKeyId);
+        }
+        if (cursor) {
+            clauses.push("e.created_at < ?");
+            binds.push(cursor);
+        }
+
+        if (tag) {
+            binds.unshift(tag);
+            return c.json(
+                await listCatalog(
+                    c.env.DB,
+                    `SELECT
+                        a.id, a.url, a.hash, a.content_type, a.size, a.expires_at,
+                        e.id AS event_id, e.created_at AS event_created_at,
+                        e.app_key_id, e.app_name, e.attribution_source,
+                        e.creation_source, e.visibility, e.prompt, e.model
+                     FROM media_tag t
+                     JOIN media_event e ON e.id = t.event_id
+                     JOIN media_asset a ON a.id = e.media_id
+                     WHERE t.tag = ? AND ${clauses.join(" AND ")}
+                     ORDER BY e.created_at DESC
+                     LIMIT ?`,
+                    binds,
+                    limit,
+                ),
+            );
+        }
+
+        return c.json(
+            await listCatalog(
+                c.env.DB,
+                `SELECT
+                    a.id, a.url, a.hash, a.content_type, a.size, a.expires_at,
+                    e.id AS event_id, e.created_at AS event_created_at,
+                    e.app_key_id, e.app_name, e.attribution_source,
+                    e.creation_source, e.visibility, e.prompt, e.model
+                 FROM media_event e
+                 JOIN media_asset a ON a.id = e.media_id
+                 WHERE ${clauses.join(" AND ")}
+                 ORDER BY e.created_at DESC
+                 LIMIT ?`,
+                binds,
+                limit,
+            ),
+        );
+    },
+);
+
+api.get(
+    "/tags/:tag",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media by tag",
+        responses: {
+            200: {
+                description: "Public media with the requested tag",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const [tag] = parseTags(c.req.param("tag"));
+        if (!tag) return c.json({ items: [], nextCursor: null });
+        const url = new URL(c.req.url);
+        const limit = parseLimit(url.searchParams.get("limit"));
+        const cursor = parseCursor(url.searchParams.get("cursor"));
+        const cursorClause = cursor ? "AND e.created_at < ?" : "";
+        const binds = cursor ? [tag, cursor] : [tag];
+
+        return c.json(
+            await listCatalog(
+                c.env.DB,
+                `SELECT
+                    a.id, a.url, a.hash, a.content_type, a.size, a.expires_at,
+                    e.id AS event_id, e.created_at AS event_created_at,
+                    e.app_key_id, e.app_name, e.attribution_source,
+                    e.creation_source, e.visibility, e.prompt, e.model
+                 FROM media_tag t
+                 JOIN media_event e ON e.id = t.event_id
+                 JOIN media_asset a ON a.id = e.media_id
+                 WHERE t.tag = ? AND e.visibility = 'public' ${cursorClause}
+                 ORDER BY e.created_at DESC
+                 LIMIT ?`,
+                binds,
+                limit,
+            ),
+        );
+    },
+);
+
+api.get(
+    "/:hash/children",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public derivative media",
+        responses: {
+            200: {
+                description: "Public children of the requested media hash",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+            400: {
+                description: "Invalid hash format",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const hash = c.req.param("hash").toLowerCase();
+        if (!HASH_PATTERN.test(hash)) {
+            return c.json({ error: "Invalid hash format" }, 400);
+        }
+
+        const url = new URL(c.req.url);
+        const limit = parseLimit(url.searchParams.get("limit"));
+        const cursor = parseCursor(url.searchParams.get("cursor"));
+        const cursorClause = cursor ? "AND e.created_at < ?" : "";
+        const binds = cursor ? [hash, cursor] : [hash];
+
+        return c.json(
+            await listCatalog(
+                c.env.DB,
+                `SELECT
+                    a.id, a.url, a.hash, a.content_type, a.size, a.expires_at,
+                    e.id AS event_id, e.created_at AS event_created_at,
+                    e.app_key_id, e.app_name, e.attribution_source,
+                    e.creation_source, e.visibility, e.prompt, e.model
+                 FROM media_edge edge
+                 JOIN media_event e ON e.id = edge.event_id
+                 JOIN media_asset a ON a.id = edge.child_media_id
+                 WHERE edge.parent_media_id = ?
+                    AND e.visibility = 'public'
+                    ${cursorClause}
+                 ORDER BY e.created_at DESC
+                 LIMIT ?`,
+                binds,
+                limit,
+            ),
+        );
     },
 );
 
@@ -450,6 +1069,9 @@ app.get("/", (c) => {
         endpoints: {
             upload: "POST /upload (requires API key)",
             retrieve: "GET /:hash",
+            me: "GET /me/media (requires API key)",
+            gallery: "GET /media?app_key=...&tag=...",
+            children: "GET /:hash/children",
             docs: "GET /openapi.json",
         },
         limits: {

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -17,6 +17,29 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    recordId: string;
+    visibility: string;
+    parentIds: string[];
+    tags: string[];
+    appKeyId: string | null;
+    attributionSource: string;
+    createdAt: string;
+    expiresAt: string;
+}
+
+interface CatalogListResponse {
+    items: Array<{
+        id: string;
+        url: string;
+        recordId: string;
+        appKeyId: string | null;
+        appName: string | null;
+        visibility: string;
+        creationSource: string;
+        prompt: string | null;
+        model: string | null;
+    }>;
+    nextCursor: string | null;
 }
 
 const VALID_KEY = "pk_test_key_123";
@@ -31,8 +54,13 @@ function mockAuth() {
             200,
             JSON.stringify({
                 valid: true,
-                type: "publishable",
+                type: "secret",
                 name: "test-user",
+                userId: "user_test_1",
+                apiKeyId: "api_key_test_1",
+                byopClientKeyId: "app_key_test_1",
+                byopClientName: "CatGPT Test",
+                byopClientUserId: "app_owner_test_1",
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -124,6 +152,85 @@ describe("media.pollinations.ai", () => {
         const dup = (await dupRes.json()) as UploadResponse;
         expect(dup.id).toBe(upload.id);
         expect(dup.duplicate).toBe(true);
+    });
+
+    it("indexes uploads for user, app, tag, and child queries", async () => {
+        const tag = `catgpt-${crypto.randomUUID()}`;
+        const parentForm = new FormData();
+        parentForm.append(
+            "file",
+            new File([TINY_PNG], "catalog-parent.png", { type: "image/png" }),
+        );
+
+        const parentRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: parentForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        const parent = (await parentRes.json()) as UploadResponse;
+
+        const childForm = new FormData();
+        childForm.append(
+            "file",
+            new File([TINY_PNG], "catalog-child.png", { type: "image/png" }),
+        );
+        childForm.append("parents", parent.url);
+        childForm.append("tags", `${tag},remix`);
+        childForm.append("kind", "edit");
+        childForm.append("prompt", "make it stranger");
+        childForm.append("model", "nanobanana");
+
+        const childRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: childForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(childRes.status).toBe(200);
+        const child = (await childRes.json()) as UploadResponse;
+        expect(child.recordId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+        expect(child.parentIds).toEqual([parent.id]);
+        expect(child.tags).toContain(tag);
+        expect(child.appKeyId).toBe("app_key_test_1");
+        expect(child.attributionSource).toBe("byop_key");
+
+        const meRes = await SELF.fetch("https://media.pollinations.ai/me/media", {
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        const me = (await meRes.json()) as CatalogListResponse;
+        expect(me.items.some((item) => item.id === child.id)).toBe(true);
+
+        const appRes = await SELF.fetch(
+            "https://media.pollinations.ai/media?app_key_id=app_key_test_1",
+        );
+        const app = (await appRes.json()) as CatalogListResponse;
+        expect(app.items.some((item) => item.id === child.id)).toBe(true);
+
+        const tagRes = await SELF.fetch(
+            `https://media.pollinations.ai/tags/${tag}`,
+        );
+        const tagged = (await tagRes.json()) as CatalogListResponse;
+        expect(tagged.items.some((item) => item.id === child.id)).toBe(true);
+
+        const childrenRes = await SELF.fetch(
+            `https://media.pollinations.ai/${parent.id}/children`,
+        );
+        const children = (await childrenRes.json()) as CatalogListResponse;
+        const indexedChild = children.items.find((item) => item.id === child.id);
+        expect(indexedChild).toMatchObject({
+            appKeyId: "app_key_test_1",
+            appName: "CatGPT Test",
+            creationSource: "edit",
+            prompt: "make it stranger",
+            model: "nanobanana",
+        });
     });
 
     it("same content with different filename produces different hash", async () => {

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -201,11 +201,21 @@ describe("media.pollinations.ai", () => {
         expect(child.appKeyId).toBe("app_key_test_1");
         expect(child.attributionSource).toBe("byop_key");
 
-        const meRes = await SELF.fetch("https://media.pollinations.ai/me/media", {
-            headers: { Authorization: `Bearer ${VALID_KEY}` },
-        });
+        const meRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            {
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
         const me = (await meRes.json()) as CatalogListResponse;
         expect(me.items.some((item) => item.id === child.id)).toBe(true);
+
+        const meTaggedRes = await SELF.fetch(
+            `https://media.pollinations.ai/me/media?tag=${tag}&app_key_id=app_key_test_1`,
+            { headers: { Authorization: `Bearer ${VALID_KEY}` } },
+        );
+        const meTagged = (await meTaggedRes.json()) as CatalogListResponse;
+        expect(meTagged.items.some((item) => item.id === child.id)).toBe(true);
 
         const appRes = await SELF.fetch(
             "https://media.pollinations.ai/media?app_key_id=app_key_test_1",
@@ -223,7 +233,9 @@ describe("media.pollinations.ai", () => {
             `https://media.pollinations.ai/${parent.id}/children`,
         );
         const children = (await childrenRes.json()) as CatalogListResponse;
-        const indexedChild = children.items.find((item) => item.id === child.id);
+        const indexedChild = children.items.find(
+            (item) => item.id === child.id,
+        );
         expect(indexedChild).toMatchObject({
             appKeyId: "app_key_test_1",
             appName: "CatGPT Test",

--- a/media.pollinations.ai/test/setup/apply-migrations.ts
+++ b/media.pollinations.ai/test/setup/apply-migrations.ts
@@ -1,0 +1,3 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);

--- a/media.pollinations.ai/vitest.config.ts
+++ b/media.pollinations.ai/vitest.config.ts
@@ -1,14 +1,32 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import path from "node:path";
+import {
+    defineWorkersConfig,
+    readD1Migrations,
+} from "@cloudflare/vitest-pool-workers/config";
 
-export default defineWorkersConfig({
-    test: {
-        poolOptions: {
-            workers: {
-                singleWorker: true,
-                wrangler: {
-                    configPath: "./wrangler.toml",
+export default defineWorkersConfig(async () => {
+    const migrationsPath = path.join(
+        __dirname,
+        "../enter.pollinations.ai/drizzle",
+    );
+    const migrations = await readD1Migrations(migrationsPath);
+
+    return {
+        test: {
+            setupFiles: ["./test/setup/apply-migrations.ts"],
+            poolOptions: {
+                workers: {
+                    singleWorker: true,
+                    wrangler: {
+                        configPath: "./wrangler.toml",
+                    },
+                    miniflare: {
+                        bindings: {
+                            TEST_MIGRATIONS: migrations,
+                        },
+                    },
                 },
             },
         },
-    },
+    };
 });

--- a/media.pollinations.ai/wrangler.toml
+++ b/media.pollinations.ai/wrangler.toml
@@ -15,6 +15,11 @@ MAX_FILE_SIZE = "52428800"  # 50MB in bytes
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media-dev"
 
+[[env.development.d1_databases]]
+binding = "DB"
+database_name = "development-pollinations-enter-db"
+database_id = "2b844596-9890-4a2e-9da9-6c65681fa24d"
+
 # Production environment
 [env.production]
 name = "pollinations-media-prod"
@@ -31,12 +36,22 @@ custom_domain = true
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media"
 
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "production-pollinations-enter-db"
+database_id = "fc771b05-4e24-48bf-980c-d09f21279bd1"
+
 [vars]
 MAX_FILE_SIZE = "52428800"  # 50MB in bytes
 
 [[r2_buckets]]
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "development-pollinations-enter-db"
+database_id = "2b844596-9890-4a2e-9da9-6c65681fa24d"
 
 # Dev server settings
 [dev]


### PR DESCRIPTION
- Adds D1-backed media catalog rows for upload events, tags, parent edges, and public/user listing.
- Stamps user and app attribution from verified key data; app filters use server-stamped BYOP app key ids.
- Wires CatGPT, voice-edit remix/walkthrough, Chat, AI Dungeon Master, Virtual Makeup, and Product Packaging Designer into catalog uploads.
- Validated with media tests, TypeScript, Biome, and touched app builds/type checks.