### PR TITLE
fix: use global pricing for Claude Opus 4.8

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -68,16 +68,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "claude-opus-4.8": {
     "cost": {
-      "completionTextTokens": 0.0000275,
-      "promptCacheWriteTokens": 0.000006875,
-      "promptCachedTokens": 5.5e-7,
-      "promptTextTokens": 0.0000055,
+      "completionTextTokens": 0.000025,
+      "promptCacheWriteTokens": 0.00000625,
+      "promptCachedTokens": 5e-7,
+      "promptTextTokens": 0.000005,
     },
     "price": {
-      "completionTextTokens": 0.00004125,
-      "promptCacheWriteTokens": 0.0000103125,
-      "promptCachedTokens": 8.25e-7,
-      "promptTextTokens": 0.00000825,
+      "completionTextTokens": 0.0000375,
+      "promptCacheWriteTokens": 0.000009375,
+      "promptCachedTokens": 7.5e-7,
+      "promptTextTokens": 0.0000075,
     },
   },
   "cohere-embed-v4": {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -173,7 +173,7 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
     "claude-opus-4-8": () =>
         createBedrockNativeConfig({
-            model: "us.anthropic.claude-opus-4-8",
+            model: "global.anthropic.claude-opus-4-8",
             defaultOptions: { max_tokens: 128000 },
         }),
     "claude-haiku-4-5": () =>

--- a/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
@@ -37,7 +37,7 @@ describe("processParameters", () => {
 
     it.each([
         "us.anthropic.claude-opus-4-7",
-        "us.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-opus-4-8",
     ])("strips temperature/top_p/top_k for %s", (model) => {
         const result = processParameters(messages, {
             model,

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -723,12 +723,11 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1.5,
         cost: {
-            // Bedrock us.anthropic.claude-opus-4-8 — Anthropic list $5/$25 per M
-            // (+ ~10% Bedrock premium), 5-minute cache writes at 1.25x input.
-            promptTextTokens: perMillion(5.5),
-            promptCachedTokens: perMillion(0.55),
-            promptCacheWriteTokens: perMillion(6.875),
-            completionTextTokens: perMillion(27.5),
+            // Bedrock global.anthropic.claude-opus-4-8 global standard rates.
+            promptTextTokens: perMillion(5),
+            promptCachedTokens: perMillion(0.5),
+            promptCacheWriteTokens: perMillion(6.25),
+            completionTextTokens: perMillion(25),
         },
         description: "Claude Opus 4.8 - Most Intelligent Model",
         inputModalities: ["text", "image"],


### PR DESCRIPTION
- Switches Claude Opus 4.8 Bedrock routing to `global.anthropic.claude-opus-4-8`
- Uses AWS/Anthropic global rates as the cost basis before the `1.5x` multiplier
- Updates the effective pricing snapshot and parameter transform test fixture

Verified:
- `npx biome check --write shared/registry/text.ts gen.pollinations.ai/src/text/configs/modelConfigs.ts gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap`
- `npx vitest run test/effective-prices.snapshot.test.ts`
- `npx vitest run test/text/transforms/parameterProcessor.test.ts`