### PR TITLE
expose baseline_price and cost_usd in developer earnings export

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/developer_earnings.pipe
+++ b/enter.pollinations.ai/observability/endpoints/developer_earnings.pipe
@@ -29,6 +29,8 @@ SQL >
         ge.api_key_client_id AS app_key_id,
         ge.user_id AS user_id,
         ge.start_time AS start_time,
+        ge.dev_price AS baseline_price,
+        ge.total_price AS cost_usd,
         ge.total_price - ge.dev_price AS earned,
         ge.markup_rate AS markup_rate,
         coalesce(nullIf(al.app_name, ''), ge.api_key_client_id) AS app_name
@@ -59,7 +61,9 @@ SQL >
         app_key_id,
         any(app_name) AS app_name,
         count() AS requests,
+        sum(baseline_price) AS baseline_price,
         sum(earned) AS pollen_earned,
+        sum(cost_usd) AS cost_usd,
         avg(markup_rate) AS markup_rate,
         toUInt64(0) AS unique_users
     FROM dev_events
@@ -72,7 +76,9 @@ SQL >
         app_key_id,
         any(app_name) AS app_name,
         count() AS requests,
+        sum(baseline_price) AS baseline_price,
         sum(earned) AS pollen_earned,
+        sum(cost_usd) AS cost_usd,
         avg(markup_rate) AS markup_rate,
         uniq(user_id) AS unique_users
     FROM dev_events
@@ -85,7 +91,9 @@ SQL >
         '' AS app_key_id,
         '' AS app_name,
         count() AS requests,
+        sum(baseline_price) AS baseline_price,
         sum(earned) AS pollen_earned,
+        sum(cost_usd) AS cost_usd,
         if(count() = 0, toFloat64(0), avg(markup_rate)) AS markup_rate,
         uniq(user_id) AS unique_users
     FROM dev_events

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1147,9 +1147,11 @@ export const accountRoutes = new Hono<Env>()
             const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
             const tinybirdToken = requireTinybirdReadToken(c.env);
             const kv = c.env.KV;
+            // v2: payload added `baseline_price` and `cost_usd` — bump to drop
+            // any old cached rows that would render as undefined in CSV.
             const cacheKeyPrefix = devUserOverridden
-                ? `earnings:debug:${devUserId}`
-                : `earnings:${devUserId}`;
+                ? `earnings:v2:debug:${devUserId}`
+                : `earnings:v2:${devUserId}`;
             const periodCacheKey =
                 granularity && period ? `${granularity}:${period}` : `${days}d`;
             const cacheKey = `${cacheKeyPrefix}:${periodCacheKey}:grain:${grain}:${apiKeyIds.length > 0 ? `keys:${apiKeyIds.join(",")}` : "all"}`;

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -528,7 +528,9 @@ type DeveloperEarningsRow = {
     app_key_id: string;
     app_name: string;
     requests: number;
+    baseline_price: number;
     pollen_earned: number;
+    cost_usd: number;
     markup_rate: number;
     unique_users: number;
 };
@@ -544,7 +546,17 @@ const developerEarningsRowSchema = z.object({
         .describe("BYOP app key id; empty string on the global rollup row"),
     app_name: z.string().describe("App display name"),
     requests: z.number().describe("Number of billed requests"),
-    pollen_earned: z.number().describe("Pollen earned (markup take)"),
+    baseline_price: z
+        .number()
+        .describe("Model cost before markup (sum over the bucket)"),
+    pollen_earned: z
+        .number()
+        .describe("Developer credit — markup take (cost_usd − baseline_price)"),
+    cost_usd: z
+        .number()
+        .describe(
+            "Markup-inclusive total charged to payers (sum over the bucket)",
+        ),
     markup_rate: z.number().describe("Average markup rate applied"),
     unique_users: z
         .number()
@@ -566,7 +578,7 @@ const developerEarningsResponseSchema = z.object({
 });
 
 function dailyEarningsRowToCsvRow(row: DeveloperEarningsRow): string {
-    return `${escapeCSV(row.date)},${escapeCSV(row.app_key_id)},${escapeCSV(row.app_name)},${row.requests},${row.pollen_earned},${row.markup_rate}`;
+    return `${escapeCSV(row.date)},${escapeCSV(row.app_key_id)},${escapeCSV(row.app_name)},${row.requests},${row.baseline_price},${row.pollen_earned},${row.cost_usd},${row.markup_rate}`;
 }
 
 async function fetchDetailedUsagePage(
@@ -1088,7 +1100,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Developer Earnings",
             description:
-                "Returns developer earnings (BYOP markup) in one response: per-(date, app) buckets, per-app rollups, and the global rollup across all apps. Earnings = total_price − dev_price. Use `days` for rolling windows or `granularity` and `period` for exact day/week/month periods. Cached for 1 hour. Requires `account:usage` permission when using API keys.",
+                "Returns developer earnings (BYOP markup) in one response: per-(date, app) buckets, per-app rollups, and the global rollup across all apps. Each row breaks the markup math down into `baseline_price` (model cost before markup), `pollen_earned` (developer credit = `cost_usd − baseline_price`), `cost_usd` (markup-inclusive total charged to payers), and average `markup_rate`. Use `days` for rolling windows or `granularity` and `period` for exact day/week/month periods. Cached for 1 hour. Requires `account:usage` permission when using API keys.",
             responses: {
                 200: {
                     description: "Combined earnings buckets and rollups",
@@ -1221,7 +1233,7 @@ export const accountRoutes = new Hono<Env>()
 
                 if (format === "csv") {
                     const header =
-                        "date,app_key_id,app_name,requests,pollen_earned,markup_rate";
+                        "date,app_key_id,app_name,requests,baseline_price,pollen_earned,cost_usd,markup_rate";
                     const rows = payload.daily.map(dailyEarningsRowToCsvRow);
                     const csv = [header, ...rows].join("\n");
 

--- a/enter.pollinations.ai/test/account-earnings.test.ts
+++ b/enter.pollinations.ai/test/account-earnings.test.ts
@@ -1,0 +1,122 @@
+import { SELF } from "cloudflare:test";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+const authHeaders = (sessionToken: string) => ({
+    Cookie: `better-auth.session_token=${sessionToken}`,
+});
+
+const earningsRow = (overrides: Record<string, unknown> = {}) => ({
+    date: "2026-04-14",
+    app_key_id: "key_byop_app_1",
+    app_name: "BYOP App",
+    requests: 5,
+    baseline_price: 0.4,
+    pollen_earned: 0.1,
+    cost_usd: 0.5,
+    markup_rate: 0.25,
+    unique_users: 0,
+    ...overrides,
+});
+
+test("GET /api/account/earnings returns baseline_price, pollen_earned, and cost_usd in JSON", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    mocks.tinybird.state.earningsResponse = [
+        earningsRow(),
+        earningsRow({
+            date: "",
+            requests: 5,
+            baseline_price: 0.4,
+            pollen_earned: 0.1,
+            cost_usd: 0.5,
+            unique_users: 3,
+        }),
+        earningsRow({
+            date: "",
+            app_key_id: "",
+            app_name: "",
+            requests: 5,
+            baseline_price: 0.4,
+            pollen_earned: 0.1,
+            cost_usd: 0.5,
+            unique_users: 3,
+        }),
+    ];
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/earnings?days=30",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+        daily: Record<string, number>[];
+        perApp: Record<string, number>[];
+        global: Record<string, number> | null;
+    };
+
+    expect(body.daily).toHaveLength(1);
+    expect(body.daily[0]).toMatchObject({
+        baseline_price: 0.4,
+        pollen_earned: 0.1,
+        cost_usd: 0.5,
+        markup_rate: 0.25,
+    });
+    expect(body.perApp).toHaveLength(1);
+    expect(body.perApp[0]).toMatchObject({
+        baseline_price: 0.4,
+        pollen_earned: 0.1,
+        cost_usd: 0.5,
+    });
+    expect(body.global).toMatchObject({
+        baseline_price: 0.4,
+        pollen_earned: 0.1,
+        cost_usd: 0.5,
+    });
+});
+
+test("GET /api/account/earnings emits baseline_price/pollen_earned/cost_usd columns in CSV", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    mocks.tinybird.state.earningsResponse = [
+        earningsRow({
+            date: "2026-04-14",
+            baseline_price: 0.4,
+            pollen_earned: 0.1,
+            cost_usd: 0.5,
+            markup_rate: 0.25,
+        }),
+        earningsRow({
+            date: "2026-04-15",
+            baseline_price: 0.8,
+            pollen_earned: 0.2,
+            cost_usd: 1,
+            markup_rate: 0.25,
+        }),
+    ];
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/earnings?days=30&format=csv",
+        { headers: authHeaders(sessionToken) },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/csv");
+
+    const csv = await response.text();
+    const [header, ...rows] = csv.split("\n");
+
+    expect(header).toBe(
+        "date,app_key_id,app_name,requests,baseline_price,pollen_earned,cost_usd,markup_rate",
+    );
+    expect(rows[0]).toBe(
+        "2026-04-14,key_byop_app_1,BYOP App,5,0.4,0.1,0.5,0.25",
+    );
+    expect(rows[1]).toBe("2026-04-15,key_byop_app_1,BYOP App,5,0.8,0.2,1,0.25");
+});

--- a/shared/test/mocks/tinybird.ts
+++ b/shared/test/mocks/tinybird.ts
@@ -24,6 +24,7 @@ export type MockTinybirdState = {
     stripeEvents: Record<string, unknown>[];
     dailyResponse: UsageRow[];
     usageResponse: UsageRow[];
+    earningsResponse: UsageRow[];
     pipeCalls: PipeCall[];
 };
 
@@ -34,6 +35,7 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
         stripeEvents: [],
         dailyResponse: [],
         usageResponse: [],
+        earningsResponse: [],
         pipeCalls: [],
     };
 
@@ -80,6 +82,10 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
         .get("/v0/pipes/user_usage_daily_filtered.json", (c) => {
             state.pipeCalls.push({ url: c.req.url, query: c.req.query() });
             return c.json({ data: state.dailyResponse }, 200);
+        })
+        .get("/v0/pipes/developer_earnings.json", (c) => {
+            state.pipeCalls.push({ url: c.req.url, query: c.req.query() });
+            return c.json({ data: state.earningsResponse }, 200);
         });
 
     const handlerMap = {
@@ -92,6 +98,7 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
         state.stripeEvents = [];
         state.dailyResponse = [];
         state.usageResponse = [];
+        state.earningsResponse = [];
         state.pipeCalls = [];
     };
 


### PR DESCRIPTION
- Adds `baseline_price` (sum of `dev_price`) and `cost_usd` (sum of `total_price`) to `/account/earnings` JSON and CSV
- Per-bucket markup math is now `baseline_price + pollen_earned = cost_usd @ markup_rate`
- `pollen_earned` and `markup_rate` already existed, kept as-is
- `/account/usage` intentionally unchanged — breakdown lives on the earnings export only
- New `account-earnings.test.ts` covers JSON shape and CSV header/rows

Pipe (`developer_earnings.pipe`) needs to be deployed to Tinybird staging then prod before this merges, otherwise `baseline_price` / `cost_usd` come back as undefined.

Fixes #10735