### PR TITLE
feat(media): lightweight catalog and app integrations

### DIFF
--- a/apps/ai-dungeon-master/src/App.tsx
+++ b/apps/ai-dungeon-master/src/App.tsx
@@ -178,21 +178,42 @@ export default function App() {
                 const sceneUpload = uploadToMedia(
                     gameState.currentScene.image,
                     apiKey,
+                    {
+                        visibility: "private",
+                        source: "generation",
+                        prompt: gameState.currentScene.description,
+                        model: "flux",
+                    },
                 );
                 await Promise.all([
-                    uploadToMedia(character.avatar, apiKey).then((url) => {
+                    uploadToMedia(character.avatar, apiKey, {
+                        visibility: "private",
+                        source: "generation",
+                        prompt: `${character.name} ${character.class} avatar`,
+                        model: "flux",
+                    }).then((url) => {
                         character.avatar = url;
                     }),
                     sceneUpload.then((url) => {
                         uploadedSceneImage = url;
                     }),
                     ...storyHistory.map((entry, idx) =>
-                        uploadToMedia(entry.image, apiKey).then((url) => {
+                        uploadToMedia(entry.image, apiKey, {
+                            visibility: "private",
+                            source: "generation",
+                            prompt: entry.description,
+                            model: "flux",
+                        }).then((url) => {
                             storyHistory[idx].image = url;
                         }),
                     ),
                     ...inventory.map((item, idx) =>
-                        uploadToMedia(item.image, apiKey).then((url) => {
+                        uploadToMedia(item.image, apiKey, {
+                            visibility: "private",
+                            source: "generation",
+                            prompt: `${item.name}: ${item.description}`,
+                            model: "flux",
+                        }).then((url) => {
                             inventory[idx].image = url;
                         }),
                     ),

--- a/apps/ai-dungeon-master/src/utils/mediaUpload.ts
+++ b/apps/ai-dungeon-master/src/utils/mediaUpload.ts
@@ -1,5 +1,13 @@
-const MEDIA_URL = "https://gen.pollinations.ai";
+const MEDIA_UPLOAD_URL = "https://media.pollinations.ai/upload";
 const MEDIA_HOST = "media.pollinations.ai";
+
+type MediaCatalogFields = {
+    visibility?: "private" | "public";
+    source?: "upload" | "generation" | "remix";
+    remixOf?: string;
+    prompt?: string;
+    model?: string;
+};
 
 /** Check if a URL is already uploaded to media.pollinations.ai */
 function isMediaUrl(url: string): boolean {
@@ -18,6 +26,7 @@ function isMediaUrl(url: string): boolean {
 export async function uploadToMedia(
     genUrl: string,
     apiKey: string,
+    fields: MediaCatalogFields = {},
 ): Promise<string> {
     if (!genUrl || isMediaUrl(genUrl)) return genUrl;
 
@@ -28,8 +37,11 @@ export async function uploadToMedia(
         const blob = await response.blob();
         const formData = new FormData();
         formData.append("file", blob);
+        for (const [key, value] of Object.entries(fields)) {
+            if (value) formData.append(key, value);
+        }
 
-        const uploadRes = await fetch(`${MEDIA_URL}/media`, {
+        const uploadRes = await fetch(MEDIA_UPLOAD_URL, {
             method: "POST",
             headers: { Authorization: `Bearer ${apiKey}` },
             body: formData,

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -9,6 +9,8 @@ const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const AUTH_KEY = "catgpt_api_key";
 const APP_KEY = "pk_uWjreBEkxFAhjDHo";
 
+export const CATGPT_APP_KEY = APP_KEY;
+
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
 export const getStoredApiKey = () => {
@@ -181,5 +183,43 @@ export async function handleImageUpload(file, notify) {
             );
             return null;
         }
+    }
+}
+
+export function extractMediaHash(url) {
+    try {
+        const parsed = new URL(url);
+        return parsed.hostname === "media.pollinations.ai"
+            ? parsed.pathname.slice(1).split("/")[0]
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+export async function uploadGeneratedMeme(blob, { prompt, model, parentHash }) {
+    const form = new FormData();
+    form.append("file", blob, `catgpt-${Date.now()}.png`);
+    form.append("visibility", "public");
+    form.append("source", "generation");
+    form.append("prompt", prompt);
+    form.append("model", model);
+    form.append("tag", "catgpt");
+    if (parentHash) {
+        form.append("parent", parentHash);
+        form.append("relationship", "reply");
+    }
+
+    try {
+        const res = await fetch(MEDIA_UPLOAD, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${getStoredApiKey()}` },
+            body: form,
+        });
+        if (!res.ok) return null;
+        return (await res.json()).url || null;
+    } catch (err) {
+        console.warn("Media catalog save failed:", err);
+        return null;
     }
 }

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">Public Gallery</h2>
+            <div class="public-gallery-grid" id="publicGalleryGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -1,10 +1,12 @@
 // CatGPT Meme Generator — UI, state, and DOM logic
 
 import {
+    CATGPT_APP_KEY,
     clearApiKey,
     createImageGenerationPrompt,
     EXAMPLE_PROMPTS,
     extractApiKeyFromFragment,
+    extractMediaHash,
     fetchBalance,
     fetchProfile,
     generateCatReply,
@@ -14,6 +16,7 @@ import {
     handleImageUpload,
     pickModel,
     storeApiKey,
+    uploadGeneratedMeme,
 } from "./ai.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -75,6 +78,7 @@ const dom = {
     shareBtn: $("shareBtn"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
+    publicGalleryGrid: $("publicGalleryGrid"),
     imageUpload: $("imageUpload"),
     imageUploadContainer: $("imageUploadContainer"),
     imageThumbnailContainer: $("imageThumbnailContainer"),
@@ -161,19 +165,63 @@ const STORAGE_KEY = "catgpt-generated";
 
 function getSavedMemes() {
     try {
-        return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        return (JSON.parse(localStorage.getItem(STORAGE_KEY)) || []).filter(
+            (meme) => isShareableMediaUrl(meme.url),
+        );
     } catch {
         return [];
     }
 }
 
+function isShareableMediaUrl(url) {
+    try {
+        const parsed = new URL(url);
+        return (
+            parsed.hostname === "media.pollinations.ai" &&
+            !parsed.searchParams.has("key") &&
+            !parsed.searchParams.has("api_key")
+        );
+    } catch {
+        return false;
+    }
+}
+
 function saveGeneratedMeme(prompt, url) {
+    if (!isShareableMediaUrl(url)) return;
     const saved = getSavedMemes();
     const updated = [
         { prompt, url, model: activeModel },
         ...saved.filter((m) => m.prompt !== prompt),
     ].slice(0, 8);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}
+
+async function fetchAccountMemes() {
+    const apiKey = getStoredApiKey();
+    if (!apiKey) return getSavedMemes();
+    const res = await fetch(
+        `https://media.pollinations.ai/me/media?${new URLSearchParams({
+            app_key: CATGPT_APP_KEY,
+            limit: "8",
+        })}`,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    if (!res.ok) throw new Error("media list failed");
+    const data = await res.json();
+    const items = (data.items || [])
+        .filter((item) => item.url)
+        .map((item) => ({
+            prompt: item.prompt || "CatGPT meme",
+            url: item.url,
+            model: item.model || activeModel,
+        }));
+    return [...items, ...getSavedMemes()]
+        .filter(
+            (meme, index, all) =>
+                isShareableMediaUrl(meme.url) &&
+                all.findIndex((entry) => entry.url === meme.url) === index,
+        )
+        .slice(0, 8);
 }
 
 // ── Animations ───────────────────────────────────────────────────────────────
@@ -333,9 +381,9 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
+async function loadUserMemes() {
     dom.yourMemesGrid.innerHTML = "";
-    const saved = getSavedMemes();
+    const saved = await fetchAccountMemes().catch(() => getSavedMemes());
 
     if (!saved.length) {
         const p = document.createElement("p");
@@ -350,6 +398,33 @@ function loadUserMemes() {
         const card = createMemeCard(meme.prompt, i, meme.url);
         if (card) dom.yourMemesGrid.appendChild(card);
     });
+}
+
+async function loadPublicGallery() {
+    if (!dom.publicGalleryGrid) return;
+    dom.publicGalleryGrid.innerHTML = "";
+    try {
+        const res = await fetch(
+            `https://media.pollinations.ai/gallery?${new URLSearchParams({
+                app_key: CATGPT_APP_KEY,
+                limit: "6",
+            })}`,
+        );
+        if (!res.ok) throw new Error("gallery failed");
+        const data = await res.json();
+        const items = (data.items || []).filter((item) => item.url);
+        if (!items.length) return;
+        items.forEach((item, i) => {
+            const card = createMemeCard(
+                item.prompt || "CatGPT meme",
+                i,
+                item.url,
+            );
+            if (card) dom.publicGalleryGrid.appendChild(card);
+        });
+    } catch {
+        dom.publicGalleryGrid.innerHTML = "";
+    }
 }
 
 function loadExamples() {
@@ -411,17 +486,30 @@ async function generateMeme() {
             throw new Error(text.slice(0, 200) || `Error ${response.status}`);
         }
 
-        // Use the pollinations URL directly (shareable, cacheable)
-        await response.blob(); // ensure the image is fully loaded
+        const blob = await response.blob();
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+        const mediaUrl = await uploadGeneratedMeme(blob, {
+            prompt: question,
+            model: activeModel,
+            parentHash: extractMediaHash(uploadedImageUrl),
+        });
+        if (cancelled) return;
+        const displayUrl = mediaUrl || URL.createObjectURL(blob);
+        dom.generatedMeme.src = displayUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
-        loadUserMemes();
+        saveGeneratedMeme(question, mediaUrl);
+        if (!mediaUrl) {
+            notify(
+                "Generated, but catalog save failed. Download this one locally.",
+                "warning",
+            );
+        }
+        await loadUserMemes();
+        await loadPublicGallery();
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +706,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadPublicGallery();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/catgpt/styles.css
+++ b/apps/catgpt/styles.css
@@ -581,7 +581,8 @@ header {
 /* === Cards === */
 
 .examples-grid,
-.your-memes-grid {
+.your-memes-grid,
+.public-gallery-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
@@ -740,7 +741,8 @@ footer a {
     }
 
     .examples-grid,
-    .your-memes-grid {
+    .your-memes-grid,
+    .public-gallery-grid {
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
     }
@@ -801,7 +803,8 @@ footer a {
     }
 
     .examples-grid,
-    .your-memes-grid {
+    .your-memes-grid,
+    .public-gallery-grid {
         grid-template-columns: 1fr;
     }
 

--- a/apps/chat/src/utils/api.js
+++ b/apps/chat/src/utils/api.js
@@ -1,5 +1,6 @@
 // Pollinations API utilities — updated to match gen.pollinations.ai spec
 const BASE_URL = "https://gen.pollinations.ai";
+const MEDIA_UPLOAD_URL = "https://media.pollinations.ai/upload";
 const ENV_API_TOKEN = import.meta.env.VITE_POLLINATIONS_API_KEY || "";
 export const BYOP_STORAGE_KEY = "pollinations_byop_api_key";
 
@@ -73,6 +74,57 @@ const parseApiError = async (response) => {
         /* ignore */
     }
     return buildClientError(response.status);
+};
+
+const blobToDataUrl = (blob) =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+
+const extensionForMime = (mimeType, fallback) => {
+    if (mimeType?.includes("png")) return "png";
+    if (mimeType?.includes("jpeg")) return "jpg";
+    if (mimeType?.includes("webp")) return "webp";
+    if (mimeType?.includes("mp4")) return "mp4";
+    if (mimeType?.includes("webm")) return "webm";
+    if (mimeType?.includes("mpeg")) return "mp3";
+    if (mimeType?.includes("wav")) return "wav";
+    return fallback;
+};
+
+const uploadGeneratedMedia = async (blob, token, filename, fields) => {
+    if (!token) return null;
+
+    try {
+        const form = new FormData();
+        form.append("file", blob, filename);
+
+        for (const [key, value] of Object.entries(fields)) {
+            if (value !== undefined && value !== null && value !== "") {
+                form.append(key, String(value));
+            }
+        }
+
+        const response = await fetch(MEDIA_UPLOAD_URL, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+            body: form,
+        });
+
+        if (!response.ok) return null;
+
+        const data = await response.json();
+        return (
+            data.url ||
+            (data.id ? `https://media.pollinations.ai/${data.id}` : null)
+        );
+    } catch (error) {
+        console.warn("Media catalog upload failed:", error);
+        return null;
+    }
 };
 
 export const loadModels = async () => {
@@ -530,13 +582,28 @@ export const generateImage = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, width, height, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const extension = extensionForMime(blob.type, "png");
+    const mediaUrl = await uploadGeneratedMedia(
+        blob,
+        token,
+        `chat-image-${Date.now()}.${extension}`,
+        {
+            visibility: "private",
+            source: "generation",
+            prompt,
+            model,
+            tag: "chat",
+        },
+    );
+
+    return {
+        url: mediaUrl || (await blobToDataUrl(blob)),
+        prompt,
+        model,
+        width,
+        height,
+        seed,
+    };
 };
 
 export const generateVideo = async (prompt, options = {}) => {
@@ -556,13 +623,26 @@ export const generateVideo = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const extension = extensionForMime(blob.type, "mp4");
+    const mediaUrl = await uploadGeneratedMedia(
+        blob,
+        token,
+        `chat-video-${Date.now()}.${extension}`,
+        {
+            visibility: "private",
+            source: "generation",
+            prompt,
+            model,
+            tag: "chat",
+        },
+    );
+
+    return {
+        url: mediaUrl || (await blobToDataUrl(blob)),
+        prompt,
+        model,
+        seed,
+    };
 };
 
 // Generate speech/audio — GET /audio/{text}?voice=...
@@ -578,11 +658,25 @@ export const generateAudio = async (text, options = {}) => {
 
     const blob = await response.blob();
     const mimeType = blob.type || "audio/mpeg";
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, text, voice, model, mimeType });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const extension = extensionForMime(mimeType, "mp3");
+    const mediaUrl = await uploadGeneratedMedia(
+        blob,
+        token,
+        `chat-audio-${Date.now()}.${extension}`,
+        {
+            visibility: "private",
+            source: "generation",
+            prompt: text,
+            model,
+            tag: "chat",
+        },
+    );
+
+    return {
+        url: mediaUrl || (await blobToDataUrl(blob)),
+        text,
+        voice,
+        model,
+        mimeType,
+    };
 };

--- a/apps/pollicraft/README.md
+++ b/apps/pollicraft/README.md
@@ -1,0 +1,27 @@
+# pollicraft
+
+A tiny single-file paper-alchemy game. Drag two ingredients together; the
+combination is named by a small LLM, illustrated by an image model, and
+uploaded to the media catalog. Every player builds on the same shared tree.
+
+## How it uses the media catalog
+
+- Each newly crafted element is uploaded to `media.pollinations.ai` via the
+  authenticated upload endpoint. The upload carries:
+  - `parent=<alphabetically-first ingredient hash>` — the lineage edge
+  - `tag=element:<slug>` — element identity
+  - `tag=recipe:<a>+<b>` — deterministic recipe key (sorted)
+  - `tag=name:<slugified-name>` — display name
+- Server stamps `app:pollicraft` and `owner:<userId>` (these are server-attested,
+  not client-claimed).
+- Before crafting, the app checks `GET /apps/pollicraft/media` for an existing
+  element with the same `recipe:<a>+<b>` tag — that's the global recipe cache.
+- "mine" tab reads `GET /me/media?app=pollicraft`.
+- "community" tab reads `GET /apps/pollicraft/media`.
+
+No backend. No PocketBase. The catalog is the database.
+
+## Open
+
+Start a local static server and open `index.html`. You'll need a pollinations
+API key — click **connect** to run the OAuth flow.

--- a/apps/pollicraft/index.html
+++ b/apps/pollicraft/index.html
@@ -1,0 +1,515 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pollicraft — paper alchemy</title>
+<style>
+  :root {
+    --paper: #f6f1e3;
+    --ink: #1d1c18;
+    --ink-soft: #6f6a5a;
+    --accent: #b53a2c;
+    --shadow: 0 1px 0 rgba(29,28,24,.12), 0 8px 18px rgba(29,28,24,.08);
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; background: var(--paper); color: var(--ink);
+    font-family: "Iowan Old Style", "Book Antiqua", "Palatino Linotype", Georgia, serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .app { display: grid; grid-template-columns: 1fr 280px; gap: 18px; height: 100%; padding: 18px; }
+  @media (max-width: 720px) { .app { grid-template-columns: 1fr; padding: 10px; gap: 12px; } }
+
+  header {
+    grid-column: 1 / -1; display: flex; align-items: center; gap: 14px;
+    border-bottom: 1px solid var(--ink-soft); padding-bottom: 8px;
+  }
+  header h1 {
+    margin: 0; font-family: "Segoe Print", "Bradley Hand ITC", "Comic Sans MS", cursive;
+    font-size: 1.6rem; font-weight: 600;
+  }
+  header .tagline { color: var(--ink-soft); font-style: italic; }
+  header .account { margin-left: auto; display: flex; gap: 8px; align-items: center; font-size: 14px; }
+
+  .btn {
+    background: transparent; color: var(--ink); border: 1px solid var(--ink-soft);
+    border-radius: 6px; padding: 6px 10px; cursor: pointer; font: inherit;
+  }
+  .btn.accent { background: var(--accent); color: white; border-color: var(--accent); }
+  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .table {
+    position: relative; min-height: 320px; background: var(--paper);
+    border: 1px dashed var(--ink-soft); border-radius: 14px;
+    overflow: hidden; box-shadow: var(--shadow);
+  }
+  .placed {
+    position: absolute; width: 96px; height: 96px; cursor: grab;
+    border-radius: 10px; background: var(--paper);
+    box-shadow: var(--shadow); display: grid; place-items: center; padding: 6px;
+    text-align: center; font-size: 12px; touch-action: none; user-select: none;
+  }
+  .placed img { max-width: 100%; max-height: 64px; pointer-events: none; }
+  .placed .name { margin-top: 2px; font-weight: 600; }
+  .placed.dragging { cursor: grabbing; z-index: 5; }
+  .placed.crafting { outline: 2px dashed var(--accent); animation: pulse 1s infinite; }
+  @keyframes pulse { 0%,100% { transform: scale(1); } 50% { transform: scale(1.04); } }
+
+  .shelf {
+    background: var(--paper); border: 1px solid var(--ink-soft); border-radius: 14px;
+    padding: 10px; display: flex; flex-direction: column; gap: 10px; min-height: 0;
+    box-shadow: var(--shadow);
+  }
+  .shelf h2 { margin: 0; font-size: 1rem; font-weight: 600; }
+  .shelf .tabs { display: flex; gap: 6px; font-size: 13px; }
+  .shelf .tabs button { background: transparent; border: 0; cursor: pointer; padding: 4px 6px; border-bottom: 2px solid transparent; }
+  .shelf .tabs button.active { border-color: var(--accent); color: var(--accent); }
+  .inventory {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(82px, 1fr));
+    gap: 8px; overflow-y: auto; padding-right: 4px;
+  }
+  .inv-item {
+    border: 1px solid var(--ink-soft); border-radius: 8px; padding: 6px; text-align: center;
+    cursor: grab; background: var(--paper); touch-action: none; user-select: none;
+  }
+  .inv-item img { width: 56px; height: 56px; object-fit: contain; pointer-events: none; }
+  .inv-item .name { font-size: 11px; margin-top: 2px; font-weight: 600; }
+  .inv-item .meta { font-size: 10px; color: var(--ink-soft); }
+
+  .status { color: var(--ink-soft); font-size: 13px; padding: 4px 0; min-height: 18px; }
+  .error { color: var(--accent); font-weight: 600; }
+</style>
+
+<body>
+  <main class="app">
+    <header>
+      <h1>Pollicraft</h1>
+      <span class="tagline">paper alchemy · drag two to craft</span>
+      <div class="account">
+        <span id="status" class="status">ready</span>
+        <button id="connectBtn" class="btn accent">connect</button>
+      </div>
+    </header>
+
+    <section class="table" id="table"></section>
+
+    <aside class="shelf">
+      <h2>Inventory</h2>
+      <div class="tabs">
+        <button class="active" data-tab="mine">mine</button>
+        <button data-tab="community">community</button>
+      </div>
+      <div id="inventory" class="inventory"></div>
+    </aside>
+  </main>
+
+<script type="module">
+const GEN_BASE = "https://gen.pollinations.ai";
+const MEDIA_BASE = "https://media.pollinations.ai";
+const ENTER_BASE = "https://enter.pollinations.ai";
+const APP_KEY = "pk_pollicraft";  // replace with a real publishable key once minted
+const APP_ID = "pollicraft";
+const KEY_STORAGE = "pollicraft:apiKey";
+
+const SEEDS = [
+  { slug: "water", name: "Water" },
+  { slug: "fire", name: "Fire" },
+  { slug: "wind", name: "Wind" },
+  { slug: "earth", name: "Earth" },
+];
+
+const $ = (id) => document.getElementById(id);
+const els = {
+  table: $("table"),
+  inventory: $("inventory"),
+  status: $("status"),
+  connect: $("connectBtn"),
+};
+
+const state = {
+  // Inventory keyed by slug -> { slug, name, url, hash, parent }
+  // `mine` = personal discoveries; `community` = catalog reads
+  inventoryByTab: { mine: new Map(), community: new Map() },
+  activeTab: "mine",
+  placed: [],  // { uid, slug, x, y, el }
+  apiKey: localStorage.getItem(KEY_STORAGE) || null,
+};
+
+function setStatus(msg, isError = false) {
+  els.status.textContent = msg;
+  els.status.classList.toggle("error", isError);
+}
+
+function authHeaders(extra = {}) {
+  return state.apiKey
+    ? { Authorization: `Bearer ${state.apiKey}`, ...extra }
+    : { ...extra };
+}
+
+// ── Auth ────────────────────────────────────────────────────────────────────
+
+function extractKeyFromFragment() {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return null;
+  const k = new URLSearchParams(hash).get("api_key");
+  return k && /^(sk_|pk_|plln_)/.test(k) ? k : null;
+}
+
+function refreshConnectionUI() {
+  els.connect.textContent = state.apiKey ? "connected" : "connect";
+  els.connect.disabled = !!state.apiKey;
+}
+
+els.connect.addEventListener("click", () => {
+  const redirect = window.location.href.split("#")[0];
+  const url = `${ENTER_BASE}/authorize?${new URLSearchParams({
+    redirect_url: redirect,
+    app_key: APP_KEY,
+    budget: "5",
+    models: "flux,nanobanana",
+    permissions: "profile,usage",
+  })}`;
+  window.location.href = url;
+});
+
+(function captureKeyFromFragment() {
+  const k = extractKeyFromFragment();
+  if (k) {
+    state.apiKey = k;
+    localStorage.setItem(KEY_STORAGE, k);
+    history.replaceState(null, "", location.pathname + location.search);
+  }
+  refreshConnectionUI();
+})();
+
+// ── Element creation ────────────────────────────────────────────────────────
+
+function buildPrompt(name, leftName, rightName) {
+  return `small hand-painted ${name}, paper texture, indie game icon, made from ${leftName} and ${rightName}, white background`;
+}
+
+async function generateElementImage(name, leftName, rightName) {
+  const prompt = buildPrompt(name, leftName, rightName);
+  const url = `${GEN_BASE}/image/${encodeURIComponent(prompt)}?model=flux&width=512&height=512&nologo=true`;
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`image gen failed: ${res.status}`);
+  return res.blob();
+}
+
+// Ask a tiny LLM to name the combination.
+async function pickElementName(leftName, rightName) {
+  const res = await fetch(`${GEN_BASE}/v1/chat/completions`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      model: "openai-fast",
+      messages: [
+        {
+          role: "system",
+          content: "You play a craft naming game. Given two ingredients, reply with the most evocative one-word (or short two-word) name for what they make together. Lowercase. No punctuation, no quotes, no explanation. Just the name.",
+        },
+        { role: "user", content: `${leftName} + ${rightName} =` },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`naming failed: ${res.status}`);
+  const data = await res.json();
+  const raw = (data.choices?.[0]?.message?.content || "").trim().toLowerCase();
+  return raw.replace(/[^a-z0-9 ]/g, "").slice(0, 40) || `${leftName}-${rightName}`;
+}
+
+function slugify(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 32);
+}
+
+// ── Media catalog integration ───────────────────────────────────────────────
+
+async function uploadElement(blob, slug, name, leftHash, rightHash, recipeTag) {
+  const form = new FormData();
+  form.append("file", new File([blob], `${slug}.png`, { type: blob.type || "image/png" }));
+  // Pick one parent hash for the lineage edge — by convention the alphabetically
+  // first ingredient. The recipe tag below records both for community lookup.
+  const parent = [leftHash, rightHash].filter(Boolean).sort()[0];
+  if (parent) form.append("parent", parent);
+  form.append("tag", `element:${slug}`);
+  form.append("tag", recipeTag);
+  form.append("tag", `name:${slugify(name)}`);
+  const res = await fetch(`${MEDIA_BASE}/upload`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(`upload failed: ${res.status}`);
+  return res.json();
+}
+
+// Build the deterministic recipe tag from two slugs.
+function recipeTag(a, b) {
+  return `recipe:${[a, b].sort().join("+")}`;
+}
+
+// Look up an existing community discovery for a given recipe.
+async function lookupRecipe(a, b) {
+  const tag = recipeTag(a, b);
+  // tags/v1/<tag>/... is read-public; we hit the per-app catalog filtered
+  // client-side because there is no dedicated tag-read endpoint yet.
+  const res = await fetch(`${MEDIA_BASE}/apps/${APP_ID}/media?limit=200`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  for (const item of data.items || []) {
+    if (Array.isArray(item.userTags) && item.userTags.includes(tag)) {
+      return item;
+    }
+  }
+  return null;
+}
+
+async function fetchMyInventory() {
+  if (!state.apiKey) return [];
+  const res = await fetch(`${MEDIA_BASE}/me/media?limit=100`, { headers: authHeaders() });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.items || []).filter((it) => it.app === APP_ID);
+}
+
+async function fetchCommunityInventory() {
+  const res = await fetch(`${MEDIA_BASE}/apps/${APP_ID}/media?limit=100`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.items || [];
+}
+
+function itemToElement(item) {
+  const tags = Array.isArray(item.userTags) ? item.userTags : [];
+  const elementTag = tags.find((t) => t.startsWith("element:"));
+  const nameTag = tags.find((t) => t.startsWith("name:"));
+  const slug = elementTag ? elementTag.slice("element:".length) : item.hash;
+  const name = nameTag ? nameTag.slice("name:".length).replace(/-/g, " ") : slug;
+  return { slug, name, url: item.url, hash: item.hash, parent: item.parent };
+}
+
+// ── Inventory rendering ─────────────────────────────────────────────────────
+
+function ensureSeeds(tab) {
+  const map = state.inventoryByTab[tab];
+  for (const seed of SEEDS) {
+    if (!map.has(seed.slug)) {
+      // Seeds use placeholder icons (CSS-only) — no media hash yet, so they
+      // never produce a `parent` edge when used in a first-time combination.
+      map.set(seed.slug, { slug: seed.slug, name: seed.name, url: "", hash: null });
+    }
+  }
+}
+
+function renderInventory() {
+  const map = state.inventoryByTab[state.activeTab];
+  els.inventory.innerHTML = "";
+  const items = Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+  for (const item of items) {
+    const card = document.createElement("div");
+    card.className = "inv-item";
+    card.draggable = false;
+    card.dataset.slug = item.slug;
+    if (item.url) {
+      const img = document.createElement("img");
+      img.src = item.url;
+      img.alt = item.name;
+      img.loading = "lazy";
+      card.appendChild(img);
+    } else {
+      const placeholder = document.createElement("div");
+      placeholder.style.cssText = "width:56px;height:56px;display:grid;place-items:center;font-size:32px;";
+      placeholder.textContent = { water: "💧", fire: "🔥", wind: "🌬️", earth: "🪨" }[item.slug] || "🜍";
+      card.appendChild(placeholder);
+    }
+    const n = document.createElement("div");
+    n.className = "name";
+    n.textContent = item.name;
+    card.appendChild(n);
+    card.addEventListener("pointerdown", (e) => beginDragFromInventory(e, item));
+    els.inventory.appendChild(card);
+  }
+}
+
+for (const tabBtn of document.querySelectorAll(".tabs button")) {
+  tabBtn.addEventListener("click", async () => {
+    for (const b of document.querySelectorAll(".tabs button")) {
+      b.classList.toggle("active", b === tabBtn);
+    }
+    state.activeTab = tabBtn.dataset.tab;
+    if (state.activeTab === "community" && state.inventoryByTab.community.size === 0) {
+      setStatus("loading community discoveries...");
+      const items = await fetchCommunityInventory();
+      for (const it of items) {
+        const el = itemToElement(it);
+        state.inventoryByTab.community.set(el.slug, el);
+      }
+      setStatus(`${items.length} community discoveries`);
+    }
+    ensureSeeds(state.activeTab);
+    renderInventory();
+  });
+}
+
+// ── Table drag + craft ──────────────────────────────────────────────────────
+
+let dragState = null;
+
+function placeOnTable(item, x, y) {
+  const uid = Math.random().toString(36).slice(2, 9);
+  const el = document.createElement("div");
+  el.className = "placed";
+  el.style.left = `${x - 48}px`;
+  el.style.top = `${y - 48}px`;
+  if (item.url) {
+    const img = document.createElement("img");
+    img.src = item.url; img.alt = item.name; el.appendChild(img);
+  } else {
+    const ph = document.createElement("div");
+    ph.style.fontSize = "40px";
+    ph.textContent = { water: "💧", fire: "🔥", wind: "🌬️", earth: "🪨" }[item.slug] || "🜍";
+    el.appendChild(ph);
+  }
+  const n = document.createElement("div");
+  n.className = "name"; n.textContent = item.name; el.appendChild(n);
+  els.table.appendChild(el);
+  const placed = { uid, slug: item.slug, name: item.name, hash: item.hash, x, y, el };
+  el.addEventListener("pointerdown", (e) => beginDragPlaced(e, placed));
+  el.addEventListener("dblclick", () => removePlaced(placed));
+  state.placed.push(placed);
+  return placed;
+}
+
+function removePlaced(p) {
+  p.el.remove();
+  state.placed = state.placed.filter((q) => q !== p);
+}
+
+function beginDragFromInventory(e, item) {
+  e.preventDefault();
+  const tableRect = els.table.getBoundingClientRect();
+  const insideTable = e.clientX >= tableRect.left && e.clientX <= tableRect.right
+    && e.clientY >= tableRect.top && e.clientY <= tableRect.bottom;
+  let placed;
+  if (insideTable) {
+    placed = placeOnTable(item, e.clientX - tableRect.left, e.clientY - tableRect.top);
+  } else {
+    placed = placeOnTable(item, tableRect.width / 2, tableRect.height / 2);
+  }
+  beginDragPlaced(e, placed);
+}
+
+function beginDragPlaced(e, p) {
+  e.preventDefault();
+  const rect = p.el.getBoundingClientRect();
+  dragState = {
+    placed: p,
+    offsetX: e.clientX - rect.left,
+    offsetY: e.clientY - rect.top,
+  };
+  p.el.classList.add("dragging");
+  p.el.setPointerCapture(e.pointerId);
+  p.el.addEventListener("pointermove", onDragMove);
+  p.el.addEventListener("pointerup", onDragEnd, { once: true });
+  p.el.addEventListener("pointercancel", onDragEnd, { once: true });
+}
+
+function onDragMove(e) {
+  if (!dragState) return;
+  const tableRect = els.table.getBoundingClientRect();
+  const x = e.clientX - tableRect.left - dragState.offsetX + 48;
+  const y = e.clientY - tableRect.top - dragState.offsetY + 48;
+  dragState.placed.x = x;
+  dragState.placed.y = y;
+  dragState.placed.el.style.left = `${x - 48}px`;
+  dragState.placed.el.style.top = `${y - 48}px`;
+  highlightCollision(dragState.placed);
+}
+
+function distance(a, b) { return Math.hypot(a.x - b.x, a.y - b.y); }
+
+function highlightCollision(active) {
+  for (const p of state.placed) p.el.classList.remove("crafting");
+  const partner = findCollision(active);
+  if (partner) {
+    active.el.classList.add("crafting");
+    partner.el.classList.add("crafting");
+  }
+}
+
+function findCollision(active) {
+  return state.placed.find((p) => p !== active && distance(p, active) < 80) || null;
+}
+
+async function onDragEnd() {
+  if (!dragState) return;
+  const active = dragState.placed;
+  active.el.classList.remove("dragging");
+  active.el.removeEventListener("pointermove", onDragMove);
+  const partner = findCollision(active);
+  dragState = null;
+  for (const p of state.placed) p.el.classList.remove("crafting");
+  if (!partner) return;
+  if (active.slug === partner.slug) return;
+  await craftFromPlaced(active, partner);
+}
+
+async function craftFromPlaced(a, b) {
+  if (!state.apiKey) {
+    setStatus("connect first to craft new elements", true);
+    return;
+  }
+  setStatus(`crafting ${a.name} + ${b.name}...`);
+  try {
+    // First, check community catalog for a pre-existing recipe.
+    const existing = await lookupRecipe(a.slug, b.slug);
+    if (existing) {
+      const el = itemToElement(existing);
+      addToInventory("mine", el);
+      placeOnTable(el, (a.x + b.x) / 2, (a.y + b.y) / 2);
+      removePlaced(a); removePlaced(b);
+      setStatus(`discovered ${el.name} (from community)`);
+      renderInventory();
+      return;
+    }
+    const name = await pickElementName(a.name, b.name);
+    const slug = slugify(name) || `${a.slug}-${b.slug}`;
+    const blob = await generateElementImage(name, a.name, b.name);
+    const uploaded = await uploadElement(blob, slug, name, a.hash, b.hash, recipeTag(a.slug, b.slug));
+    const el = { slug, name, url: uploaded.url, hash: uploaded.id, parent: uploaded.parent };
+    addToInventory("mine", el);
+    placeOnTable(el, (a.x + b.x) / 2, (a.y + b.y) / 2);
+    removePlaced(a); removePlaced(b);
+    setStatus(`✨ discovered ${name}`);
+    renderInventory();
+  } catch (err) {
+    console.error(err);
+    setStatus(err.message || "craft failed", true);
+  }
+}
+
+function addToInventory(tab, el) {
+  state.inventoryByTab[tab].set(el.slug, el);
+}
+
+// ── Init ────────────────────────────────────────────────────────────────────
+
+(async function init() {
+  ensureSeeds("mine");
+  ensureSeeds("community");
+  renderInventory();
+  if (state.apiKey) {
+    setStatus("loading your inventory...");
+    const items = await fetchMyInventory();
+    for (const it of items) {
+      const el = itemToElement(it);
+      state.inventoryByTab.mine.set(el.slug, el);
+    }
+    setStatus(`${items.length} of your discoveries loaded`);
+    renderInventory();
+  }
+})();
+</script>
+</body>
+</html>

--- a/apps/pollicraft/index.html
+++ b/apps/pollicraft/index.html
@@ -110,6 +110,7 @@ const MEDIA_BASE = "https://media.pollinations.ai";
 const ENTER_BASE = "https://enter.pollinations.ai";
 const APP_KEY = "pk_pollicraft";  // replace with a real publishable key once minted
 const APP_ID = "pollicraft";
+const APP_TAG = `app:${APP_ID}`;
 const KEY_STORAGE = "pollicraft:apiKey";
 
 const SEEDS = [
@@ -194,7 +195,7 @@ async function generateElementImage(name, leftName, rightName) {
   const url = `${GEN_BASE}/image/${encodeURIComponent(prompt)}?model=flux&width=512&height=512&nologo=true`;
   const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) throw new Error(`image gen failed: ${res.status}`);
-  return res.blob();
+  return { blob: await res.blob(), prompt };
 }
 
 // Ask a tiny LLM to name the combination.
@@ -225,13 +226,18 @@ function slugify(name) {
 
 // ── Media catalog integration ───────────────────────────────────────────────
 
-async function uploadElement(blob, slug, name, leftHash, rightHash, recipeTag) {
+async function uploadElement(blob, slug, name, leftHash, rightHash, recipeTag, prompt) {
   const form = new FormData();
   form.append("file", new File([blob], `${slug}.png`, { type: blob.type || "image/png" }));
-  // Pick one parent hash for the lineage edge — by convention the alphabetically
-  // first ingredient. The recipe tag below records both for community lookup.
-  const parent = [leftHash, rightHash].filter(Boolean).sort()[0];
-  if (parent) form.append("parent", parent);
+  for (const parent of [leftHash, rightHash].filter(Boolean)) {
+    form.append("parent", parent);
+  }
+  form.append("visibility", "public");
+  form.append("source", "generation");
+  form.append("relationship", "combine");
+  form.append("prompt", prompt);
+  form.append("model", "flux");
+  form.append("tag", APP_TAG);
   form.append("tag", `element:${slug}`);
   form.append("tag", recipeTag);
   form.append("tag", `name:${slugify(name)}`);
@@ -249,44 +255,80 @@ function recipeTag(a, b) {
   return `recipe:${[a, b].sort().join("+")}`;
 }
 
+function hasRegisteredAppKey() {
+  return APP_KEY && APP_KEY !== "pk_pollicraft";
+}
+
+function itemTags(item) {
+  return Array.isArray(item.tags) ? item.tags : Array.isArray(item.userTags) ? item.userTags : [];
+}
+
+function isPollicraftItem(item) {
+  return item.appId === APP_ID || item.app === APP_ID || itemTags(item).includes(APP_TAG);
+}
+
+function appScopedQuery(limit) {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (hasRegisteredAppKey()) {
+    params.set("app_key", APP_KEY);
+  } else {
+    params.set("app", APP_ID);
+  }
+  return params;
+}
+
+function taggedUrl(tag, params) {
+  return `${MEDIA_BASE}/tags/${encodeURIComponent(tag)}?${params}`;
+}
+
 // Look up an existing community discovery for a given recipe.
 async function lookupRecipe(a, b) {
   const tag = recipeTag(a, b);
-  // tags/v1/<tag>/... is read-public; we hit the per-app catalog filtered
-  // client-side because there is no dedicated tag-read endpoint yet.
-  const res = await fetch(`${MEDIA_BASE}/apps/${APP_ID}/media?limit=200`);
-  if (!res.ok) return null;
-  const data = await res.json();
+  const res = await fetch(taggedUrl(tag, appScopedQuery(20)));
+  if (!res.ok && hasRegisteredAppKey()) return null;
+  const data = res.ok ? await res.json() : { items: [] };
   for (const item of data.items || []) {
-    if (Array.isArray(item.userTags) && item.userTags.includes(tag)) {
-      return item;
-    }
+    if (isPollicraftItem(item)) return item;
+  }
+  if (hasRegisteredAppKey()) return null;
+
+  const fallback = await fetch(taggedUrl(tag, new URLSearchParams({ limit: "20" })));
+  if (!fallback.ok) return null;
+  const fallbackData = await fallback.json();
+  for (const item of fallbackData.items || []) {
+    if (isPollicraftItem(item)) return item;
   }
   return null;
 }
 
 async function fetchMyInventory() {
   if (!state.apiKey) return [];
-  const res = await fetch(`${MEDIA_BASE}/me/media?limit=100`, { headers: authHeaders() });
+  const params = hasRegisteredAppKey()
+    ? new URLSearchParams({ app_key: APP_KEY, limit: "100" })
+    : new URLSearchParams({ limit: "100" });
+  const res = await fetch(`${MEDIA_BASE}/me/media?${params}`, { headers: authHeaders() });
   if (!res.ok) return [];
   const data = await res.json();
-  return (data.items || []).filter((it) => it.app === APP_ID);
+  return (data.items || []).filter(isPollicraftItem);
 }
 
 async function fetchCommunityInventory() {
-  const res = await fetch(`${MEDIA_BASE}/apps/${APP_ID}/media?limit=100`);
+  const url = hasRegisteredAppKey()
+    ? `${MEDIA_BASE}/gallery?${new URLSearchParams({ app_key: APP_KEY, limit: "100" })}`
+    : taggedUrl(APP_TAG, new URLSearchParams({ limit: "100" }));
+  const res = await fetch(url);
   if (!res.ok) return [];
   const data = await res.json();
-  return data.items || [];
+  return (data.items || []).filter(isPollicraftItem);
 }
 
 function itemToElement(item) {
-  const tags = Array.isArray(item.userTags) ? item.userTags : [];
+  const tags = itemTags(item);
   const elementTag = tags.find((t) => t.startsWith("element:"));
   const nameTag = tags.find((t) => t.startsWith("name:"));
   const slug = elementTag ? elementTag.slice("element:".length) : item.hash;
   const name = nameTag ? nameTag.slice("name:".length).replace(/-/g, " ") : slug;
-  return { slug, name, url: item.url, hash: item.hash, parent: item.parent };
+  return { slug, name, url: item.url, hash: item.hash, parent: item.remixOf || item.parent };
 }
 
 // ── Inventory rendering ─────────────────────────────────────────────────────
@@ -475,8 +517,8 @@ async function craftFromPlaced(a, b) {
     }
     const name = await pickElementName(a.name, b.name);
     const slug = slugify(name) || `${a.slug}-${b.slug}`;
-    const blob = await generateElementImage(name, a.name, b.name);
-    const uploaded = await uploadElement(blob, slug, name, a.hash, b.hash, recipeTag(a.slug, b.slug));
+    const generated = await generateElementImage(name, a.name, b.name);
+    const uploaded = await uploadElement(generated.blob, slug, name, a.hash, b.hash, recipeTag(a.slug, b.slug), generated.prompt);
     const el = { slug, name, url: uploaded.url, hash: uploaded.id, parent: uploaded.parent };
     addToInventory("mine", el);
     placeOnTable(el, (a.x + b.x) / 2, (a.y + b.y) / 2);

--- a/apps/product-packaging-designer/src/App.tsx
+++ b/apps/product-packaging-designer/src/App.tsx
@@ -79,7 +79,7 @@ const packagingTypes: PackagingType[] = [
     { id: "can", label: "Can", icon: Package, prompt: "can packaging" },
 ];
 const POLLINATIONS_API = "https://gen.pollinations.ai/image";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const MAX_DISPLAY_SIZE = 10 * 1024 * 1024;
@@ -236,7 +236,57 @@ function App() {
             setFile(null);
         }
     };
-    const uploadToPollinationsMedia = async (file: File): Promise<string> => {
+    const uploadMediaBlob = async (
+        blob: Blob,
+        filename: string,
+        fields: Record<string, string> = {},
+    ): Promise<string> => {
+        if (!apiKey) {
+            throw new Error("No API key available for media upload");
+        }
+
+        const formData = new FormData();
+        formData.append("file", blob, filename);
+        for (const [key, value] of Object.entries(fields)) {
+            if (value) formData.append(key, value);
+        }
+
+        const response = await fetch(POLLINATIONS_MEDIA_API, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+            },
+            body: formData,
+            signal: AbortSignal.timeout(UPLOAD_TIMEOUT),
+        });
+
+        if (!response.ok) {
+            let errorMessage = "Upload failed";
+            try {
+                const errorData = await response.json();
+                errorMessage =
+                    errorData.error?.message ||
+                    `HTTP ${response.status}: ${response.statusText}`;
+            } catch {
+                errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+            }
+            throw new Error(errorMessage);
+        }
+
+        const data = await response.json();
+        if (!data.url && !data.secure_url && !data.media_url) {
+            throw new Error(
+                "Invalid response from Pollinations media service - no URL received",
+            );
+        }
+
+        return data.url || data.secure_url || data.media_url;
+    };
+
+    const uploadToPollinationsMedia = async (
+        file: File,
+        fields: Record<string, string> = {},
+    ): Promise<string> => {
         const validation = validateFile(file, MAX_FILE_SIZE);
         if (!validation.isValid) {
             throw new Error(validation.error || "File validation failed");
@@ -246,41 +296,8 @@ function App() {
             throw new Error("No API key available for media upload");
         }
 
-        const formData = new FormData();
-        formData.append("file", file);
-
         try {
-            const response = await fetch(POLLINATIONS_MEDIA_API, {
-                method: "POST",
-                headers: {
-                    "Authorization": `Bearer ${apiKey}`,
-                },
-                body: formData,
-                signal: AbortSignal.timeout(UPLOAD_TIMEOUT),
-            });
-
-            if (!response.ok) {
-                let errorMessage = "Upload failed";
-                try {
-                    const errorData = await response.json();
-                    errorMessage =
-                        errorData.error?.message ||
-                        `HTTP ${response.status}: ${response.statusText}`;
-                } catch {
-                    errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-                }
-                throw new Error(errorMessage);
-            }
-
-            const data = await response.json();
-            if (!data.url && !data.secure_url && !data.media_url) {
-                throw new Error(
-                    "Invalid response from Pollinations media service - no URL received",
-                );
-            }
-
-            const mediaUrl = data.url || data.secure_url || data.media_url;
-            return mediaUrl;
+            return await uploadMediaBlob(file, file.name, fields);
         } catch (error) {
             console.error("Pollinations media upload failed:", error);
 
@@ -335,7 +352,11 @@ function App() {
             let uploadedUrl: string = "";
 
             if (file) {
-                uploadedUrl = await uploadToPollinationsMedia(file);
+                uploadedUrl = await uploadToPollinationsMedia(file, {
+                    visibility: "private",
+                    source: "upload",
+                    prompt: brandName.trim() || "Packaging source image",
+                });
             } else {
                 uploadedUrl = uploadedImage || "";
             }
@@ -385,8 +406,17 @@ ${brandName.trim() ? ` Brand name: "${brandName}".` : ""}
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setGeneratedImage(blobUrl);
+            const mediaUrl = await uploadMediaBlob(
+                blob,
+                `packaging-mockup-${Date.now()}.png`,
+                {
+                    visibility: "private",
+                    source: "generation",
+                    prompt,
+                    model: "nanobanana",
+                },
+            );
+            setGeneratedImage(mediaUrl);
             setImageLoaded(true);
         } catch (error) {
             console.error("Error in generatePackaging:", error);

--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -1,119 +1,193 @@
 // Pollinations API Service
 
-import {
-  PollinationsRequest,
-  ImageGenerationResponse
-} from './types';
+import type { ImageGenerationResponse, PollinationsRequest } from "./types";
 
-const POLLINATIONS_API_BASE = 'https://gen.pollinations.ai';
+const POLLINATIONS_API_BASE = "https://gen.pollinations.ai";
+const MEDIA_UPLOAD_URL = "https://media.pollinations.ai/upload";
 const DEFAULT_CONFIG = {
-  model: 'gptimage' as const,
-  enhance: true,
-  nologo: true,
+    model: "gptimage" as const,
+    enhance: true,
+    nologo: true,
 };
 
 export class PollinationsService {
-  private token: string | null = null;
+    private token: string | null = null;
 
-  setToken(token: string | null): void {
-    this.token = token;
-  }
-
-  async generateImageFromPrompt(
-    sectionPrompt: string,
-    projectPrompt?: string,
-    options?: Partial<PollinationsRequest>,
-    inputImageUrl?: string
-  ): Promise<ImageGenerationResponse> {
-    try {
-      const finalPrompt = projectPrompt
-        ? `${projectPrompt}\n\n${sectionPrompt}`
-        : sectionPrompt;
-
-      if (!options?.width || !options?.height) {
-        throw new Error('Width and height must be specified for image generation');
-      }
-
-      const payload: PollinationsRequest = {
-        prompt: finalPrompt,
-        model: options?.model || DEFAULT_CONFIG.model,
-        width: options.width,
-        height: options.height,
-        enhance: options?.enhance ?? DEFAULT_CONFIG.enhance,
-        nologo: options?.nologo ?? DEFAULT_CONFIG.nologo,
-        seed: options?.seed || Math.floor(Math.random() * 1000000),
-        ...(inputImageUrl && { imageUrl: inputImageUrl }),
-      };
-
-      // Build GET URL: https://gen.pollinations.ai/image/{prompt}
-      const encodedPrompt = encodeURIComponent(payload.prompt);
-      const url = new URL(`${POLLINATIONS_API_BASE}/image/${encodedPrompt}`);
-
-      url.searchParams.set('model', payload.model || DEFAULT_CONFIG.model);
-      url.searchParams.set('width', payload.width.toString());
-      url.searchParams.set('height', payload.height.toString());
-      url.searchParams.set('enhance', (payload.enhance ?? DEFAULT_CONFIG.enhance).toString());
-      url.searchParams.set('nologo', (payload.nologo ?? DEFAULT_CONFIG.nologo).toString());
-      url.searchParams.set('seed', payload.seed!.toString());
-
-      if (payload.imageUrl && this.isValidUrl(payload.imageUrl)) {
-        url.searchParams.set('imageUrl', payload.imageUrl);
-      }
-
-      const token = this.token || import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 || import.meta.env.VITE_POLLINATIONS_AI_TOKEN;
-
-      // Publishable keys (pk_) use query param, Secret keys (sk_) use Authorization header
-      const headers: HeadersInit = {};
-      if (token) {
-        if (token.startsWith('pk_')) {
-          url.searchParams.set('key', token);
-        } else {
-          headers['Authorization'] = `Bearer ${token}`;
-        }
-      }
-
-      const response = await fetch(url.toString(), {
-        method: 'GET',
-        headers,
-        signal: AbortSignal.timeout(300000), // 5 minute timeout
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error(`API error: ${response.status} ${response.statusText}`, errorText);
-
-        if (response.status === 500) {
-          throw new Error(`Backend overloaded (500) - Wait a few seconds and try again`);
-        } else if (response.status === 401) {
-          throw new Error(`Authentication failed (401) - Check your API key`);
-        } else if (response.status === 403) {
-          throw new Error(`Insufficient pollen balance (403) - Check https://enter.pollinations.ai`);
-        } else {
-          throw new Error(`Pollinations API error: ${response.status} ${response.statusText}`);
-        }
-      }
-
-      const result: ImageGenerationResponse = {
-        url: url.toString(),
-        provider: 'pollinations',
-        seed: payload.seed,
-        cached: false,
-      };
-
-      return result;
-
-    } catch (error) {
-      console.error('Pollinations generation failed:', error);
-      throw error;
+    setToken(token: string | null): void {
+        this.token = token;
     }
-  }
 
-  private isValidUrl(urlString: string): boolean {
-    try {
-      const url = new URL(urlString);
-      return url.protocol === 'http:' || url.protocol === 'https:';
-    } catch {
-      return false;
+    async generateImageFromPrompt(
+        sectionPrompt: string,
+        projectPrompt?: string,
+        options?: Partial<PollinationsRequest>,
+        inputImageUrl?: string,
+    ): Promise<ImageGenerationResponse> {
+        try {
+            const finalPrompt = projectPrompt
+                ? `${projectPrompt}\n\n${sectionPrompt}`
+                : sectionPrompt;
+
+            if (!options?.width || !options?.height) {
+                throw new Error(
+                    "Width and height must be specified for image generation",
+                );
+            }
+
+            const payload: PollinationsRequest = {
+                prompt: finalPrompt,
+                model: options?.model || DEFAULT_CONFIG.model,
+                width: options.width,
+                height: options.height,
+                enhance: options?.enhance ?? DEFAULT_CONFIG.enhance,
+                nologo: options?.nologo ?? DEFAULT_CONFIG.nologo,
+                seed: options?.seed || Math.floor(Math.random() * 1000000),
+                ...(inputImageUrl && { imageUrl: inputImageUrl }),
+            };
+
+            // Build GET URL: https://gen.pollinations.ai/image/{prompt}
+            const encodedPrompt = encodeURIComponent(payload.prompt);
+            const url = new URL(
+                `${POLLINATIONS_API_BASE}/image/${encodedPrompt}`,
+            );
+
+            url.searchParams.set(
+                "model",
+                payload.model || DEFAULT_CONFIG.model,
+            );
+            url.searchParams.set("width", payload.width.toString());
+            url.searchParams.set("height", payload.height.toString());
+            url.searchParams.set(
+                "enhance",
+                (payload.enhance ?? DEFAULT_CONFIG.enhance).toString(),
+            );
+            url.searchParams.set(
+                "nologo",
+                (payload.nologo ?? DEFAULT_CONFIG.nologo).toString(),
+            );
+            url.searchParams.set("seed", String(payload.seed));
+
+            if (payload.imageUrl && this.isValidUrl(payload.imageUrl)) {
+                url.searchParams.set("imageUrl", payload.imageUrl);
+            }
+
+            const token = this.getToken();
+
+            // Publishable keys (pk_) use query param, Secret keys (sk_) use Authorization header
+            const headers: HeadersInit = {};
+            if (token) {
+                if (token.startsWith("pk_")) {
+                    url.searchParams.set("key", token);
+                } else {
+                    headers["Authorization"] = `Bearer ${token}`;
+                }
+            }
+
+            const response = await fetch(url.toString(), {
+                method: "GET",
+                headers,
+                signal: AbortSignal.timeout(300000), // 5 minute timeout
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                console.error(
+                    `API error: ${response.status} ${response.statusText}`,
+                    errorText,
+                );
+
+                if (response.status === 500) {
+                    throw new Error(
+                        `Backend overloaded (500) - Wait a few seconds and try again`,
+                    );
+                } else if (response.status === 401) {
+                    throw new Error(
+                        `Authentication failed (401) - Check your API key`,
+                    );
+                } else if (response.status === 403) {
+                    throw new Error(
+                        `Insufficient pollen balance (403) - Check https://enter.pollinations.ai`,
+                    );
+                } else {
+                    throw new Error(
+                        `Pollinations API error: ${response.status} ${response.statusText}`,
+                    );
+                }
+            }
+
+            const result: ImageGenerationResponse = {
+                url:
+                    (await this.uploadGeneratedImageBlob(
+                        await response.blob(),
+                        payload.prompt,
+                        payload.model || DEFAULT_CONFIG.model,
+                    )) || url.toString(),
+                provider: "pollinations",
+                seed: payload.seed,
+                cached: false,
+            };
+
+            return result;
+        } catch (error) {
+            console.error("Pollinations generation failed:", error);
+            throw error;
+        }
     }
-  }
+
+    private isValidUrl(urlString: string): boolean {
+        try {
+            const url = new URL(urlString);
+            return url.protocol === "http:" || url.protocol === "https:";
+        } catch {
+            return false;
+        }
+    }
+
+    private getToken(): string | null {
+        return (
+            this.token ||
+            import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 ||
+            import.meta.env.VITE_POLLINATIONS_AI_TOKEN ||
+            null
+        );
+    }
+
+    private async uploadGeneratedImageBlob(
+        blob: Blob,
+        prompt: string,
+        model: string,
+    ): Promise<string | null> {
+        const token = this.getToken();
+        if (!token) return null;
+
+        try {
+            const form = new FormData();
+            form.append("file", blob, `slidepainter-${Date.now()}.png`);
+            form.append("visibility", "private");
+            form.append("source", "generation");
+            form.append("prompt", prompt);
+            form.append("model", model);
+            form.append("tag", "slidepainter");
+
+            const response = await fetch(MEDIA_UPLOAD_URL, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${token}` },
+                body: form,
+            });
+
+            if (!response.ok) return null;
+
+            const data = (await response.json()) as {
+                url?: string;
+                id?: string;
+            };
+            return (
+                data.url ||
+                (data.id ? `https://media.pollinations.ai/${data.id}` : null)
+            );
+        } catch (error) {
+            console.warn("Media catalog upload failed:", error);
+            return null;
+        }
+    }
 }

--- a/apps/virtual-makeup/src/App.jsx
+++ b/apps/virtual-makeup/src/App.jsx
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from "react";
 
 const APP_KEY = "pk_pollinations_virtual_makeup";
 const POLLINATIONS_AUTH_URL = "https://enter.pollinations.ai/authorize";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 const POLLINATIONS_IMAGE_API = "https://gen.pollinations.ai/image";
 
 const MAKEUP_STYLES = [
@@ -117,9 +117,12 @@ function App() {
         }
     };
 
-    const uploadToPollinations = async (file) => {
+    const uploadToPollinations = async (file, fields = {}) => {
         const formData = new FormData();
         formData.append("file", file);
+        for (const [key, value] of Object.entries(fields)) {
+            if (value) formData.append(key, String(value));
+        }
 
         const response = await fetch(POLLINATIONS_MEDIA_API, {
             method: "POST",
@@ -153,7 +156,11 @@ function App() {
 
             const encodedPrompt = encodeURIComponent(prompt);
 
-            const pollinationsUrl = await uploadToPollinations(uploadedFile);
+            const pollinationsUrl = await uploadToPollinations(uploadedFile, {
+                visibility: "private",
+                source: "upload",
+                prompt: "Virtual Makeup source image",
+            });
 
             const encodedImageURL = encodeURIComponent(pollinationsUrl);
 
@@ -172,8 +179,13 @@ function App() {
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setMakeupImage(blobUrl);
+            const mediaUrl = await uploadToPollinations(blob, {
+                visibility: "private",
+                source: "generation",
+                prompt,
+                model: "nanobanana",
+            });
+            setMakeupImage(mediaUrl);
             setImageLoaded(true);
             setIsLoading(false);
         } catch (error) {

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -1,0 +1,1609 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Remix | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --line: #110518;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--line);
+    --raise: 2px 2px 0 var(--line);
+    --stage-max: calc(100vh - 210px);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  button, input, select { font: inherit; color: inherit; }
+  button { touch-action: manipulation; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .btn, .select, .frame, .overlay-panel, .pin, .pill {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+    font-weight: 700;
+  }
+  .btn {
+    padding: 0 12px;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--line); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; max-width: min(100%, 20rem); }
+  .branch-strip {
+    display: none;
+    gap: 10px;
+    overflow-x: auto;
+    padding: 2px 2px 8px;
+  }
+  .branch-strip.visible { display: flex; }
+  .branch-card {
+    flex: 0 0 96px;
+    padding: 0;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    cursor: pointer;
+  }
+  .branch-card img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
+  }
+  .branch-card span {
+    display: block;
+    padding: 5px;
+    font-size: 0.65rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mode-toggle, .swatches {
+    display: inline-flex;
+    align-items: center;
+  }
+  .mode-toggle {
+    gap: 0;
+  }
+  .mode-toggle button {
+    width: 38px;
+    height: 38px;
+    border: var(--border);
+    background: var(--surface);
+    font: inherit;
+    font-size: 1.05rem;
+    cursor: pointer;
+  }
+  .mode-toggle button + button {
+    margin-left: -3px;
+  }
+  .mode-toggle button.active {
+    background: var(--accent);
+    z-index: 1;
+  }
+  .mode-toggle button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+  .history { margin-left: auto; }
+
+  .swatches {
+    gap: 5px;
+  }
+  .swatch {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: var(--border);
+    border-radius: 0;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    cursor: pointer;
+  }
+  .swatch.active { outline-color: var(--accent); }
+  .swatch[data-color="white"] { background: #fff; }
+  .swatch[data-color="black"] { background: #000; }
+  .swatch[data-color="red"] { background: red; }
+
+  .frame {
+    position: relative;
+    min-height: 280px;
+    overflow: visible;
+    display: grid;
+    place-items: center;
+  }
+  .frame.drop { outline: 4px dashed var(--accent); outline-offset: -10px; }
+  .stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    touch-action: none;
+  }
+  .stage canvas {
+    display: block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    width: auto;
+    height: auto;
+  }
+  #markCanvas, #pinLayer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  #pinLayer { z-index: 4; pointer-events: none; overflow: visible; }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(243, 235, 222, 0.88);
+    backdrop-filter: blur(2px);
+  }
+  .frame.locked .overlay { display: flex; }
+  .overlay-panel {
+    width: min(22rem, calc(100% - 32px));
+    padding: 18px;
+    text-align: center;
+  }
+  .overlay-panel p { margin: 0 0 12px; font-size: 0.9rem; }
+
+  .pin {
+    position: absolute;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    max-width: min(16rem, 48vw);
+    width: max-content;
+    padding: 5px 9px;
+    transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    overflow-wrap: break-word;
+  }
+  .pin.processing { background: var(--accent); }
+  .pin.history { background: var(--paper); opacity: 0.85; }
+  .pin.flip {
+    flex-direction: row-reverse;
+    transform: translate(calc(-100% + 0.55rem + 0.275rem + 1.5px), -50%);
+  }
+  .pin .dot {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    background: var(--line);
+    border: 1.5px solid var(--line);
+  }
+  .pin span:last-child { min-width: 0; }
+
+  .pill {
+    position: fixed;
+    z-index: 20;
+    display: none;
+    align-items: center;
+    gap: 9px;
+    max-width: min(18rem, calc(100vw - 24px));
+    padding: 8px 12px 8px 8px;
+    transform: translate(18px, -50%);
+    font-size: 0.9rem;
+    font-weight: 700;
+    pointer-events: none;
+    overflow-wrap: anywhere;
+  }
+  .pill.visible { display: inline-flex; }
+  .pill .mic {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: var(--accent);
+    border: var(--border);
+  }
+  .pill .bar {
+    width: 3px;
+    background: var(--line);
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  .pill .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  .pill .bar:nth-child(2) { height: 10px; animation-delay: 0.15s; }
+  .pill .bar:nth-child(3) { height: 6px; animation-delay: 0.3s; }
+  .pill .placeholder { opacity: 0.55; font-style: italic; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+
+  @media (max-width: 720px) {
+    .app { --stage-max: calc(100vh - 260px); width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .topbar { gap: 6px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .history { margin-left: 0; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .frame { min-height: 240px; }
+    .pin { max-width: 62vw; }
+  }
+  .frame.locked .stage { filter: grayscale(0.35) opacity(0.55); }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / remix</h1>
+      <span class="tagline">draw. talk. release.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="tools">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="uploadBtn" class="btn" title="load an image from disk">load</button>
+      <button id="shuffleBtn" class="btn" title="next sample image">sample</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="image model">
+        <option value="nanobanana">nanobanana</option>
+      </select>
+      <div id="colorPicker" class="swatches" aria-label="marker color">
+        <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
+        <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
+        <button type="button" class="swatch" data-color="white" aria-label="white marker"></button>
+      </div>
+      <div id="inputMode" class="mode-toggle" aria-label="input mode">
+        <button type="button" data-mode="mic" aria-label="use microphone">🎙️</button>
+        <button type="button" data-mode="type" aria-label="type prompt">⌨️</button>
+      </div>
+      <button id="undoBtn" class="btn history" disabled title="undo">undo</button>
+      <button id="redoBtn" class="btn" disabled title="redo">redo</button>
+      <button id="downloadBtn" class="btn" title="download image with embedded history - drop it back onto the app to restore">save</button>
+      <button id="shareBtn" class="btn" title="upload PNG with embedded history and copy link">share</button>
+      <button id="remixesBtn" class="btn" title="show public remixes of this image">remixes</button>
+      <button id="walkthroughBtn" class="btn" title="open this remix history as a video walkthrough">walkthrough</button>
+    </section>
+    <section id="branchStrip" class="branch-strip" aria-label="public remixes"></section>
+
+    <section id="frame" class="frame">
+      <div id="stage" class="stage">
+        <canvas id="imageCanvas" width="1024" height="768"></canvas>
+        <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <div id="pinLayer"></div>
+      </div>
+      <div class="overlay">
+        <div class="overlay-panel">
+          <p>connect to pollinations to start editing</p>
+          <button id="connectOverlayBtn" class="btn accent">connect</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div id="cursorPill" class="pill" aria-hidden="true">
+    <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
+    <span id="pillText" class="placeholder">listening...</span>
+  </div>
+
+<script>
+const KEY_STORAGE = "voice-edit:user-key";
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const STARTERS = [
+  { name: "cell", url: "https://media.pollinations.ai/10efdd0c1cfc65fa" },
+  { name: "octopus", url: "https://media.pollinations.ai/73775b7374f9b864" },
+  { name: "grand prismatic", url: "https://media.pollinations.ai/98280006f6099cb0" },
+  { name: "cosmic cliffs", url: "https://media.pollinations.ai/d05180b3bf21c01c" },
+  { name: "mars rover", url: "https://media.pollinations.ai/9a138c75c377d84a" },
+  { name: "relativity", url: "https://media.pollinations.ai/e7fc55d8a304edb3" },
+  { name: "da vinci", url: "https://media.pollinations.ai/31f553055c73b482" },
+  { name: "tomaselli", url: "https://media.pollinations.ai/9f450191ad9b8253" },
+  { name: "mushroom", url: "https://media.pollinations.ai/ad65acf0fd23ff85" },
+  { name: "surreal room", url: "https://media.pollinations.ai/fbc6c13d37c55f0b" },
+];
+const STARTER = STARTERS[0].url;
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const STT_MODEL = "scribe";
+const STT_LANG = (navigator.language || "en").slice(0, 2);
+const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+  .find((m) => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+const CAN_RECORD = Boolean(window.MediaRecorder && navigator.mediaDevices?.getUserMedia);
+const DRAG_THRESHOLD = 0.03;
+const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+
+const $ = (id) => document.getElementById(id);
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const pairs = (items) => items.slice(1).map((item, i) => [items[i], item]);
+const distance = (a, b) => Math.hypot(b.x - a.x, b.y - a.y);
+const minCanvasSide = () => Math.min(els.markCanvas.width, els.markCanvas.height);
+
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  frame: "frame",
+  imageCanvas: "imageCanvas",
+  markCanvas: "markCanvas",
+  pinLayer: "pinLayer",
+  connect: "connectBtn",
+  connectOverlay: "connectOverlayBtn",
+  upload: "uploadBtn",
+  shuffle: "shuffleBtn",
+  file: "fileInput",
+  model: "modelSel",
+  inputMode: "inputMode",
+  undo: "undoBtn",
+  redo: "redoBtn",
+  download: "downloadBtn",
+  share: "shareBtn",
+  remixes: "remixesBtn",
+  walkthrough: "walkthroughBtn",
+  branches: "branchStrip",
+  colorPicker: "colorPicker",
+  pill: "cursorPill",
+  pillText: "pillText",
+}).map(([key, id]) => [key, $(id)]));
+const imageCtx = els.imageCanvas.getContext("2d");
+const markCtx = els.markCanvas.getContext("2d");
+
+const app = {
+  image: null,
+  imageURL: "",
+  stateURL: "",
+  history: [],
+  historyIndex: -1,
+  micStream: null,
+  active: null,
+  busy: false,
+  queue: [],
+  currentJob: null,
+  markerColor: "red",
+  inputMode: CAN_RECORD ? "mic" : "type",
+  micAvailable: CAN_RECORD,
+  accountUser: "",
+  accountBalance: null,
+  branchItems: [],
+  branchesOpen: false,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = (extra = {}) => ({ Authorization: `Bearer ${key()}`, ...extra });
+
+function render() {
+  const locked = app.busy || Boolean(app.active);
+  els.undo.disabled = !mediaHistory.canUndo() || locked;
+  els.redo.disabled = !mediaHistory.canRedo() || locked;
+  [els.upload, els.shuffle, els.model, els.share, els.remixes, els.walkthrough].forEach((el) => { el.disabled = locked; });
+  renderInputMode(locked);
+  renderPins();
+  renderBranches();
+}
+
+function renderInputMode(locked = false) {
+  for (const button of els.inputMode.querySelectorAll("button")) {
+    const mode = button.dataset.mode;
+    button.classList.toggle("active", app.inputMode === mode);
+    button.disabled = locked || (mode === "mic" && !app.micAvailable);
+  }
+}
+
+function setInputMode(mode) {
+  if (mode === "mic" && !app.micAvailable) return;
+  app.inputMode = mode;
+  render();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function setMarkerColor(color) {
+  app.markerColor = color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button.dataset.color === color);
+  }
+}
+
+function renderPins() {
+  const jobs = [app.currentJob, ...app.queue].filter(Boolean);
+  const items = jobs.length
+    ? jobs.map((job) => ({
+      cls: job === app.currentJob ? "processing" : "queued",
+      text: job.text,
+      xPct: job.xPct,
+      yPct: job.yPct,
+    }))
+    : pinForCurrentFrame();
+  const layerBox = els.pinLayer.getBoundingClientRect();
+  els.pinLayer.replaceChildren(...items.map((item) => {
+    const pin = document.createElement("div");
+    pin.className = `pin ${item.cls}`;
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    const text = document.createElement("span");
+    text.textContent = item.text;
+    pin.append(dot, text);
+    pin.style.left = `${item.xPct}%`;
+    pin.style.top = `${item.yPct}%`;
+    const anchorX = layerBox.left + (layerBox.width * item.xPct / 100);
+    const rightSpace = window.innerWidth - anchorX - 16;
+    const leftSpace = anchorX - 16;
+    const flip = rightSpace < 140 && leftSpace > rightSpace;
+    pin.classList.toggle("flip", flip);
+    pin.style.maxWidth = `${clamp(flip ? leftSpace : rightSpace, 40, 256)}px`;
+    return pin;
+  }));
+}
+
+function renderBranches() {
+  els.remixes.textContent = app.branchItems.length ? `remixes ${app.branchItems.length}` : "remixes";
+  els.branches.classList.toggle("visible", app.branchesOpen);
+  if (!app.branchesOpen) return;
+  if (!app.branchItems.length) {
+    const empty = document.createElement("span");
+    empty.className = "tagline";
+    empty.textContent = "no public remixes yet";
+    els.branches.replaceChildren(empty);
+    return;
+  }
+  els.branches.replaceChildren(...app.branchItems.map((item) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "branch-card";
+    button.title = item.prompt || "open remix";
+    const img = document.createElement("img");
+    img.src = item.url;
+    img.alt = item.prompt || "public remix";
+    img.loading = "lazy";
+    const label = document.createElement("span");
+    label.textContent = item.prompt || "remix";
+    button.append(img, label);
+    button.addEventListener("click", () => openStartURL(item.url).catch((err) => showError(err.message)));
+    return button;
+  }));
+}
+
+function pinForCurrentFrame() {
+  const frame = app.history[app.historyIndex];
+  if (frame?.kind !== "prep" || frame.xPct == null || frame.yPct == null) return [];
+  return [{
+    cls: "history",
+    text: frame.promptText || "",
+    xPct: frame.xPct,
+    yPct: frame.yPct,
+  }];
+}
+
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) els.pill.style.left = `${x}px`;
+  if (y != null) els.pill.style.top = `${y}px`;
+  if (text !== undefined) {
+    els.pillText.textContent = text;
+    els.pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) els.pill.classList.toggle("visible", visible);
+}
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (apiKey) {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    history.replaceState(null, "", location.pathname + location.search);
+  } else if (params.get("error")) {
+    showError(`Authorization failed: ${params.get("error")}`);
+  }
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  els.frame.classList.toggle("locked", !connected);
+  if (!connected) {
+    app.accountUser = "";
+    app.accountBalance = null;
+    renderAccount();
+    setStatus("not connected");
+    return;
+  }
+  renderAccount();
+  warmMic();
+  loadUser();
+  loadBalance();
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname + location.search,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  stopMic();
+  refreshConnectionUI();
+}
+
+async function loadUser() {
+  try {
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const user = await res.json();
+    app.accountUser = user?.preferred_username || "";
+    renderAccount();
+  } catch {}
+}
+
+async function loadBalance() {
+  try {
+    const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const { balance } = await res.json();
+    app.accountBalance = Number(balance);
+    renderAccount();
+  } catch {}
+}
+
+async function warmMic() {
+  if (app.micStream || !app.micAvailable) return;
+  try {
+    app.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+  } catch (err) {
+    app.micAvailable = false;
+    app.inputMode = "type";
+    render();
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use type instead.`);
+  }
+}
+
+function stopMic() {
+  if (!app.micStream) return;
+  for (const track of app.micStream.getTracks()) track.stop();
+  app.micStream = null;
+}
+
+const mediaHistory = {
+  canUndo: () => app.historyIndex > 0,
+  canRedo: () => app.historyIndex >= 0 && app.historyIndex < app.history.length - 1,
+  add(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  addSilent(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  async go(index) {
+    const frame = app.history[index];
+    if (!frame) return;
+    await renderFrame(frame);
+    app.historyIndex = index;
+    syncStartToFrame(frame);
+    render();
+  },
+  async set(frame, { add = false } = {}) {
+    await renderFrame(frame);
+    if (add) mediaHistory.add(frame);
+    else {
+      syncStartToFrame(frame);
+      render();
+    }
+  },
+  async reset(frame, stateURL = frame.url) {
+    app.history = [frame];
+    app.historyIndex = 0;
+    app.stateURL = scrubURL(stateURL) || scrubURL(frame.url);
+    await renderFrame(frame);
+    syncStartToFrame(frame, { force: true });
+    render();
+  },
+};
+
+async function loadModels() {
+  try {
+    const res = await fetch(`${BASE}/image/models`);
+    if (!res.ok) return;
+    const models = await res.json();
+    const editModels = models
+      .filter((m) => m.input_modalities?.includes("image") && m.output_modalities?.includes("image"))
+      .sort((a, b) => {
+        const ra = RECOMMENDED_MODELS.has(a.name) ? 0 : 1;
+        const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
+        return ra - rb || a.name.localeCompare(b.name);
+      });
+    els.model.replaceChildren(...editModels.map((m) => {
+      const tags = [];
+      if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
+      if (m.paid_only) tags.push("paid");
+      return new Option(tags.length ? `${m.name} (${tags.join(", ")})` : m.name, m.name);
+    }));
+    if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+  } catch {}
+}
+
+async function renderFrame(frame) {
+  clearError();
+  await drawImage(frame.url);
+  clearMarks();
+  setStatus("ready");
+}
+
+async function drawImage(src) {
+  setStatus("loading image...");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = () => reject(new Error("could not load image"));
+    img.src = src;
+  });
+  app.image = img;
+  app.imageURL = src;
+  resizeCanvases(img.naturalWidth, img.naturalHeight);
+  imageCtx.drawImage(img, 0, 0);
+}
+
+function resizeCanvases(width, height) {
+  for (const canvas of [els.imageCanvas, els.markCanvas]) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function clearMarks() {
+  markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function pointerPoint(event) {
+  const rect = els.markCanvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
+  const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
+  return {
+    x: clamp(Math.round(x), 0, els.markCanvas.width),
+    y: clamp(Math.round(y), 0, els.markCanvas.height),
+  };
+}
+
+function strokeWidth() {
+  return Math.max(6, Math.round(minCanvasSide() * 0.015));
+}
+
+function drawSegment(from, to) {
+  markCtx.save();
+  markCtx.strokeStyle = app.markerColor;
+  markCtx.lineWidth = strokeWidth();
+  markCtx.lineCap = "round";
+  markCtx.lineJoin = "round";
+  markCtx.beginPath();
+  markCtx.moveTo(from.x, from.y);
+  markCtx.lineTo(to.x, to.y);
+  markCtx.stroke();
+  markCtx.restore();
+}
+
+function pathLength(points) {
+  return pairs(points).reduce((total, [a, b]) => total + distance(a, b), 0);
+}
+
+function pathBounds(points) {
+  return points.reduce((bounds, point) => ({
+    minX: Math.min(bounds.minX, point.x),
+    maxX: Math.max(bounds.maxX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    maxY: Math.max(bounds.maxY, point.y),
+  }), { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity });
+}
+
+function markerFromGesture({ points }) {
+  const marked = pathLength(points) >= minCanvasSide() * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const bounds = marked ? pathBounds(points) : null;
+  return {
+    marked,
+    marker: marked ? els.markCanvas.toDataURL("image/png") : "",
+    pinPoint: marked ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 } : points[0],
+  };
+}
+
+async function composeSnapshot(marker = "") {
+  const out = document.createElement("canvas");
+  out.width = els.imageCanvas.width;
+  out.height = els.imageCanvas.height;
+  const outCtx = out.getContext("2d");
+  outCtx.drawImage(els.imageCanvas, 0, 0);
+  if (marker) {
+    const markerImage = await loadImageElement(marker);
+    outCtx.drawImage(markerImage, 0, 0, out.width, out.height);
+  }
+  return out.toDataURL("image/png");
+}
+
+function buildPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
+}
+
+function pinPct(point) {
+  return {
+    xPct: (point.x / els.markCanvas.width) * 100,
+    yPct: (point.y / els.markCanvas.height) * 100,
+  };
+}
+
+function loadImageElement(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load marker"));
+    img.src = src;
+  });
+}
+
+function enqueueJob({ text, marked = false, marker = "", pinPoint, color }) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  const pin = pinPct(pinPoint);
+  app.queue.push({
+    text,
+    marked,
+    marker,
+    color,
+    model: els.model.value,
+    xPct: pin.xPct,
+    yPct: pin.yPct,
+  });
+  render();
+  runQueue();
+}
+
+function beginRecording(clientX, clientY) {
+  clearError();
+  if (!app.micAvailable) return { error: "Voice input is not available in this browser. Use type instead." };
+  if (!app.micStream) {
+    warmMic();
+    return { error: "microphone not ready - click once, allow access, then try again" };
+  }
+  const capture = { chunks: [], recorder: null, error: "" };
+  try {
+    capture.recorder = new MediaRecorder(app.micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (event) => {
+      if (event.data?.size) capture.chunks.push(event.data);
+    };
+    capture.recorder.start();
+  } catch (err) {
+    capture.error = err?.message || "could not start recording";
+    return capture;
+  }
+  pill({ x: clientX, y: clientY, text: "listening...", placeholder: true, visible: true });
+  setStatus("listening...");
+  return capture;
+}
+
+async function stopAndTranscribe(capture) {
+  if (capture.error || !capture.recorder) return { text: "", error: capture.error };
+  setStatus("transcribing...");
+  pill({ text: "transcribing...", placeholder: true });
+  const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
+  capture.recorder.stop();
+  await stopped;
+  const type = capture.recorder.mimeType || "audio/webm";
+  const ext = type.includes("mp4") ? "mp4" : "webm";
+  const blob = new Blob(capture.chunks, { type });
+  if (blob.size < 1000) return { text: "", error: "no audio captured - hold and speak" };
+  const form = new FormData();
+  form.append("file", blob, `voice.${ext}`);
+  form.append("model", STT_MODEL);
+  form.append("language", STT_LANG);
+  form.append("response_format", "json");
+  try {
+    const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    });
+    if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
+    const json = await res.json();
+    return { text: (json.text || "").trim(), error: "" };
+  } catch (err) {
+    return { text: "", error: err?.message || "transcription failed" };
+  }
+}
+
+async function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  els.pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing...");
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (text) => {
+      if (done) return;
+      done = true;
+      input.replaceWith(els.pillText);
+      pill({ visible: false });
+      resolve(text.trim());
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") { event.preventDefault(); finish(input.value); }
+      if (event.key === "Escape") { event.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value));
+  });
+}
+
+async function uploadDataURL(dataURL, filename = "annot.png") {
+  const blob = await (await fetch(dataURL)).blob();
+  return uploadBlob(blob, filename);
+}
+
+async function uploadBlob(blob, filename, fields = {}) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  for (const [key, value] of Object.entries(fields)) {
+    if (value != null && value !== "") form.append(key, String(value));
+  }
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+function canvasBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("canvas toBlob failed"))), "image/png");
+  });
+}
+
+async function runEdit(imageURL, prompt, model) {
+  const res = await fetch(`${BASE}/v1/images/edits`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
+  const json = await res.json();
+  const item = json.data?.[0];
+  if (!item) throw new Error("no image in response");
+  if (item.url) return item.url;
+  if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
+  throw new Error("no url or b64_json in response");
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+async function runQueue() {
+  if (app.busy) return;
+  app.busy = true;
+  render();
+  try {
+    while (app.queue.length) {
+      const job = app.queue.shift();
+      const parentHash = mediaHashFromURL(app.stateURL || app.history[app.historyIndex]?.url || app.imageURL);
+      app.currentJob = job;
+      render();
+      setStatus(`editing... (${app.queue.length + 1} in queue)`);
+      try {
+        const snapshot = await composeSnapshot(job.marker);
+        const uploaded = await uploadDataURL(snapshot, "annot.png");
+        mediaHistory.addSilent({
+          kind: "prep",
+          url: uploaded,
+          promptText: job.text,
+          marked: job.marked,
+          color: job.color,
+          xPct: job.xPct,
+          yPct: job.yPct,
+        });
+        const prompt = buildPrompt(job.text, job.marked, job.color);
+        const result = await runEdit(uploaded, prompt, job.model);
+        await mediaHistory.set({ url: result }, { add: true });
+        setStatus("packaging share link...");
+        const packaged = await packageCurrentFrameWithHistory(parentHash ? {
+          remixOf: parentHash,
+          relationship: "edit",
+          visibility: "public",
+          source: "remix",
+          prompt: job.text,
+          model: job.model,
+        } : {});
+        const frame = app.history[app.historyIndex];
+        if (frame?.url === result) {
+          frame.url = packaged;
+          app.imageURL = packaged;
+          app.stateURL = packaged;
+          syncStartToCurrent({ force: true });
+          refreshBranches();
+          render();
+        }
+        await loadBalance();
+      } catch (err) {
+        showError(err.message);
+      } finally {
+        app.currentJob = null;
+        render();
+      }
+    }
+    setStatus("done");
+  } finally {
+    app.busy = false;
+    app.currentJob = null;
+    render();
+  }
+}
+
+function cancelGesture() {
+  if (app.active?.capture?.recorder?.state === "recording") {
+    try { app.active.capture.recorder.stop(); } catch {}
+  }
+  app.active = null;
+  clearMarks();
+  pill({ visible: false });
+  setStatus(app.busy ? "editing..." : "ready");
+  render();
+}
+
+els.markCanvas.addEventListener("pointerdown", async (event) => {
+  if (!app.image) { showError("Load an image first."); return; }
+  if (app.active) return;
+  event.preventDefault();
+  clearError();
+  clearMarks();
+  const start = pointerPoint(event);
+
+  if (app.inputMode === "type") {
+    app.active = { pointerId: event.pointerId, points: [start], typing: true, color: app.markerColor };
+    render();
+    try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+    return;
+  }
+
+  const capture = beginRecording(event.clientX, event.clientY);
+  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+});
+
+els.markCanvas.addEventListener("pointermove", (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  pill({ x: event.clientX, y: event.clientY });
+  const point = pointerPoint(event);
+  const prev = gesture.points[gesture.points.length - 1];
+  drawSegment(prev, point);
+  gesture.points.push(point);
+});
+
+els.markCanvas.addEventListener("pointerup", async (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  app.active = null;
+  if (gesture.typing) {
+    const annotation = markerFromGesture(gesture);
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    if (!text) {
+      clearMarks();
+      setStatus(app.busy ? "editing..." : "ready");
+      return;
+    }
+    try {
+      enqueueJob({ text, ...annotation, color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+      clearMarks();
+    }
+    return;
+  }
+  const annotation = markerFromGesture(gesture);
+  try {
+    const { text, error } = await stopAndTranscribe(gesture.capture);
+    pill({ visible: false });
+    if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    enqueueJob({ text, ...annotation, color: gesture.color });
+  } catch (err) {
+    showError(err.message);
+    clearMarks();
+  }
+});
+
+els.markCanvas.addEventListener("pointercancel", cancelGesture);
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape") return;
+  event.preventDefault();
+  cancelGesture();
+});
+
+els.connect.addEventListener("click", startConnect);
+els.connectOverlay.addEventListener("click", startConnect);
+els.upload.addEventListener("click", () => els.file.click());
+els.inputMode.addEventListener("click", (event) => {
+  const button = event.target.closest("button");
+  if (button) setInputMode(button.dataset.mode);
+});
+els.shuffle.addEventListener("click", () => {
+  const starter = nextStarter();
+  openStartURL(starter.url)
+    .then(() => setStatus(`loaded ${starter.name}`))
+    .catch((err) => showError(err.message));
+});
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image");
+    await openStartURL(mediaURL);
+    setStatus(`loaded ${file.name || "image"}`);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+
+els.colorPicker.addEventListener("click", (event) => {
+  const swatch = event.target.closest(".swatch");
+  if (!swatch) return;
+  setMarkerColor(swatch.dataset.color);
+});
+
+const setDrop = (drop) => (event) => {
+  event.preventDefault();
+  els.frame.classList.toggle("drop", drop);
+};
+["dragenter", "dragover"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(true));
+});
+["dragleave", "drop"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(false));
+});
+els.frame.addEventListener("drop", (event) => {
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+  uploadBlob(file, file.name || "image")
+    .then((mediaURL) => openStartURL(mediaURL))
+    .then(() => setStatus(`loaded ${file.name || "image"}`))
+    .catch((err) => showError(err.message));
+});
+
+// PNG tEXt chunk helpers — pure JS, no deps.
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c;
+  }
+  return t;
+})();
+function crc32(bytes) {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function writeUint32(view, offset, value) {
+  view.setUint32(offset, value >>> 0, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0) {
+        const k = dec.decode(data.subarray(0, sep));
+        if (k === keyword) return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+function injectTextChunk(bytes, keyword, text) {
+  if (!isValidPng(bytes)) throw new Error("not a PNG");
+  // Find IEND so we can insert before it.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let iendOffset = -1;
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    if (type === "IEND") { iendOffset = pos; break; }
+    pos = pos + 8 + length + 4;
+  }
+  if (iendOffset < 0) throw new Error("PNG missing IEND");
+  // Build tEXt chunk: <length:4><type:4>"tEXt"<keyword>\0<text><crc:4>
+  const enc = new TextEncoder();
+  const kw = enc.encode(keyword);
+  const tx = enc.encode(text);
+  const data = new Uint8Array(kw.length + 1 + tx.length);
+  data.set(kw, 0);
+  data[kw.length] = 0;
+  data.set(tx, kw.length + 1);
+  const chunk = new Uint8Array(4 + 4 + data.length + 4);
+  const chunkView = new DataView(chunk.buffer);
+  writeUint32(chunkView, 0, data.length);
+  chunk.set([0x74, 0x45, 0x58, 0x74], 4); // "tEXt"
+  chunk.set(data, 8);
+  const crcInput = chunk.subarray(4, 8 + data.length);
+  writeUint32(chunkView, 8 + data.length, crc32(crcInput));
+  // Splice into PNG before IEND.
+  const out = new Uint8Array(bytes.length + chunk.length);
+  out.set(bytes.subarray(0, iendOffset), 0);
+  out.set(chunk, iendOffset);
+  out.set(bytes.subarray(iendOffset), iendOffset + chunk.length);
+  return out;
+}
+async function bytesFromBlob(blob) {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+async function readRemixState(blob) {
+  const bytes = await bytesFromBlob(blob);
+  const text = isValidPng(bytes) ? readTextChunk(bytes, HISTORY_KEYWORD) : null;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed?.history) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function mediaHashFromURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const parsed = new URL(url, location.href);
+    if (parsed.hostname !== "media.pollinations.ai") return "";
+    const hash = parsed.pathname.replace(/^\/+/, "").split("/")[0];
+    return /^[a-f0-9]{16}$/i.test(hash) ? hash.toLowerCase() : "";
+  } catch {
+    return "";
+  }
+}
+
+function cleanHistoryFrames(frames) {
+  return frames
+    .map((frame) => cleanHistoryFrame(frame))
+    .filter((frame) => frame.url);
+}
+
+function cleanHistoryFrame(frame) {
+  const source = typeof frame === "string" ? { url: frame } : (frame || {});
+  const clean = { url: scrubURL(source.url) };
+  if (!clean.url) return clean;
+  if (source.kind === "prep") clean.kind = "prep";
+  if (source.promptText) clean.promptText = String(source.promptText);
+  if (source.marked != null) clean.marked = Boolean(source.marked);
+  if (source.color) clean.color = String(source.color);
+  if (Number.isFinite(source.xPct)) clean.xPct = source.xPct;
+  if (Number.isFinite(source.yPct)) clean.yPct = source.yPct;
+  return clean;
+}
+
+async function restoreRemix(state, fallbackURL, sourceURL = "") {
+  const frames = cleanHistoryFrames(state.history);
+  if (!frames.length) {
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    return;
+  }
+  const source = scrubURL(sourceURL);
+  const sourceIndex = clamp(state.historyIndex ?? frames.length - 1, 0, frames.length - 1);
+  const requestedIndex = startIndexFromLocation();
+  let currentIndex = sourceIndex;
+  if (source) {
+    if (frames[sourceIndex]?.kind === "prep") {
+      frames.splice(sourceIndex + 1, 0, { url: source });
+      currentIndex = sourceIndex + 1;
+    } else {
+      frames[sourceIndex].url = source;
+    }
+  }
+  const index = requestedIndex == null || (currentIndex !== sourceIndex && requestedIndex === sourceIndex)
+    ? currentIndex
+    : requestedIndex;
+  app.history = frames;
+  app.historyIndex = clamp(index, 0, frames.length - 1);
+  app.stateURL = source || scrubURL(fallbackURL);
+  try {
+    await mediaHistory.go(app.historyIndex);
+    setStatus(`restored ${frames.length} frames`);
+  } catch (err) {
+    app.history = [];
+    app.historyIndex = -1;
+    app.stateURL = "";
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    showError(`History URLs unavailable; loaded image only. ${err.message}`);
+  }
+}
+
+function remixPayload() {
+  const history = cleanHistoryFrames(app.history);
+  const current = scrubURL(app.history[app.historyIndex]?.url);
+  const found = history.findIndex((frame) => frame.url === current);
+  return JSON.stringify({
+    v: 1,
+    app: "voice-edit-remix",
+    history,
+    historyIndex: found >= 0 ? found : history.length - 1,
+  });
+}
+
+async function remixPNGBlob() {
+  const bytes = await bytesFromBlob(await canvasBlob(els.imageCanvas));
+  const png = injectTextChunk(bytes, HISTORY_KEYWORD, remixPayload());
+  return new Blob([png], { type: "image/png" });
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function loadStartImage(url) {
+  try {
+    const res = await fetch(url, { mode: "cors" });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const blob = await res.blob();
+    const remix = await readRemixState(blob);
+    if (remix) {
+      await restoreRemix(remix, url, url);
+      refreshBranches();
+      return;
+    }
+  } catch {
+    // Fall through to URL loading; the browser may still be able to render it.
+  }
+  await mediaHistory.reset({ url }, url);
+  refreshBranches();
+}
+
+function refreshBranches(options) {
+  loadBranches(options).catch(() => {
+    app.branchItems = [];
+    renderBranches();
+  });
+}
+
+async function loadBranches({ show = false } = {}) {
+  const hash = mediaHashFromURL(app.stateURL || app.history[app.historyIndex]?.url || app.imageURL);
+  if (!hash) {
+    app.branchItems = [];
+    app.branchesOpen = false;
+    renderBranches();
+    return;
+  }
+  const res = await fetch(`https://media.pollinations.ai/${hash}/children?limit=12`);
+  if (!res.ok) return;
+  const data = await res.json();
+  app.branchItems = Array.isArray(data.items) ? data.items : [];
+  if (show) app.branchesOpen = true;
+  renderBranches();
+}
+
+function nextStarter() {
+  const current = scrubURL(app.stateURL || app.imageURL);
+  const index = STARTERS.findIndex((starter) => scrubURL(starter.url) === current);
+  return STARTERS[(index + 1) % STARTERS.length] || STARTERS[0];
+}
+
+function startLink(mediaURL, index = 0) {
+  const url = new URL(location.href);
+  url.searchParams.delete("start");
+  const params = new URLSearchParams({ start: mediaURL });
+  if (index > 0) params.set("index", String(index));
+  url.hash = params.toString();
+  return url;
+}
+
+function syncStartToFrame(frame, { force = false } = {}) {
+  if (app.busy && !force) return;
+  const url = app.stateURL || frame?.url || app.imageURL;
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return;
+  const index = app.stateURL && app.history.length > 1 ? app.historyIndex : 0;
+  window.history.replaceState(null, "", startLink(url, index));
+}
+
+function syncStartToCurrent(options = {}) {
+  syncStartToFrame(app.history[app.historyIndex] || { url: app.imageURL }, options);
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const params = new URLSearchParams(location.hash.slice(1));
+  const value = params.get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+async function loadFromLocation() {
+  const startURL = startURLFromLocation();
+  if (startURL) {
+    await loadStartImage(startURL);
+  } else {
+    await mediaHistory.reset({ url: STARTER }, STARTER);
+    refreshBranches();
+  }
+}
+
+async function followLocationStart() {
+  const startURL = startURLFromLocation();
+  const startIndex = startIndexFromLocation();
+  const currentURL = scrubURL(app.stateURL || app.history[app.historyIndex]?.url);
+  if (!startURL || (scrubURL(startURL) === currentURL && (startIndex == null || startIndex === app.historyIndex))) return;
+  if (app.busy || app.active) return;
+  await loadStartImage(startURL);
+}
+
+async function openStartURL(mediaURL) {
+  window.history.pushState(null, "", startLink(mediaURL));
+  await followLocationStart();
+}
+
+async function packageCurrentFrameWithHistory(fields = {}) {
+  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png", {
+    visibility: "public",
+    source: "remix",
+    tag: "voice-edit",
+    ...fields,
+  });
+}
+
+const goHistory = (delta, label) => () => {
+  const canGo = delta < 0 ? mediaHistory.canUndo() : mediaHistory.canRedo();
+  if (!canGo || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + delta).then(() => setStatus(label)).catch((err) => showError(err.message));
+};
+els.undo.addEventListener("click", goHistory(-1, "undone"));
+els.redo.addEventListener("click", goHistory(1, "redone"));
+els.download.addEventListener("click", async () => {
+  try {
+    downloadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`);
+    setStatus(`saved with ${cleanHistoryFrames(app.history).length} frames`);
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.share.addEventListener("click", async () => {
+  try {
+    const mediaURL = await uploadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`, {
+      visibility: "public",
+      source: "upload",
+      tag: "voice-edit",
+    });
+    const frame = app.history[app.historyIndex];
+    if (frame) {
+      frame.url = mediaURL;
+      app.imageURL = mediaURL;
+      app.stateURL = mediaURL;
+      syncStartToFrame(frame, { force: true });
+    }
+    const shareURL = startLink(mediaURL);
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(shareURL.href);
+      setStatus("share link copied");
+    } else {
+      window.prompt("share link", shareURL.href);
+      setStatus("share link ready");
+    }
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.remixes.addEventListener("click", async () => {
+  app.branchesOpen = !app.branchesOpen;
+  renderBranches();
+  if (!app.branchesOpen) return;
+  try {
+    await loadBranches({ show: true });
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.walkthrough.addEventListener("click", () => {
+  const url = app.stateURL || app.history[app.historyIndex]?.url || app.imageURL;
+  if (!url) return;
+  const params = new URLSearchParams({ start: url });
+  if (app.history.length > 1) params.set("index", String(app.historyIndex));
+  location.href = `walkthrough.html#${params}`;
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadModels();
+window.addEventListener("hashchange", () => followLocationStart().catch((err) => showError(err.message)));
+window.addEventListener("popstate", () => followLocationStart().catch((err) => showError(err.message)));
+loadFromLocation().catch((err) => showError(err.message));
+setMarkerColor(app.markerColor);
+</script>
+</body>
+</html>

--- a/apps/voice-edit/walkthrough.html
+++ b/apps/voice-edit/walkthrough.html
@@ -1,0 +1,1122 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Walkthrough | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--dark);
+    --raise: 2px 2px 0 var(--dark);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+  button, input, select { font: inherit; color: inherit; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .btn, .input, .select, .panel, .thumb, .clip {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+  }
+  .btn {
+    padding: 0 12px;
+    font-weight: 700;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--dark); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; }
+  .narrate {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+  }
+  .narrate input { margin: 0; }
+  .narrate-count { opacity: 0.7; font-variant-numeric: tabular-nums; }
+  .narrate input:disabled + .narrate-count,
+  .narrate input:disabled { opacity: 0.4; }
+  .prompt {
+    display: grid;
+    gap: 4px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .prompt textarea {
+    width: 100%;
+    min-height: 56px;
+    padding: 8px 10px;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    border-radius: 0;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    resize: vertical;
+  }
+  .prompt textarea:focus { outline: 2px solid var(--accent); outline-offset: 0; }
+  .prompt .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .prompt .row button {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .panel {
+    min-height: 320px;
+    padding: 12px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .panel img, .panel video {
+    display: block;
+    max-width: 100%;
+    max-height: calc(100vh - 290px);
+    background: #000;
+  }
+  .strip {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px 2px 6px;
+  }
+  .thumb, .clip {
+    flex: 0 0 auto;
+    width: 86px;
+    height: 64px;
+    padding: 0;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+  }
+  .thumb.active, .clip.active { outline: 3px solid var(--accent); outline-offset: 2px; }
+  .clip.pending { opacity: 0.55; cursor: wait; }
+  .clip.failed { opacity: 0.7; }
+  .clip-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--muted);
+    font-size: 1.4rem;
+    animation: clip-pulse 1.6s ease-in-out infinite;
+  }
+  .clip.failed .clip-placeholder {
+    animation: none;
+    color: #ff8888;
+    background: rgba(255, 80, 80, 0.18);
+  }
+  @keyframes clip-pulse {
+    0%, 100% { background: rgba(255, 255, 255, 0.05); }
+    50% { background: rgba(255, 255, 255, 0.15); }
+  }
+  .thumb img, .clip video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .thumb span, .clip span {
+    position: absolute;
+    left: 3px;
+    bottom: 2px;
+    background: var(--accent);
+    padding: 0 4px;
+    font-size: 0.65rem;
+    font-weight: 700;
+  }
+  .meta {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  @media (max-width: 720px) {
+    .app { width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .panel { min-height: 240px; }
+    .panel img, .panel video { max-height: calc(100vh - 340px); }
+  }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / walkthrough</h1>
+      <span class="tagline">history to video.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="walkthrough controls">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="loadBtn" class="btn" title="upload an image from disk">load</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="video model" disabled>
+        <option value="">loading models...</option>
+      </select>
+      <button id="makeBtn" class="btn accent">make</button>
+      <label class="narrate" title="insert a 2s card showing the marked-up image and prompt between video clips">
+        <input id="narrateToggle" type="checkbox"> narrate
+        <span id="narrateCount" class="narrate-count" aria-hidden="true"></span>
+      </label>
+      <button id="playAllBtn" class="btn" disabled title="play all clips in sequence">play all</button>
+      <button id="downloadAllBtn" class="btn" disabled title="download a single stitched .mp4 of all clips">download</button>
+    </section>
+
+    <label class="prompt">
+      <div class="row">
+        <span>video prompt</span>
+        <button type="button" id="promptReset" title="restore default prompt">reset</button>
+      </div>
+      <textarea id="promptInput" rows="2" spellcheck="false"></textarea>
+    </label>
+
+    <section id="viewer" class="panel"></section>
+    <div id="frameStrip" class="strip" aria-label="history frames"></div>
+    <div id="clipStrip" class="strip" aria-label="generated video clips"></div>
+    <div id="meta" class="meta"></div>
+  </main>
+
+<script type="module">
+import {ALL_FORMATS,BlobSource, BufferTarget,
+  CanvasSource, Conversion, canEncodeVideo, EncodedAudioPacketSource,
+  EncodedPacketSink, EncodedVideoPacketSource,
+  Input, Mp4OutputFormat,Output,
+} from "https://esm.sh/mediabunny@1.45.3";
+
+const KEY_STORAGE = "voice-edit:user-key";
+const PROMPT_STORAGE = "voice-edit:walkthrough-prompt";
+const NARRATE_STORAGE = "voice-edit:walkthrough-narrate";
+const NARRATE_DURATION_SEC = 3.5;
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const DEFAULT_PROMPT = "Smooth visual transition from the first image to the second image. Preserve the subject, composition, and style. No text, labels, captions, or subtitles.";
+
+const $ = (id) => document.getElementById(id);
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  connect: "connectBtn",
+  load: "loadBtn",
+  file: "fileInput",
+  model: "modelSel",
+  make: "makeBtn",
+  playAll: "playAllBtn",
+  downloadAll: "downloadAllBtn",
+  prompt: "promptInput",
+  promptReset: "promptReset",
+  narrate: "narrateToggle",
+  narrateCount: "narrateCount",
+  viewer: "viewer",
+  frameStrip: "frameStrip",
+  clipStrip: "clipStrip",
+  meta: "meta",
+}).map(([key, id]) => [key, $(id)]));
+
+const app = {
+  sourceURL: "",
+  history: [],
+  currentFrame: 0,
+  clips: [],
+  currentClip: -1,
+  busy: false,
+  modelsReady: false,
+  playAll: false,
+  playAllIndex: 0,
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = () => ({ Authorization: `Bearer ${key()}` });
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (!apiKey) return;
+  localStorage.setItem(KEY_STORAGE, apiKey);
+  params.delete("api_key");
+  history.replaceState(null, "", params.toString() ? `${location.pathname}#${params}` : location.pathname);
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname + location.hash,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  refreshConnectionUI();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  renderAccount();
+  if (connected) {
+    loadUser();
+    loadBalance();
+  }
+  render();
+}
+
+async function loadUser() {
+  const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const user = await res.json();
+  app.accountUser = user?.preferred_username || "";
+  renderAccount();
+}
+
+async function loadBalance() {
+  const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const { balance } = await res.json();
+  app.accountBalance = Number(balance);
+  renderAccount();
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const value = new URLSearchParams(location.hash.slice(1)).get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function frameURL(frame) {
+  return scrubURL(typeof frame === "string" ? frame : frame?.url);
+}
+
+function cleanHistoryFrames(frames) {
+  return frames.map((frame) => {
+    const url = frameURL(frame);
+    if (!url) return null;
+    if (typeof frame === "string") return { url };
+    return {
+      url,
+      kind: frame?.kind,
+      promptText: frame?.promptText,
+      marked: frame?.marked,
+      color: frame?.color,
+    };
+  }).filter(Boolean);
+}
+
+function setHash(start, index = 0) {
+  const params = new URLSearchParams({ start });
+  if (index > 0) params.set("index", String(index));
+  history.replaceState(null, "", `${location.pathname}#${params}`);
+}
+
+async function loadSource(url) {
+  clearError();
+  const source = scrubURL(url);
+  if (!source) throw new Error("Enter a public image URL");
+  setStatus("loading...");
+  const res = await fetch(source, { mode: "cors" });
+  if (!res.ok) throw new Error(`Image load failed: ${res.status} ${res.statusText}`);
+  const blob = await res.blob();
+  const state = await readRemixState(blob);
+  const rawFrames = state ? cleanHistoryFrames(state.history) : [{ url: source }];
+  if (!rawFrames.length) throw new Error("No history frames found");
+  const sourceIndex = state ? Math.max(0, Math.min(state.historyIndex ?? rawFrames.length - 1, rawFrames.length - 1)) : 0;
+  if (state && rawFrames[sourceIndex]?.kind !== "prep") {
+    rawFrames[sourceIndex].url = source;
+  }
+  // Attach each prep frame's narration data (annotated URL + prompt text) to the
+  // clean frame it produced — that's the very next non-prep entry in the raw list.
+  let pendingPrep = null;
+  const frames = [];
+  for (const frame of rawFrames) {
+    if (frame.kind === "prep") {
+      pendingPrep = frame;
+      continue;
+    }
+    if (pendingPrep) {
+      frame.narration = {
+        annotatedURL: pendingPrep.url,
+        promptText: pendingPrep.promptText || "",
+      };
+      pendingPrep = null;
+    }
+    frames.push(frame);
+  }
+  if (!frames.length) throw new Error("No clean frames found (all entries are annotated previews)");
+  const targetURL = rawFrames[sourceIndex]?.kind === "prep" ? source : rawFrames[sourceIndex]?.url;
+  const sourceIndexClean = Math.max(
+    0,
+    frames.findIndex((frame) => frame.url === targetURL),
+  );
+  const requestedIndex = startIndexFromLocation();
+  const requestedIndexClean = requestedIndex == null
+    ? null
+    : Math.max(0, Math.min(requestedIndex, frames.length - 1));
+  const index = requestedIndexClean == null || requestedIndexClean === sourceIndex
+    ? sourceIndexClean
+    : requestedIndexClean;
+  app.sourceURL = source;
+  app.history = frames;
+  app.currentFrame = Math.max(0, Math.min(index, frames.length - 1));
+  app.clips = [];
+  app.currentClip = -1;
+  setHash(source, app.currentFrame);
+  render();
+  setStatus(state ? `loaded ${frames.length} clean frames` : "loaded image");
+}
+
+async function uploadBlob(blob, filename) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+function render() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const locked = app.busy || app.history.length < 2 || !connected || !app.modelsReady;
+  els.make.disabled = locked;
+  els.load.disabled = app.busy || !connected;
+  els.model.disabled = app.busy || !app.modelsReady;
+  const hasClips = app.clips.length > 0 && !app.busy;
+  els.playAll.disabled = !hasClips;
+  els.downloadAll.disabled = !hasClips;
+  els.playAll.textContent = app.playAll ? "stop" : "play all";
+  const narratable = app.history.filter((f) => f?.narration).length;
+  els.narrate.disabled = narratable === 0 || app.busy;
+  els.narrateCount.textContent = narratable ? `(${narratable})` : "(none)";
+  renderViewer();
+  renderFrames();
+  renderClips();
+  els.meta.textContent = app.history.length > 1
+    ? `${app.history.length} frames -> ${app.history.length - 1} transitions${narratable ? ` · ${narratable} narration card${narratable === 1 ? "" : "s"}` : ""}`
+    : "load a remix image with history to make a walkthrough";
+}
+
+function renderViewer() {
+  if (app.playAll && app.clips.length) {
+    const video = document.createElement("video");
+    video.src = app.clips[app.playAllIndex].src;
+    video.controls = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    video.addEventListener("ended", () => {
+      if (!app.playAll) return;
+      app.playAllIndex = (app.playAllIndex + 1) % app.clips.length;
+      app.currentClip = app.playAllIndex;
+      render();
+    });
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const clip = app.clips[app.currentClip];
+  if (clip && clip.src) {
+    const video = document.createElement("video");
+    video.src = clip.src;
+    video.controls = true;
+    video.loop = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const frame = app.history[app.currentFrame];
+  if (!frame) {
+    els.viewer.textContent = "load an image";
+    return;
+  }
+  const img = document.createElement("img");
+  img.src = frame.url;
+  img.alt = "";
+  els.viewer.replaceChildren(img);
+}
+
+function renderFrames() {
+  els.frameStrip.replaceChildren(...app.history.map((frame, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `thumb${index === app.currentFrame && app.currentClip < 0 ? " active" : ""}`;
+    button.addEventListener("click", () => {
+      app.currentFrame = index;
+      app.currentClip = -1;
+      setHash(app.sourceURL, index);
+      render();
+    });
+    const img = document.createElement("img");
+    img.src = frame.url;
+    img.alt = "";
+    const label = document.createElement("span");
+    label.textContent = String(index + 1);
+    button.append(img, label);
+    return button;
+  }));
+}
+
+function renderClips() {
+  let videoCount = 0;
+  els.clipStrip.replaceChildren(...app.clips.map((clip, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    const isReady = !!clip.src;
+    const cls = [
+      "clip",
+      index === app.currentClip ? "active" : "",
+      clip.pending ? "pending" : "",
+      clip.failed ? "failed" : "",
+    ].filter(Boolean).join(" ");
+    button.className = cls;
+    if (isReady) {
+      button.addEventListener("click", () => {
+        app.currentClip = index;
+        render();
+      });
+    } else {
+      button.disabled = true;
+    }
+    const media = document.createElement(isReady ? "video" : "div");
+    if (isReady) {
+      media.src = clip.src;
+      media.muted = true;
+      media.playsInline = true;
+    } else {
+      media.className = "clip-placeholder";
+      media.textContent = clip.failed ? "×" : "…";
+    }
+    const label = document.createElement("span");
+    if (clip.kind === "narration") {
+      // narration card intros the next video, so label it with that video's number
+      label.textContent = `intro ${videoCount + 1}`;
+    } else {
+      videoCount += 1;
+      label.textContent = `${videoCount}->${videoCount + 1}`;
+    }
+    button.append(media, label);
+    return button;
+  }));
+}
+
+async function loadVideoModels() {
+  try {
+    const res = await fetch(`${BASE}/models`);
+    if (!res.ok) throw new Error(`models fetch failed: ${res.status}`);
+    const all = await res.json();
+    const supported = all.filter((m) =>
+      Array.isArray(m.video_capabilities) && m.video_capabilities.includes("end_frame"),
+    );
+    if (!supported.length) throw new Error("no models advertise end_frame");
+    const preferred = ["veo", "seedance-2.0", "wan-fast"];
+    supported.sort((a, b) => {
+      const ai = preferred.indexOf(a.name);
+      const bi = preferred.indexOf(b.name);
+      if (ai === -1 && bi === -1) return a.name.localeCompare(b.name);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+    els.model.replaceChildren(...supported.map((m) => {
+      const opt = document.createElement("option");
+      opt.value = m.name;
+      opt.textContent = `${m.name} start+end`;
+      opt.title = m.description || "";
+      return opt;
+    }));
+  } catch (err) {
+    els.model.replaceChildren(
+      Object.assign(document.createElement("option"), { value: "veo", textContent: "veo start+end" }),
+      Object.assign(document.createElement("option"), { value: "seedance-2.0", textContent: "seedance-2.0 start+end" }),
+      Object.assign(document.createElement("option"), { value: "wan-fast", textContent: "wan-fast start+end" }),
+    );
+    console.warn("video model discovery failed, using fallback list:", err);
+  } finally {
+    app.modelsReady = true;
+    render();
+  }
+}
+
+function currentPrompt() {
+  const text = (els.prompt.value || "").trim();
+  return text || DEFAULT_PROMPT;
+}
+
+function videoRequestURL(start, end, model) {
+  const url = new URL(`${BASE}/video/${encodeURIComponent(currentPrompt())}`);
+  url.searchParams.set("model", model);
+  url.searchParams.set("duration", "4");
+  url.searchParams.set("audio", "false");
+  url.searchParams.set("image", `${start}|${end}`);
+  return url;
+}
+
+async function makeWalkthrough() {
+  if (app.history.length < 2 || app.busy) return;
+  app.busy = true;
+  for (const clip of app.clips) if (clip.src) URL.revokeObjectURL(clip.src);
+  app.clips = [];
+  app.currentClip = -1;
+
+  const narrate = els.narrate.checked;
+  const transitions = app.history.length - 1;
+  // Pre-populate placeholders in display order: (intro?, video) per transition.
+  const slots = []; // parallel array mapping transitionIndex -> { videoSlot, narrationSlot? }
+  for (let i = 0; i < transitions; i++) {
+    const target = app.history[i + 1];
+    const slot = {};
+    if (narrate && target?.narration) {
+      app.clips.push({ kind: "narration", pending: true });
+      slot.narrationSlot = app.clips.length - 1;
+    }
+    app.clips.push({ kind: "video", pending: true });
+    slot.videoSlot = app.clips.length - 1;
+    slots.push(slot);
+  }
+  render();
+
+  let videosDone = 0;
+  let firstError = null;
+  const setProgress = () => setStatus(`videos ${videosDone}/${transitions} ready...`);
+  setProgress();
+
+  await Promise.all(slots.map(async (slot, i) => {
+    const request = videoRequestURL(app.history[i].url, app.history[i + 1].url, els.model.value);
+    try {
+      const res = await fetch(request, { headers: authHeaders() });
+      if (!res.ok) throw new Error(await friendlyError(res, `Video ${i + 1} failed`));
+      const blob = await res.blob();
+
+      // Fill the video slot
+      const videoEntry = { url: request.href, src: URL.createObjectURL(blob), blob, kind: "video" };
+      app.clips[slot.videoSlot] = videoEntry;
+      if (app.currentClip < 0) app.currentClip = slot.videoSlot;
+
+      // Render the narration card for this transition (needs the just-finished clip as codec ref)
+      if (slot.narrationSlot != null) {
+        try {
+          const cardBlob = await renderNarrationClip(app.history[i + 1].narration, blob);
+          app.clips[slot.narrationSlot] = { src: URL.createObjectURL(cardBlob), blob: cardBlob, kind: "narration" };
+        } catch (err) {
+          console.warn(`narration card ${i + 1} failed`, err);
+          showError(`narration card ${i + 1} skipped: ${err.message}`);
+          // Remove the failed placeholder by marking it dropped; we'll compact at the end.
+          app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+        }
+      }
+
+      videosDone++;
+      setProgress();
+      render();
+    } catch (err) {
+      firstError = firstError || err;
+      app.clips[slot.videoSlot] = { kind: "video", failed: true, error: err.message };
+      if (slot.narrationSlot != null) app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+      videosDone++;
+      setProgress();
+      render();
+    }
+  }));
+
+  // Compact: drop slots that were never filled (failed videos / dropped cards)
+  app.clips = app.clips.filter((c) => !c.dropped && !c.failed);
+  if (app.currentClip >= app.clips.length) app.currentClip = app.clips.length - 1;
+
+  loadBalance().catch(() => {});
+  if (firstError) showError(firstError.message);
+  setStatus(firstError ? `done with errors` : "done");
+  app.busy = false;
+  render();
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) return `${label}: authorization expired. Connect again.`;
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const dec = new TextDecoder("latin1");
+  let pos = 8;
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0 && dec.decode(data.subarray(0, sep)) === keyword) {
+        return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+async function readRemixState(blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const text = readTextChunk(bytes, HISTORY_KEYWORD);
+  if (!text) return null;
+  const state = JSON.parse(text);
+  return Array.isArray(state?.history) ? state : null;
+}
+
+els.connect.addEventListener("click", startConnect);
+els.load.addEventListener("click", () => els.file.click());
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image");
+    setHash(mediaURL);
+    await loadSource(mediaURL);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+els.make.addEventListener("click", () => {
+  makeWalkthrough().catch((err) => {
+    app.busy = false;
+    showError(err.message);
+    render();
+  });
+});
+els.playAll.addEventListener("click", () => {
+  if (!app.clips.length) return;
+  app.playAll = !app.playAll;
+  if (app.playAll) {
+    app.playAllIndex = 0;
+    app.currentClip = 0;
+  }
+  render();
+});
+function loadImageBlob(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load narration image"));
+    img.src = url;
+  });
+}
+
+function wrapText(ctx, text, maxWidth) {
+  const lines = [];
+  for (const para of text.split(/\n/)) {
+    const words = para.split(/\s+/).filter(Boolean);
+    if (!words.length) { lines.push(""); continue; }
+    let line = words[0];
+    for (let i = 1; i < words.length; i++) {
+      const test = line + " " + words[i];
+      if (ctx.measureText(test).width > maxWidth) { lines.push(line); line = words[i]; }
+      else line = test;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+function drawNarrationCard(canvas, image, promptText) {
+  const ctx = canvas.getContext("2d");
+  const { width: W, height: H } = canvas;
+  ctx.fillStyle = "#110518";
+  ctx.fillRect(0, 0, W, H);
+  // contain-fit the annotated image
+  const s = Math.min(W / image.width, H / image.height);
+  const dw = image.width * s;
+  const dh = image.height * s;
+  ctx.drawImage(image, (W - dw) / 2, (H - dh) / 2, dw, dh);
+  // prompt text overlay at the bottom — subtitle-style
+  if (promptText) {
+    const fontPx = Math.min(26, Math.max(14, Math.round(H * 0.03)));
+    ctx.font = `500 ${fontPx}px "IBM Plex Mono", ui-monospace, Menlo, monospace`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    const lines = wrapText(ctx, promptText, W * 0.9);
+    const padY = Math.round(fontPx * 0.55);
+    const lineH = Math.round(fontPx * 1.3);
+    const bandH = lines.length * lineH + padY * 2;
+    ctx.fillStyle = "rgba(17, 5, 24, 0.75)";
+    ctx.fillRect(0, H - bandH, W, bandH);
+    ctx.fillStyle = "#fff";
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], W / 2, H - padY - (lines.length - 1 - i) * lineH);
+    }
+  }
+}
+
+async function probeVideoSpec(blob) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const track = await input.getPrimaryVideoTrack();
+  if (!track) throw new Error("reference clip has no video track");
+  const cfg = await track.getDecoderConfig();
+  return {
+    codec: track.codec,                    // e.g. "avc"
+    fullCodecString: cfg?.codec,           // e.g. "avc1.640028"
+    width: track.codedWidth,
+    height: track.codedHeight,
+  };
+}
+
+async function renderNarrationClip(narration, refBlob) {
+  const spec = await probeVideoSpec(refBlob);
+  // Force even dimensions (H.264 requires it).
+  const width = spec.width - (spec.width % 2);
+  const height = spec.height - (spec.height % 2);
+  const fps = 24;
+  const bitrate = 2_000_000;
+  if (typeof canEncodeVideo === "function") {
+    const ok = await canEncodeVideo(spec.codec, { width, height, bitrate });
+    if (!ok) throw new Error(`browser cannot encode ${spec.codec} ${width}x${height}`);
+  }
+
+  const image = await loadImageBlob(narration.annotatedURL);
+  const canvas = typeof OffscreenCanvas !== "undefined"
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement("canvas"), { width, height });
+  drawNarrationCard(canvas, image, narration.promptText);
+
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const sourceCfg = { codec: spec.codec, bitrate, keyFrameInterval: 1 };
+  if (spec.fullCodecString) sourceCfg.fullCodecString = spec.fullCodecString;
+  const source = new CanvasSource(canvas, sourceCfg);
+  output.addVideoTrack(source, { frameRate: fps });
+  await output.start();
+  const total = Math.max(1, Math.round(NARRATE_DURATION_SEC * fps));
+  const frameDur = 1 / fps;
+  for (let i = 0; i < total; i++) {
+    await source.add(i * frameDur, frameDur);
+  }
+  source.close();
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function remuxMp4Clips(blobs) {
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  let videoSrc = null;
+  let audioSrc = null;
+  let vOffset = 0;
+  let aOffset = 0;
+  let vMaxOut = 0;
+  let aMaxOut = 0;
+  let vCfgSent = false;
+  let aCfgSent = false;
+
+  for (let i = 0; i < blobs.length; i++) {
+    const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blobs[i]) });
+    const vTrack = await input.getPrimaryVideoTrack();
+    if (!vTrack) throw new Error(`clip ${i + 1} has no video track`);
+    const aTrack = await input.getPrimaryAudioTrack();
+
+    if (i === 0) {
+      videoSrc = new EncodedVideoPacketSource(vTrack.codec);
+      output.addVideoTrack(videoSrc);
+      if (aTrack) {
+        audioSrc = new EncodedAudioPacketSource(aTrack.codec);
+        output.addAudioTrack(audioSrc);
+      }
+      await output.start();
+    }
+
+    const vMeta = { decoderConfig: await vTrack.getDecoderConfig() };
+    const vSink = new EncodedPacketSink(vTrack);
+    let vClipMax = 0;
+    for (let p = await vSink.getFirstPacket(); p; p = await vSink.getNextPacket(p)) {
+      let ts = Math.max(0, p.timestamp + vOffset);
+      if (i > 0 && ts <= vMaxOut) ts = vMaxOut + 1e-6;
+      await videoSrc.add(p.clone({ timestamp: ts }), vCfgSent ? undefined : vMeta);
+      vCfgSent = true;
+      vMaxOut = Math.max(vMaxOut, ts);
+      vClipMax = Math.max(vClipMax, p.timestamp + p.duration);
+    }
+    vOffset += vClipMax;
+
+    if (aTrack && audioSrc) {
+      const aMeta = { decoderConfig: await aTrack.getDecoderConfig() };
+      const aSink = new EncodedPacketSink(aTrack);
+      let aClipMax = 0;
+      for (let p = await aSink.getFirstPacket(); p; p = await aSink.getNextPacket(p)) {
+        let ts = Math.max(0, p.timestamp + aOffset);
+        if (i > 0 && ts <= aMaxOut) ts = aMaxOut + 1e-6;
+        await audioSrc.add(p.clone({ timestamp: ts }), aCfgSent ? undefined : aMeta);
+        aCfgSent = true;
+        aMaxOut = Math.max(aMaxOut, ts);
+        aClipMax = Math.max(aClipMax, p.timestamp + p.duration);
+      }
+      aOffset += aClipMax;
+    } else if (audioSrc) {
+      // No audio in this clip but we have an audio track — keep the audio
+      // offset in lock-step with video so later audio packets land in the
+      // right spot. The merged audio track will just contain a silent gap.
+      aOffset += vClipMax;
+    }
+  }
+
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function normalizeMp4(blob, targetBitrate) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const conv = await Conversion.init({
+    input, output,
+    video: { codec: "avc", bitrate: targetBitrate },
+  });
+  await conv.execute();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+els.downloadAll.addEventListener("click", async () => {
+  if (!app.clips.length) return;
+  const originalLabel = els.downloadAll.textContent;
+  els.downloadAll.disabled = true;
+  els.downloadAll.textContent = "stitching…";
+  try {
+    const clips = app.clips.filter((c) => c.blob);
+    if (!clips.length) throw new Error("No video data to download");
+
+    // If we have any narration cards mixed in, the source clips and the cards
+    // will have different H.264 SPS/PPS — the player only honours the first
+    // avcC box, so naive remux silently drops the cards. Re-encode every clip
+    // to one uniform target so the final stream has a single decoder config.
+    let blobs = clips.map((c) => c.blob);
+    const mixed = clips.some((c) => c.kind === "narration");
+    if (mixed) {
+      const targetBitrate = 4_000_000;
+      const normalized = [];
+      for (let i = 0; i < clips.length; i++) {
+        els.downloadAll.textContent = `re-encoding ${i + 1}/${clips.length}…`;
+        normalized.push(await normalizeMp4(clips[i].blob, targetBitrate));
+      }
+      blobs = normalized;
+      els.downloadAll.textContent = "stitching…";
+    }
+
+    let merged;
+    let ext = "mp4";
+    try {
+      merged = await remuxMp4Clips(blobs);
+    } catch (remuxErr) {
+      console.warn("mediabunny remux failed, falling back to naive concat", remuxErr);
+      const type = blobs[0].type || "video/mp4";
+      merged = new Blob(blobs, { type });
+      ext = type.includes("webm") ? "webm" : "mp4";
+    }
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(merged);
+    a.download = `walkthrough-${Date.now()}.${ext}`;
+    document.body.append(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(a.href), 60_000);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.downloadAll.textContent = originalLabel;
+    els.downloadAll.disabled = !app.clips.length || app.busy;
+  }
+});
+window.addEventListener("hashchange", () => {
+  const start = startURLFromLocation();
+  if (start && scrubURL(start) !== app.sourceURL && !app.busy) loadSource(start).catch((err) => showError(err.message));
+});
+
+els.prompt.value = localStorage.getItem(PROMPT_STORAGE) ?? DEFAULT_PROMPT;
+els.prompt.placeholder = DEFAULT_PROMPT;
+els.prompt.addEventListener("input", () => {
+  localStorage.setItem(PROMPT_STORAGE, els.prompt.value);
+});
+els.promptReset.addEventListener("click", () => {
+  els.prompt.value = DEFAULT_PROMPT;
+  localStorage.setItem(PROMPT_STORAGE, DEFAULT_PROMPT);
+});
+
+els.narrate.checked = localStorage.getItem(NARRATE_STORAGE) === "1";
+els.narrate.addEventListener("change", () => {
+  localStorage.setItem(NARRATE_STORAGE, els.narrate.checked ? "1" : "0");
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadVideoModels();
+const start = startURLFromLocation();
+if (start) loadSource(start).catch((err) => showError(err.message));
+else render();
+</script>
+</body>
+</html>

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1431,6 +1431,9 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Whether the API key is valid and active",
                                         ),
+                                    keyId: z
+                                        .string()
+                                        .describe("Stable API key id"),
                                     type: z
                                         .enum(["publishable", "secret"])
                                         .describe("Type of API key"),
@@ -1439,6 +1442,42 @@ export const accountRoutes = new Hono<Env>()
                                         .nullable()
                                         .describe(
                                             "Display name of the API key",
+                                        ),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for this API key",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Publishable app key id that minted this key, when present",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Display name for the app that minted this key, when present",
+                                        ),
+                                    appId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Alias of byopClientKeyId for server-attested app attribution",
+                                        ),
+                                    appName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Alias of byopClientName for server-attested app attribution",
+                                        ),
+                                    byopClientUserId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "User id of the BYOP app owner, when present — useful for app-developer dashboards",
                                         ),
                                     expiresAt: z
                                         .string()
@@ -1548,8 +1587,15 @@ export const accountRoutes = new Hono<Env>()
 
             return c.json({
                 valid: true, // If we got here, the key is valid
+                keyId: apiKey.id,
                 type: keyType,
                 name: apiKey.name || null,
+                userId: c.var.auth.user?.id || null,
+                byopClientKeyId: apiKey.byopClientKeyId || null,
+                byopClientName: apiKey.byopClientName || null,
+                appId: apiKey.byopClientKeyId || null,
+                appName: apiKey.byopClientName || null,
+                byopClientUserId: apiKey.byopClientUserId || null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -39,8 +39,13 @@ test(
 
         const data = await response.json();
         expect(data.valid).toBe(true);
+        expect(data.keyId).toBeTruthy();
         expect(data.type).toBe("secret");
         expect(data.name).toBeTruthy();
+        expect(data.userId).toBeTruthy();
+        expect(data).toHaveProperty("byopClientKeyId");
+        expect(data).toHaveProperty("byopClientName");
+        expect(data).toHaveProperty("byopClientUserId");
         expect(data).toHaveProperty("expiresAt");
         expect(data).toHaveProperty("expiresIn");
         expect(data).toHaveProperty("permissions");

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -16,6 +16,14 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const CATALOG_PREFIX = "catalog/v1";
+const LINEAGE_PREFIX = "lineage/v1";
+const TAG_PREFIX = "tags/v1";
+const MAX_LIST_LIMIT = 100;
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_TAGS = 8;
+const FACET_PATTERN = /^[a-z0-9][a-z0-9._-]{0,95}$/i;
+const TAG_PATTERN = /^[a-z0-9][a-z0-9._:+-]{0,95}$/i;
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
@@ -24,9 +32,60 @@ interface Env {
 
 interface AuthResult {
     valid: boolean;
+    keyId?: string;
     type: string;
     name: string | null;
+    userId?: string | null;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    appId?: string | null;
+    appName?: string | null;
 }
+
+type Visibility = "private" | "public";
+type CatalogSource = "upload" | "generation" | "remix";
+
+// Lineage edges support up to MAX_PARENTS distinct parents per child. Apps
+// that combine multiple inputs (recipe/mash-up apps, voice-edit
+// composites) need this; single-parent apps just pass one. `remixOf` is kept
+// as the canonical first parent for backwards-compat in the response.
+const MAX_PARENTS = 4;
+const RELATIONSHIP_PATTERN = /^[a-z][a-z0-9_]{0,31}$/i;
+
+type UploadCatalogInput = {
+    visibility: Visibility;
+    source: CatalogSource;
+    parents: string[];
+    // Optional typed edge label: "edit", "remix", "combine", "reply", etc.
+    // Apps use it to give the lineage UI meaningful copy ("3 edits" vs
+    // "5 combinations"). Sanitized to alphanumeric + underscore.
+    relationship: string | null;
+    prompt: string | null;
+    model: string | null;
+    tags: string[];
+};
+
+type CatalogItem = {
+    hash: string;
+    url: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    visibility: Visibility;
+    source: CatalogSource;
+    ownerId?: string;
+    ownerName?: string;
+    appId?: string;
+    appName?: string;
+    // remixOf is the first parent (backwards-compat). parents is the full set.
+    remixOf?: string;
+    parents?: string[];
+    relationship?: string;
+    prompt?: string;
+    model?: string;
+    tags?: string[];
+    userTags?: string[];
+};
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
     try {
@@ -69,6 +128,33 @@ const ErrorSchema = z.object({
     error: z.string(),
 });
 
+const CatalogItemSchema = z.object({
+    hash: z.string(),
+    url: z.string(),
+    contentType: z.string(),
+    size: z.number().int(),
+    createdAt: z.string(),
+    visibility: z.enum(["private", "public"]),
+    source: z.enum(["upload", "generation", "remix"]),
+    ownerId: z.string().optional(),
+    ownerName: z.string().optional(),
+    appId: z.string().optional(),
+    appName: z.string().optional(),
+    remixOf: z.string().optional(),
+    parents: z.array(z.string()).optional(),
+    relationship: z.string().optional(),
+    prompt: z.string().optional(),
+    model: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    userTags: z.array(z.string()).optional(),
+});
+
+const CatalogListResponseSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    cursor: z.string().optional(),
+    nextCursor: z.string().optional(),
+});
+
 const MetadataResponseSchema = z.object({
     hash: z.string().describe("16-char hex content hash"),
     contentType: z.string(),
@@ -80,6 +166,321 @@ const MetadataResponseSchema = z.object({
 });
 
 const api = new Hono<{ Bindings: Env }>();
+
+function stringField(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+    key: string,
+): string | null {
+    let value: unknown;
+    if (fields instanceof FormData) {
+        value = fields.get(key);
+    } else if (fields instanceof URLSearchParams) {
+        value = fields.get(key);
+    } else {
+        value = fields[key];
+    }
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function boundedText(value: string | null, maxLength: number): string | null {
+    if (!value) return null;
+    return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function parseVisibility(value: string | null): Visibility {
+    return value === "public" ? "public" : "private";
+}
+
+function parseSource(value: string | null): CatalogSource {
+    if (value === "generation" || value === "remix") return value;
+    return "upload";
+}
+
+// Parents may come in as 16-hex hashes or full media URLs; we accept either.
+const PARENT_URL_RE = /^https?:\/\/media\.pollinations\.ai\/([a-f0-9]{16})/i;
+function parseParents(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): string[] {
+    const out = new Set<string>();
+    // Accept legacy `remixOf` / `parent` as the canonical first slot, plus
+    // multi-value `parents` / `parent` arrays for combine-style apps.
+    const candidates = [
+        ...collectFieldValues(fields, ["remixOf", "parent", "parents"]),
+    ];
+    for (const raw of candidates) {
+        const parts = raw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        for (const part of parts) {
+            const m = PARENT_URL_RE.exec(part);
+            const candidate = (m ? m[1] : part).toLowerCase();
+            if (HASH_PATTERN.test(candidate)) out.add(candidate);
+            if (out.size >= MAX_PARENTS) return [...out];
+        }
+    }
+    return [...out];
+}
+
+function parseRelationship(value: string | null): string | null {
+    if (!value) return null;
+    const lower = value.trim().toLowerCase();
+    return RELATIONSHIP_PATTERN.test(lower) ? lower : null;
+}
+
+function collectFieldValues(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+    keys: string[],
+): string[] {
+    const values: string[] = [];
+    if (fields instanceof FormData || fields instanceof URLSearchParams) {
+        for (const key of keys) {
+            for (const value of fields.getAll(key)) {
+                if (typeof value === "string") values.push(value);
+            }
+        }
+        return values;
+    }
+
+    for (const key of keys) {
+        const value = fields[key];
+        if (Array.isArray(value)) {
+            values.push(
+                ...value.filter(
+                    (entry): entry is string => typeof entry === "string",
+                ),
+            );
+        } else if (typeof value === "string") {
+            values.push(value);
+        }
+    }
+    return values;
+}
+
+function normalizeTag(raw: string): string | null {
+    const tag = raw.trim().toLowerCase();
+    return TAG_PATTERN.test(tag) ? tag : null;
+}
+
+function normalizeTags(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): string[] {
+    const tags = new Set<string>();
+    for (const value of collectFieldValues(fields, ["tag", "tags"])) {
+        for (const part of value.split(",")) {
+            const tag = normalizeTag(part);
+            if (tag) tags.add(tag);
+            if (tags.size >= MAX_TAGS) return [...tags];
+        }
+    }
+    return [...tags];
+}
+
+function hasInvalidRemixOf(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): boolean {
+    // Reject if any candidate parent value (after URL-prefix stripping)
+    // doesn't look like a 16-hex hash. Multi-parent friendly.
+    const candidates = collectFieldValues(fields, [
+        "remixOf",
+        "parent",
+        "parents",
+    ]);
+    for (const raw of candidates) {
+        for (const part of raw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)) {
+            const m = PARENT_URL_RE.exec(part);
+            const candidate = m ? m[1] : part;
+            if (!HASH_PATTERN.test(candidate)) return true;
+        }
+    }
+    return false;
+}
+
+function parseUploadCatalogInput(
+    fields: FormData | Record<string, unknown> | URLSearchParams,
+): UploadCatalogInput {
+    return {
+        visibility: parseVisibility(stringField(fields, "visibility")),
+        source: parseSource(stringField(fields, "source")),
+        parents: parseParents(fields),
+        relationship: parseRelationship(stringField(fields, "relationship")),
+        prompt: boundedText(stringField(fields, "prompt"), 500),
+        model: boundedText(stringField(fields, "model"), 80),
+        tags: normalizeTags(fields),
+    };
+}
+
+function reverseTimestamp(now = Date.now()): string {
+    return String(Number.MAX_SAFE_INTEGER - now).padStart(16, "0");
+}
+
+function catalogIndexKey(
+    prefix: string,
+    hash: string,
+    now = Date.now(),
+): string {
+    return `${prefix}/${reverseTimestamp(now)}-${hash}.json`;
+}
+
+function itemKey(hash: string): string {
+    return `${CATALOG_PREFIX}/items/${hash}.json`;
+}
+
+async function putJson(bucket: R2Bucket, key: string, value: unknown) {
+    await bucket.put(key, JSON.stringify(value), {
+        httpMetadata: {
+            contentType: "application/json",
+            cacheControl: "no-store",
+        },
+    });
+}
+
+async function readCatalogItem(
+    bucket: R2Bucket,
+    key: string,
+): Promise<CatalogItem | null> {
+    const object = await bucket.get(key);
+    if (!object) return null;
+    try {
+        return (await object.json()) as CatalogItem;
+    } catch {
+        return null;
+    }
+}
+
+async function listCatalogItems(
+    bucket: R2Bucket,
+    prefix: string,
+    limit: number,
+    cursor?: string | null,
+): Promise<{ items: CatalogItem[]; cursor?: string; nextCursor?: string }> {
+    const list = await bucket.list({
+        prefix,
+        limit,
+        cursor: cursor || undefined,
+    });
+    const items = (
+        await Promise.all(
+            list.objects.map((object) => readCatalogItem(bucket, object.key)),
+        )
+    ).filter((item): item is CatalogItem => Boolean(item));
+
+    return {
+        items,
+        ...(list.truncated && list.cursor
+            ? { cursor: list.cursor, nextCursor: list.cursor }
+            : {}),
+    };
+}
+
+function listLimit(raw: string | null): number {
+    const parsed = Number.parseInt(raw || "", 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIST_LIMIT;
+    return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
+async function resolveAppIdFromQuery(
+    app: string | null,
+    appKey: string | null,
+): Promise<string | null> {
+    if (app?.trim()) {
+        const normalized = app.trim();
+        return FACET_PATTERN.test(normalized) ? normalized : null;
+    }
+    if (!appKey?.trim()) return null;
+    const auth = await verifyApiKey(appKey.trim());
+    return auth?.keyId || null;
+}
+
+function authAppId(auth: AuthResult): string | null {
+    return auth.byopClientKeyId || auth.appId || null;
+}
+
+function authAppName(auth: AuthResult): string | null {
+    return auth.byopClientName || auth.appName || null;
+}
+
+async function writeCatalogEntries(
+    bucket: R2Bucket,
+    auth: AuthResult,
+    item: CatalogItem,
+) {
+    const keys = [itemKey(item.hash)];
+    const now = Date.now();
+    const appId = authAppId(auth);
+
+    if (auth.userId) {
+        keys.push(
+            catalogIndexKey(
+                `${CATALOG_PREFIX}/by-owner/${auth.userId}`,
+                item.hash,
+                now,
+            ),
+        );
+        if (appId) {
+            keys.push(
+                catalogIndexKey(
+                    `${CATALOG_PREFIX}/by-owner-app/${auth.userId}/${appId}`,
+                    item.hash,
+                    now,
+                ),
+            );
+        }
+    }
+
+    if (item.visibility === "public" && appId) {
+        keys.push(
+            catalogIndexKey(
+                `${CATALOG_PREFIX}/public-app/${appId}`,
+                item.hash,
+                now,
+            ),
+        );
+    }
+
+    // Lineage edges. Multi-parent: one index entry per parent so each parent's
+    // `/children` endpoint can find this child independently. A child can't
+    // appear under itself (parseParents already filtered self-refs).
+    const parents = item.parents || (item.remixOf ? [item.remixOf] : []);
+    if (item.visibility === "public") {
+        for (const parent of parents) {
+            keys.push(
+                `${LINEAGE_PREFIX}/by-parent/${parent}/${item.hash}.json`,
+                `${LINEAGE_PREFIX}/by-child/${item.hash}/${parent}.json`,
+            );
+        }
+    }
+
+    if (item.visibility === "public") {
+        for (const tag of item.tags || []) {
+            // Global tag namespace + per-app namespace. Per-app tags let an
+            // app use the catalog as a keyed lookup (`recipe:<a>+<b>` can
+            // dedupe combinations across users).
+            keys.push(catalogIndexKey(`${TAG_PREFIX}/${tag}`, item.hash, now));
+            if (appId) {
+                keys.push(
+                    catalogIndexKey(
+                        `${TAG_PREFIX}/by-app/${appId}/${tag}`,
+                        item.hash,
+                        now,
+                    ),
+                );
+            }
+        }
+    }
+
+    const results = await Promise.allSettled(
+        keys.map((key) => putJson(bucket, key, item)),
+    );
+    for (const result of results) {
+        if (result.status === "rejected") {
+            console.error("Catalog index write failed:", result.reason);
+        }
+    }
+}
 
 api.post(
     "/upload",
@@ -140,6 +541,9 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        const searchParams = new URL(c.req.url).searchParams;
+        let invalidRemixOf = hasInvalidRemixOf(searchParams);
+        let catalogInput = parseUploadCatalogInput(searchParams);
 
         const requestContentType = c.req.header("content-type") || "";
 
@@ -161,6 +565,8 @@ api.post(
                     return c.json(fileTooLargeError(maxSize), 413);
                 }
 
+                invalidRemixOf = hasInvalidRemixOf(formData);
+                catalogInput = parseUploadCatalogInput(formData);
                 fileBuffer = await file.arrayBuffer();
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
@@ -169,6 +575,16 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
+                    visibility?: string;
+                    source?: string;
+                    remixOf?: string;
+                    parent?: string;
+                    parents?: string | string[];
+                    relationship?: string;
+                    prompt?: string;
+                    model?: string;
+                    tag?: string | string[];
+                    tags?: string | string[];
                 }>();
 
                 if (!body.data) {
@@ -195,6 +611,8 @@ api.post(
                     return c.json({ error: "Empty file" }, 400);
                 }
 
+                invalidRemixOf = hasInvalidRemixOf(body);
+                catalogInput = parseUploadCatalogInput(body);
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
             } else {
@@ -208,6 +626,10 @@ api.post(
                 }
 
                 contentType = requestContentType || "application/octet-stream";
+            }
+
+            if (invalidRemixOf) {
+                return c.json({ error: "Invalid remixOf hash" }, 400);
             }
 
             const hash = await generateHash(fileBuffer, fileName);
@@ -240,6 +662,35 @@ api.post(
                 }),
             );
 
+            const createdAt = new Date().toISOString();
+            const appId = authAppId(authResult);
+            const appName = authAppName(authResult);
+            const tags =
+                catalogInput.tags.length > 0 ? catalogInput.tags : undefined;
+            const parents = catalogInput.parents.filter((p) => p !== hash);
+            const remixOf = parents[0];
+            await writeCatalogEntries(c.env.MEDIA_BUCKET, authResult, {
+                hash,
+                url: mediaUrl(hash),
+                contentType,
+                size: fileBuffer.byteLength,
+                createdAt,
+                visibility: catalogInput.visibility,
+                source: parents.length > 0 ? "remix" : catalogInput.source,
+                ...(authResult.userId && { ownerId: authResult.userId }),
+                ...(authResult.name && { ownerName: authResult.name }),
+                ...(appId && { appId }),
+                ...(appName && { appName }),
+                ...(remixOf && { remixOf }),
+                ...(parents.length > 0 && { parents }),
+                ...(catalogInput.relationship && {
+                    relationship: catalogInput.relationship,
+                }),
+                ...(catalogInput.prompt && { prompt: catalogInput.prompt }),
+                ...(catalogInput.model && { model: catalogInput.model }),
+                ...(tags && { tags, userTags: tags }),
+            });
+
             return c.json({
                 id: hash,
                 url: mediaUrl(hash),
@@ -251,6 +702,185 @@ api.post(
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List authenticated user's media",
+        responses: {
+            200: {
+                description: "Media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) return c.json({ error: "API key required" }, 401);
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult?.userId) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+
+        const url = new URL(c.req.url);
+        const app = url.searchParams.get("app");
+        const appKey = url.searchParams.get("app_key");
+        const appId = await resolveAppIdFromQuery(app, appKey);
+        if ((app || appKey) && !appId) {
+            return c.json({ error: "Invalid app or app_key" }, 400);
+        }
+        const prefix = appId
+            ? `${CATALOG_PREFIX}/by-owner-app/${authResult.userId}/${appId}/`
+            : `${CATALOG_PREFIX}/by-owner/${authResult.userId}/`;
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                prefix,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/gallery",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public app media",
+        responses: {
+            200: {
+                description: "Public media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Missing or invalid app",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const app = url.searchParams.get("app");
+        const appKey = url.searchParams.get("app_key");
+        const appId = await resolveAppIdFromQuery(app, appKey);
+        if (!appId) return c.json({ error: "app or app_key required" }, 400);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${CATALOG_PREFIX}/public-app/${appId}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/apps/:app/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media for a verified app id",
+        responses: {
+            200: {
+                description: "Public media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid app id",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const app = c.req.param("app");
+        if (!FACET_PATTERN.test(app)) {
+            return c.json({ error: "Invalid app id" }, 400);
+        }
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${CATALOG_PREFIX}/public-app/${app}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/tags/:tag",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media tagged with a user tag",
+        responses: {
+            200: {
+                description: "Tagged public media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid tag",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const tag = normalizeTag(c.req.param("tag"));
+        if (!tag) return c.json({ error: "Invalid tag" }, 400);
+
+        const url = new URL(c.req.url);
+        const app = url.searchParams.get("app");
+        const appKey = url.searchParams.get("app_key");
+        const appId = await resolveAppIdFromQuery(app, appKey);
+        if ((app || appKey) && !appId) {
+            return c.json({ error: "Invalid app or app_key" }, 400);
+        }
+        // App-scoped tag listing has its own prefix so a `recipe:water+fire`
+        // lookup is O(1) regardless of how many other apps
+        // happen to use the same tag.
+        const prefix = appId
+            ? `${TAG_PREFIX}/by-app/${appId}/${tag}/`
+            : `${TAG_PREFIX}/${tag}/`;
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                prefix,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
     },
 );
 
@@ -315,6 +945,45 @@ api.get(
             console.error("Retrieve error:", error);
             return c.json({ error: "Retrieval failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/:hash/children",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public remixes of a media object",
+        responses: {
+            200: {
+                description: "Child media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid hash format",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const hash = c.req.param("hash");
+        if (!HASH_PATTERN.test(hash)) {
+            return c.json({ error: "Invalid hash format" }, 400);
+        }
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${LINEAGE_PREFIX}/by-parent/${hash}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
     },
 );
 
@@ -449,6 +1118,11 @@ app.get("/", (c) => {
         version: "1.0.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
+            myMedia: "GET /me/media (requires API key)",
+            gallery: "GET /gallery?app_key=pk_...",
+            appGallery: "GET /apps/:app/media",
+            tags: "GET /tags/:tag",
+            children: "GET /:hash/children",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -19,20 +19,62 @@ interface UploadResponse {
     duplicate: boolean;
 }
 
+interface CatalogItem {
+    hash: string;
+    url: string;
+    prompt?: string;
+    appId?: string;
+    ownerId?: string;
+    tags?: string[];
+    userTags?: string[];
+}
+
 const VALID_KEY = "pk_test_key_123";
+const APP_KEY = "pk_app_test";
 
 function mockAuth() {
     fetchMock.activate();
     fetchMock.disableNetConnect();
     fetchMock
         .get("https://gen.pollinations.ai")
-        .intercept({ path: "/account/key" })
+        .intercept({
+            path: "/account/key",
+            headers: { authorization: `Bearer ${VALID_KEY}` },
+        })
         .reply(
             200,
             JSON.stringify({
                 valid: true,
+                keyId: "user-key-test",
                 type: "publishable",
                 name: "test-user",
+                userId: "user-test",
+                byopClientKeyId: "app-test",
+                byopClientName: "CatGPT Test",
+                appId: "app-test",
+                appName: "CatGPT Test",
+            }),
+            { headers: { "content-type": "application/json" } },
+        )
+        .persist();
+    fetchMock
+        .get("https://gen.pollinations.ai")
+        .intercept({
+            path: "/account/key",
+            headers: { authorization: `Bearer ${APP_KEY}` },
+        })
+        .reply(
+            200,
+            JSON.stringify({
+                valid: true,
+                keyId: "app-test",
+                type: "publishable",
+                name: "CatGPT Test",
+                userId: "app-owner-test",
+                byopClientKeyId: null,
+                byopClientName: null,
+                appId: null,
+                appName: null,
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -154,6 +196,149 @@ describe("media.pollinations.ai", () => {
         expect(upload1.id).not.toBe(upload2.id);
     });
 
+    it("indexes uploaded media for owner and public app gallery", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "catgpt-public.png", { type: "image/png" }),
+        );
+        form.append("visibility", "public");
+        form.append("source", "generation");
+        form.append("prompt", "Why is the box mine?");
+        form.append("model", "nanobanana");
+        form.append("tag", "catgpt");
+        form.append("tags", "meme,invalid tag");
+
+        const uploadRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(uploadRes.status).toBe(200);
+        const upload = (await uploadRes.json()) as UploadResponse;
+
+        const mineRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media?app=app-test",
+            { headers: { Authorization: `Bearer ${VALID_KEY}` } },
+        );
+        expect(mineRes.status).toBe(200);
+        const mine = (await mineRes.json()) as { items: CatalogItem[] };
+        expect(mine.items.some((item) => item.hash === upload.id)).toBe(true);
+
+        const galleryRes = await SELF.fetch(
+            `https://media.pollinations.ai/gallery?app_key=${APP_KEY}`,
+        );
+        expect(galleryRes.status).toBe(200);
+        const gallery = (await galleryRes.json()) as { items: CatalogItem[] };
+        const item = gallery.items.find((entry) => entry.hash === upload.id);
+        expect(item?.prompt).toBe("Why is the box mine?");
+        expect(item?.appId).toBe("app-test");
+        expect(item?.tags).toEqual(["catgpt", "meme"]);
+
+        const appRes = await SELF.fetch(
+            "https://media.pollinations.ai/apps/app-test/media",
+        );
+        expect(appRes.status).toBe(200);
+        const appGallery = (await appRes.json()) as { items: CatalogItem[] };
+        expect(appGallery.items.some((entry) => entry.hash === upload.id)).toBe(
+            true,
+        );
+
+        const tagRes = await SELF.fetch(
+            `https://media.pollinations.ai/tags/catgpt?app_key=${APP_KEY}`,
+        );
+        expect(tagRes.status).toBe(200);
+        const tagged = (await tagRes.json()) as { items: CatalogItem[] };
+        expect(tagged.items.some((entry) => entry.hash === upload.id)).toBe(
+            true,
+        );
+    });
+
+    it("indexes remix children by parent hash", async () => {
+        const parentForm = new FormData();
+        parentForm.append(
+            "file",
+            new File([TINY_PNG], "parent.png", { type: "image/png" }),
+        );
+        const parentRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: parentForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        const parent = (await parentRes.json()) as UploadResponse;
+
+        const childForm = new FormData();
+        childForm.append(
+            "file",
+            new File([TINY_PNG], "child.png", { type: "image/png" }),
+        );
+        childForm.append("visibility", "public");
+        childForm.append("source", "remix");
+        childForm.append("remixOf", parent.id);
+        childForm.append("prompt", "make it glow");
+        const childRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: childForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(childRes.status).toBe(200);
+        const child = (await childRes.json()) as UploadResponse;
+
+        const privateChildForm = new FormData();
+        privateChildForm.append(
+            "file",
+            new File([TINY_PNG], "private-child.png", { type: "image/png" }),
+        );
+        privateChildForm.append("source", "remix");
+        privateChildForm.append("remixOf", parent.id);
+        const privateChildRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: privateChildForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(privateChildRes.status).toBe(200);
+        const privateChild = (await privateChildRes.json()) as UploadResponse;
+
+        const childrenRes = await SELF.fetch(
+            `https://media.pollinations.ai/${parent.id}/children`,
+        );
+        expect(childrenRes.status).toBe(200);
+        const children = (await childrenRes.json()) as { items: CatalogItem[] };
+        const item = children.items.find((entry) => entry.hash === child.id);
+        expect(item?.prompt).toBe("make it glow");
+        expect(
+            children.items.some((entry) => entry.hash === privateChild.id),
+        ).toBe(false);
+    });
+
+    it("rejects invalid remix parents", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "bad-remix.png", { type: "image/png" }),
+        );
+        form.append("remixOf", "not-a-hash");
+
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        expect(res.status).toBe(400);
+    });
+
     it("GET /:invalid-hash returns 400", async () => {
         const res = await SELF.fetch(
             "https://media.pollinations.ai/not-a-valid-hash",
@@ -166,5 +351,142 @@ describe("media.pollinations.ai", () => {
             "https://media.pollinations.ai/0000000000000000",
         );
         expect(res.status).toBe(404);
+    });
+
+    // Adversarial: request body declares a fake owner/app, server must ignore
+    // them. The catalog must be stamped only with values from the verified key.
+    it("request-supplied owner/app fields cannot override verified identity", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "spoofed.png", { type: "image/png" }),
+        );
+        form.append("visibility", "public");
+        // These should be ignored by the server.
+        form.append("ownerId", "attacker-user");
+        form.append("appId", "victim-app");
+        form.append("appName", "Stolen App");
+
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        expect(res.status).toBe(200);
+        const upload = (await res.json()) as UploadResponse;
+
+        const gallery = (await (
+            await SELF.fetch(
+                "https://media.pollinations.ai/apps/victim-app/media",
+            )
+        ).json()) as { items: CatalogItem[] };
+        expect(gallery.items.some((it) => it.hash === upload.id)).toBe(false);
+
+        const realApp = (await (
+            await SELF.fetch(
+                "https://media.pollinations.ai/apps/app-test/media",
+            )
+        ).json()) as { items: CatalogItem[] };
+        const found = realApp.items.find((it) => it.hash === upload.id);
+        expect(found?.ownerId).toBe("user-test");
+        expect(found?.appId).toBe("app-test");
+    });
+
+    // Multi-parent: recipe and mash-up apps combine multiple inputs.
+    it("indexes a child under each declared parent", async () => {
+        const parents: string[] = [];
+        for (const name of ["ingredient-a.png", "ingredient-b.png"]) {
+            const form = new FormData();
+            form.append(
+                "file",
+                new File([TINY_PNG], name, { type: "image/png" }),
+            );
+            form.append("visibility", "public");
+            const r = await SELF.fetch("https://media.pollinations.ai/upload", {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            });
+            parents.push(((await r.json()) as UploadResponse).id);
+        }
+
+        const childForm = new FormData();
+        childForm.append(
+            "file",
+            new File([TINY_PNG], "combo.png", { type: "image/png" }),
+        );
+        childForm.append("visibility", "public");
+        childForm.append("relationship", "combine");
+        // Multiple `parent` entries — order shouldn't matter for indexing.
+        for (const p of parents) childForm.append("parent", p);
+        const childRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: childForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(childRes.status).toBe(200);
+        const child = (await childRes.json()) as UploadResponse;
+
+        for (const parent of parents) {
+            const listRes = await SELF.fetch(
+                `https://media.pollinations.ai/${parent}/children`,
+            );
+            const list = (await listRes.json()) as { items: CatalogItem[] };
+            const entry = list.items.find((it) => it.hash === child.id) as
+                | (CatalogItem & {
+                      parents?: string[];
+                      relationship?: string;
+                  })
+                | undefined;
+            expect(entry).toBeTruthy();
+            expect(entry?.parents).toEqual(parents);
+            expect(entry?.relationship).toBe("combine");
+        }
+    });
+
+    // Recipe-style apps can use tag=recipe:water+fire to dedupe combinations
+    // across users without scanning the global tag namespace.
+    it("indexes per-app tags for recipe-style lookups", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "steam.png", { type: "image/png" }),
+        );
+        form.append("visibility", "public");
+        form.append("tag", "recipe:water+fire");
+        form.append("tag", "element:steam");
+        const r = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        const upload = (await r.json()) as UploadResponse;
+
+        const tagRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/recipe:water%2Bfire?app=app-test",
+        );
+        expect(tagRes.status).toBe(200);
+        const tagged = (await tagRes.json()) as { items: CatalogItem[] };
+        expect(tagged.items.some((it) => it.hash === upload.id)).toBe(true);
+    });
+
+    // Multi-value invalid parent must reject the whole upload.
+    it("rejects upload if any parent is malformed", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "bad.png", { type: "image/png" }),
+        );
+        form.append("parent", "0000000000000000");
+        form.append("parent", "not-a-hash");
+        const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+            method: "POST",
+            body: form,
+            headers: { Authorization: `Bearer ${VALID_KEY}` },
+        });
+        expect(res.status).toBe(400);
     });
 });


### PR DESCRIPTION
- Adds an R2-backed media catalog index for owner, verified app, public tags, and public remix children.
- Exposes server-attested key/user/app identity from /account/key.
- Wires CatGPT, voice-edit remix/walkthrough, AI Dungeon Master, Product Packaging Designer, Virtual Makeup, Chat, SlidePainter, and Pollicraft into catalog uploads where auth/media flow already exists.
- Keeps app identity server-stamped; unverified app tags remain queryable but are not trusted for attribution.

Validation:
- npx biome check --write apps/chat/src/utils/api.js apps/slidepainter/src/services/pollinations.ts
- node --check apps/chat/src/utils/api.js
- Pollicraft module script syntax check
- apps/chat: npm run build
- apps/slidepainter: npm run build
- media.pollinations.ai: npm run test
- enter.pollinations.ai: npm run decrypt-vars && npx vitest run test/account-key.test.ts
- app builds: ai-dungeon-master, product-packaging-designer, virtual-makeup
- node syntax checks: CatGPT JS, voice-edit remix/walkthrough module scripts