### PR TITLE
feat: add lightweight media catalog

### DIFF
--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -9,6 +9,8 @@ const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const AUTH_KEY = "catgpt_api_key";
 const APP_KEY = "pk_uWjreBEkxFAhjDHo";
 
+export const CATGPT_APP_KEY = APP_KEY;
+
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
 export const getStoredApiKey = () => {
@@ -182,4 +184,21 @@ export async function handleImageUpload(file, notify) {
             return null;
         }
     }
+}
+
+export async function uploadGeneratedMeme(blob, { prompt, model }) {
+    const form = new FormData();
+    form.append("file", blob, `catgpt-${Date.now()}.png`);
+    form.append("visibility", "public");
+    form.append("source", "generation");
+    form.append("prompt", prompt);
+    form.append("model", model);
+
+    const res = await fetch(MEDIA_UPLOAD, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${getStoredApiKey()}` },
+        body: form,
+    });
+    if (!res.ok) throw new Error("Media save failed");
+    return (await res.json()).url;
 }

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">Public Gallery</h2>
+            <div class="public-gallery-grid" id="publicGalleryGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -1,6 +1,7 @@
 // CatGPT Meme Generator — UI, state, and DOM logic
 
 import {
+    CATGPT_APP_KEY,
     clearApiKey,
     createImageGenerationPrompt,
     EXAMPLE_PROMPTS,
@@ -14,6 +15,7 @@ import {
     handleImageUpload,
     pickModel,
     storeApiKey,
+    uploadGeneratedMeme,
 } from "./ai.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -75,6 +77,7 @@ const dom = {
     shareBtn: $("shareBtn"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
+    publicGalleryGrid: $("publicGalleryGrid"),
     imageUpload: $("imageUpload"),
     imageUploadContainer: $("imageUploadContainer"),
     imageThumbnailContainer: $("imageThumbnailContainer"),
@@ -174,6 +177,28 @@ function saveGeneratedMeme(prompt, url) {
         ...saved.filter((m) => m.prompt !== prompt),
     ].slice(0, 8);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}
+
+async function fetchAccountMemes() {
+    const apiKey = getStoredApiKey();
+    if (!apiKey) return getSavedMemes();
+    const res = await fetch(
+        `https://media.pollinations.ai/me/media?${new URLSearchParams({
+            app_key: CATGPT_APP_KEY,
+            limit: "8",
+        })}`,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!res.ok) throw new Error("media list failed");
+    const data = await res.json();
+    const items = (data.items || [])
+        .filter((item) => item.url)
+        .map((item) => ({
+            prompt: item.prompt || "CatGPT meme",
+            url: item.url,
+            model: item.model || activeModel,
+        }));
+    return items.length ? items : getSavedMemes();
 }
 
 // ── Animations ───────────────────────────────────────────────────────────────
@@ -333,9 +358,9 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
+async function loadUserMemes() {
     dom.yourMemesGrid.innerHTML = "";
-    const saved = getSavedMemes();
+    const saved = await fetchAccountMemes().catch(() => getSavedMemes());
 
     if (!saved.length) {
         const p = document.createElement("p");
@@ -350,6 +375,33 @@ function loadUserMemes() {
         const card = createMemeCard(meme.prompt, i, meme.url);
         if (card) dom.yourMemesGrid.appendChild(card);
     });
+}
+
+async function loadPublicGallery() {
+    if (!dom.publicGalleryGrid) return;
+    dom.publicGalleryGrid.innerHTML = "";
+    try {
+        const res = await fetch(
+            `https://media.pollinations.ai/gallery?${new URLSearchParams({
+                app_key: CATGPT_APP_KEY,
+                limit: "6",
+            })}`,
+        );
+        if (!res.ok) throw new Error("gallery failed");
+        const data = await res.json();
+        const items = (data.items || []).filter((item) => item.url);
+        if (!items.length) return;
+        items.forEach((item, i) => {
+            const card = createMemeCard(
+                item.prompt || "CatGPT meme",
+                i,
+                item.url,
+            );
+            if (card) dom.publicGalleryGrid.appendChild(card);
+        });
+    } catch {
+        dom.publicGalleryGrid.innerHTML = "";
+    }
 }
 
 function loadExamples() {
@@ -411,17 +463,22 @@ async function generateMeme() {
             throw new Error(text.slice(0, 200) || `Error ${response.status}`);
         }
 
-        // Use the pollinations URL directly (shareable, cacheable)
-        await response.blob(); // ensure the image is fully loaded
+        const blob = await response.blob();
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+        const mediaUrl = await uploadGeneratedMeme(blob, {
+            prompt: question,
+            model: activeModel,
+        });
+        if (cancelled) return;
+        dom.generatedMeme.src = mediaUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
-        loadUserMemes();
+        saveGeneratedMeme(question, mediaUrl);
+        await loadUserMemes();
+        await loadPublicGallery();
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +675,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadPublicGallery();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/catgpt/styles.css
+++ b/apps/catgpt/styles.css
@@ -581,7 +581,8 @@ header {
 /* === Cards === */
 
 .examples-grid,
-.your-memes-grid {
+.your-memes-grid,
+.public-gallery-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
@@ -740,7 +741,8 @@ footer a {
     }
 
     .examples-grid,
-    .your-memes-grid {
+    .your-memes-grid,
+    .public-gallery-grid {
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
     }
@@ -801,7 +803,8 @@ footer a {
     }
 
     .examples-grid,
-    .your-memes-grid {
+    .your-memes-grid,
+    .public-gallery-grid {
         grid-template-columns: 1fr;
     }
 

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -105,6 +105,35 @@
   .btn:disabled { opacity: 0.45; cursor: not-allowed; }
   .btn.accent { background: var(--accent); }
   .select { padding: 0 10px; max-width: min(100%, 20rem); }
+  .branch-strip {
+    display: none;
+    gap: 10px;
+    overflow-x: auto;
+    padding: 2px 2px 8px;
+  }
+  .branch-strip.visible { display: flex; }
+  .branch-card {
+    flex: 0 0 96px;
+    padding: 0;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    cursor: pointer;
+  }
+  .branch-card img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
+  }
+  .branch-card span {
+    display: block;
+    padding: 5px;
+    font-size: 0.65rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
   .mode-toggle, .swatches {
     display: inline-flex;
@@ -316,8 +345,10 @@
       <button id="redoBtn" class="btn" disabled title="redo">redo</button>
       <button id="downloadBtn" class="btn" title="download image with embedded history - drop it back onto the app to restore">save</button>
       <button id="shareBtn" class="btn" title="upload PNG with embedded history and copy link">share</button>
+      <button id="remixesBtn" class="btn" title="show public remixes of this image">remixes</button>
       <button id="walkthroughBtn" class="btn" title="open this remix history as a video walkthrough">walkthrough</button>
     </section>
+    <section id="branchStrip" class="branch-strip" aria-label="public remixes"></section>
 
     <section id="frame" class="frame">
       <div id="stage" class="stage">
@@ -392,7 +423,9 @@ const els = Object.fromEntries(Object.entries({
   redo: "redoBtn",
   download: "downloadBtn",
   share: "shareBtn",
+  remixes: "remixesBtn",
   walkthrough: "walkthroughBtn",
+  branches: "branchStrip",
   colorPicker: "colorPicker",
   pill: "cursorPill",
   pillText: "pillText",
@@ -416,6 +449,8 @@ const app = {
   micAvailable: CAN_RECORD,
   accountUser: "",
   accountBalance: null,
+  branchItems: [],
+  branchesOpen: false,
 };
 
 function setStatus(text) {
@@ -444,9 +479,10 @@ function render() {
   const locked = app.busy || Boolean(app.active);
   els.undo.disabled = !mediaHistory.canUndo() || locked;
   els.redo.disabled = !mediaHistory.canRedo() || locked;
-  [els.upload, els.shuffle, els.model, els.share, els.walkthrough].forEach((el) => { el.disabled = locked; });
+  [els.upload, els.shuffle, els.model, els.share, els.remixes, els.walkthrough].forEach((el) => { el.disabled = locked; });
   renderInputMode(locked);
   renderPins();
+  renderBranches();
 }
 
 function renderInputMode(locked = false) {
@@ -513,6 +549,34 @@ function renderPins() {
     pin.classList.toggle("flip", flip);
     pin.style.maxWidth = `${clamp(flip ? leftSpace : rightSpace, 40, 256)}px`;
     return pin;
+  }));
+}
+
+function renderBranches() {
+  els.remixes.textContent = app.branchItems.length ? `remixes ${app.branchItems.length}` : "remixes";
+  els.branches.classList.toggle("visible", app.branchesOpen);
+  if (!app.branchesOpen) return;
+  if (!app.branchItems.length) {
+    const empty = document.createElement("span");
+    empty.className = "tagline";
+    empty.textContent = "no public remixes yet";
+    els.branches.replaceChildren(empty);
+    return;
+  }
+  els.branches.replaceChildren(...app.branchItems.map((item) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "branch-card";
+    button.title = item.prompt || "open remix";
+    const img = document.createElement("img");
+    img.src = item.url;
+    img.alt = item.prompt || "public remix";
+    img.loading = "lazy";
+    const label = document.createElement("span");
+    label.textContent = item.prompt || "remix";
+    button.append(img, label);
+    button.addEventListener("click", () => openStartURL(item.url).catch((err) => showError(err.message)));
+    return button;
   }));
 }
 
@@ -904,10 +968,13 @@ async function uploadDataURL(dataURL, filename = "annot.png") {
   return uploadBlob(blob, filename);
 }
 
-async function uploadBlob(blob, filename) {
+async function uploadBlob(blob, filename, fields = {}) {
   setStatus("uploading...");
   const form = new FormData();
   form.append("file", blob, filename);
+  for (const [key, value] of Object.entries(fields)) {
+    if (value != null && value !== "") form.append(key, String(value));
+  }
   const res = await fetch("https://media.pollinations.ai/upload", {
     method: "POST",
     headers: authHeaders(),
@@ -963,6 +1030,7 @@ async function runQueue() {
   try {
     while (app.queue.length) {
       const job = app.queue.shift();
+      const parentHash = mediaHashFromURL(app.stateURL || app.history[app.historyIndex]?.url || app.imageURL);
       app.currentJob = job;
       render();
       setStatus(`editing... (${app.queue.length + 1} in queue)`);
@@ -982,13 +1050,20 @@ async function runQueue() {
         const result = await runEdit(uploaded, prompt, job.model);
         await mediaHistory.set({ url: result }, { add: true });
         setStatus("packaging share link...");
-        const packaged = await packageCurrentFrameWithHistory();
+        const packaged = await packageCurrentFrameWithHistory(parentHash ? {
+          remixOf: parentHash,
+          visibility: "public",
+          source: "remix",
+          prompt: job.text,
+          model: job.model,
+        } : {});
         const frame = app.history[app.historyIndex];
         if (frame?.url === result) {
           frame.url = packaged;
           app.imageURL = packaged;
           app.stateURL = packaged;
           syncStartToCurrent({ force: true });
+          refreshBranches();
           render();
         }
         await loadBalance();
@@ -1254,6 +1329,18 @@ function scrubURL(url) {
   }
 }
 
+function mediaHashFromURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const parsed = new URL(url, location.href);
+    if (parsed.hostname !== "media.pollinations.ai") return "";
+    const hash = parsed.pathname.replace(/^\/+/, "").split("/")[0];
+    return /^[a-f0-9]{16}$/i.test(hash) ? hash.toLowerCase() : "";
+  } catch {
+    return "";
+  }
+}
+
 function cleanHistoryFrames(frames) {
   return frames
     .map((frame) => cleanHistoryFrame(frame))
@@ -1344,12 +1431,37 @@ async function loadStartImage(url) {
     const remix = await readRemixState(blob);
     if (remix) {
       await restoreRemix(remix, url, url);
+      refreshBranches();
       return;
     }
   } catch {
     // Fall through to URL loading; the browser may still be able to render it.
   }
   await mediaHistory.reset({ url }, url);
+  refreshBranches();
+}
+
+function refreshBranches(options) {
+  loadBranches(options).catch(() => {
+    app.branchItems = [];
+    renderBranches();
+  });
+}
+
+async function loadBranches({ show = false } = {}) {
+  const hash = mediaHashFromURL(app.stateURL || app.history[app.historyIndex]?.url || app.imageURL);
+  if (!hash) {
+    app.branchItems = [];
+    app.branchesOpen = false;
+    renderBranches();
+    return;
+  }
+  const res = await fetch(`https://media.pollinations.ai/${hash}/children?limit=12`);
+  if (!res.ok) return;
+  const data = await res.json();
+  app.branchItems = Array.isArray(data.items) ? data.items : [];
+  if (show) app.branchesOpen = true;
+  renderBranches();
 }
 
 function nextStarter() {
@@ -1398,6 +1510,7 @@ async function loadFromLocation() {
     await loadStartImage(startURL);
   } else {
     await mediaHistory.reset({ url: STARTER }, STARTER);
+    refreshBranches();
   }
 }
 
@@ -1415,8 +1528,8 @@ async function openStartURL(mediaURL) {
   await followLocationStart();
 }
 
-async function packageCurrentFrameWithHistory() {
-  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png");
+async function packageCurrentFrameWithHistory(fields = {}) {
+  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png", fields);
 }
 
 const goHistory = (delta, label) => () => {
@@ -1452,6 +1565,16 @@ els.share.addEventListener("click", async () => {
       window.prompt("share link", shareURL.href);
       setStatus("share link ready");
     }
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.remixes.addEventListener("click", async () => {
+  app.branchesOpen = !app.branchesOpen;
+  renderBranches();
+  if (!app.branchesOpen) return;
+  try {
+    await loadBranches({ show: true });
   } catch (err) {
     showError(err.message);
   }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1431,6 +1431,9 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Whether the API key is valid and active",
                                         ),
+                                    keyId: z
+                                        .string()
+                                        .describe("Stable API key id"),
                                     type: z
                                         .enum(["publishable", "secret"])
                                         .describe("Type of API key"),
@@ -1439,6 +1442,24 @@ export const accountRoutes = new Hono<Env>()
                                         .nullable()
                                         .describe(
                                             "Display name of the API key",
+                                        ),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for this API key",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Publishable app key id that minted this key, when present",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Display name for the app that minted this key, when present",
                                         ),
                                     expiresAt: z
                                         .string()
@@ -1548,8 +1569,12 @@ export const accountRoutes = new Hono<Env>()
 
             return c.json({
                 valid: true, // If we got here, the key is valid
+                keyId: apiKey.id,
                 type: keyType,
                 name: apiKey.name || null,
+                userId: c.var.auth.user?.id || null,
+                byopClientKeyId: apiKey.byopClientKeyId || null,
+                byopClientName: apiKey.byopClientName || null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -39,8 +39,12 @@ test(
 
         const data = await response.json();
         expect(data.valid).toBe(true);
+        expect(data.keyId).toBeTruthy();
         expect(data.type).toBe("secret");
         expect(data.name).toBeTruthy();
+        expect(data.userId).toBeTruthy();
+        expect(data).toHaveProperty("byopClientKeyId");
+        expect(data).toHaveProperty("byopClientName");
         expect(data).toHaveProperty("expiresAt");
         expect(data).toHaveProperty("expiresIn");
         expect(data).toHaveProperty("permissions");

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -16,6 +16,10 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const CATALOG_PREFIX = "catalog/v1";
+const LINEAGE_PREFIX = "lineage/v1";
+const MAX_LIST_LIMIT = 100;
+const DEFAULT_LIST_LIMIT = 50;
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
@@ -24,9 +28,41 @@ interface Env {
 
 interface AuthResult {
     valid: boolean;
+    keyId?: string;
     type: string;
     name: string | null;
+    userId?: string | null;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
 }
+
+type Visibility = "private" | "public";
+type CatalogSource = "upload" | "generation" | "remix";
+
+type UploadCatalogInput = {
+    visibility: Visibility;
+    source: CatalogSource;
+    remixOf: string | null;
+    prompt: string | null;
+    model: string | null;
+};
+
+type CatalogItem = {
+    hash: string;
+    url: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    visibility: Visibility;
+    source: CatalogSource;
+    ownerId?: string;
+    ownerName?: string;
+    appId?: string;
+    appName?: string;
+    remixOf?: string;
+    prompt?: string;
+    model?: string;
+};
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
     try {
@@ -69,6 +105,28 @@ const ErrorSchema = z.object({
     error: z.string(),
 });
 
+const CatalogItemSchema = z.object({
+    hash: z.string(),
+    url: z.string(),
+    contentType: z.string(),
+    size: z.number().int(),
+    createdAt: z.string(),
+    visibility: z.enum(["private", "public"]),
+    source: z.enum(["upload", "generation", "remix"]),
+    ownerId: z.string().optional(),
+    ownerName: z.string().optional(),
+    appId: z.string().optional(),
+    appName: z.string().optional(),
+    remixOf: z.string().optional(),
+    prompt: z.string().optional(),
+    model: z.string().optional(),
+});
+
+const CatalogListResponseSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    cursor: z.string().optional(),
+});
+
 const MetadataResponseSchema = z.object({
     hash: z.string().describe("16-char hex content hash"),
     contentType: z.string(),
@@ -80,6 +138,181 @@ const MetadataResponseSchema = z.object({
 });
 
 const api = new Hono<{ Bindings: Env }>();
+
+function stringField(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+    key: string,
+): string | null {
+    let value: unknown;
+    if (fields instanceof FormData) {
+        value = fields.get(key);
+    } else if (fields instanceof URLSearchParams) {
+        value = fields.get(key);
+    } else {
+        value = fields[key];
+    }
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function boundedText(value: string | null, maxLength: number): string | null {
+    if (!value) return null;
+    return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function parseVisibility(value: string | null): Visibility {
+    return value === "public" ? "public" : "private";
+}
+
+function parseSource(value: string | null): CatalogSource {
+    if (value === "generation" || value === "remix") return value;
+    return "upload";
+}
+
+function rawRemixOf(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): string | null {
+    return stringField(fields, "remixOf") || stringField(fields, "parent");
+}
+
+function hasInvalidRemixOf(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): boolean {
+    const remixOf = rawRemixOf(fields);
+    return Boolean(remixOf && !HASH_PATTERN.test(remixOf));
+}
+
+function parseUploadCatalogInput(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): UploadCatalogInput {
+    const remixOf = rawRemixOf(fields);
+    return {
+        visibility: parseVisibility(stringField(fields, "visibility")),
+        source: parseSource(stringField(fields, "source")),
+        remixOf: remixOf && HASH_PATTERN.test(remixOf) ? remixOf.toLowerCase() : null,
+        prompt: boundedText(stringField(fields, "prompt"), 500),
+        model: boundedText(stringField(fields, "model"), 80),
+    };
+}
+
+function reverseTimestamp(now = Date.now()): string {
+    return String(Number.MAX_SAFE_INTEGER - now).padStart(16, "0");
+}
+
+function catalogIndexKey(prefix: string, hash: string, now = Date.now()): string {
+    return `${prefix}/${reverseTimestamp(now)}-${hash}.json`;
+}
+
+function itemKey(hash: string): string {
+    return `${CATALOG_PREFIX}/items/${hash}.json`;
+}
+
+async function putJson(bucket: R2Bucket, key: string, value: unknown) {
+    await bucket.put(key, JSON.stringify(value), {
+        httpMetadata: {
+            contentType: "application/json",
+            cacheControl: "no-store",
+        },
+    });
+}
+
+async function readCatalogItem(
+    bucket: R2Bucket,
+    key: string,
+): Promise<CatalogItem | null> {
+    const object = await bucket.get(key);
+    if (!object) return null;
+    try {
+        return (await object.json()) as CatalogItem;
+    } catch {
+        return null;
+    }
+}
+
+async function listCatalogItems(
+    bucket: R2Bucket,
+    prefix: string,
+    limit: number,
+    cursor?: string | null,
+): Promise<{ items: CatalogItem[]; cursor?: string }> {
+    const list = await bucket.list({
+        prefix,
+        limit,
+        cursor: cursor || undefined,
+    });
+    const items = (
+        await Promise.all(
+            list.objects.map((object) => readCatalogItem(bucket, object.key)),
+        )
+    ).filter((item): item is CatalogItem => Boolean(item));
+
+    return {
+        items,
+        ...(list.truncated && list.cursor ? { cursor: list.cursor } : {}),
+    };
+}
+
+function listLimit(raw: string | null): number {
+    const parsed = Number.parseInt(raw || "", 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIST_LIMIT;
+    return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
+async function resolveAppIdFromQuery(
+    app: string | null,
+    appKey: string | null,
+): Promise<string | null> {
+    if (app?.trim()) return app.trim();
+    if (!appKey?.trim()) return null;
+    const auth = await verifyApiKey(appKey.trim());
+    return auth?.keyId || null;
+}
+
+async function writeCatalogEntries(
+    bucket: R2Bucket,
+    auth: AuthResult,
+    item: CatalogItem,
+) {
+    const keys = [itemKey(item.hash)];
+    const now = Date.now();
+
+    if (auth.userId) {
+        keys.push(
+            catalogIndexKey(
+                `${CATALOG_PREFIX}/by-owner/${auth.userId}`,
+                item.hash,
+                now,
+            ),
+        );
+        if (auth.byopClientKeyId) {
+            keys.push(
+                catalogIndexKey(
+                    `${CATALOG_PREFIX}/by-owner-app/${auth.userId}/${auth.byopClientKeyId}`,
+                    item.hash,
+                    now,
+                ),
+            );
+        }
+    }
+
+    if (item.visibility === "public" && auth.byopClientKeyId) {
+        keys.push(
+            catalogIndexKey(
+                `${CATALOG_PREFIX}/public-app/${auth.byopClientKeyId}`,
+                item.hash,
+                now,
+            ),
+        );
+    }
+
+    if (item.remixOf && item.visibility === "public") {
+        keys.push(
+            `${LINEAGE_PREFIX}/by-parent/${item.remixOf}/${item.hash}.json`,
+            `${LINEAGE_PREFIX}/by-child/${item.hash}/${item.remixOf}.json`,
+        );
+    }
+
+    await Promise.all(keys.map((key) => putJson(bucket, key, item)));
+}
 
 api.post(
     "/upload",
@@ -140,6 +373,9 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        const searchParams = new URL(c.req.url).searchParams;
+        let invalidRemixOf = hasInvalidRemixOf(searchParams);
+        let catalogInput = parseUploadCatalogInput(searchParams);
 
         const requestContentType = c.req.header("content-type") || "";
 
@@ -161,6 +397,8 @@ api.post(
                     return c.json(fileTooLargeError(maxSize), 413);
                 }
 
+                invalidRemixOf = hasInvalidRemixOf(formData);
+                catalogInput = parseUploadCatalogInput(formData);
                 fileBuffer = await file.arrayBuffer();
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
@@ -169,6 +407,12 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
+                    visibility?: string;
+                    source?: string;
+                    remixOf?: string;
+                    parent?: string;
+                    prompt?: string;
+                    model?: string;
                 }>();
 
                 if (!body.data) {
@@ -195,6 +439,8 @@ api.post(
                     return c.json({ error: "Empty file" }, 400);
                 }
 
+                invalidRemixOf = hasInvalidRemixOf(body);
+                catalogInput = parseUploadCatalogInput(body);
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
             } else {
@@ -208,6 +454,10 @@ api.post(
                 }
 
                 contentType = requestContentType || "application/octet-stream";
+            }
+
+            if (invalidRemixOf) {
+                return c.json({ error: "Invalid remixOf hash" }, 400);
             }
 
             const hash = await generateHash(fileBuffer, fileName);
@@ -240,6 +490,28 @@ api.post(
                 }),
             );
 
+            const createdAt = new Date().toISOString();
+            await writeCatalogEntries(c.env.MEDIA_BUCKET, authResult, {
+                hash,
+                url: mediaUrl(hash),
+                contentType,
+                size: fileBuffer.byteLength,
+                createdAt,
+                visibility: catalogInput.visibility,
+                source: catalogInput.remixOf ? "remix" : catalogInput.source,
+                ...(authResult.userId && { ownerId: authResult.userId }),
+                ...(authResult.name && { ownerName: authResult.name }),
+                ...(authResult.byopClientKeyId && {
+                    appId: authResult.byopClientKeyId,
+                }),
+                ...(authResult.byopClientName && {
+                    appName: authResult.byopClientName,
+                }),
+                ...(catalogInput.remixOf && { remixOf: catalogInput.remixOf }),
+                ...(catalogInput.prompt && { prompt: catalogInput.prompt }),
+                ...(catalogInput.model && { model: catalogInput.model }),
+            });
+
             return c.json({
                 id: hash,
                 url: mediaUrl(hash),
@@ -251,6 +523,95 @@ api.post(
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List authenticated user's media",
+        responses: {
+            200: {
+                description: "Media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) return c.json({ error: "API key required" }, 401);
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult?.userId) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+
+        const url = new URL(c.req.url);
+        const appId = await resolveAppIdFromQuery(
+            url.searchParams.get("app"),
+            url.searchParams.get("app_key"),
+        );
+        const prefix = appId
+            ? `${CATALOG_PREFIX}/by-owner-app/${authResult.userId}/${appId}/`
+            : `${CATALOG_PREFIX}/by-owner/${authResult.userId}/`;
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                prefix,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/gallery",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public app media",
+        responses: {
+            200: {
+                description: "Public media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Missing or invalid app",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const appId = await resolveAppIdFromQuery(
+            url.searchParams.get("app"),
+            url.searchParams.get("app_key"),
+        );
+        if (!appId) return c.json({ error: "app or app_key required" }, 400);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${CATALOG_PREFIX}/public-app/${appId}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
     },
 );
 
@@ -315,6 +676,45 @@ api.get(
             console.error("Retrieve error:", error);
             return c.json({ error: "Retrieval failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/:hash/children",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public remixes of a media object",
+        responses: {
+            200: {
+                description: "Child media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid hash format",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const hash = c.req.param("hash");
+        if (!HASH_PATTERN.test(hash)) {
+            return c.json({ error: "Invalid hash format" }, 400);
+        }
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${LINEAGE_PREFIX}/by-parent/${hash}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
     },
 );
 
@@ -449,6 +849,9 @@ app.get("/", (c) => {
         version: "1.0.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
+            myMedia: "GET /me/media (requires API key)",
+            gallery: "GET /gallery?app_key=pk_...",
+            children: "GET /:hash/children",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -19,6 +19,14 @@ interface UploadResponse {
     duplicate: boolean;
 }
 
+interface CatalogItem {
+    hash: string;
+    url: string;
+    prompt?: string;
+    appId?: string;
+    ownerId?: string;
+}
+
 const VALID_KEY = "pk_test_key_123";
 
 function mockAuth() {
@@ -31,8 +39,12 @@ function mockAuth() {
             200,
             JSON.stringify({
                 valid: true,
+                keyId: "key-test",
                 type: "publishable",
                 name: "test-user",
+                userId: "user-test",
+                byopClientKeyId: "app-test",
+                byopClientName: "CatGPT Test",
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -152,6 +164,128 @@ describe("media.pollinations.ai", () => {
         const upload1 = (await res1.json()) as UploadResponse;
         const upload2 = (await res2.json()) as UploadResponse;
         expect(upload1.id).not.toBe(upload2.id);
+    });
+
+    it("indexes uploaded media for owner and public app gallery", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "catgpt-public.png", { type: "image/png" }),
+        );
+        form.append("visibility", "public");
+        form.append("source", "generation");
+        form.append("prompt", "Why is the box mine?");
+        form.append("model", "nanobanana");
+
+        const uploadRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(uploadRes.status).toBe(200);
+        const upload = (await uploadRes.json()) as UploadResponse;
+
+        const mineRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media?app=app-test",
+            { headers: { Authorization: `Bearer ${VALID_KEY}` } },
+        );
+        expect(mineRes.status).toBe(200);
+        const mine = (await mineRes.json()) as { items: CatalogItem[] };
+        expect(mine.items.some((item) => item.hash === upload.id)).toBe(true);
+
+        const galleryRes = await SELF.fetch(
+            "https://media.pollinations.ai/gallery?app=app-test",
+        );
+        expect(galleryRes.status).toBe(200);
+        const gallery = (await galleryRes.json()) as { items: CatalogItem[] };
+        const item = gallery.items.find((entry) => entry.hash === upload.id);
+        expect(item?.prompt).toBe("Why is the box mine?");
+        expect(item?.appId).toBe("app-test");
+    });
+
+    it("indexes remix children by parent hash", async () => {
+        const parentForm = new FormData();
+        parentForm.append(
+            "file",
+            new File([TINY_PNG], "parent.png", { type: "image/png" }),
+        );
+        const parentRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: parentForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        const parent = (await parentRes.json()) as UploadResponse;
+
+        const childForm = new FormData();
+        childForm.append(
+            "file",
+            new File([TINY_PNG], "child.png", { type: "image/png" }),
+        );
+        childForm.append("visibility", "public");
+        childForm.append("source", "remix");
+        childForm.append("remixOf", parent.id);
+        childForm.append("prompt", "make it glow");
+        const childRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: childForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(childRes.status).toBe(200);
+        const child = (await childRes.json()) as UploadResponse;
+
+        const privateChildForm = new FormData();
+        privateChildForm.append(
+            "file",
+            new File([TINY_PNG], "private-child.png", { type: "image/png" }),
+        );
+        privateChildForm.append("source", "remix");
+        privateChildForm.append("remixOf", parent.id);
+        const privateChildRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: privateChildForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(privateChildRes.status).toBe(200);
+        const privateChild = (await privateChildRes.json()) as UploadResponse;
+
+        const childrenRes = await SELF.fetch(
+            `https://media.pollinations.ai/${parent.id}/children`,
+        );
+        expect(childrenRes.status).toBe(200);
+        const children = (await childrenRes.json()) as { items: CatalogItem[] };
+        const item = children.items.find((entry) => entry.hash === child.id);
+        expect(item?.prompt).toBe("make it glow");
+        expect(
+            children.items.some((entry) => entry.hash === privateChild.id),
+        ).toBe(false);
+    });
+
+    it("rejects invalid remix parents", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "bad-remix.png", { type: "image/png" }),
+        );
+        form.append("remixOf", "not-a-hash");
+
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        expect(res.status).toBe(400);
     });
 
     it("GET /:invalid-hash returns 400", async () => {


### PR DESCRIPTION
- Adds R2-backed catalog sidecars for owner media, public app galleries, and public remix children.\n- Exposes key id, user id, and BYOP app attribution from /account/key for server-stamped indexes.\n- Saves CatGPT generated memes through media.pollinations.ai and reads user/public galleries.\n- Stamps voice-edit remixes with parent hashes and shows a public remixes strip.\n\nTests:\n- media.pollinations.ai: npm run test\n- enter.pollinations.ai: npx vitest run test/account-key.test.ts\n- root: npx biome check --write touched JS/TS/CSS files\n- root: git diff --check; node --check apps/catgpt/ai.js apps/catgpt/script.js