### PR TITLE
feat: add sidecar media catalog

### DIFF
--- a/apps/ai-dungeon-master/src/App.tsx
+++ b/apps/ai-dungeon-master/src/App.tsx
@@ -175,28 +175,70 @@ export default function App() {
             let uploadedSceneImage = gameState.currentScene.image;
 
             if (withUpload && apiKey) {
-                const sceneUpload = uploadToMedia(
-                    gameState.currentScene.image,
+                const originalLastStoryImage =
+                    gameState.storyHistory.at(-1)?.image;
+
+                character.avatar = await uploadToMedia(
+                    character.avatar,
                     apiKey,
+                    {
+                        visibility: "private",
+                        relationship: "rpg_character",
+                        tags: ["character"],
+                        prompt: `${character.name} ${character.class} avatar`,
+                        model: "flux",
+                    },
                 );
-                await Promise.all([
-                    uploadToMedia(character.avatar, apiKey).then((url) => {
-                        character.avatar = url;
-                    }),
-                    sceneUpload.then((url) => {
-                        uploadedSceneImage = url;
-                    }),
-                    ...storyHistory.map((entry, idx) =>
-                        uploadToMedia(entry.image, apiKey).then((url) => {
-                            storyHistory[idx].image = url;
-                        }),
-                    ),
-                    ...inventory.map((item, idx) =>
-                        uploadToMedia(item.image, apiKey).then((url) => {
+
+                let previousStoryImage = character.avatar;
+                for (let idx = 0; idx < storyHistory.length; idx++) {
+                    const entry = storyHistory[idx];
+                    storyHistory[idx].image = await uploadToMedia(
+                        entry.image,
+                        apiKey,
+                        {
+                            visibility: "private",
+                            relationship: "rpg_scene",
+                            tags: ["scene"],
+                            parents: [previousStoryImage].filter(Boolean),
+                            prompt: entry.description,
+                            model: "flux",
+                        },
+                    );
+                    previousStoryImage = storyHistory[idx].image;
+                }
+
+                if (originalLastStoryImage === gameState.currentScene.image) {
+                    uploadedSceneImage = previousStoryImage;
+                } else {
+                    uploadedSceneImage = await uploadToMedia(
+                        gameState.currentScene.image,
+                        apiKey,
+                        {
+                            visibility: "private",
+                            relationship: "rpg_current_scene",
+                            tags: ["scene", "current"],
+                            parents: [previousStoryImage].filter(Boolean),
+                            prompt: gameState.currentScene.description,
+                            model: "flux",
+                        },
+                    );
+                }
+
+                await Promise.all(
+                    inventory.map((item, idx) =>
+                        uploadToMedia(item.image, apiKey, {
+                            visibility: "private",
+                            relationship: "rpg_inventory_item",
+                            tags: ["inventory"],
+                            parents: [uploadedSceneImage].filter(Boolean),
+                            prompt: `${item.name}: ${item.description}`,
+                            model: "flux",
+                        }).then((url) => {
                             inventory[idx].image = url;
                         }),
                     ),
-                ]);
+                );
             }
 
             const currentScene = {

--- a/apps/ai-dungeon-master/src/utils/mediaUpload.ts
+++ b/apps/ai-dungeon-master/src/utils/mediaUpload.ts
@@ -1,5 +1,14 @@
-const MEDIA_URL = "https://gen.pollinations.ai";
 const MEDIA_HOST = "media.pollinations.ai";
+const MEDIA_UPLOAD_URL = `https://${MEDIA_HOST}/upload`;
+
+type MediaUploadOptions = {
+    visibility?: "private" | "unlisted" | "public";
+    relationship?: string;
+    tags?: string[];
+    parents?: string[];
+    prompt?: string;
+    model?: string;
+};
 
 /** Check if a URL is already uploaded to media.pollinations.ai */
 function isMediaUrl(url: string): boolean {
@@ -10,6 +19,28 @@ function isMediaUrl(url: string): boolean {
     }
 }
 
+function mediaParent(url: string | undefined): string | null {
+    if (!url || !isMediaUrl(url)) return null;
+    return url;
+}
+
+function appendCatalogFields(
+    formData: FormData,
+    options: MediaUploadOptions,
+): void {
+    formData.append("visibility", options.visibility ?? "private");
+    formData.append("relationship", options.relationship ?? "rpg_media");
+    for (const tag of ["ai-dungeon-master", ...(options.tags ?? [])]) {
+        formData.append("tags", tag);
+    }
+    for (const parent of options.parents ?? []) {
+        const cleanParent = mediaParent(parent);
+        if (cleanParent) formData.append("parents", cleanParent);
+    }
+    if (options.prompt) formData.append("prompt", options.prompt);
+    if (options.model) formData.append("model", options.model);
+}
+
 /**
  * Upload a gen.pollinations.ai image to media.pollinations.ai for permanent storage.
  * Returns the permanent media URL on success, or the original URL on any error.
@@ -18,6 +49,7 @@ function isMediaUrl(url: string): boolean {
 export async function uploadToMedia(
     genUrl: string,
     apiKey: string,
+    options: MediaUploadOptions = {},
 ): Promise<string> {
     if (!genUrl || isMediaUrl(genUrl)) return genUrl;
 
@@ -27,9 +59,10 @@ export async function uploadToMedia(
 
         const blob = await response.blob();
         const formData = new FormData();
-        formData.append("file", blob);
+        formData.append("file", blob, "ai-dungeon-master.png");
+        appendCatalogFields(formData, options);
 
-        const uploadRes = await fetch(`${MEDIA_URL}/media`, {
+        const uploadRes = await fetch(MEDIA_UPLOAD_URL, {
             method: "POST",
             headers: { Authorization: `Bearer ${apiKey}` },
             body: formData,

--- a/apps/catgpt-bot/bot.ts
+++ b/apps/catgpt-bot/bot.ts
@@ -15,12 +15,23 @@ const TOKEN = process.env.BOT_TOKEN_CATGPT;
 const API_KEY = process.env.TEXT_POLLINATIONS_TOKEN;
 const TEXT_API = "https://gen.pollinations.ai/v1/chat/completions";
 const IMAGE_API = "https://gen.pollinations.ai/image";
+const MEDIA_API = "https://media.pollinations.ai";
+const MEDIA_UPLOAD = `${MEDIA_API}/upload`;
 const AUTH = API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {};
 
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const MODEL = "nanobanana";
+
+type CatalogUploadOptions = {
+    visibility?: "private" | "unlisted" | "public";
+    relationship?: string;
+    tags?: string[];
+    parents?: string[];
+    prompt?: string;
+    model?: string;
+};
 
 function log(...args: any[]) {
     console.log(`[${new Date().toISOString()}]`, ...args);
@@ -103,6 +114,60 @@ async function fetchImage(url: string): Promise<Buffer> {
     return Buffer.from(res.data);
 }
 
+function mediaParent(urlString: string): string | null {
+    try {
+        const url = new URL(urlString);
+        return url.hostname === "media.pollinations.ai" ? urlString : null;
+    } catch {
+        return null;
+    }
+}
+
+function appendCatalogFields(form: FormData, options: CatalogUploadOptions) {
+    form.append("visibility", options.visibility || "public");
+    form.append("relationship", options.relationship || "catgpt_bot_reply");
+    form.append("kind", "generation");
+    for (const tag of options.tags || []) form.append("tags", tag);
+    for (const parent of options.parents || []) {
+        const cleanParent = mediaParent(parent);
+        if (cleanParent) form.append("parents", cleanParent);
+    }
+    if (options.prompt) form.append("prompt", options.prompt);
+    if (options.model) form.append("model", options.model);
+}
+
+async function uploadImageBuffer(
+    buffer: Buffer,
+    filename: string,
+    options: CatalogUploadOptions,
+): Promise<string | null> {
+    if (!API_KEY) return null;
+
+    try {
+        const fileBytes = new ArrayBuffer(buffer.byteLength);
+        new Uint8Array(fileBytes).set(buffer);
+        const form = new FormData();
+        form.append(
+            "file",
+            new Blob([fileBytes], { type: "image/png" }),
+            filename,
+        );
+        appendCatalogFields(form, options);
+
+        const res = await axios.post(MEDIA_UPLOAD, form, {
+            headers: AUTH,
+            timeout: 60_000,
+        });
+        const mediaUrl =
+            res.data?.url || (res.data?.id ? `${MEDIA_API}/${res.data.id}` : null);
+        if (mediaUrl) log(`Cataloged media: ${mediaUrl}`);
+        return mediaUrl;
+    } catch (err: any) {
+        logError(`Media catalog upload failed: ${err.message}`);
+        return null;
+    }
+}
+
 const processing = new Set<string>();
 
 async function handleMessage(msg: Message, client: Client): Promise<void> {
@@ -136,6 +201,14 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
             const imageBuffer = await fetchImage(imageUrl);
+            await uploadImageBuffer(imageBuffer, "catgpt.png", {
+                visibility: "public",
+                relationship: "catgpt_bot_reply",
+                tags: ["catgpt", "catgpt-bot", "meme"],
+                parents: [SELFIE_CATGPT],
+                prompt,
+                model: MODEL,
+            });
             const attachment = new AttachmentBuilder(imageBuffer, {
                 name: "catgpt.png",
             });

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -2,7 +2,8 @@
 
 const API = "https://gen.pollinations.ai/image";
 const ENTER = "https://enter.pollinations.ai";
-const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA = "https://media.pollinations.ai";
+const MEDIA_UPLOAD = `${MEDIA}/upload`;
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
@@ -53,6 +54,16 @@ async function fetchAccount(apiKey, path) {
 
 export const fetchProfile = (apiKey) => fetchAccount(apiKey, "profile");
 export const fetchBalance = (apiKey) => fetchAccount(apiKey, "balance");
+export const fetchKeyInfo = (apiKey) => fetchAccount(apiKey, "key");
+
+export async function resolveAppKeyId() {
+    const res = await fetch(
+        `${ENTER}/api/app-lookup?${new URLSearchParams({ app_key: APP_KEY })}`,
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.found ? data.clientId : null;
+}
 
 // ── Cat Reply ───────────────────────────────────────────────────────────────
 
@@ -146,6 +157,72 @@ export async function pickModel(apiKey) {
 
 // ── Media Upload ─────────────────────────────────────────────────────────────
 
+function appendCatalogFields(form, options = {}) {
+    if (options.visibility) form.append("visibility", options.visibility);
+    if (options.relationship) form.append("relationship", options.relationship);
+    for (const tag of options.tags || []) form.append("tags", tag);
+    for (const parent of options.parents || []) form.append("parents", parent);
+    if (options.prompt) form.append("prompt", options.prompt);
+    if (options.model) form.append("model", options.model);
+}
+
+function authHeader() {
+    return { Authorization: `Bearer ${getStoredApiKey()}` };
+}
+
+function isMediaUrl(url) {
+    if (!url) return false;
+    try {
+        return new URL(url).hostname === "media.pollinations.ai";
+    } catch {
+        return false;
+    }
+}
+
+async function uploadMediaBlob(blob, filename, options = {}) {
+    const form = new FormData();
+    form.append("file", blob, filename);
+    appendCatalogFields(form, options);
+    const res = await fetch(MEDIA_UPLOAD, {
+        method: "POST",
+        headers: authHeader(),
+        body: form,
+    });
+    if (!res.ok) throw new Error("Upload failed");
+    return res.json();
+}
+
+export async function uploadGeneratedMeme(blob, parentUrl = null, metadata = {}) {
+    const parents = isMediaUrl(parentUrl) ? [parentUrl] : [];
+    const media = await uploadMediaBlob(blob, `catgpt-${Date.now()}.png`, {
+        visibility: "public",
+        relationship: "catgpt_reply",
+        tags: ["catgpt", "meme"],
+        parents,
+        prompt: metadata.prompt,
+        model: metadata.model,
+    });
+    return media.url || `${MEDIA}/${media.id}`;
+}
+
+export async function fetchMyMedia() {
+    const res = await fetch(`${MEDIA}/me/media?limit=50`, {
+        headers: authHeader(),
+    });
+    if (!res.ok) throw new Error("Could not load media");
+    return res.json();
+}
+
+export async function fetchAppMedia() {
+    const appKeyId = await resolveAppKeyId();
+    if (!appKeyId) return { items: [] };
+    const res = await fetch(
+        `${MEDIA}/apps/${encodeURIComponent(appKeyId)}/media?limit=50`,
+    );
+    if (!res.ok) throw new Error("Could not load app media");
+    return res.json();
+}
+
 export async function handleImageUpload(file, notify) {
     if (!file) return null;
     if (file.size > 5 * 1024 * 1024) {
@@ -155,15 +232,11 @@ export async function handleImageUpload(file, notify) {
 
     try {
         notify("Uploading image...", "info");
-        const form = new FormData();
-        form.append("file", file);
-        const res = await fetch(MEDIA_UPLOAD, {
-            method: "POST",
-            headers: { Authorization: `Bearer ${getStoredApiKey()}` },
-            body: form,
+        const media = await uploadMediaBlob(file, file.name || "catgpt.png", {
+            visibility: "unlisted",
+            tags: ["catgpt", "source"],
         });
-        if (!res.ok) throw new Error("Upload failed");
-        return (await res.json()).url;
+        return media.url || `${MEDIA}/${media.id}`;
     } catch (err) {
         console.error("Media upload failed:", err);
         notify("Upload failed. Trying local fallback...", "warning");

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">CatGPT Gallery</h2>
+            <div class="catgpt-gallery-grid" id="catgptGalleryGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -5,7 +5,10 @@ import {
     createImageGenerationPrompt,
     EXAMPLE_PROMPTS,
     extractApiKeyFromFragment,
+    fetchAppMedia,
     fetchBalance,
+    fetchKeyInfo,
+    fetchMyMedia,
     fetchProfile,
     generateCatReply,
     generateImageURL,
@@ -14,6 +17,7 @@ import {
     handleImageUpload,
     pickModel,
     storeApiKey,
+    uploadGeneratedMeme,
 } from "./ai.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -73,6 +77,7 @@ const dom = {
     generatedMeme: $("generatedMeme"),
     downloadBtn: $("downloadBtn"),
     shareBtn: $("shareBtn"),
+    catgptGalleryGrid: $("catgptGalleryGrid"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
     imageUpload: $("imageUpload"),
@@ -174,6 +179,23 @@ function saveGeneratedMeme(prompt, url) {
         ...saved.filter((m) => m.prompt !== prompt),
     ].slice(0, 8);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}
+
+function uniqueByUrl(items) {
+    const seen = new Set();
+    return items.filter((item) => {
+        if (!item.url || seen.has(item.url)) return false;
+        seen.add(item.url);
+        return true;
+    });
+}
+
+function catalogItemToMeme(item, prompt = "CatGPT meme") {
+    return {
+        prompt: item.prompt || prompt,
+        url: item.url,
+        model: item.model || "media",
+    };
 }
 
 // ── Animations ───────────────────────────────────────────────────────────────
@@ -333,11 +355,34 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
+async function loadUserMemes() {
     dom.yourMemesGrid.innerHTML = "";
     const saved = getSavedMemes();
+    let catalogMemes = [];
+    const apiKey = getStoredApiKey();
 
-    if (!saved.length) {
+    if (apiKey) {
+        try {
+            const [keyInfo, media] = await Promise.all([
+                fetchKeyInfo(apiKey),
+                fetchMyMedia(),
+            ]);
+            catalogMemes = (media.items || [])
+                .filter((item) => item.verifiedApp?.keyId)
+                .filter(
+                    (item) =>
+                        item.verifiedApp.keyId === keyInfo.byopClientKeyId,
+                )
+                .filter((item) => item.tags.includes("meme"))
+                .map((item) => catalogItemToMeme(item));
+        } catch (error) {
+            console.warn("Could not load cataloged CatGPT memes", error);
+        }
+    }
+
+    const memes = uniqueByUrl([...catalogMemes, ...saved]).slice(0, 12);
+
+    if (!memes.length) {
         const p = document.createElement("p");
         p.textContent = "No memes yet! Generate one to see it here. 🎨";
         p.style.cssText =
@@ -346,10 +391,38 @@ function loadUserMemes() {
         return;
     }
 
-    saved.forEach((meme, i) => {
+    memes.forEach((meme, i) => {
         const card = createMemeCard(meme.prompt, i, meme.url);
         if (card) dom.yourMemesGrid.appendChild(card);
     });
+}
+
+async function loadCatgptGallery() {
+    if (!dom.catgptGalleryGrid) return;
+    dom.catgptGalleryGrid.innerHTML = "";
+
+    try {
+        const media = await fetchAppMedia();
+        const memes = (media.items || [])
+            .filter((item) => item.tags.includes("meme"))
+            .map((item) => catalogItemToMeme(item));
+
+        if (!memes.length) {
+            const p = document.createElement("p");
+            p.textContent = "No public memes yet.";
+            p.style.cssText =
+                "grid-column: 1/-1; text-align: center; color: var(--color-muted); padding: 2rem; font-style: italic;";
+            dom.catgptGalleryGrid.appendChild(p);
+            return;
+        }
+
+        memes.slice(0, 12).forEach((meme, i) => {
+            const card = createMemeCard(meme.prompt, i, meme.url);
+            if (card) dom.catgptGalleryGrid.appendChild(card);
+        });
+    } catch (error) {
+        console.warn("Could not load public CatGPT gallery", error);
+    }
 }
 
 function loadExamples() {
@@ -412,16 +485,32 @@ async function generateMeme() {
         }
 
         // Use the pollinations URL directly (shareable, cacheable)
-        await response.blob(); // ensure the image is fully loaded
+        const imageBlob = await response.blob(); // ensure the image is fully loaded
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+
+        let memeUrl = imageUrl;
+        try {
+            memeUrl = await uploadGeneratedMeme(imageBlob, uploadedImageUrl, {
+                prompt: question,
+                model: activeModel,
+            });
+        } catch (error) {
+            console.warn("Could not catalog generated meme", error);
+            notify(
+                "Meme generated, but media catalog upload failed.",
+                "warning",
+            );
+        }
+
+        dom.generatedMeme.src = memeUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
+        saveGeneratedMeme(question, memeUrl);
         loadUserMemes();
+        loadCatgptGallery();
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +707,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadCatgptGallery();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/catgpt/styles.css
+++ b/apps/catgpt/styles.css
@@ -581,6 +581,7 @@ header {
 /* === Cards === */
 
 .examples-grid,
+.catgpt-gallery-grid,
 .your-memes-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -740,6 +741,7 @@ footer a {
     }
 
     .examples-grid,
+    .catgpt-gallery-grid,
     .your-memes-grid {
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
@@ -801,6 +803,7 @@ footer a {
     }
 
     .examples-grid,
+    .catgpt-gallery-grid,
     .your-memes-grid {
         grid-template-columns: 1fr;
     }

--- a/apps/chat/src/utils/api.js
+++ b/apps/chat/src/utils/api.js
@@ -1,5 +1,7 @@
 // Pollinations API utilities — updated to match gen.pollinations.ai spec
 const BASE_URL = "https://gen.pollinations.ai";
+const MEDIA_API_URL = "https://media.pollinations.ai";
+const MEDIA_UPLOAD_URL = `${MEDIA_API_URL}/upload`;
 const ENV_API_TOKEN = import.meta.env.VITE_POLLINATIONS_API_KEY || "";
 export const BYOP_STORAGE_KEY = "pollinations_byop_api_key";
 
@@ -74,6 +76,62 @@ const parseApiError = async (response) => {
     }
     return buildClientError(response.status);
 };
+
+function appendCatalogFields(form, fields = {}) {
+    const {
+        visibility = "private",
+        tags = [],
+        parents = [],
+        kind = "generation",
+        prompt,
+        model,
+    } = fields;
+    form.append("visibility", visibility);
+    form.append("kind", kind);
+    if (prompt) form.append("prompt", prompt);
+    if (model) form.append("model", model);
+    if (tags.length) form.append("tags", JSON.stringify(tags));
+    if (parents.length) form.append("parents", JSON.stringify(parents));
+}
+
+async function uploadGeneratedMedia(blob, filename, fields) {
+    const token = getApiToken();
+    if (!token) throw new Error("No API key available for media upload");
+
+    const form = new FormData();
+    form.append("file", blob, filename);
+    appendCatalogFields(form, fields);
+
+    const response = await fetch(MEDIA_UPLOAD_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+    });
+    if (!response.ok) throw new Error("Media upload failed");
+
+    const data = await response.json();
+    if (data.url) return data.url;
+    if (data.id) return `${MEDIA_API_URL}/${data.id}`;
+    throw new Error("Media upload response missing URL");
+}
+
+function blobToDataUrl(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+async function catalogOrDataUrl(blob, filename, fields) {
+    try {
+        return await uploadGeneratedMedia(blob, filename, fields);
+    } catch (error) {
+        console.warn("Media catalog upload failed, using data URL:", error);
+        return blobToDataUrl(blob);
+    }
+}
 
 export const loadModels = async () => {
     if (
@@ -530,13 +588,18 @@ export const generateImage = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, width, height, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-image-${Date.now()}.png`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-image"],
+            kind: "generation",
+            prompt,
+            model,
+        },
+    );
+    return { url: mediaUrl, prompt, model, width, height, seed };
 };
 
 export const generateVideo = async (prompt, options = {}) => {
@@ -556,13 +619,18 @@ export const generateVideo = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-video-${Date.now()}.mp4`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-video"],
+            kind: "generation",
+            prompt,
+            model,
+        },
+    );
+    return { url: mediaUrl, prompt, model, seed };
 };
 
 // Generate speech/audio — GET /audio/{text}?voice=...
@@ -578,11 +646,21 @@ export const generateAudio = async (text, options = {}) => {
 
     const blob = await response.blob();
     const mimeType = blob.type || "audio/mpeg";
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, text, voice, model, mimeType });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-    });
+    const ext = mimeType.includes("wav")
+        ? "wav"
+        : mimeType.includes("ogg")
+          ? "ogg"
+          : "mp3";
+    const mediaUrl = await catalogOrDataUrl(
+        blob,
+        `chat-audio-${Date.now()}.${ext}`,
+        {
+            visibility: "private",
+            tags: ["chat", "chat-audio"],
+            kind: "generation",
+            prompt: text,
+            model,
+        },
+    );
+    return { url: mediaUrl, text, voice, model, mimeType };
 };

--- a/apps/opposite-prompt-bot/bot.ts
+++ b/apps/opposite-prompt-bot/bot.ts
@@ -15,7 +15,17 @@ const TOKEN = process.env.BOT_TOKEN_OPPOSITE_PROMPT;
 const API_KEY = process.env.TEXT_POLLINATIONS_TOKEN;
 const TEXT_API = "https://gen.pollinations.ai/v1/chat/completions";
 const IMAGE_API = "https://gen.pollinations.ai/image";
+const MEDIA_API = "https://media.pollinations.ai";
+const MEDIA_UPLOAD = `${MEDIA_API}/upload`;
 const AUTH = API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {};
+
+type CatalogUploadOptions = {
+    visibility?: "private" | "unlisted" | "public";
+    relationship?: string;
+    tags?: string[];
+    prompt?: string;
+    model?: string;
+};
 
 const OPPOSITE_PROMPT = `You are a safe image prompt generator. Your #1 rule: NEVER output anything involving nudity, bare skin, undressed people, children, violence, gore, or anything sexual. This rule overrides ALL other instructions.
 
@@ -85,6 +95,50 @@ async function fetchImage(prompt: string): Promise<Buffer> {
     return Buffer.from(res.data);
 }
 
+function appendCatalogFields(form: FormData, options: CatalogUploadOptions) {
+    form.append("visibility", options.visibility || "public");
+    form.append(
+        "relationship",
+        options.relationship || "opposite_prompt_reply",
+    );
+    form.append("kind", "generation");
+    for (const tag of options.tags || []) form.append("tags", tag);
+    if (options.prompt) form.append("prompt", options.prompt);
+    if (options.model) form.append("model", options.model);
+}
+
+async function uploadImageBuffer(
+    buffer: Buffer,
+    filename: string,
+    options: CatalogUploadOptions,
+): Promise<string | null> {
+    if (!API_KEY) return null;
+
+    try {
+        const fileBytes = new ArrayBuffer(buffer.byteLength);
+        new Uint8Array(fileBytes).set(buffer);
+        const form = new FormData();
+        form.append(
+            "file",
+            new Blob([fileBytes], { type: "image/png" }),
+            filename,
+        );
+        appendCatalogFields(form, options);
+
+        const res = await axios.post(MEDIA_UPLOAD, form, {
+            headers: AUTH,
+            timeout: 60_000,
+        });
+        const mediaUrl =
+            res.data?.url || (res.data?.id ? `${MEDIA_API}/${res.data.id}` : null);
+        if (mediaUrl) log(`Cataloged media: ${mediaUrl}`);
+        return mediaUrl;
+    } catch (err: any) {
+        logError(`Media catalog upload failed: ${err.message}`);
+        return null;
+    }
+}
+
 const processing = new Set<string>();
 
 async function handleMessage(msg: Message, client: Client): Promise<void> {
@@ -117,6 +171,13 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
             } catch {}
 
             const imageBuffer = await fetchImage(opposite);
+            await uploadImageBuffer(imageBuffer, "opposite.png", {
+                visibility: "public",
+                relationship: "opposite_prompt_reply",
+                tags: ["opposite-prompt", "opposite-prompt-bot"],
+                prompt: opposite,
+                model: "zimage",
+            });
             const attachment = new AttachmentBuilder(imageBuffer, {
                 name: "opposite.png",
             });

--- a/apps/product-packaging-designer/src/App.tsx
+++ b/apps/product-packaging-designer/src/App.tsx
@@ -12,7 +12,8 @@ import {
     Sun,
     Upload,
 } from "lucide-react";
-import { type React, useEffect, useState } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 type StyleOption = {
     id: string;
@@ -79,7 +80,7 @@ const packagingTypes: PackagingType[] = [
     { id: "can", label: "Can", icon: Package, prompt: "can packaging" },
 ];
 const POLLINATIONS_API = "https://gen.pollinations.ai/image";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const MAX_DISPLAY_SIZE = 10 * 1024 * 1024;
@@ -120,6 +121,15 @@ const validateFile = (
 };
 const APP_KEY = "pk_pollinations_packaging_designer"; // Your publishable key
 const POLLINATIONS_AUTH_URL = "https://enter.pollinations.ai/authorize";
+
+type MediaUploadOptions = {
+    visibility?: "private" | "unlisted" | "public";
+    relationship?: string;
+    tags?: string[];
+    parents?: string[];
+    prompt?: string;
+    model?: string;
+};
 
 function App() {
     const [uploadedImage, setUploadedImage] = useState<string | null>(null);
@@ -236,10 +246,16 @@ function App() {
             setFile(null);
         }
     };
-    const uploadToPollinationsMedia = async (file: File): Promise<string> => {
-        const validation = validateFile(file, MAX_FILE_SIZE);
-        if (!validation.isValid) {
-            throw new Error(validation.error || "File validation failed");
+    const uploadToPollinationsMedia = async (
+        media: Blob,
+        filename: string,
+        options: MediaUploadOptions = {},
+    ): Promise<string> => {
+        if (media instanceof File) {
+            const validation = validateFile(media, MAX_FILE_SIZE);
+            if (!validation.isValid) {
+                throw new Error(validation.error || "File validation failed");
+            }
         }
 
         if (!apiKey) {
@@ -247,7 +263,24 @@ function App() {
         }
 
         const formData = new FormData();
-        formData.append("file", file);
+        formData.append("file", media, filename);
+        formData.append("visibility", options.visibility || "unlisted");
+        formData.append(
+            "relationship",
+            options.relationship || "packaging_media",
+        );
+        for (const tag of ["packaging", ...(options.tags || [])]) {
+            formData.append("tags", tag);
+        }
+        for (const parent of options.parents || []) {
+            try {
+                if (new URL(parent).hostname === "media.pollinations.ai") {
+                    formData.append("parents", parent);
+                }
+            } catch {}
+        }
+        if (options.prompt) formData.append("prompt", options.prompt);
+        if (options.model) formData.append("model", options.model);
 
         try {
             const response = await fetch(POLLINATIONS_MEDIA_API, {
@@ -335,7 +368,11 @@ function App() {
             let uploadedUrl: string = "";
 
             if (file) {
-                uploadedUrl = await uploadToPollinationsMedia(file);
+                uploadedUrl = await uploadToPollinationsMedia(file, file.name, {
+                    visibility: "private",
+                    relationship: "packaging_source",
+                    tags: ["source", packagingType],
+                });
             } else {
                 uploadedUrl = uploadedImage || "";
             }
@@ -385,8 +422,27 @@ ${brandName.trim() ? ` Brand name: "${brandName}".` : ""}
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setGeneratedImage(blobUrl);
+            let resultUrl = URL.createObjectURL(blob);
+            try {
+                resultUrl = await uploadToPollinationsMedia(
+                    blob,
+                    `packaging-${Date.now()}.png`,
+                    {
+                        visibility: "unlisted",
+                        relationship: "packaging_design",
+                        tags: ["result", packagingType, selectedStyle],
+                        parents: [uploadedUrl],
+                        prompt,
+                        model: "nanobanana",
+                    },
+                );
+            } catch (uploadError) {
+                console.warn(
+                    "Could not catalog packaging result:",
+                    uploadError,
+                );
+            }
+            setGeneratedImage(resultUrl);
             setImageLoaded(true);
         } catch (error) {
             console.error("Error in generatePackaging:", error);

--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -6,10 +6,22 @@ import {
 } from './types';
 
 const POLLINATIONS_API_BASE = 'https://gen.pollinations.ai';
+const MEDIA_API_BASE = 'https://media.pollinations.ai';
+const MEDIA_UPLOAD_URL = `${MEDIA_API_BASE}/upload`;
+const MEDIA_HOST = 'media.pollinations.ai';
 const DEFAULT_CONFIG = {
   model: 'gptimage' as const,
   enhance: true,
   nologo: true,
+};
+
+type MediaUploadOptions = {
+  visibility?: 'private' | 'unlisted' | 'public';
+  relationship?: string;
+  tags?: string[];
+  parents?: string[];
+  prompt?: string;
+  model?: string;
 };
 
 export class PollinationsService {
@@ -93,8 +105,31 @@ export class PollinationsService {
         }
       }
 
+      let resultUrl = url.toString();
+      if (token) {
+        try {
+          const blob = await response.blob();
+          const mediaUrl = await this.uploadGeneratedMedia(
+            blob,
+            `slidepainter-${Date.now()}.png`,
+            token,
+            {
+              visibility: 'private',
+              relationship: inputImageUrl ? 'slide_edit' : 'slide_generation',
+              tags: ['slidepainter', 'slide'],
+              parents: inputImageUrl ? [inputImageUrl] : [],
+              prompt: finalPrompt,
+              model: payload.model,
+            }
+          );
+          if (mediaUrl) resultUrl = mediaUrl;
+        } catch (uploadError) {
+          console.warn('Media catalog upload failed, using generated image URL:', uploadError);
+        }
+      }
+
       const result: ImageGenerationResponse = {
-        url: url.toString(),
+        url: resultUrl,
         provider: 'pollinations',
         seed: payload.seed,
         cached: false,
@@ -115,5 +150,53 @@ export class PollinationsService {
     } catch {
       return false;
     }
+  }
+
+  private mediaParent(urlString: string): string | null {
+    try {
+      const url = new URL(urlString);
+      return url.hostname === MEDIA_HOST ? urlString : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private appendCatalogFields(formData: FormData, options: MediaUploadOptions): void {
+    formData.append('visibility', options.visibility ?? 'private');
+    formData.append('relationship', options.relationship ?? 'slide_generation');
+    formData.append('kind', 'generation');
+    for (const tag of options.tags ?? []) {
+      formData.append('tags', tag);
+    }
+    for (const parent of options.parents ?? []) {
+      const cleanParent = this.mediaParent(parent);
+      if (cleanParent) formData.append('parents', cleanParent);
+    }
+    if (options.prompt) formData.append('prompt', options.prompt);
+    if (options.model) formData.append('model', options.model);
+  }
+
+  private async uploadGeneratedMedia(
+    blob: Blob,
+    filename: string,
+    token: string,
+    options: MediaUploadOptions
+  ): Promise<string | null> {
+    const formData = new FormData();
+    formData.append('file', blob, filename);
+    this.appendCatalogFields(formData, options);
+
+    const response = await fetch(MEDIA_UPLOAD_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    if (data.url) return data.url;
+    if (data.id) return `${MEDIA_API_BASE}/${data.id}`;
+    return null;
   }
 }

--- a/apps/virtual-makeup/src/App.jsx
+++ b/apps/virtual-makeup/src/App.jsx
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from "react";
 
 const APP_KEY = "pk_pollinations_virtual_makeup";
 const POLLINATIONS_AUTH_URL = "https://enter.pollinations.ai/authorize";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 const POLLINATIONS_IMAGE_API = "https://gen.pollinations.ai/image";
 
 const MAKEUP_STYLES = [
@@ -117,9 +117,26 @@ function App() {
         }
     };
 
-    const uploadToPollinations = async (file) => {
+    const uploadToPollinations = async (file, options = {}) => {
         const formData = new FormData();
         formData.append("file", file);
+        formData.append("visibility", options.visibility || "private");
+        formData.append(
+            "relationship",
+            options.relationship || "virtual_makeup_source",
+        );
+        for (const tag of ["virtual-makeup", ...(options.tags || [])]) {
+            formData.append("tags", tag);
+        }
+        for (const parent of options.parents || []) {
+            try {
+                if (new URL(parent).hostname === "media.pollinations.ai") {
+                    formData.append("parents", parent);
+                }
+            } catch {}
+        }
+        if (options.prompt) formData.append("prompt", options.prompt);
+        if (options.model) formData.append("model", options.model);
 
         const response = await fetch(POLLINATIONS_MEDIA_API, {
             method: "POST",
@@ -139,6 +156,17 @@ function App() {
         return data.url || data.secure_url || data.media_url;
     };
 
+    const uploadGeneratedMakeup = async (blob, parentUrl, styleId) => {
+        return uploadToPollinations(blob, {
+            visibility: "private",
+            relationship: "virtual_makeup_result",
+            tags: ["result", styleId || "custom"],
+            parents: [parentUrl],
+            prompt: useCustom ? customPrompt : MAKEUP_STYLES.find((style) => style.id === styleId)?.prompt,
+            model: "nanobanana",
+        });
+    };
+
     const applyMakeup = async () => {
         if (!uploadedImage || !uploadedFile || !apiKey) return;
 
@@ -153,7 +181,9 @@ function App() {
 
             const encodedPrompt = encodeURIComponent(prompt);
 
-            const pollinationsUrl = await uploadToPollinations(uploadedFile);
+            const pollinationsUrl = await uploadToPollinations(uploadedFile, {
+                tags: ["source"],
+            });
 
             const encodedImageURL = encodeURIComponent(pollinationsUrl);
 
@@ -172,8 +202,17 @@ function App() {
             }
 
             const blob = await response.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            setMakeupImage(blobUrl);
+            let resultUrl = URL.createObjectURL(blob);
+            try {
+                resultUrl = await uploadGeneratedMakeup(
+                    blob,
+                    pollinationsUrl,
+                    useCustom ? "custom" : selectedStyle,
+                );
+            } catch (uploadError) {
+                console.warn("Could not catalog makeup result:", uploadError);
+            }
+            setMakeupImage(resultUrl);
             setImageLoaded(true);
             setIsLoading(false);
         } catch (error) {

--- a/apps/voice-edit/remix.html
+++ b/apps/voice-edit/remix.html
@@ -1,0 +1,1528 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Remix | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --line: #110518;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--line);
+    --raise: 2px 2px 0 var(--line);
+    --stage-max: calc(100vh - 210px);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  button, input, select { font: inherit; color: inherit; }
+  button { touch-action: manipulation; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .btn, .select, .frame, .overlay-panel, .pin, .pill {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+    font-weight: 700;
+  }
+  .btn {
+    padding: 0 12px;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--line); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; max-width: min(100%, 20rem); }
+
+  .mode-toggle, .swatches {
+    display: inline-flex;
+    align-items: center;
+  }
+  .mode-toggle {
+    gap: 0;
+  }
+  .mode-toggle button {
+    width: 38px;
+    height: 38px;
+    border: var(--border);
+    background: var(--surface);
+    font: inherit;
+    font-size: 1.05rem;
+    cursor: pointer;
+  }
+  .mode-toggle button + button {
+    margin-left: -3px;
+  }
+  .mode-toggle button.active {
+    background: var(--accent);
+    z-index: 1;
+  }
+  .mode-toggle button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+  .history { margin-left: auto; }
+
+  .swatches {
+    gap: 5px;
+  }
+  .swatch {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: var(--border);
+    border-radius: 0;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    cursor: pointer;
+  }
+  .swatch.active { outline-color: var(--accent); }
+  .swatch[data-color="white"] { background: #fff; }
+  .swatch[data-color="black"] { background: #000; }
+  .swatch[data-color="red"] { background: red; }
+
+  .frame {
+    position: relative;
+    min-height: 280px;
+    overflow: visible;
+    display: grid;
+    place-items: center;
+  }
+  .frame.drop { outline: 4px dashed var(--accent); outline-offset: -10px; }
+  .stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    touch-action: none;
+  }
+  .stage canvas {
+    display: block;
+    max-width: 100%;
+    max-height: var(--stage-max);
+    width: auto;
+    height: auto;
+  }
+  #markCanvas, #pinLayer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+  #markCanvas { cursor: crosshair; z-index: 2; touch-action: none; }
+  #pinLayer { z-index: 4; pointer-events: none; overflow: visible; }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(243, 235, 222, 0.88);
+    backdrop-filter: blur(2px);
+  }
+  .frame.locked .overlay { display: flex; }
+  .overlay-panel {
+    width: min(22rem, calc(100% - 32px));
+    padding: 18px;
+    text-align: center;
+  }
+  .overlay-panel p { margin: 0 0 12px; font-size: 0.9rem; }
+
+  .pin {
+    position: absolute;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    max-width: min(16rem, 48vw);
+    width: max-content;
+    padding: 5px 9px;
+    transform: translate(calc(-0.55rem - 0.275rem - 1.5px), -50%);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    overflow-wrap: break-word;
+  }
+  .pin.processing { background: var(--accent); }
+  .pin.history { background: var(--paper); opacity: 0.85; }
+  .pin.flip {
+    flex-direction: row-reverse;
+    transform: translate(calc(-100% + 0.55rem + 0.275rem + 1.5px), -50%);
+  }
+  .pin .dot {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    background: var(--line);
+    border: 1.5px solid var(--line);
+  }
+  .pin span:last-child { min-width: 0; }
+
+  .pill {
+    position: fixed;
+    z-index: 20;
+    display: none;
+    align-items: center;
+    gap: 9px;
+    max-width: min(18rem, calc(100vw - 24px));
+    padding: 8px 12px 8px 8px;
+    transform: translate(18px, -50%);
+    font-size: 0.9rem;
+    font-weight: 700;
+    pointer-events: none;
+    overflow-wrap: anywhere;
+  }
+  .pill.visible { display: inline-flex; }
+  .pill .mic {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    background: var(--accent);
+    border: var(--border);
+  }
+  .pill .bar {
+    width: 3px;
+    background: var(--line);
+    animation: micbar 0.9s ease-in-out infinite;
+  }
+  .pill .bar:nth-child(1) { height: 6px; animation-delay: 0s; }
+  .pill .bar:nth-child(2) { height: 10px; animation-delay: 0.15s; }
+  .pill .bar:nth-child(3) { height: 6px; animation-delay: 0.3s; }
+  .pill .placeholder { opacity: 0.55; font-style: italic; }
+  @keyframes micbar { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1.2); } }
+
+  @media (max-width: 720px) {
+    .app { --stage-max: calc(100vh - 260px); width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .topbar { gap: 6px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .history { margin-left: 0; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .frame { min-height: 240px; }
+    .pin { max-width: 62vw; }
+  }
+  .frame.locked .stage { filter: grayscale(0.35) opacity(0.55); }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / remix</h1>
+      <span class="tagline">draw. talk. release.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="tools">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="uploadBtn" class="btn" title="load an image from disk">load</button>
+      <button id="shuffleBtn" class="btn" title="next sample image">sample</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="image model">
+        <option value="nanobanana">nanobanana</option>
+      </select>
+      <div id="colorPicker" class="swatches" aria-label="marker color">
+        <button type="button" class="swatch" data-color="red" aria-label="red marker"></button>
+        <button type="button" class="swatch" data-color="black" aria-label="black marker"></button>
+        <button type="button" class="swatch" data-color="white" aria-label="white marker"></button>
+      </div>
+      <div id="inputMode" class="mode-toggle" aria-label="input mode">
+        <button type="button" data-mode="mic" aria-label="use microphone">🎙️</button>
+        <button type="button" data-mode="type" aria-label="type prompt">⌨️</button>
+      </div>
+      <button id="undoBtn" class="btn history" disabled title="undo">undo</button>
+      <button id="redoBtn" class="btn" disabled title="redo">redo</button>
+      <button id="downloadBtn" class="btn" title="download image with embedded history - drop it back onto the app to restore">save</button>
+      <button id="shareBtn" class="btn" title="upload PNG with embedded history and copy link">share</button>
+      <button id="walkthroughBtn" class="btn" title="open this remix history as a video walkthrough">walkthrough</button>
+    </section>
+
+    <section id="frame" class="frame">
+      <div id="stage" class="stage">
+        <canvas id="imageCanvas" width="1024" height="768"></canvas>
+        <canvas id="markCanvas" width="1024" height="768"></canvas>
+        <div id="pinLayer"></div>
+      </div>
+      <div class="overlay">
+        <div class="overlay-panel">
+          <p>connect to pollinations to start editing</p>
+          <button id="connectOverlayBtn" class="btn accent">connect</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div id="cursorPill" class="pill" aria-hidden="true">
+    <span class="mic"><span class="bar"></span><span class="bar"></span><span class="bar"></span></span>
+    <span id="pillText" class="placeholder">listening...</span>
+  </div>
+
+<script>
+const KEY_STORAGE = "voice-edit:user-key";
+const APP_KEY = ""; // Set to a registered pk_ app key to stamp verified app attribution.
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const MEDIA = "https://media.pollinations.ai";
+const STARTERS = [
+  { name: "cell", url: "https://media.pollinations.ai/10efdd0c1cfc65fa" },
+  { name: "octopus", url: "https://media.pollinations.ai/73775b7374f9b864" },
+  { name: "grand prismatic", url: "https://media.pollinations.ai/98280006f6099cb0" },
+  { name: "cosmic cliffs", url: "https://media.pollinations.ai/d05180b3bf21c01c" },
+  { name: "mars rover", url: "https://media.pollinations.ai/9a138c75c377d84a" },
+  { name: "relativity", url: "https://media.pollinations.ai/e7fc55d8a304edb3" },
+  { name: "da vinci", url: "https://media.pollinations.ai/31f553055c73b482" },
+  { name: "tomaselli", url: "https://media.pollinations.ai/9f450191ad9b8253" },
+  { name: "mushroom", url: "https://media.pollinations.ai/ad65acf0fd23ff85" },
+  { name: "surreal room", url: "https://media.pollinations.ai/fbc6c13d37c55f0b" },
+];
+const STARTER = STARTERS[0].url;
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const STT_MODEL = "scribe";
+const STT_LANG = (navigator.language || "en").slice(0, 2);
+const STT_MIME = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+  .find((m) => window.MediaRecorder?.isTypeSupported?.(m)) || "";
+const CAN_RECORD = Boolean(window.MediaRecorder && navigator.mediaDevices?.getUserMedia);
+const DRAG_THRESHOLD = 0.03;
+const RECOMMENDED_MODELS = new Set(["p-image-edit", "nanobanana", "nanobanana-2", "kontext", "gpt-image-2"]);
+
+const $ = (id) => document.getElementById(id);
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const pairs = (items) => items.slice(1).map((item, i) => [items[i], item]);
+const distance = (a, b) => Math.hypot(b.x - a.x, b.y - a.y);
+const minCanvasSide = () => Math.min(els.markCanvas.width, els.markCanvas.height);
+
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  frame: "frame",
+  imageCanvas: "imageCanvas",
+  markCanvas: "markCanvas",
+  pinLayer: "pinLayer",
+  connect: "connectBtn",
+  connectOverlay: "connectOverlayBtn",
+  upload: "uploadBtn",
+  shuffle: "shuffleBtn",
+  file: "fileInput",
+  model: "modelSel",
+  inputMode: "inputMode",
+  undo: "undoBtn",
+  redo: "redoBtn",
+  download: "downloadBtn",
+  share: "shareBtn",
+  walkthrough: "walkthroughBtn",
+  colorPicker: "colorPicker",
+  pill: "cursorPill",
+  pillText: "pillText",
+}).map(([key, id]) => [key, $(id)]));
+const imageCtx = els.imageCanvas.getContext("2d");
+const markCtx = els.markCanvas.getContext("2d");
+
+const app = {
+  image: null,
+  imageURL: "",
+  stateURL: "",
+  history: [],
+  historyIndex: -1,
+  micStream: null,
+  active: null,
+  busy: false,
+  queue: [],
+  currentJob: null,
+  markerColor: "red",
+  inputMode: CAN_RECORD ? "mic" : "type",
+  micAvailable: CAN_RECORD,
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = (extra = {}) => ({ Authorization: `Bearer ${key()}`, ...extra });
+
+function render() {
+  const locked = app.busy || Boolean(app.active);
+  els.undo.disabled = !mediaHistory.canUndo() || locked;
+  els.redo.disabled = !mediaHistory.canRedo() || locked;
+  [els.upload, els.shuffle, els.model, els.share, els.walkthrough].forEach((el) => { el.disabled = locked; });
+  renderInputMode(locked);
+  renderPins();
+}
+
+function renderInputMode(locked = false) {
+  for (const button of els.inputMode.querySelectorAll("button")) {
+    const mode = button.dataset.mode;
+    button.classList.toggle("active", app.inputMode === mode);
+    button.disabled = locked || (mode === "mic" && !app.micAvailable);
+  }
+}
+
+function setInputMode(mode) {
+  if (mode === "mic" && !app.micAvailable) return;
+  app.inputMode = mode;
+  render();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function setMarkerColor(color) {
+  app.markerColor = color;
+  for (const button of els.colorPicker.querySelectorAll(".swatch")) {
+    button.classList.toggle("active", button.dataset.color === color);
+  }
+}
+
+function renderPins() {
+  const jobs = [app.currentJob, ...app.queue].filter(Boolean);
+  const items = jobs.length
+    ? jobs.map((job) => ({
+      cls: job === app.currentJob ? "processing" : "queued",
+      text: job.text,
+      xPct: job.xPct,
+      yPct: job.yPct,
+    }))
+    : pinForCurrentFrame();
+  const layerBox = els.pinLayer.getBoundingClientRect();
+  els.pinLayer.replaceChildren(...items.map((item) => {
+    const pin = document.createElement("div");
+    pin.className = `pin ${item.cls}`;
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    const text = document.createElement("span");
+    text.textContent = item.text;
+    pin.append(dot, text);
+    pin.style.left = `${item.xPct}%`;
+    pin.style.top = `${item.yPct}%`;
+    const anchorX = layerBox.left + (layerBox.width * item.xPct / 100);
+    const rightSpace = window.innerWidth - anchorX - 16;
+    const leftSpace = anchorX - 16;
+    const flip = rightSpace < 140 && leftSpace > rightSpace;
+    pin.classList.toggle("flip", flip);
+    pin.style.maxWidth = `${clamp(flip ? leftSpace : rightSpace, 40, 256)}px`;
+    return pin;
+  }));
+}
+
+function pinForCurrentFrame() {
+  const frame = app.history[app.historyIndex];
+  if (frame?.kind !== "prep" || frame.xPct == null || frame.yPct == null) return [];
+  return [{
+    cls: "history",
+    text: frame.promptText || "",
+    xPct: frame.xPct,
+    yPct: frame.yPct,
+  }];
+}
+
+function pill({ x, y, text, placeholder, visible }) {
+  if (x != null) els.pill.style.left = `${x}px`;
+  if (y != null) els.pill.style.top = `${y}px`;
+  if (text !== undefined) {
+    els.pillText.textContent = text;
+    els.pillText.classList.toggle("placeholder", !!placeholder);
+  }
+  if (visible !== undefined) els.pill.classList.toggle("visible", visible);
+}
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (apiKey) {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+    history.replaceState(null, "", location.pathname + location.search);
+  } else if (params.get("error")) {
+    showError(`Authorization failed: ${params.get("error")}`);
+  }
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  els.frame.classList.toggle("locked", !connected);
+  if (!connected) {
+    app.accountUser = "";
+    app.accountBalance = null;
+    renderAccount();
+    setStatus("not connected");
+    return;
+  }
+  renderAccount();
+  warmMic();
+  loadUser();
+  loadBalance();
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_url: location.origin + location.pathname + location.search,
+    scope: "generate",
+  });
+  if (APP_KEY) params.set("app_key", APP_KEY);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  stopMic();
+  refreshConnectionUI();
+}
+
+async function loadUser() {
+  try {
+    const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const user = await res.json();
+    app.accountUser = user?.preferred_username || "";
+    renderAccount();
+  } catch {}
+}
+
+async function loadBalance() {
+  try {
+    const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+    if (!res.ok) return;
+    const { balance } = await res.json();
+    app.accountBalance = Number(balance);
+    renderAccount();
+  } catch {}
+}
+
+async function warmMic() {
+  if (app.micStream || !app.micAvailable) return;
+  try {
+    app.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+  } catch (err) {
+    app.micAvailable = false;
+    app.inputMode = "type";
+    render();
+    showError(`Microphone unavailable (${err?.message || "denied"}). Use type instead.`);
+  }
+}
+
+function stopMic() {
+  if (!app.micStream) return;
+  for (const track of app.micStream.getTracks()) track.stop();
+  app.micStream = null;
+}
+
+const mediaHistory = {
+  canUndo: () => app.historyIndex > 0,
+  canRedo: () => app.historyIndex >= 0 && app.historyIndex < app.history.length - 1,
+  add(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  addSilent(frame) {
+    app.history = app.history.slice(0, app.historyIndex + 1);
+    app.history.push(frame);
+    app.historyIndex = app.history.length - 1;
+    syncStartToFrame(frame);
+    render();
+  },
+  async go(index) {
+    const frame = app.history[index];
+    if (!frame) return;
+    await renderFrame(frame);
+    app.historyIndex = index;
+    syncStartToFrame(frame);
+    render();
+  },
+  async set(frame, { add = false } = {}) {
+    await renderFrame(frame);
+    if (add) mediaHistory.add(frame);
+    else {
+      syncStartToFrame(frame);
+      render();
+    }
+  },
+  async reset(frame, stateURL = frame.url) {
+    app.history = [frame];
+    app.historyIndex = 0;
+    app.stateURL = scrubURL(stateURL) || scrubURL(frame.url);
+    await renderFrame(frame);
+    syncStartToFrame(frame, { force: true });
+    render();
+  },
+};
+
+async function loadModels() {
+  try {
+    const res = await fetch(`${BASE}/image/models`);
+    if (!res.ok) return;
+    const models = await res.json();
+    const editModels = models
+      .filter((m) => m.input_modalities?.includes("image") && m.output_modalities?.includes("image"))
+      .sort((a, b) => {
+        const ra = RECOMMENDED_MODELS.has(a.name) ? 0 : 1;
+        const rb = RECOMMENDED_MODELS.has(b.name) ? 0 : 1;
+        return ra - rb || a.name.localeCompare(b.name);
+      });
+    els.model.replaceChildren(...editModels.map((m) => {
+      const tags = [];
+      if (RECOMMENDED_MODELS.has(m.name)) tags.push("*");
+      if (m.paid_only) tags.push("paid");
+      return new Option(tags.length ? `${m.name} (${tags.join(", ")})` : m.name, m.name);
+    }));
+    if ([...els.model.options].some((option) => option.value === "nanobanana")) els.model.value = "nanobanana";
+  } catch {}
+}
+
+async function renderFrame(frame) {
+  clearError();
+  await drawImage(frame.url);
+  clearMarks();
+  setStatus("ready");
+}
+
+async function drawImage(src) {
+  setStatus("loading image...");
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = () => reject(new Error("could not load image"));
+    img.src = src;
+  });
+  app.image = img;
+  app.imageURL = src;
+  resizeCanvases(img.naturalWidth, img.naturalHeight);
+  imageCtx.drawImage(img, 0, 0);
+}
+
+function resizeCanvases(width, height) {
+  for (const canvas of [els.imageCanvas, els.markCanvas]) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function clearMarks() {
+  markCtx.clearRect(0, 0, els.markCanvas.width, els.markCanvas.height);
+}
+
+function pointerPoint(event) {
+  const rect = els.markCanvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * (els.markCanvas.width / rect.width);
+  const y = (event.clientY - rect.top) * (els.markCanvas.height / rect.height);
+  return {
+    x: clamp(Math.round(x), 0, els.markCanvas.width),
+    y: clamp(Math.round(y), 0, els.markCanvas.height),
+  };
+}
+
+function strokeWidth() {
+  return Math.max(6, Math.round(minCanvasSide() * 0.015));
+}
+
+function drawSegment(from, to) {
+  markCtx.save();
+  markCtx.strokeStyle = app.markerColor;
+  markCtx.lineWidth = strokeWidth();
+  markCtx.lineCap = "round";
+  markCtx.lineJoin = "round";
+  markCtx.beginPath();
+  markCtx.moveTo(from.x, from.y);
+  markCtx.lineTo(to.x, to.y);
+  markCtx.stroke();
+  markCtx.restore();
+}
+
+function pathLength(points) {
+  return pairs(points).reduce((total, [a, b]) => total + distance(a, b), 0);
+}
+
+function pathBounds(points) {
+  return points.reduce((bounds, point) => ({
+    minX: Math.min(bounds.minX, point.x),
+    maxX: Math.max(bounds.maxX, point.x),
+    minY: Math.min(bounds.minY, point.y),
+    maxY: Math.max(bounds.maxY, point.y),
+  }), { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity });
+}
+
+function markerFromGesture({ points }) {
+  const marked = pathLength(points) >= minCanvasSide() * DRAG_THRESHOLD;
+  if (!marked) clearMarks();
+  const bounds = marked ? pathBounds(points) : null;
+  return {
+    marked,
+    marker: marked ? els.markCanvas.toDataURL("image/png") : "",
+    pinPoint: marked ? { x: bounds.maxX, y: (bounds.minY + bounds.maxY) / 2 } : points[0],
+  };
+}
+
+async function composeSnapshot(marker = "") {
+  const out = document.createElement("canvas");
+  out.width = els.imageCanvas.width;
+  out.height = els.imageCanvas.height;
+  const outCtx = out.getContext("2d");
+  outCtx.drawImage(els.imageCanvas, 0, 0);
+  if (marker) {
+    const markerImage = await loadImageElement(marker);
+    outCtx.drawImage(markerImage, 0, 0, out.width, out.height);
+  }
+  return out.toDataURL("image/png");
+}
+
+function buildPrompt(text, marked, color) {
+  if (!marked) return text;
+  return `The ${color} markings indicate the area the prompt is referring to. Prompt: ${text}. Output without ${color} markings.`;
+}
+
+function pinPct(point) {
+  return {
+    xPct: (point.x / els.markCanvas.width) * 100,
+    yPct: (point.y / els.markCanvas.height) * 100,
+  };
+}
+
+function loadImageElement(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load marker"));
+    img.src = src;
+  });
+}
+
+function enqueueJob({ text, marked = false, marker = "", pinPoint, color }) {
+  if (!text.trim()) throw new Error("Nothing heard. Type an edit if voice input is unavailable.");
+  const pin = pinPct(pinPoint);
+  app.queue.push({
+    text,
+    marked,
+    marker,
+    color,
+    model: els.model.value,
+    xPct: pin.xPct,
+    yPct: pin.yPct,
+  });
+  render();
+  runQueue();
+}
+
+function beginRecording(clientX, clientY) {
+  clearError();
+  if (!app.micAvailable) return { error: "Voice input is not available in this browser. Use type instead." };
+  if (!app.micStream) {
+    warmMic();
+    return { error: "microphone not ready - click once, allow access, then try again" };
+  }
+  const capture = { chunks: [], recorder: null, error: "" };
+  try {
+    capture.recorder = new MediaRecorder(app.micStream, STT_MIME ? { mimeType: STT_MIME } : undefined);
+    capture.recorder.ondataavailable = (event) => {
+      if (event.data?.size) capture.chunks.push(event.data);
+    };
+    capture.recorder.start();
+  } catch (err) {
+    capture.error = err?.message || "could not start recording";
+    return capture;
+  }
+  pill({ x: clientX, y: clientY, text: "listening...", placeholder: true, visible: true });
+  setStatus("listening...");
+  return capture;
+}
+
+async function stopAndTranscribe(capture) {
+  if (capture.error || !capture.recorder) return { text: "", error: capture.error };
+  setStatus("transcribing...");
+  pill({ text: "transcribing...", placeholder: true });
+  const stopped = new Promise((resolve) => { capture.recorder.onstop = resolve; });
+  capture.recorder.stop();
+  await stopped;
+  const type = capture.recorder.mimeType || "audio/webm";
+  const ext = type.includes("mp4") ? "mp4" : "webm";
+  const blob = new Blob(capture.chunks, { type });
+  if (blob.size < 1000) return { text: "", error: "no audio captured - hold and speak" };
+  const form = new FormData();
+  form.append("file", blob, `voice.${ext}`);
+  form.append("model", STT_MODEL);
+  form.append("language", STT_LANG);
+  form.append("response_format", "json");
+  try {
+    const res = await fetch(`${BASE}/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    });
+    if (!res.ok) return { text: "", error: await friendlyError(res, "Transcription failed") };
+    const json = await res.json();
+    return { text: (json.text || "").trim(), error: "" };
+  } catch (err) {
+    return { text: "", error: err?.message || "transcription failed" };
+  }
+}
+
+async function promptTypedEdit(clientX, clientY) {
+  pill({ x: clientX, y: clientY, text: "", placeholder: true, visible: true });
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "type edit, press enter";
+  input.style.cssText = "border:none;outline:none;background:transparent;font:inherit;width:14rem;color:var(--dark);";
+  els.pillText.replaceWith(input);
+  input.focus();
+  setStatus("typing...");
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (text) => {
+      if (done) return;
+      done = true;
+      input.replaceWith(els.pillText);
+      pill({ visible: false });
+      resolve(text.trim());
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") { event.preventDefault(); finish(input.value); }
+      if (event.key === "Escape") { event.preventDefault(); finish(""); }
+    });
+    input.addEventListener("blur", () => finish(input.value));
+  });
+}
+
+async function uploadDataURL(dataURL, filename = "annot.png", options = {}) {
+  const blob = await (await fetch(dataURL)).blob();
+  return uploadBlob(blob, filename, options);
+}
+
+function mediaParent(url) {
+  const clean = scrubURL(url);
+  if (!clean) return "";
+  try {
+    return new URL(clean).hostname === "media.pollinations.ai" ? clean : "";
+  } catch {
+    return "";
+  }
+}
+
+function uniqueValues(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function currentMediaParent() {
+  return mediaParent(app.history[app.historyIndex]?.url || app.stateURL || app.imageURL);
+}
+
+function previousMediaParent() {
+  return mediaParent(app.history[app.historyIndex - 1]?.url);
+}
+
+function appendCatalogFields(form, options = {}) {
+  form.append("visibility", options.visibility || "unlisted");
+  form.append("relationship", options.relationship || "voice_edit_media");
+  for (const tag of uniqueValues(["voice-edit", ...(options.tags || [])])) form.append("tags", tag);
+  for (const parent of uniqueValues(options.parents || [])) form.append("parents", parent);
+}
+
+async function uploadBlob(blob, filename, options = {}) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  appendCatalogFields(form, options);
+  const res = await fetch(`${MEDIA}/upload`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `${MEDIA}/${json.id}`;
+}
+
+function canvasBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("canvas toBlob failed"))), "image/png");
+  });
+}
+
+async function runEdit(imageURL, prompt, model) {
+  const res = await fetch(`${BASE}/v1/images/edits`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ prompt, image: imageURL, model, response_format: "url" }),
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Edit failed"));
+  const json = await res.json();
+  const item = json.data?.[0];
+  if (!item) throw new Error("no image in response");
+  if (item.url) return item.url;
+  if (item.b64_json) return `data:image/png;base64,${item.b64_json}`;
+  throw new Error("no url or b64_json in response");
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem(KEY_STORAGE);
+    refreshConnectionUI();
+    return `${label}: authorization expired. Connect again.`;
+  }
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment or switch models.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+async function runQueue() {
+  if (app.busy) return;
+  app.busy = true;
+  render();
+  try {
+    while (app.queue.length) {
+      const job = app.queue.shift();
+      app.currentJob = job;
+      render();
+      setStatus(`editing... (${app.queue.length + 1} in queue)`);
+      try {
+        const snapshot = await composeSnapshot(job.marker);
+        const sourceParent = currentMediaParent();
+        const uploaded = await uploadDataURL(snapshot, "annot.png", {
+          parents: [sourceParent],
+          relationship: "voice_edit_annotation",
+          tags: ["annotation"],
+        });
+        mediaHistory.addSilent({
+          kind: "prep",
+          url: uploaded,
+          promptText: job.text,
+          marked: job.marked,
+          color: job.color,
+          xPct: job.xPct,
+          yPct: job.yPct,
+        });
+        const prompt = buildPrompt(job.text, job.marked, job.color);
+        const result = await runEdit(uploaded, prompt, job.model);
+        await mediaHistory.set({ url: result }, { add: true });
+        setStatus("packaging share link...");
+        const packaged = await packageCurrentFrameWithHistory({
+          parents: [sourceParent],
+          relationship: "voice_edit_remix",
+          tags: ["remix"],
+        });
+        const frame = app.history[app.historyIndex];
+        if (frame?.url === result) {
+          frame.url = packaged;
+          app.imageURL = packaged;
+          app.stateURL = packaged;
+          syncStartToCurrent({ force: true });
+          render();
+        }
+        await loadBalance();
+      } catch (err) {
+        showError(err.message);
+      } finally {
+        app.currentJob = null;
+        render();
+      }
+    }
+    setStatus("done");
+  } finally {
+    app.busy = false;
+    app.currentJob = null;
+    render();
+  }
+}
+
+function cancelGesture() {
+  if (app.active?.capture?.recorder?.state === "recording") {
+    try { app.active.capture.recorder.stop(); } catch {}
+  }
+  app.active = null;
+  clearMarks();
+  pill({ visible: false });
+  setStatus(app.busy ? "editing..." : "ready");
+  render();
+}
+
+els.markCanvas.addEventListener("pointerdown", async (event) => {
+  if (!app.image) { showError("Load an image first."); return; }
+  if (app.active) return;
+  event.preventDefault();
+  clearError();
+  clearMarks();
+  const start = pointerPoint(event);
+
+  if (app.inputMode === "type") {
+    app.active = { pointerId: event.pointerId, points: [start], typing: true, color: app.markerColor };
+    render();
+    try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+    return;
+  }
+
+  const capture = beginRecording(event.clientX, event.clientY);
+  app.active = { pointerId: event.pointerId, points: [start], capture, color: app.markerColor };
+  try { els.markCanvas.setPointerCapture(event.pointerId); } catch {}
+});
+
+els.markCanvas.addEventListener("pointermove", (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  pill({ x: event.clientX, y: event.clientY });
+  const point = pointerPoint(event);
+  const prev = gesture.points[gesture.points.length - 1];
+  drawSegment(prev, point);
+  gesture.points.push(point);
+});
+
+els.markCanvas.addEventListener("pointerup", async (event) => {
+  const gesture = app.active;
+  if (!gesture) return;
+  event.preventDefault();
+  app.active = null;
+  if (gesture.typing) {
+    const annotation = markerFromGesture(gesture);
+    render();
+    const text = await promptTypedEdit(event.clientX, event.clientY);
+    if (!text) {
+      clearMarks();
+      setStatus(app.busy ? "editing..." : "ready");
+      return;
+    }
+    try {
+      enqueueJob({ text, ...annotation, color: gesture.color });
+    } catch (err) {
+      showError(err.message);
+      clearMarks();
+    }
+    return;
+  }
+  const annotation = markerFromGesture(gesture);
+  try {
+    const { text, error } = await stopAndTranscribe(gesture.capture);
+    pill({ visible: false });
+    if (!text && error) throw new Error(`Voice input failed (${error}). Type an edit instead.`);
+    enqueueJob({ text, ...annotation, color: gesture.color });
+  } catch (err) {
+    showError(err.message);
+    clearMarks();
+  }
+});
+
+els.markCanvas.addEventListener("pointercancel", cancelGesture);
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape") return;
+  event.preventDefault();
+  cancelGesture();
+});
+
+els.connect.addEventListener("click", startConnect);
+els.connectOverlay.addEventListener("click", startConnect);
+els.upload.addEventListener("click", () => els.file.click());
+els.inputMode.addEventListener("click", (event) => {
+  const button = event.target.closest("button");
+  if (button) setInputMode(button.dataset.mode);
+});
+els.shuffle.addEventListener("click", () => {
+  const starter = nextStarter();
+  openStartURL(starter.url)
+    .then(() => setStatus(`loaded ${starter.name}`))
+    .catch((err) => showError(err.message));
+});
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image", {
+      tags: ["source"],
+    });
+    await openStartURL(mediaURL);
+    setStatus(`loaded ${file.name || "image"}`);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+
+els.colorPicker.addEventListener("click", (event) => {
+  const swatch = event.target.closest(".swatch");
+  if (!swatch) return;
+  setMarkerColor(swatch.dataset.color);
+});
+
+const setDrop = (drop) => (event) => {
+  event.preventDefault();
+  els.frame.classList.toggle("drop", drop);
+};
+["dragenter", "dragover"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(true));
+});
+["dragleave", "drop"].forEach((eventName) => {
+  els.frame.addEventListener(eventName, setDrop(false));
+});
+els.frame.addEventListener("drop", (event) => {
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+  uploadBlob(file, file.name || "image", { tags: ["source"] })
+    .then((mediaURL) => openStartURL(mediaURL))
+    .then(() => setStatus(`loaded ${file.name || "image"}`))
+    .catch((err) => showError(err.message));
+});
+
+// PNG tEXt chunk helpers — pure JS, no deps.
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c;
+  }
+  return t;
+})();
+function crc32(bytes) {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function writeUint32(view, offset, value) {
+  view.setUint32(offset, value >>> 0, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0) {
+        const k = dec.decode(data.subarray(0, sep));
+        if (k === keyword) return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+function injectTextChunk(bytes, keyword, text) {
+  if (!isValidPng(bytes)) throw new Error("not a PNG");
+  // Find IEND so we can insert before it.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let iendOffset = -1;
+  let pos = 8;
+  const dec = new TextDecoder("latin1");
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    if (type === "IEND") { iendOffset = pos; break; }
+    pos = pos + 8 + length + 4;
+  }
+  if (iendOffset < 0) throw new Error("PNG missing IEND");
+  // Build tEXt chunk: <length:4><type:4>"tEXt"<keyword>\0<text><crc:4>
+  const enc = new TextEncoder();
+  const kw = enc.encode(keyword);
+  const tx = enc.encode(text);
+  const data = new Uint8Array(kw.length + 1 + tx.length);
+  data.set(kw, 0);
+  data[kw.length] = 0;
+  data.set(tx, kw.length + 1);
+  const chunk = new Uint8Array(4 + 4 + data.length + 4);
+  const chunkView = new DataView(chunk.buffer);
+  writeUint32(chunkView, 0, data.length);
+  chunk.set([0x74, 0x45, 0x58, 0x74], 4); // "tEXt"
+  chunk.set(data, 8);
+  const crcInput = chunk.subarray(4, 8 + data.length);
+  writeUint32(chunkView, 8 + data.length, crc32(crcInput));
+  // Splice into PNG before IEND.
+  const out = new Uint8Array(bytes.length + chunk.length);
+  out.set(bytes.subarray(0, iendOffset), 0);
+  out.set(chunk, iendOffset);
+  out.set(bytes.subarray(iendOffset), iendOffset + chunk.length);
+  return out;
+}
+async function bytesFromBlob(blob) {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+async function readRemixState(blob) {
+  const bytes = await bytesFromBlob(blob);
+  const text = isValidPng(bytes) ? readTextChunk(bytes, HISTORY_KEYWORD) : null;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed?.history) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function cleanHistoryFrames(frames) {
+  return frames
+    .map((frame) => cleanHistoryFrame(frame))
+    .filter((frame) => frame.url);
+}
+
+function cleanHistoryFrame(frame) {
+  const source = typeof frame === "string" ? { url: frame } : (frame || {});
+  const clean = { url: scrubURL(source.url) };
+  if (!clean.url) return clean;
+  if (source.kind === "prep") clean.kind = "prep";
+  if (source.promptText) clean.promptText = String(source.promptText);
+  if (source.marked != null) clean.marked = Boolean(source.marked);
+  if (source.color) clean.color = String(source.color);
+  if (Number.isFinite(source.xPct)) clean.xPct = source.xPct;
+  if (Number.isFinite(source.yPct)) clean.yPct = source.yPct;
+  return clean;
+}
+
+async function restoreRemix(state, fallbackURL, sourceURL = "") {
+  const frames = cleanHistoryFrames(state.history);
+  if (!frames.length) {
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    return;
+  }
+  const source = scrubURL(sourceURL);
+  const sourceIndex = clamp(state.historyIndex ?? frames.length - 1, 0, frames.length - 1);
+  const requestedIndex = startIndexFromLocation();
+  let currentIndex = sourceIndex;
+  if (source) {
+    if (frames[sourceIndex]?.kind === "prep") {
+      frames.splice(sourceIndex + 1, 0, { url: source });
+      currentIndex = sourceIndex + 1;
+    } else {
+      frames[sourceIndex].url = source;
+    }
+  }
+  const index = requestedIndex == null || (currentIndex !== sourceIndex && requestedIndex === sourceIndex)
+    ? currentIndex
+    : requestedIndex;
+  app.history = frames;
+  app.historyIndex = clamp(index, 0, frames.length - 1);
+  app.stateURL = source || scrubURL(fallbackURL);
+  try {
+    await mediaHistory.go(app.historyIndex);
+    setStatus(`restored ${frames.length} frames`);
+  } catch (err) {
+    app.history = [];
+    app.historyIndex = -1;
+    app.stateURL = "";
+    await mediaHistory.reset({ url: fallbackURL }, sourceURL || fallbackURL);
+    showError(`History URLs unavailable; loaded image only. ${err.message}`);
+  }
+}
+
+function remixPayload() {
+  const history = cleanHistoryFrames(app.history);
+  const current = scrubURL(app.history[app.historyIndex]?.url);
+  const found = history.findIndex((frame) => frame.url === current);
+  return JSON.stringify({
+    v: 1,
+    app: "voice-edit-remix",
+    history,
+    historyIndex: found >= 0 ? found : history.length - 1,
+  });
+}
+
+async function remixPNGBlob() {
+  const bytes = await bytesFromBlob(await canvasBlob(els.imageCanvas));
+  const png = injectTextChunk(bytes, HISTORY_KEYWORD, remixPayload());
+  return new Blob([png], { type: "image/png" });
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function loadStartImage(url) {
+  try {
+    const res = await fetch(url, { mode: "cors" });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const blob = await res.blob();
+    const remix = await readRemixState(blob);
+    if (remix) {
+      await restoreRemix(remix, url, url);
+      return;
+    }
+  } catch {
+    // Fall through to URL loading; the browser may still be able to render it.
+  }
+  await mediaHistory.reset({ url }, url);
+}
+
+function nextStarter() {
+  const current = scrubURL(app.stateURL || app.imageURL);
+  const index = STARTERS.findIndex((starter) => scrubURL(starter.url) === current);
+  return STARTERS[(index + 1) % STARTERS.length] || STARTERS[0];
+}
+
+function startLink(mediaURL, index = 0) {
+  const url = new URL(location.href);
+  url.searchParams.delete("start");
+  const params = new URLSearchParams({ start: mediaURL });
+  if (index > 0) params.set("index", String(index));
+  url.hash = params.toString();
+  return url;
+}
+
+function syncStartToFrame(frame, { force = false } = {}) {
+  if (app.busy && !force) return;
+  const url = app.stateURL || frame?.url || app.imageURL;
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return;
+  const index = app.stateURL && app.history.length > 1 ? app.historyIndex : 0;
+  window.history.replaceState(null, "", startLink(url, index));
+}
+
+function syncStartToCurrent(options = {}) {
+  syncStartToFrame(app.history[app.historyIndex] || { url: app.imageURL }, options);
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const params = new URLSearchParams(location.hash.slice(1));
+  const value = params.get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+async function loadFromLocation() {
+  const startURL = startURLFromLocation();
+  if (startURL) {
+    await loadStartImage(startURL);
+  } else {
+    await mediaHistory.reset({ url: STARTER }, STARTER);
+  }
+}
+
+async function followLocationStart() {
+  const startURL = startURLFromLocation();
+  const startIndex = startIndexFromLocation();
+  const currentURL = scrubURL(app.stateURL || app.history[app.historyIndex]?.url);
+  if (!startURL || (scrubURL(startURL) === currentURL && (startIndex == null || startIndex === app.historyIndex))) return;
+  if (app.busy || app.active) return;
+  await loadStartImage(startURL);
+}
+
+async function openStartURL(mediaURL) {
+  window.history.pushState(null, "", startLink(mediaURL));
+  await followLocationStart();
+}
+
+async function packageCurrentFrameWithHistory(options = {}) {
+  return uploadBlob(await remixPNGBlob(), "voice-edit-frame.png", {
+    parents: [previousMediaParent()],
+    relationship: "voice_edit_remix",
+    tags: ["remix"],
+    ...options,
+  });
+}
+
+const goHistory = (delta, label) => () => {
+  const canGo = delta < 0 ? mediaHistory.canUndo() : mediaHistory.canRedo();
+  if (!canGo || app.busy || app.active) return;
+  mediaHistory.go(app.historyIndex + delta).then(() => setStatus(label)).catch((err) => showError(err.message));
+};
+els.undo.addEventListener("click", goHistory(-1, "undone"));
+els.redo.addEventListener("click", goHistory(1, "redone"));
+els.download.addEventListener("click", async () => {
+  try {
+    downloadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`);
+    setStatus(`saved with ${cleanHistoryFrames(app.history).length} frames`);
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.share.addEventListener("click", async () => {
+  try {
+    const mediaURL = await uploadBlob(await remixPNGBlob(), `voice-edit-${Date.now()}.png`, {
+      parents: [previousMediaParent()],
+      relationship: "voice_edit_share",
+      tags: ["remix", "shared"],
+      visibility: "public",
+    });
+    const frame = app.history[app.historyIndex];
+    if (frame) {
+      frame.url = mediaURL;
+      app.imageURL = mediaURL;
+      app.stateURL = mediaURL;
+      syncStartToFrame(frame, { force: true });
+    }
+    const shareURL = startLink(mediaURL);
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(shareURL.href);
+      setStatus("share link copied");
+    } else {
+      window.prompt("share link", shareURL.href);
+      setStatus("share link ready");
+    }
+  } catch (err) {
+    showError(err.message);
+  }
+});
+els.walkthrough.addEventListener("click", () => {
+  const url = app.stateURL || app.history[app.historyIndex]?.url || app.imageURL;
+  if (!url) return;
+  const params = new URLSearchParams({ start: url });
+  if (app.history.length > 1) params.set("index", String(app.historyIndex));
+  location.href = `walkthrough.html#${params}`;
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadModels();
+window.addEventListener("hashchange", () => followLocationStart().catch((err) => showError(err.message)));
+window.addEventListener("popstate", () => followLocationStart().catch((err) => showError(err.message)));
+loadFromLocation().catch((err) => showError(err.message));
+setMarkerColor(app.markerColor);
+</script>
+</body>
+</html>

--- a/apps/voice-edit/walkthrough.html
+++ b/apps/voice-edit/walkthrough.html
@@ -1,0 +1,1174 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Voice Edit Walkthrough | Pollinations</title>
+<link rel="icon" href="data:,">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --dark: #110518;
+    --paper: #f3ebde;
+    --surface: #fff;
+    --muted: #5b5265;
+    --accent: #e8f372;
+    --danger-bg: #ffe1e1;
+    --danger-line: #a02020;
+    --border: 2px solid var(--dark);
+    --raise: 2px 2px 0 var(--dark);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--dark);
+    font-family: "IBM Plex Mono", monospace;
+  }
+  button, input, select { font: inherit; color: inherit; }
+
+  .app {
+    width: min(100% - 24px, 1180px);
+    margin: 0 auto;
+    padding: 18px 0 24px;
+    display: grid;
+    gap: 12px;
+  }
+  .topbar, .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .brand {
+    margin: 0;
+    font-family: "Press Start 2P", monospace;
+    font-size: clamp(1rem, 3.4vw, 1.45rem);
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+  .tagline, .account, .status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+  .account { margin-left: auto; text-align: right; }
+  .account button {
+    margin-left: 8px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .status { min-width: 8ch; text-align: right; }
+
+  .btn, .input, .select, .panel, .thumb, .clip {
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+  }
+  .btn, .select {
+    min-height: 38px;
+    border-radius: 0;
+  }
+  .btn {
+    padding: 0 12px;
+    font-weight: 700;
+    cursor: pointer;
+    text-transform: lowercase;
+  }
+  .btn:hover:not(:disabled) { transform: translate(1px, 1px); box-shadow: 1px 1px 0 var(--dark); }
+  .btn:active:not(:disabled) { transform: translate(2px, 2px); box-shadow: none; }
+  .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn.accent { background: var(--accent); }
+  .select { padding: 0 10px; }
+  .narrate {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    cursor: pointer;
+    user-select: none;
+  }
+  .narrate input { margin: 0; }
+  .narrate-count { opacity: 0.7; font-variant-numeric: tabular-nums; }
+  .narrate input:disabled + .narrate-count,
+  .narrate input:disabled { opacity: 0.4; }
+  .prompt {
+    display: grid;
+    gap: 4px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+  .prompt textarea {
+    width: 100%;
+    min-height: 56px;
+    padding: 8px 10px;
+    background: var(--surface);
+    border: var(--border);
+    box-shadow: var(--raise);
+    border-radius: 0;
+    font: inherit;
+    font-size: 0.85rem;
+    color: inherit;
+    resize: vertical;
+  }
+  .prompt textarea:focus { outline: 2px solid var(--accent); outline-offset: 0; }
+  .prompt .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .prompt .row button {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .error {
+    display: none;
+    padding: 10px 12px;
+    background: var(--danger-bg);
+    border: 2px solid var(--danger-line);
+    box-shadow: 2px 2px 0 var(--danger-line);
+    font-size: 0.85rem;
+  }
+  .error.visible { display: block; }
+
+  .panel {
+    min-height: 320px;
+    padding: 12px;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .panel img, .panel video {
+    display: block;
+    max-width: 100%;
+    max-height: calc(100vh - 290px);
+    background: #000;
+  }
+  .strip {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px 2px 6px;
+  }
+  .thumb, .clip {
+    flex: 0 0 auto;
+    width: 86px;
+    height: 64px;
+    padding: 0;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+  }
+  .thumb.active, .clip.active { outline: 3px solid var(--accent); outline-offset: 2px; }
+  .clip.pending { opacity: 0.55; cursor: wait; }
+  .clip.failed { opacity: 0.7; }
+  .clip-placeholder {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--muted);
+    font-size: 1.4rem;
+    animation: clip-pulse 1.6s ease-in-out infinite;
+  }
+  .clip.failed .clip-placeholder {
+    animation: none;
+    color: #ff8888;
+    background: rgba(255, 80, 80, 0.18);
+  }
+  @keyframes clip-pulse {
+    0%, 100% { background: rgba(255, 255, 255, 0.05); }
+    50% { background: rgba(255, 255, 255, 0.15); }
+  }
+  .thumb img, .clip video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .thumb span, .clip span {
+    position: absolute;
+    left: 3px;
+    bottom: 2px;
+    background: var(--accent);
+    padding: 0 4px;
+    font-size: 0.65rem;
+    font-weight: 700;
+  }
+  .meta {
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  @media (max-width: 720px) {
+    .app { width: min(100% - 14px, 1180px); padding-top: 10px; gap: 9px; }
+    .account { order: 3; width: 100%; margin-left: 0; text-align: left; }
+    .status { margin-left: auto; }
+    .toolbar { gap: 7px; }
+    .btn, .select { min-height: 36px; }
+    .btn { padding: 0 9px; }
+    .panel { min-height: 240px; }
+    .panel img, .panel video { max-height: calc(100vh - 340px); }
+  }
+</style>
+
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1 class="brand">voice.edit / walkthrough</h1>
+      <span class="tagline">history to video.</span>
+      <span id="account" class="account"></span>
+      <span id="status" class="status">ready</span>
+    </header>
+
+    <div id="error" class="error"></div>
+
+    <section class="toolbar" aria-label="walkthrough controls">
+      <button id="connectBtn" class="btn accent">connect</button>
+      <button id="loadBtn" class="btn" title="upload an image from disk">load</button>
+      <input id="fileInput" type="file" accept="image/*" hidden>
+      <select id="modelSel" class="select" aria-label="video model" disabled>
+        <option value="">loading models...</option>
+      </select>
+      <button id="makeBtn" class="btn accent">make</button>
+      <label class="narrate" title="insert a 2s card showing the marked-up image and prompt between video clips">
+        <input id="narrateToggle" type="checkbox"> narrate
+        <span id="narrateCount" class="narrate-count" aria-hidden="true"></span>
+      </label>
+      <button id="playAllBtn" class="btn" disabled title="play all clips in sequence">play all</button>
+      <button id="downloadAllBtn" class="btn" disabled title="download a single stitched .mp4 of all clips">download</button>
+    </section>
+
+    <label class="prompt">
+      <div class="row">
+        <span>video prompt</span>
+        <button type="button" id="promptReset" title="restore default prompt">reset</button>
+      </div>
+      <textarea id="promptInput" rows="2" spellcheck="false"></textarea>
+    </label>
+
+    <section id="viewer" class="panel"></section>
+    <div id="frameStrip" class="strip" aria-label="history frames"></div>
+    <div id="clipStrip" class="strip" aria-label="generated video clips"></div>
+    <div id="meta" class="meta"></div>
+  </main>
+
+<script type="module">
+import {
+  Input, Output, BlobSource, BufferTarget, Mp4OutputFormat,
+  EncodedPacketSink, EncodedVideoPacketSource, EncodedAudioPacketSource,
+  CanvasSource, Conversion, canEncodeVideo, ALL_FORMATS,
+} from "https://esm.sh/mediabunny@1.45.3";
+
+const KEY_STORAGE = "voice-edit:user-key";
+const PROMPT_STORAGE = "voice-edit:walkthrough-prompt";
+const NARRATE_STORAGE = "voice-edit:walkthrough-narrate";
+const NARRATE_DURATION_SEC = 3.5;
+const APP_KEY = ""; // Set to a registered pk_ app key to stamp verified app attribution.
+const ENTER = "https://enter.pollinations.ai";
+const BASE = "https://gen.pollinations.ai";
+const MEDIA = "https://media.pollinations.ai";
+const HISTORY_KEYWORD = "pollinations:voice-edit:history";
+const DEFAULT_PROMPT = "Smooth visual transition from the first image to the second image. Preserve the subject, composition, and style. No text, labels, captions, or subtitles.";
+
+const $ = (id) => document.getElementById(id);
+const els = Object.fromEntries(Object.entries({
+  account: "account",
+  status: "status",
+  error: "error",
+  connect: "connectBtn",
+  load: "loadBtn",
+  file: "fileInput",
+  model: "modelSel",
+  make: "makeBtn",
+  playAll: "playAllBtn",
+  downloadAll: "downloadAllBtn",
+  prompt: "promptInput",
+  promptReset: "promptReset",
+  narrate: "narrateToggle",
+  narrateCount: "narrateCount",
+  viewer: "viewer",
+  frameStrip: "frameStrip",
+  clipStrip: "clipStrip",
+  meta: "meta",
+}).map(([key, id]) => [key, $(id)]));
+
+const app = {
+  sourceURL: "",
+  history: [],
+  currentFrame: 0,
+  clips: [],
+  currentClip: -1,
+  busy: false,
+  modelsReady: false,
+  playAll: false,
+  playAllIndex: 0,
+  accountUser: "",
+  accountBalance: null,
+};
+
+function setStatus(text) {
+  els.status.textContent = text;
+}
+
+function showError(message) {
+  els.error.textContent = message;
+  els.error.classList.add("visible");
+  setStatus("error");
+}
+
+function clearError() {
+  els.error.classList.remove("visible");
+}
+
+function key() {
+  const token = localStorage.getItem(KEY_STORAGE);
+  if (!token) throw new Error("not connected - click Connect");
+  return token;
+}
+
+const authHeaders = () => ({ Authorization: `Bearer ${key()}` });
+
+function captureKeyFromFragment() {
+  if (!location.hash) return;
+  const params = new URLSearchParams(location.hash.slice(1));
+  const apiKey = params.get("api_key");
+  if (!apiKey) return;
+  localStorage.setItem(KEY_STORAGE, apiKey);
+  params.delete("api_key");
+  history.replaceState(null, "", params.toString() ? `${location.pathname}#${params}` : location.pathname);
+}
+
+function startConnect() {
+  const params = new URLSearchParams({
+    redirect_url: location.origin + location.pathname + location.hash,
+    scope: "generate",
+  });
+  if (APP_KEY) params.set("app_key", APP_KEY);
+  location.href = `${ENTER}/authorize?${params}`;
+}
+
+function disconnect() {
+  localStorage.removeItem(KEY_STORAGE);
+  refreshConnectionUI();
+}
+
+function renderAccount() {
+  if (!localStorage.getItem(KEY_STORAGE)) {
+    els.account.textContent = "not connected";
+    return;
+  }
+  const user = app.accountUser ? `connected as ${app.accountUser}` : "connected";
+  const balance = app.accountBalance == null ? "" : ` · ${app.accountBalance.toFixed(2)} pollen`;
+  els.account.textContent = `${user}${balance} · `;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "disconnect";
+  button.addEventListener("click", disconnect);
+  els.account.append(button);
+}
+
+function refreshConnectionUI() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  els.connect.hidden = connected;
+  renderAccount();
+  if (connected) {
+    loadUser();
+    loadBalance();
+  }
+  render();
+}
+
+async function loadUser() {
+  const res = await fetch(`${ENTER}/api/device/userinfo`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const user = await res.json();
+  app.accountUser = user?.preferred_username || "";
+  renderAccount();
+}
+
+async function loadBalance() {
+  const res = await fetch(`${BASE}/account/balance`, { headers: authHeaders() });
+  if (!res.ok) return;
+  const { balance } = await res.json();
+  app.accountBalance = Number(balance);
+  renderAccount();
+}
+
+function startURLFromLocation() {
+  return new URLSearchParams(location.hash.slice(1)).get("start")
+    || new URLSearchParams(location.search).get("start");
+}
+
+function startIndexFromLocation() {
+  const value = new URLSearchParams(location.hash.slice(1)).get("index");
+  if (value == null) return null;
+  const index = Number(value);
+  return Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function scrubURL(url) {
+  if (!url || String(url).startsWith("data:") || String(url).startsWith("blob:")) return "";
+  try {
+    const clean = new URL(url, location.href);
+    for (const param of ["token", "key", "api_key", "apikey"]) clean.searchParams.delete(param);
+    return clean.href;
+  } catch {
+    return "";
+  }
+}
+
+function frameURL(frame) {
+  return scrubURL(typeof frame === "string" ? frame : frame?.url);
+}
+
+function cleanHistoryFrames(frames) {
+  return frames.map((frame) => {
+    const url = frameURL(frame);
+    if (!url) return null;
+    if (typeof frame === "string") return { url };
+    return {
+      url,
+      kind: frame?.kind,
+      promptText: frame?.promptText,
+      marked: frame?.marked,
+      color: frame?.color,
+    };
+  }).filter(Boolean);
+}
+
+function setHash(start, index = 0) {
+  const params = new URLSearchParams({ start });
+  if (index > 0) params.set("index", String(index));
+  history.replaceState(null, "", `${location.pathname}#${params}`);
+}
+
+async function loadSource(url) {
+  clearError();
+  const source = scrubURL(url);
+  if (!source) throw new Error("Enter a public image URL");
+  setStatus("loading...");
+  const res = await fetch(source, { mode: "cors" });
+  if (!res.ok) throw new Error(`Image load failed: ${res.status} ${res.statusText}`);
+  const blob = await res.blob();
+  const state = await readRemixState(blob);
+  const rawFrames = state ? cleanHistoryFrames(state.history) : [{ url: source }];
+  if (!rawFrames.length) throw new Error("No history frames found");
+  const sourceIndex = state ? Math.max(0, Math.min(state.historyIndex ?? rawFrames.length - 1, rawFrames.length - 1)) : 0;
+  if (state && rawFrames[sourceIndex]?.kind !== "prep") {
+    rawFrames[sourceIndex].url = source;
+  }
+  // Attach each prep frame's narration data (annotated URL + prompt text) to the
+  // clean frame it produced — that's the very next non-prep entry in the raw list.
+  let pendingPrep = null;
+  const frames = [];
+  for (const frame of rawFrames) {
+    if (frame.kind === "prep") {
+      pendingPrep = frame;
+      continue;
+    }
+    if (pendingPrep) {
+      frame.narration = {
+        annotatedURL: pendingPrep.url,
+        promptText: pendingPrep.promptText || "",
+      };
+      pendingPrep = null;
+    }
+    frames.push(frame);
+  }
+  if (!frames.length) throw new Error("No clean frames found (all entries are annotated previews)");
+  const targetURL = rawFrames[sourceIndex]?.kind === "prep" ? source : rawFrames[sourceIndex]?.url;
+  const sourceIndexClean = Math.max(
+    0,
+    frames.findIndex((frame) => frame.url === targetURL),
+  );
+  const requestedIndex = startIndexFromLocation();
+  const requestedIndexClean = requestedIndex == null
+    ? null
+    : Math.max(0, Math.min(requestedIndex, frames.length - 1));
+  const index = requestedIndexClean == null || requestedIndexClean === sourceIndex
+    ? sourceIndexClean
+    : requestedIndexClean;
+  app.sourceURL = source;
+  app.history = frames;
+  app.currentFrame = Math.max(0, Math.min(index, frames.length - 1));
+  app.clips = [];
+  app.currentClip = -1;
+  setHash(source, app.currentFrame);
+  render();
+  setStatus(state ? `loaded ${frames.length} clean frames` : "loaded image");
+}
+
+function mediaParent(url) {
+  const clean = scrubURL(url);
+  if (!clean) return "";
+  try {
+    return new URL(clean).hostname === "media.pollinations.ai" ? clean : "";
+  } catch {
+    return "";
+  }
+}
+
+function uniqueValues(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function appendCatalogFields(form, options = {}) {
+  form.append("visibility", options.visibility || "unlisted");
+  form.append("relationship", options.relationship || "voice_edit_walkthrough");
+  for (const tag of uniqueValues(["voice-edit", "walkthrough", ...(options.tags || [])])) form.append("tags", tag);
+  for (const parent of uniqueValues(options.parents || [])) form.append("parents", parent);
+}
+
+async function uploadBlob(blob, filename, options = {}) {
+  setStatus("uploading...");
+  const form = new FormData();
+  form.append("file", blob, filename);
+  appendCatalogFields(form, options);
+  const res = await fetch(`${MEDIA}/upload`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) throw new Error(await friendlyError(res, "Upload failed"));
+  const json = await res.json();
+  return json.url || `${MEDIA}/${json.id}`;
+}
+
+async function tryUploadBlob(blob, filename, options = {}) {
+  try {
+    return await uploadBlob(blob, filename, options);
+  } catch (err) {
+    console.warn(`catalog upload skipped for ${filename}`, err);
+    return "";
+  }
+}
+
+function render() {
+  const connected = !!localStorage.getItem(KEY_STORAGE);
+  const locked = app.busy || app.history.length < 2 || !connected || !app.modelsReady;
+  els.make.disabled = locked;
+  els.load.disabled = app.busy || !connected;
+  els.model.disabled = app.busy || !app.modelsReady;
+  const hasClips = app.clips.length > 0 && !app.busy;
+  els.playAll.disabled = !hasClips;
+  els.downloadAll.disabled = !hasClips;
+  els.playAll.textContent = app.playAll ? "stop" : "play all";
+  const narratable = app.history.filter((f) => f?.narration).length;
+  els.narrate.disabled = narratable === 0 || app.busy;
+  els.narrateCount.textContent = narratable ? `(${narratable})` : "(none)";
+  renderViewer();
+  renderFrames();
+  renderClips();
+  els.meta.textContent = app.history.length > 1
+    ? `${app.history.length} frames -> ${app.history.length - 1} transitions${narratable ? ` · ${narratable} narration card${narratable === 1 ? "" : "s"}` : ""}`
+    : "load a remix image with history to make a walkthrough";
+}
+
+function renderViewer() {
+  if (app.playAll && app.clips.length) {
+    const video = document.createElement("video");
+    video.src = app.clips[app.playAllIndex].src;
+    video.controls = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    video.addEventListener("ended", () => {
+      if (!app.playAll) return;
+      app.playAllIndex = (app.playAllIndex + 1) % app.clips.length;
+      app.currentClip = app.playAllIndex;
+      render();
+    });
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const clip = app.clips[app.currentClip];
+  if (clip && clip.src) {
+    const video = document.createElement("video");
+    video.src = clip.src;
+    video.controls = true;
+    video.loop = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    els.viewer.replaceChildren(video);
+    return;
+  }
+  const frame = app.history[app.currentFrame];
+  if (!frame) {
+    els.viewer.textContent = "load an image";
+    return;
+  }
+  const img = document.createElement("img");
+  img.src = frame.url;
+  img.alt = "";
+  els.viewer.replaceChildren(img);
+}
+
+function renderFrames() {
+  els.frameStrip.replaceChildren(...app.history.map((frame, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `thumb${index === app.currentFrame && app.currentClip < 0 ? " active" : ""}`;
+    button.addEventListener("click", () => {
+      app.currentFrame = index;
+      app.currentClip = -1;
+      setHash(app.sourceURL, index);
+      render();
+    });
+    const img = document.createElement("img");
+    img.src = frame.url;
+    img.alt = "";
+    const label = document.createElement("span");
+    label.textContent = String(index + 1);
+    button.append(img, label);
+    return button;
+  }));
+}
+
+function renderClips() {
+  let videoCount = 0;
+  els.clipStrip.replaceChildren(...app.clips.map((clip, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    const isReady = !!clip.src;
+    const cls = [
+      "clip",
+      index === app.currentClip ? "active" : "",
+      clip.pending ? "pending" : "",
+      clip.failed ? "failed" : "",
+    ].filter(Boolean).join(" ");
+    button.className = cls;
+    if (isReady) {
+      button.addEventListener("click", () => {
+        app.currentClip = index;
+        render();
+      });
+    } else {
+      button.disabled = true;
+    }
+    const media = document.createElement(isReady ? "video" : "div");
+    if (isReady) {
+      media.src = clip.src;
+      media.muted = true;
+      media.playsInline = true;
+    } else {
+      media.className = "clip-placeholder";
+      media.textContent = clip.failed ? "×" : "…";
+    }
+    const label = document.createElement("span");
+    if (clip.kind === "narration") {
+      // narration card intros the next video, so label it with that video's number
+      label.textContent = `intro ${videoCount + 1}`;
+    } else {
+      videoCount += 1;
+      label.textContent = `${videoCount}->${videoCount + 1}`;
+    }
+    button.append(media, label);
+    return button;
+  }));
+}
+
+async function loadVideoModels() {
+  try {
+    const res = await fetch(`${BASE}/models`);
+    if (!res.ok) throw new Error(`models fetch failed: ${res.status}`);
+    const all = await res.json();
+    const supported = all.filter((m) =>
+      Array.isArray(m.video_capabilities) && m.video_capabilities.includes("end_frame"),
+    );
+    if (!supported.length) throw new Error("no models advertise end_frame");
+    const preferred = ["veo", "seedance-2.0", "wan-fast"];
+    supported.sort((a, b) => {
+      const ai = preferred.indexOf(a.name);
+      const bi = preferred.indexOf(b.name);
+      if (ai === -1 && bi === -1) return a.name.localeCompare(b.name);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+    els.model.replaceChildren(...supported.map((m) => {
+      const opt = document.createElement("option");
+      opt.value = m.name;
+      opt.textContent = `${m.name} start+end`;
+      opt.title = m.description || "";
+      return opt;
+    }));
+  } catch (err) {
+    els.model.replaceChildren(
+      Object.assign(document.createElement("option"), { value: "veo", textContent: "veo start+end" }),
+      Object.assign(document.createElement("option"), { value: "seedance-2.0", textContent: "seedance-2.0 start+end" }),
+      Object.assign(document.createElement("option"), { value: "wan-fast", textContent: "wan-fast start+end" }),
+    );
+    console.warn("video model discovery failed, using fallback list:", err);
+  } finally {
+    app.modelsReady = true;
+    render();
+  }
+}
+
+function currentPrompt() {
+  const text = (els.prompt.value || "").trim();
+  return text || DEFAULT_PROMPT;
+}
+
+function videoRequestURL(start, end, model) {
+  const url = new URL(`${BASE}/video/${encodeURIComponent(currentPrompt())}`);
+  url.searchParams.set("model", model);
+  url.searchParams.set("duration", "4");
+  url.searchParams.set("audio", "false");
+  url.searchParams.set("image", `${start}|${end}`);
+  return url;
+}
+
+async function makeWalkthrough() {
+  if (app.history.length < 2 || app.busy) return;
+  app.busy = true;
+  for (const clip of app.clips) if (clip.src) URL.revokeObjectURL(clip.src);
+  app.clips = [];
+  app.currentClip = -1;
+
+  const narrate = els.narrate.checked;
+  const transitions = app.history.length - 1;
+  // Pre-populate placeholders in display order: (intro?, video) per transition.
+  const slots = []; // parallel array mapping transitionIndex -> { videoSlot, narrationSlot? }
+  for (let i = 0; i < transitions; i++) {
+    const target = app.history[i + 1];
+    const slot = {};
+    if (narrate && target?.narration) {
+      app.clips.push({ kind: "narration", pending: true });
+      slot.narrationSlot = app.clips.length - 1;
+    }
+    app.clips.push({ kind: "video", pending: true });
+    slot.videoSlot = app.clips.length - 1;
+    slots.push(slot);
+  }
+  render();
+
+  let videosDone = 0;
+  let firstError = null;
+  const setProgress = () => setStatus(`videos ${videosDone}/${transitions} ready...`);
+  setProgress();
+
+  await Promise.all(slots.map(async (slot, i) => {
+    const request = videoRequestURL(app.history[i].url, app.history[i + 1].url, els.model.value);
+    try {
+      const res = await fetch(request, { headers: authHeaders() });
+      if (!res.ok) throw new Error(await friendlyError(res, `Video ${i + 1} failed`));
+      const blob = await res.blob();
+      const mediaURL = await tryUploadBlob(blob, `walkthrough-${i + 1}.mp4`, {
+        parents: [mediaParent(app.history[i].url), mediaParent(app.history[i + 1].url)],
+        relationship: "voice_edit_walkthrough",
+        tags: ["clip"],
+      });
+
+      // Fill the video slot
+      const videoEntry = { url: request.href, mediaURL, src: URL.createObjectURL(blob), blob, kind: "video" };
+      app.clips[slot.videoSlot] = videoEntry;
+      if (app.currentClip < 0) app.currentClip = slot.videoSlot;
+
+      // Render the narration card for this transition (needs the just-finished clip as codec ref)
+      if (slot.narrationSlot != null) {
+        try {
+          const cardBlob = await renderNarrationClip(app.history[i + 1].narration, blob);
+          const cardMediaURL = await tryUploadBlob(cardBlob, `walkthrough-card-${i + 1}.mp4`, {
+            parents: [
+              mediaParent(app.history[i + 1].narration.annotatedURL),
+              mediaParent(app.history[i + 1].url),
+            ],
+            relationship: "voice_edit_narration",
+            tags: ["narration"],
+          });
+          app.clips[slot.narrationSlot] = {
+            mediaURL: cardMediaURL,
+            src: URL.createObjectURL(cardBlob),
+            blob: cardBlob,
+            kind: "narration",
+          };
+        } catch (err) {
+          console.warn(`narration card ${i + 1} failed`, err);
+          showError(`narration card ${i + 1} skipped: ${err.message}`);
+          // Remove the failed placeholder by marking it dropped; we'll compact at the end.
+          app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+        }
+      }
+
+      videosDone++;
+      setProgress();
+      render();
+    } catch (err) {
+      firstError = firstError || err;
+      app.clips[slot.videoSlot] = { kind: "video", failed: true, error: err.message };
+      if (slot.narrationSlot != null) app.clips[slot.narrationSlot] = { kind: "narration", dropped: true };
+      videosDone++;
+      setProgress();
+      render();
+    }
+  }));
+
+  // Compact: drop slots that were never filled (failed videos / dropped cards)
+  app.clips = app.clips.filter((c) => !c.dropped && !c.failed);
+  if (app.currentClip >= app.clips.length) app.currentClip = app.clips.length - 1;
+
+  loadBalance().catch(() => {});
+  if (firstError) showError(firstError.message);
+  setStatus(firstError ? `done with errors` : "done");
+  app.busy = false;
+  render();
+}
+
+async function friendlyError(response, label) {
+  let details = response.statusText || "request failed";
+  try {
+    const text = await response.text();
+    const json = JSON.parse(text);
+    details = json.error?.message || json.message || text;
+  } catch {}
+  if (response.status === 401 || response.status === 403) return `${label}: authorization expired. Connect again.`;
+  if (response.status === 402) return `${label}: add Pollen credits, then try again.`;
+  if (response.status === 429) return `${label}: rate limited. Wait a moment.`;
+  return `${label}: ${response.status} ${details}`;
+}
+
+const PNG_SIG = [137, 80, 78, 71, 13, 10, 26, 10];
+function readUint32(view, offset) {
+  return view.getUint32(offset, false);
+}
+function isValidPng(bytes) {
+  if (bytes.length < 8) return false;
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIG[i]) return false;
+  return true;
+}
+function readTextChunk(bytes, keyword) {
+  if (!isValidPng(bytes)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const dec = new TextDecoder("latin1");
+  let pos = 8;
+  while (pos + 12 <= bytes.length) {
+    const length = readUint32(view, pos);
+    const type = dec.decode(bytes.subarray(pos + 4, pos + 8));
+    const dataStart = pos + 8;
+    const dataEnd = dataStart + length;
+    if (type === "IEND") return null;
+    if (type === "tEXt" && dataEnd <= bytes.length) {
+      const data = bytes.subarray(dataStart, dataEnd);
+      const sep = data.indexOf(0);
+      if (sep > 0 && dec.decode(data.subarray(0, sep)) === keyword) {
+        return dec.decode(data.subarray(sep + 1));
+      }
+    }
+    pos = dataEnd + 4;
+  }
+  return null;
+}
+async function readRemixState(blob) {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const text = readTextChunk(bytes, HISTORY_KEYWORD);
+  if (!text) return null;
+  const state = JSON.parse(text);
+  return Array.isArray(state?.history) ? state : null;
+}
+
+els.connect.addEventListener("click", startConnect);
+els.load.addEventListener("click", () => els.file.click());
+els.file.addEventListener("change", async () => {
+  const file = els.file.files?.[0];
+  if (!file) return;
+  try {
+    const mediaURL = await uploadBlob(file, file.name || "image", {
+      tags: ["source"],
+    });
+    setHash(mediaURL);
+    await loadSource(mediaURL);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.file.value = "";
+  }
+});
+els.make.addEventListener("click", () => {
+  makeWalkthrough().catch((err) => {
+    app.busy = false;
+    showError(err.message);
+    render();
+  });
+});
+els.playAll.addEventListener("click", () => {
+  if (!app.clips.length) return;
+  app.playAll = !app.playAll;
+  if (app.playAll) {
+    app.playAllIndex = 0;
+    app.currentClip = 0;
+  }
+  render();
+});
+function loadImageBlob(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("could not load narration image"));
+    img.src = url;
+  });
+}
+
+function wrapText(ctx, text, maxWidth) {
+  const lines = [];
+  for (const para of text.split(/\n/)) {
+    const words = para.split(/\s+/).filter(Boolean);
+    if (!words.length) { lines.push(""); continue; }
+    let line = words[0];
+    for (let i = 1; i < words.length; i++) {
+      const test = line + " " + words[i];
+      if (ctx.measureText(test).width > maxWidth) { lines.push(line); line = words[i]; }
+      else line = test;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+function drawNarrationCard(canvas, image, promptText) {
+  const ctx = canvas.getContext("2d");
+  const { width: W, height: H } = canvas;
+  ctx.fillStyle = "#110518";
+  ctx.fillRect(0, 0, W, H);
+  // contain-fit the annotated image
+  const s = Math.min(W / image.width, H / image.height);
+  const dw = image.width * s;
+  const dh = image.height * s;
+  ctx.drawImage(image, (W - dw) / 2, (H - dh) / 2, dw, dh);
+  // prompt text overlay at the bottom — subtitle-style
+  if (promptText) {
+    const fontPx = Math.min(26, Math.max(14, Math.round(H * 0.03)));
+    ctx.font = `500 ${fontPx}px "IBM Plex Mono", ui-monospace, Menlo, monospace`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    const lines = wrapText(ctx, promptText, W * 0.9);
+    const padY = Math.round(fontPx * 0.55);
+    const lineH = Math.round(fontPx * 1.3);
+    const bandH = lines.length * lineH + padY * 2;
+    ctx.fillStyle = "rgba(17, 5, 24, 0.75)";
+    ctx.fillRect(0, H - bandH, W, bandH);
+    ctx.fillStyle = "#fff";
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], W / 2, H - padY - (lines.length - 1 - i) * lineH);
+    }
+  }
+}
+
+async function probeVideoSpec(blob) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const track = await input.getPrimaryVideoTrack();
+  if (!track) throw new Error("reference clip has no video track");
+  const cfg = await track.getDecoderConfig();
+  return {
+    codec: track.codec,                    // e.g. "avc"
+    fullCodecString: cfg?.codec,           // e.g. "avc1.640028"
+    width: track.codedWidth,
+    height: track.codedHeight,
+  };
+}
+
+async function renderNarrationClip(narration, refBlob) {
+  const spec = await probeVideoSpec(refBlob);
+  // Force even dimensions (H.264 requires it).
+  const width = spec.width - (spec.width % 2);
+  const height = spec.height - (spec.height % 2);
+  const fps = 24;
+  const bitrate = 2_000_000;
+  if (typeof canEncodeVideo === "function") {
+    const ok = await canEncodeVideo(spec.codec, { width, height, bitrate });
+    if (!ok) throw new Error(`browser cannot encode ${spec.codec} ${width}x${height}`);
+  }
+
+  const image = await loadImageBlob(narration.annotatedURL);
+  const canvas = typeof OffscreenCanvas !== "undefined"
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement("canvas"), { width, height });
+  drawNarrationCard(canvas, image, narration.promptText);
+
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const sourceCfg = { codec: spec.codec, bitrate, keyFrameInterval: 1 };
+  if (spec.fullCodecString) sourceCfg.fullCodecString = spec.fullCodecString;
+  const source = new CanvasSource(canvas, sourceCfg);
+  output.addVideoTrack(source, { frameRate: fps });
+  await output.start();
+  const total = Math.max(1, Math.round(NARRATE_DURATION_SEC * fps));
+  const frameDur = 1 / fps;
+  for (let i = 0; i < total; i++) {
+    await source.add(i * frameDur, frameDur);
+  }
+  source.close();
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function remuxMp4Clips(blobs) {
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  let videoSrc = null;
+  let audioSrc = null;
+  let vOffset = 0;
+  let aOffset = 0;
+  let vMaxOut = 0;
+  let aMaxOut = 0;
+  let vCfgSent = false;
+  let aCfgSent = false;
+
+  for (let i = 0; i < blobs.length; i++) {
+    const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blobs[i]) });
+    const vTrack = await input.getPrimaryVideoTrack();
+    if (!vTrack) throw new Error(`clip ${i + 1} has no video track`);
+    const aTrack = await input.getPrimaryAudioTrack();
+
+    if (i === 0) {
+      videoSrc = new EncodedVideoPacketSource(vTrack.codec);
+      output.addVideoTrack(videoSrc);
+      if (aTrack) {
+        audioSrc = new EncodedAudioPacketSource(aTrack.codec);
+        output.addAudioTrack(audioSrc);
+      }
+      await output.start();
+    }
+
+    const vMeta = { decoderConfig: await vTrack.getDecoderConfig() };
+    const vSink = new EncodedPacketSink(vTrack);
+    let vClipMax = 0;
+    for (let p = await vSink.getFirstPacket(); p; p = await vSink.getNextPacket(p)) {
+      let ts = Math.max(0, p.timestamp + vOffset);
+      if (i > 0 && ts <= vMaxOut) ts = vMaxOut + 1e-6;
+      await videoSrc.add(p.clone({ timestamp: ts }), vCfgSent ? undefined : vMeta);
+      vCfgSent = true;
+      vMaxOut = Math.max(vMaxOut, ts);
+      vClipMax = Math.max(vClipMax, p.timestamp + p.duration);
+    }
+    vOffset += vClipMax;
+
+    if (aTrack && audioSrc) {
+      const aMeta = { decoderConfig: await aTrack.getDecoderConfig() };
+      const aSink = new EncodedPacketSink(aTrack);
+      let aClipMax = 0;
+      for (let p = await aSink.getFirstPacket(); p; p = await aSink.getNextPacket(p)) {
+        let ts = Math.max(0, p.timestamp + aOffset);
+        if (i > 0 && ts <= aMaxOut) ts = aMaxOut + 1e-6;
+        await audioSrc.add(p.clone({ timestamp: ts }), aCfgSent ? undefined : aMeta);
+        aCfgSent = true;
+        aMaxOut = Math.max(aMaxOut, ts);
+        aClipMax = Math.max(aClipMax, p.timestamp + p.duration);
+      }
+      aOffset += aClipMax;
+    } else if (audioSrc) {
+      // No audio in this clip but we have an audio track — keep the audio
+      // offset in lock-step with video so later audio packets land in the
+      // right spot. The merged audio track will just contain a silent gap.
+      aOffset += vClipMax;
+    }
+  }
+
+  await output.finalize();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+async function normalizeMp4(blob, targetBitrate) {
+  const input = new Input({ formats: ALL_FORMATS, source: new BlobSource(blob) });
+  const output = new Output({ format: new Mp4OutputFormat(), target: new BufferTarget() });
+  const conv = await Conversion.init({
+    input, output,
+    video: { codec: "avc", bitrate: targetBitrate },
+  });
+  await conv.execute();
+  return new Blob([output.target.buffer], { type: "video/mp4" });
+}
+
+els.downloadAll.addEventListener("click", async () => {
+  if (!app.clips.length) return;
+  const originalLabel = els.downloadAll.textContent;
+  els.downloadAll.disabled = true;
+  els.downloadAll.textContent = "stitching…";
+  try {
+    const clips = app.clips.filter((c) => c.blob);
+    if (!clips.length) throw new Error("No video data to download");
+
+    // If we have any narration cards mixed in, the source clips and the cards
+    // will have different H.264 SPS/PPS — the player only honours the first
+    // avcC box, so naive remux silently drops the cards. Re-encode every clip
+    // to one uniform target so the final stream has a single decoder config.
+    let blobs = clips.map((c) => c.blob);
+    const mixed = clips.some((c) => c.kind === "narration");
+    if (mixed) {
+      const targetBitrate = 4_000_000;
+      const normalized = [];
+      for (let i = 0; i < clips.length; i++) {
+        els.downloadAll.textContent = `re-encoding ${i + 1}/${clips.length}…`;
+        normalized.push(await normalizeMp4(clips[i].blob, targetBitrate));
+      }
+      blobs = normalized;
+      els.downloadAll.textContent = "stitching…";
+    }
+
+    let merged;
+    let ext = "mp4";
+    try {
+      merged = await remuxMp4Clips(blobs);
+    } catch (remuxErr) {
+      console.warn("mediabunny remux failed, falling back to naive concat", remuxErr);
+      const type = blobs[0].type || "video/mp4";
+      merged = new Blob(blobs, { type });
+      ext = type.includes("webm") ? "webm" : "mp4";
+    }
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(merged);
+    a.download = `walkthrough-${Date.now()}.${ext}`;
+    document.body.append(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(a.href), 60_000);
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    els.downloadAll.textContent = originalLabel;
+    els.downloadAll.disabled = !app.clips.length || app.busy;
+  }
+});
+window.addEventListener("hashchange", () => {
+  const start = startURLFromLocation();
+  if (start && scrubURL(start) !== app.sourceURL && !app.busy) loadSource(start).catch((err) => showError(err.message));
+});
+
+els.prompt.value = localStorage.getItem(PROMPT_STORAGE) ?? DEFAULT_PROMPT;
+els.prompt.placeholder = DEFAULT_PROMPT;
+els.prompt.addEventListener("input", () => {
+  localStorage.setItem(PROMPT_STORAGE, els.prompt.value);
+});
+els.promptReset.addEventListener("click", () => {
+  els.prompt.value = DEFAULT_PROMPT;
+  localStorage.setItem(PROMPT_STORAGE, DEFAULT_PROMPT);
+});
+
+els.narrate.checked = localStorage.getItem(NARRATE_STORAGE) === "1";
+els.narrate.addEventListener("change", () => {
+  localStorage.setItem(NARRATE_STORAGE, els.narrate.checked ? "1" : "0");
+});
+
+captureKeyFromFragment();
+refreshConnectionUI();
+loadVideoModels();
+const start = startURLFromLocation();
+if (start) loadSource(start).catch((err) => showError(err.message));
+else render();
+</script>
+</body>
+</html>

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1440,6 +1440,38 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Display name of the API key",
                                         ),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Stable owner user id for this API key",
+                                        ),
+                                    keyId: z
+                                        .string()
+                                        .describe("Stable API key id"),
+                                    apiKeyId: z
+                                        .string()
+                                        .describe(
+                                            "Stable API key id; alias of keyId for services that use explicit API-key naming",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Publishable app key id that minted this key through authorize, when present",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Display name of the verified BYOP app, when present",
+                                        ),
+                                    byopClientUserId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id of the verified BYOP app, when present",
+                                        ),
                                     expiresAt: z
                                         .string()
                                         .nullable()
@@ -1548,8 +1580,14 @@ export const accountRoutes = new Hono<Env>()
 
             return c.json({
                 valid: true, // If we got here, the key is valid
+                keyId: apiKey.id,
+                apiKeyId: apiKey.id,
                 type: keyType,
                 name: apiKey.name || null,
+                userId: c.var.auth.user?.id ?? null,
+                byopClientKeyId: apiKey.byopClientKeyId ?? null,
+                byopClientName: apiKey.byopClientName ?? null,
+                byopClientUserId: apiKey.byopClientUserId ?? null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -41,6 +41,12 @@ test(
         expect(data.valid).toBe(true);
         expect(data.type).toBe("secret");
         expect(data.name).toBeTruthy();
+        expect(data.keyId).toBeTruthy();
+        expect(data.apiKeyId).toBe(data.keyId);
+        expect(data.userId).toBeTruthy();
+        expect(data).toHaveProperty("byopClientKeyId");
+        expect(data).toHaveProperty("byopClientName");
+        expect(data).toHaveProperty("byopClientUserId");
         expect(data).toHaveProperty("expiresAt");
         expect(data).toHaveProperty("expiresIn");
         expect(data).toHaveProperty("permissions");

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -16,6 +16,15 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const CATALOG_PREFIX = "catalog/v1";
+const LINEAGE_PREFIX = "lineage/v1";
+const TAG_PREFIX = "tags/v1";
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 100;
+const MAX_TAGS = 20;
+const MAX_PARENTS = 8;
+const MAX_PROMPT_LENGTH = 500;
+const MAX_MODEL_LENGTH = 100;
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
@@ -24,9 +33,65 @@ interface Env {
 
 interface AuthResult {
     valid: boolean;
+    keyId?: string;
+    apiKeyId?: string;
     type: string;
     name: string | null;
+    userId?: string | null;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    byopClientUserId?: string | null;
 }
+
+const VISIBILITIES = ["private", "unlisted", "public"] as const;
+type Visibility = (typeof VISIBILITIES)[number];
+type CatalogSource = "upload" | "generation" | "remix" | "edit" | "saved_generation";
+
+type UploadCatalogInput = {
+    visibility: Visibility;
+    source: CatalogSource;
+    parents: string[];
+    relationship: string;
+    tags: string[];
+    prompt: string | null;
+    model: string | null;
+};
+
+type UploadFields = {
+    visibility?: unknown;
+    source?: unknown;
+    kind?: unknown;
+    parent?: unknown;
+    parents?: unknown;
+    remixOf?: unknown;
+    relationship?: unknown;
+    tag?: unknown;
+    tags?: unknown;
+    prompt?: unknown;
+    model?: unknown;
+};
+
+type CatalogRecord = {
+    entryId: string;
+    hash: string;
+    url: string;
+    contentType: string;
+    size: number;
+    createdAt: string;
+    visibility: Visibility;
+    source: CatalogSource;
+    relationship: string;
+    parents: string[];
+    tags: string[];
+    prompt?: string;
+    model?: string;
+    ownerId?: string;
+    ownerName?: string;
+    apiKeyId?: string;
+    appId?: string;
+    appName?: string;
+    appOwnerUserId?: string;
+};
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
     try {
@@ -63,10 +128,46 @@ const UploadResponseSchema = z.object({
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    cataloged: z
+        .boolean()
+        .describe("true when the media catalog sidecar indexes were written"),
+    visibility: z.enum(VISIBILITIES),
+    source: z.string(),
+    parents: z.array(z.string()),
+    tags: z.array(z.string()),
 });
 
 const ErrorSchema = z.object({
     error: z.string(),
+});
+
+const CatalogItemSchema = z.object({
+    entryId: z.string(),
+    hash: z.string(),
+    url: z.string(),
+    contentType: z.string(),
+    size: z.number().int(),
+    createdAt: z.string(),
+    visibility: z.enum(VISIBILITIES),
+    source: z.string(),
+    relationship: z.string(),
+    parents: z.array(z.string()),
+    tags: z.array(z.string()),
+    prompt: z.string().optional(),
+    model: z.string().optional(),
+    ownerId: z.string().optional(),
+    apiKeyId: z.string().optional(),
+    verifiedApp: z
+        .object({
+            keyId: z.string(),
+            name: z.string().nullable(),
+        })
+        .nullable(),
+});
+
+const CatalogListResponseSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    nextCursor: z.string().nullable(),
 });
 
 const MetadataResponseSchema = z.object({
@@ -78,6 +179,391 @@ const MetadataResponseSchema = z.object({
         .optional()
         .describe("ISO-8601 upload timestamp, when recorded"),
 });
+
+function reverseTimestamp(now = Date.now()): string {
+    return String(Number.MAX_SAFE_INTEGER - now).padStart(16, "0");
+}
+
+function listLimit(raw: string | null): number {
+    const parsed = Number.parseInt(raw || "", 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIST_LIMIT;
+    return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
+function boundedString(value: unknown, maxLength: number): string | null {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed;
+}
+
+function parseVisibility(value: unknown): Visibility {
+    if (typeof value !== "string" || !value.trim()) return "private";
+    const normalized = value.trim().toLowerCase();
+    if ((VISIBILITIES as readonly string[]).includes(normalized)) {
+        return normalized as Visibility;
+    }
+    throw new Error("Invalid visibility");
+}
+
+function parseSource(value: unknown, parents: string[]): CatalogSource {
+    const source = typeof value === "string" ? value.trim().toLowerCase() : "";
+    if (
+        source === "upload" ||
+        source === "generation" ||
+        source === "remix" ||
+        source === "edit" ||
+        source === "saved_generation"
+    ) {
+        return source;
+    }
+    return parents.length ? "remix" : "upload";
+}
+
+function parseRelationship(value: unknown): string {
+    const relationship =
+        typeof value === "string" && value.trim()
+            ? value.trim().toLowerCase()
+            : "derived_from";
+    if (!/^[a-z][a-z0-9_-]{0,31}$/.test(relationship)) {
+        throw new Error("Invalid relationship");
+    }
+    return relationship;
+}
+
+function parseTags(value: unknown): string[] {
+    const tags = flattenStringList(value).map((tag) =>
+        tag.trim().toLowerCase(),
+    );
+    const normalized = [...new Set(tags.filter(Boolean))];
+    if (normalized.length > MAX_TAGS) {
+        throw new Error("Too many tags");
+    }
+    for (const tag of normalized) {
+        if (!/^[a-z0-9][a-z0-9._:-]{0,63}$/.test(tag)) {
+            throw new Error("Invalid tag");
+        }
+    }
+    return normalized;
+}
+
+function firstTag(value: unknown): string | null {
+    try {
+        return parseTags(value)[0] ?? null;
+    } catch {
+        return null;
+    }
+}
+
+function parseParents(value: unknown): string[] {
+    return [...new Set(flattenStringList(value).map(parseHashReference))].slice(
+        0,
+        MAX_PARENTS,
+    );
+}
+
+function parseHashReference(value: string): string {
+    const trimmed = value.trim();
+    let candidate = trimmed;
+    if (trimmed.includes("://")) {
+        try {
+            candidate =
+                new URL(trimmed).pathname.split("/").filter(Boolean).pop() ||
+                "";
+        } catch {
+            throw new Error("Invalid parent hash");
+        }
+    }
+    const hash = candidate.toLowerCase();
+    if (!HASH_PATTERN.test(hash)) {
+        throw new Error("Invalid parent hash");
+    }
+    return hash;
+}
+
+function flattenStringList(value: unknown): string[] {
+    if (value == null) return [];
+    const values = Array.isArray(value) ? value : [value];
+    return values.flatMap((item) => {
+        if (Array.isArray(item)) return flattenStringList(item);
+        if (typeof item !== "string") return [];
+        const trimmed = item.trim();
+        if (trimmed.startsWith("[")) {
+            try {
+                const parsed = JSON.parse(trimmed);
+                if (Array.isArray(parsed)) return flattenStringList(parsed);
+            } catch {
+                return [];
+            }
+        }
+        return trimmed
+            .split(",")
+            .map((part) => part.trim())
+            .filter(Boolean);
+    });
+}
+
+function parseCatalogInput(fields: UploadFields): UploadCatalogInput {
+    const parents = parseParents([
+        fields.parent,
+        fields.parents,
+        fields.remixOf,
+    ]);
+    const source = parseSource(fields.source ?? fields.kind, parents);
+    return {
+        visibility: parseVisibility(fields.visibility),
+        source,
+        parents,
+        relationship: parseRelationship(fields.relationship),
+        tags: parseTags([fields.tag, fields.tags]),
+        prompt: boundedString(fields.prompt, MAX_PROMPT_LENGTH),
+        model: boundedString(fields.model, MAX_MODEL_LENGTH),
+    };
+}
+
+function queryFields(params: URLSearchParams): UploadFields {
+    return {
+        visibility: params.get("visibility"),
+        source: params.get("source"),
+        kind: params.get("kind"),
+        parent: params.getAll("parent"),
+        parents: params.getAll("parents"),
+        remixOf: params.getAll("remixOf"),
+        relationship: params.get("relationship"),
+        tag: params.getAll("tag"),
+        tags: params.getAll("tags"),
+        prompt: params.get("prompt"),
+        model: params.get("model"),
+    };
+}
+
+function formFields(formData: FormData): UploadFields {
+    const strings = (key: string) =>
+        formData.getAll(key).filter((value): value is string => {
+            return typeof value === "string";
+        });
+    const string = (key: string) => {
+        const value = formData.get(key);
+        return typeof value === "string" ? value : null;
+    };
+    return {
+        visibility: string("visibility"),
+        source: string("source"),
+        kind: string("kind"),
+        parent: strings("parent"),
+        parents: strings("parents"),
+        remixOf: strings("remixOf"),
+        relationship: string("relationship"),
+        tag: strings("tag"),
+        tags: strings("tags"),
+        prompt: string("prompt"),
+        model: string("model"),
+    };
+}
+
+function mergeFields(base: UploadFields, next: UploadFields): UploadFields {
+    const merged = { ...base };
+    for (const [key, value] of Object.entries(next)) {
+        if (Array.isArray(value) && value.length === 0) continue;
+        if (value == null || value === "") continue;
+        merged[key as keyof UploadFields] = value;
+    }
+    return merged;
+}
+
+function isClientCatalogError(error: Error): boolean {
+    return (
+        error.message.startsWith("Invalid ") ||
+        error.message.startsWith("Too many ")
+    );
+}
+
+function keySegment(value: string): string {
+    return encodeURIComponent(value);
+}
+
+async function putJson(bucket: R2Bucket, key: string, value: unknown) {
+    await bucket.put(key, JSON.stringify(value), {
+        httpMetadata: {
+            contentType: "application/json",
+            cacheControl: "no-store",
+        },
+    });
+}
+
+function catalogKey(prefix: string, hash: string, entryId: string): string {
+    return `${prefix}/${reverseTimestamp()}-${hash}-${entryId}.json`;
+}
+
+async function writeCatalogEntries(
+    bucket: R2Bucket,
+    record: CatalogRecord,
+): Promise<void> {
+    const writes = [
+        putJson(bucket, `${CATALOG_PREFIX}/items/${record.hash}.json`, record),
+    ];
+
+    if (record.ownerId) {
+        writes.push(
+            putJson(
+                bucket,
+                catalogKey(
+                    `${CATALOG_PREFIX}/by-owner/${keySegment(record.ownerId)}`,
+                    record.hash,
+                    record.entryId,
+                ),
+                record,
+            ),
+        );
+        if (record.appId) {
+            writes.push(
+                putJson(
+                    bucket,
+                    catalogKey(
+                        `${CATALOG_PREFIX}/by-owner-app/${keySegment(record.ownerId)}/${keySegment(record.appId)}`,
+                        record.hash,
+                        record.entryId,
+                    ),
+                    record,
+                ),
+            );
+        }
+    }
+
+    if (record.visibility === "public" && record.appId) {
+        writes.push(
+            putJson(
+                bucket,
+                catalogKey(
+                    `${CATALOG_PREFIX}/public-app/${keySegment(record.appId)}`,
+                    record.hash,
+                    record.entryId,
+                ),
+                record,
+            ),
+        );
+    }
+
+    if (record.visibility !== "private") {
+        for (const parent of record.parents) {
+            writes.push(
+                putJson(
+                    bucket,
+                    catalogKey(
+                        `${LINEAGE_PREFIX}/by-parent/${parent}`,
+                        record.hash,
+                        record.entryId,
+                    ),
+                    record,
+                ),
+                putJson(
+                    bucket,
+                    `${LINEAGE_PREFIX}/by-child/${record.hash}/${parent}.json`,
+                    record,
+                ),
+            );
+        }
+    }
+
+    if (record.visibility === "public") {
+        for (const tag of record.tags) {
+            writes.push(
+                putJson(
+                    bucket,
+                    catalogKey(
+                        `${TAG_PREFIX}/${keySegment(tag)}`,
+                        record.hash,
+                        record.entryId,
+                    ),
+                    record,
+                ),
+            );
+        }
+    }
+
+    await Promise.all(writes);
+}
+
+function catalogItem(
+    record: CatalogRecord,
+    includePrivateFields = false,
+): Record<string, unknown> {
+    return {
+        entryId: record.entryId,
+        hash: record.hash,
+        url: record.url,
+        contentType: record.contentType,
+        size: record.size,
+        createdAt: record.createdAt,
+        visibility: record.visibility,
+        source: record.source,
+        relationship: record.relationship,
+        parents: record.parents,
+        tags: record.tags,
+        ...(record.prompt && { prompt: record.prompt }),
+        ...(record.model && { model: record.model }),
+        verifiedApp: record.appId
+            ? {
+                  keyId: record.appId,
+                  name: record.appName ?? null,
+              }
+            : null,
+        ...(includePrivateFields && record.ownerId
+            ? { ownerId: record.ownerId }
+            : {}),
+        ...(includePrivateFields && record.apiKeyId
+            ? { apiKeyId: record.apiKeyId }
+            : {}),
+    };
+}
+
+async function readCatalogItem(
+    bucket: R2Bucket,
+    key: string,
+): Promise<CatalogRecord | null> {
+    const object = await bucket.get(key);
+    if (!object) return null;
+    try {
+        return (await object.json()) as CatalogRecord;
+    } catch {
+        return null;
+    }
+}
+
+async function listCatalogItems(
+    bucket: R2Bucket,
+    prefix: string,
+    limit: number,
+    cursor: string | null,
+    includePrivateFields = false,
+): Promise<{ items: Record<string, unknown>[]; nextCursor: string | null }> {
+    const list = await bucket.list({
+        prefix,
+        limit,
+        cursor: cursor || undefined,
+    });
+    const records = await Promise.all(
+        list.objects.map((object) => readCatalogItem(bucket, object.key)),
+    );
+    return {
+        items: records
+            .filter((record): record is CatalogRecord => Boolean(record))
+            .map((record) => catalogItem(record, includePrivateFields)),
+        nextCursor: list.truncated && list.cursor ? list.cursor : null,
+    };
+}
+
+async function resolveAppIdFromQuery(
+    app: string | null,
+    appKey: string | null,
+): Promise<string | null> {
+    const direct = app?.trim();
+    if (direct) return direct;
+    const key = appKey?.trim();
+    if (!key) return null;
+    const auth = await verifyApiKey(key);
+    return auth?.keyId ?? null;
+}
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -140,6 +626,8 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        let catalogFields = queryFields(new URL(c.req.url).searchParams);
+        let catalogInput = parseCatalogInput(catalogFields);
 
         const requestContentType = c.req.header("content-type") || "";
 
@@ -161,6 +649,8 @@ api.post(
                     return c.json(fileTooLargeError(maxSize), 413);
                 }
 
+                catalogFields = mergeFields(catalogFields, formFields(formData));
+                catalogInput = parseCatalogInput(catalogFields);
                 fileBuffer = await file.arrayBuffer();
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
@@ -169,6 +659,17 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
+                    visibility?: string;
+                    source?: string;
+                    kind?: string;
+                    parent?: string | string[];
+                    parents?: string | string[];
+                    remixOf?: string | string[];
+                    relationship?: string;
+                    tag?: string | string[];
+                    tags?: string | string[];
+                    prompt?: string;
+                    model?: string;
                 }>();
 
                 if (!body.data) {
@@ -195,6 +696,8 @@ api.post(
                     return c.json({ error: "Empty file" }, 400);
                 }
 
+                catalogFields = mergeFields(catalogFields, body);
+                catalogInput = parseCatalogInput(catalogFields);
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
             } else {
@@ -213,6 +716,10 @@ api.post(
             const hash = await generateHash(fileBuffer, fileName);
 
             const existing = await c.env.MEDIA_BUCKET.head(hash);
+            const createdAt = new Date().toISOString();
+            const ownerId = authResult.userId ?? undefined;
+            const apiKeyId = authResult.keyId ?? authResult.apiKeyId;
+            const appId = authResult.byopClientKeyId ?? undefined;
 
             // Always re-PUT to reset the R2 object timestamp (resets lifecycle TTL).
             await c.env.MEDIA_BUCKET.put(hash, fileBuffer, {
@@ -221,12 +728,50 @@ api.post(
                     cacheControl: CACHE_CONTROL,
                 },
                 customMetadata: {
-                    uploadedAt: new Date().toISOString(),
+                    uploadedAt: createdAt,
                     originalName: fileName || "",
                     uploadedBy: authResult.name || "",
                     keyType: authResult.type,
+                    ownerId: ownerId || "",
+                    apiKeyId: apiKeyId || "",
+                    appId: appId || "",
+                    parent: catalogInput.parents[0] || "",
                 },
             });
+
+            const record: CatalogRecord = {
+                entryId: crypto.randomUUID(),
+                hash,
+                url: mediaUrl(hash),
+                contentType,
+                size: fileBuffer.byteLength,
+                createdAt,
+                visibility: catalogInput.visibility,
+                source: catalogInput.source,
+                relationship: catalogInput.relationship,
+                parents: catalogInput.parents.filter((parent) => parent !== hash),
+                tags: catalogInput.tags,
+                ...(catalogInput.prompt && { prompt: catalogInput.prompt }),
+                ...(catalogInput.model && { model: catalogInput.model }),
+                ...(ownerId && { ownerId }),
+                ...(authResult.name && { ownerName: authResult.name }),
+                ...(apiKeyId && { apiKeyId }),
+                ...(appId && { appId }),
+                ...(authResult.byopClientName && {
+                    appName: authResult.byopClientName,
+                }),
+                ...(authResult.byopClientUserId && {
+                    appOwnerUserId: authResult.byopClientUserId,
+                }),
+            };
+
+            let cataloged = false;
+            try {
+                await writeCatalogEntries(c.env.MEDIA_BUCKET, record);
+                cataloged = true;
+            } catch (catalogError) {
+                console.error("Catalog write error:", catalogError);
+            }
 
             console.log(
                 JSON.stringify({
@@ -237,6 +782,13 @@ api.post(
                     keyType: authResult.type,
                     uploadedBy: authResult.name || "unknown",
                     duplicate: !!existing,
+                    ownerId: ownerId || null,
+                    appId: appId || null,
+                    visibility: record.visibility,
+                    source: record.source,
+                    parents: record.parents,
+                    tags: record.tags,
+                    cataloged,
                 }),
             );
 
@@ -246,11 +798,265 @@ api.post(
                 contentType,
                 size: fileBuffer.byteLength,
                 duplicate: !!existing,
+                cataloged,
+                visibility: record.visibility,
+                source: record.source,
+                parents: record.parents,
+                tags: record.tags,
             });
         } catch (error) {
+            if (error instanceof Error && isClientCatalogError(error)) {
+                return c.json({ error: error.message }, 400);
+            }
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List authenticated user's media",
+        responses: {
+            200: {
+                description: "Cataloged media for the authenticated user",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) return c.json({ error: "API key required" }, 401);
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+        if (!authResult.userId) {
+            return c.json({ items: [], nextCursor: null });
+        }
+
+        const url = new URL(c.req.url);
+        const appId = await resolveAppIdFromQuery(
+            url.searchParams.get("app") || url.searchParams.get("app_key_id"),
+            url.searchParams.get("app_key"),
+        );
+        const tag = firstTag(url.searchParams.get("tag"));
+        const prefix = appId
+            ? `${CATALOG_PREFIX}/by-owner-app/${keySegment(authResult.userId)}/${keySegment(appId)}/`
+            : `${CATALOG_PREFIX}/by-owner/${keySegment(authResult.userId)}/`;
+        const result = await listCatalogItems(
+            c.env.MEDIA_BUCKET,
+            prefix,
+            listLimit(url.searchParams.get("limit")),
+            url.searchParams.get("cursor"),
+            true,
+        );
+        if (tag) {
+            result.items = result.items.filter((item) =>
+                Array.isArray(item.tags) ? item.tags.includes(tag) : false,
+            );
+        }
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/gallery",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public app or tag media",
+        responses: {
+            200: {
+                description: "Public media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Missing or invalid app/tag",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const appId = await resolveAppIdFromQuery(
+            url.searchParams.get("app") || url.searchParams.get("app_key_id"),
+            url.searchParams.get("app_key"),
+        );
+        const tag = firstTag(url.searchParams.get("tag"));
+        if (!appId && !tag) {
+            return c.json({ error: "app, app_key, or tag required" }, 400);
+        }
+        const prefix = appId
+            ? `${CATALOG_PREFIX}/public-app/${keySegment(appId)}/`
+            : `${TAG_PREFIX}/${keySegment(tag ?? "")}/`;
+        const result = await listCatalogItems(
+            c.env.MEDIA_BUCKET,
+            prefix,
+            listLimit(url.searchParams.get("limit")),
+            url.searchParams.get("cursor"),
+        );
+        if (tag && appId) {
+            result.items = result.items.filter((item) =>
+                Array.isArray(item.tags) ? item.tags.includes(tag) : false,
+            );
+        }
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/apps/:appKeyId/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media attributed to a verified app",
+        description:
+            "Returns public uploads stamped with the app key id from the verified /account/key response. App attribution is never trusted from upload params.",
+        responses: {
+            200: {
+                description: "Public app media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const appKeyId = c.req.param("appKeyId").trim();
+        const url = new URL(c.req.url);
+        const result = await listCatalogItems(
+            c.env.MEDIA_BUCKET,
+            `${CATALOG_PREFIX}/public-app/${keySegment(appKeyId)}/`,
+            listLimit(url.searchParams.get("limit")),
+            url.searchParams.get("cursor"),
+        );
+        const tag = firstTag(url.searchParams.get("tag"));
+        if (tag) {
+            result.items = result.items.filter((item) =>
+                Array.isArray(item.tags) ? item.tags.includes(tag) : false,
+            );
+        }
+        return c.json(result);
+    },
+);
+
+api.get(
+    "/tags/:tag",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media tagged with a tag",
+        responses: {
+            200: {
+                description: "Public tagged media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const tag = firstTag(c.req.param("tag"));
+        if (!tag) return c.json({ items: [], nextCursor: null });
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${TAG_PREFIX}/${keySegment(tag)}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/tags/:tag/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media tagged with a tag",
+        responses: {
+            200: {
+                description: "Public tagged media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const tag = firstTag(c.req.param("tag"));
+        if (!tag) return c.json({ items: [], nextCursor: null });
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${TAG_PREFIX}/${keySegment(tag)}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/:hash/children",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public or unlisted children of a media object",
+        responses: {
+            200: {
+                description: "Child media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid hash format",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const hash = c.req.param("hash").toLowerCase();
+        if (!HASH_PATTERN.test(hash)) {
+            return c.json({ error: "Invalid hash format" }, 400);
+        }
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${LINEAGE_PREFIX}/by-parent/${hash}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
     },
 );
 
@@ -449,6 +1255,11 @@ app.get("/", (c) => {
         version: "1.0.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
+            myMedia: "GET /me/media (requires API key)",
+            appMedia: "GET /apps/:appKeyId/media",
+            gallery: "GET /gallery?app_key=pk_... or /gallery?tag=...",
+            tagMedia: "GET /tags/:tag/media",
+            children: "GET /:hash/children",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -17,6 +17,28 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    cataloged: boolean;
+    visibility: string;
+    source: string;
+    parents: string[];
+    tags: string[];
+}
+
+interface CatalogItem {
+    entryId: string;
+    hash: string;
+    url: string;
+    visibility: string;
+    tags: string[];
+    parents: string[];
+    ownerId?: string;
+    apiKeyId?: string;
+    verifiedApp: { keyId: string; name: string | null } | null;
+}
+
+interface CatalogList {
+    items: CatalogItem[];
+    nextCursor: string | null;
 }
 
 const VALID_KEY = "pk_test_key_123";
@@ -31,8 +53,14 @@ function mockAuth() {
             200,
             JSON.stringify({
                 valid: true,
+                keyId: "key_user_123",
+                apiKeyId: "key_user_123",
                 type: "publishable",
                 name: "test-user",
+                userId: "user_123",
+                byopClientKeyId: "app_catgpt",
+                byopClientName: "CatGPT",
+                byopClientUserId: "app_owner_123",
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -85,6 +113,7 @@ describe("media.pollinations.ai", () => {
         expect(upload.url).toContain(upload.id);
         expect(upload.contentType).toBe("image/png");
         expect(upload.size).toBe(TINY_PNG.length);
+        expect(upload.cataloged).toBe(true);
 
         // Retrieve — check Content-Disposition
         const getRes = await SELF.fetch(
@@ -124,6 +153,152 @@ describe("media.pollinations.ai", () => {
         const dup = (await dupRes.json()) as UploadResponse;
         expect(dup.id).toBe(upload.id);
         expect(dup.duplicate).toBe(true);
+    });
+
+    it("catalogs owner media, verified app media, tags, and lineage", async () => {
+        const parentForm = new FormData();
+        parentForm.append(
+            "file",
+            new File([TINY_PNG], "parent.png", { type: "image/png" }),
+        );
+        parentForm.append("visibility", "public");
+        parentForm.append("source", "generation");
+        parentForm.append("tags", "catgpt,meme");
+        parentForm.append("prompt", "parent prompt");
+
+        const parentRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload?app=spoofed_app",
+            {
+                method: "POST",
+                body: parentForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(parentRes.status).toBe(200);
+        const parent = (await parentRes.json()) as UploadResponse;
+        expect(parent.cataloged).toBe(true);
+        expect(parent.tags).toEqual(["catgpt", "meme"]);
+
+        const childForm = new FormData();
+        childForm.append(
+            "file",
+            new File([TINY_PNG], "child.png", { type: "image/png" }),
+        );
+        childForm.append("visibility", "public");
+        childForm.append("kind", "edit");
+        childForm.append("parents", parent.url);
+        childForm.append("relationship", "catgpt_reply");
+        childForm.append("tag", "meme");
+
+        const childRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: childForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(childRes.status).toBe(200);
+        const child = (await childRes.json()) as UploadResponse;
+        expect(child.parents).toEqual([parent.id]);
+
+        const meRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media?tag=meme",
+            { headers: { Authorization: `Bearer ${VALID_KEY}` } },
+        );
+        expect(meRes.status).toBe(200);
+        const me = (await meRes.json()) as CatalogList;
+        expect(me.items.some((item) => item.hash === parent.id)).toBe(true);
+        expect(me.items[0].ownerId).toBe("user_123");
+        expect(me.items[0].apiKeyId).toBe("key_user_123");
+
+        const spoofedAppRes = await SELF.fetch(
+            "https://media.pollinations.ai/apps/spoofed_app/media",
+        );
+        const spoofedApp = (await spoofedAppRes.json()) as CatalogList;
+        expect(spoofedApp.items).toHaveLength(0);
+
+        const appRes = await SELF.fetch(
+            "https://media.pollinations.ai/apps/app_catgpt/media?tag=meme",
+        );
+        expect(appRes.status).toBe(200);
+        const app = (await appRes.json()) as CatalogList;
+        expect(app.items.some((item) => item.hash === parent.id)).toBe(true);
+        expect(app.items.some((item) => item.hash === child.id)).toBe(true);
+        expect(app.items[0].ownerId).toBeUndefined();
+        expect(app.items[0].apiKeyId).toBeUndefined();
+        expect(app.items[0].verifiedApp?.keyId).toBe("app_catgpt");
+
+        const childrenRes = await SELF.fetch(
+            `https://media.pollinations.ai/${parent.id}/children`,
+        );
+        expect(childrenRes.status).toBe(200);
+        const children = (await childrenRes.json()) as CatalogList;
+        expect(children.items.map((item) => item.hash)).toContain(child.id);
+
+        const tagRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/meme/media",
+        );
+        expect(tagRes.status).toBe(200);
+        const tagged = (await tagRes.json()) as CatalogList;
+        expect(tagged.items.map((item) => item.hash)).toEqual(
+            expect.arrayContaining([parent.id, child.id]),
+        );
+        expect(tagged.items[0].ownerId).toBeUndefined();
+    });
+
+    it("keeps private media out of public app, tag, and children indexes", async () => {
+        const parentForm = new FormData();
+        parentForm.append(
+            "file",
+            new File([TINY_PNG], "private-parent.png", { type: "image/png" }),
+        );
+        parentForm.append("visibility", "public");
+        const parentRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: parentForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        const parent = (await parentRes.json()) as UploadResponse;
+
+        const privateForm = new FormData();
+        privateForm.append(
+            "file",
+            new File([TINY_PNG], "private-child.png", { type: "image/png" }),
+        );
+        privateForm.append("visibility", "private");
+        privateForm.append("parents", parent.id);
+        privateForm.append("tag", "secret");
+
+        const privateRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: privateForm,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        const privateUpload = (await privateRes.json()) as UploadResponse;
+
+        const [appRes, tagRes, childrenRes] = await Promise.all([
+            SELF.fetch("https://media.pollinations.ai/apps/app_catgpt/media"),
+            SELF.fetch("https://media.pollinations.ai/tags/secret/media"),
+            SELF.fetch(`https://media.pollinations.ai/${parent.id}/children`),
+        ]);
+        const app = (await appRes.json()) as CatalogList;
+        const tag = (await tagRes.json()) as CatalogList;
+        const children = (await childrenRes.json()) as CatalogList;
+
+        expect(app.items.map((item) => item.hash)).not.toContain(
+            privateUpload.id,
+        );
+        expect(tag.items).toHaveLength(0);
+        expect(children.items.map((item) => item.hash)).not.toContain(
+            privateUpload.id,
+        );
     });
 
     it("same content with different filename produces different hash", async () => {


### PR DESCRIPTION
- Adds R2 sidecar media catalog indexes for owner media, app galleries, tags, and remix children.
- Stamps owner and app attribution only from verified /account/key identity.
- Wires CatGPT, voice-edit remix/walkthrough, Chat, AI Dungeon Master, Virtual Makeup, and Product Packaging uploads.
- Keeps public listings free of owner/API-key fields; private media stays out of public indexes.
- Tests cover app spoofing, lineage, tags, visibility, and account key identity.