### PR TITLE
Cap realtime session spend

### DIFF
--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -1,4 +1,5 @@
-import { getUserBalance } from "@shared/billing/balance.ts";
+import { getUserBalance, type UserBalance } from "@shared/billing/balance.ts";
+import { MARKUP_PCT } from "@shared/billing/markup.ts";
 import {
     handleBalanceDeduction,
     type MarkupResolution,
@@ -49,6 +50,8 @@ const CREDENTIAL_QUERY_PARAMS = new Set([
 ]);
 const UNSUPPORTED_TRANSCRIPTION_MESSAGE =
     "Realtime input transcription is not supported yet.";
+const REALTIME_SPEND_LIMIT_MESSAGE = "Realtime session spend limit reached.";
+const REALTIME_MAX_RESPONSE_OUTPUT_TOKENS = 4096;
 type WebSocketResponse = Response & { webSocket?: WebSocket };
 type WebSocketResponseInit = ResponseInit & { webSocket?: WebSocket };
 type RealtimeDeduction = Awaited<ReturnType<typeof handleBalanceDeduction>>;
@@ -80,6 +83,9 @@ type RealtimeBillingContext = {
     settled: boolean;
     deduction?: RealtimeDeduction;
     rateLimitConsumed: boolean;
+    sessionPriceLimit: number;
+    maxResponseOutputTokens: number;
+    spendLimitReached: boolean;
 };
 
 function requireAllowedModel(c: Context<Env>, model: string): void {
@@ -177,6 +183,7 @@ function forwardMessage(
     target: WebSocket,
     validate?: (data: unknown) => string | null,
     onReject?: () => void,
+    transform?: (data: unknown) => unknown,
 ): void {
     source.addEventListener("message", (event) => {
         const error = validate?.(event.data);
@@ -186,7 +193,7 @@ function forwardMessage(
             onReject?.();
             return;
         }
-        if (isOpen(target)) target.send(event.data);
+        if (isOpen(target)) target.send(transform?.(event.data) ?? event.data);
     });
 }
 
@@ -218,6 +225,56 @@ function addUsage(target: Usage, delta: Usage): void {
         if (!amount || amount <= 0) continue;
         target[usageType] = (target[usageType] ?? 0) + amount;
     }
+}
+
+function getRealtimeMaxOutputTokenPrice(): number {
+    const priceDefinition = getPriceDefinition(DEFAULT_REALTIME_MODEL) ?? {};
+    return Math.max(
+        priceDefinition.completionTextTokens ?? 0,
+        priceDefinition.completionAudioTokens ?? 0,
+    );
+}
+
+function getRealtimeUserSpendLimit(balances: UserBalance): number {
+    return Math.max(0, balances.tierBalance ?? 0, balances.packBalance ?? 0);
+}
+
+function getRealtimeSessionPriceLimit(args: {
+    balances: UserBalance;
+    apiKeyPollenBalance?: number | null;
+    byopClientKeyId?: string | null;
+}): number {
+    const userLimit = getRealtimeUserSpendLimit(args.balances);
+    const apiKeyLimit =
+        typeof args.apiKeyPollenBalance === "number"
+            ? Math.max(0, args.apiKeyPollenBalance)
+            : Number.POSITIVE_INFINITY;
+    const rawLimit = Math.min(userLimit, apiKeyLimit);
+    const markupMultiplier = args.byopClientKeyId ? 1 + MARKUP_PCT : 1;
+    return rawLimit / markupMultiplier;
+}
+
+function getRealtimeMaxResponseOutputTokens(sessionPriceLimit: number): number {
+    const maxOutputTokenPrice = getRealtimeMaxOutputTokenPrice();
+    if (maxOutputTokenPrice <= 0) return REALTIME_MAX_RESPONSE_OUTPUT_TOKENS;
+    const affordableTokens = Math.floor(
+        sessionPriceLimit / maxOutputTokenPrice,
+    );
+    return Math.max(
+        1,
+        Math.min(REALTIME_MAX_RESPONSE_OUTPUT_TOKENS, affordableTokens),
+    );
+}
+
+function capRealtimePrice(
+    price: UsagePrice,
+    sessionPriceLimit: number,
+): UsagePrice {
+    if (price.totalPrice <= sessionPriceLimit) return price;
+    return {
+        ...price,
+        totalPrice: sessionPriceLimit,
+    };
 }
 
 function realtimeUsageToUsage(rawUsage: unknown): Usage {
@@ -319,6 +376,59 @@ function validateClientRealtimeEvent(data: unknown): string | null {
     }
 
     return null;
+}
+
+function getClampedOutputTokenLimit(
+    value: unknown,
+    maxOutputTokens: number,
+): number {
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+        return maxOutputTokens;
+    }
+    return Math.max(1, Math.min(maxOutputTokens, Math.floor(value)));
+}
+
+function clampRealtimeOutputTokens(
+    payload: Record<string, unknown>,
+    maxOutputTokens: number,
+): Record<string, unknown> {
+    const clamped = {
+        ...payload,
+        max_output_tokens: getClampedOutputTokenLimit(
+            payload.max_output_tokens,
+            maxOutputTokens,
+        ),
+    };
+
+    if ("max_response_output_tokens" in clamped) {
+        clamped.max_response_output_tokens = getClampedOutputTokenLimit(
+            clamped.max_response_output_tokens,
+            maxOutputTokens,
+        );
+    }
+
+    return clamped;
+}
+
+function limitClientRealtimeEvent(
+    data: unknown,
+    maxOutputTokens: number,
+): unknown {
+    const parsed = parseEventData(data);
+    const event = asRecord(parsed);
+    const type = event.type;
+    if (type !== "session.update" && type !== "response.create") return data;
+
+    const payloadKey = type === "session.update" ? "session" : "response";
+    const payload = clampRealtimeOutputTokens(
+        asRecord(event[payloadKey]),
+        maxOutputTokens,
+    );
+
+    return JSON.stringify({
+        ...event,
+        [payloadKey]: payload,
+    });
 }
 
 function isInputAudioTranscriptionEventType(type: unknown): type is string {
@@ -490,7 +600,8 @@ async function settleRealtimeSession(
     }
 
     const cost = calculateCost(DEFAULT_REALTIME_MODEL, usage);
-    const price = calculatePrice(DEFAULT_REALTIME_MODEL, usage);
+    const rawPrice = calculatePrice(DEFAULT_REALTIME_MODEL, usage);
+    const price = capRealtimePrice(rawPrice, tracking.sessionPriceLimit);
     if (price.totalPrice <= 0) {
         tracking.settled = true;
         return;
@@ -540,6 +651,7 @@ async function settleRealtimeSession(
 function collectBillingEvents(
     upstream: WebSocket,
     billing: RealtimeBillingContext,
+    onSpendLimitReached?: () => void,
 ): void {
     upstream.addEventListener("message", (event) => {
         const eventData = parseEventData(event.data);
@@ -548,6 +660,15 @@ function collectBillingEvents(
             extractUnsupportedInputTranscriptionUsage(eventData);
         if (!usage) return;
         addUsage(billing.usage, usage);
+
+        const price = calculatePrice(DEFAULT_REALTIME_MODEL, billing.usage);
+        if (
+            price.totalPrice >= billing.sessionPriceLimit &&
+            !billing.spendLimitReached
+        ) {
+            billing.spendLimitReached = true;
+            onSpendLimitReached?.();
+        }
     });
 }
 
@@ -625,9 +746,31 @@ function proxyRealtimeWebSockets(
     downstream.binaryType = "arraybuffer";
     downstream.accept({ allowHalfOpen: true });
 
-    collectBillingEvents(upstream, tracking);
-    forwardMessage(downstream, upstream, validateClientRealtimeEvent, () =>
-        scheduleRealtimeSettlement(c, tracking),
+    if (isOpen(upstream)) {
+        upstream.send(
+            JSON.stringify({
+                type: "session.update",
+                session: {
+                    max_output_tokens: tracking.maxResponseOutputTokens,
+                },
+            }),
+        );
+    }
+
+    const closeForSpendLimit = () => {
+        closeSocket(downstream, 1008, REALTIME_SPEND_LIMIT_MESSAGE);
+        closeSocket(upstream, 1008, REALTIME_SPEND_LIMIT_MESSAGE);
+        scheduleRealtimeSettlement(c, tracking);
+    };
+
+    collectBillingEvents(upstream, tracking, closeForSpendLimit);
+    forwardMessage(
+        downstream,
+        upstream,
+        validateClientRealtimeEvent,
+        () => scheduleRealtimeSettlement(c, tracking),
+        (data) =>
+            limitClientRealtimeEvent(data, tracking.maxResponseOutputTokens),
     );
     forwardMessage(upstream, downstream, validateUpstreamRealtimeEvent, () =>
         scheduleRealtimeSettlement(c, tracking),
@@ -645,6 +788,24 @@ async function createRealtimeBillingContext(
     c: Context<Env>,
 ): Promise<RealtimeBillingContext> {
     const user = c.var.auth.requireUser();
+    const apiKeyPollenBalance = c.var.auth.apiKey?.pollenBalance;
+    const byopClientKeyId = c.var.auth.apiKey?.byopClientKeyId;
+    const balances = await c.var.balance.getBalance(user.id);
+    const sessionPriceLimit = getRealtimeSessionPriceLimit({
+        balances,
+        apiKeyPollenBalance,
+        byopClientKeyId,
+    });
+    const maxResponseOutputTokens =
+        getRealtimeMaxResponseOutputTokens(sessionPriceLimit);
+
+    if (!Number.isFinite(sessionPriceLimit) || sessionPriceLimit <= 0) {
+        throw new HTTPException(402, {
+            message:
+                "Realtime sessions require positive user balance and API key budget.",
+        });
+    }
+
     const apiKeyMetadata = c.var.auth.apiKey?.metadata as
         | Record<string, unknown>
         | undefined;
@@ -666,8 +827,8 @@ async function createRealtimeBillingContext(
         apiKeyCreatedForUserId:
             c.var.auth.apiKey?.byopClientUserId ?? undefined,
         apiKeyClientId: c.var.auth.apiKey?.byopClientKeyId ?? undefined,
-        apiKeyPollenBalance: c.var.auth.apiKey?.pollenBalance,
-        byopClientKeyId: c.var.auth.apiKey?.byopClientKeyId,
+        apiKeyPollenBalance,
+        byopClientKeyId,
         requestId: c.get("requestId"),
         requestPath: getRoutePath(c),
         environment: c.env.ENVIRONMENT,
@@ -680,6 +841,9 @@ async function createRealtimeBillingContext(
         settlementAttempts: 0,
         settled: false,
         rateLimitConsumed: false,
+        sessionPriceLimit,
+        maxResponseOutputTokens,
+        spendLimitReached: false,
     };
 }
 

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -3,7 +3,10 @@ import {
     env,
     waitOnExecutionContext,
 } from "cloudflare:test";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    apikey as apiKeyTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import { createTestApiKey, test } from "@shared/test/fixtures/index.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -115,6 +118,15 @@ async function getUserBalances(userId: string) {
     return user;
 }
 
+async function getApiKeyBudget(apiKeyId: string) {
+    const db = drizzle(env.DB);
+    const [apiKey] = await db
+        .select({ pollenBalance: apiKeyTable.pollenBalance })
+        .from(apiKeyTable)
+        .where(eq(apiKeyTable.id, apiKeyId));
+    return apiKey?.pollenBalance ?? null;
+}
+
 async function waitForPackBalanceBelow(userId: string, maxBalance: number) {
     for (let attempt = 0; attempt < 20; attempt++) {
         const user = await getUserBalances(userId);
@@ -159,7 +171,15 @@ async function expectClientEventRejected(
     upstream.server.accept();
 
     let upstreamReceived = false;
-    upstream.server.addEventListener("message", () => {
+    upstream.server.addEventListener("message", (event) => {
+        const data = JSON.parse(String(event.data)) as Record<string, unknown>;
+        if (
+            data.type === "session.update" &&
+            JSON.stringify(data.session) ===
+                JSON.stringify({ max_output_tokens: 4096 })
+        ) {
+            return;
+        }
         upstreamReceived = true;
     });
 
@@ -208,13 +228,28 @@ test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
     client.accept();
     upstream.server.accept();
 
+    await expect(nextMessage(upstream.server)).resolves.toBe(
+        JSON.stringify({
+            type: "session.update",
+            session: { max_output_tokens: 4096 },
+        }),
+    );
+
     const upstreamMessage = nextMessage(upstream.server);
     const clientEvent = JSON.stringify({
         type: "session.update",
         session: { instructions: "test" },
     });
     client.send(clientEvent);
-    await expect(upstreamMessage).resolves.toBe(clientEvent);
+    await expect(upstreamMessage).resolves.toBe(
+        JSON.stringify({
+            type: "session.update",
+            session: {
+                instructions: "test",
+                max_output_tokens: 4096,
+            },
+        }),
+    );
 
     const downstreamMessage = nextMessage(client);
     const serverEvent = JSON.stringify({
@@ -495,6 +530,66 @@ test("deducts aggregate session usage from paid pack balance on close", async ()
     expect(telemetry.tokenCountCompletionText).toBe(100);
     expect(telemetry.tokenCountCompletionAudio).toBe(50);
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 8);
+});
+
+test("caps low-budget realtime sessions before they can overdraw balance and key budget", async () => {
+    const { key, id, userId } = await createTestApiKey({
+        name: "capped-low-budget-realtime-key",
+        pollenBudget: 0.04,
+        user: { tierBalance: 0, packBalance: 0.04 },
+    });
+    const upstream = mockOpenAIRealtime();
+
+    const { response, ctx } = await fetchWorkerWithContext(
+        "/v1/realtime?model=gpt-realtime-2",
+        {
+            headers: {
+                Authorization: `Bearer ${key}`,
+                Upgrade: "websocket",
+            },
+        },
+    );
+
+    expect(response.status).toBe(101);
+    const client = response.webSocket;
+    if (!client) throw new Error("Expected downstream WebSocket");
+    client.accept();
+    upstream.server.accept();
+
+    await expect(nextMessage(upstream.server)).resolves.toBe(
+        JSON.stringify({
+            type: "session.update",
+            session: { max_output_tokens: 625 },
+        }),
+    );
+
+    const closeEvent = nextClose(client);
+    upstream.server.send(
+        JSON.stringify({
+            type: "response.done",
+            response: {
+                usage: {
+                    input_tokens: 0,
+                    output_tokens: 2000,
+                    output_token_details: {
+                        audio_tokens: 2000,
+                    },
+                },
+            },
+        }),
+    );
+
+    await expect(closeEvent).resolves.toMatchObject({
+        code: 1008,
+        reason: "Realtime session spend limit reached.",
+    });
+    upstream.server.close();
+    await waitOnExecutionContext(ctx);
+
+    const user = await waitForPackBalanceBelow(userId, 0.04);
+    expect(user?.packBalance).toBeCloseTo(0, 8);
+    await expect(getApiKeyBudget(id)).resolves.toBeCloseTo(0, 8);
+    expect(upstream.tinybirdRequests).toHaveLength(1);
 });
 
 test("falls back to aggregate realtime token totals when details are absent", async () => {


### PR DESCRIPTION
## Summary
- derive a realtime session spend limit from the caller's usable balance and finite API key budget
- clamp realtime response output token settings before forwarding client events upstream
- close and settle sessions when observed usage reaches the authorized spend limit, while capping the settled charge to that limit
- add a regression test for a low-budget realtime session that previously could overdraw both user balance and key budget

## Tests
- npm test -- --run test/realtime.test.ts
- npm run typecheck --workspace pollinations-gen
- npx biome check gen.pollinations.ai/src/routes/realtime.ts gen.pollinations.ai/test/realtime.test.ts