### PR TITLE
[FEAT]: Addons of a Download Button in the API Documentation (gen.pollinations)

### DIFF
--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -302,12 +302,18 @@ function pollinationsHeaderHtml(scalarHosted = false): string {
 <header class="ph-bar">
   <a href="/" class="ph-brand"><img src="/docs/logo.svg" alt="Pollinations" /></a>
 </header>
-<div class="ph-fab-cluster">
+
+    <div class="ph-fab-cluster">
   <button class="ph-fab ph-fab-copy" type="button">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
     <span>Copy for LLMs</span>
   </button>
+  <button class="ph-fab ph-fab-download" type="button">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+    <span>Download</span>
+  </button>
 </div>
+
 <script>
 (function () {
   // Copy for LLMs — always copies the full doc (api + integrations).

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -329,6 +329,26 @@ function pollinationsHeaderHtml(scalarHosted = false): string {
       setTimeout(function () { label.textContent = prev; }, 1200);
     });
   }
+    var dl = document.querySelector('.ph-fab-download');
+if (dl) {
+  var dlLabel = dl.querySelector('span');
+  dl.addEventListener('click', async function () {
+    var res = await fetch('/docs/llm.txt');
+    var blob = await res.blob();
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'pollinations-llm-docs.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    var prev = dlLabel.textContent;
+    dlLabel.textContent = 'Downloaded';
+    setTimeout(function () { dlLabel.textContent = prev; }, 1200);
+  });
+}
+
   // Text-based DOM scan for Scalar buttons whose class names get hashed
   // by the CDN bundle — we tag them by their stable label so our CSS can
   // hide ("Ask AI") or style ("Show more") them in amber.


### PR DESCRIPTION
## Changes Made:- 

- Adds sibling button in .ph-fab-cluster with arrow-down-tray icon
- Click triggers Blob download of /docs/llm.txt as pollinations-llm-docs.txt
- Mirrors existing Copy button label-flip feedback pattern
- No new endpoint; reuses existing /llm.txt route at line 1565

> Fixes #11428 