### PR TITLE
Add Claude Opus 4.8

### DIFF
--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -53,6 +53,7 @@ SCHEMA >
 -- Pricing
 `token_price_prompt_text`          Float64  `json:$.tokenPricePromptText` DEFAULT 0,
 `token_price_prompt_cached`        Float64  `json:$.tokenPricePromptCached` DEFAULT 0,
+`token_price_prompt_cache_write`   Float64  `json:$.tokenPricePromptCacheWrite` DEFAULT 0,
 `token_price_prompt_audio`         Float64  `json:$.tokenPricePromptAudio` DEFAULT 0,
 `token_price_prompt_image`         Float64  `json:$.tokenPricePromptImage` DEFAULT 0,
 `token_price_prompt_video`         Float64  `json:$.tokenPricePromptVideo` DEFAULT 0,
@@ -67,6 +68,7 @@ SCHEMA >
 `token_count_prompt_text`          UInt32   `json:$.tokenCountPromptText` DEFAULT 0,
 `token_count_prompt_audio`         UInt32   `json:$.tokenCountPromptAudio` DEFAULT 0,
 `token_count_prompt_cached`        UInt32   `json:$.tokenCountPromptCached` DEFAULT 0,
+`token_count_prompt_cache_write`   UInt32   `json:$.tokenCountPromptCacheWrite` DEFAULT 0,
 `token_count_prompt_image`         UInt32   `json:$.tokenCountPromptImage` DEFAULT 0,
 `token_count_prompt_video`         UInt32   `json:$.tokenCountPromptVideo` DEFAULT 0,
 `token_count_completion_text`      UInt32   `json:$.tokenCountCompletionText` DEFAULT 0,

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -58,6 +58,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000055,
     },
   },
+  "claude-opus-4.8": {
+    "cost": {
+      "completionTextTokens": 0.0000275,
+      "promptCachedTokens": 5.5e-7,
+      "promptTextTokens": 0.0000055,
+    },
+    "price": {
+      "completionTextTokens": 0.00004125,
+      "promptCachedTokens": 8.25e-7,
+      "promptTextTokens": 0.00000825,
+    },
+  },
   "cohere-embed-v4": {
     "cost": {
       "promptTextTokens": 1.2e-7,

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -13,11 +13,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "claude": {
     "cost": {
       "completionTextTokens": 0.0000165,
+      "promptCacheWriteTokens": 0.000004125,
       "promptCachedTokens": 3.3e-7,
       "promptTextTokens": 0.0000033,
     },
     "price": {
       "completionTextTokens": 0.0000165,
+      "promptCacheWriteTokens": 0.000004125,
       "promptCachedTokens": 3.3e-7,
       "promptTextTokens": 0.0000033,
     },
@@ -25,11 +27,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "claude-fast": {
     "cost": {
       "completionTextTokens": 0.0000055,
+      "promptCacheWriteTokens": 0.000001375,
       "promptCachedTokens": 1.1e-7,
       "promptTextTokens": 0.0000011,
     },
     "price": {
       "completionTextTokens": 0.0000055,
+      "promptCacheWriteTokens": 0.000001375,
       "promptCachedTokens": 1.1e-7,
       "promptTextTokens": 0.0000011,
     },
@@ -37,11 +41,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "claude-large": {
     "cost": {
       "completionTextTokens": 0.0000275,
+      "promptCacheWriteTokens": 0.000006875,
       "promptCachedTokens": 5.5e-7,
       "promptTextTokens": 0.0000055,
     },
     "price": {
       "completionTextTokens": 0.0000275,
+      "promptCacheWriteTokens": 0.000006875,
       "promptCachedTokens": 5.5e-7,
       "promptTextTokens": 0.0000055,
     },
@@ -49,11 +55,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "claude-opus-4.7": {
     "cost": {
       "completionTextTokens": 0.0000275,
+      "promptCacheWriteTokens": 0.000006875,
       "promptCachedTokens": 5.5e-7,
       "promptTextTokens": 0.0000055,
     },
     "price": {
       "completionTextTokens": 0.0000275,
+      "promptCacheWriteTokens": 0.000006875,
       "promptCachedTokens": 5.5e-7,
       "promptTextTokens": 0.0000055,
     },
@@ -61,11 +69,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "claude-opus-4.8": {
     "cost": {
       "completionTextTokens": 0.0000275,
+      "promptCacheWriteTokens": 0.000006875,
       "promptCachedTokens": 5.5e-7,
       "promptTextTokens": 0.0000055,
     },
     "price": {
       "completionTextTokens": 0.00004125,
+      "promptCacheWriteTokens": 0.0000103125,
       "promptCachedTokens": 8.25e-7,
       "promptTextTokens": 0.00000825,
     },

--- a/enter.pollinations.ai/test/helpers/billing-assertions.ts
+++ b/enter.pollinations.ai/test/helpers/billing-assertions.ts
@@ -14,6 +14,7 @@ type BillingEvent = {
     selectedMeterSlug?: string | null;
     tokenPricePromptText: number;
     tokenPricePromptCached: number;
+    tokenPricePromptCacheWrite?: number;
     tokenPricePromptAudio: number;
     tokenPricePromptImage: number;
     tokenPriceCompletionText: number;
@@ -24,6 +25,7 @@ type BillingEvent = {
     tokenPriceCompletionVideoTokens?: number;
     tokenCountPromptText: number;
     tokenCountPromptCached: number;
+    tokenCountPromptCacheWrite?: number;
     tokenCountPromptAudio: number;
     tokenCountPromptImage: number;
     tokenCountCompletionText: number;
@@ -40,6 +42,7 @@ function usageFromEvent(event: BillingEvent): Usage {
     return {
         promptTextTokens: event.tokenCountPromptText,
         promptCachedTokens: event.tokenCountPromptCached,
+        promptCacheWriteTokens: event.tokenCountPromptCacheWrite || 0,
         promptAudioTokens: event.tokenCountPromptAudio,
         promptImageTokens: event.tokenCountPromptImage,
         completionTextTokens: event.tokenCountCompletionText,
@@ -72,6 +75,9 @@ export function assertTrackedBillingEvent(
     );
     expect(event.tokenPricePromptCached).toBe(
         priceDefinition?.promptCachedTokens || 0,
+    );
+    expect(event.tokenPricePromptCacheWrite || 0).toBe(
+        priceDefinition?.promptCacheWriteTokens || 0,
     );
     expect(event.tokenPricePromptAudio).toBe(
         priceDefinition?.promptAudioTokens || 0,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -125,6 +125,10 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["claude-opus-4-7"],
     },
     {
+        name: "claude-opus-4.8",
+        config: portkeyConfig["claude-opus-4-8"],
+    },
+    {
         name: "gemini",
         config: portkeyConfig["gemini-3-flash-preview"],
         transform: pipe(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -171,6 +171,11 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "us.anthropic.claude-opus-4-7",
             defaultOptions: { max_tokens: 128000 },
         }),
+    "claude-opus-4-8": () =>
+        createBedrockNativeConfig({
+            model: "us.anthropic.claude-opus-4-8",
+            defaultOptions: { max_tokens: 128000 },
+        }),
     "claude-haiku-4-5": () =>
         createBedrockNativeConfig({
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
+++ b/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
@@ -74,12 +74,12 @@ export function processParameters(
         updatedOptions.temperature = 1;
     }
 
-    // Claude Opus 4.7 deprecated temperature/top_p/top_k — non-default values
+    // Claude Opus 4.7/4.8 deprecated temperature/top_p/top_k — non-default values
     // return 400 from Anthropic. Strip them entirely.
-    if (/claude-opus-4-7/i.test(model)) {
+    if (/claude-opus-4-[78]/i.test(model)) {
         for (const param of ["temperature", "top_p", "top_k"] as const) {
             if (updatedOptions[param] !== undefined) {
-                log(`Stripping ${param} for Claude Opus 4.7`);
+                log(`Stripping ${param} for ${model}`);
                 delete updatedOptions[param];
             }
         }

--- a/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
@@ -35,9 +35,12 @@ describe("processParameters", () => {
         expect(result.options.max_completion_tokens).toBeUndefined();
     });
 
-    it("strips temperature/top_p/top_k for Claude Opus 4.7", () => {
+    it.each([
+        "us.anthropic.claude-opus-4-7",
+        "us.anthropic.claude-opus-4-8",
+    ])("strips temperature/top_p/top_k for %s", (model) => {
         const result = processParameters(messages, {
-            model: "us.anthropic.claude-opus-4-7",
+            model,
             temperature: 0.7,
             top_p: 0.9,
             top_k: 40,

--- a/gen.pollinations.ai/test/usage-headers.test.ts
+++ b/gen.pollinations.ai/test/usage-headers.test.ts
@@ -48,6 +48,17 @@ describe("buildUsageHeaders", () => {
         expect(headers["x-usage-prompt-cached-tokens"]).toBe("50");
     });
 
+    it("should include prompt cache write tokens header when present", () => {
+        const usage: Usage = {
+            promptTextTokens: 100,
+            promptCacheWriteTokens: 4096,
+            completionTextTokens: 20,
+        };
+        const headers = buildUsageHeaders("claude-large", usage);
+
+        expect(headers["x-usage-prompt-cache-write-tokens"]).toBe("4096");
+    });
+
     it("should include reasoning tokens header when present", () => {
         const usage: Usage = {
             promptTextTokens: 100,
@@ -113,6 +124,26 @@ describe("openaiUsageToUsage", () => {
 
         expect(usage.promptTextTokens).toBe(70); // 100 - 30
         expect(usage.promptCachedTokens).toBe(30);
+    });
+
+    it("should handle Anthropic cache creation tokens", () => {
+        const openaiUsage = {
+            prompt_tokens: 8596,
+            completion_tokens: 8,
+            total_tokens: 8604,
+            prompt_tokens_details: {
+                cached_tokens: 0,
+            },
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 8584,
+        };
+
+        const usage = openaiUsageToUsage(openaiUsage);
+
+        expect(usage.promptTextTokens).toBe(12);
+        expect(usage.promptCacheWriteTokens).toBe(8584);
+        expect(usage.promptCachedTokens).toBe(0);
+        expect(usage.completionTextTokens).toBe(8);
     });
 
     it("should handle reasoning tokens in completion_tokens_details", () => {
@@ -346,12 +377,14 @@ describe("parseUsageHeaders", () => {
             "x-model-used": "claude-large",
             "x-usage-prompt-text-tokens": "200",
             "x-usage-prompt-cached-tokens": "100",
+            "x-usage-prompt-cache-write-tokens": "4096",
         });
 
         const usage = parseUsageHeaders(headers);
 
         expect(usage.promptTextTokens).toBe(200);
         expect(usage.promptCachedTokens).toBe(100);
+        expect(usage.promptCacheWriteTokens).toBe(4096);
     });
 
     it("should omit missing headers", () => {
@@ -372,6 +405,7 @@ describe("buildUsageHeaders + parseUsageHeaders round-trip", () => {
         const originalUsage: Usage = {
             promptTextTokens: 100,
             promptCachedTokens: 50,
+            promptCacheWriteTokens: 4096,
             promptAudioTokens: 200,
             completionTextTokens: 75,
             completionReasoningTokens: 150,
@@ -386,6 +420,9 @@ describe("buildUsageHeaders + parseUsageHeaders round-trip", () => {
         );
         expect(parsedUsage.promptCachedTokens).toBe(
             originalUsage.promptCachedTokens,
+        );
+        expect(parsedUsage.promptCacheWriteTokens).toBe(
+            originalUsage.promptCacheWriteTokens,
         );
         expect(parsedUsage.promptAudioTokens).toBe(
             originalUsage.promptAudioTokens,

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -11,9 +11,10 @@ import {
 } from "./registry";
 
 // Pricing uses registry field names directly, filtering out zero/undefined values
-// Fields: promptTextTokens, promptCachedTokens, promptAudioTokens, promptAudioSeconds,
-//         promptImageTokens, completionTextTokens, completionReasoningTokens,
-//         completionAudioTokens, completionImageTokens, completionVideoSeconds, completionVideoTokens
+// Fields: promptTextTokens, promptCachedTokens, promptCacheWriteTokens,
+//         promptAudioTokens, promptAudioSeconds, promptImageTokens,
+//         completionTextTokens, completionReasoningTokens, completionAudioTokens,
+//         completionImageTokens, completionVideoSeconds, completionVideoTokens
 export const ModelInfoSchema = z.object({
     name: z.string(),
     aliases: z.array(z.string()),

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -35,6 +35,7 @@ export type Category =
 export type UsageType =
     | "promptTextTokens"
     | "promptCachedTokens"
+    | "promptCacheWriteTokens"
     | "promptAudioTokens"
     | "promptAudioSeconds"
     | "promptImageTokens"

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -709,6 +709,29 @@ export const TEXT_SERVICES = {
         contextLength: 200000,
         isSpecialized: false,
     },
+    "claude-opus-4.8": {
+        aliases: [],
+        modelId: "claude-opus-4-8",
+        provider: "bedrock",
+        brand: "Anthropic",
+        category: "text",
+        addedDate: new Date("2026-05-29").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1.5,
+        cost: {
+            // Bedrock us.anthropic.claude-opus-4-8 — Anthropic list $5/$25 per M
+            // (+ ~10% Bedrock premium), prompt-cache read at $0.55/M.
+            promptTextTokens: perMillion(5.5),
+            promptCachedTokens: perMillion(0.55),
+            completionTextTokens: perMillion(27.5),
+        },
+        description: "Claude Opus 4.8 - Most Intelligent Model",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        tools: true,
+        contextLength: 200000,
+        isSpecialized: false,
+    },
     "perplexity-fast": {
         aliases: ["sonar"],
         modelId: "sonar",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -637,6 +637,7 @@ export const TEXT_SERVICES = {
         cost: {
             promptTextTokens: perMillion(1.1),
             promptCachedTokens: perMillion(0.11),
+            promptCacheWriteTokens: perMillion(1.375),
             completionTextTokens: perMillion(5.5),
         },
         description: "Claude Haiku 4.5 - Fast & Intelligent",
@@ -658,6 +659,7 @@ export const TEXT_SERVICES = {
         cost: {
             promptTextTokens: perMillion(3.3),
             promptCachedTokens: perMillion(0.33),
+            promptCacheWriteTokens: perMillion(4.125),
             completionTextTokens: perMillion(16.5),
         },
         description: "Claude Sonnet 4.6 - Most Capable & Balanced",
@@ -679,6 +681,7 @@ export const TEXT_SERVICES = {
         cost: {
             promptTextTokens: perMillion(5.5),
             promptCachedTokens: perMillion(0.55),
+            promptCacheWriteTokens: perMillion(6.875),
             completionTextTokens: perMillion(27.5),
         },
         description: "Claude Opus 4.6 - Most Intelligent Model",
@@ -700,6 +703,7 @@ export const TEXT_SERVICES = {
         cost: {
             promptTextTokens: perMillion(5.5),
             promptCachedTokens: perMillion(0.55),
+            promptCacheWriteTokens: perMillion(6.875),
             completionTextTokens: perMillion(27.5),
         },
         description: "Claude Opus 4.7 - Most Intelligent Model",
@@ -720,16 +724,17 @@ export const TEXT_SERVICES = {
         priceMultiplier: 1.5,
         cost: {
             // Bedrock us.anthropic.claude-opus-4-8 — Anthropic list $5/$25 per M
-            // (+ ~10% Bedrock premium), prompt-cache read at $0.55/M.
+            // (+ ~10% Bedrock premium), 5-minute cache writes at 1.25x input.
             promptTextTokens: perMillion(5.5),
             promptCachedTokens: perMillion(0.55),
+            promptCacheWriteTokens: perMillion(6.875),
             completionTextTokens: perMillion(27.5),
         },
         description: "Claude Opus 4.8 - Most Intelligent Model",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         tools: true,
-        contextLength: 200000,
+        contextLength: 1000000,
         isSpecialized: false,
     },
     "perplexity-fast": {

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -6,6 +6,7 @@ import type { Usage, UsageType } from "./registry.ts";
 export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
     promptTextTokens: "x-usage-prompt-text-tokens",
     promptCachedTokens: "x-usage-prompt-cached-tokens",
+    promptCacheWriteTokens: "x-usage-prompt-cache-write-tokens",
     promptAudioTokens: "x-usage-prompt-audio-tokens",
     promptAudioSeconds: "x-usage-prompt-audio-seconds",
     promptImageTokens: "x-usage-prompt-image-tokens",
@@ -44,6 +45,8 @@ export function openaiUsageToUsage(openaiUsage: {
         audio_tokens?: number | null;
         image_tokens?: number | null;
     } | null;
+    cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
     completion_tokens_details?: {
         reasoning_tokens?: number | null;
         audio_tokens?: number | null;
@@ -51,8 +54,14 @@ export function openaiUsageToUsage(openaiUsage: {
         rejected_prediction_tokens?: number | null;
     } | null;
 }): Usage {
+    const promptCachedTokens =
+        openaiUsage.prompt_tokens_details?.cached_tokens ||
+        openaiUsage.cache_read_input_tokens ||
+        0;
+    const promptCacheWriteTokens = openaiUsage.cache_creation_input_tokens ?? 0;
     const promptDetails = [
-        openaiUsage.prompt_tokens_details?.cached_tokens || 0,
+        promptCachedTokens,
+        promptCacheWriteTokens,
         openaiUsage.prompt_tokens_details?.audio_tokens || 0,
         openaiUsage.prompt_tokens_details?.image_tokens || 0,
     ];
@@ -91,14 +100,19 @@ export function openaiUsageToUsage(openaiUsage: {
         ? openaiUsage.completion_tokens
         : openaiUsage.completion_tokens - sumTokens(cappedCompletionDetails);
 
-    const [promptCachedTokens, promptAudioTokens, promptImageTokens] =
-        cappedPromptDetails;
+    const [
+        cappedPromptCachedTokens,
+        cappedPromptCacheWriteTokens,
+        promptAudioTokens,
+        promptImageTokens,
+    ] = cappedPromptDetails;
     const [, , completionAudioTokens, completionReasoningTokens] =
         cappedCompletionDetails;
 
     return {
         promptTextTokens,
-        promptCachedTokens,
+        promptCachedTokens: cappedPromptCachedTokens,
+        promptCacheWriteTokens: cappedPromptCacheWriteTokens,
         promptAudioTokens,
         promptImageTokens,
         completionTextTokens,

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -61,6 +61,7 @@ export type TinybirdEvent = {
     // Pricing
     tokenPricePromptText: number;
     tokenPricePromptCached: number;
+    tokenPricePromptCacheWrite: number;
     tokenPricePromptAudio: number;
     tokenPricePromptImage: number;
     tokenPricePromptVideo: number;
@@ -75,6 +76,7 @@ export type TinybirdEvent = {
     tokenCountPromptText: number;
     tokenCountPromptAudio: number;
     tokenCountPromptCached: number;
+    tokenCountPromptCacheWrite: number;
     tokenCountPromptImage: number;
     tokenCountPromptVideo: number;
     tokenCountCompletionText: number;
@@ -127,6 +129,7 @@ export type SelectGenerationEvent = TinybirdEvent;
 export type GenerationEventPriceParams = {
     tokenPricePromptText: number;
     tokenPricePromptCached: number;
+    tokenPricePromptCacheWrite: number;
     tokenPricePromptAudio: number;
     tokenPricePromptImage: number;
     tokenPricePromptVideo: number;
@@ -141,6 +144,7 @@ export type GenerationEventPriceParams = {
 export type GenerationEventUsageParams = {
     tokenCountPromptText: number;
     tokenCountPromptCached: number;
+    tokenCountPromptCacheWrite: number;
     tokenCountPromptAudio: number;
     tokenCountPromptImage: number;
     tokenCountPromptVideo: number;
@@ -164,6 +168,8 @@ export function priceToEventParams(
             priceDefinition?.promptTextTokens || 0,
         tokenPricePromptCached: 
             priceDefinition?.promptCachedTokens || 0,
+        tokenPricePromptCacheWrite:
+            priceDefinition?.promptCacheWriteTokens || 0,
         tokenPricePromptAudio: 
             priceDefinition?.promptAudioTokens || 0,
         tokenPricePromptImage:
@@ -191,6 +197,7 @@ export function usageToEventParams(usage?: Usage): GenerationEventUsageParams {
     return {
         tokenCountPromptText: usage?.promptTextTokens || 0,
         tokenCountPromptCached: usage?.promptCachedTokens || 0,
+        tokenCountPromptCacheWrite: usage?.promptCacheWriteTokens || 0,
         tokenCountPromptAudio: usage?.promptAudioTokens || 0,
         tokenCountPromptImage: usage?.promptImageTokens || 0,
         tokenCountPromptVideo: usage?.promptVideoTokens || 0,

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -407,6 +407,8 @@ const ChatCompletionChoiceLogprobsSchema = z
 
 export const CompletionUsageSchema = z
     .object({
+        cache_creation_input_tokens: z.number().int().nonnegative().nullish(),
+        cache_read_input_tokens: z.number().int().nonnegative().nullish(),
         completion_tokens: z.number().int().nonnegative(),
         completion_tokens_details: z
             .object({
@@ -429,6 +431,7 @@ export const CompletionUsageSchema = z
             .object({
                 audio_tokens: z.number().int().nonnegative().nullish(),
                 cached_tokens: z.number().int().nonnegative().nullish(),
+                image_tokens: z.number().int().nonnegative().nullish(),
             })
             .nullish(),
         total_tokens: z.number().int().nonnegative(),


### PR DESCRIPTION
Adds Claude Opus 4.8 via AWS Bedrock.

- Model `claude-opus-4.8` → `us.anthropic.claude-opus-4-8`
- Sets `paidOnly: true`, `priceMultiplier: 1.5`, text+image input, tools, and 1M context
- Adds Claude prompt-cache-write billing from `cache_creation_input_tokens`
- Adds usage headers, event schema fields, Tinybird columns, and tests for cache writes

Verified:
- Tinybird staging deployment #20 live
- Tinybird prod deployment #124 live
- enter pricing tests: 205 passed
- gen usage/model/parameter tests: 39 passed
- gen + enter typecheck passed