### PR TITLE
fix: consistent, locale-stable response count formatting in model table

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/calculations.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/calculations.ts
@@ -6,18 +6,33 @@
  */
 
 import { canCoverEstimatedCharge } from "@shared/billing/bucket-selection.ts";
-import millify from "millify";
 import type { ModelPrice } from "./types.ts";
 
 export const TOP_UP_TOOLTIP = "🔒 Top up to use this model";
+
+/** Abbreviate a value >= 1000 as K/M/B with one decimal (locale-stable, "1.5K"). */
+function compact(num: number): string {
+    for (const [divisor, suffix] of [
+        [1e9, "B"],
+        [1e6, "M"],
+        [1e3, "K"],
+    ] as const) {
+        if (num >= divisor) {
+            const value = Math.round((num / divisor) * 10) / 10;
+            return `${value}${suffix}`;
+        }
+    }
+    return num.toString();
+}
 
 /** Format number as coarse estimate (not precise - it's an average) */
 function formatCount(num: number): string {
     if (num < 1) return "1";
     if (num < 10) return Math.round(num).toString();
     if (num < 100) return (Math.round(num / 5) * 5).toString();
-    if (num < 1000) return (Math.round(num / 50) * 50).toString();
-    return millify(Math.round(num / 100) * 100, { precision: 1 });
+    const rounded = Math.round(num / 50) * 50;
+    if (rounded < 1000) return rounded.toString();
+    return compact(Math.round(num / 100) * 100);
 }
 
 /**

--- a/enter.pollinations.ai/package.json
+++ b/enter.pollinations.ai/package.json
@@ -53,7 +53,6 @@
         "hono": "^4.10.6",
         "hono-openapi": "^1.2.0",
         "hono-rate-limiter": "^0.4.2",
-        "millify": "^6.1.0",
         "nanoid": "^5.1.6",
         "neverthrow": "^8.2.0",
         "react": "^19.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,7 +155,6 @@
         "hono": "^4.10.6",
         "hono-openapi": "^1.2.0",
         "hono-rate-limiter": "^0.4.2",
-        "millify": "^6.1.0",
         "nanoid": "^5.1.6",
         "neverthrow": "^8.2.0",
         "react": "^19.2.0",
@@ -10462,6 +10461,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10471,6 +10471,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11258,6 +11259,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -11295,6 +11297,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11307,6 +11310,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -12312,6 +12316,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -12442,6 +12447,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12698,6 +12704,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -13495,6 +13502,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15131,18 +15139,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/millify": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/millify/-/millify-6.1.0.tgz",
-      "integrity": "sha512-H/E3J6t+DQs/F2YgfDhxUVZz/dF8JXPPKTLHL/yHCcLZLtCXJDUaqvhJXQwqOVBvbyNn4T0WjLpIHd7PAw7fBA==",
-      "license": "MIT",
-      "dependencies": {
-        "yargs": "^17.0.1"
-      },
-      "bin": {
-        "millify": "bin/millify"
-      }
-    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -16594,6 +16590,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17101,6 +17098,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -17147,6 +17145,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18384,6 +18383,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -18455,6 +18455,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -18486,6 +18487,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -18504,6 +18506,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
Supersedes #8876 (which targeted the pre-refactor path `src/client/components/pricing/calculations.ts`, now relocated to `frontend/src/components/models/`).

- Fixes #8875: `formatCount` rounded 975–999 to `"1000"` (`.toString()`) while all values ≥1000 went through `millify` → `"1K"`, so adjacent models showed `"1000"` vs `"1K"` in the same column.
- Drops the `millify` dependency — it was the sole consumer, and it abbreviates via `navigator`-locale `toLocaleString`, rendering `1050` as `"1,1K"` on non-en-US browsers. Every other formatter in the app builds compact strings manually and is locale-stable; replaced with a small inline K/M/B helper matching the existing chart style.
- All other displayed values unchanged (verified across the full range).

Verified: `tsc --noEmit` clean, biome clean, behavior table matches old output except the intended 975–999 → `"1K"`.