### PR TITLE
feat(media): add saved media reference catalog

### DIFF
--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -3,11 +3,13 @@
 const API = "https://gen.pollinations.ai/image";
 const ENTER = "https://enter.pollinations.ai";
 const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA_SAVE = "https://media.pollinations.ai/save";
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const AUTH_KEY = "catgpt_api_key";
 const APP_KEY = "pk_uWjreBEkxFAhjDHo";
+export const CATGPT_APP_KEY = APP_KEY;
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -120,6 +122,33 @@ export function generateImageURL(prompt, model, imageUrl = null) {
         url += `&enhance=true&image=${encodeURIComponent(ORIGINAL_CATGPT)}`;
     }
     return url;
+}
+
+export async function saveGeneratedMemeReference(prompt, url, model) {
+    const key = getStoredApiKey();
+    if (!key || !url) return null;
+
+    try {
+        const res = await fetch(MEDIA_SAVE, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${key}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                url,
+                visibility: "public",
+                prompt,
+                model,
+                tags: ["catgpt", "meme"],
+            }),
+        });
+        if (!res.ok) return null;
+        return res.json();
+    } catch (err) {
+        console.warn("Media catalog save failed:", err);
+        return null;
+    }
 }
 
 // ── Models ──────────────────────────────────────────────────────────────────

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">Public Gallery</h2>
+            <div class="your-memes-grid" id="publicGalleryGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -1,6 +1,7 @@
 // CatGPT Meme Generator — UI, state, and DOM logic
 
 import {
+    CATGPT_APP_KEY,
     clearApiKey,
     createImageGenerationPrompt,
     EXAMPLE_PROMPTS,
@@ -13,6 +14,7 @@ import {
     getStoredApiKey,
     handleImageUpload,
     pickModel,
+    saveGeneratedMemeReference,
     storeApiKey,
 } from "./ai.js";
 
@@ -75,6 +77,7 @@ const dom = {
     shareBtn: $("shareBtn"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
+    publicGalleryGrid: $("publicGalleryGrid"),
     imageUpload: $("imageUpload"),
     imageUploadContainer: $("imageUploadContainer"),
     imageThumbnailContainer: $("imageThumbnailContainer"),
@@ -352,6 +355,36 @@ function loadUserMemes() {
     });
 }
 
+async function loadPublicGallery() {
+    if (!dom.publicGalleryGrid) return;
+    dom.publicGalleryGrid.innerHTML = "";
+    try {
+        const res = await fetch(
+            `https://media.pollinations.ai/gallery?${new URLSearchParams({
+                app_key: CATGPT_APP_KEY,
+                limit: "8",
+            })}`,
+        );
+        if (!res.ok) throw new Error("gallery failed");
+        const data = await res.json();
+        const items = Array.isArray(data.items) ? data.items : [];
+        if (!items.length) {
+            const p = document.createElement("p");
+            p.textContent = "No public memes saved yet.";
+            p.style.cssText =
+                "grid-column: 1/-1; text-align: center; color: var(--color-muted); padding: 2rem; font-style: italic;";
+            dom.publicGalleryGrid.appendChild(p);
+            return;
+        }
+        items.forEach((item, i) => {
+            const card = createMemeCard(item.prompt || "CatGPT", i, item.url);
+            if (card) dom.publicGalleryGrid.appendChild(card);
+        });
+    } catch (error) {
+        console.warn("Could not load public gallery:", error);
+    }
+}
+
 function loadExamples() {
     dom.examplesGrid.innerHTML = "";
     EXAMPLE_PROMPTS.forEach((q, i) => {
@@ -411,17 +444,24 @@ async function generateMeme() {
             throw new Error(text.slice(0, 200) || `Error ${response.status}`);
         }
 
-        // Use the pollinations URL directly (shareable, cacheable)
+        // Save the generated URL as a catalog reference; no blob re-upload.
         await response.blob(); // ensure the image is fully loaded
         if (cancelled) return;
-        dom.generatedMeme.src = imageUrl;
+        const saved = await saveGeneratedMemeReference(
+            question,
+            imageUrl,
+            activeModel,
+        );
+        const finalUrl = saved?.url || imageUrl;
+        dom.generatedMeme.src = finalUrl;
 
         resetButton();
         show(dom.resultSection);
         scrollToGenerator();
         celebrate();
-        saveGeneratedMeme(question, imageUrl);
+        saveGeneratedMeme(question, finalUrl);
         loadUserMemes();
+        loadPublicGallery();
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +658,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadPublicGallery();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/chat/src/utils/api.js
+++ b/apps/chat/src/utils/api.js
@@ -1,5 +1,6 @@
 // Pollinations API utilities — updated to match gen.pollinations.ai spec
 const BASE_URL = "https://gen.pollinations.ai";
+const MEDIA_SAVE_URL = "https://media.pollinations.ai/save";
 const ENV_API_TOKEN = import.meta.env.VITE_POLLINATIONS_API_KEY || "";
 export const BYOP_STORAGE_KEY = "pollinations_byop_api_key";
 
@@ -73,6 +74,39 @@ const parseApiError = async (response) => {
         /* ignore */
     }
     return buildClientError(response.status);
+};
+
+const blobToDataUrl = (blob) =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+
+const saveGeneratedReference = async (url, token, fields) => {
+    if (!token) return null;
+    try {
+        const response = await fetch(MEDIA_SAVE_URL, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                url,
+                visibility: "private",
+                tags: ["chat"],
+                ...fields,
+            }),
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        return data.url || null;
+    } catch (error) {
+        console.warn("Media catalog save failed:", error);
+        return null;
+    }
 };
 
 export const loadModels = async () => {
@@ -530,13 +564,19 @@ export const generateImage = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, width, height, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
+    const savedUrl = await saveGeneratedReference(url, token, {
+        prompt,
+        model,
+        tags: ["chat", "chat-image"],
     });
+    return {
+        url: savedUrl || (await blobToDataUrl(blob)),
+        prompt,
+        model,
+        width,
+        height,
+        seed,
+    };
 };
 
 export const generateVideo = async (prompt, options = {}) => {
@@ -556,13 +596,17 @@ export const generateVideo = async (prompt, options = {}) => {
     if (!response.ok) throw await parseApiError(response);
 
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, prompt, model, seed });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
+    const savedUrl = await saveGeneratedReference(url, token, {
+        prompt,
+        model,
+        tags: ["chat", "chat-video"],
     });
+    return {
+        url: savedUrl || (await blobToDataUrl(blob)),
+        prompt,
+        model,
+        seed,
+    };
 };
 
 // Generate speech/audio — GET /audio/{text}?voice=...
@@ -578,11 +622,16 @@ export const generateAudio = async (text, options = {}) => {
 
     const blob = await response.blob();
     const mimeType = blob.type || "audio/mpeg";
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () =>
-            resolve({ url: reader.result, text, voice, model, mimeType });
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
+    const savedUrl = await saveGeneratedReference(url, token, {
+        prompt: text,
+        model,
+        tags: ["chat", "chat-audio"],
     });
+    return {
+        url: savedUrl || (await blobToDataUrl(blob)),
+        text,
+        voice,
+        model,
+        mimeType,
+    };
 };

--- a/apps/product-packaging-designer/src/App.tsx
+++ b/apps/product-packaging-designer/src/App.tsx
@@ -12,7 +12,7 @@ import {
     Sun,
     Upload,
 } from "lucide-react";
-import { type React, useEffect, useState } from "react";
+import { type ChangeEvent, useEffect, useState } from "react";
 
 type StyleOption = {
     id: string;
@@ -79,7 +79,8 @@ const packagingTypes: PackagingType[] = [
     { id: "can", label: "Can", icon: Package, prompt: "can packaging" },
 ];
 const POLLINATIONS_API = "https://gen.pollinations.ai/image";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
+const POLLINATIONS_MEDIA_SAVE_API = "https://media.pollinations.ai/save";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const MAX_DISPLAY_SIZE = 10 * 1024 * 1024;
@@ -189,7 +190,7 @@ function App() {
         localStorage.setItem("theme", newTheme);
     };
 
-    const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
         // Check authentication first
         if (!isAuthenticated || !apiKey) {
             alert("Please authenticate with Pollinations to upload images.");
@@ -305,6 +306,36 @@ function App() {
         }
     };
 
+    const saveGeneratedReference = async (
+        url: string,
+        prompt: string,
+    ): Promise<string | null> => {
+        if (!apiKey) return null;
+
+        try {
+            const response = await fetch(POLLINATIONS_MEDIA_SAVE_API, {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    url,
+                    visibility: "private",
+                    tags: ["product-packaging-designer"],
+                    prompt,
+                    model: "nanobanana",
+                }),
+            });
+            if (!response.ok) return null;
+            const data = await response.json();
+            return typeof data.url === "string" ? data.url : null;
+        } catch (error) {
+            console.warn("Media catalog save failed:", error);
+            return null;
+        }
+    };
+
     const generatePackaging = async () => {
         // Check authentication
         if (!isAuthenticated || !apiKey) {
@@ -386,7 +417,8 @@ ${brandName.trim() ? ` Brand name: "${brandName}".` : ""}
 
             const blob = await response.blob();
             const blobUrl = URL.createObjectURL(blob);
-            setGeneratedImage(blobUrl);
+            const savedUrl = await saveGeneratedReference(imageUrl, prompt);
+            setGeneratedImage(savedUrl || blobUrl);
             setImageLoaded(true);
         } catch (error) {
             console.error("Error in generatePackaging:", error);

--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -6,6 +6,7 @@ import {
 } from './types';
 
 const POLLINATIONS_API_BASE = 'https://gen.pollinations.ai';
+const MEDIA_SAVE_URL = 'https://media.pollinations.ai/save';
 const DEFAULT_CONFIG = {
   model: 'gptimage' as const,
   enhance: true,
@@ -93,8 +94,9 @@ export class PollinationsService {
         }
       }
 
+      await response.blob();
       const result: ImageGenerationResponse = {
-        url: url.toString(),
+        url: await this.saveGeneratedReference(url.toString(), payload.prompt, payload.model || DEFAULT_CONFIG.model) || url.toString(),
         provider: 'pollinations',
         seed: payload.seed,
         cached: false,
@@ -114,6 +116,38 @@ export class PollinationsService {
       return url.protocol === 'http:' || url.protocol === 'https:';
     } catch {
       return false;
+    }
+  }
+
+  private getToken(): string | null {
+    return this.token || import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 || import.meta.env.VITE_POLLINATIONS_AI_TOKEN || null;
+  }
+
+  private async saveGeneratedReference(url: string, prompt: string, model: string): Promise<string | null> {
+    const token = this.getToken();
+    if (!token) return null;
+
+    try {
+      const response = await fetch(MEDIA_SAVE_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          url,
+          visibility: 'private',
+          tags: ['slidepainter'],
+          prompt,
+          model,
+        }),
+      });
+      if (!response.ok) return null;
+      const data = await response.json() as { url?: string };
+      return data.url || null;
+    } catch (error) {
+      console.warn('Media catalog save failed:', error);
+      return null;
     }
   }
 }

--- a/apps/virtual-makeup/src/App.jsx
+++ b/apps/virtual-makeup/src/App.jsx
@@ -14,7 +14,8 @@ import { useEffect, useRef, useState } from "react";
 
 const APP_KEY = "pk_pollinations_virtual_makeup";
 const POLLINATIONS_AUTH_URL = "https://enter.pollinations.ai/authorize";
-const POLLINATIONS_MEDIA_API = "https://gen.pollinations.ai/media";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
+const POLLINATIONS_MEDIA_SAVE_API = "https://media.pollinations.ai/save";
 const POLLINATIONS_IMAGE_API = "https://gen.pollinations.ai/image";
 
 const MAKEUP_STYLES = [
@@ -139,6 +140,33 @@ function App() {
         return data.url || data.secure_url || data.media_url;
     };
 
+    const saveGeneratedReference = async (url, prompt) => {
+        if (!apiKey) return null;
+
+        try {
+            const response = await fetch(POLLINATIONS_MEDIA_SAVE_API, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    url,
+                    visibility: "private",
+                    tags: ["virtual-makeup"],
+                    prompt,
+                    model: "nanobanana",
+                }),
+            });
+            if (!response.ok) return null;
+            const data = await response.json();
+            return typeof data.url === "string" ? data.url : null;
+        } catch (error) {
+            console.warn("Media catalog save failed:", error);
+            return null;
+        }
+    };
+
     const applyMakeup = async () => {
         if (!uploadedImage || !uploadedFile || !apiKey) return;
 
@@ -173,7 +201,8 @@ function App() {
 
             const blob = await response.blob();
             const blobUrl = URL.createObjectURL(blob);
-            setMakeupImage(blobUrl);
+            const savedUrl = await saveGeneratedReference(apiUrl, prompt);
+            setMakeupImage(savedUrl || blobUrl);
             setImageLoaded(true);
             setIsLoading(false);
         } catch (error) {

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1431,6 +1431,9 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Whether the API key is valid and active",
                                         ),
+                                    keyId: z
+                                        .string()
+                                        .describe("Stable API key id"),
                                     type: z
                                         .enum(["publishable", "secret"])
                                         .describe("Type of API key"),
@@ -1439,6 +1442,36 @@ export const accountRoutes = new Hono<Env>()
                                         .nullable()
                                         .describe(
                                             "Display name of the API key",
+                                        ),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user id for this API key",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Publishable app key id that minted this key, when present",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Display name for the app that minted this key, when present",
+                                        ),
+                                    appId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Alias of byopClientKeyId for server-attested app attribution",
+                                        ),
+                                    appName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Alias of byopClientName for server-attested app attribution",
                                         ),
                                     expiresAt: z
                                         .string()
@@ -1548,8 +1581,14 @@ export const accountRoutes = new Hono<Env>()
 
             return c.json({
                 valid: true, // If we got here, the key is valid
+                keyId: apiKey.id,
                 type: keyType,
                 name: apiKey.name || null,
+                userId: c.var.auth.user?.id || null,
+                byopClientKeyId: apiKey.byopClientKeyId || null,
+                byopClientName: apiKey.byopClientName || null,
+                appId: apiKey.byopClientKeyId || null,
+                appName: apiKey.byopClientName || null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -39,6 +39,12 @@ test(
 
         const data = await response.json();
         expect(data.valid).toBe(true);
+        expect(data).toHaveProperty("keyId");
+        expect(data).toHaveProperty("userId");
+        expect(data).toHaveProperty("byopClientKeyId");
+        expect(data).toHaveProperty("byopClientName");
+        expect(data).toHaveProperty("appId");
+        expect(data).toHaveProperty("appName");
         expect(data.type).toBe("secret");
         expect(data.name).toBeTruthy();
         expect(data).toHaveProperty("expiresAt");

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -16,6 +16,13 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const CATALOG_PREFIX = "catalog/v1";
+const TAG_PREFIX = "tags/v1";
+const MAX_LIST_LIMIT = 100;
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_TAGS = 8;
+const TAG_PATTERN = /^[a-z0-9][a-z0-9._:+-]{0,95}$/i;
+const FACET_PATTERN = /^[a-z0-9][a-z0-9._-]{0,95}$/i;
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
@@ -24,8 +31,15 @@ interface Env {
 
 interface AuthResult {
     valid: boolean;
+    keyId?: string;
+    apiKeyId?: string;
     type: string;
     name: string | null;
+    userId?: string | null;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    appId?: string | null;
+    appName?: string | null;
 }
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
@@ -57,16 +71,68 @@ function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
 }
 
+type Visibility = "private" | "public";
+
+type CatalogInput = {
+    url?: string;
+    visibility: Visibility;
+    tags: string[];
+    prompt: string | null;
+    model: string | null;
+};
+
+type CatalogItem = {
+    id: string;
+    url: string;
+    createdAt: string;
+    visibility: Visibility;
+    ownerId?: string;
+    ownerName?: string;
+    appId?: string;
+    appName?: string;
+    tags?: string[];
+    prompt?: string;
+    model?: string;
+    contentType?: string;
+    size?: number;
+};
+
 const UploadResponseSchema = z.object({
     id: z.string().describe("16-char hex content hash"),
     url: z.string().describe("Public retrieval URL"),
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    cataloged: z
+        .boolean()
+        .optional()
+        .describe("true if a catalog reference was written"),
 });
 
 const ErrorSchema = z.object({
     error: z.string(),
+});
+
+const CatalogItemSchema = z.object({
+    id: z.string(),
+    url: z.string(),
+    createdAt: z.string(),
+    visibility: z.enum(["private", "public"]),
+    ownerId: z.string().optional(),
+    ownerName: z.string().optional(),
+    appId: z.string().optional(),
+    appName: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    prompt: z.string().optional(),
+    model: z.string().optional(),
+    contentType: z.string().optional(),
+    size: z.number().int().optional(),
+});
+
+const CatalogListResponseSchema = z.object({
+    items: z.array(CatalogItemSchema),
+    cursor: z.string().optional(),
+    nextCursor: z.string().optional(),
 });
 
 const MetadataResponseSchema = z.object({
@@ -80,6 +146,348 @@ const MetadataResponseSchema = z.object({
 });
 
 const api = new Hono<{ Bindings: Env }>();
+
+function stringField(
+    fields: FormData | URLSearchParams | Record<string, unknown>,
+    key: string,
+): string | null {
+    const value =
+        fields instanceof FormData || fields instanceof URLSearchParams
+            ? fields.get(key)
+            : fields[key];
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function collectFieldValues(
+    fields: FormData | URLSearchParams | Record<string, unknown>,
+    keys: string[],
+): string[] {
+    const values: string[] = [];
+    for (const key of keys) {
+        if (fields instanceof FormData || fields instanceof URLSearchParams) {
+            for (const value of fields.getAll(key)) {
+                if (typeof value === "string") values.push(value);
+            }
+            continue;
+        }
+
+        const value = fields[key];
+        if (Array.isArray(value)) {
+            values.push(
+                ...value.filter(
+                    (entry): entry is string => typeof entry === "string",
+                ),
+            );
+        } else if (typeof value === "string") {
+            values.push(value);
+        }
+    }
+    return values;
+}
+
+function splitTagList(value: string): string[] {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith("[")) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) {
+                return parsed.filter(
+                    (entry): entry is string => typeof entry === "string",
+                );
+            }
+        } catch {
+            // Fall through to comma splitting.
+        }
+    }
+    return trimmed.split(",").map((part) => part.trim());
+}
+
+function normalizeTag(raw: string): string | null {
+    const tag = raw.trim().toLowerCase();
+    return TAG_PATTERN.test(tag) ? tag : null;
+}
+
+function normalizeTags(
+    fields: FormData | URLSearchParams | Record<string, unknown>,
+): string[] {
+    const tags = new Set<string>();
+    for (const value of collectFieldValues(fields, ["tag", "tags"])) {
+        for (const part of splitTagList(value)) {
+            const tag = normalizeTag(part);
+            if (tag) tags.add(tag);
+            if (tags.size >= MAX_TAGS) return [...tags];
+        }
+    }
+    return [...tags];
+}
+
+function parseVisibility(value: string | null): Visibility {
+    return value === "public" ? "public" : "private";
+}
+
+function boundedText(value: string | null, maxLength: number): string | null {
+    if (!value) return null;
+    return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function parseCatalogInput(
+    fields: FormData | URLSearchParams | Record<string, unknown>,
+): CatalogInput {
+    return {
+        url: stringField(fields, "url") || undefined,
+        visibility: parseVisibility(stringField(fields, "visibility")),
+        tags: normalizeTags(fields),
+        prompt: boundedText(stringField(fields, "prompt"), 500),
+        model: boundedText(stringField(fields, "model"), 80),
+    };
+}
+
+function authUserId(auth: AuthResult): string | null {
+    return auth.userId || null;
+}
+
+function authAppId(auth: AuthResult): string | null {
+    return auth.byopClientKeyId || auth.appId || null;
+}
+
+function authAppName(auth: AuthResult): string | null {
+    return auth.byopClientName || auth.appName || null;
+}
+
+async function resolveAppIdFromQuery(
+    app: string | null,
+    appKey: string | null,
+): Promise<string | null> {
+    if (app?.trim()) {
+        const normalized = app.trim();
+        return FACET_PATTERN.test(normalized) ? normalized : null;
+    }
+    if (!appKey?.trim()) return null;
+    const auth = await verifyApiKey(appKey.trim());
+    return auth?.keyId || auth?.apiKeyId || null;
+}
+
+function reverseTimestamp(now = Date.now()): string {
+    return String(Number.MAX_SAFE_INTEGER - now).padStart(16, "0");
+}
+
+function catalogIndexKey(prefix: string, id: string, now = Date.now()): string {
+    return `${prefix}/${reverseTimestamp(now)}-${id}.json`;
+}
+
+function catalogItemKey(id: string): string {
+    return `${CATALOG_PREFIX}/items/${id}.json`;
+}
+
+async function putJson(bucket: R2Bucket, key: string, value: unknown) {
+    await bucket.put(key, JSON.stringify(value), {
+        httpMetadata: {
+            contentType: "application/json",
+            cacheControl: "no-store",
+        },
+    });
+}
+
+function publicCatalogItem(item: CatalogItem): CatalogItem {
+    const { ownerId: _ownerId, ownerName: _ownerName, ...publicItem } = item;
+    return publicItem;
+}
+
+async function readCatalogItem(
+    bucket: R2Bucket,
+    key: string,
+    includeOwner = false,
+): Promise<CatalogItem | null> {
+    const object = await bucket.get(key);
+    if (!object) return null;
+    try {
+        const item = (await object.json()) as CatalogItem;
+        return includeOwner ? item : publicCatalogItem(item);
+    } catch {
+        return null;
+    }
+}
+
+async function listCatalogItems(
+    bucket: R2Bucket,
+    prefix: string,
+    limit: number,
+    cursor?: string | null,
+    includeOwner = false,
+): Promise<{ items: CatalogItem[]; cursor?: string; nextCursor?: string }> {
+    const list = await bucket.list({
+        prefix,
+        limit: Math.min(limit * 3, 1000),
+        cursor: cursor || undefined,
+    });
+    const seen = new Set<string>();
+    const items: CatalogItem[] = [];
+    for (const object of list.objects) {
+        const item = await readCatalogItem(
+            bucket,
+            object.key,
+            includeOwner,
+        );
+        if (!item || seen.has(item.id)) continue;
+        seen.add(item.id);
+        items.push(item);
+        if (items.length >= limit) break;
+    }
+    return {
+        items,
+        ...(list.truncated && list.cursor
+            ? { cursor: list.cursor, nextCursor: list.cursor }
+            : {}),
+    };
+}
+
+function listLimit(raw: string | null): number {
+    const parsed = Number.parseInt(raw || "", 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIST_LIMIT;
+    return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
+async function stableId(value: string): Promise<string> {
+    const hashBuffer = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(value),
+    );
+    return Array.from(new Uint8Array(hashBuffer))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")
+        .substring(0, 16);
+}
+
+function mediaHashFromUrl(url: string): string | null {
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname !== DOMAIN) return null;
+        const hash = parsed.pathname.split("/").filter(Boolean)[0];
+        return hash && HASH_PATTERN.test(hash) ? hash.toLowerCase() : null;
+    } catch {
+        return null;
+    }
+}
+
+function normalizePollinationsUrl(raw: string): string | null {
+    try {
+        const url = new URL(raw);
+        if (url.protocol !== "https:") return null;
+
+        if (url.hostname === DOMAIN) {
+            const hash = url.pathname.split("/").filter(Boolean)[0];
+            return hash && HASH_PATTERN.test(hash) ? mediaUrl(hash) : null;
+        }
+
+        if (url.hostname === "gen.pollinations.ai") {
+            const [kind] = url.pathname.split("/").filter(Boolean);
+            if (!["image", "video", "audio"].includes(kind || "")) {
+                return null;
+            }
+            for (const secretParam of ["key", "api_key", "token"]) {
+                url.searchParams.delete(secretParam);
+            }
+            return url.toString();
+        }
+    } catch {
+        return null;
+    }
+    return null;
+}
+
+async function buildCatalogItem(params: {
+    auth: AuthResult;
+    input: CatalogInput;
+    url: string;
+    contentType?: string;
+    size?: number;
+    id?: string;
+}): Promise<CatalogItem | null> {
+    const normalizedUrl = normalizePollinationsUrl(params.url);
+    if (!normalizedUrl) return null;
+    const id =
+        params.id || mediaHashFromUrl(normalizedUrl) || (await stableId(normalizedUrl));
+    const ownerId = authUserId(params.auth);
+    const appId = authAppId(params.auth);
+    const appName = authAppName(params.auth);
+    return {
+        id,
+        url: normalizedUrl,
+        createdAt: new Date().toISOString(),
+        visibility: params.input.visibility,
+        ...(ownerId && { ownerId }),
+        ...(params.auth.name && { ownerName: params.auth.name }),
+        ...(appId && { appId }),
+        ...(appName && { appName }),
+        ...(params.input.tags.length > 0 && { tags: params.input.tags }),
+        ...(params.input.prompt && { prompt: params.input.prompt }),
+        ...(params.input.model && { model: params.input.model }),
+        ...(params.contentType && { contentType: params.contentType }),
+        ...(params.size !== undefined && { size: params.size }),
+    };
+}
+
+async function writeCatalogEntries(
+    bucket: R2Bucket,
+    item: CatalogItem,
+): Promise<boolean> {
+    const now = Date.now();
+    const keys = [catalogItemKey(item.id)];
+
+    if (item.ownerId) {
+        keys.push(
+            catalogIndexKey(
+                `${CATALOG_PREFIX}/by-owner/${item.ownerId}`,
+                item.id,
+                now,
+            ),
+        );
+        if (item.appId) {
+            keys.push(
+                catalogIndexKey(
+                    `${CATALOG_PREFIX}/by-owner-app/${item.ownerId}/${item.appId}`,
+                    item.id,
+                    now,
+                ),
+            );
+        }
+    }
+
+    if (item.visibility === "public") {
+        if (item.appId) {
+            keys.push(
+                catalogIndexKey(
+                    `${CATALOG_PREFIX}/public-app/${item.appId}`,
+                    item.id,
+                    now,
+                ),
+            );
+        }
+        for (const tag of item.tags || []) {
+            keys.push(catalogIndexKey(`${TAG_PREFIX}/${tag}`, item.id, now));
+            if (item.appId) {
+                keys.push(
+                    catalogIndexKey(
+                        `${TAG_PREFIX}/by-app/${item.appId}/${tag}`,
+                        item.id,
+                        now,
+                    ),
+                );
+            }
+        }
+    }
+
+    const results = await Promise.allSettled(
+        keys.map((key) => putJson(bucket, key, item)),
+    );
+    for (const result of results) {
+        if (result.status === "rejected") {
+            console.error("Catalog index write failed:", result.reason);
+        }
+    }
+    return results.every((result) => result.status === "fulfilled");
+}
 
 api.post(
     "/upload",
@@ -140,12 +548,14 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        let catalogInput = parseCatalogInput(new URL(c.req.url).searchParams);
 
         const requestContentType = c.req.header("content-type") || "";
 
         try {
             if (requestContentType.includes("multipart/form-data")) {
                 const formData = await c.req.formData();
+                catalogInput = parseCatalogInput(formData);
                 const file = formData.get("file") as File | null;
 
                 if (!(file instanceof File)) {
@@ -169,7 +579,13 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
+                    visibility?: string;
+                    tag?: string | string[];
+                    tags?: string | string[];
+                    prompt?: string;
+                    model?: string;
                 }>();
+                catalogInput = parseCatalogInput(body);
 
                 if (!body.data) {
                     return c.json(
@@ -240,17 +656,280 @@ api.post(
                 }),
             );
 
+            const catalogItem = await buildCatalogItem({
+                auth: authResult,
+                input: catalogInput,
+                url: mediaUrl(hash),
+                contentType,
+                size: fileBuffer.byteLength,
+                id: hash,
+            });
+            const cataloged = catalogItem
+                ? await writeCatalogEntries(c.env.MEDIA_BUCKET, catalogItem)
+                : false;
+
             return c.json({
                 id: hash,
                 url: mediaUrl(hash),
                 contentType,
                 size: fileBuffer.byteLength,
                 duplicate: !!existing,
+                cataloged,
             });
         } catch (error) {
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.post(
+    "/save",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "Save a media reference",
+        description:
+            "Catalog an existing Pollinations media or generation URL without uploading bytes. Use tags for app-specific grouping such as parent:<hash> or recipe:water+fire.",
+        responses: {
+            200: {
+                description: "Catalog item",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogItemSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid URL or catalog data",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) return c.json({ error: "API key required" }, 401);
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+
+        try {
+            const requestContentType = c.req.header("content-type") || "";
+            const fields = requestContentType.includes("multipart/form-data")
+                ? await c.req.formData()
+                : requestContentType.includes("application/json")
+                  ? await c.req.json<Record<string, unknown>>()
+                  : new URL(c.req.url).searchParams;
+            const input = parseCatalogInput(fields);
+            if (!input.url) return c.json({ error: "Missing url" }, 400);
+
+            const item = await buildCatalogItem({
+                auth: authResult,
+                input,
+                url: input.url,
+            });
+            if (!item) {
+                return c.json(
+                    {
+                        error: "URL must be a media.pollinations.ai URL or a gen.pollinations.ai image/video/audio URL",
+                    },
+                    400,
+                );
+            }
+
+            const ok = await writeCatalogEntries(c.env.MEDIA_BUCKET, item);
+            if (!ok) return c.json({ error: "Catalog write failed" }, 500);
+            return c.json(item);
+        } catch (error) {
+            console.error("Save error:", error);
+            return c.json({ error: "Save failed" }, 500);
+        }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List authenticated user's saved media",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) return c.json({ error: "API key required" }, 401);
+        const authResult = await verifyApiKey(apiKey);
+        const ownerId = authResult && authUserId(authResult);
+        if (!ownerId) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+
+        const url = new URL(c.req.url);
+        const app = url.searchParams.get("app");
+        const appKey = url.searchParams.get("app_key");
+        const appId = await resolveAppIdFromQuery(app, appKey);
+        if ((app || appKey) && !appId) {
+            return c.json({ error: "Invalid app or app_key" }, 400);
+        }
+        const prefix = appId
+            ? `${CATALOG_PREFIX}/by-owner-app/${ownerId}/${appId}/`
+            : `${CATALOG_PREFIX}/by-owner/${ownerId}/`;
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                prefix,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+                true,
+            ),
+        );
+    },
+);
+
+api.get(
+    "/gallery",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public app media",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Missing or invalid app",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const url = new URL(c.req.url);
+        const app = url.searchParams.get("app");
+        const appKey = url.searchParams.get("app_key");
+        const appId = await resolveAppIdFromQuery(app, appKey);
+        if (!appId) return c.json({ error: "app or app_key required" }, 400);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${CATALOG_PREFIX}/public-app/${appId}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/apps/:app/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media for a verified app id",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid app id",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const app = c.req.param("app");
+        if (!FACET_PATTERN.test(app)) {
+            return c.json({ error: "Invalid app id" }, 400);
+        }
+        const url = new URL(c.req.url);
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                `${CATALOG_PREFIX}/public-app/${app}/`,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
+    },
+);
+
+api.get(
+    "/tags/:tag",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media tagged with a user tag",
+        responses: {
+            200: {
+                description: "Catalog items",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid tag or app",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const tag = normalizeTag(c.req.param("tag"));
+        if (!tag) return c.json({ error: "Invalid tag" }, 400);
+
+        const url = new URL(c.req.url);
+        const app = url.searchParams.get("app");
+        const appKey = url.searchParams.get("app_key");
+        const appId = await resolveAppIdFromQuery(app, appKey);
+        if ((app || appKey) && !appId) {
+            return c.json({ error: "Invalid app or app_key" }, 400);
+        }
+        const prefix = appId
+            ? `${TAG_PREFIX}/by-app/${appId}/${tag}/`
+            : `${TAG_PREFIX}/${tag}/`;
+        return c.json(
+            await listCatalogItems(
+                c.env.MEDIA_BUCKET,
+                prefix,
+                listLimit(url.searchParams.get("limit")),
+                url.searchParams.get("cursor"),
+            ),
+        );
     },
 );
 
@@ -452,6 +1131,10 @@ app.get("/", (c) => {
         version: "1.0.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
+            save: "POST /save (requires API key)",
+            myMedia: "GET /me/media (requires API key)",
+            gallery: "GET /gallery?app_key=pk_...",
+            tags: "GET /tags/:tag",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },
@@ -468,7 +1151,7 @@ app.get("/openapi.json", async (c, next) => {
                 title: "media.pollinations.ai",
                 version: "1.0.0",
                 description:
-                    "Content-addressed media storage. Upload images, audio, and video with deduplication via SHA-256 hashing. Uploads require a pollinations.ai API key (`pk_` or `sk_`). Retrieval is public.",
+                    "Content-addressed media storage plus a lightweight catalog for saved Pollinations media references. Uploads and saves require a pollinations.ai API key (`pk_` or `sk_`). Retrieval and public catalog reads are public.",
             },
             servers: [{ url: `https://${DOMAIN}` }],
             components: {

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -17,6 +17,20 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    cataloged?: boolean;
+}
+
+interface CatalogItem {
+    id: string;
+    url: string;
+    visibility: "private" | "public";
+    ownerId?: string;
+    appId?: string;
+    tags?: string[];
+}
+
+interface CatalogList {
+    items: CatalogItem[];
 }
 
 const VALID_KEY = "pk_test_key_123";
@@ -31,8 +45,12 @@ function mockAuth() {
             200,
             JSON.stringify({
                 valid: true,
+                keyId: "app-test",
                 type: "publishable",
                 name: "test-user",
+                userId: "user-test",
+                byopClientKeyId: "app-test",
+                byopClientName: "Test App",
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -152,6 +170,117 @@ describe("media.pollinations.ai", () => {
         const upload1 = (await res1.json()) as UploadResponse;
         const upload2 = (await res2.json()) as UploadResponse;
         expect(upload1.id).not.toBe(upload2.id);
+    });
+
+    it("catalogs uploads for owner, app gallery, and tags", async () => {
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "catalog.png", { type: "image/png" }),
+        );
+        form.append("visibility", "public");
+        form.append("tag", "catgpt");
+        form.append("tag", "parent:0000000000000000");
+        form.append("prompt", "cat with a hat");
+        form.append("model", "flux");
+
+        const uploadRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload?ownerId=spoofed&appId=spoofed",
+            {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(uploadRes.status).toBe(200);
+        const upload = (await uploadRes.json()) as UploadResponse;
+        expect(upload.cataloged).toBe(true);
+
+        const mineRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            { headers: { Authorization: `Bearer ${VALID_KEY}` } },
+        );
+        const mine = (await mineRes.json()) as CatalogList;
+        const mineItem = mine.items.find((item) => item.id === upload.id);
+        expect(mineItem?.ownerId).toBe("user-test");
+        expect(mineItem?.appId).toBe("app-test");
+
+        const galleryRes = await SELF.fetch(
+            "https://media.pollinations.ai/gallery?app=app-test",
+        );
+        const gallery = (await galleryRes.json()) as CatalogList;
+        const publicItem = gallery.items.find((item) => item.id === upload.id);
+        expect(publicItem?.ownerId).toBeUndefined();
+        expect(publicItem?.appId).toBe("app-test");
+
+        const taggedRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/parent:0000000000000000?app=app-test",
+        );
+        const tagged = (await taggedRes.json()) as CatalogList;
+        expect(tagged.items.some((item) => item.id === upload.id)).toBe(true);
+    });
+
+    it("saves cached generation URLs without uploading bytes", async () => {
+        const url =
+            "https://gen.pollinations.ai/image/steam?model=flux&width=512&height=512&seed=42&key=secret";
+        const saveRes = await SELF.fetch("https://media.pollinations.ai/save", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${VALID_KEY}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                url,
+                visibility: "public",
+                tags: ["recipe:fire+water", "element:steam"],
+                prompt: "steam",
+                model: "flux",
+            }),
+        });
+        expect(saveRes.status).toBe(200);
+        const saved = (await saveRes.json()) as CatalogItem;
+        expect(saved.id).toMatch(/^[a-f0-9]{16}$/);
+        expect(saved.url).not.toContain("key=secret");
+        expect(saved.url).toContain("seed=42");
+
+        const recipeRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/recipe:fire%2Bwater?app_key=pk_any",
+        );
+        expect(recipeRes.status).toBe(200);
+        const recipe = (await recipeRes.json()) as CatalogList;
+        expect(recipe.items.some((item) => item.id === saved.id)).toBe(true);
+    });
+
+    it("keeps private saved references out of public tag listings", async () => {
+        const saveRes = await SELF.fetch("https://media.pollinations.ai/save", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${VALID_KEY}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                url: "https://gen.pollinations.ai/image/private-cat?model=flux",
+                visibility: "private",
+                tag: "catgpt-private",
+            }),
+        });
+        const saved = (await saveRes.json()) as CatalogItem;
+
+        const publicTags = (await (
+            await SELF.fetch(
+                "https://media.pollinations.ai/tags/catgpt-private",
+            )
+        ).json()) as CatalogList;
+        expect(publicTags.items.some((item) => item.id === saved.id)).toBe(
+            false,
+        );
+
+        const mine = (await (
+            await SELF.fetch("https://media.pollinations.ai/me/media", {
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            })
+        ).json()) as CatalogList;
+        expect(mine.items.some((item) => item.id === saved.id)).toBe(true);
     });
 
     it("GET /:invalid-hash returns 400", async () => {


### PR DESCRIPTION
- Adds a lightweight media catalog in the media worker using saved Pollinations URLs plus optional tags, with no relationship table or multi-parent model.
- Adds `POST /save`, upload cataloging, `/me/media`, `/gallery`, `/apps/:app/media`, and `/tags/:tag`.
- Exposes key/user/app attribution from `/account/key` so media can stamp owner/app metadata from verified tokens.
- Wires CatGPT, Chat, SlidePainter, Product Packaging Designer, and Virtual Makeup to save generated media refs; CatGPT also reads a public gallery.

Validation:
- `npx biome check --write ...`
- `media.pollinations.ai`: `npm run test`
- `enter.pollinations.ai`: `npm run build:frontend && npm run decrypt-vars && npx vitest run test/account-key.test.ts && npm run typecheck`
- `apps/chat`, `apps/slidepainter`, `apps/product-packaging-designer`, `apps/virtual-makeup`: `npm run build`
- `apps/product-packaging-designer`: `npm run typecheck`