### PR TITLE
[PATCH]: Correct language and misspelled "badge" for the contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,7 @@ If you're interested in coding, we enthusiastically welcome contributions in the
 - **Code Optimization:** Refactoring and improving the efficiency, readability, and maintainability of the codebase.
 - **New Functionalities:** Developing innovative features that expand the project's scope.
 
-### How to earn the "pollinations.ai Contributor" badge
-
-To earn this badge, contributors need to:
+### A Short Hands on For a Quick Contribution Flow:-
 
 1. Submit at least one meaningful pull request that gets merged into the repository.
 2. Ensure the pull request follows the project's contribution guidelines.


### PR DESCRIPTION
## Changes Made:- 

- We don't offer a badge after we are done with hacktoberfest for any means of recognition, the `CONTRIBUTING.md` was mentioning it wrong `L:57`. Shipped a fix for that