### PR TITLE
fix: publish UI package

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "packages/sdk/**"
+      - "packages/ui/**"
       - "packages/mcp/**"
       - "packages/polli-cli/**"
 
@@ -15,6 +16,7 @@ jobs:
       contents: read
     outputs:
       sdk: ${{ steps.changes.outputs.sdk }}
+      ui: ${{ steps.changes.outputs.ui }}
       mcp: ${{ steps.changes.outputs.mcp }}
       polli-cli: ${{ steps.changes.outputs.polli-cli }}
     steps:
@@ -27,6 +29,7 @@ jobs:
         run: |
           changed=$(git diff --name-only HEAD~1 HEAD)
           echo "sdk=$(echo "$changed" | grep -q '^packages/sdk/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "ui=$(echo "$changed" | grep -q '^packages/ui/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "mcp=$(echo "$changed" | grep -q '^packages/mcp/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "polli-cli=$(echo "$changed" | grep -q '^packages/polli-cli/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
@@ -82,6 +85,63 @@ jobs:
             const pkg = require('./package.json');
             pkg.name = '@pollinations/sdk';
             pkg.repository = { type: 'git', url: 'https://github.com/pollinations/pollinations.git', directory: 'packages/sdk' };
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+          "
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          echo "@pollinations:registry=https://npm.pkg.github.com" >> .npmrc
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-ui:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ui == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies & build
+        run: |
+          npm ci
+          npm run build --workspace @pollinations_ai/sdk
+          npm run build --workspace @pollinations_ai/ui
+
+      - name: Check if version already published
+        id: check
+        working-directory: packages/ui
+        run: |
+          name=$(node -p "require('./package.json').name")
+          v=$(node -p "require('./package.json').version")
+          if npm view "$name@$v" version >/dev/null 2>&1; then
+            echo "Version $v already on npm — skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to NPM
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/ui
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_KEY }}
+
+      - name: Publish to GitHub Packages
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/ui
+        run: |
+          node -e "
+            const pkg = require('./package.json');
+            pkg.name = '@pollinations/ui';
+            pkg.repository = { type: 'git', url: 'https://github.com/pollinations/pollinations.git', directory: 'packages/ui' };
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -72,7 +72,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pollinations/pollinations.git",
+    "url": "git+https://github.com/pollinations/pollinations.git",
     "directory": "packages/sdk"
   },
   "homepage": "https://pollinations.ai",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pollinations/pollinations.git",
+    "directory": "packages/ui"
+  },
   "peerDependencies": {
     "@pollinations_ai/sdk": "^4.4.0",
     "react": "^18.2.0 || ^19.0.0"


### PR DESCRIPTION
- Adds `packages/ui/**` to the package publish workflow trigger and change detection.
- Adds a `publish-ui` job that builds the SDK + UI package before publishing `@pollinations_ai/ui`.
- Adds repository metadata to the SDK/UI package manifests so dry-run publish no longer needs npm autocorrection.

Validation:
- `actionlint .github/workflows/publish-packages.yml`
- `npm publish --dry-run --access public --workspace @pollinations_ai/ui`
- `npm publish --dry-run --access public --workspace @pollinations_ai/sdk`

Note: the merged SDK publish run for #11217 failed with npm 404 on `@pollinations_ai/sdk@4.4.0`, which points to npm token/package access rather than a build/package-shape issue. This PR fixes the missing UI publish path; the npm secret may still need permission correction or rerun after update.