### PR TITLE
feat: add R2 media catalog

### DIFF
--- a/apps/ai-dungeon-master/src/App.tsx
+++ b/apps/ai-dungeon-master/src/App.tsx
@@ -178,21 +178,42 @@ export default function App() {
                 const sceneUpload = uploadToMedia(
                     gameState.currentScene.image,
                     apiKey,
+                    {
+                        visibility: "private",
+                        tags: ["ai-dungeon-master", "scene"],
+                        source: "saved_generation",
+                        prompt: gameState.currentScene.description,
+                    },
                 );
                 await Promise.all([
-                    uploadToMedia(character.avatar, apiKey).then((url) => {
+                    uploadToMedia(character.avatar, apiKey, {
+                        visibility: "private",
+                        tags: ["ai-dungeon-master", "character"],
+                        source: "saved_generation",
+                        prompt: character.name,
+                    }).then((url) => {
                         character.avatar = url;
                     }),
                     sceneUpload.then((url) => {
                         uploadedSceneImage = url;
                     }),
                     ...storyHistory.map((entry, idx) =>
-                        uploadToMedia(entry.image, apiKey).then((url) => {
+                        uploadToMedia(entry.image, apiKey, {
+                            visibility: "private",
+                            tags: ["ai-dungeon-master", "story"],
+                            source: "saved_generation",
+                            prompt: entry.description,
+                        }).then((url) => {
                             storyHistory[idx].image = url;
                         }),
                     ),
                     ...inventory.map((item, idx) =>
-                        uploadToMedia(item.image, apiKey).then((url) => {
+                        uploadToMedia(item.image, apiKey, {
+                            visibility: "private",
+                            tags: ["ai-dungeon-master", "inventory"],
+                            source: "saved_generation",
+                            prompt: item.name,
+                        }).then((url) => {
                             inventory[idx].image = url;
                         }),
                     ),

--- a/apps/ai-dungeon-master/src/utils/mediaUpload.ts
+++ b/apps/ai-dungeon-master/src/utils/mediaUpload.ts
@@ -1,5 +1,15 @@
-const MEDIA_URL = "https://gen.pollinations.ai";
+const MEDIA_URL = "https://media.pollinations.ai";
+const MEDIA_UPLOAD_URL = `${MEDIA_URL}/upload`;
 const MEDIA_HOST = "media.pollinations.ai";
+
+export interface MediaCatalogFields {
+    visibility?: "public" | "private";
+    tags?: string[];
+    parents?: string[];
+    source?: "upload" | "generation" | "edit" | "saved_generation" | "remix";
+    prompt?: string;
+    model?: string;
+}
 
 /** Check if a URL is already uploaded to media.pollinations.ai */
 function isMediaUrl(url: string): boolean {
@@ -10,6 +20,25 @@ function isMediaUrl(url: string): boolean {
     }
 }
 
+function appendCatalogFields(
+    formData: FormData,
+    {
+        visibility = "private",
+        tags = [],
+        parents = [],
+        source = "saved_generation",
+        prompt,
+        model,
+    }: MediaCatalogFields,
+) {
+    formData.append("visibility", visibility);
+    formData.append("source", source);
+    if (prompt) formData.append("prompt", prompt);
+    if (model) formData.append("model", model);
+    if (tags.length) formData.append("tags", JSON.stringify(tags));
+    if (parents.length) formData.append("parents", JSON.stringify(parents));
+}
+
 /**
  * Upload a gen.pollinations.ai image to media.pollinations.ai for permanent storage.
  * Returns the permanent media URL on success, or the original URL on any error.
@@ -18,6 +47,7 @@ function isMediaUrl(url: string): boolean {
 export async function uploadToMedia(
     genUrl: string,
     apiKey: string,
+    catalog: MediaCatalogFields = {},
 ): Promise<string> {
     if (!genUrl || isMediaUrl(genUrl)) return genUrl;
 
@@ -27,9 +57,10 @@ export async function uploadToMedia(
 
         const blob = await response.blob();
         const formData = new FormData();
-        formData.append("file", blob);
+        formData.append("file", blob, `ai-dungeon-${Date.now()}.png`);
+        appendCatalogFields(formData, catalog);
 
-        const uploadRes = await fetch(`${MEDIA_URL}/media`, {
+        const uploadRes = await fetch(MEDIA_UPLOAD_URL, {
             method: "POST",
             headers: { Authorization: `Bearer ${apiKey}` },
             body: formData,
@@ -38,7 +69,7 @@ export async function uploadToMedia(
         if (!uploadRes.ok) return genUrl;
 
         const data = await uploadRes.json();
-        return data.url || genUrl;
+        return data.url || (data.id ? `${MEDIA_URL}/${data.id}` : genUrl);
     } catch {
         return genUrl;
     }

--- a/apps/catgpt-bot/bot.ts
+++ b/apps/catgpt-bot/bot.ts
@@ -15,6 +15,8 @@ const TOKEN = process.env.BOT_TOKEN_CATGPT;
 const API_KEY = process.env.TEXT_POLLINATIONS_TOKEN;
 const TEXT_API = "https://gen.pollinations.ai/v1/chat/completions";
 const IMAGE_API = "https://gen.pollinations.ai/image";
+const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA_API = "https://media.pollinations.ai";
 const AUTH = API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {};
 
 const ORIGINAL_CATGPT =
@@ -22,12 +24,34 @@ const ORIGINAL_CATGPT =
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const MODEL = "nanobanana";
 
-function log(...args: any[]) {
+type MediaUploadResponse = {
+    id?: string;
+    url?: string;
+};
+
+type TypingChannel = {
+    sendTyping: () => Promise<unknown>;
+};
+
+function log(...args: unknown[]) {
     console.log(`[${new Date().toISOString()}]`, ...args);
 }
 
-function logError(...args: any[]) {
+function logError(...args: unknown[]) {
     console.error(`[${new Date().toISOString()}]`, ...args);
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function canSendTyping(
+    channel: Message["channel"],
+): channel is Message["channel"] & TypingChannel {
+    return (
+        "sendTyping" in channel &&
+        typeof (channel as { sendTyping?: unknown }).sendTyping === "function"
+    );
 }
 
 const CAT_SYSTEM = `You are CatGPT — a supremely aloof, sarcastic cat who barely tolerates humans. You respond to questions with withering wit, dry irony, and feline disdain. Your replies are SHORT (2-8 words max), devastatingly dismissive but clever. You don't just say "no" — you find the most cutting, ironic angle. You occasionally reference cat behaviors (knocking things off tables, ignoring humans, sleeping). Never break character. Never be helpful. Never be impressed by human achievements. If an image is attached, you may roast whatever is in it (person, object, pet — anything) in your usual aloof cat way. Examples:
@@ -103,6 +127,61 @@ async function fetchImage(url: string): Promise<Buffer> {
     return Buffer.from(res.data);
 }
 
+function appendCatalogFields(
+    form: FormData,
+    fields: {
+        prompt: string;
+        model: string;
+        parents?: string[];
+        tags: string[];
+    },
+) {
+    form.append("visibility", "public");
+    form.append("source", "generation");
+    form.append("prompt", fields.prompt);
+    form.append("model", fields.model);
+    form.append("tags", JSON.stringify(fields.tags));
+    if (fields.parents?.length) {
+        form.append("parents", JSON.stringify(fields.parents));
+    }
+}
+
+async function uploadImageToMedia(
+    buffer: Buffer,
+    filename: string,
+    fields: {
+        prompt: string;
+        model: string;
+        parents?: string[];
+        tags: string[];
+    },
+): Promise<string | null> {
+    if (!API_KEY) return null;
+
+    try {
+        const form = new FormData();
+        form.append(
+            "file",
+            new Blob([new Uint8Array(buffer)], { type: "image/png" }),
+            filename,
+        );
+        appendCatalogFields(form, fields);
+
+        const res = await fetch(MEDIA_UPLOAD, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${API_KEY}` },
+            body: form,
+        });
+        if (!res.ok) throw new Error(`media upload failed: ${res.status}`);
+
+        const json = (await res.json()) as MediaUploadResponse;
+        return json.url || (json.id ? `${MEDIA_API}/${json.id}` : null);
+    } catch (err: unknown) {
+        logError("Media catalog upload failed:", errorMessage(err));
+        return null;
+    }
+}
+
 const processing = new Set<string>();
 
 async function handleMessage(msg: Message, client: Client): Promise<void> {
@@ -120,8 +199,7 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
     log(`Question from ${msg.author.username}: "${question}"`);
 
     try {
-        if ("sendTyping" in msg.channel)
-            await (msg.channel as any).sendTyping();
+        if (canSendTyping(msg.channel)) await msg.channel.sendTyping();
     } catch {}
 
     const avatarUrl = msg.author.displayAvatarURL({
@@ -136,15 +214,26 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
             const imageBuffer = await fetchImage(imageUrl);
+            const mediaUrl = await uploadImageToMedia(
+                imageBuffer,
+                `catgpt-bot-${msg.id}.png`,
+                {
+                    prompt: question,
+                    model: MODEL,
+                    parents: [SELFIE_CATGPT],
+                    tags: ["catgpt", "catgpt-bot"],
+                },
+            );
             const attachment = new AttachmentBuilder(imageBuffer, {
                 name: "catgpt.png",
             });
             await msg.reply({ files: [attachment] });
+            if (mediaUrl) log(`Cataloged media: ${mediaUrl}`);
             log(`Reply sent for "${question}"`);
             return;
-        } catch (err: any) {
+        } catch (err: unknown) {
             logError(
-                `Attempt ${attempt + 1}/${maxRetries + 1}: ${err.message}`,
+                `Attempt ${attempt + 1}/${maxRetries + 1}: ${errorMessage(err)}`,
             );
             if (attempt < maxRetries) {
                 const wait = 2000 * (attempt + 1);

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -3,11 +3,15 @@
 const API = "https://gen.pollinations.ai/image";
 const ENTER = "https://enter.pollinations.ai";
 const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA_API = "https://media.pollinations.ai";
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const AUTH_KEY = "catgpt_api_key";
 const APP_KEY = "pk_uWjreBEkxFAhjDHo";
+const CATGPT_TAGS = ["catgpt", "catgpt-generated"];
+
+export const CATGPT_APP_KEY = APP_KEY;
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -146,6 +150,77 @@ export async function pickModel(apiKey) {
 
 // ── Media Upload ─────────────────────────────────────────────────────────────
 
+function appendMediaCatalogFields(form, fields = {}) {
+    const {
+        visibility = "public",
+        tags = [],
+        parents = [],
+        source,
+        prompt,
+        model,
+    } = fields;
+    form.append("visibility", visibility);
+    if (source) form.append("source", source);
+    if (prompt) form.append("prompt", prompt);
+    if (model) form.append("model", model);
+    if (tags.length) form.append("tags", JSON.stringify(tags));
+    if (parents.length) form.append("parents", JSON.stringify(parents));
+}
+
+async function uploadToMedia(blob, filename, fields) {
+    const key = getStoredApiKey();
+    if (!key) throw new Error("No API key available for media upload");
+
+    const form = new FormData();
+    form.append("file", blob, filename);
+    appendMediaCatalogFields(form, fields);
+
+    const res = await fetch(MEDIA_UPLOAD, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${key}` },
+        body: form,
+    });
+    if (!res.ok) throw new Error("Media upload failed");
+    const json = await res.json();
+    return json.url || `${MEDIA_API}/${json.id}`;
+}
+
+export async function saveGeneratedMemeToMedia(
+    blob,
+    { question, model, parentUrls = [] },
+) {
+    return uploadToMedia(blob, `catgpt-meme-${Date.now()}.png`, {
+        visibility: "public",
+        tags: CATGPT_TAGS,
+        parents: [SELFIE_CATGPT, ...parentUrls].filter(Boolean),
+        source: "generation",
+        prompt: question,
+        model,
+    });
+}
+
+export async function fetchSavedCatGptMemes() {
+    const key = getStoredApiKey();
+    if (!key) return [];
+
+    const params = new URLSearchParams({
+        app_key: APP_KEY,
+        tag: "catgpt-generated",
+        limit: "12",
+    });
+    const res = await fetch(`${MEDIA_API}/me/media?${params}`, {
+        headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) return [];
+
+    const data = await res.json();
+    return (data.items || []).map((item) => ({
+        prompt: item.prompt || "CatGPT meme",
+        url: item.url,
+        model: item.model,
+    }));
+}
+
 export async function handleImageUpload(file, notify) {
     if (!file) return null;
     if (file.size > 5 * 1024 * 1024) {
@@ -155,15 +230,11 @@ export async function handleImageUpload(file, notify) {
 
     try {
         notify("Uploading image...", "info");
-        const form = new FormData();
-        form.append("file", file);
-        const res = await fetch(MEDIA_UPLOAD, {
-            method: "POST",
-            headers: { Authorization: `Bearer ${getStoredApiKey()}` },
-            body: form,
+        return await uploadToMedia(file, file.name || "catgpt-source.png", {
+            visibility: "private",
+            tags: ["catgpt", "catgpt-source"],
+            source: "upload",
         });
-        if (!res.ok) throw new Error("Upload failed");
-        return (await res.json()).url;
     } catch (err) {
         console.error("Media upload failed:", err);
         notify("Upload failed. Trying local fallback...", "warning");

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">Public Gallery</h2>
+            <div class="public-gallery-grid" id="publicGalleryGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -1,18 +1,21 @@
 // CatGPT Meme Generator — UI, state, and DOM logic
 
 import {
+    CATGPT_APP_KEY,
     clearApiKey,
     createImageGenerationPrompt,
     EXAMPLE_PROMPTS,
     extractApiKeyFromFragment,
     fetchBalance,
     fetchProfile,
+    fetchSavedCatGptMemes,
     generateCatReply,
     generateImageURL,
     getAuthorizeUrl,
     getStoredApiKey,
     handleImageUpload,
     pickModel,
+    saveGeneratedMemeToMedia,
     storeApiKey,
 } from "./ai.js";
 
@@ -75,6 +78,7 @@ const dom = {
     shareBtn: $("shareBtn"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
+    publicGalleryGrid: $("publicGalleryGrid"),
     imageUpload: $("imageUpload"),
     imageUploadContainer: $("imageUploadContainer"),
     imageThumbnailContainer: $("imageThumbnailContainer"),
@@ -174,6 +178,22 @@ function saveGeneratedMeme(prompt, url) {
         ...saved.filter((m) => m.prompt !== prompt),
     ].slice(0, 8);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}
+
+async function fetchPublicCatGptMemes() {
+    const params = new URLSearchParams({
+        app_key: CATGPT_APP_KEY,
+        tag: "catgpt-generated",
+        limit: "6",
+    });
+    const res = await fetch(`https://media.pollinations.ai/gallery?${params}`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.items || []).map((item) => ({
+        prompt: item.prompt || "CatGPT meme",
+        url: item.url,
+        model: item.model,
+    }));
 }
 
 // ── Animations ───────────────────────────────────────────────────────────────
@@ -333,9 +353,16 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
+async function loadUserMemes() {
     dom.yourMemesGrid.innerHTML = "";
-    const saved = getSavedMemes();
+    const localSaved = getSavedMemes();
+    const remoteSaved = await fetchSavedCatGptMemes().catch(() => []);
+    const saved = [
+        ...remoteSaved,
+        ...localSaved.filter(
+            (local) => !remoteSaved.some((remote) => remote.url === local.url),
+        ),
+    ].slice(0, 12);
 
     if (!saved.length) {
         const p = document.createElement("p");
@@ -349,6 +376,19 @@ function loadUserMemes() {
     saved.forEach((meme, i) => {
         const card = createMemeCard(meme.prompt, i, meme.url);
         if (card) dom.yourMemesGrid.appendChild(card);
+    });
+}
+
+async function loadPublicGallery() {
+    if (!dom.publicGalleryGrid) return;
+    dom.publicGalleryGrid.innerHTML = "";
+
+    const memes = await fetchPublicCatGptMemes().catch(() => []);
+    if (!memes.length) return;
+
+    memes.forEach((meme, i) => {
+        const card = createMemeCard(meme.prompt, i, meme.url);
+        if (card) dom.publicGalleryGrid.appendChild(card);
     });
 }
 
@@ -396,8 +436,13 @@ async function generateMeme() {
     const catReply = await generateCatReply(question, uploadedImageUrl);
     if (cancelled) return;
 
+    const imagePrompt = createImageGenerationPrompt(
+        question,
+        catReply,
+        !!uploadedImageUrl,
+    );
     const imageUrl = generateImageURL(
-        createImageGenerationPrompt(question, catReply, !!uploadedImageUrl),
+        imagePrompt,
         activeModel,
         uploadedImageUrl,
     );
@@ -411,17 +456,28 @@ async function generateMeme() {
             throw new Error(text.slice(0, 200) || `Error ${response.status}`);
         }
 
-        // Use the pollinations URL directly (shareable, cacheable)
-        await response.blob(); // ensure the image is fully loaded
+        const blob = await response.blob();
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+        let savedUrl = imageUrl;
+        try {
+            savedUrl = await saveGeneratedMemeToMedia(blob, {
+                question,
+                model: activeModel,
+                parentUrls: [uploadedImageUrl],
+            });
+        } catch (err) {
+            console.warn("Generated meme catalog save failed:", err);
+        }
+        if (cancelled) return;
+        dom.generatedMeme.src = savedUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
-        loadUserMemes();
+        saveGeneratedMeme(question, savedUrl);
+        await loadUserMemes();
+        await loadPublicGallery();
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +674,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadPublicGallery();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/catgpt/styles.css
+++ b/apps/catgpt/styles.css
@@ -581,7 +581,8 @@ header {
 /* === Cards === */
 
 .examples-grid,
-.your-memes-grid {
+.your-memes-grid,
+.public-gallery-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
@@ -740,7 +741,8 @@ footer a {
     }
 
     .examples-grid,
-    .your-memes-grid {
+    .your-memes-grid,
+    .public-gallery-grid {
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
     }
@@ -801,7 +803,8 @@ footer a {
     }
 
     .examples-grid,
-    .your-memes-grid {
+    .your-memes-grid,
+    .public-gallery-grid {
         grid-template-columns: 1fr;
     }
 

--- a/apps/chat/src/utils/api.js
+++ b/apps/chat/src/utils/api.js
@@ -1,5 +1,7 @@
 // Pollinations API utilities — updated to match gen.pollinations.ai spec
 const BASE_URL = "https://gen.pollinations.ai";
+const MEDIA_API_URL = "https://media.pollinations.ai";
+const MEDIA_UPLOAD_URL = `${MEDIA_API_URL}/upload`;
 const ENV_API_TOKEN = import.meta.env.VITE_POLLINATIONS_API_KEY || "";
 export const BYOP_STORAGE_KEY = "pollinations_byop_api_key";
 
@@ -74,6 +76,62 @@ const parseApiError = async (response) => {
     }
     return buildClientError(response.status);
 };
+
+function appendCatalogFields(form, fields = {}) {
+    const {
+        visibility = "private",
+        tags = [],
+        parents = [],
+        source = "generation",
+        prompt,
+        model,
+    } = fields;
+    form.append("visibility", visibility);
+    form.append("source", source);
+    if (prompt) form.append("prompt", prompt);
+    if (model) form.append("model", model);
+    if (tags.length) form.append("tags", JSON.stringify(tags));
+    if (parents.length) form.append("parents", JSON.stringify(parents));
+}
+
+async function uploadGeneratedMedia(blob, filename, fields) {
+    const token = getApiToken();
+    if (!token) throw new Error("No API key available for media upload");
+
+    const form = new FormData();
+    form.append("file", blob, filename);
+    appendCatalogFields(form, fields);
+
+    const response = await fetch(MEDIA_UPLOAD_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+    });
+    if (!response.ok) throw new Error("Media upload failed");
+
+    const data = await response.json();
+    if (data.url) return data.url;
+    if (data.id) return `${MEDIA_API_URL}/${data.id}`;
+    throw new Error("Media upload response missing URL");
+}
+
+function blobToDataUrl(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+async function catalogOrDataUrl(blob, filename, fields) {
+    try {
+        return await uploadGeneratedMedia(blob, filename, fields);
+    } catch (error) {
+        console.warn("Media catalog upload failed, using data URL:", error);
+        return blobToDataUrl(blob);
+    }
+}
 
 export const loadModels = async () => {
     if (
@@ -530,13 +588,18 @@ export const generateImage = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, width, height, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-image-${Date.now()}.png`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-image"],
+            source: "generation",
+            prompt,
+            model,
+        },
+    );
+    return { url: mediaUrl, prompt, model, width, height, seed };
 };
 
 export const generateVideo = async (prompt, options = {}) => {
@@ -556,13 +619,18 @@ export const generateVideo = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-video-${Date.now()}.mp4`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-video"],
+            source: "generation",
+            prompt,
+            model,
+        },
+    );
+    return { url: mediaUrl, prompt, model, seed };
 };
 
 // Generate speech/audio — GET /audio/{text}?voice=...
@@ -578,11 +646,21 @@ export const generateAudio = async (text, options = {}) => {
 
     const blob = await response.blob();
     const mimeType = blob.type || "audio/mpeg";
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, text, voice, model, mimeType });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const ext = mimeType.includes("wav")
+        ? "wav"
+        : mimeType.includes("ogg")
+          ? "ogg"
+          : "mp3";
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-audio-${Date.now()}.${ext}`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-audio"],
+            source: "generation",
+            prompt: text,
+            model,
+        },
+    );
+    return { url: mediaUrl, text, voice, model, mimeType };
 };

--- a/apps/opposite-prompt-bot/bot.ts
+++ b/apps/opposite-prompt-bot/bot.ts
@@ -15,7 +15,18 @@ const TOKEN = process.env.BOT_TOKEN_OPPOSITE_PROMPT;
 const API_KEY = process.env.TEXT_POLLINATIONS_TOKEN;
 const TEXT_API = "https://gen.pollinations.ai/v1/chat/completions";
 const IMAGE_API = "https://gen.pollinations.ai/image";
+const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA_API = "https://media.pollinations.ai";
 const AUTH = API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {};
+
+type MediaUploadResponse = {
+    id?: string;
+    url?: string;
+};
+
+type TypingChannel = {
+    sendTyping: () => Promise<unknown>;
+};
 
 const OPPOSITE_PROMPT = `You are a safe image prompt generator. Your #1 rule: NEVER output anything involving nudity, bare skin, undressed people, children, violence, gore, or anything sexual. This rule overrides ALL other instructions.
 
@@ -32,17 +43,30 @@ When in doubt, make it about landscapes, objects, or abstract concepts — NEVER
 
 If your output mentions any person, you MUST explicitly include "fully clothed" or "wearing [specific clothing]" in the phrase. Image models default to bare skin otherwise.`;
 
-function log(...args: any[]) {
+function log(...args: unknown[]) {
     console.log(`[${new Date().toISOString()}]`, ...args);
 }
 
-function logError(...args: any[]) {
+function logError(...args: unknown[]) {
     console.error(`[${new Date().toISOString()}]`, ...args);
 }
 
-function logAxiosError(context: string, err: any) {
-    logError(`${context}: ${err.message}`);
-    if (err.response) {
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function canSendTyping(
+    channel: Message["channel"],
+): channel is Message["channel"] & TypingChannel {
+    return (
+        "sendTyping" in channel &&
+        typeof (channel as { sendTyping?: unknown }).sendTyping === "function"
+    );
+}
+
+function logAxiosError(context: string, err: unknown) {
+    logError(`${context}: ${errorMessage(err)}`);
+    if (axios.isAxiosError(err) && err.response) {
         logError(`  Status: ${err.response.status}`);
         logError(`  Headers:`, JSON.stringify(err.response.headers, null, 2));
         const body =
@@ -50,7 +74,7 @@ function logAxiosError(context: string, err: any) {
                 ? err.response.data.toString("utf-8").slice(0, 2000)
                 : JSON.stringify(err.response.data, null, 2)?.slice(0, 2000);
         logError(`  Body:`, body);
-    } else if (err.code) {
+    } else if (axios.isAxiosError(err) && err.code) {
         logError(`  Code: ${err.code}`);
     }
 }
@@ -85,6 +109,41 @@ async function fetchImage(prompt: string): Promise<Buffer> {
     return Buffer.from(res.data);
 }
 
+async function uploadImageToMedia(
+    buffer: Buffer,
+    filename: string,
+    fields: { prompt: string; model: string; tags: string[] },
+): Promise<string | null> {
+    if (!API_KEY) return null;
+
+    try {
+        const form = new FormData();
+        form.append(
+            "file",
+            new Blob([new Uint8Array(buffer)], { type: "image/png" }),
+            filename,
+        );
+        form.append("visibility", "public");
+        form.append("source", "generation");
+        form.append("prompt", fields.prompt);
+        form.append("model", fields.model);
+        form.append("tags", JSON.stringify(fields.tags));
+
+        const res = await fetch(MEDIA_UPLOAD, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${API_KEY}` },
+            body: form,
+        });
+        if (!res.ok) throw new Error(`media upload failed: ${res.status}`);
+
+        const json = (await res.json()) as MediaUploadResponse;
+        return json.url || (json.id ? `${MEDIA_API}/${json.id}` : null);
+    } catch (err: unknown) {
+        logError("Media catalog upload failed:", errorMessage(err));
+        return null;
+    }
+}
+
 const processing = new Set<string>();
 
 async function handleMessage(msg: Message, client: Client): Promise<void> {
@@ -102,8 +161,7 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
     log(`Prompt from ${msg.author.username} in ${msg.channelId}: "${prompt}"`);
 
     try {
-        if ("sendTyping" in msg.channel)
-            await (msg.channel as any).sendTyping();
+        if (canSendTyping(msg.channel)) await msg.channel.sendTyping();
     } catch {}
 
     const maxRetries = 2;
@@ -112,19 +170,28 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
             const opposite = await generateOpposite(prompt);
 
             try {
-                if ("sendTyping" in msg.channel)
-                    await (msg.channel as any).sendTyping();
+                if (canSendTyping(msg.channel)) await msg.channel.sendTyping();
             } catch {}
 
             const imageBuffer = await fetchImage(opposite);
+            const mediaUrl = await uploadImageToMedia(
+                imageBuffer,
+                `opposite-prompt-${msg.id}.png`,
+                {
+                    prompt: `${prompt} -> ${opposite}`,
+                    model: "zimage",
+                    tags: ["opposite-prompt", "opposite-prompt-bot"],
+                },
+            );
             const attachment = new AttachmentBuilder(imageBuffer, {
                 name: "opposite.png",
             });
 
             await msg.reply({ files: [attachment] });
+            if (mediaUrl) log(`Cataloged media: ${mediaUrl}`);
             log(`Reply sent successfully for "${prompt}" → "${opposite}"`);
             return;
-        } catch (err: any) {
+        } catch (err: unknown) {
             logAxiosError(
                 `Attempt ${attempt + 1}/${maxRetries + 1} for "${prompt}"`,
                 err,

--- a/apps/product-packaging-designer/src/App.tsx
+++ b/apps/product-packaging-designer/src/App.tsx
@@ -29,6 +29,15 @@ type PackagingType = {
     prompt: string;
 };
 
+type CatalogFields = {
+    visibility?: "public" | "private";
+    tags?: string[];
+    parents?: string[];
+    source?: "upload" | "generation" | "edit" | "saved_generation" | "remix";
+    prompt?: string;
+    model?: string;
+};
+
 const styleOptions: StyleOption[] = [
     {
         id: "minimalist",
@@ -79,7 +88,8 @@ const packagingTypes: PackagingType[] = [
     { id: "can", label: "Can", icon: Package, prompt: "can packaging" },
 ];
 const POLLINATIONS_API = "https://gen.pollinations.ai/image";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
+const PACKAGING_TAGS = ["product-packaging-designer"];
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const MAX_DISPLAY_SIZE = 10 * 1024 * 1024;
@@ -236,18 +246,37 @@ function App() {
             setFile(null);
         }
     };
-    const uploadToPollinationsMedia = async (file: File): Promise<string> => {
-        const validation = validateFile(file, MAX_FILE_SIZE);
-        if (!validation.isValid) {
-            throw new Error(validation.error || "File validation failed");
-        }
+    const appendCatalogFields = (
+        formData: FormData,
+        {
+            visibility = "private",
+            tags = PACKAGING_TAGS,
+            parents = [],
+            source = "generation",
+            prompt,
+            model,
+        }: CatalogFields = {},
+    ) => {
+        formData.append("visibility", visibility);
+        formData.append("source", source);
+        if (prompt) formData.append("prompt", prompt);
+        if (model) formData.append("model", model);
+        if (tags.length) formData.append("tags", JSON.stringify(tags));
+        if (parents.length) formData.append("parents", JSON.stringify(parents));
+    };
 
+    const uploadBlobToPollinationsMedia = async (
+        blob: Blob,
+        filename: string,
+        catalog: CatalogFields = {},
+    ): Promise<string> => {
         if (!apiKey) {
             throw new Error("No API key available for media upload");
         }
 
         const formData = new FormData();
-        formData.append("file", file);
+        formData.append("file", blob, filename);
+        appendCatalogFields(formData, catalog);
 
         try {
             const response = await fetch(POLLINATIONS_MEDIA_API, {
@@ -303,6 +332,23 @@ function App() {
 
             throw new Error("An unexpected error occurred during upload");
         }
+    };
+
+    const uploadToPollinationsMedia = async (file: File): Promise<string> => {
+        const validation = validateFile(file, MAX_FILE_SIZE);
+        if (!validation.isValid) {
+            throw new Error(validation.error || "File validation failed");
+        }
+
+        return uploadBlobToPollinationsMedia(
+            file,
+            file.name || "packaging-source.png",
+            {
+                visibility: "private",
+                tags: [...PACKAGING_TAGS, "packaging-source"],
+                source: "upload",
+            },
+        );
     };
 
     const generatePackaging = async () => {
@@ -385,8 +431,32 @@ ${brandName.trim() ? ` Brand name: "${brandName}".` : ""}
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setGeneratedImage(blobUrl);
+            let resultUrl = URL.createObjectURL(blob);
+            try {
+                resultUrl = await uploadBlobToPollinationsMedia(
+                    blob,
+                    `packaging-mockup-${Date.now()}.png`,
+                    {
+                        visibility: "private",
+                        tags: [
+                            ...PACKAGING_TAGS,
+                            "packaging-result",
+                            packagingType,
+                            style,
+                        ],
+                        parents: [uploadedUrl],
+                        source: "edit",
+                        prompt,
+                        model: "nanobanana",
+                    },
+                );
+            } catch (uploadError) {
+                console.warn(
+                    "Packaging result catalog upload failed:",
+                    uploadError,
+                );
+            }
+            setGeneratedImage(resultUrl);
             setImageLoaded(true);
         } catch (error) {
             console.error("Error in generatePackaging:", error);

--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -1,119 +1,217 @@
 // Pollinations API Service
 
-import {
-  PollinationsRequest,
-  ImageGenerationResponse
-} from './types';
+import type { ImageGenerationResponse, PollinationsRequest } from "./types";
 
-const POLLINATIONS_API_BASE = 'https://gen.pollinations.ai';
+const POLLINATIONS_API_BASE = "https://gen.pollinations.ai";
+const MEDIA_API_BASE = "https://media.pollinations.ai";
 const DEFAULT_CONFIG = {
-  model: 'gptimage' as const,
-  enhance: true,
-  nologo: true,
+    model: "gptimage" as const,
+    enhance: true,
+    nologo: true,
 };
 
 export class PollinationsService {
-  private token: string | null = null;
+    private token: string | null = null;
 
-  setToken(token: string | null): void {
-    this.token = token;
-  }
-
-  async generateImageFromPrompt(
-    sectionPrompt: string,
-    projectPrompt?: string,
-    options?: Partial<PollinationsRequest>,
-    inputImageUrl?: string
-  ): Promise<ImageGenerationResponse> {
-    try {
-      const finalPrompt = projectPrompt
-        ? `${projectPrompt}\n\n${sectionPrompt}`
-        : sectionPrompt;
-
-      if (!options?.width || !options?.height) {
-        throw new Error('Width and height must be specified for image generation');
-      }
-
-      const payload: PollinationsRequest = {
-        prompt: finalPrompt,
-        model: options?.model || DEFAULT_CONFIG.model,
-        width: options.width,
-        height: options.height,
-        enhance: options?.enhance ?? DEFAULT_CONFIG.enhance,
-        nologo: options?.nologo ?? DEFAULT_CONFIG.nologo,
-        seed: options?.seed || Math.floor(Math.random() * 1000000),
-        ...(inputImageUrl && { imageUrl: inputImageUrl }),
-      };
-
-      // Build GET URL: https://gen.pollinations.ai/image/{prompt}
-      const encodedPrompt = encodeURIComponent(payload.prompt);
-      const url = new URL(`${POLLINATIONS_API_BASE}/image/${encodedPrompt}`);
-
-      url.searchParams.set('model', payload.model || DEFAULT_CONFIG.model);
-      url.searchParams.set('width', payload.width.toString());
-      url.searchParams.set('height', payload.height.toString());
-      url.searchParams.set('enhance', (payload.enhance ?? DEFAULT_CONFIG.enhance).toString());
-      url.searchParams.set('nologo', (payload.nologo ?? DEFAULT_CONFIG.nologo).toString());
-      url.searchParams.set('seed', payload.seed!.toString());
-
-      if (payload.imageUrl && this.isValidUrl(payload.imageUrl)) {
-        url.searchParams.set('imageUrl', payload.imageUrl);
-      }
-
-      const token = this.token || import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 || import.meta.env.VITE_POLLINATIONS_AI_TOKEN;
-
-      // Publishable keys (pk_) use query param, Secret keys (sk_) use Authorization header
-      const headers: HeadersInit = {};
-      if (token) {
-        if (token.startsWith('pk_')) {
-          url.searchParams.set('key', token);
-        } else {
-          headers['Authorization'] = `Bearer ${token}`;
-        }
-      }
-
-      const response = await fetch(url.toString(), {
-        method: 'GET',
-        headers,
-        signal: AbortSignal.timeout(300000), // 5 minute timeout
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error(`API error: ${response.status} ${response.statusText}`, errorText);
-
-        if (response.status === 500) {
-          throw new Error(`Backend overloaded (500) - Wait a few seconds and try again`);
-        } else if (response.status === 401) {
-          throw new Error(`Authentication failed (401) - Check your API key`);
-        } else if (response.status === 403) {
-          throw new Error(`Insufficient pollen balance (403) - Check https://enter.pollinations.ai`);
-        } else {
-          throw new Error(`Pollinations API error: ${response.status} ${response.statusText}`);
-        }
-      }
-
-      const result: ImageGenerationResponse = {
-        url: url.toString(),
-        provider: 'pollinations',
-        seed: payload.seed,
-        cached: false,
-      };
-
-      return result;
-
-    } catch (error) {
-      console.error('Pollinations generation failed:', error);
-      throw error;
+    setToken(token: string | null): void {
+        this.token = token;
     }
-  }
 
-  private isValidUrl(urlString: string): boolean {
-    try {
-      const url = new URL(urlString);
-      return url.protocol === 'http:' || url.protocol === 'https:';
-    } catch {
-      return false;
+    async generateImageFromPrompt(
+        sectionPrompt: string,
+        projectPrompt?: string,
+        options?: Partial<PollinationsRequest>,
+        inputImageUrl?: string,
+    ): Promise<ImageGenerationResponse> {
+        try {
+            const finalPrompt = projectPrompt
+                ? `${projectPrompt}\n\n${sectionPrompt}`
+                : sectionPrompt;
+
+            if (!options?.width || !options?.height) {
+                throw new Error(
+                    "Width and height must be specified for image generation",
+                );
+            }
+
+            const seed = options.seed ?? Math.floor(Math.random() * 1000000);
+            const payload: PollinationsRequest = {
+                prompt: finalPrompt,
+                model: options?.model || DEFAULT_CONFIG.model,
+                width: options.width,
+                height: options.height,
+                enhance: options?.enhance ?? DEFAULT_CONFIG.enhance,
+                nologo: options?.nologo ?? DEFAULT_CONFIG.nologo,
+                seed,
+                ...(inputImageUrl && { imageUrl: inputImageUrl }),
+            };
+
+            // Build GET URL: https://gen.pollinations.ai/image/{prompt}
+            const encodedPrompt = encodeURIComponent(payload.prompt);
+            const url = new URL(
+                `${POLLINATIONS_API_BASE}/image/${encodedPrompt}`,
+            );
+
+            url.searchParams.set(
+                "model",
+                payload.model || DEFAULT_CONFIG.model,
+            );
+            url.searchParams.set("width", payload.width.toString());
+            url.searchParams.set("height", payload.height.toString());
+            url.searchParams.set(
+                "enhance",
+                (payload.enhance ?? DEFAULT_CONFIG.enhance).toString(),
+            );
+            url.searchParams.set(
+                "nologo",
+                (payload.nologo ?? DEFAULT_CONFIG.nologo).toString(),
+            );
+            url.searchParams.set("seed", seed.toString());
+
+            if (payload.imageUrl && this.isValidUrl(payload.imageUrl)) {
+                url.searchParams.set("imageUrl", payload.imageUrl);
+            }
+
+            const token = this.getToken();
+
+            // Publishable keys (pk_) use query param, Secret keys (sk_) use Authorization header
+            const headers: HeadersInit = {};
+            if (token) {
+                if (token.startsWith("pk_")) {
+                    url.searchParams.set("key", token);
+                } else {
+                    headers["Authorization"] = `Bearer ${token}`;
+                }
+            }
+
+            const response = await fetch(url.toString(), {
+                method: "GET",
+                headers,
+                signal: AbortSignal.timeout(300000), // 5 minute timeout
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                console.error(
+                    `API error: ${response.status} ${response.statusText}`,
+                    errorText,
+                );
+
+                if (response.status === 500) {
+                    throw new Error(
+                        `Backend overloaded (500) - Wait a few seconds and try again`,
+                    );
+                } else if (response.status === 401) {
+                    throw new Error(
+                        `Authentication failed (401) - Check your API key`,
+                    );
+                } else if (response.status === 403) {
+                    throw new Error(
+                        `Insufficient pollen balance (403) - Check https://enter.pollinations.ai`,
+                    );
+                } else {
+                    throw new Error(
+                        `Pollinations API error: ${response.status} ${response.statusText}`,
+                    );
+                }
+            }
+
+            const generatedUrl = url.toString();
+            const mediaUrl = token
+                ? await this.uploadGeneratedImage(await response.blob(), {
+                      prompt: finalPrompt,
+                      model: payload.model || DEFAULT_CONFIG.model,
+                      parents: inputImageUrl ? [inputImageUrl] : [],
+                  })
+                : null;
+
+            const result: ImageGenerationResponse = {
+                url: mediaUrl || generatedUrl,
+                provider: "pollinations",
+                seed,
+                cached: false,
+            };
+
+            return result;
+        } catch (error) {
+            console.error("Pollinations generation failed:", error);
+            throw error;
+        }
     }
-  }
+
+    private isValidUrl(urlString: string): boolean {
+        try {
+            const url = new URL(urlString);
+            return url.protocol === "http:" || url.protocol === "https:";
+        } catch {
+            return false;
+        }
+    }
+
+    private getToken(): string | null {
+        return (
+            this.token ||
+            import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 ||
+            import.meta.env.VITE_POLLINATIONS_AI_TOKEN ||
+            null
+        );
+    }
+
+    private appendCatalogFields(
+        form: FormData,
+        fields: {
+            prompt: string;
+            model: string;
+            parents: string[];
+        },
+    ): void {
+        form.append("visibility", "private");
+        form.append(
+            "source",
+            fields.parents.length > 0 ? "edit" : "generation",
+        );
+        form.append("tags", JSON.stringify(["slidepainter", "slide"]));
+        form.append("prompt", fields.prompt);
+        form.append("model", fields.model);
+        if (fields.parents.length > 0) {
+            form.append("parents", JSON.stringify(fields.parents));
+        }
+    }
+
+    private async uploadGeneratedImage(
+        blob: Blob,
+        fields: {
+            prompt: string;
+            model: string;
+            parents: string[];
+        },
+    ): Promise<string | null> {
+        const token = this.getToken();
+        if (!token) return null;
+
+        try {
+            const form = new FormData();
+            form.append("file", blob, `slidepainter-${Date.now()}.png`);
+            this.appendCatalogFields(form, fields);
+
+            const uploadResponse = await fetch(`${MEDIA_API_BASE}/upload`, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${token}` },
+                body: form,
+                signal: AbortSignal.timeout(60000),
+            });
+            if (!uploadResponse.ok) return null;
+
+            const data = (await uploadResponse.json()) as {
+                id?: string;
+                url?: string;
+            };
+            return (
+                data.url || (data.id ? `${MEDIA_API_BASE}/${data.id}` : null)
+            );
+        } catch (error) {
+            console.warn("SlidePainter media catalog upload failed:", error);
+            return null;
+        }
+    }
 }

--- a/apps/virtual-makeup/src/App.jsx
+++ b/apps/virtual-makeup/src/App.jsx
@@ -14,8 +14,9 @@ import { useEffect, useRef, useState } from "react";
 
 const APP_KEY = "pk_pollinations_virtual_makeup";
 const POLLINATIONS_AUTH_URL = "https://enter.pollinations.ai/authorize";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 const POLLINATIONS_IMAGE_API = "https://gen.pollinations.ai/image";
+const MAKEUP_TAGS = ["virtual-makeup"];
 
 const MAKEUP_STYLES = [
     {
@@ -117,9 +118,27 @@ function App() {
         }
     };
 
-    const uploadToPollinations = async (file) => {
+    const appendCatalogFields = (formData, fields = {}) => {
+        const {
+            visibility = "private",
+            tags = MAKEUP_TAGS,
+            parents = [],
+            source = "generation",
+            prompt,
+            model,
+        } = fields;
+        formData.append("visibility", visibility);
+        formData.append("source", source);
+        if (prompt) formData.append("prompt", prompt);
+        if (model) formData.append("model", model);
+        if (tags.length) formData.append("tags", JSON.stringify(tags));
+        if (parents.length) formData.append("parents", JSON.stringify(parents));
+    };
+
+    const uploadBlobToPollinations = async (blob, filename, catalog = {}) => {
         const formData = new FormData();
-        formData.append("file", file);
+        formData.append("file", blob, filename);
+        appendCatalogFields(formData, catalog);
 
         const response = await fetch(POLLINATIONS_MEDIA_API, {
             method: "POST",
@@ -137,6 +156,18 @@ function App() {
 
         const data = await response.json();
         return data.url || data.secure_url || data.media_url;
+    };
+
+    const uploadToPollinations = async (file) => {
+        return uploadBlobToPollinations(
+            file,
+            file.name || "makeup-source.png",
+            {
+                visibility: "private",
+                tags: [...MAKEUP_TAGS, "virtual-makeup-source"],
+                source: "upload",
+            },
+        );
     };
 
     const applyMakeup = async () => {
@@ -172,8 +203,31 @@ function App() {
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setMakeupImage(blobUrl);
+            let resultUrl = URL.createObjectURL(blob);
+            try {
+                resultUrl = await uploadBlobToPollinations(
+                    blob,
+                    `makeup-result-${Date.now()}.png`,
+                    {
+                        visibility: "private",
+                        tags: [
+                            ...MAKEUP_TAGS,
+                            "virtual-makeup-result",
+                            selectedStyle,
+                        ],
+                        parents: [pollinationsUrl],
+                        source: "edit",
+                        prompt,
+                        model: "nanobanana",
+                    },
+                );
+            } catch (uploadError) {
+                console.warn(
+                    "Makeup result catalog upload failed:",
+                    uploadError,
+                );
+            }
+            setMakeupImage(resultUrl);
             setImageLoaded(true);
             setIsLoading(false);
         } catch (error) {

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -1,0 +1,1616 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Remix | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --line: #110518;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--line);
+    --raise: 2px 2px 0 var(--line);
+    --stage-max: calc(100vh - 210px);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  button, input, select { font: inherit; color: inherit; }
+  button { touch-action: manipulation; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .btn, .select, .frame, .overlay-panel, .pin, .pill {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+    font-weight: 700;
+  }
+  .btn {
+    padding: 0 12px;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--line); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; max-width: min(100%, 20rem); }
+  .branch-strip {
+    display: none;
+    gap: 10px;
+    overflow-x: auto;
+    padding: 2px 2px 8px;
+  }
+  .branch-strip.visible { display: flex; }
+  .branch-card {
+    flex: 0 0 96px;
+    padding: 0;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    cursor: pointer;
+  }
+  .branch-card img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
+  }
+  .branch-card span {
+    display: block;
+    padding: 5px;
+    font-size: 0.65rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mode-toggle, .swatches {
+    display: inline-flex;
+    align-items: center;
+  }
+  .mode-toggle {
+    gap: 0;
+  }
+  .mode-toggle button {
+    width: 38px;
+    height: 38px;
+    border: var(--border);
+    background: var(--surface);
+    font: inherit;
+    font-size: 1.05rem;
+    cursor: pointer;
+  }
+  .mode-toggle button + button {
+    margin-left: -3px;
+  }
+  .mode-toggle button.active {
+    background: var(--accent);
+    z-index: 1;
+  }
+  .mode-toggle button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+  .history { margin-left: auto; }
+
+  .swatches {
+    gap: 5px;
+  }
+  .swatch {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: var(--border);
+    border-radius: 0;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    cursor: pointer;
+  }
+  .swatch.active { outline-color: var(--accent); }
+  .swatch[data-color="white"] { background: #fff; }
+  .swatch[data-color="black"] { background: #000; }
+  .swatch[data-color="red"] { background: red; }
+
+  .frame {
+    position: relative;
+    min-height: 280px;
+    overflow: visible;
+    display: grid;
+    place-items: center;
+  }
+  .frame.drop { outline: 4px dashed var(--accent); outline-offset: -10px; }
+  .stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    touch-action: none;
+  }
+  .stage canvas {
+    display: block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    width: auto;
+    height: auto;
+  }
+  #markCanvas, #pinLayer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  #pinLayer { z-index: 4; pointer-events: none; overflow: visible; }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(243, 235, 222, 0.88);
+    backdrop-filter: blur(2px);
+  }
+  .frame.locked .overlay { display: flex; }
+  .overlay-panel {
+    width: min(22rem, calc(100% - 32px));
+    padding: 18px;
+    text-align: center;
+  }
+  .overlay-panel p { margin: 0 0 12px; font-size: 0.9rem; }
+
+  .pin {
+    position: absolute;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    max-width: min(16rem, 48vw);
+    width: max-content;
+    padding: 5px 9px;
+    transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    overflow-wrap: break-word;
+  }
+  .pin.processing { background: var(--accent); }
+  .pin.history { background: var(--paper); opacity: 0.85; }
+  .pin.flip {
+    flex-direction: row-reverse;
+    transform: translate(calc(-100% + 0.55rem + 0.275rem + 1.5px), -50%);
+  }
+  .pin .dot {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    background: var(--line);
+    border: 1.5px solid var(--line);
+  }
+  .pin span:last-child { min-width: 0; }
+
+  .pill {
+    position: fixed;
+    z-index: 20;
+    display: none;
+    align-items: center;
+    gap: 9px;
+    max-width: min(18rem, calc(100vw - 24px));
+    padding: 8px 12px 8px 8px;
+    transform: translate(18px, -50%);
+    font-size: 0.9rem;
+    font-weight: 700;
+    pointer-events: none;
+    overflow-wrap: anywhere;
+  }
+  .pill.visible { display: inline-flex; }
+  .pill .mic {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: var(--accent);
+    border: var(--border);
+  }
+  .pill .bar {
+    width: 3px;
+    background: var(--line);
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  .pill .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  .pill .bar:nth-child(2) { height: 10px; animation-delay: 0.15s; }
+  .pill .bar:nth-child(3) { height: 6px; animation-delay: 0.3s; }
+  .pill .placeholder { opacity: 0.55; font-style: italic; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+
+  @media (max-width: 720px) {
+    .app { --stage-max: calc(100vh - 260px); width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .topbar { gap: 6px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .history { margin-left: 0; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .frame { min-height: 240px; }
+    .pin { max-width: 62vw; }
+  }
+  .frame.locked .stage { filter: grayscale(0.35) opacity(0.55); }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / remix</h1>
+      <span class="tagline">draw. talk. release.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="tools">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="uploadBtn" class="btn" title="load an image from disk">load</button>
+      <button id="shuffleBtn" class="btn" title="next sample image">sample</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="image model">
+        <option value="nanobanana">nanobanana</option>
+      </select>
+      <div id="colorPicker" class="swatches" aria-label="marker color">
+        <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
+        <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
+        <button type="button" class="swatch" data-color="white" aria-label="white marker"></button>
+      </div>
+      <div id="inputMode" class="mode-toggle" aria-label="input mode">
+        <button type="button" data-mode="mic" aria-label="use microphone">🎙️</button>
+        <button type="button" data-mode="type" aria-label="type prompt">⌨️</button>
+      </div>
+      <button id="undoBtn" class="btn history" disabled title="undo">undo</button>
+      <button id="redoBtn" class="btn" disabled title="redo">redo</button>
+      <button id="downloadBtn" class="btn" title="download image with embedded history - drop it back onto the app to restore">save</button>
+      <button id="shareBtn" class="btn" title="upload PNG with embedded history and copy link">share</button>
+      <button id="remixesBtn" class="btn" title="show public remixes of this image">remixes</button>
+      <button id="walkthroughBtn" class="btn" title="open this remix history as a video walkthrough">walkthrough</button>
+    </section>
+    <section id="branchStrip" class="branch-strip" aria-label="public remixes"></section>
+
+    <section id="frame" class="frame">
+      <div id="stage" class="stage">
+        <canvas id="imageCanvas" width="1024" height="768"></canvas>
+        <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <div id="pinLayer"></div>
+      </div>
+      <div class="overlay">
+        <div class="overlay-panel">
+          <p>connect to pollinations to start editing</p>
+          <button id="connectOverlayBtn" class="btn accent">connect</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div id="cursorPill" class="pill" aria-hidden="true">
+    <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
+    <span id="pillText" class="placeholder">listening...</span>
+  </div>
+
+<script>
+const KEY_STORAGE = "voice-edit:user-key";
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const STARTERS = [
+  { name: "cell", url: "https://media.pollinations.ai/10efdd0c1cfc65fa" },
+  { name: "octopus", url: "https://media.pollinations.ai/73775b7374f9b864" },
+  { name: "grand prismatic", url: "https://media.pollinations.ai/98280006f6099cb0" },
+  { name: "cosmic cliffs", url: "https://media.pollinations.ai/d05180b3bf21c01c" },
+  { name: "mars rover", url: "https://media.pollinations.ai/9a138c75c377d84a" },
+  { name: "relativity", url: "https://media.pollinations.ai/e7fc55d8a304edb3" },
+  { name: "da vinci", url: "https://media.pollinations.ai/31f553055c73b482" },
+  { name: "tomaselli", url: "https://media.pollinations.ai/9f450191ad9b8253" },
+  { name: "mushroom", url: "https://media.pollinations.ai/ad65acf0fd23ff85" },
+  { name: "surreal room", url: "https://media.pollinations.ai/fbc6c13d37c55f0b" },
+];
+const STARTER = STARTERS[0].url;
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const STT_MODEL = "scribe";
+const STT_LANG = (navigator.language || "en").slice(0, 2);
+const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+  .find((m) => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+const CAN_RECORD = Boolean(window.MediaRecorder && navigator.mediaDevices?.getUserMedia);
+const DRAG_THRESHOLD = 0.03;
+const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+
+const $ = (id) => document.getElementById(id);
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const pairs = (items) => items.slice(1).map((item, i) => [items[i], item]);
+const distance = (a, b) => Math.hypot(b.x - a.x, b.y - a.y);
+const minCanvasSide = () => Math.min(els.markCanvas.width, els.markCanvas.height);
+
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  frame: "frame",
+  imageCanvas: "imageCanvas",
+  markCanvas: "markCanvas",
+  pinLayer: "pinLayer",
+  connect: "connectBtn",
+  connectOverlay: "connectOverlayBtn",
+  upload: "uploadBtn",
+  shuffle: "shuffleBtn",
+  file: "fileInput",
+  model: "modelSel",
+  inputMode: "inputMode",
+  undo: "undoBtn",
+  redo: "redoBtn",
+  download: "downloadBtn",
+  share: "shareBtn",
+  remixes: "remixesBtn",
+  walkthrough: "walkthroughBtn",
+  branches: "branchStrip",
+  colorPicker: "colorPicker",
+  pill: "cursorPill",
+  pillText: "pillText",
+}).map(([key, id]) => [key, $(id)]));
+const imageCtx = els.imageCanvas.getContext("2d");
+const markCtx = els.markCanvas.getContext("2d");
+
+const app = {
+  image: null,
+  imageURL: "",
+  stateURL: "",
+  history: [],
+  historyIndex: -1,
+  micStream: null,
+  active: null,
+  busy: false,
+  queue: [],
+  currentJob: null,
+  markerColor: "red",
+  inputMode: CAN_RECORD ? "mic" : "type",
+  micAvailable: CAN_RECORD,
+  accountUser: "",
+  accountBalance: null,
+  branchItems: [],
+  branchesOpen: false,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = (extra = {}) => ({ Authorization: `Bearer ${key()}`, ...extra });
+
+function render() {
+  const locked = app.busy || Boolean(app.active);
+  els.undo.disabled = !mediaHistory.canUndo() || locked;
+  els.redo.disabled = !mediaHistory.canRedo() || locked;
+  [els.upload, els.shuffle, els.model, els.share, els.remixes, els.walkthrough].forEach((el) => { el.disabled = locked; });
+  renderInputMode(locked);
+  renderPins();
+  renderBranches();
+}
+
+function renderInputMode(locked = false) {
+  for (const button of els.inputMode.querySelectorAll("button")) {
+    const mode = button.dataset.mode;
+    button.classList.toggle("active", app.inputMode === mode);
+    button.disabled = locked || (mode === "mic" && !app.micAvailable);
+  }
+}
+
+function setInputMode(mode) {
+  if (mode === "mic" && !app.micAvailable) return;
+  app.inputMode = mode;
+  render();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function setMarkerColor(color) {
+  app.markerColor = color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button.dataset.color === color);
+  }
+}
+
+function renderPins() {
+  const jobs = [app.currentJob, ...app.queue].filter(Boolean);
+  const items = jobs.length
+    ? jobs.map((job) => ({
+      cls: job === app.currentJob ? "processing" : "queued",
+      text: job.text,
+      xPct: job.xPct,
+      yPct: job.yPct,
+    }))
+    : pinForCurrentFrame();
+  const layerBox = els.pinLayer.getBoundingClientRect();
+  els.pinLayer.replaceChildren(...items.map((item) => {
+    const pin = document.createElement("div");
+    pin.className = `pin ${item.cls}`;
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    const text = document.createElement("span");
+    text.textContent = item.text;
+    pin.append(dot, text);
+    pin.style.left = `${item.xPct}%`;
+    pin.style.top = `${item.yPct}%`;
+    const anchorX = layerBox.left + (layerBox.width * item.xPct / 100);
+    const rightSpace = window.innerWidth - anchorX - 16;
+    const leftSpace = anchorX - 16;
+    const flip = rightSpace < 140 && leftSpace > rightSpace;
+    pin.classList.toggle("flip", flip);
+    pin.style.maxWidth = `${clamp(flip ? leftSpace : rightSpace, 40, 256)}px`;
+    return pin;
+  }));
+}
+
+function renderBranches() {
+  els.remixes.textContent = app.branchItems.length ? `remixes ${app.branchItems.length}` : "remixes";
+  els.branches.classList.toggle("visible", app.branchesOpen);
+  if (!app.branchesOpen) return;
+  if (!app.branchItems.length) {
+    const empty = document.createElement("span");
+    empty.className = "tagline";
+    empty.textContent = "no public remixes yet";
+    els.branches.replaceChildren(empty);
+    return;
+  }
+  els.branches.replaceChildren(...app.branchItems.map((item) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "branch-card";
+    button.title = item.prompt || "open remix";
+    const img = document.createElement("img");
+    img.src = item.url;
+    img.alt = item.prompt || "public remix";
+    img.loading = "lazy";
+    const label = document.createElement("span");
+    label.textContent = item.prompt || "remix";
+    button.append(img, label);
+    button.addEventListener("click", () => openStartURL(item.url).catch((err) => showError(err.message)));
+    return button;
+  }));
+}
+
+function pinForCurrentFrame() {
+  const frame = app.history[app.historyIndex];
+  if (frame?.kind !== "prep" || frame.xPct == null || frame.yPct == null) return [];
+  return [{
+    cls: "history",
+    text: frame.promptText || "",
+    xPct: frame.xPct,
+    yPct: frame.yPct,
+  }];
+}
+
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) els.pill.style.left = `${x}px`;
+  if (y != null) els.pill.style.top = `${y}px`;
+  if (text !== undefined) {
+    els.pillText.textContent = text;
+    els.pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) els.pill.classList.toggle("visible", visible);
+}
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (apiKey) {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    history.replaceState(null, "", location.pathname + location.search);
+  } else if (params.get("error")) {
+    showError(`Authorization failed: ${params.get("error")}`);
+  }
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  els.frame.classList.toggle("locked", !connected);
+  if (!connected) {
+    app.accountUser = "";
+    app.accountBalance = null;
+    renderAccount();
+    setStatus("not connected");
+    return;
+  }
+  renderAccount();
+  warmMic();
+  loadUser();
+  loadBalance();
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname + location.search,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  stopMic();
+  refreshConnectionUI();
+}
+
+async function loadUser() {
+  try {
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const user = await res.json();
+    app.accountUser = user?.preferred_username || "";
+    renderAccount();
+  } catch {}
+}
+
+async function loadBalance() {
+  try {
+    const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const { balance } = await res.json();
+    app.accountBalance = Number(balance);
+    renderAccount();
+  } catch {}
+}
+
+async function warmMic() {
+  if (app.micStream || !app.micAvailable) return;
+  try {
+    app.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+  } catch (err) {
+    app.micAvailable = false;
+    app.inputMode = "type";
+    render();
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use type instead.`);
+  }
+}
+
+function stopMic() {
+  if (!app.micStream) return;
+  for (const track of app.micStream.getTracks()) track.stop();
+  app.micStream = null;
+}
+
+const mediaHistory = {
+  canUndo: () => app.historyIndex > 0,
+  canRedo: () => app.historyIndex >= 0 && app.historyIndex < app.history.length - 1,
+  add(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  addSilent(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  async go(index) {
+    const frame = app.history[index];
+    if (!frame) return;
+    await renderFrame(frame);
+    app.historyIndex = index;
+    syncStartToFrame(frame);
+    render();
+  },
+  async set(frame, { add = false } = {}) {
+    await renderFrame(frame);
+    if (add) mediaHistory.add(frame);
+    else {
+      syncStartToFrame(frame);
+      render();
+    }
+  },
+  async reset(frame, stateURL = frame.url) {
+    app.history = [frame];
+    app.historyIndex = 0;
+    app.stateURL = scrubURL(stateURL) || scrubURL(frame.url);
+    await renderFrame(frame);
+    syncStartToFrame(frame, { force: true });
+    render();
+  },
+};
+
+async function loadModels() {
+  try {
+    const res = await fetch(`${BASE}/image/models`);
+    if (!res.ok) return;
+    const models = await res.json();
+    const editModels = models
+      .filter((m) => m.input_modalities?.includes("image") && m.output_modalities?.includes("image"))
+      .sort((a, b) => {
+        const ra = RECOMMENDED_MODELS.has(a.name) ? 0 : 1;
+        const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
+        return ra - rb || a.name.localeCompare(b.name);
+      });
+    els.model.replaceChildren(...editModels.map((m) => {
+      const tags = [];
+      if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
+      if (m.paid_only) tags.push("paid");
+      return new Option(tags.length ? `${m.name} (${tags.join(", ")})` : m.name, m.name);
+    }));
+    if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+  } catch {}
+}
+
+async function renderFrame(frame) {
+  clearError();
+  await drawImage(frame.url);
+  clearMarks();
+  setStatus("ready");
+}
+
+async function drawImage(src) {
+  setStatus("loading image...");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = () => reject(new Error("could not load image"));
+    img.src = src;
+  });
+  app.image = img;
+  app.imageURL = src;
+  resizeCanvases(img.naturalWidth, img.naturalHeight);
+  imageCtx.drawImage(img, 0, 0);
+}
+
+function resizeCanvases(width, height) {
+  for (const canvas of [els.imageCanvas, els.markCanvas]) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function clearMarks() {
+  markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function pointerPoint(event) {
+  const rect = els.markCanvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
+  const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
+  return {
+    x: clamp(Math.round(x), 0, els.markCanvas.width),
+    y: clamp(Math.round(y), 0, els.markCanvas.height),
+  };
+}
+
+function strokeWidth() {
+  return Math.max(6, Math.round(minCanvasSide() * 0.015));
+}
+
+function drawSegment(from, to) {
+  markCtx.save();
+  markCtx.strokeStyle = app.markerColor;
+  markCtx.lineWidth = strokeWidth();
+  markCtx.lineCap = "round";
+  markCtx.lineJoin = "round";
+  markCtx.beginPath();
+  markCtx.moveTo(from.x, from.y);
+  markCtx.lineTo(to.x, to.y);
+  markCtx.stroke();
+  markCtx.restore();
+}
+
+function pathLength(points) {
+  return pairs(points).reduce((total, [a, b]) => total + distance(a, b), 0);
+}
+
+function pathBounds(points) {
+  return points.reduce((bounds, point) => ({
+    minX: Math.min(bounds.minX, point.x),
+    maxX: Math.max(bounds.maxX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    maxY: Math.max(bounds.maxY, point.y),
+  }), { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity });
+}
+
+function markerFromGesture({ points }) {
+  const marked = pathLength(points) >= minCanvasSide() * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const bounds = marked ? pathBounds(points) : null;
+  return {
+    marked,
+    marker: marked ? els.markCanvas.toDataURL("image/png") : "",
+    pinPoint: marked ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 } : points[0],
+  };
+}
+
+async function composeSnapshot(marker = "") {
+  const out = document.createElement("canvas");
+  out.width = els.imageCanvas.width;
+  out.height = els.imageCanvas.height;
+  const outCtx = out.getContext("2d");
+  outCtx.drawImage(els.imageCanvas, 0, 0);
+  if (marker) {
+    const markerImage = await loadImageElement(marker);
+    outCtx.drawImage(markerImage, 0, 0, out.width, out.height);
+  }
+  return out.toDataURL("image/png");
+}
+
+function buildPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
+}
+
+function pinPct(point) {
+  return {
+    xPct: (point.x / els.markCanvas.width) * 100,
+    yPct: (point.y / els.markCanvas.height) * 100,
+  };
+}
+
+function loadImageElement(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load marker"));
+    img.src = src;
+  });
+}
+
+function enqueueJob({ text, marked = false, marker = "", pinPoint, color }) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  const pin = pinPct(pinPoint);
+  app.queue.push({
+    text,
+    marked,
+    marker,
+    color,
+    model: els.model.value,
+    xPct: pin.xPct,
+    yPct: pin.yPct,
+  });
+  render();
+  runQueue();
+}
+
+function beginRecording(clientX, clientY) {
+  clearError();
+  if (!app.micAvailable) return { error: "Voice input is not available in this browser. Use type instead." };
+  if (!app.micStream) {
+    warmMic();
+    return { error: "microphone not ready - click once, allow access, then try again" };
+  }
+  const capture = { chunks: [], recorder: null, error: "" };
+  try {
+    capture.recorder = new MediaRecorder(app.micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (event) => {
+      if (event.data?.size) capture.chunks.push(event.data);
+    };
+    capture.recorder.start();
+  } catch (err) {
+    capture.error = err?.message || "could not start recording";
+    return capture;
+  }
+  pill({ x: clientX, y: clientY, text: "listening...", placeholder: true, visible: true });
+  setStatus("listening...");
+  return capture;
+}
+
+async function stopAndTranscribe(capture) {
+  if (capture.error || !capture.recorder) return { text: "", error: capture.error };
+  setStatus("transcribing...");
+  pill({ text: "transcribing...", placeholder: true });
+  const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
+  capture.recorder.stop();
+  await stopped;
+  const type = capture.recorder.mimeType || "audio/webm";
+  const ext = type.includes("mp4") ? "mp4" : "webm";
+  const blob = new Blob(capture.chunks, { type });
+  if (blob.size < 1000) return { text: "", error: "no audio captured - hold and speak" };
+  const form = new FormData();
+  form.append("file", blob, `voice.${ext}`);
+  form.append("model", STT_MODEL);
+  form.append("language", STT_LANG);
+  form.append("response_format", "json");
+  try {
+    const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    });
+    if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
+    const json = await res.json();
+    return { text: (json.text || "").trim(), error: "" };
+  } catch (err) {
+    return { text: "", error: err?.message || "transcription failed" };
+  }
+}
+
+async function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  els.pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing...");
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (text) => {
+      if (done) return;
+      done = true;
+      input.replaceWith(els.pillText);
+      pill({ visible: false });
+      resolve(text.trim());
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") { event.preventDefault(); finish(input.value); }
+      if (event.key === "Escape") { event.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value));
+  });
+}
+
+async function uploadDataURL(dataURL, filename = "annot.png") {
+  const blob = await (await fetch(dataURL)).blob();
+  return uploadBlob(blob, filename);
+}
+
+async function uploadBlob(blob, filename, fields = {}) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  for (const [key, value] of Object.entries(fields)) {
+    if (value != null && value !== "") {
+      form.append(key, Array.isArray(value) ? JSON.stringify(value) : String(value));
+    }
+  }
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+function canvasBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("canvas toBlob failed"))), "image/png");
+  });
+}
+
+async function runEdit(imageURL, prompt, model) {
+  const res = await fetch(`${BASE}/v1/images/edits`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
+  const json = await res.json();
+  const item = json.data?.[0];
+  if (!item) throw new Error("no image in response");
+  if (item.url) return item.url;
+  if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
+  throw new Error("no url or b64_json in response");
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+async function runQueue() {
+  if (app.busy) return;
+  app.busy = true;
+  render();
+  try {
+    while (app.queue.length) {
+      const job = app.queue.shift();
+      const parentHash = mediaHashFromURL(app.stateURL || app.history[app.historyIndex]?.url || app.imageURL);
+      app.currentJob = job;
+      render();
+      setStatus(`editing... (${app.queue.length + 1} in queue)`);
+      try {
+        const snapshot = await composeSnapshot(job.marker);
+        const uploaded = await uploadDataURL(snapshot, "annot.png");
+        mediaHistory.addSilent({
+          kind: "prep",
+          url: uploaded,
+          promptText: job.text,
+          marked: job.marked,
+          color: job.color,
+          xPct: job.xPct,
+          yPct: job.yPct,
+        });
+        const prompt = buildPrompt(job.text, job.marked, job.color);
+        const result = await runEdit(uploaded, prompt, job.model);
+        await mediaHistory.set({ url: result }, { add: true });
+        setStatus("packaging share link...");
+        const packaged = await packageCurrentFrameWithHistory(parentHash ? {
+          parents: [parentHash],
+          tags: ["voice-edit", "voice-edit-remix"],
+          visibility: "public",
+          source: "remix",
+          prompt: job.text,
+          model: job.model,
+        } : {});
+        const frame = app.history[app.historyIndex];
+        if (frame?.url === result) {
+          frame.url = packaged;
+          app.imageURL = packaged;
+          app.stateURL = packaged;
+          syncStartToCurrent({ force: true });
+          refreshBranches();
+          render();
+        }
+        await loadBalance();
+      } catch (err) {
+        showError(err.message);
+      } finally {
+        app.currentJob = null;
+        render();
+      }
+    }
+    setStatus("done");
+  } finally {
+    app.busy = false;
+    app.currentJob = null;
+    render();
+  }
+}
+
+function cancelGesture() {
+  if (app.active?.capture?.recorder?.state === "recording") {
+    try { app.active.capture.recorder.stop(); } catch {}
+  }
+  app.active = null;
+  clearMarks();
+  pill({ visible: false });
+  setStatus(app.busy ? "editing..." : "ready");
+  render();
+}
+
+els.markCanvas.addEventListener("pointerdown", async (event) => {
+  if (!app.image) { showError("Load an image first."); return; }
+  if (app.active) return;
+  event.preventDefault();
+  clearError();
+  clearMarks();
+  const start = pointerPoint(event);
+
+  if (app.inputMode === "type") {
+    app.active = { pointerId: event.pointerId, points: [start], typing: true, color: app.markerColor };
+    render();
+    try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+    return;
+  }
+
+  const capture = beginRecording(event.clientX, event.clientY);
+  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+});
+
+els.markCanvas.addEventListener("pointermove", (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  pill({ x: event.clientX, y: event.clientY });
+  const point = pointerPoint(event);
+  const prev = gesture.points[gesture.points.length - 1];
+  drawSegment(prev, point);
+  gesture.points.push(point);
+});
+
+els.markCanvas.addEventListener("pointerup", async (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  app.active = null;
+  if (gesture.typing) {
+    const annotation = markerFromGesture(gesture);
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    if (!text) {
+      clearMarks();
+      setStatus(app.busy ? "editing..." : "ready");
+      return;
+    }
+    try {
+      enqueueJob({ text, ...annotation, color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+      clearMarks();
+    }
+    return;
+  }
+  const annotation = markerFromGesture(gesture);
+  try {
+    const { text, error } = await stopAndTranscribe(gesture.capture);
+    pill({ visible: false });
+    if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    enqueueJob({ text, ...annotation, color: gesture.color });
+  } catch (err) {
+    showError(err.message);
+    clearMarks();
+  }
+});
+
+els.markCanvas.addEventListener("pointercancel", cancelGesture);
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape") return;
+  event.preventDefault();
+  cancelGesture();
+});
+
+els.connect.addEventListener("click", startConnect);
+els.connectOverlay.addEventListener("click", startConnect);
+els.upload.addEventListener("click", () => els.file.click());
+els.inputMode.addEventListener("click", (event) => {
+  const button = event.target.closest("button");
+  if (button) setInputMode(button.dataset.mode);
+});
+els.shuffle.addEventListener("click", () => {
+  const starter = nextStarter();
+  openStartURL(starter.url)
+    .then(() => setStatus(`loaded ${starter.name}`))
+    .catch((err) => showError(err.message));
+});
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image", {
+      visibility: "private",
+      tags: ["voice-edit", "voice-edit-source"],
+      source: "upload",
+    });
+    await openStartURL(mediaURL);
+    setStatus(`loaded ${file.name || "image"}`);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+
+els.colorPicker.addEventListener("click", (event) => {
+  const swatch = event.target.closest(".swatch");
+  if (!swatch) return;
+  setMarkerColor(swatch.dataset.color);
+});
+
+const setDrop = (drop) => (event) => {
+  event.preventDefault();
+  els.frame.classList.toggle("drop", drop);
+};
+["dragenter", "dragover"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(true));
+});
+["dragleave", "drop"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(false));
+});
+els.frame.addEventListener("drop", (event) => {
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+  uploadBlob(file, file.name || "image", {
+    visibility: "private",
+    tags: ["voice-edit", "voice-edit-source"],
+    source: "upload",
+  })
+    .then((mediaURL) => openStartURL(mediaURL))
+    .then(() => setStatus(`loaded ${file.name || "image"}`))
+    .catch((err) => showError(err.message));
+});
+
+// PNG tEXt chunk helpers — pure JS, no deps.
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c;
+  }
+  return t;
+})();
+function crc32(bytes) {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function writeUint32(view, offset, value) {
+  view.setUint32(offset, value >>> 0, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0) {
+        const k = dec.decode(data.subarray(0, sep));
+        if (k === keyword) return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+function injectTextChunk(bytes, keyword, text) {
+  if (!isValidPng(bytes)) throw new Error("not a PNG");
+  // Find IEND so we can insert before it.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let iendOffset = -1;
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    if (type === "IEND") { iendOffset = pos; break; }
+    pos = pos + 8 + length + 4;
+  }
+  if (iendOffset < 0) throw new Error("PNG missing IEND");
+  // Build tEXt chunk: <length:4><type:4>"tEXt"<keyword>\0<text><crc:4>
+  const enc = new TextEncoder();
+  const kw = enc.encode(keyword);
+  const tx = enc.encode(text);
+  const data = new Uint8Array(kw.length + 1 + tx.length);
+  data.set(kw, 0);
+  data[kw.length] = 0;
+  data.set(tx, kw.length + 1);
+  const chunk = new Uint8Array(4 + 4 + data.length + 4);
+  const chunkView = new DataView(chunk.buffer);
+  writeUint32(chunkView, 0, data.length);
+  chunk.set([0x74, 0x45, 0x58, 0x74], 4); // "tEXt"
+  chunk.set(data, 8);
+  const crcInput = chunk.subarray(4, 8 + data.length);
+  writeUint32(chunkView, 8 + data.length, crc32(crcInput));
+  // Splice into PNG before IEND.
+  const out = new Uint8Array(bytes.length + chunk.length);
+  out.set(bytes.subarray(0, iendOffset), 0);
+  out.set(chunk, iendOffset);
+  out.set(bytes.subarray(iendOffset), iendOffset + chunk.length);
+  return out;
+}
+async function bytesFromBlob(blob) {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+async function readRemixState(blob) {
+  const bytes = await bytesFromBlob(blob);
+  const text = isValidPng(bytes) ? readTextChunk(bytes, HISTORY_KEYWORD) : null;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed?.history) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function mediaHashFromURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const parsed = new URL(url, location.href);
+    if (parsed.hostname !== "media.pollinations.ai") return "";
+    const hash = parsed.pathname.replace(/^\/+/, "").split("/")[0];
+    return /^[a-f0-9]{16}$/i.test(hash) ? hash.toLowerCase() : "";
+  } catch {
+    return "";
+  }
+}
+
+function cleanHistoryFrames(frames) {
+  return frames
+    .map((frame) => cleanHistoryFrame(frame))
+    .filter((frame) => frame.url);
+}
+
+function cleanHistoryFrame(frame) {
+  const source = typeof frame === "string" ? { url: frame } : (frame || {});
+  const clean = { url: scrubURL(source.url) };
+  if (!clean.url) return clean;
+  if (source.kind === "prep") clean.kind = "prep";
+  if (source.promptText) clean.promptText = String(source.promptText);
+  if (source.marked != null) clean.marked = Boolean(source.marked);
+  if (source.color) clean.color = String(source.color);
+  if (Number.isFinite(source.xPct)) clean.xPct = source.xPct;
+  if (Number.isFinite(source.yPct)) clean.yPct = source.yPct;
+  return clean;
+}
+
+async function restoreRemix(state, fallbackURL, sourceURL = "") {
+  const frames = cleanHistoryFrames(state.history);
+  if (!frames.length) {
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    return;
+  }
+  const source = scrubURL(sourceURL);
+  const sourceIndex = clamp(state.historyIndex ?? frames.length - 1, 0, frames.length - 1);
+  const requestedIndex = startIndexFromLocation();
+  let currentIndex = sourceIndex;
+  if (source) {
+    if (frames[sourceIndex]?.kind === "prep") {
+      frames.splice(sourceIndex + 1, 0, { url: source });
+      currentIndex = sourceIndex + 1;
+    } else {
+      frames[sourceIndex].url = source;
+    }
+  }
+  const index = requestedIndex == null || (currentIndex !== sourceIndex && requestedIndex === sourceIndex)
+    ? currentIndex
+    : requestedIndex;
+  app.history = frames;
+  app.historyIndex = clamp(index, 0, frames.length - 1);
+  app.stateURL = source || scrubURL(fallbackURL);
+  try {
+    await mediaHistory.go(app.historyIndex);
+    setStatus(`restored ${frames.length} frames`);
+  } catch (err) {
+    app.history = [];
+    app.historyIndex = -1;
+    app.stateURL = "";
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    showError(`History URLs unavailable; loaded image only. ${err.message}`);
+  }
+}
+
+function remixPayload() {
+  const history = cleanHistoryFrames(app.history);
+  const current = scrubURL(app.history[app.historyIndex]?.url);
+  const found = history.findIndex((frame) => frame.url === current);
+  return JSON.stringify({
+    v: 1,
+    app: "voice-edit-remix",
+    history,
+    historyIndex: found >= 0 ? found : history.length - 1,
+  });
+}
+
+async function remixPNGBlob() {
+  const bytes = await bytesFromBlob(await canvasBlob(els.imageCanvas));
+  const png = injectTextChunk(bytes, HISTORY_KEYWORD, remixPayload());
+  return new Blob([png], { type: "image/png" });
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function loadStartImage(url) {
+  try {
+    const res = await fetch(url, { mode: "cors" });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const blob = await res.blob();
+    const remix = await readRemixState(blob);
+    if (remix) {
+      await restoreRemix(remix, url, url);
+      refreshBranches();
+      return;
+    }
+  } catch {
+    // Fall through to URL loading; the browser may still be able to render it.
+  }
+  await mediaHistory.reset({ url }, url);
+  refreshBranches();
+}
+
+function refreshBranches(options) {
+  loadBranches(options).catch(() => {
+    app.branchItems = [];
+    renderBranches();
+  });
+}
+
+async function loadBranches({ show = false } = {}) {
+  const hash = mediaHashFromURL(app.stateURL || app.history[app.historyIndex]?.url || app.imageURL);
+  if (!hash) {
+    app.branchItems = [];
+    app.branchesOpen = false;
+    renderBranches();
+    return;
+  }
+  const res = await fetch(`https://media.pollinations.ai/${hash}/children?limit=12`);
+  if (!res.ok) return;
+  const data = await res.json();
+  app.branchItems = Array.isArray(data.items) ? data.items : [];
+  if (show) app.branchesOpen = true;
+  renderBranches();
+}
+
+function nextStarter() {
+  const current = scrubURL(app.stateURL || app.imageURL);
+  const index = STARTERS.findIndex((starter) => scrubURL(starter.url) === current);
+  return STARTERS[(index + 1) % STARTERS.length] || STARTERS[0];
+}
+
+function startLink(mediaURL, index = 0) {
+  const url = new URL(location.href);
+  url.searchParams.delete("start");
+  const params = new URLSearchParams({ start: mediaURL });
+  if (index > 0) params.set("index", String(index));
+  url.hash = params.toString();
+  return url;
+}
+
+function syncStartToFrame(frame, { force = false } = {}) {
+  if (app.busy && !force) return;
+  const url = app.stateURL || frame?.url || app.imageURL;
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return;
+  const index = app.stateURL && app.history.length > 1 ? app.historyIndex : 0;
+  window.history.replaceState(null, "", startLink(url, index));
+}
+
+function syncStartToCurrent(options = {}) {
+  syncStartToFrame(app.history[app.historyIndex] || { url: app.imageURL }, options);
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const params = new URLSearchParams(location.hash.slice(1));
+  const value = params.get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+async function loadFromLocation() {
+  const startURL = startURLFromLocation();
+  if (startURL) {
+    await loadStartImage(startURL);
+  } else {
+    await mediaHistory.reset({ url: STARTER }, STARTER);
+    refreshBranches();
+  }
+}
+
+async function followLocationStart() {
+  const startURL = startURLFromLocation();
+  const startIndex = startIndexFromLocation();
+  const currentURL = scrubURL(app.stateURL || app.history[app.historyIndex]?.url);
+  if (!startURL || (scrubURL(startURL) === currentURL && (startIndex == null || startIndex === app.historyIndex))) return;
+  if (app.busy || app.active) return;
+  await loadStartImage(startURL);
+}
+
+async function openStartURL(mediaURL) {
+  window.history.pushState(null, "", startLink(mediaURL));
+  await followLocationStart();
+}
+
+async function packageCurrentFrameWithHistory(fields = {}) {
+  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png", fields);
+}
+
+const goHistory = (delta, label) => () => {
+  const canGo = delta < 0 ? mediaHistory.canUndo() : mediaHistory.canRedo();
+  if (!canGo || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + delta).then(() => setStatus(label)).catch((err) => showError(err.message));
+};
+els.undo.addEventListener("click", goHistory(-1, "undone"));
+els.redo.addEventListener("click", goHistory(1, "redone"));
+els.download.addEventListener("click", async () => {
+  try {
+    downloadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`);
+    setStatus(`saved with ${cleanHistoryFrames(app.history).length} frames`);
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.share.addEventListener("click", async () => {
+  try {
+    const parentHash = mediaHashFromURL(app.stateURL || app.imageURL);
+    const mediaURL = await uploadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`, {
+      ...(parentHash ? { parents: [parentHash] } : {}),
+      tags: ["voice-edit", "voice-edit-share"],
+      visibility: "public",
+      source: parentHash ? "remix" : "saved_generation",
+    });
+    const frame = app.history[app.historyIndex];
+    if (frame) {
+      frame.url = mediaURL;
+      app.imageURL = mediaURL;
+      app.stateURL = mediaURL;
+      syncStartToFrame(frame, { force: true });
+    }
+    const shareURL = startLink(mediaURL);
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(shareURL.href);
+      setStatus("share link copied");
+    } else {
+      window.prompt("share link", shareURL.href);
+      setStatus("share link ready");
+    }
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.remixes.addEventListener("click", async () => {
+  app.branchesOpen = !app.branchesOpen;
+  renderBranches();
+  if (!app.branchesOpen) return;
+  try {
+    await loadBranches({ show: true });
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.walkthrough.addEventListener("click", () => {
+  const url = app.stateURL || app.history[app.historyIndex]?.url || app.imageURL;
+  if (!url) return;
+  const params = new URLSearchParams({ start: url });
+  if (app.history.length > 1) params.set("index", String(app.historyIndex));
+  location.href = `walkthrough.html#${params}`;
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadModels();
+window.addEventListener("hashchange", () => followLocationStart().catch((err) => showError(err.message)));
+window.addEventListener("popstate", () => followLocationStart().catch((err) => showError(err.message)));
+loadFromLocation().catch((err) => showError(err.message));
+setMarkerColor(app.markerColor);
+</script>
+</body>
+</html>

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -372,7 +372,6 @@
   </div>
 
 <script>
-const KEY_STORAGE = "voice-edit:user-key";
 const CLIENT_ID = "";
 const ENTER = "https://enter.pollinations.ai";
 const BASE = "https://gen.pollinations.ai";
@@ -449,6 +448,7 @@ const app = {
   micAvailable: CAN_RECORD,
   accountUser: "",
   accountBalance: null,
+  apiKey: "",
   branchItems: [],
   branchesOpen: false,
 };
@@ -468,9 +468,8 @@ function clearError() {
 }
 
 function key() {
-  const token = localStorage.getItem(KEY_STORAGE);
-  if (!token) throw new Error("not connected - click Connect");
-  return token;
+  if (!app.apiKey) throw new Error("not connected - click Connect");
+  return app.apiKey;
 }
 
 const authHeaders = (extra = {}) => ({ Authorization: `Bearer ${key()}`, ...extra });
@@ -500,7 +499,7 @@ function setInputMode(mode) {
 }
 
 function renderAccount() {
-  if (!localStorage.getItem(KEY_STORAGE)) {
+  if (!app.apiKey) {
     els.account.textContent = "not connected";
     return;
   }
@@ -606,7 +605,7 @@ function captureKeyFromFragment() {
   const params = new URLSearchParams(location.hash.slice(1));
   const apiKey = params.get("api_key");
   if (apiKey) {
-    localStorage.setItem(KEY_STORAGE, apiKey);
+    app.apiKey = apiKey;
     history.replaceState(null, "", location.pathname + location.search);
   } else if (params.get("error")) {
     showError(`Authorization failed: ${params.get("error")}`);
@@ -614,7 +613,7 @@ function captureKeyFromFragment() {
 }
 
 function refreshConnectionUI() {
-  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const connected = !!app.apiKey;
   els.connect.hidden = connected;
   els.frame.classList.toggle("locked", !connected);
   if (!connected) {
@@ -640,7 +639,7 @@ function startConnect() {
 }
 
 function disconnect() {
-  localStorage.removeItem(KEY_STORAGE);
+  app.apiKey = "";
   stopMic();
   refreshConnectionUI();
 }
@@ -1016,7 +1015,7 @@ async function friendlyError(response, label) {
     details = json.error?.message || json.message || text;
   } catch {}
   if (response.status === 401 || response.status === 403) {
-    localStorage.removeItem(KEY_STORAGE);
+    app.apiKey = "";
     refreshConnectionUI();
     return `${label}: authorization expired. Connect again.`;
   }

--- a/apps/voice-edit/walkthrough.html
+++ b/apps/voice-edit/walkthrough.html
@@ -269,13 +269,13 @@
   </main>
 
 <script type="module">
+// biome-ignore assist/source/organizeImports: keep the remote bundle import readable.
 import {
   Input, Output, BlobSource, BufferTarget, Mp4OutputFormat,
   EncodedPacketSink, EncodedVideoPacketSource, EncodedAudioPacketSource,
   CanvasSource, Conversion, canEncodeVideo, ALL_FORMATS,
 } from "https://esm.sh/mediabunny@1.45.3";
 
-const KEY_STORAGE = "voice-edit:user-key";
 const PROMPT_STORAGE = "voice-edit:walkthrough-prompt";
 const NARRATE_STORAGE = "voice-edit:walkthrough-narrate";
 const NARRATE_DURATION_SEC = 3.5;
@@ -319,6 +319,7 @@ const app = {
   playAllIndex: 0,
   accountUser: "",
   accountBalance: null,
+  apiKey: "",
 };
 
 function setStatus(text) {
@@ -336,9 +337,8 @@ function clearError() {
 }
 
 function key() {
-  const token = localStorage.getItem(KEY_STORAGE);
-  if (!token) throw new Error("not connected - click Connect");
-  return token;
+  if (!app.apiKey) throw new Error("not connected - click Connect");
+  return app.apiKey;
 }
 
 const authHeaders = () => ({ Authorization: `Bearer ${key()}` });
@@ -348,7 +348,7 @@ function captureKeyFromFragment() {
   const params = new URLSearchParams(location.hash.slice(1));
   const apiKey = params.get("api_key");
   if (!apiKey) return;
-  localStorage.setItem(KEY_STORAGE, apiKey);
+  app.apiKey = apiKey;
   params.delete("api_key");
   history.replaceState(null, "", params.toString() ? `${location.pathname}#${params}` : location.pathname);
 }
@@ -363,12 +363,12 @@ function startConnect() {
 }
 
 function disconnect() {
-  localStorage.removeItem(KEY_STORAGE);
+  app.apiKey = "";
   refreshConnectionUI();
 }
 
 function renderAccount() {
-  if (!localStorage.getItem(KEY_STORAGE)) {
+  if (!app.apiKey) {
     els.account.textContent = "not connected";
     return;
   }
@@ -383,7 +383,7 @@ function renderAccount() {
 }
 
 function refreshConnectionUI() {
-  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const connected = !!app.apiKey;
   els.connect.hidden = connected;
   renderAccount();
   if (connected) {
@@ -533,7 +533,7 @@ async function uploadBlob(blob, filename, fields = {}) {
 }
 
 function render() {
-  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const connected = !!app.apiKey;
   const locked = app.busy || app.history.length < 2 || !connected || !app.modelsReady;
   els.make.disabled = locked;
   els.load.disabled = app.busy || !connected;
@@ -570,7 +570,7 @@ function renderViewer() {
     return;
   }
   const clip = app.clips[app.currentClip];
-  if (clip && clip.src) {
+  if (clip?.src) {
     const video = document.createElement("video");
     video.src = clip.src;
     video.controls = true;
@@ -889,7 +889,7 @@ function wrapText(ctx, text, maxWidth) {
     if (!words.length) { lines.push(""); continue; }
     let line = words[0];
     for (let i = 1; i < words.length; i++) {
-      const test = line + " " + words[i];
+      const test = `${line} ${words[i]}`;
       if (ctx.measureText(test).width > maxWidth) { lines.push(line); line = words[i]; }
       else line = test;
     }

--- a/apps/voice-edit/walkthrough.html
+++ b/apps/voice-edit/walkthrough.html
@@ -1,0 +1,1131 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Walkthrough | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--dark);
+    --raise: 2px 2px 0 var(--dark);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+  button, input, select { font: inherit; color: inherit; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .btn, .input, .select, .panel, .thumb, .clip {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+  }
+  .btn {
+    padding: 0 12px;
+    font-weight: 700;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--dark); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; }
+  .narrate {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+  }
+  .narrate input { margin: 0; }
+  .narrate-count { opacity: 0.7; font-variant-numeric: tabular-nums; }
+  .narrate input:disabled + .narrate-count,
+  .narrate input:disabled { opacity: 0.4; }
+  .prompt {
+    display: grid;
+    gap: 4px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .prompt textarea {
+    width: 100%;
+    min-height: 56px;
+    padding: 8px 10px;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    border-radius: 0;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    resize: vertical;
+  }
+  .prompt textarea:focus { outline: 2px solid var(--accent); outline-offset: 0; }
+  .prompt .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .prompt .row button {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .panel {
+    min-height: 320px;
+    padding: 12px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .panel img, .panel video {
+    display: block;
+    max-width: 100%;
+    max-height: calc(100vh - 290px);
+    background: #000;
+  }
+  .strip {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px 2px 6px;
+  }
+  .thumb, .clip {
+    flex: 0 0 auto;
+    width: 86px;
+    height: 64px;
+    padding: 0;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+  }
+  .thumb.active, .clip.active { outline: 3px solid var(--accent); outline-offset: 2px; }
+  .clip.pending { opacity: 0.55; cursor: wait; }
+  .clip.failed { opacity: 0.7; }
+  .clip-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--muted);
+    font-size: 1.4rem;
+    animation: clip-pulse 1.6s ease-in-out infinite;
+  }
+  .clip.failed .clip-placeholder {
+    animation: none;
+    color: #ff8888;
+    background: rgba(255, 80, 80, 0.18);
+  }
+  @keyframes clip-pulse {
+    0%, 100% { background: rgba(255, 255, 255, 0.05); }
+    50% { background: rgba(255, 255, 255, 0.15); }
+  }
+  .thumb img, .clip video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .thumb span, .clip span {
+    position: absolute;
+    left: 3px;
+    bottom: 2px;
+    background: var(--accent);
+    padding: 0 4px;
+    font-size: 0.65rem;
+    font-weight: 700;
+  }
+  .meta {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  @media (max-width: 720px) {
+    .app { width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .panel { min-height: 240px; }
+    .panel img, .panel video { max-height: calc(100vh - 340px); }
+  }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / walkthrough</h1>
+      <span class="tagline">history to video.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="walkthrough controls">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="loadBtn" class="btn" title="upload an image from disk">load</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="video model" disabled>
+        <option value="">loading models...</option>
+      </select>
+      <button id="makeBtn" class="btn accent">make</button>
+      <label class="narrate" title="insert a 2s card showing the marked-up image and prompt between video clips">
+        <input id="narrateToggle" type="checkbox"> narrate
+        <span id="narrateCount" class="narrate-count" aria-hidden="true"></span>
+      </label>
+      <button id="playAllBtn" class="btn" disabled title="play all clips in sequence">play all</button>
+      <button id="downloadAllBtn" class="btn" disabled title="download a single stitched .mp4 of all clips">download</button>
+    </section>
+
+    <label class="prompt">
+      <div class="row">
+        <span>video prompt</span>
+        <button type="button" id="promptReset" title="restore default prompt">reset</button>
+      </div>
+      <textarea id="promptInput" rows="2" spellcheck="false"></textarea>
+    </label>
+
+    <section id="viewer" class="panel"></section>
+    <div id="frameStrip" class="strip" aria-label="history frames"></div>
+    <div id="clipStrip" class="strip" aria-label="generated video clips"></div>
+    <div id="meta" class="meta"></div>
+  </main>
+
+<script type="module">
+import {
+  Input, Output, BlobSource, BufferTarget, Mp4OutputFormat,
+  EncodedPacketSink, EncodedVideoPacketSource, EncodedAudioPacketSource,
+  CanvasSource, Conversion, canEncodeVideo, ALL_FORMATS,
+} from "https://esm.sh/mediabunny@1.45.3";
+
+const KEY_STORAGE = "voice-edit:user-key";
+const PROMPT_STORAGE = "voice-edit:walkthrough-prompt";
+const NARRATE_STORAGE = "voice-edit:walkthrough-narrate";
+const NARRATE_DURATION_SEC = 3.5;
+const CLIENT_ID = "";
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const DEFAULT_PROMPT = "Smooth visual transition from the first image to the second image. Preserve the subject, composition, and style. No text, labels, captions, or subtitles.";
+
+const $ = (id) => document.getElementById(id);
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  connect: "connectBtn",
+  load: "loadBtn",
+  file: "fileInput",
+  model: "modelSel",
+  make: "makeBtn",
+  playAll: "playAllBtn",
+  downloadAll: "downloadAllBtn",
+  prompt: "promptInput",
+  promptReset: "promptReset",
+  narrate: "narrateToggle",
+  narrateCount: "narrateCount",
+  viewer: "viewer",
+  frameStrip: "frameStrip",
+  clipStrip: "clipStrip",
+  meta: "meta",
+}).map(([key, id]) => [key, $(id)]));
+
+const app = {
+  sourceURL: "",
+  history: [],
+  currentFrame: 0,
+  clips: [],
+  currentClip: -1,
+  busy: false,
+  modelsReady: false,
+  playAll: false,
+  playAllIndex: 0,
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = () => ({ Authorization: `Bearer ${key()}` });
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (!apiKey) return;
+  localStorage.setItem(KEY_STORAGE, apiKey);
+  params.delete("api_key");
+  history.replaceState(null, "", params.toString() ? `${location.pathname}#${params}` : location.pathname);
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_uri: location.origin + location.pathname + location.hash,
+    scope: "generate",
+  });
+  if (CLIENT_ID) params.set("client_id", CLIENT_ID);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  refreshConnectionUI();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  renderAccount();
+  if (connected) {
+    loadUser();
+    loadBalance();
+  }
+  render();
+}
+
+async function loadUser() {
+  const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const user = await res.json();
+  app.accountUser = user?.preferred_username || "";
+  renderAccount();
+}
+
+async function loadBalance() {
+  const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const { balance } = await res.json();
+  app.accountBalance = Number(balance);
+  renderAccount();
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const value = new URLSearchParams(location.hash.slice(1)).get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function frameURL(frame) {
+  return scrubURL(typeof frame === "string" ? frame : frame?.url);
+}
+
+function cleanHistoryFrames(frames) {
+  return frames.map((frame) => {
+    const url = frameURL(frame);
+    if (!url) return null;
+    if (typeof frame === "string") return { url };
+    return {
+      url,
+      kind: frame?.kind,
+      promptText: frame?.promptText,
+      marked: frame?.marked,
+      color: frame?.color,
+    };
+  }).filter(Boolean);
+}
+
+function setHash(start, index = 0) {
+  const params = new URLSearchParams({ start });
+  if (index > 0) params.set("index", String(index));
+  history.replaceState(null, "", `${location.pathname}#${params}`);
+}
+
+async function loadSource(url) {
+  clearError();
+  const source = scrubURL(url);
+  if (!source) throw new Error("Enter a public image URL");
+  setStatus("loading...");
+  const res = await fetch(source, { mode: "cors" });
+  if (!res.ok) throw new Error(`Image load failed: ${res.status} ${res.statusText}`);
+  const blob = await res.blob();
+  const state = await readRemixState(blob);
+  const rawFrames = state ? cleanHistoryFrames(state.history) : [{ url: source }];
+  if (!rawFrames.length) throw new Error("No history frames found");
+  const sourceIndex = state ? Math.max(0, Math.min(state.historyIndex ?? rawFrames.length - 1, rawFrames.length - 1)) : 0;
+  if (state && rawFrames[sourceIndex]?.kind !== "prep") {
+    rawFrames[sourceIndex].url = source;
+  }
+  // Attach each prep frame's narration data (annotated URL + prompt text) to the
+  // clean frame it produced — that's the very next non-prep entry in the raw list.
+  let pendingPrep = null;
+  const frames = [];
+  for (const frame of rawFrames) {
+    if (frame.kind === "prep") {
+      pendingPrep = frame;
+      continue;
+    }
+    if (pendingPrep) {
+      frame.narration = {
+        annotatedURL: pendingPrep.url,
+        promptText: pendingPrep.promptText || "",
+      };
+      pendingPrep = null;
+    }
+    frames.push(frame);
+  }
+  if (!frames.length) throw new Error("No clean frames found (all entries are annotated previews)");
+  const targetURL = rawFrames[sourceIndex]?.kind === "prep" ? source : rawFrames[sourceIndex]?.url;
+  const sourceIndexClean = Math.max(
+    0,
+    frames.findIndex((frame) => frame.url === targetURL),
+  );
+  const requestedIndex = startIndexFromLocation();
+  const requestedIndexClean = requestedIndex == null
+    ? null
+    : Math.max(0, Math.min(requestedIndex, frames.length - 1));
+  const index = requestedIndexClean == null || requestedIndexClean === sourceIndex
+    ? sourceIndexClean
+    : requestedIndexClean;
+  app.sourceURL = source;
+  app.history = frames;
+  app.currentFrame = Math.max(0, Math.min(index, frames.length - 1));
+  app.clips = [];
+  app.currentClip = -1;
+  setHash(source, app.currentFrame);
+  render();
+  setStatus(state ? `loaded ${frames.length} clean frames` : "loaded image");
+}
+
+async function uploadBlob(blob, filename, fields = {}) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  for (const [key, value] of Object.entries(fields)) {
+    if (value != null && value !== "") {
+      form.append(key, Array.isArray(value) ? JSON.stringify(value) : String(value));
+    }
+  }
+  const res = await fetch("https://media.pollinations.ai/upload", {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `https://media.pollinations.ai/${json.id}`;
+}
+
+function render() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const locked = app.busy || app.history.length < 2 || !connected || !app.modelsReady;
+  els.make.disabled = locked;
+  els.load.disabled = app.busy || !connected;
+  els.model.disabled = app.busy || !app.modelsReady;
+  const hasClips = app.clips.length > 0 && !app.busy;
+  els.playAll.disabled = !hasClips;
+  els.downloadAll.disabled = !hasClips;
+  els.playAll.textContent = app.playAll ? "stop" : "play all";
+  const narratable = app.history.filter((f) => f?.narration).length;
+  els.narrate.disabled = narratable === 0 || app.busy;
+  els.narrateCount.textContent = narratable ? `(${narratable})` : "(none)";
+  renderViewer();
+  renderFrames();
+  renderClips();
+  els.meta.textContent = app.history.length > 1
+    ? `${app.history.length} frames -> ${app.history.length - 1} transitions${narratable ? ` · ${narratable} narration card${narratable === 1 ? "" : "s"}` : ""}`
+    : "load a remix image with history to make a walkthrough";
+}
+
+function renderViewer() {
+  if (app.playAll && app.clips.length) {
+    const video = document.createElement("video");
+    video.src = app.clips[app.playAllIndex].src;
+    video.controls = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    video.addEventListener("ended", () => {
+      if (!app.playAll) return;
+      app.playAllIndex = (app.playAllIndex + 1) % app.clips.length;
+      app.currentClip = app.playAllIndex;
+      render();
+    });
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const clip = app.clips[app.currentClip];
+  if (clip && clip.src) {
+    const video = document.createElement("video");
+    video.src = clip.src;
+    video.controls = true;
+    video.loop = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const frame = app.history[app.currentFrame];
+  if (!frame) {
+    els.viewer.textContent = "load an image";
+    return;
+  }
+  const img = document.createElement("img");
+  img.src = frame.url;
+  img.alt = "";
+  els.viewer.replaceChildren(img);
+}
+
+function renderFrames() {
+  els.frameStrip.replaceChildren(...app.history.map((frame, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `thumb${index === app.currentFrame && app.currentClip < 0 ? " active" : ""}`;
+    button.addEventListener("click", () => {
+      app.currentFrame = index;
+      app.currentClip = -1;
+      setHash(app.sourceURL, index);
+      render();
+    });
+    const img = document.createElement("img");
+    img.src = frame.url;
+    img.alt = "";
+    const label = document.createElement("span");
+    label.textContent = String(index + 1);
+    button.append(img, label);
+    return button;
+  }));
+}
+
+function renderClips() {
+  let videoCount = 0;
+  els.clipStrip.replaceChildren(...app.clips.map((clip, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    const isReady = !!clip.src;
+    const cls = [
+      "clip",
+      index === app.currentClip ? "active" : "",
+      clip.pending ? "pending" : "",
+      clip.failed ? "failed" : "",
+    ].filter(Boolean).join(" ");
+    button.className = cls;
+    if (isReady) {
+      button.addEventListener("click", () => {
+        app.currentClip = index;
+        render();
+      });
+    } else {
+      button.disabled = true;
+    }
+    const media = document.createElement(isReady ? "video" : "div");
+    if (isReady) {
+      media.src = clip.src;
+      media.muted = true;
+      media.playsInline = true;
+    } else {
+      media.className = "clip-placeholder";
+      media.textContent = clip.failed ? "×" : "…";
+    }
+    const label = document.createElement("span");
+    if (clip.kind === "narration") {
+      // narration card intros the next video, so label it with that video's number
+      label.textContent = `intro ${videoCount + 1}`;
+    } else {
+      videoCount += 1;
+      label.textContent = `${videoCount}->${videoCount + 1}`;
+    }
+    button.append(media, label);
+    return button;
+  }));
+}
+
+async function loadVideoModels() {
+  try {
+    const res = await fetch(`${BASE}/models`);
+    if (!res.ok) throw new Error(`models fetch failed: ${res.status}`);
+    const all = await res.json();
+    const supported = all.filter((m) =>
+      Array.isArray(m.video_capabilities) && m.video_capabilities.includes("end_frame"),
+    );
+    if (!supported.length) throw new Error("no models advertise end_frame");
+    const preferred = ["veo", "seedance-2.0", "wan-fast"];
+    supported.sort((a, b) => {
+      const ai = preferred.indexOf(a.name);
+      const bi = preferred.indexOf(b.name);
+      if (ai === -1 && bi === -1) return a.name.localeCompare(b.name);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+    els.model.replaceChildren(...supported.map((m) => {
+      const opt = document.createElement("option");
+      opt.value = m.name;
+      opt.textContent = `${m.name} start+end`;
+      opt.title = m.description || "";
+      return opt;
+    }));
+  } catch (err) {
+    els.model.replaceChildren(
+      Object.assign(document.createElement("option"), { value: "veo", textContent: "veo start+end" }),
+      Object.assign(document.createElement("option"), { value: "seedance-2.0", textContent: "seedance-2.0 start+end" }),
+      Object.assign(document.createElement("option"), { value: "wan-fast", textContent: "wan-fast start+end" }),
+    );
+    console.warn("video model discovery failed, using fallback list:", err);
+  } finally {
+    app.modelsReady = true;
+    render();
+  }
+}
+
+function currentPrompt() {
+  const text = (els.prompt.value || "").trim();
+  return text || DEFAULT_PROMPT;
+}
+
+function videoRequestURL(start, end, model) {
+  const url = new URL(`${BASE}/video/${encodeURIComponent(currentPrompt())}`);
+  url.searchParams.set("model", model);
+  url.searchParams.set("duration", "4");
+  url.searchParams.set("audio", "false");
+  url.searchParams.set("image", `${start}|${end}`);
+  return url;
+}
+
+async function makeWalkthrough() {
+  if (app.history.length < 2 || app.busy) return;
+  app.busy = true;
+  for (const clip of app.clips) if (clip.src) URL.revokeObjectURL(clip.src);
+  app.clips = [];
+  app.currentClip = -1;
+
+  const narrate = els.narrate.checked;
+  const transitions = app.history.length - 1;
+  // Pre-populate placeholders in display order: (intro?, video) per transition.
+  const slots = []; // parallel array mapping transitionIndex -> { videoSlot, narrationSlot? }
+  for (let i = 0; i < transitions; i++) {
+    const target = app.history[i + 1];
+    const slot = {};
+    if (narrate && target?.narration) {
+      app.clips.push({ kind: "narration", pending: true });
+      slot.narrationSlot = app.clips.length - 1;
+    }
+    app.clips.push({ kind: "video", pending: true });
+    slot.videoSlot = app.clips.length - 1;
+    slots.push(slot);
+  }
+  render();
+
+  let videosDone = 0;
+  let firstError = null;
+  const setProgress = () => setStatus(`videos ${videosDone}/${transitions} ready...`);
+  setProgress();
+
+  await Promise.all(slots.map(async (slot, i) => {
+    const request = videoRequestURL(app.history[i].url, app.history[i + 1].url, els.model.value);
+    try {
+      const res = await fetch(request, { headers: authHeaders() });
+      if (!res.ok) throw new Error(await friendlyError(res, `Video ${i + 1} failed`));
+      const blob = await res.blob();
+
+      // Fill the video slot
+      const videoEntry = { url: request.href, src: URL.createObjectURL(blob), blob, kind: "video" };
+      app.clips[slot.videoSlot] = videoEntry;
+      if (app.currentClip < 0) app.currentClip = slot.videoSlot;
+
+      // Render the narration card for this transition (needs the just-finished clip as codec ref)
+      if (slot.narrationSlot != null) {
+        try {
+          const cardBlob = await renderNarrationClip(app.history[i + 1].narration, blob);
+          app.clips[slot.narrationSlot] = { src: URL.createObjectURL(cardBlob), blob: cardBlob, kind: "narration" };
+        } catch (err) {
+          console.warn(`narration card ${i + 1} failed`, err);
+          showError(`narration card ${i + 1} skipped: ${err.message}`);
+          // Remove the failed placeholder by marking it dropped; we'll compact at the end.
+          app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+        }
+      }
+
+      videosDone++;
+      setProgress();
+      render();
+    } catch (err) {
+      firstError = firstError || err;
+      app.clips[slot.videoSlot] = { kind: "video", failed: true, error: err.message };
+      if (slot.narrationSlot != null) app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+      videosDone++;
+      setProgress();
+      render();
+    }
+  }));
+
+  // Compact: drop slots that were never filled (failed videos / dropped cards)
+  app.clips = app.clips.filter((c) => !c.dropped && !c.failed);
+  if (app.currentClip >= app.clips.length) app.currentClip = app.clips.length - 1;
+
+  loadBalance().catch(() => {});
+  if (firstError) showError(firstError.message);
+  setStatus(firstError ? `done with errors` : "done");
+  app.busy = false;
+  render();
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) return `${label}: authorization expired. Connect again.`;
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const dec = new TextDecoder("latin1");
+  let pos = 8;
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0 && dec.decode(data.subarray(0, sep)) === keyword) {
+        return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+async function readRemixState(blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const text = readTextChunk(bytes, HISTORY_KEYWORD);
+  if (!text) return null;
+  const state = JSON.parse(text);
+  return Array.isArray(state?.history) ? state : null;
+}
+
+els.connect.addEventListener("click", startConnect);
+els.load.addEventListener("click", () => els.file.click());
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image", {
+      visibility: "private",
+      tags: ["voice-edit", "voice-edit-walkthrough-source"],
+      source: "upload",
+    });
+    setHash(mediaURL);
+    await loadSource(mediaURL);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+els.make.addEventListener("click", () => {
+  makeWalkthrough().catch((err) => {
+    app.busy = false;
+    showError(err.message);
+    render();
+  });
+});
+els.playAll.addEventListener("click", () => {
+  if (!app.clips.length) return;
+  app.playAll = !app.playAll;
+  if (app.playAll) {
+    app.playAllIndex = 0;
+    app.currentClip = 0;
+  }
+  render();
+});
+function loadImageBlob(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load narration image"));
+    img.src = url;
+  });
+}
+
+function wrapText(ctx, text, maxWidth) {
+  const lines = [];
+  for (const para of text.split(/\n/)) {
+    const words = para.split(/\s+/).filter(Boolean);
+    if (!words.length) { lines.push(""); continue; }
+    let line = words[0];
+    for (let i = 1; i < words.length; i++) {
+      const test = line + " " + words[i];
+      if (ctx.measureText(test).width > maxWidth) { lines.push(line); line = words[i]; }
+      else line = test;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+function drawNarrationCard(canvas, image, promptText) {
+  const ctx = canvas.getContext("2d");
+  const { width: W, height: H } = canvas;
+  ctx.fillStyle = "#110518";
+  ctx.fillRect(0, 0, W, H);
+  // contain-fit the annotated image
+  const s = Math.min(W / image.width, H / image.height);
+  const dw = image.width * s;
+  const dh = image.height * s;
+  ctx.drawImage(image, (W - dw) / 2, (H - dh) / 2, dw, dh);
+  // prompt text overlay at the bottom — subtitle-style
+  if (promptText) {
+    const fontPx = Math.min(26, Math.max(14, Math.round(H * 0.03)));
+    ctx.font = `500 ${fontPx}px "IBM Plex Mono", ui-monospace, Menlo, monospace`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    const lines = wrapText(ctx, promptText, W * 0.9);
+    const padY = Math.round(fontPx * 0.55);
+    const lineH = Math.round(fontPx * 1.3);
+    const bandH = lines.length * lineH + padY * 2;
+    ctx.fillStyle = "rgba(17, 5, 24, 0.75)";
+    ctx.fillRect(0, H - bandH, W, bandH);
+    ctx.fillStyle = "#fff";
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], W / 2, H - padY - (lines.length - 1 - i) * lineH);
+    }
+  }
+}
+
+async function probeVideoSpec(blob) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const track = await input.getPrimaryVideoTrack();
+  if (!track) throw new Error("reference clip has no video track");
+  const cfg = await track.getDecoderConfig();
+  return {
+    codec: track.codec,                    // e.g. "avc"
+    fullCodecString: cfg?.codec,           // e.g. "avc1.640028"
+    width: track.codedWidth,
+    height: track.codedHeight,
+  };
+}
+
+async function renderNarrationClip(narration, refBlob) {
+  const spec = await probeVideoSpec(refBlob);
+  // Force even dimensions (H.264 requires it).
+  const width = spec.width - (spec.width % 2);
+  const height = spec.height - (spec.height % 2);
+  const fps = 24;
+  const bitrate = 2_000_000;
+  if (typeof canEncodeVideo === "function") {
+    const ok = await canEncodeVideo(spec.codec, { width, height, bitrate });
+    if (!ok) throw new Error(`browser cannot encode ${spec.codec} ${width}x${height}`);
+  }
+
+  const image = await loadImageBlob(narration.annotatedURL);
+  const canvas = typeof OffscreenCanvas !== "undefined"
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement("canvas"), { width, height });
+  drawNarrationCard(canvas, image, narration.promptText);
+
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const sourceCfg = { codec: spec.codec, bitrate, keyFrameInterval: 1 };
+  if (spec.fullCodecString) sourceCfg.fullCodecString = spec.fullCodecString;
+  const source = new CanvasSource(canvas, sourceCfg);
+  output.addVideoTrack(source, { frameRate: fps });
+  await output.start();
+  const total = Math.max(1, Math.round(NARRATE_DURATION_SEC * fps));
+  const frameDur = 1 / fps;
+  for (let i = 0; i < total; i++) {
+    await source.add(i * frameDur, frameDur);
+  }
+  source.close();
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function remuxMp4Clips(blobs) {
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  let videoSrc = null;
+  let audioSrc = null;
+  let vOffset = 0;
+  let aOffset = 0;
+  let vMaxOut = 0;
+  let aMaxOut = 0;
+  let vCfgSent = false;
+  let aCfgSent = false;
+
+  for (let i = 0; i < blobs.length; i++) {
+    const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blobs[i]) });
+    const vTrack = await input.getPrimaryVideoTrack();
+    if (!vTrack) throw new Error(`clip ${i + 1} has no video track`);
+    const aTrack = await input.getPrimaryAudioTrack();
+
+    if (i === 0) {
+      videoSrc = new EncodedVideoPacketSource(vTrack.codec);
+      output.addVideoTrack(videoSrc);
+      if (aTrack) {
+        audioSrc = new EncodedAudioPacketSource(aTrack.codec);
+        output.addAudioTrack(audioSrc);
+      }
+      await output.start();
+    }
+
+    const vMeta = { decoderConfig: await vTrack.getDecoderConfig() };
+    const vSink = new EncodedPacketSink(vTrack);
+    let vClipMax = 0;
+    for (let p = await vSink.getFirstPacket(); p; p = await vSink.getNextPacket(p)) {
+      let ts = Math.max(0, p.timestamp + vOffset);
+      if (i > 0 && ts <= vMaxOut) ts = vMaxOut + 1e-6;
+      await videoSrc.add(p.clone({ timestamp: ts }), vCfgSent ? undefined : vMeta);
+      vCfgSent = true;
+      vMaxOut = Math.max(vMaxOut, ts);
+      vClipMax = Math.max(vClipMax, p.timestamp + p.duration);
+    }
+    vOffset += vClipMax;
+
+    if (aTrack && audioSrc) {
+      const aMeta = { decoderConfig: await aTrack.getDecoderConfig() };
+      const aSink = new EncodedPacketSink(aTrack);
+      let aClipMax = 0;
+      for (let p = await aSink.getFirstPacket(); p; p = await aSink.getNextPacket(p)) {
+        let ts = Math.max(0, p.timestamp + aOffset);
+        if (i > 0 && ts <= aMaxOut) ts = aMaxOut + 1e-6;
+        await audioSrc.add(p.clone({ timestamp: ts }), aCfgSent ? undefined : aMeta);
+        aCfgSent = true;
+        aMaxOut = Math.max(aMaxOut, ts);
+        aClipMax = Math.max(aClipMax, p.timestamp + p.duration);
+      }
+      aOffset += aClipMax;
+    } else if (audioSrc) {
+      // No audio in this clip but we have an audio track — keep the audio
+      // offset in lock-step with video so later audio packets land in the
+      // right spot. The merged audio track will just contain a silent gap.
+      aOffset += vClipMax;
+    }
+  }
+
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function normalizeMp4(blob, targetBitrate) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const conv = await Conversion.init({
+    input, output,
+    video: { codec: "avc", bitrate: targetBitrate },
+  });
+  await conv.execute();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+els.downloadAll.addEventListener("click", async () => {
+  if (!app.clips.length) return;
+  const originalLabel = els.downloadAll.textContent;
+  els.downloadAll.disabled = true;
+  els.downloadAll.textContent = "stitching…";
+  try {
+    const clips = app.clips.filter((c) => c.blob);
+    if (!clips.length) throw new Error("No video data to download");
+
+    // If we have any narration cards mixed in, the source clips and the cards
+    // will have different H.264 SPS/PPS — the player only honours the first
+    // avcC box, so naive remux silently drops the cards. Re-encode every clip
+    // to one uniform target so the final stream has a single decoder config.
+    let blobs = clips.map((c) => c.blob);
+    const mixed = clips.some((c) => c.kind === "narration");
+    if (mixed) {
+      const targetBitrate = 4_000_000;
+      const normalized = [];
+      for (let i = 0; i < clips.length; i++) {
+        els.downloadAll.textContent = `re-encoding ${i + 1}/${clips.length}…`;
+        normalized.push(await normalizeMp4(clips[i].blob, targetBitrate));
+      }
+      blobs = normalized;
+      els.downloadAll.textContent = "stitching…";
+    }
+
+    let merged;
+    let ext = "mp4";
+    try {
+      merged = await remuxMp4Clips(blobs);
+    } catch (remuxErr) {
+      console.warn("mediabunny remux failed, falling back to naive concat", remuxErr);
+      const type = blobs[0].type || "video/mp4";
+      merged = new Blob(blobs, { type });
+      ext = type.includes("webm") ? "webm" : "mp4";
+    }
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(merged);
+    a.download = `walkthrough-${Date.now()}.${ext}`;
+    document.body.append(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(a.href), 60_000);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.downloadAll.textContent = originalLabel;
+    els.downloadAll.disabled = !app.clips.length || app.busy;
+  }
+});
+window.addEventListener("hashchange", () => {
+  const start = startURLFromLocation();
+  if (start && scrubURL(start) !== app.sourceURL && !app.busy) loadSource(start).catch((err) => showError(err.message));
+});
+
+els.prompt.value = localStorage.getItem(PROMPT_STORAGE) ?? DEFAULT_PROMPT;
+els.prompt.placeholder = DEFAULT_PROMPT;
+els.prompt.addEventListener("input", () => {
+  localStorage.setItem(PROMPT_STORAGE, els.prompt.value);
+});
+els.promptReset.addEventListener("click", () => {
+  els.prompt.value = DEFAULT_PROMPT;
+  localStorage.setItem(PROMPT_STORAGE, DEFAULT_PROMPT);
+});
+
+els.narrate.checked = localStorage.getItem(NARRATE_STORAGE) === "1";
+els.narrate.addEventListener("change", () => {
+  localStorage.setItem(NARRATE_STORAGE, els.narrate.checked ? "1" : "0");
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadVideoModels();
+const start = startURLFromLocation();
+if (start) loadSource(start).catch((err) => showError(err.message));
+else render();
+</script>
+</body>
+</html>

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1434,11 +1434,40 @@ export const accountRoutes = new Hono<Env>()
                                     type: z
                                         .enum(["publishable", "secret"])
                                         .describe("Type of API key"),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for the API key",
+                                        ),
+                                    apiKeyId: z
+                                        .string()
+                                        .describe(
+                                            "Stable server-side API key id",
+                                        ),
                                     name: z
                                         .string()
                                         .nullable()
                                         .describe(
                                             "Display name of the API key",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "App key id that minted this key, when created through authorize",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "App key name that minted this key, when available",
+                                        ),
+                                    byopClientUserId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for the app key that minted this key",
                                         ),
                                     expiresAt: z
                                         .string()
@@ -1549,7 +1578,12 @@ export const accountRoutes = new Hono<Env>()
             return c.json({
                 valid: true, // If we got here, the key is valid
                 type: keyType,
+                userId: c.var.auth.user?.id ?? null,
+                apiKeyId: apiKey.id,
                 name: apiKey.name || null,
+                byopClientKeyId: apiKey.byopClientKeyId ?? null,
+                byopClientName: apiKey.byopClientName ?? null,
+                byopClientUserId: apiKey.byopClientUserId ?? null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -431,7 +431,7 @@ function generateLLMDoc(): string {
 
     lines.push("### GET /account/key");
     lines.push(
-        "Info about the current API key: { valid, type, name, expiresAt, expiresIn, permissions, pollenBudget, rateLimitEnabled }.",
+        "Info about the current API key: { valid, type, userId, apiKeyId, name, byopClientKeyId, byopClientName, byopClientUserId, expiresAt, expiresIn, permissions, pollenBudget, rateLimitEnabled }.",
     );
     lines.push("Requires API key authentication (any key type).");
     lines.push("");
@@ -1044,7 +1044,12 @@ const RESPONSE_EXAMPLES: Record<string, unknown> = {
     "get /account/key": {
         valid: true,
         type: "secret",
+        userId: "user_123",
+        apiKeyId: "key_123",
         name: "my-bot",
+        byopClientKeyId: null,
+        byopClientName: null,
+        byopClientUserId: null,
         expiresAt: null,
         expiresIn: null,
         permissions: {

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -40,12 +40,83 @@ test(
         const data = await response.json();
         expect(data.valid).toBe(true);
         expect(data.type).toBe("secret");
+        expect(typeof data.userId).toBe("string");
+        expect(typeof data.apiKeyId).toBe("string");
         expect(data.name).toBeTruthy();
+        expect(data.byopClientKeyId).toBeNull();
+        expect(data.byopClientName).toBeNull();
+        expect(data.byopClientUserId).toBeNull();
         expect(data).toHaveProperty("expiresAt");
         expect(data).toHaveProperty("expiresIn");
         expect(data).toHaveProperty("permissions");
         expect(data).toHaveProperty("pollenBudget");
         expect(data).toHaveProperty("rateLimitEnabled");
+    },
+);
+
+test(
+    "GET /api/account/key - exposes server-attested BYOP app attribution",
+    { timeout: 30000 },
+    async ({ sessionToken, mocks }) => {
+        await mocks.enable("tinybird");
+
+        const appResponse = await SELF.fetch(
+            "http://localhost:3000/api/api-keys",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+                body: JSON.stringify({
+                    name: "media-catalog-test-app",
+                    type: "publishable",
+                    metadata: {
+                        redirectUris: [
+                            "https://media-catalog.example/callback",
+                        ],
+                    },
+                }),
+            },
+        );
+        expect(appResponse.status).toBe(200);
+        const appKey = await appResponse.json();
+
+        const userKeyResponse = await SELF.fetch(
+            "http://localhost:3000/api/api-keys",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+                body: JSON.stringify({
+                    name: "media-catalog-user-key",
+                    type: "secret",
+                    metadata: {
+                        requestedClientId: appKey.key,
+                        redirectUri: "https://media-catalog.example/callback",
+                        redirectOrigin: "https://media-catalog.example",
+                    },
+                }),
+            },
+        );
+        expect(userKeyResponse.status).toBe(200);
+        const userKey = await userKeyResponse.json();
+
+        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+            headers: {
+                Authorization: `Bearer ${userKey.key}`,
+            },
+        });
+        expect(response.status).toBe(200);
+
+        const data = await response.json();
+        expect(data.valid).toBe(true);
+        expect(data.apiKeyId).toBe(userKey.id);
+        expect(data.byopClientKeyId).toBe(appKey.id);
+        expect(data.byopClientName).toBe("media-catalog-test-app");
+        expect(typeof data.byopClientUserId).toBe("string");
     },
 );
 

--- a/media.pollinations.ai/README.md
+++ b/media.pollinations.ai/README.md
@@ -8,6 +8,7 @@ Upload files and get back a content-addressed URL to use with Pollinations model
 
 - **Upload** media files via `POST /upload`
 - **Retrieve** media by hash via `GET /:hash`
+- **Catalog** optional upload metadata for user libraries, public app galleries, tags, and remix lineage
 - **Deduplicate** - identical files return the same URL (SHA-256 content hashing)
 - **CORS enabled** for browser uploads
 
@@ -21,7 +22,10 @@ Uploads require a pollinations.ai API key. Get one at [enter.pollinations.ai](ht
 # Multipart form-data
 curl -X POST https://media.pollinations.ai/upload \
   -H "Authorization: Bearer <your-api-key>" \
-  -F "file=@image.jpg"
+  -F "file=@image.jpg" \
+  -F "visibility=public" \
+  -F "tags=catgpt,remix" \
+  -F "parents=[\"10efdd0c1cfc65fa\"]"
 
 # Raw binary
 curl -X POST https://media.pollinations.ai/upload \
@@ -45,7 +49,12 @@ curl -X POST https://media.pollinations.ai/upload \
 #   "url": "https://media.pollinations.ai/a3f2b1c4d5e6f7...",
 #   "contentType": "image/jpeg",
 #   "size": 123456,
-#   "duplicate": false
+#   "duplicate": false,
+#   "cataloged": true,
+#   "visibility": "public",
+#   "source": "edit",
+#   "parents": ["10efdd0c1cfc65fa"],
+#   "tags": ["catgpt", "remix"]
 # }
 ```
 
@@ -80,6 +89,8 @@ Upload a media file. **Requires API key** via `Authorization: Bearer <key>` head
     "name": "image.jpg"
   }
   ```
+- Optional catalog fields: `visibility` (`private`, `unlisted`, `public`), `source` (`upload`, `generation`, `saved_generation`, `edit`, `remix`), `parents`/`parent`/`remixOf`, `tags`, `prompt`, `model`.
+- Owner and app attribution are stamped from the verified API key. Client-submitted app ids are ignored.
 
 **Response:**
 ```json
@@ -88,7 +99,12 @@ Upload a media file. **Requires API key** via `Authorization: Bearer <key>` head
   "url": "https://media.pollinations.ai/{hash}",
   "contentType": "image/jpeg",
   "size": 123456,
-  "duplicate": false
+  "duplicate": false,
+  "cataloged": true,
+  "visibility": "private",
+  "source": "upload",
+  "parents": [],
+  "tags": []
 }
 ```
 
@@ -125,6 +141,22 @@ Check if a file exists without downloading.
 ### `GET /`
 
 Service info and health check.
+
+### `GET /me/media`
+
+List cataloged media owned by the authenticated key user. Requires API key. Optional query parameters: `app`, `app_key`, `tag`, `limit`, `cursor`.
+
+### `GET /gallery?app=<app-key-id>`
+
+List public media stamped with a server-attested BYOP app key id. `app_key=<publishable-key>` is also accepted and resolved server-side.
+
+### `GET /tags/:tag`
+
+List public media carrying a normalized tag.
+
+### `GET /:hash/children`
+
+List public or unlisted catalog items that name `:hash` as a parent.
 
 
 
@@ -182,7 +214,7 @@ Files are stored using a truncated SHA-256 hash (16 hex characters = 64 bits) as
 
 - **30-day retention:** Files are retained for 30 days after upload. Re-uploading the same file resets the timer.
 - **No delete endpoint:** Content-addressed storage is append-only. Files cannot be deleted via the API.
-- **No user file listing:** There is no endpoint to list or manage your uploaded files.
+- **Catalog listing:** Authenticated users can list their cataloged uploads through `/me/media`. Public gallery endpoints only return items uploaded with `visibility=public`.
 - **Abuse/copyright:** For takedown requests, contact the Pollinations team.
 
 ## 🔑 Authentication

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -16,6 +16,15 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const CATALOG_PREFIX = "catalog/v1";
+const LINEAGE_PREFIX = "lineage/v1";
+const TAG_PREFIX = "tags/v1";
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 100;
+const MAX_TAGS = 12;
+const MAX_PARENTS = 20;
+const MAX_PROMPT_LENGTH = 1000;
+const MAX_MODEL_LENGTH = 120;
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
@@ -26,6 +35,49 @@ interface AuthResult {
     valid: boolean;
     type: string;
     name: string | null;
+    userId?: string | null;
+    apiKeyId?: string | null;
+    keyId?: string | null;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    byopClientUserId?: string | null;
+}
+
+type Visibility = "private" | "unlisted" | "public";
+type CatalogSource =
+    | "upload"
+    | "generation"
+    | "saved_generation"
+    | "edit"
+    | "remix";
+
+interface CatalogInput {
+    visibility: Visibility;
+    source: CatalogSource;
+    parents: string[];
+    tags: string[];
+    prompt?: string;
+    model?: string;
+}
+
+interface CatalogItem {
+    hash: string;
+    url: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    visibility: Visibility;
+    source: CatalogSource;
+    ownerId?: string;
+    ownerName?: string;
+    apiKeyId?: string;
+    appId?: string;
+    appName?: string;
+    appOwnerUserId?: string;
+    parents: string[];
+    tags: string[];
+    prompt?: string;
+    model?: string;
 }
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
@@ -57,16 +109,429 @@ function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
 }
 
+function reverseTimestampKey(date = new Date()): string {
+    return (9999999999999 - date.getTime()).toString().padStart(13, "0");
+}
+
+function safeFacet(value: string): string {
+    return value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 160);
+}
+
+function normalizeMediaHash(value: string): string | null {
+    let candidate = value.trim();
+    if (!candidate) return null;
+
+    try {
+        const url = new URL(candidate);
+        candidate = url.pathname.split("/").filter(Boolean).pop() || "";
+    } catch {
+        candidate = candidate.split("/").filter(Boolean).pop() || candidate;
+    }
+
+    const match = candidate.match(/[a-f0-9]{16}/i);
+    return match ? match[0].toLowerCase() : null;
+}
+
+function normalizeTag(value: string): string | null {
+    const tag = safeFacet(value).replace(/-+/g, "-").slice(0, 64);
+    return tag || null;
+}
+
+function stringFromUnknown(value: unknown): string | null {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed || null;
+}
+
+function fieldValues(
+    source: FormData | URLSearchParams | Record<string, unknown>,
+    names: string[],
+): unknown[] {
+    const values: unknown[] = [];
+    for (const name of names) {
+        if (source instanceof FormData || source instanceof URLSearchParams) {
+            values.push(...source.getAll(name));
+        } else if (name in source) {
+            values.push(source[name]);
+        }
+    }
+    return values;
+}
+
+function flattenStringList(values: unknown[]): string[] {
+    const strings: string[] = [];
+
+    for (const value of values) {
+        if (Array.isArray(value)) {
+            strings.push(...flattenStringList(value));
+            continue;
+        }
+        if (value instanceof File) continue;
+        if (typeof value !== "string") continue;
+
+        const trimmed = value.trim();
+        if (!trimmed) continue;
+
+        if (trimmed.startsWith("[")) {
+            try {
+                const parsed = JSON.parse(trimmed);
+                if (Array.isArray(parsed)) {
+                    strings.push(...flattenStringList(parsed));
+                    continue;
+                }
+            } catch {
+                // Fall through to comma splitting.
+            }
+        }
+
+        strings.push(...trimmed.split(",").map((part) => part.trim()));
+    }
+
+    return strings.filter(Boolean);
+}
+
+function firstString(
+    source: FormData | URLSearchParams | Record<string, unknown>,
+    names: string[],
+): string | null {
+    for (const value of fieldValues(source, names)) {
+        const stringValue = stringFromUnknown(value);
+        if (stringValue) return stringValue;
+    }
+    return null;
+}
+
+function parseVisibility(value: string | null): Visibility {
+    if (value === "public" || value === "unlisted" || value === "private") {
+        return value;
+    }
+    return "private";
+}
+
+function parseSource(value: string | null, parents: string[]): CatalogSource {
+    if (
+        value === "upload" ||
+        value === "generation" ||
+        value === "saved_generation" ||
+        value === "edit" ||
+        value === "remix"
+    ) {
+        return value;
+    }
+    return parents.length > 0 ? "edit" : "upload";
+}
+
+function parseCatalogInput(
+    source: FormData | URLSearchParams | Record<string, unknown>,
+): CatalogInput {
+    const parents = Array.from(
+        new Set(
+            flattenStringList(
+                fieldValues(source, [
+                    "parent",
+                    "parents",
+                    "parentIds",
+                    "parent_id",
+                    "remixOf",
+                    "sourceHash",
+                ]),
+            )
+                .map(normalizeMediaHash)
+                .filter((hash): hash is string => !!hash),
+        ),
+    ).slice(0, MAX_PARENTS);
+
+    const tags = Array.from(
+        new Set(
+            flattenStringList(fieldValues(source, ["tag", "tags"]))
+                .map(normalizeTag)
+                .filter((tag): tag is string => !!tag),
+        ),
+    ).slice(0, MAX_TAGS);
+
+    const prompt = firstString(source, ["prompt", "description"])?.slice(
+        0,
+        MAX_PROMPT_LENGTH,
+    );
+    const model = firstString(source, ["model"])?.slice(0, MAX_MODEL_LENGTH);
+    const visibility = parseVisibility(firstString(source, ["visibility"]));
+    const sourceKind = parseSource(
+        firstString(source, ["source", "kind"]),
+        parents,
+    );
+
+    return {
+        visibility,
+        source: sourceKind,
+        parents,
+        tags,
+        ...(prompt && { prompt }),
+        ...(model && { model }),
+    };
+}
+
+function catalogItemForUpload(params: {
+    hash: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    authResult: AuthResult;
+    input: CatalogInput;
+}): CatalogItem {
+    const apiKeyId = params.authResult.apiKeyId || params.authResult.keyId;
+    return {
+        hash: params.hash,
+        url: mediaUrl(params.hash),
+        contentType: params.contentType,
+        size: params.size,
+        createdAt: params.createdAt,
+        visibility: params.input.visibility,
+        source: params.input.source,
+        ...(params.authResult.userId && { ownerId: params.authResult.userId }),
+        ...(params.authResult.name && { ownerName: params.authResult.name }),
+        ...(apiKeyId && { apiKeyId }),
+        ...(params.authResult.byopClientKeyId && {
+            appId: params.authResult.byopClientKeyId,
+        }),
+        ...(params.authResult.byopClientName && {
+            appName: params.authResult.byopClientName,
+        }),
+        ...(params.authResult.byopClientUserId && {
+            appOwnerUserId: params.authResult.byopClientUserId,
+        }),
+        parents: params.input.parents,
+        tags: params.input.tags,
+        ...(params.input.prompt && { prompt: params.input.prompt }),
+        ...(params.input.model && { model: params.input.model }),
+    };
+}
+
+async function putCatalogJson(
+    bucket: R2Bucket,
+    key: string,
+    value: unknown,
+): Promise<void> {
+    await bucket.put(key, JSON.stringify(value), {
+        httpMetadata: { contentType: "application/json" },
+    });
+}
+
+async function writeCatalogEntries(
+    bucket: R2Bucket,
+    item: CatalogItem,
+): Promise<boolean> {
+    const timestampKey = reverseTimestampKey(new Date(item.createdAt));
+    const indexName = `${timestampKey}-${item.hash}.json`;
+    const writes: Promise<void>[] = [
+        putCatalogJson(
+            bucket,
+            `${CATALOG_PREFIX}/items/${item.hash}.json`,
+            item,
+        ),
+    ];
+
+    if (item.ownerId) {
+        const ownerId = safeFacet(item.ownerId);
+        writes.push(
+            putCatalogJson(
+                bucket,
+                `${CATALOG_PREFIX}/by-owner/${ownerId}/${indexName}`,
+                item,
+            ),
+        );
+
+        if (item.appId) {
+            writes.push(
+                putCatalogJson(
+                    bucket,
+                    `${CATALOG_PREFIX}/by-owner-app/${ownerId}/${safeFacet(
+                        item.appId,
+                    )}/${indexName}`,
+                    item,
+                ),
+            );
+        }
+    }
+
+    if (item.visibility === "public" && item.appId) {
+        writes.push(
+            putCatalogJson(
+                bucket,
+                `${CATALOG_PREFIX}/public-app/${safeFacet(item.appId)}/${indexName}`,
+                item,
+            ),
+        );
+    }
+
+    if (item.visibility === "public") {
+        for (const tag of item.tags) {
+            writes.push(
+                putCatalogJson(
+                    bucket,
+                    `${TAG_PREFIX}/${safeFacet(tag)}/${indexName}`,
+                    item,
+                ),
+            );
+        }
+    }
+
+    if (item.visibility !== "private") {
+        for (const parent of item.parents) {
+            writes.push(
+                putCatalogJson(
+                    bucket,
+                    `${LINEAGE_PREFIX}/by-parent/${parent}/${indexName}`,
+                    item,
+                ),
+            );
+        }
+    }
+
+    const results = await Promise.allSettled(writes);
+    const failures = results.filter((result) => result.status === "rejected");
+    if (failures.length) {
+        console.error(
+            JSON.stringify({
+                event: "catalog_write_failed",
+                hash: item.hash,
+                failures: failures.length,
+            }),
+        );
+    }
+    return failures.length === 0;
+}
+
+async function readCatalogJson<T>(
+    bucket: R2Bucket,
+    key: string,
+): Promise<T | null> {
+    const object = await bucket.get(key);
+    if (!object) return null;
+    try {
+        return JSON.parse(await object.text()) as T;
+    } catch {
+        return null;
+    }
+}
+
+function parseListOptions(url: URL): { limit: number; cursor?: string } {
+    const requestedLimit = Number.parseInt(
+        url.searchParams.get("limit") || "",
+        10,
+    );
+    const limit = Number.isFinite(requestedLimit)
+        ? Math.min(Math.max(requestedLimit, 1), MAX_LIST_LIMIT)
+        : DEFAULT_LIST_LIMIT;
+    const cursor = url.searchParams.get("cursor") || undefined;
+    return { limit, cursor };
+}
+
+async function listCatalogPrefix(
+    bucket: R2Bucket,
+    prefix: string,
+    options: { limit: number; cursor?: string },
+    filter?: (item: CatalogItem) => boolean,
+): Promise<{ items: CatalogItem[]; nextCursor?: string }> {
+    const listed = await bucket.list({
+        prefix,
+        limit: Math.min(options.limit * 3, 1000),
+        cursor: options.cursor,
+    });
+    const items: CatalogItem[] = [];
+    const seen = new Set<string>();
+
+    for (const object of listed.objects) {
+        const item = await readCatalogJson<CatalogItem>(bucket, object.key);
+        if (!item || seen.has(item.hash)) continue;
+        if (filter && !filter(item)) continue;
+        seen.add(item.hash);
+        items.push(item);
+        if (items.length >= options.limit) break;
+    }
+
+    return {
+        items,
+        ...(listed.truncated && listed.cursor
+            ? { nextCursor: listed.cursor }
+            : {}),
+    };
+}
+
+async function resolveRequestedAppId(
+    appRef: string | null,
+): Promise<string | null> {
+    if (!appRef) return null;
+    if (appRef.startsWith("pk_") || appRef.startsWith("sk_")) {
+        const keyInfo = await verifyApiKey(appRef);
+        return keyInfo?.apiKeyId || keyInfo?.keyId || null;
+    }
+    return safeFacet(appRef);
+}
+
 const UploadResponseSchema = z.object({
     id: z.string().describe("16-char hex content hash"),
     url: z.string().describe("Public retrieval URL"),
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    cataloged: z.boolean().describe("true when catalog index writes succeeded"),
+    visibility: z.enum(["private", "unlisted", "public"]),
+    source: z.enum([
+        "upload",
+        "generation",
+        "saved_generation",
+        "edit",
+        "remix",
+    ]),
+    parents: z
+        .array(z.string())
+        .describe("Parent media hashes for remixes/edits"),
+    tags: z.array(z.string()).describe("Normalized public discovery tags"),
+    appId: z.string().optional().describe("Server-attested BYOP app key id"),
+    appName: z
+        .string()
+        .optional()
+        .describe("Server-attested BYOP app key name"),
 });
 
 const ErrorSchema = z.object({
     error: z.string(),
+});
+
+const CatalogItemSchema = z.object({
+    hash: z.string(),
+    url: z.string(),
+    contentType: z.string(),
+    size: z.number().int(),
+    createdAt: z.string(),
+    visibility: z.enum(["private", "unlisted", "public"]),
+    source: z.enum([
+        "upload",
+        "generation",
+        "saved_generation",
+        "edit",
+        "remix",
+    ]),
+    ownerId: z.string().optional(),
+    ownerName: z.string().optional(),
+    apiKeyId: z.string().optional(),
+    appId: z.string().optional(),
+    appName: z.string().optional(),
+    appOwnerUserId: z.string().optional(),
+    parents: z.array(z.string()),
+    tags: z.array(z.string()),
+    prompt: z.string().optional(),
+    model: z.string().optional(),
+});
+
+const CatalogListSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    nextCursor: z.string().optional(),
 });
 
 const MetadataResponseSchema = z.object({
@@ -140,6 +605,7 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        let catalogInput = parseCatalogInput(new URL(c.req.url).searchParams);
 
         const requestContentType = c.req.header("content-type") || "";
 
@@ -164,11 +630,24 @@ api.post(
                 fileBuffer = await file.arrayBuffer();
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
+                catalogInput = parseCatalogInput(formData);
             } else if (requestContentType.includes("application/json")) {
                 const body = await c.req.json<{
                     data: string;
                     contentType?: string;
                     name?: string;
+                    visibility?: string;
+                    source?: string;
+                    kind?: string;
+                    parent?: string;
+                    parents?: string[] | string;
+                    parentIds?: string[] | string;
+                    remixOf?: string;
+                    tags?: string[] | string;
+                    tag?: string[] | string;
+                    prompt?: string;
+                    description?: string;
+                    model?: string;
                 }>();
 
                 if (!body.data) {
@@ -197,6 +676,7 @@ api.post(
 
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
+                catalogInput = parseCatalogInput(body);
             } else {
                 fileBuffer = await c.req.arrayBuffer();
 
@@ -213,6 +693,15 @@ api.post(
             const hash = await generateHash(fileBuffer, fileName);
 
             const existing = await c.env.MEDIA_BUCKET.head(hash);
+            const uploadedAt = new Date().toISOString();
+            const catalogItem = catalogItemForUpload({
+                hash,
+                contentType,
+                size: fileBuffer.byteLength,
+                createdAt: uploadedAt,
+                authResult,
+                input: catalogInput,
+            });
 
             // Always re-PUT to reset the R2 object timestamp (resets lifecycle TTL).
             await c.env.MEDIA_BUCKET.put(hash, fileBuffer, {
@@ -221,12 +710,21 @@ api.post(
                     cacheControl: CACHE_CONTROL,
                 },
                 customMetadata: {
-                    uploadedAt: new Date().toISOString(),
+                    uploadedAt,
                     originalName: fileName || "",
                     uploadedBy: authResult.name || "",
                     keyType: authResult.type,
+                    ownerId: authResult.userId || "",
+                    apiKeyId: authResult.apiKeyId || authResult.keyId || "",
+                    appId: authResult.byopClientKeyId || "",
+                    visibility: catalogInput.visibility,
+                    source: catalogInput.source,
                 },
             });
+            const cataloged = await writeCatalogEntries(
+                c.env.MEDIA_BUCKET,
+                catalogItem,
+            );
 
             console.log(
                 JSON.stringify({
@@ -236,6 +734,10 @@ api.post(
                     contentType,
                     keyType: authResult.type,
                     uploadedBy: authResult.name || "unknown",
+                    ownerId: authResult.userId || null,
+                    appId: authResult.byopClientKeyId || null,
+                    visibility: catalogInput.visibility,
+                    source: catalogInput.source,
                     duplicate: !!existing,
                 }),
             );
@@ -246,11 +748,242 @@ api.post(
                 contentType,
                 size: fileBuffer.byteLength,
                 duplicate: !!existing,
+                cataloged,
+                visibility: catalogItem.visibility,
+                source: catalogItem.source,
+                parents: catalogItem.parents,
+                tags: catalogItem.tags,
+                ...(catalogItem.appId && { appId: catalogItem.appId }),
+                ...(catalogItem.appName && { appName: catalogItem.appName }),
             });
         } catch (error) {
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List media for the authenticated user",
+        description:
+            "Returns cataloged uploads owned by the API key user. Optional query params: app/app_key, tag, limit, cursor.",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) {
+            return c.json(
+                {
+                    error: "API key required. Pass via Authorization: Bearer <key> or ?key=<key>",
+                },
+                401,
+            );
+        }
+
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+        if (!authResult.userId) {
+            return c.json({ error: "API key owner is unavailable" }, 400);
+        }
+
+        const url = new URL(c.req.url);
+        const appRef =
+            url.searchParams.get("app_key") ||
+            url.searchParams.get("app") ||
+            url.searchParams.get("app_id");
+        const appId = await resolveRequestedAppId(appRef);
+        const tag = normalizeTag(url.searchParams.get("tag") || "");
+        const source = firstString(url.searchParams, ["source", "kind"]);
+        const ownerId = safeFacet(authResult.userId);
+        const prefix = appId
+            ? `${CATALOG_PREFIX}/by-owner-app/${ownerId}/${safeFacet(appId)}/`
+            : `${CATALOG_PREFIX}/by-owner/${ownerId}/`;
+        const result = await listCatalogPrefix(
+            c.env.MEDIA_BUCKET,
+            prefix,
+            parseListOptions(url),
+            (item) =>
+                (!tag || item.tags.includes(tag)) &&
+                (!source || item.source === source),
+        );
+
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/gallery",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public app media",
+        description:
+            "Returns public catalog items for a server-attested app. Pass app=<app key id> or app_key=<publishable key>.",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+            400: {
+                description: "Missing app",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const appRef =
+            url.searchParams.get("app_key") ||
+            url.searchParams.get("app") ||
+            url.searchParams.get("app_id");
+        const appId = await resolveRequestedAppId(appRef);
+        if (!appId) {
+            return c.json(
+                {
+                    error: "Missing app. Pass app=<app key id> or app_key=<key>.",
+                },
+                400,
+            );
+        }
+
+        const tag = normalizeTag(url.searchParams.get("tag") || "");
+        const source = firstString(url.searchParams, ["source", "kind"]);
+        const result = await listCatalogPrefix(
+            c.env.MEDIA_BUCKET,
+            `${CATALOG_PREFIX}/public-app/${safeFacet(appId)}/`,
+            parseListOptions(url),
+            (item) =>
+                (!tag || item.tags.includes(tag)) &&
+                (!source || item.source === source),
+        );
+
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/apps/:app/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public app media by app id",
+        description:
+            "Returns public catalog items for a server-attested app key id.",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const appId = safeFacet(c.req.param("app"));
+        const tag = normalizeTag(url.searchParams.get("tag") || "");
+        const result = await listCatalogPrefix(
+            c.env.MEDIA_BUCKET,
+            `${CATALOG_PREFIX}/public-app/${appId}/`,
+            parseListOptions(url),
+            (item) => !tag || item.tags.includes(tag),
+        );
+
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/tags/:tag",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media by tag",
+        description: "Returns public catalog items carrying a normalized tag.",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const tag = normalizeTag(c.req.param("tag") || "");
+        if (!tag) return c.json({ items: [] });
+
+        return c.json(
+            await listCatalogPrefix(
+                c.env.MEDIA_BUCKET,
+                `${TAG_PREFIX}/${tag}/`,
+                parseListOptions(url),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/:hash/children",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public/unlisted remixes of a media hash",
+        description:
+            "Returns cataloged public or unlisted children whose parents include the requested hash.",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": { schema: resolver(CatalogListSchema) },
+                },
+            },
+            400: {
+                description: "Invalid hash format",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const hash = c.req.param("hash").toLowerCase();
+        if (!HASH_PATTERN.test(hash)) {
+            return c.json({ error: "Invalid hash format" }, 400);
+        }
+
+        const url = new URL(c.req.url);
+        const tag = normalizeTag(url.searchParams.get("tag") || "");
+        const appId = safeFacet(url.searchParams.get("app") || "");
+        const result = await listCatalogPrefix(
+            c.env.MEDIA_BUCKET,
+            `${LINEAGE_PREFIX}/by-parent/${hash}/`,
+            parseListOptions(url),
+            (item) =>
+                (!tag || item.tags.includes(tag)) &&
+                (!appId || safeFacet(item.appId || "") === appId),
+        );
+
+        return c.json(result);
     },
 );
 
@@ -449,6 +1182,10 @@ app.get("/", (c) => {
         version: "1.0.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
+            myMedia: "GET /me/media (requires API key)",
+            appGallery: "GET /gallery?app=<app-key-id>",
+            tagGallery: "GET /tags/:tag",
+            children: "GET /:hash/children",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -17,9 +17,63 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    cataloged: boolean;
+    visibility: "private" | "unlisted" | "public";
+    source: "upload" | "generation" | "saved_generation" | "edit" | "remix";
+    parents: string[];
+    tags: string[];
+    appId?: string;
+    appName?: string;
+}
+
+interface CatalogListResponse {
+    items: Array<{
+        hash: string;
+        url: string;
+        visibility: "private" | "unlisted" | "public";
+        source: string;
+        appId?: string;
+        appName?: string;
+        parents: string[];
+        tags: string[];
+        prompt?: string;
+        model?: string;
+    }>;
+    nextCursor?: string;
 }
 
 const VALID_KEY = "pk_test_key_123";
+const AUTH_USER_ID = "user_test_1";
+const AUTH_API_KEY_ID = "api_key_test_1";
+const AUTH_APP_ID = "app_key_test_1";
+const AUTH_APP_NAME = "CatGPT Test";
+
+async function uploadPng(
+    name: string,
+    fields: Record<string, string> = {},
+): Promise<UploadResponse> {
+    const form = new FormData();
+    form.append("file", new File([TINY_PNG], name, { type: "image/png" }));
+    for (const [key, value] of Object.entries(fields)) {
+        form.append(key, value);
+    }
+
+    const response = await SELF.fetch("https://media.pollinations.ai/upload", {
+        method: "POST",
+        body: form,
+        headers: { Authorization: `Bearer ${VALID_KEY}` },
+    });
+    expect(response.status).toBe(200);
+    return (await response.json()) as UploadResponse;
+}
+
+async function listCatalog(path: string): Promise<CatalogListResponse> {
+    const response = await SELF.fetch(`https://media.pollinations.ai${path}`, {
+        headers: { Authorization: `Bearer ${VALID_KEY}` },
+    });
+    expect(response.status).toBe(200);
+    return (await response.json()) as CatalogListResponse;
+}
 
 function mockAuth() {
     fetchMock.activate();
@@ -33,6 +87,11 @@ function mockAuth() {
                 valid: true,
                 type: "publishable",
                 name: "test-user",
+                userId: AUTH_USER_ID,
+                apiKeyId: AUTH_API_KEY_ID,
+                byopClientKeyId: AUTH_APP_ID,
+                byopClientName: AUTH_APP_NAME,
+                byopClientUserId: "app_owner_test_1",
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -85,6 +144,8 @@ describe("media.pollinations.ai", () => {
         expect(upload.url).toContain(upload.id);
         expect(upload.contentType).toBe("image/png");
         expect(upload.size).toBe(TINY_PNG.length);
+        expect(upload.cataloged).toBe(true);
+        expect(upload.visibility).toBe("private");
 
         // Retrieve — check Content-Disposition
         const getRes = await SELF.fetch(
@@ -152,6 +213,82 @@ describe("media.pollinations.ai", () => {
         const upload1 = (await res1.json()) as UploadResponse;
         const upload2 = (await res2.json()) as UploadResponse;
         expect(upload1.id).not.toBe(upload2.id);
+    });
+
+    it("catalogs owner media, app galleries, tags, and public lineage", async () => {
+        const nonce = crypto.randomUUID();
+        const parent = await uploadPng(`catalog-parent-${nonce}.png`, {
+            visibility: "public",
+            tags: "catgpt",
+            source: "generation",
+            prompt: "a source cat portrait",
+            model: "flux",
+        });
+        const privateChild = await uploadPng(`catalog-private-${nonce}.png`, {
+            parent: parent.url,
+            tags: "catgpt",
+            source: "edit",
+        });
+        const child = await uploadPng(`catalog-child-${nonce}.png`, {
+            parents: JSON.stringify([parent.url]),
+            tags: JSON.stringify(["CatGPT", "Remix!!"]),
+            visibility: "public",
+            source: "edit",
+            prompt: "add a tiny wizard hat",
+            model: "flux",
+        });
+
+        expect(child.cataloged).toBe(true);
+        expect(child.visibility).toBe("public");
+        expect(child.source).toBe("edit");
+        expect(child.parents).toEqual([parent.id]);
+        expect(child.tags).toEqual(["catgpt", "remix"]);
+        expect(child.appId).toBe(AUTH_APP_ID);
+        expect(child.appName).toBe(AUTH_APP_NAME);
+
+        const mine = await listCatalog("/me/media?limit=50");
+        expect(mine.items.some((item) => item.hash === child.id)).toBe(true);
+        expect(mine.items.some((item) => item.hash === privateChild.id)).toBe(
+            true,
+        );
+
+        const mineByApp = await listCatalog(
+            `/me/media?app=${AUTH_APP_ID}&tag=catgpt&limit=50`,
+        );
+        expect(mineByApp.items.some((item) => item.hash === child.id)).toBe(
+            true,
+        );
+
+        const appGallery = await listCatalog(
+            `/gallery?app=${AUTH_APP_ID}&tag=catgpt&limit=50`,
+        );
+        expect(appGallery.items.some((item) => item.hash === child.id)).toBe(
+            true,
+        );
+        expect(
+            appGallery.items.some((item) => item.hash === privateChild.id),
+        ).toBe(false);
+
+        const appAlias = await listCatalog(
+            `/apps/${AUTH_APP_ID}/media?tag=catgpt&limit=50`,
+        );
+        expect(appAlias.items.some((item) => item.hash === child.id)).toBe(
+            true,
+        );
+
+        const tagged = await listCatalog("/tags/remix?limit=50");
+        expect(tagged.items.some((item) => item.hash === child.id)).toBe(true);
+
+        const children = await listCatalog(`/${parent.id}/children?limit=50`);
+        const listedChild = children.items.find(
+            (item) => item.hash === child.id,
+        );
+        expect(listedChild).toBeTruthy();
+        expect(listedChild?.parents).toEqual([parent.id]);
+        expect(listedChild?.prompt).toBe("add a tiny wizard hat");
+        expect(
+            children.items.some((item) => item.hash === privateChild.id),
+        ).toBe(false);
     });
 
     it("GET /:invalid-hash returns 400", async () => {


### PR DESCRIPTION
- Adds an R2 sidecar media catalog with owner/app indexes, public app galleries, tag lists, and remix children.
- Exposes server-attested user/app key claims from /account/key so media stamps app provenance from verified tokens, not client params.
- Wires catalog metadata into CatGPT, CatGPT bot, Opposite Prompt bot, voice-edit remix/walkthrough, Chat, AI Dungeon, SlidePainter, Virtual Makeup, and Product Packaging.
- Covers catalog listing, public lineage, tags, and BYOP app attribution in focused tests.