### PR TITLE
Add StepFun Step 3.5 Flash

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -964,6 +964,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.0525,
     },
   },
+  "step-3.5-flash": {
+    "cost": {
+      "completionTextTokens": 3e-7,
+      "promptCachedTokens": 2e-8,
+      "promptTextTokens": 9e-8,
+    },
+    "price": {
+      "completionTextTokens": 3e-7,
+      "promptCachedTokens": 2e-8,
+      "promptTextTokens": 9e-8,
+    },
+  },
   "step-flash": {
     "cost": {
       "completionTextTokens": 0.00000115,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -63,6 +63,10 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["qwen/qwen3-vl-235b-a22b-thinking"],
     },
     {
+        name: "step-3.5-flash",
+        config: portkeyConfig["stepfun/step-3.5-flash"],
+    },
+    {
         name: "step-flash",
         config: portkeyConfig["stepfun/step-3.7-flash"],
     },

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -264,6 +264,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- OpenRouter (StepFun) -------------------------------------------------
+    "stepfun/step-3.5-flash": () =>
+        createOpenRouterModelConfig({
+            model: "stepfun/step-3.5-flash",
+        }),
     "stepfun/step-3.7-flash": () =>
         createOpenRouterModelConfig({
             model: "stepfun/step-3.7-flash",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1222,6 +1222,29 @@ export const TEXT_SERVICES = {
         contextLength: 256000,
         isSpecialized: false,
     },
+    "step-3.5-flash": {
+        aliases: ["stepfun-3.5-flash", "step-flash-3.5"],
+        modelId: "stepfun/step-3.5-flash",
+        provider: "openrouter",
+        brand: "StepFun",
+        category: "text",
+        addedDate: new Date("2026-05-29").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter stepfun/step-3.5-flash posted rates (2026-05-29):
+            // prompt $0.09/M, completion $0.30/M, cache read $0.02/M
+            promptTextTokens: perMillion(0.09),
+            promptCachedTokens: perMillion(0.02),
+            completionTextTokens: perMillion(0.3),
+        },
+        description: "StepFun Step 3.5 Flash - Fast text reasoning model",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
     "qwen-safety": {
         aliases: ["qwen3guard-gen-8b"],
         modelId: "Qwen3Guard-Gen-8B",


### PR DESCRIPTION
Adds OpenRouter StepFun Step 3.5 Flash.

- Adds `step-3.5-flash` → `stepfun/step-3.5-flash`
- Sets text-only modalities, reasoning, tools, 262144 context
- Adds OpenRouter pricing: $0.09/M input, $0.30/M output, $0.02/M cache read
- Updates effective pricing snapshot

Verified:
- `npx biome check --write ...`
- enter model/pricing tests: 207 passed
- gen model tests: 8 passed
- gen + enter typecheck passed
- local gen E2E: basic, streaming, tools