### PR TITLE
fix(enter): drop WeChat Pay from payment banner

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -26,7 +26,7 @@ const PINNED_NEWS: Highlight[] = [
         emoji: "💳",
         title: "Local payment methods are here",
         description:
-            "Buy Pollen your way — UPI in India, Pix in Brazil, Alipay & WeChat Pay in China, and iDEAL in Europe. More local options now show automatically based on your country.",
+            "Buy Pollen your way — UPI in India, Pix in Brazil, Alipay in China, and iDEAL in Europe. More local options now show automatically based on your country.",
     },
     {
         date: "2026-05-07",


### PR DESCRIPTION
- Removes "WeChat Pay" from the local-payment-methods pinned banner
- WeChat Pay is not enabled on the live Stripe PMC (only Alipay is)