### PR TITLE
feat: add tag-based media catalog

### DIFF
--- a/apps/ai-dungeon-master/src/App.tsx
+++ b/apps/ai-dungeon-master/src/App.tsx
@@ -380,7 +380,7 @@ Core rules you must ALWAYS follow:
                 return generateFallbackImage("mysterious fantasy scene");
 
             const imagePrompt = `fantasy rpg scene, ${cleanDescription}, digital art, detailed, atmospheric, high quality`;
-            const imageUrl = `${API_URL.image}${encodeURIComponent(imagePrompt)}?width=1024&height=768&model=flux&seed=${Date.now()}&key=${apiKey}`;
+            const imageUrl = `${API_URL.image}${encodeURIComponent(imagePrompt)}?width=1024&height=768&model=flux&seed=${Date.now()}&key=${apiKey}&save=1&tag=ai-dungeon-master&tag=ai-dungeon-master:scene`;
 
             return imageUrl;
         } catch (error) {
@@ -392,7 +392,7 @@ Core rules you must ALWAYS follow:
     // Generate fallback image when main image generation fails
     const generateFallbackImage = (_description: string): string => {
         const fallbackPrompt = `fantasy rpg, medieval, atmospheric, digital art`;
-        return `${API_URL.image}${encodeURIComponent(fallbackPrompt)}?width=1024&height=768&model=flux&seed=fallback${apiKey ? `&key=${apiKey}` : ""}`;
+        return `${API_URL.image}${encodeURIComponent(fallbackPrompt)}?width=1024&height=768&model=flux&seed=fallback${apiKey ? `&key=${apiKey}&save=1&tag=ai-dungeon-master&tag=ai-dungeon-master:scene` : ""}`;
     };
 
     // Fetch AI-generated character avatar
@@ -404,7 +404,7 @@ Core rules you must ALWAYS follow:
         try {
             const avatarPrompt = `fantasy character portrait, ${character.name} the ${character.class}, ${character.backstory}, medieval fantasy art, detailed face, character design, portrait style`;
             if (!apiKey) return "";
-            const avatarUrl = `${API_URL.image}${encodeURIComponent(avatarPrompt)}?width=512&height=512&model=flux&key=${apiKey}`;
+            const avatarUrl = `${API_URL.image}${encodeURIComponent(avatarPrompt)}?width=512&height=512&model=flux&key=${apiKey}&save=1&tag=ai-dungeon-master&tag=ai-dungeon-master:avatar`;
             return avatarUrl;
         } catch (error) {
             console.error("Error fetching character avatar:", error);
@@ -656,7 +656,7 @@ Core rules you must ALWAYS follow:
         try {
             const imagePrompt = `fantasy RPG item, ${itemName}, ${itemType}, detailed game asset, item icon, clean background`;
             if (!apiKey) return "";
-            const imageUrl = `${API_URL.image}${encodeURIComponent(imagePrompt)}?width=256&height=256&model=flux&key=${apiKey}`;
+            const imageUrl = `${API_URL.image}${encodeURIComponent(imagePrompt)}?width=256&height=256&model=flux&key=${apiKey}&save=1&tag=ai-dungeon-master&tag=ai-dungeon-master:item`;
             return imageUrl;
         } catch (error) {
             console.error("Error fetching item image:", error);

--- a/apps/ai-dungeon-master/src/components/GalleryModal.tsx
+++ b/apps/ai-dungeon-master/src/components/GalleryModal.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { ScrollArea } from "./ui/scroll-area";
 
 const MEDIA_HOST = "media.pollinations.ai";
+const GEN_HOST = "gen.pollinations.ai";
 
 interface Character {
     name: string;
@@ -44,7 +45,14 @@ const RARITY_COLORS: Record<string, string> = {
 
 function isUploaded(url: string): boolean {
     try {
-        return !!url && new URL(url).hostname === MEDIA_HOST;
+        const parsed = new URL(url);
+        return (
+            !!url &&
+            (parsed.hostname === MEDIA_HOST ||
+                (parsed.hostname === GEN_HOST &&
+                    (parsed.searchParams.get("save") === "1" ||
+                        parsed.searchParams.get("catalog") === "1")))
+        );
     } catch {
         return false;
     }

--- a/apps/ai-dungeon-master/src/utils/mediaUpload.ts
+++ b/apps/ai-dungeon-master/src/utils/mediaUpload.ts
@@ -1,44 +1,47 @@
-const MEDIA_URL = "https://gen.pollinations.ai";
+const MEDIA_URL = "https://media.pollinations.ai";
 const MEDIA_HOST = "media.pollinations.ai";
+const GEN_HOST = "gen.pollinations.ai";
 
-/** Check if a URL is already uploaded to media.pollinations.ai */
-function isMediaUrl(url: string): boolean {
+/** Check if a URL is already durable or already asks gen to catalog it. */
+function isPersistedUrl(url: string): boolean {
     try {
-        return new URL(url).hostname === MEDIA_HOST;
+        const parsed = new URL(url);
+        return (
+            parsed.hostname === MEDIA_HOST ||
+            (parsed.hostname === GEN_HOST &&
+                (parsed.searchParams.get("save") === "1" ||
+                    parsed.searchParams.get("catalog") === "1"))
+        );
     } catch {
         return false;
     }
 }
 
 /**
- * Upload a gen.pollinations.ai image to media.pollinations.ai for permanent storage.
- * Returns the permanent media URL on success, or the original URL on any error.
- * Skips upload if already a media URL (idempotent).
+ * Catalog a gen.pollinations.ai image for later lookup without downloading and
+ * re-uploading bytes. Returns the original URL so existing saves remain stable.
  */
 export async function uploadToMedia(
     genUrl: string,
     apiKey: string,
 ): Promise<string> {
-    if (!genUrl || isMediaUrl(genUrl)) return genUrl;
+    if (!genUrl || isPersistedUrl(genUrl)) return genUrl;
 
     try {
-        const response = await fetch(genUrl);
-        if (!response.ok) return genUrl;
-
-        const blob = await response.blob();
-        const formData = new FormData();
-        formData.append("file", blob);
-
-        const uploadRes = await fetch(`${MEDIA_URL}/media`, {
+        await fetch(`${MEDIA_URL}/catalog`, {
             method: "POST",
-            headers: { Authorization: `Bearer ${apiKey}` },
-            body: formData,
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+                url: genUrl,
+                tags: ["ai-dungeon-master"],
+                visibility: "private",
+            }),
         });
 
-        if (!uploadRes.ok) return genUrl;
-
-        const data = await uploadRes.json();
-        return data.url || genUrl;
+        return genUrl;
     } catch {
         return genUrl;
     }
@@ -58,24 +61,24 @@ export function countPendingUploads(gameState: {
 
     if (
         gameState.character?.avatar &&
-        !isMediaUrl(gameState.character.avatar)
+        !isPersistedUrl(gameState.character.avatar)
     ) {
         count++;
     }
 
     if (
         gameState.currentScene?.image &&
-        !isMediaUrl(gameState.currentScene.image)
+        !isPersistedUrl(gameState.currentScene.image)
     ) {
         count++;
     }
 
     for (const entry of gameState.storyHistory) {
-        if (entry.image && !isMediaUrl(entry.image)) count++;
+        if (entry.image && !isPersistedUrl(entry.image)) count++;
     }
 
     for (const item of gameState.inventory) {
-        if (item.image && !isMediaUrl(item.image)) count++;
+        if (item.image && !isPersistedUrl(item.image)) count++;
     }
 
     return count;

--- a/apps/catgpt-bot/bot.ts
+++ b/apps/catgpt-bot/bot.ts
@@ -82,7 +82,9 @@ function createPrompt(
 
 function buildImageUrl(prompt: string, avatarUrl: string | null): string {
     let url = `${IMAGE_API}/${encodeURIComponent(prompt)}?height=1024&width=1024&model=${MODEL}&nologo=true`;
-    if (API_KEY) url += `&key=${encodeURIComponent(API_KEY)}`;
+    if (API_KEY) {
+        url += `&key=${encodeURIComponent(API_KEY)}&save=1&visibility=public&tag=catgpt&tag=catgpt-bot`;
+    }
 
     if (avatarUrl) {
         url += `&enhance=false&image=${encodeURIComponent(`${avatarUrl},${SELFIE_CATGPT}`)}`;

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -9,6 +9,7 @@ const ORIGINAL_CATGPT =
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
 const AUTH_KEY = "catgpt_api_key";
 const APP_KEY = "pk_uWjreBEkxFAhjDHo";
+const APP_TAG = `app:${APP_KEY.toLowerCase()}`;
 
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
@@ -156,20 +157,23 @@ function normalizeCatalogItems(data) {
 }
 
 export async function fetchMyCatGptMemes(apiKey) {
-    const res = await fetch(`${MEDIA_CATALOG}/me/media?limit=24`, {
+    const res = await fetch(`${MEDIA_CATALOG}/catalog?scope=mine&limit=24`, {
         headers: { Authorization: `Bearer ${apiKey}` },
     });
     if (!res.ok) throw new Error(`My media failed: ${res.status}`);
     return normalizeCatalogItems(await res.json()).filter(
         (item) =>
             item.appName === "CatGPT" ||
+            item.tags?.includes(APP_TAG) ||
             item.tags?.includes("catgpt") ||
             item.tags?.includes("catgpt:meme"),
     );
 }
 
 export async function fetchPublicCatGptMemes() {
-    const res = await fetch(`${MEDIA_CATALOG}/gallery?app=catgpt&limit=24`);
+    const res = await fetch(
+        `${MEDIA_CATALOG}/catalog?tag=${encodeURIComponent(APP_TAG)}&limit=24`,
+    );
     if (!res.ok) throw new Error(`Gallery failed: ${res.status}`);
     return normalizeCatalogItems(await res.json());
 }

--- a/apps/catgpt/ai.js
+++ b/apps/catgpt/ai.js
@@ -3,6 +3,7 @@
 const API = "https://gen.pollinations.ai/image";
 const ENTER = "https://enter.pollinations.ai";
 const MEDIA_UPLOAD = "https://media.pollinations.ai/upload";
+const MEDIA_CATALOG = "https://media.pollinations.ai";
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
 const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
@@ -110,16 +111,67 @@ export function createImageGenerationPrompt(
         : `${base} Human with bob hair.`;
 }
 
-export function generateImageURL(prompt, model, imageUrl = null) {
+export function generateImageURL(prompt, model, imageUrl = null, options = {}) {
     const key = getStoredApiKey();
-    let url = `${API}/${encodeURIComponent(prompt)}?height=1024&width=1024&model=${model}&key=${encodeURIComponent(key)}`;
+    const url = new URL(`${API}/${encodeURIComponent(prompt)}`);
+    url.searchParams.set("height", "1024");
+    url.searchParams.set("width", "1024");
+    url.searchParams.set("model", model);
+
+    if (key && options.save) {
+        url.searchParams.set("key", key);
+        url.searchParams.set("save", "1");
+        url.searchParams.set("visibility", "public");
+        url.searchParams.append("tag", "catgpt");
+        url.searchParams.append("tag", "catgpt:meme");
+    }
 
     if (imageUrl) {
-        url += `&enhance=false&image=${encodeURIComponent(`${imageUrl},${SELFIE_CATGPT}`)}`;
+        url.searchParams.set("enhance", "false");
+        url.searchParams.set("image", `${imageUrl},${SELFIE_CATGPT}`);
+        const parentHash = mediaHashFromUrl(imageUrl);
+        if (parentHash) url.searchParams.append("tag", `parent:${parentHash}`);
     } else {
-        url += `&enhance=true&image=${encodeURIComponent(ORIGINAL_CATGPT)}`;
+        url.searchParams.set("enhance", "true");
+        url.searchParams.set("image", ORIGINAL_CATGPT);
     }
-    return url;
+    return url.toString();
+}
+
+function mediaHashFromUrl(url) {
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname !== "media.pollinations.ai") return null;
+        const hash = parsed.pathname.split("/").filter(Boolean)[0];
+        return /^[a-f0-9]{16}$/i.test(hash) ? hash.toLowerCase() : null;
+    } catch {
+        return null;
+    }
+}
+
+function normalizeCatalogItems(data) {
+    return Array.isArray(data?.media)
+        ? data.media.filter((item) => item?.url)
+        : [];
+}
+
+export async function fetchMyCatGptMemes(apiKey) {
+    const res = await fetch(`${MEDIA_CATALOG}/me/media?limit=24`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) throw new Error(`My media failed: ${res.status}`);
+    return normalizeCatalogItems(await res.json()).filter(
+        (item) =>
+            item.appName === "CatGPT" ||
+            item.tags?.includes("catgpt") ||
+            item.tags?.includes("catgpt:meme"),
+    );
+}
+
+export async function fetchPublicCatGptMemes() {
+    const res = await fetch(`${MEDIA_CATALOG}/gallery?app=catgpt&limit=24`);
+    if (!res.ok) throw new Error(`Gallery failed: ${res.status}`);
+    return normalizeCatalogItems(await res.json());
 }
 
 // ── Models ──────────────────────────────────────────────────────────────────

--- a/apps/catgpt/index.html
+++ b/apps/catgpt/index.html
@@ -110,6 +110,8 @@
         <div class="section-card">
             <h2>Your Memes</h2>
             <div class="your-memes-grid" id="yourMemesGrid"></div>
+            <h2 style="margin-top: 2rem;">Community Memes</h2>
+            <div class="your-memes-grid" id="communityMemesGrid"></div>
             <h2 style="margin-top: 2rem;">Examples</h2>
             <div class="examples-grid" id="examplesGrid"></div>
         </div>

--- a/apps/catgpt/script.js
+++ b/apps/catgpt/script.js
@@ -6,7 +6,9 @@ import {
     EXAMPLE_PROMPTS,
     extractApiKeyFromFragment,
     fetchBalance,
+    fetchMyCatGptMemes,
     fetchProfile,
+    fetchPublicCatGptMemes,
     generateCatReply,
     generateImageURL,
     getAuthorizeUrl,
@@ -73,6 +75,7 @@ const dom = {
     generatedMeme: $("generatedMeme"),
     downloadBtn: $("downloadBtn"),
     shareBtn: $("shareBtn"),
+    communityMemesGrid: $("communityMemesGrid"),
     examplesGrid: $("examplesGrid"),
     yourMemesGrid: $("yourMemesGrid"),
     imageUpload: $("imageUpload"),
@@ -174,6 +177,25 @@ function saveGeneratedMeme(prompt, url) {
         ...saved.filter((m) => m.prompt !== prompt),
     ].slice(0, 8);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}
+
+function catalogItemToMeme(item) {
+    return {
+        prompt: item.prompt || "CatGPT meme",
+        url: item.url,
+        model: item.model,
+    };
+}
+
+function mergeMemes(remoteItems, localItems) {
+    const seen = new Set();
+    return [...remoteItems.map(catalogItemToMeme), ...localItems].filter(
+        (item) => {
+            if (!item.url || seen.has(item.url)) return false;
+            seen.add(item.url);
+            return true;
+        },
+    );
 }
 
 // ── Animations ───────────────────────────────────────────────────────────────
@@ -333,9 +355,19 @@ function createMemeCard(prompt, index, imageUrl) {
     return card;
 }
 
-function loadUserMemes() {
+async function loadUserMemes() {
     dom.yourMemesGrid.innerHTML = "";
-    const saved = getSavedMemes();
+    const localMemes = getSavedMemes();
+    let saved = localMemes;
+
+    const apiKey = getStoredApiKey();
+    if (apiKey) {
+        try {
+            saved = mergeMemes(await fetchMyCatGptMemes(apiKey), localMemes);
+        } catch (error) {
+            console.warn("Could not load cataloged CatGPT memes:", error);
+        }
+    }
 
     if (!saved.length) {
         const p = document.createElement("p");
@@ -350,6 +382,30 @@ function loadUserMemes() {
         const card = createMemeCard(meme.prompt, i, meme.url);
         if (card) dom.yourMemesGrid.appendChild(card);
     });
+}
+
+async function loadCommunityMemes() {
+    if (!dom.communityMemesGrid) return;
+    dom.communityMemesGrid.innerHTML = "";
+
+    try {
+        const memes = (await fetchPublicCatGptMemes()).map(catalogItemToMeme);
+        if (!memes.length) {
+            const p = document.createElement("p");
+            p.textContent = "No public CatGPT memes yet.";
+            p.style.cssText =
+                "grid-column: 1/-1; text-align: center; color: var(--color-muted); padding: 2rem; font-style: italic;";
+            dom.communityMemesGrid.appendChild(p);
+            return;
+        }
+
+        memes.forEach((meme, i) => {
+            const card = createMemeCard(meme.prompt, i, meme.url);
+            if (card) dom.communityMemesGrid.appendChild(card);
+        });
+    } catch (error) {
+        console.warn("Could not load public CatGPT gallery:", error);
+    }
 }
 
 function loadExamples() {
@@ -400,6 +456,7 @@ async function generateMeme() {
         createImageGenerationPrompt(question, catReply, !!uploadedImageUrl),
         activeModel,
         uploadedImageUrl,
+        { save: true },
     );
 
     try {
@@ -422,6 +479,7 @@ async function generateMeme() {
         celebrate();
         saveGeneratedMeme(question, imageUrl);
         loadUserMemes();
+        loadCommunityMemes();
     } catch (error) {
         if (cancelled) return;
         console.error("Generation error:", error);
@@ -618,6 +676,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateAuthUI({ skipModelPick: !!model });
     loadUserMemes();
+    loadCommunityMemes();
     loadExamples();
     addFloatingEmojis();
     if (image) {

--- a/apps/chat/src/utils/api.js
+++ b/apps/chat/src/utils/api.js
@@ -15,6 +15,13 @@ const getApiToken = () => {
     return ENV_API_TOKEN;
 };
 
+const addCatalogParams = (params, tags) => {
+    const token = getApiToken();
+    if (!token) return;
+    params.set("save", "1");
+    for (const tag of tags) params.append("tag", tag);
+};
+
 let textModels = [];
 let imageModels = [];
 let videoModels = [];
@@ -523,6 +530,7 @@ export const generateImage = async (prompt, options = {}) => {
         safe,
         quality,
     });
+    addCatalogParams(params, ["pollinations-chat", "pollinations-chat:image"]);
     const url = `${BASE_URL}/image/${encodeURIComponent(prompt)}?${params}`;
     const token = getApiToken();
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
@@ -548,6 +556,7 @@ export const generateVideo = async (prompt, options = {}) => {
     } = options;
 
     const params = new URLSearchParams({ model, seed, nologo, nofeed });
+    addCatalogParams(params, ["pollinations-chat", "pollinations-chat:video"]);
     // Correct endpoint: /video/{prompt}  (not /image/{prompt})
     const url = `${BASE_URL}/video/${encodeURIComponent(prompt)}?${params}`;
     const token = getApiToken();
@@ -570,6 +579,7 @@ export const generateAudio = async (text, options = {}) => {
     const { voice = "nova", model = "openai-audio" } = options;
 
     const params = new URLSearchParams({ voice, model });
+    addCatalogParams(params, ["pollinations-chat", "pollinations-chat:audio"]);
     const url = `${BASE_URL}/audio/${encodeURIComponent(text)}?${params}`;
     const token = getApiToken();
     const headers = token ? { Authorization: `Bearer ${token}` } : {};

--- a/apps/opposite-prompt-bot/bot.ts
+++ b/apps/opposite-prompt-bot/bot.ts
@@ -74,7 +74,10 @@ async function generateOpposite(prompt: string): Promise<string> {
 }
 
 async function fetchImage(prompt: string): Promise<Buffer> {
-    const url = `${IMAGE_API}/${encodeURIComponent(prompt)}?model=zimage&nologo=true`;
+    let url = `${IMAGE_API}/${encodeURIComponent(prompt)}?model=zimage&nologo=true`;
+    if (API_KEY) {
+        url += "&save=1&visibility=public&tag=opposite-prompt-bot";
+    }
     log(`Image API request: ${url}`);
     const res = await axios.get(url, {
         headers: AUTH,

--- a/apps/product-packaging-designer/src/App.tsx
+++ b/apps/product-packaging-designer/src/App.tsx
@@ -12,7 +12,8 @@ import {
     Sun,
     Upload,
 } from "lucide-react";
-import { type React, useEffect, useState } from "react";
+import type React from "react";
+import { useEffect, useState } from "react";
 
 type StyleOption = {
     id: string;
@@ -370,7 +371,7 @@ ${brandName.trim() ? ` Brand name: "${brandName}".` : ""}
             const encodedPrompt = encodeURIComponent(prompt);
             const imageUrl = `${POLLINATIONS_API}/${encodedPrompt}?model=nanobanana&image=${encodeURIComponent(
                 uploadedUrl,
-            )}&quality=high`;
+            )}&quality=high&save=1&tag=product-packaging-designer&tag=product-packaging-designer:mockup`;
 
             const response = await fetch(imageUrl, {
                 headers: {

--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -70,6 +70,9 @@ export class PollinationsService {
         } else {
           headers['Authorization'] = `Bearer ${token}`;
         }
+        url.searchParams.set('save', '1');
+        url.searchParams.append('tag', 'slidepainter');
+        url.searchParams.append('tag', 'slidepainter:slide');
       }
 
       const response = await fetch(url.toString(), {

--- a/apps/virtual-makeup/src/App.jsx
+++ b/apps/virtual-makeup/src/App.jsx
@@ -159,7 +159,7 @@ function App() {
 
             const randomSeed = Math.floor(Math.random() * 1000000);
 
-            const apiUrl = `${POLLINATIONS_IMAGE_API}/prompt/${encodedPrompt}?model=nanobanana&image=${encodedImageURL}&referrer=virtualmakeuptryon&width=1024&height=1024&nologo=true&enhance=true&seed=${randomSeed}`;
+            const apiUrl = `${POLLINATIONS_IMAGE_API}/prompt/${encodedPrompt}?model=nanobanana&image=${encodedImageURL}&referrer=virtualmakeuptryon&width=1024&height=1024&nologo=true&enhance=true&seed=${randomSeed}&save=1&tag=virtual-makeup&tag=virtual-makeup:result`;
 
             const response = await fetch(apiUrl, {
                 headers: {

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1440,6 +1440,39 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Display name of the API key",
                                         ),
+                                    userId: z
+                                        .string()
+                                        .describe(
+                                            "User ID that owns this API key",
+                                        ),
+                                    apiKeyId: z
+                                        .string()
+                                        .describe(
+                                            "Stable API key ID. This is not the secret key value.",
+                                        ),
+                                    keyId: z
+                                        .string()
+                                        .describe(
+                                            "Alias for apiKeyId for callers that already use keyId.",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Publishable app key ID that minted this BYOP key, when present.",
+                                        ),
+                                    byopClientName: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Display name of the app that minted this BYOP key, when present.",
+                                        ),
+                                    byopClientUserId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Owner user ID of the app that minted this BYOP key, when present.",
+                                        ),
                                     expiresAt: z
                                         .string()
                                         .nullable()
@@ -1501,6 +1534,7 @@ export const accountRoutes = new Hono<Env>()
                         "API key required. This endpoint validates API keys.",
                 });
             }
+            const user = c.var.auth.requireUser();
 
             log.debug("Returning status for API key: {keyId}", {
                 keyId: apiKey.id,
@@ -1550,6 +1584,12 @@ export const accountRoutes = new Hono<Env>()
                 valid: true, // If we got here, the key is valid
                 type: keyType,
                 name: apiKey.name || null,
+                userId: user.id,
+                apiKeyId: apiKey.id,
+                keyId: apiKey.id,
+                byopClientKeyId: apiKey.byopClientKeyId ?? null,
+                byopClientName: apiKey.byopClientName ?? null,
+                byopClientUserId: apiKey.byopClientUserId ?? null,
                 expiresAt,
                 expiresIn,
                 permissions,

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -41,6 +41,12 @@ test(
         expect(data.valid).toBe(true);
         expect(data.type).toBe("secret");
         expect(data.name).toBeTruthy();
+        expect(data.userId).toBeTruthy();
+        expect(data.apiKeyId).toBeTruthy();
+        expect(data.keyId).toBe(data.apiKeyId);
+        expect(data.byopClientKeyId).toBeNull();
+        expect(data.byopClientName).toBeNull();
+        expect(data.byopClientUserId).toBeNull();
         expect(data).toHaveProperty("expiresAt");
         expect(data).toHaveProperty("expiresIn");
         expect(data).toHaveProperty("permissions");

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -342,6 +342,20 @@ describe("API Key Management", () => {
             const created = await response.json();
             expect(created.metadata.clientId).toBeUndefined();
             expect(created.byopClientKeyId).toBe(appKey.id);
+
+            const keyInfoResponse = await SELF.fetch(
+                "http://localhost:3000/api/account/key",
+                {
+                    headers: {
+                        Authorization: `Bearer ${created.key}`,
+                    },
+                },
+            );
+            expect(keyInfoResponse.status).toBe(200);
+            const keyInfo = await keyInfoResponse.json();
+            expect(keyInfo.byopClientKeyId).toBe(appKey.id);
+            expect(keyInfo.byopClientName).toBe(appKey.name);
+            expect(keyInfo.byopClientUserId).toBeTruthy();
         });
 
         test("allows device-flow attribution without redirect_uri when client_id matches the device code", async ({

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -10,6 +10,7 @@
 
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { RequestIdVariables } from "hono/request-id";
 import type { LoggerVariables } from "@/middleware/logger.ts";
@@ -33,11 +34,22 @@ type MediaCacheConfig = {
     label: string;
 };
 
+const MEDIA_CATALOG_URL = "https://media.pollinations.ai/catalog";
+const CATALOG_CONTROL_PARAMS = [
+    "key",
+    "save",
+    "catalog",
+    "tag",
+    "tags",
+    "visibility",
+];
+
 export function createMediaCache(config: MediaCacheConfig) {
     return createMiddleware<MediaCacheEnv>(async (c, next) => {
         const log = c.get("log").getChild(config.label);
+        const requestUrl = new URL(c.req.url);
 
-        const seedParam = new URL(c.req.url).searchParams.get("seed");
+        const seedParam = requestUrl.searchParams.get("seed");
         if (seedParam === "-1") {
             log.debug("seed=-1 detected, skipping cache");
             return next();
@@ -53,6 +65,12 @@ export function createMediaCache(config: MediaCacheConfig) {
             const cached = await c.env.IMAGE_BUCKET.get(cacheKey);
             if (cached) {
                 log.info("Cache HIT");
+                queueMediaCatalogWrite(
+                    c,
+                    requestUrl,
+                    cached.httpMetadata?.contentType ||
+                        config.defaultContentType,
+                );
                 setHttpMetadataHeaders(
                     c,
                     cached.httpMetadata,
@@ -88,8 +106,111 @@ export function createMediaCache(config: MediaCacheConfig) {
                 config.defaultContentType,
                 c.res,
             );
+            queueMediaCatalogWrite(
+                c,
+                requestUrl,
+                contentType || config.defaultContentType,
+            );
         }
     });
+}
+
+function queueMediaCatalogWrite(
+    c: Context<MediaCacheEnv>,
+    requestUrl: URL,
+    contentType: string,
+): void {
+    if (!shouldCatalog(requestUrl)) return;
+
+    const apiKey = extractApiKey(c.req.raw, requestUrl);
+    if (!apiKey) return;
+
+    const canonicalUrl = new URL(requestUrl);
+    for (const param of CATALOG_CONTROL_PARAMS) {
+        canonicalUrl.searchParams.delete(param);
+    }
+
+    const tags = extractTags(requestUrl);
+    const model = requestUrl.searchParams.get("model");
+    const prompt = promptFromPath(requestUrl.pathname);
+    const body = {
+        url: canonicalUrl.toString(),
+        visibility: normalizeVisibility(
+            requestUrl.searchParams.get("visibility"),
+        ),
+        tags,
+        contentType,
+        ...(model && { model }),
+        ...(prompt && { prompt }),
+    };
+
+    c.header("X-Media-Catalog", "queued");
+    c.executionCtx.waitUntil(
+        fetch(MEDIA_CATALOG_URL, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(body),
+        })
+            .then(async (response) => {
+                if (response.ok) return;
+                const text = await response.text().catch(() => "");
+                c.get("log").warn(
+                    "Media catalog write failed with status {status}: {body}",
+                    {
+                        status: response.status,
+                        body: text.slice(0, 200),
+                    },
+                );
+            })
+            .catch((error) => {
+                c.get("log").warn("Media catalog write failed: {error}", {
+                    error,
+                });
+            }),
+    );
+}
+
+function shouldCatalog(url: URL): boolean {
+    const value =
+        url.searchParams.get("save") || url.searchParams.get("catalog");
+    return value === "1" || value === "true" || value === "yes";
+}
+
+function extractApiKey(request: Request, url: URL): string | null {
+    const bearer = request.headers
+        .get("authorization")
+        ?.match(/^Bearer (.+)$/)?.[1];
+    if (bearer) return bearer;
+    return url.searchParams.get("key");
+}
+
+function normalizeVisibility(
+    value: string | null,
+): "private" | "public" | "unlisted" {
+    return value === "public" || value === "unlisted" ? value : "private";
+}
+
+function extractTags(url: URL): string[] {
+    const tags = [
+        ...url.searchParams.getAll("tag"),
+        ...url.searchParams.getAll("tags").flatMap((value) => value.split(",")),
+    ]
+        .map((tag) => tag.trim())
+        .filter(Boolean);
+    return [...new Set(tags)];
+}
+
+function promptFromPath(pathname: string): string | undefined {
+    const match = pathname.match(/^\/(?:image|video|audio)\/(.+)$/);
+    if (!match) return undefined;
+    try {
+        return decodeURIComponent(match[1]);
+    } catch {
+        return match[1];
+    }
 }
 
 export const imageCache = createMediaCache({

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -9,7 +9,16 @@ import { parseSafeFeatures } from "@shared/schemas/safety.ts";
 import type { Context } from "hono";
 import { removeUnset } from "@/util.ts";
 
-const EXCLUDED_PARAMS = ["nofeed", "no-cache", "key"];
+const EXCLUDED_PARAMS = [
+    "nofeed",
+    "no-cache",
+    "key",
+    "save",
+    "catalog",
+    "tag",
+    "tags",
+    "visibility",
+];
 const SAFETY_CACHE_VERSION = "bedrock-input-v1";
 const CACHED_HEADER_PREFIXES = ["x-safety-"];
 

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -6,7 +6,7 @@ import type { Logger } from "@logtape/logtape";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { Hono } from "hono";
 import type { RequestIdVariables } from "hono/request-id";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { audioCache, imageCache } from "@/middleware/media-cache.ts";
 
@@ -130,6 +130,11 @@ async function consumeAndWait(result: Awaited<ReturnType<typeof dispatch>>) {
 }
 
 describe("media cache", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
     it.each([
         { label: "image", cache: imageCache, contentType: "image/png" },
         { label: "audio", cache: audioCache, contentType: "audio/mpeg" },
@@ -174,6 +179,56 @@ describe("media cache", () => {
             "Authentication required",
         );
         expect(missNoAuth.response.status).toBe(401);
+        expect(media.originHits).toBe(1);
+    });
+
+    it("queues save/catalog writes without changing cache identity", async () => {
+        const catalogFetch = vi.fn<
+            (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+        >(async () => Response.json({ ok: true }));
+        vi.stubGlobal("fetch", catalogFetch);
+
+        const media = createMediaCacheApp(imageCache, "image/png");
+        const env = createMediaCacheEnv();
+        const saved = await dispatch(
+            media.app,
+            "/media/generated?save=1&visibility=public&tag=catgpt&tags=parent:abc123&model=flux&key=test-key",
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+
+        expect(await consumeAndWait(saved)).toBe("origin:1");
+        expect(catalogFetch).toHaveBeenCalledOnce();
+        const [catalogUrl, catalogRequest] = catalogFetch.mock.calls[0];
+        expect(catalogUrl).toBe("https://media.pollinations.ai/catalog");
+
+        if (!catalogRequest) throw new Error("Missing catalog request init");
+        const catalogBody = JSON.parse(catalogRequest.body as string);
+        expect(catalogRequest.headers).toMatchObject({
+            Authorization: "Bearer test-key",
+        });
+        expect(catalogBody).toMatchObject({
+            url: "https://gen.pollinations.ai/media/generated?model=flux",
+            visibility: "public",
+            tags: ["catgpt", "parent:abc123"],
+            contentType: "image/png",
+            model: "flux",
+        });
+
+        const cachedWithoutCatalogParams = await dispatch(
+            media.app,
+            "/media/generated?model=flux",
+            undefined,
+            env,
+        );
+        expect(await consumeAndWait(cachedWithoutCatalogParams)).toBe(
+            "origin:1",
+        );
+        expect(cachedWithoutCatalogParams.response.headers.get("X-Cache")).toBe(
+            "HIT",
+        );
         expect(media.originHits).toBe(1);
     });
 });

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -1,0 +1,381 @@
+const CATALOG_PREFIX = "catalog/v1";
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 100;
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 96;
+const MAX_TEXT_LENGTH = 1000;
+const MAX_MODEL_LENGTH = 128;
+const MAX_CONTENT_TYPE_LENGTH = 128;
+const REVERSE_TIMESTAMP_MAX = 9_999_999_999_999;
+
+const ALLOWED_CATALOG_HOSTS = new Set([
+    "gen.pollinations.ai",
+    "media.pollinations.ai",
+]);
+
+const CATALOG_URL_PARAMS = new Set([
+    "key",
+    "save",
+    "catalog",
+    "tag",
+    "tags",
+    "visibility",
+]);
+
+export type Visibility = "private" | "public" | "unlisted";
+
+export interface CatalogFields {
+    visibility: Visibility;
+    tags: string[];
+    prompt?: string;
+    model?: string;
+    contentType?: string;
+    size?: number;
+}
+
+export interface CatalogEntry {
+    entryId: string;
+    url: string;
+    hash?: string;
+    contentType?: string;
+    size?: number;
+    createdAt: string;
+    visibility: Visibility;
+    tags: string[];
+    prompt?: string;
+    model?: string;
+    ownerUserId?: string;
+    ownerName?: string | null;
+    apiKeyId?: string;
+    keyType?: string;
+    appKeyId?: string | null;
+    appName?: string | null;
+    appOwnerUserId?: string | null;
+}
+
+export type CatalogPublicItem = ReturnType<typeof catalogItem>;
+
+export function catalogFieldsFromFormData(formData: FormData): CatalogFields {
+    return normalizeCatalogFields({
+        tag: formData.getAll("tag"),
+        tags: formData.getAll("tags"),
+        visibility: formData.get("visibility"),
+        prompt: formData.get("prompt"),
+        model: formData.get("model"),
+        contentType: formData.get("contentType"),
+        size: formData.get("size"),
+    });
+}
+
+export function catalogFieldsFromObject(
+    body: Record<string, unknown>,
+): CatalogFields {
+    return normalizeCatalogFields(body);
+}
+
+export function catalogFieldsFromSearchParams(
+    params: URLSearchParams,
+): CatalogFields {
+    return normalizeCatalogFields({
+        tag: params.getAll("tag"),
+        tags: params.getAll("tags"),
+        visibility: params.get("visibility"),
+        prompt: params.get("prompt"),
+        model: params.get("model"),
+        contentType: params.get("contentType"),
+        size: params.get("size"),
+    });
+}
+
+export function normalizeTag(input: unknown): string | null {
+    if (typeof input !== "string") return null;
+    const tag = input
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9._:-]+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^[-.:_]+|[-.:_]+$/g, "")
+        .slice(0, MAX_TAG_LENGTH);
+    return tag || null;
+}
+
+export function safeFacet(input: unknown, fallback = "unknown"): string {
+    return normalizeTag(String(input ?? "")) || fallback;
+}
+
+export function parseListLimit(value: string | null): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIST_LIMIT;
+    return Math.min(Math.floor(parsed), MAX_LIST_LIMIT);
+}
+
+export function createCatalogEntry(input: {
+    url: string;
+    hash?: string;
+    contentType?: string;
+    size?: number;
+    fields: CatalogFields;
+    ownerUserId?: string;
+    ownerName?: string | null;
+    apiKeyId?: string;
+    keyType?: string;
+    appKeyId?: string | null;
+    appName?: string | null;
+    appOwnerUserId?: string | null;
+}): CatalogEntry {
+    return {
+        entryId: crypto.randomUUID(),
+        url: input.url,
+        ...(input.hash && { hash: input.hash }),
+        ...(input.contentType && { contentType: input.contentType }),
+        ...(input.size !== undefined && { size: input.size }),
+        createdAt: new Date().toISOString(),
+        visibility: input.fields.visibility,
+        tags: input.fields.tags,
+        ...(input.fields.prompt && { prompt: input.fields.prompt }),
+        ...(input.fields.model && { model: input.fields.model }),
+        ...(input.ownerUserId && { ownerUserId: input.ownerUserId }),
+        ownerName: input.ownerName ?? null,
+        ...(input.apiKeyId && { apiKeyId: input.apiKeyId }),
+        ...(input.keyType && { keyType: input.keyType }),
+        appKeyId: input.appKeyId ?? null,
+        appName: input.appName ?? null,
+        appOwnerUserId: input.appOwnerUserId ?? null,
+    };
+}
+
+export async function writeCatalogEntry(
+    bucket: R2Bucket,
+    entry: CatalogEntry,
+): Promise<void> {
+    const body = JSON.stringify(entry);
+    const keys = new Set<string>([
+        `${CATALOG_PREFIX}/entries/${entry.entryId}.json`,
+    ]);
+
+    const suffix = `${reverseTimestamp(entry.createdAt)}-${entry.entryId}.json`;
+    const ownerFacet = safeFacet(entry.ownerUserId || entry.ownerName);
+    if (ownerFacet !== "unknown") {
+        keys.add(`${CATALOG_PREFIX}/owner/${ownerFacet}/${suffix}`);
+    }
+
+    if (entry.visibility === "public") {
+        keys.add(`${CATALOG_PREFIX}/public/${suffix}`);
+        if (entry.hash) {
+            keys.add(`${CATALOG_PREFIX}/hash/${entry.hash}/${suffix}`);
+        }
+        for (const tag of entry.tags) {
+            keys.add(`${CATALOG_PREFIX}/tag/${safeFacet(tag)}/${suffix}`);
+        }
+        for (const app of appFacets(entry)) {
+            keys.add(`${CATALOG_PREFIX}/app/${app}/${suffix}`);
+        }
+    }
+
+    await Promise.all(
+        [...keys].map((key) =>
+            bucket.put(key, body, {
+                httpMetadata: { contentType: "application/json" },
+            }),
+        ),
+    );
+}
+
+export async function listCatalogEntries(
+    bucket: R2Bucket,
+    prefix: string,
+    limit: number,
+): Promise<CatalogEntry[]> {
+    const listed = await bucket.list({ prefix, limit });
+    const entries = await Promise.all(
+        listed.objects.map(async (object) => {
+            try {
+                const stored = await bucket.get(object.key);
+                if (!stored) return null;
+                return await stored.json<CatalogEntry>();
+            } catch {
+                return null;
+            }
+        }),
+    );
+
+    const seen = new Set<string>();
+    return entries.filter((entry): entry is CatalogEntry => {
+        if (!entry || seen.has(entry.entryId)) return false;
+        seen.add(entry.entryId);
+        return true;
+    });
+}
+
+export function catalogPrefix(
+    kind: "public" | "owner" | "tag" | "app" | "hash",
+    facet?: string,
+): string {
+    if (kind === "public") return `${CATALOG_PREFIX}/public/`;
+    return `${CATALOG_PREFIX}/${kind}/${safeFacet(facet)}/`;
+}
+
+export function catalogItem(entry: CatalogEntry, includePrivateFields = false) {
+    const item = {
+        entryId: entry.entryId,
+        url: entry.url,
+        ...(entry.hash && { hash: entry.hash }),
+        ...(entry.contentType && { contentType: entry.contentType }),
+        ...(entry.size !== undefined && { size: entry.size }),
+        createdAt: entry.createdAt,
+        visibility: entry.visibility,
+        tags: entry.tags,
+        ...(entry.prompt && { prompt: entry.prompt }),
+        ...(entry.model && { model: entry.model }),
+        ...(entry.appKeyId && { appKeyId: entry.appKeyId }),
+        ...(entry.appName && { appName: entry.appName }),
+    };
+
+    if (!includePrivateFields) return item;
+
+    return {
+        ...item,
+        ...(entry.ownerUserId && { ownerUserId: entry.ownerUserId }),
+        ...(entry.ownerName && { ownerName: entry.ownerName }),
+        ...(entry.apiKeyId && { apiKeyId: entry.apiKeyId }),
+        ...(entry.keyType && { keyType: entry.keyType }),
+        ...(entry.appOwnerUserId && { appOwnerUserId: entry.appOwnerUserId }),
+    };
+}
+
+export function normalizeCatalogUrl(input: unknown): {
+    url: string;
+    hash?: string;
+} {
+    if (typeof input !== "string" || !input.trim()) {
+        throw new Error("url is required");
+    }
+
+    const url = new URL(input);
+    if (url.protocol !== "https:") {
+        throw new Error("Only HTTPS media URLs can be cataloged");
+    }
+
+    if (!ALLOWED_CATALOG_HOSTS.has(url.hostname)) {
+        throw new Error("Only Pollinations media URLs can be cataloged");
+    }
+
+    for (const param of CATALOG_URL_PARAMS) {
+        url.searchParams.delete(param);
+    }
+
+    const firstPathSegment = url.pathname.split("/").filter(Boolean)[0];
+    const hash =
+        url.hostname === "media.pollinations.ai" &&
+        /^[a-f0-9]{16}$/i.test(firstPathSegment)
+            ? firstPathSegment.toLowerCase()
+            : undefined;
+
+    return {
+        url: url.toString(),
+        ...(hash && { hash }),
+    };
+}
+
+export async function resolveCatalogAppFacet(
+    appRef: string | null,
+    verifyApiKey: (apiKey: string) => Promise<{
+        apiKeyId?: string;
+        keyId?: string;
+        name?: string | null;
+    } | null>,
+): Promise<string | null> {
+    if (!appRef) return null;
+    if (/^(pk_|plln_pk_)/.test(appRef)) {
+        const verified = await verifyApiKey(appRef);
+        return (
+            normalizeTag(verified?.apiKeyId) ||
+            normalizeTag(verified?.keyId) ||
+            normalizeTag(verified?.name)
+        );
+    }
+    return normalizeTag(appRef);
+}
+
+function normalizeCatalogFields(raw: Record<string, unknown>): CatalogFields {
+    return {
+        visibility: normalizeVisibility(raw.visibility),
+        tags: normalizeTags([raw.tag, raw.tags]),
+        ...(normalizeText(raw.prompt, MAX_TEXT_LENGTH) && {
+            prompt: normalizeText(raw.prompt, MAX_TEXT_LENGTH),
+        }),
+        ...(normalizeText(raw.model, MAX_MODEL_LENGTH) && {
+            model: normalizeText(raw.model, MAX_MODEL_LENGTH),
+        }),
+        ...(normalizeText(raw.contentType, MAX_CONTENT_TYPE_LENGTH) && {
+            contentType: normalizeText(
+                raw.contentType,
+                MAX_CONTENT_TYPE_LENGTH,
+            ),
+        }),
+        ...(normalizeSize(raw.size) !== undefined && {
+            size: normalizeSize(raw.size),
+        }),
+    };
+}
+
+function normalizeVisibility(input: unknown): Visibility {
+    return input === "public" || input === "unlisted" || input === "private"
+        ? input
+        : "private";
+}
+
+function normalizeText(input: unknown, maxLength: number): string | undefined {
+    if (typeof input !== "string") return undefined;
+    const text = input.trim().slice(0, maxLength);
+    return text || undefined;
+}
+
+function normalizeSize(input: unknown): number | undefined {
+    const value = Number(input);
+    if (!Number.isFinite(value) || value < 0) return undefined;
+    return Math.floor(value);
+}
+
+function normalizeTags(input: unknown[]): string[] {
+    const seen = new Set<string>();
+    for (const part of input.flatMap(tagParts)) {
+        const tag = normalizeTag(part);
+        if (!tag || seen.has(tag)) continue;
+        seen.add(tag);
+        if (seen.size >= MAX_TAGS) break;
+    }
+    return [...seen];
+}
+
+function tagParts(input: unknown): string[] {
+    if (input === undefined || input === null) return [];
+    if (Array.isArray(input)) return input.flatMap(tagParts);
+    if (typeof input !== "string") return [String(input)];
+
+    const trimmed = input.trim();
+    if (!trimmed) return [];
+
+    if (trimmed.startsWith("[")) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) return parsed.flatMap(tagParts);
+        } catch {
+            // Fall through to comma parsing.
+        }
+    }
+
+    return trimmed.split(",").map((tag) => tag.trim());
+}
+
+function reverseTimestamp(createdAt: string): string {
+    const timestamp = Date.parse(createdAt);
+    const reversed = REVERSE_TIMESTAMP_MAX - timestamp;
+    return String(reversed).padStart(13, "0");
+}
+
+function appFacets(entry: CatalogEntry): string[] {
+    const facets = [normalizeTag(entry.appKeyId), normalizeTag(entry.appName)];
+    return [...new Set(facets.filter((facet): facet is string => !!facet))];
+}

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -7,6 +7,7 @@ const MAX_TEXT_LENGTH = 1000;
 const MAX_MODEL_LENGTH = 128;
 const MAX_CONTENT_TYPE_LENGTH = 128;
 const REVERSE_TIMESTAMP_MAX = 9_999_999_999_999;
+const RESERVED_SYSTEM_TAG_PREFIXES = ["app:", "hash:"];
 
 const ALLOWED_CATALOG_HOSTS = new Set([
     "gen.pollinations.ai",
@@ -124,6 +125,11 @@ export function createCatalogEntry(input: {
     appName?: string | null;
     appOwnerUserId?: string | null;
 }): CatalogEntry {
+    const tags = mergeTags(input.fields.tags, [
+        input.hash ? `hash:${input.hash}` : null,
+        input.appKeyId ? `app:${input.appKeyId}` : null,
+    ]);
+
     return {
         entryId: crypto.randomUUID(),
         url: input.url,
@@ -132,7 +138,7 @@ export function createCatalogEntry(input: {
         ...(input.size !== undefined && { size: input.size }),
         createdAt: new Date().toISOString(),
         visibility: input.fields.visibility,
-        tags: input.fields.tags,
+        tags,
         ...(input.fields.prompt && { prompt: input.fields.prompt }),
         ...(input.fields.model && { model: input.fields.model }),
         ...(input.ownerUserId && { ownerUserId: input.ownerUserId }),
@@ -161,15 +167,8 @@ export async function writeCatalogEntry(
     }
 
     if (entry.visibility === "public") {
-        keys.add(`${CATALOG_PREFIX}/public/${suffix}`);
-        if (entry.hash) {
-            keys.add(`${CATALOG_PREFIX}/hash/${entry.hash}/${suffix}`);
-        }
         for (const tag of entry.tags) {
             keys.add(`${CATALOG_PREFIX}/tag/${safeFacet(tag)}/${suffix}`);
-        }
-        for (const app of appFacets(entry)) {
-            keys.add(`${CATALOG_PREFIX}/app/${app}/${suffix}`);
         }
     }
 
@@ -208,11 +207,7 @@ export async function listCatalogEntries(
     });
 }
 
-export function catalogPrefix(
-    kind: "public" | "owner" | "tag" | "app" | "hash",
-    facet?: string,
-): string {
-    if (kind === "public") return `${CATALOG_PREFIX}/public/`;
+export function catalogPrefix(kind: "owner" | "tag", facet?: string): string {
     return `${CATALOG_PREFIX}/${kind}/${safeFacet(facet)}/`;
 }
 
@@ -278,26 +273,6 @@ export function normalizeCatalogUrl(input: unknown): {
     };
 }
 
-export async function resolveCatalogAppFacet(
-    appRef: string | null,
-    verifyApiKey: (apiKey: string) => Promise<{
-        apiKeyId?: string;
-        keyId?: string;
-        name?: string | null;
-    } | null>,
-): Promise<string | null> {
-    if (!appRef) return null;
-    if (/^(pk_|plln_pk_)/.test(appRef)) {
-        const verified = await verifyApiKey(appRef);
-        return (
-            normalizeTag(verified?.apiKeyId) ||
-            normalizeTag(verified?.keyId) ||
-            normalizeTag(verified?.name)
-        );
-    }
-    return normalizeTag(appRef);
-}
-
 function normalizeCatalogFields(raw: Record<string, unknown>): CatalogFields {
     return {
         visibility: normalizeVisibility(raw.visibility),
@@ -342,11 +317,29 @@ function normalizeTags(input: unknown[]): string[] {
     const seen = new Set<string>();
     for (const part of input.flatMap(tagParts)) {
         const tag = normalizeTag(part);
-        if (!tag || seen.has(tag)) continue;
+        if (!tag || isReservedSystemTag(tag) || seen.has(tag)) continue;
         seen.add(tag);
         if (seen.size >= MAX_TAGS) break;
     }
     return [...seen];
+}
+
+function mergeTags(
+    userTags: string[],
+    systemTagInputs: Array<string | null>,
+): string[] {
+    const seen = new Set(userTags);
+    for (const input of systemTagInputs) {
+        const tag = normalizeTag(input);
+        if (tag) seen.add(tag);
+    }
+    return [...seen];
+}
+
+function isReservedSystemTag(tag: string): boolean {
+    return RESERVED_SYSTEM_TAG_PREFIXES.some((prefix) =>
+        tag.startsWith(prefix),
+    );
 }
 
 function tagParts(input: unknown): string[] {
@@ -373,9 +366,4 @@ function reverseTimestamp(createdAt: string): string {
     const timestamp = Date.parse(createdAt);
     const reversed = REVERSE_TIMESTAMP_MAX - timestamp;
     return String(reversed).padStart(13, "0");
-}
-
-function appFacets(entry: CatalogEntry): string[] {
-    const facets = [normalizeTag(entry.appKeyId), normalizeTag(entry.appName)];
-    return [...new Set(facets.filter((facet): facet is string => !!facet))];
 }

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -13,8 +13,8 @@ import {
     createCatalogEntry,
     listCatalogEntries,
     normalizeCatalogUrl,
+    normalizeTag,
     parseListLimit,
-    resolveCatalogAppFacet,
     safeFacet,
     writeCatalogEntry,
 } from "./catalog";
@@ -102,10 +102,30 @@ function catalogListResponse(
     limit: number,
     includePrivateFields = false,
 ) {
-    const media = entries.map((entry) =>
-        catalogItem(entry, includePrivateFields),
-    );
+    const seen = new Set<string>();
+    const media = entries
+        .filter((entry) => {
+            if (seen.has(entry.entryId)) return false;
+            seen.add(entry.entryId);
+            return true;
+        })
+        .map((entry) => catalogItem(entry, includePrivateFields));
     return { media, count: media.length, limit };
+}
+
+function catalogQueryTags(req: {
+    queries: (key: string) => string[] | undefined;
+}) {
+    return [
+        ...(req.queries("tag") ?? []),
+        ...(req.queries("tags") ?? []).flatMap((value) => value.split(",")),
+    ]
+        .map((tag) => normalizeTag(tag))
+        .filter((tag): tag is string => !!tag);
+}
+
+function isMineCatalogQuery(value: string | undefined): boolean {
+    return value === "mine";
 }
 
 const UploadResponseSchema = z.object({
@@ -440,12 +460,13 @@ api.post(
 );
 
 api.get(
-    "/me/media",
+    "/catalog",
     describeRoute({
         tags: ["media.pollinations.ai"],
-        summary: "List my media",
+        summary: "List catalog entries",
         description:
-            "List catalog entries created by the authenticated user, including private entries.",
+            "List public catalog entries by tag. Pass `scope=mine` with an API key to list entries created by the caller, including private entries. App and media-hash attribution are server-stamped tags such as `app:<app-key-id>` and `hash:<media-hash>`.",
+        security: [],
         responses: {
             200: {
                 description: "Catalog entries",
@@ -455,8 +476,14 @@ api.get(
                     },
                 },
             },
+            400: {
+                description: "Missing tag for public catalog query",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
             401: {
-                description: "Missing or invalid API key",
+                description: "Missing or invalid API key for scope=mine",
                 content: {
                     "application/json": { schema: resolver(ErrorSchema) },
                 },
@@ -464,120 +491,54 @@ api.get(
         },
     }),
     async (c) => {
-        const authResult = await requireApiKey(c.req.raw);
-        if (!authResult) {
-            return c.json({ error: "Missing or invalid API key" }, 401);
+        const limit = parseListLimit(c.req.query("limit") ?? null);
+        const queryTags = catalogQueryTags(c.req);
+
+        if (isMineCatalogQuery(c.req.query("scope"))) {
+            const authResult = await requireApiKey(c.req.raw);
+            if (!authResult) {
+                return c.json({ error: "Missing or invalid API key" }, 401);
+            }
+
+            const owner = safeFacet(authResult.userId || authResult.name);
+            const entries = (
+                await listCatalogEntries(
+                    c.env.MEDIA_BUCKET,
+                    catalogPrefix("owner", owner),
+                    limit,
+                )
+            ).filter(
+                (entry) =>
+                    queryTags.length === 0 ||
+                    queryTags.some((tag) => entry.tags.includes(tag)),
+            );
+            return c.json(catalogListResponse(entries, limit, true));
         }
 
-        const limit = parseListLimit(c.req.query("limit") ?? null);
-        const owner = safeFacet(authResult.userId || authResult.name);
-        const entries = await listCatalogEntries(
-            c.env.MEDIA_BUCKET,
-            catalogPrefix("owner", owner),
-            limit,
-        );
-        return c.json(catalogListResponse(entries, limit, true));
-    },
-);
-
-api.get(
-    "/gallery",
-    describeRoute({
-        tags: ["media.pollinations.ai"],
-        summary: "List public media",
-        description:
-            "List public catalog entries. Filter with `tag`, `app`, or `app_key`.",
-        security: [],
-        responses: {
-            200: {
-                description: "Public catalog entries",
-                content: {
-                    "application/json": {
-                        schema: resolver(CatalogListResponseSchema),
-                    },
-                },
-            },
-        },
-    }),
-    async (c) => {
-        const limit = parseListLimit(c.req.query("limit") ?? null);
-        const tag = c.req.query("tag");
-        const appRef = c.req.query("app_key") || c.req.query("app");
-        const appFacet = await resolveCatalogAppFacet(
-            appRef ?? null,
-            verifyApiKey,
-        );
-        if (appRef && !appFacet) {
-            return c.json(catalogListResponse([], limit));
+        if (queryTags.length === 0) {
+            return c.json({ error: "tag is required unless scope=mine" }, 400);
         }
-        const prefix = tag
-            ? catalogPrefix("tag", tag)
-            : appFacet
-              ? catalogPrefix("app", appFacet)
-              : catalogPrefix("public");
+
         const entries = (
-            await listCatalogEntries(c.env.MEDIA_BUCKET, prefix, limit)
-        ).filter((entry) => entry.visibility === "public");
-        return c.json(catalogListResponse(entries, limit));
+            await Promise.all(
+                queryTags.map((tag) =>
+                    listCatalogEntries(
+                        c.env.MEDIA_BUCKET,
+                        catalogPrefix("tag", tag),
+                        limit,
+                    ),
+                ),
+            )
+        ).flat();
+
+        return c.json(
+            catalogListResponse(
+                entries.filter((entry) => entry.visibility === "public"),
+                limit,
+            ),
+        );
     },
 );
-
-api.get("/apps/:app/media", async (c) => {
-    const limit = parseListLimit(c.req.query("limit") ?? null);
-    const appFacet = await resolveCatalogAppFacet(
-        c.req.param("app"),
-        verifyApiKey,
-    );
-    if (!appFacet) return c.json({ error: "Invalid app" }, 400);
-    const entries = (
-        await listCatalogEntries(
-            c.env.MEDIA_BUCKET,
-            catalogPrefix("app", appFacet),
-            limit,
-        )
-    ).filter((entry) => entry.visibility === "public");
-    return c.json(catalogListResponse(entries, limit));
-});
-
-api.get("/tags/:tag", async (c) => {
-    const limit = parseListLimit(c.req.query("limit") ?? null);
-    const entries = (
-        await listCatalogEntries(
-            c.env.MEDIA_BUCKET,
-            catalogPrefix("tag", c.req.param("tag")),
-            limit,
-        )
-    ).filter((entry) => entry.visibility === "public");
-    return c.json(catalogListResponse(entries, limit));
-});
-
-api.get("/tags/:tag/media", async (c) => {
-    const limit = parseListLimit(c.req.query("limit") ?? null);
-    const entries = (
-        await listCatalogEntries(
-            c.env.MEDIA_BUCKET,
-            catalogPrefix("tag", c.req.param("tag")),
-            limit,
-        )
-    ).filter((entry) => entry.visibility === "public");
-    return c.json(catalogListResponse(entries, limit));
-});
-
-api.get("/:hash/catalog", async (c) => {
-    const hash = c.req.param("hash");
-    if (!HASH_PATTERN.test(hash)) {
-        return c.json({ error: "Invalid hash format" }, 400);
-    }
-    const limit = parseListLimit(c.req.query("limit") ?? null);
-    const entries = (
-        await listCatalogEntries(
-            c.env.MEDIA_BUCKET,
-            catalogPrefix("hash", hash),
-            limit,
-        )
-    ).filter((entry) => entry.visibility === "public");
-    return c.json(catalogListResponse(entries, limit));
-});
 
 api.get(
     "/:hash",
@@ -778,8 +739,8 @@ app.get("/", (c) => {
         endpoints: {
             upload: "POST /upload (requires API key)",
             catalog: "POST /catalog (requires API key)",
-            myMedia: "GET /me/media (requires API key)",
-            gallery: "GET /gallery",
+            catalogQuery:
+                "GET /catalog?tag=<tag> or /catalog?scope=mine (scope=mine requires API key)",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -2,6 +2,22 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi";
 import { z } from "zod";
+import {
+    type CatalogEntry,
+    type CatalogFields,
+    catalogFieldsFromFormData,
+    catalogFieldsFromObject,
+    catalogFieldsFromSearchParams,
+    catalogItem,
+    catalogPrefix,
+    createCatalogEntry,
+    listCatalogEntries,
+    normalizeCatalogUrl,
+    parseListLimit,
+    resolveCatalogAppFacet,
+    safeFacet,
+    writeCatalogEntry,
+} from "./catalog";
 
 const DOMAIN = "media.pollinations.ai";
 // gen.pollinations.ai proxies /account/* to enter — using the public path
@@ -26,6 +42,12 @@ interface AuthResult {
     valid: boolean;
     type: string;
     name: string | null;
+    userId?: string;
+    apiKeyId?: string;
+    keyId?: string;
+    byopClientKeyId?: string | null;
+    byopClientName?: string | null;
+    byopClientUserId?: string | null;
 }
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
@@ -57,16 +79,75 @@ function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
 }
 
+function authCatalogFields(authResult: AuthResult) {
+    return {
+        ownerUserId: authResult.userId,
+        ownerName: authResult.name,
+        apiKeyId: authResult.apiKeyId || authResult.keyId,
+        keyType: authResult.type,
+        appKeyId: authResult.byopClientKeyId ?? null,
+        appName: authResult.byopClientName ?? null,
+        appOwnerUserId: authResult.byopClientUserId ?? null,
+    };
+}
+
+async function requireApiKey(req: Request) {
+    const apiKey = extractApiKey(req);
+    if (!apiKey) return null;
+    return verifyApiKey(apiKey);
+}
+
+function catalogListResponse(
+    entries: CatalogEntry[],
+    limit: number,
+    includePrivateFields = false,
+) {
+    const media = entries.map((entry) =>
+        catalogItem(entry, includePrivateFields),
+    );
+    return { media, count: media.length, limit };
+}
+
 const UploadResponseSchema = z.object({
     id: z.string().describe("16-char hex content hash"),
     url: z.string().describe("Public retrieval URL"),
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    entryId: z.string().describe("Catalog entry ID"),
+    visibility: z.enum(["private", "public", "unlisted"]),
+    tags: z.array(z.string()),
+    appKeyId: z.string().nullable().optional(),
+    appName: z.string().nullable().optional(),
 });
 
 const ErrorSchema = z.object({
     error: z.string(),
+});
+
+const CatalogItemSchema = z.object({
+    entryId: z.string(),
+    url: z.string(),
+    hash: z.string().optional(),
+    contentType: z.string().optional(),
+    size: z.number().int().optional(),
+    createdAt: z.string(),
+    visibility: z.enum(["private", "public", "unlisted"]),
+    tags: z.array(z.string()),
+    prompt: z.string().optional(),
+    model: z.string().optional(),
+    appKeyId: z.string().optional(),
+    appName: z.string().optional(),
+});
+
+const CatalogListResponseSchema = z.object({
+    media: z.array(CatalogItemSchema),
+    count: z.number().int(),
+    limit: z.number().int(),
+});
+
+const CatalogCreateResponseSchema = CatalogItemSchema.extend({
+    cataloged: z.boolean(),
 });
 
 const MetadataResponseSchema = z.object({
@@ -140,12 +221,16 @@ api.post(
         let fileBuffer: ArrayBuffer;
         let contentType: string;
         let fileName: string | undefined;
+        let catalogFields: CatalogFields = catalogFieldsFromSearchParams(
+            new URL(c.req.url).searchParams,
+        );
 
         const requestContentType = c.req.header("content-type") || "";
 
         try {
             if (requestContentType.includes("multipart/form-data")) {
                 const formData = await c.req.formData();
+                catalogFields = catalogFieldsFromFormData(formData);
                 const file = formData.get("file") as File | null;
 
                 if (!(file instanceof File)) {
@@ -169,7 +254,15 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
+                    tag?: string | string[];
+                    tags?: string | string[];
+                    visibility?: string;
+                    prompt?: string;
+                    model?: string;
                 }>();
+                catalogFields = catalogFieldsFromObject(
+                    body as Record<string, unknown>,
+                );
 
                 if (!body.data) {
                     return c.json(
@@ -228,6 +321,16 @@ api.post(
                 },
             });
 
+            const entry = createCatalogEntry({
+                url: mediaUrl(hash),
+                hash,
+                contentType,
+                size: fileBuffer.byteLength,
+                fields: catalogFields,
+                ...authCatalogFields(authResult),
+            });
+            await writeCatalogEntry(c.env.MEDIA_BUCKET, entry);
+
             console.log(
                 JSON.stringify({
                     event: "upload",
@@ -236,7 +339,12 @@ api.post(
                     contentType,
                     keyType: authResult.type,
                     uploadedBy: authResult.name || "unknown",
+                    userId: authResult.userId,
+                    appKeyId: authResult.byopClientKeyId,
                     duplicate: !!existing,
+                    entryId: entry.entryId,
+                    visibility: entry.visibility,
+                    tags: entry.tags,
                 }),
             );
 
@@ -246,6 +354,11 @@ api.post(
                 contentType,
                 size: fileBuffer.byteLength,
                 duplicate: !!existing,
+                entryId: entry.entryId,
+                visibility: entry.visibility,
+                tags: entry.tags,
+                appKeyId: entry.appKeyId,
+                appName: entry.appName,
             });
         } catch (error) {
             console.error("Upload error:", error);
@@ -253,6 +366,218 @@ api.post(
         }
     },
 );
+
+api.post(
+    "/catalog",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "Catalog existing media",
+        description:
+            "Create a tag-indexed catalog entry for an existing Pollinations media URL without uploading bytes again. Relationships can be modeled as ordinary tags such as `parent:<hash>`.",
+        responses: {
+            200: {
+                description: "Catalog entry created",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogCreateResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid URL or catalog fields",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const authResult = await requireApiKey(c.req.raw);
+        if (!authResult) {
+            return c.json({ error: "Missing or invalid API key" }, 401);
+        }
+
+        try {
+            const requestContentType = c.req.header("content-type") || "";
+            let body: Record<string, unknown>;
+            let fields: CatalogFields;
+
+            if (requestContentType.includes("multipart/form-data")) {
+                const formData = await c.req.formData();
+                body = Object.fromEntries(formData.entries());
+                fields = catalogFieldsFromFormData(formData);
+            } else {
+                body = (await c.req.json()) as Record<string, unknown>;
+                fields = catalogFieldsFromObject(body);
+            }
+
+            const normalized = normalizeCatalogUrl(body.url);
+            const entry = createCatalogEntry({
+                ...normalized,
+                contentType: fields.contentType,
+                size: fields.size,
+                fields,
+                ...authCatalogFields(authResult),
+            });
+            await writeCatalogEntry(c.env.MEDIA_BUCKET, entry);
+
+            return c.json({
+                cataloged: true,
+                ...catalogItem(entry, true),
+            });
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : "Catalog failed";
+            return c.json({ error: message }, 400);
+        }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List my media",
+        description:
+            "List catalog entries created by the authenticated user, including private entries.",
+        responses: {
+            200: {
+                description: "Catalog entries",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const authResult = await requireApiKey(c.req.raw);
+        if (!authResult) {
+            return c.json({ error: "Missing or invalid API key" }, 401);
+        }
+
+        const limit = parseListLimit(c.req.query("limit") ?? null);
+        const owner = safeFacet(authResult.userId || authResult.name);
+        const entries = await listCatalogEntries(
+            c.env.MEDIA_BUCKET,
+            catalogPrefix("owner", owner),
+            limit,
+        );
+        return c.json(catalogListResponse(entries, limit, true));
+    },
+);
+
+api.get(
+    "/gallery",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List public media",
+        description:
+            "List public catalog entries. Filter with `tag`, `app`, or `app_key`.",
+        security: [],
+        responses: {
+            200: {
+                description: "Public catalog entries",
+                content: {
+                    "application/json": {
+                        schema: resolver(CatalogListResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const limit = parseListLimit(c.req.query("limit") ?? null);
+        const tag = c.req.query("tag");
+        const appRef = c.req.query("app_key") || c.req.query("app");
+        const appFacet = await resolveCatalogAppFacet(
+            appRef ?? null,
+            verifyApiKey,
+        );
+        if (appRef && !appFacet) {
+            return c.json(catalogListResponse([], limit));
+        }
+        const prefix = tag
+            ? catalogPrefix("tag", tag)
+            : appFacet
+              ? catalogPrefix("app", appFacet)
+              : catalogPrefix("public");
+        const entries = (
+            await listCatalogEntries(c.env.MEDIA_BUCKET, prefix, limit)
+        ).filter((entry) => entry.visibility === "public");
+        return c.json(catalogListResponse(entries, limit));
+    },
+);
+
+api.get("/apps/:app/media", async (c) => {
+    const limit = parseListLimit(c.req.query("limit") ?? null);
+    const appFacet = await resolveCatalogAppFacet(
+        c.req.param("app"),
+        verifyApiKey,
+    );
+    if (!appFacet) return c.json({ error: "Invalid app" }, 400);
+    const entries = (
+        await listCatalogEntries(
+            c.env.MEDIA_BUCKET,
+            catalogPrefix("app", appFacet),
+            limit,
+        )
+    ).filter((entry) => entry.visibility === "public");
+    return c.json(catalogListResponse(entries, limit));
+});
+
+api.get("/tags/:tag", async (c) => {
+    const limit = parseListLimit(c.req.query("limit") ?? null);
+    const entries = (
+        await listCatalogEntries(
+            c.env.MEDIA_BUCKET,
+            catalogPrefix("tag", c.req.param("tag")),
+            limit,
+        )
+    ).filter((entry) => entry.visibility === "public");
+    return c.json(catalogListResponse(entries, limit));
+});
+
+api.get("/tags/:tag/media", async (c) => {
+    const limit = parseListLimit(c.req.query("limit") ?? null);
+    const entries = (
+        await listCatalogEntries(
+            c.env.MEDIA_BUCKET,
+            catalogPrefix("tag", c.req.param("tag")),
+            limit,
+        )
+    ).filter((entry) => entry.visibility === "public");
+    return c.json(catalogListResponse(entries, limit));
+});
+
+api.get("/:hash/catalog", async (c) => {
+    const hash = c.req.param("hash");
+    if (!HASH_PATTERN.test(hash)) {
+        return c.json({ error: "Invalid hash format" }, 400);
+    }
+    const limit = parseListLimit(c.req.query("limit") ?? null);
+    const entries = (
+        await listCatalogEntries(
+            c.env.MEDIA_BUCKET,
+            catalogPrefix("hash", hash),
+            limit,
+        )
+    ).filter((entry) => entry.visibility === "public");
+    return c.json(catalogListResponse(entries, limit));
+});
 
 api.get(
     "/:hash",
@@ -452,6 +777,9 @@ app.get("/", (c) => {
         version: "1.0.0",
         endpoints: {
             upload: "POST /upload (requires API key)",
+            catalog: "POST /catalog (requires API key)",
+            myMedia: "GET /me/media (requires API key)",
+            gallery: "GET /gallery",
             retrieve: "GET /:hash",
             docs: "GET /openapi.json",
         },

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -83,6 +83,11 @@ describe("media.pollinations.ai", () => {
         expect(res.status).toBe(401);
     });
 
+    it("public catalog reads require a tag", async () => {
+        const res = await SELF.fetch("https://media.pollinations.ai/catalog");
+        expect(res.status).toBe(400);
+    });
+
     it("upload, retrieve, and deduplicate", async () => {
         const form = new FormData();
         form.append(
@@ -154,7 +159,10 @@ describe("media.pollinations.ai", () => {
             new File([TINY_PNG], "catalog.png", { type: "image/png" }),
         );
         form.append("visibility", "public");
-        form.append("tags", `catgpt,${tag},${parentTag}`);
+        form.append(
+            "tags",
+            `catgpt,${tag},${parentTag},app:forged,hash:forged`,
+        );
         form.append("prompt", "catalog test prompt");
         form.append("model", "flux");
 
@@ -172,9 +180,13 @@ describe("media.pollinations.ai", () => {
         expect(upload.visibility).toBe("public");
         expect(upload.tags).toContain(tag);
         expect(upload.tags).toContain(parentTag);
+        expect(upload.tags).toContain(`app:${TEST_APP_KEY_ID}`);
+        expect(upload.tags).toContain(`hash:${upload.id}`);
+        expect(upload.tags).not.toContain("app:forged");
+        expect(upload.tags).not.toContain("hash:forged");
 
         const meRes = await SELF.fetch(
-            "https://media.pollinations.ai/me/media",
+            "https://media.pollinations.ai/catalog?scope=mine",
             { headers: { Authorization: `Bearer ${VALID_KEY}` } },
         );
         expect(meRes.status).toBe(200);
@@ -187,7 +199,7 @@ describe("media.pollinations.ai", () => {
         expect(privateItem?.apiKeyId).toBe(TEST_API_KEY_ID);
 
         const tagRes = await SELF.fetch(
-            `https://media.pollinations.ai/tags/${encodeURIComponent(tag)}`,
+            `https://media.pollinations.ai/catalog?tag=${encodeURIComponent(tag)}`,
         );
         expect(tagRes.status).toBe(200);
         const byTag = (await tagRes.json()) as CatalogListResponse;
@@ -200,7 +212,7 @@ describe("media.pollinations.ai", () => {
         expect(publicItem?.apiKeyId).toBeUndefined();
 
         const hashRes = await SELF.fetch(
-            `https://media.pollinations.ai/${upload.id}/catalog`,
+            `https://media.pollinations.ai/catalog?tag=${encodeURIComponent(`hash:${upload.id}`)}`,
         );
         expect(hashRes.status).toBe(200);
         const byHash = (await hashRes.json()) as CatalogListResponse;
@@ -235,12 +247,12 @@ describe("media.pollinations.ai", () => {
         );
         expect(entry.appKeyId).toBe(TEST_APP_KEY_ID);
 
-        const galleryRes = await SELF.fetch(
-            `https://media.pollinations.ai/gallery?tag=${encodeURIComponent(tag)}`,
+        const catalogRes = await SELF.fetch(
+            `https://media.pollinations.ai/catalog?tag=${encodeURIComponent(tag)}`,
         );
-        expect(galleryRes.status).toBe(200);
-        const gallery = (await galleryRes.json()) as CatalogListResponse;
-        const publicItem = gallery.media.find(
+        expect(catalogRes.status).toBe(200);
+        const catalog = (await catalogRes.json()) as CatalogListResponse;
+        const publicItem = catalog.media.find(
             (item) => item.entryId === entry.entryId,
         );
         expect(publicItem).toBeTruthy();

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -17,9 +17,22 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    entryId: string;
+    visibility: string;
+    tags: string[];
 }
 
 const VALID_KEY = "pk_test_key_123";
+const TEST_USER_ID = "test-user-id";
+const TEST_API_KEY_ID = "test-api-key-id";
+const TEST_APP_KEY_ID = "test-app-key-id";
+const TEST_APP_NAME = "CatGPT";
+
+interface CatalogListResponse {
+    media: Array<Record<string, unknown>>;
+    count: number;
+    limit: number;
+}
 
 function mockAuth() {
     fetchMock.activate();
@@ -33,6 +46,12 @@ function mockAuth() {
                 valid: true,
                 type: "publishable",
                 name: "test-user",
+                userId: TEST_USER_ID,
+                apiKeyId: TEST_API_KEY_ID,
+                keyId: TEST_API_KEY_ID,
+                byopClientKeyId: TEST_APP_KEY_ID,
+                byopClientName: TEST_APP_NAME,
+                byopClientUserId: "test-app-owner-id",
             }),
             { headers: { "content-type": "application/json" } },
         )
@@ -124,6 +143,111 @@ describe("media.pollinations.ai", () => {
         const dup = (await dupRes.json()) as UploadResponse;
         expect(dup.id).toBe(upload.id);
         expect(dup.duplicate).toBe(true);
+    });
+
+    it("catalogs uploads with public tags and redacts public lists", async () => {
+        const tag = `test:${crypto.randomUUID()}`;
+        const parentTag = "parent:abcdef1234567890";
+        const form = new FormData();
+        form.append(
+            "file",
+            new File([TINY_PNG], "catalog.png", { type: "image/png" }),
+        );
+        form.append("visibility", "public");
+        form.append("tags", `catgpt,${tag},${parentTag}`);
+        form.append("prompt", "catalog test prompt");
+        form.append("model", "flux");
+
+        const uploadRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: form,
+                headers: { Authorization: `Bearer ${VALID_KEY}` },
+            },
+        );
+        expect(uploadRes.status).toBe(200);
+        const upload = (await uploadRes.json()) as UploadResponse;
+        expect(upload.entryId).toBeTruthy();
+        expect(upload.visibility).toBe("public");
+        expect(upload.tags).toContain(tag);
+        expect(upload.tags).toContain(parentTag);
+
+        const meRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            { headers: { Authorization: `Bearer ${VALID_KEY}` } },
+        );
+        expect(meRes.status).toBe(200);
+        const me = (await meRes.json()) as CatalogListResponse;
+        const privateItem = me.media.find(
+            (item) => item.entryId === upload.entryId,
+        );
+        expect(privateItem).toBeTruthy();
+        expect(privateItem?.ownerUserId).toBe(TEST_USER_ID);
+        expect(privateItem?.apiKeyId).toBe(TEST_API_KEY_ID);
+
+        const tagRes = await SELF.fetch(
+            `https://media.pollinations.ai/tags/${encodeURIComponent(tag)}`,
+        );
+        expect(tagRes.status).toBe(200);
+        const byTag = (await tagRes.json()) as CatalogListResponse;
+        const publicItem = byTag.media.find(
+            (item) => item.entryId === upload.entryId,
+        );
+        expect(publicItem).toBeTruthy();
+        expect(publicItem?.appName).toBe(TEST_APP_NAME);
+        expect(publicItem?.ownerUserId).toBeUndefined();
+        expect(publicItem?.apiKeyId).toBeUndefined();
+
+        const hashRes = await SELF.fetch(
+            `https://media.pollinations.ai/${upload.id}/catalog`,
+        );
+        expect(hashRes.status).toBe(200);
+        const byHash = (await hashRes.json()) as CatalogListResponse;
+        expect(
+            byHash.media.some((item) => item.entryId === upload.entryId),
+        ).toBe(true);
+    });
+
+    it("catalogs existing gen URLs without storing the key in the URL", async () => {
+        const tag = `gen:${crypto.randomUUID()}`;
+        const res = await SELF.fetch("https://media.pollinations.ai/catalog", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${VALID_KEY}`,
+            },
+            body: JSON.stringify({
+                url: `https://gen.pollinations.ai/image/test?width=512&key=${VALID_KEY}&save=1&tag=ignored`,
+                visibility: "public",
+                tags: ["catgpt", tag, "parent:abcdef1234567890"],
+                prompt: "test",
+                model: "flux",
+                contentType: "image/png",
+                size: 67,
+            }),
+        });
+        expect(res.status).toBe(200);
+        const entry = (await res.json()) as Record<string, unknown>;
+        expect(entry.cataloged).toBe(true);
+        expect(entry.url).toBe(
+            "https://gen.pollinations.ai/image/test?width=512",
+        );
+        expect(entry.appKeyId).toBe(TEST_APP_KEY_ID);
+
+        const galleryRes = await SELF.fetch(
+            `https://media.pollinations.ai/gallery?tag=${encodeURIComponent(tag)}`,
+        );
+        expect(galleryRes.status).toBe(200);
+        const gallery = (await galleryRes.json()) as CatalogListResponse;
+        const publicItem = gallery.media.find(
+            (item) => item.entryId === entry.entryId,
+        );
+        expect(publicItem).toBeTruthy();
+        expect(publicItem?.url).toBe(
+            "https://gen.pollinations.ai/image/test?width=512",
+        );
+        expect(publicItem?.apiKeyId).toBeUndefined();
     });
 
     it("same content with different filename produces different hash", async () => {


### PR DESCRIPTION
- Adds a tag-only media catalog with private owner lists, public gallery/tag/app indexes, and redacted public responses.
- Exposes server-attested user and BYOP app claims from /account/key for media stamping.
- Lets gen cached image/video/audio URLs opt into cataloging with save/tag params without changing cache identity.
- Wires CatGPT, chat, dungeon, slide, bot, makeup, and packaging examples to catalog generated media without app-side reupload.