### PR TITLE
fix(audio): repair WAV RIFF header sizes in TTS responses

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -115,6 +115,45 @@ function mapOutputFormat(format: string): string {
     return formatMap[format] || "mp3_44100_128";
 }
 
+/**
+ * ElevenLabs streams WAV with a placeholder length in the RIFF header (the
+ * data-chunk size and the overall RIFF size are written as 0x7FFFFFFF and never
+ * back-patched once the real length is known). Tools that trust the header
+ * (Python `wave`, ffmpeg) then crash or truncate. Rewrite both size fields to
+ * the real byte counts. No-op if the header is already correct or not RIFF/WAVE.
+ */
+export function fixWavHeader(buffer: ArrayBuffer): ArrayBuffer {
+    const bytes = new Uint8Array(buffer);
+    if (bytes.length < 44) return buffer; // too short to be a valid WAV header
+    const view = new DataView(buffer);
+    const tag = (offset: number) =>
+        String.fromCharCode(
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        );
+    if (tag(0) !== "RIFF" || tag(8) !== "WAVE") return buffer;
+
+    // Walk the chunk list (offset 12 onward) to find the `data` sub-chunk,
+    // honouring declared sizes rather than scanning bytes (which could match
+    // "data" inside the PCM payload).
+    let offset = 12;
+    while (offset + 8 <= bytes.length) {
+        const chunkId = tag(offset);
+        const chunkSize = view.getUint32(offset + 4, true);
+        if (chunkId === "data") {
+            const actualDataSize = bytes.length - (offset + 8);
+            if (chunkSize === actualDataSize) return buffer; // already correct
+            view.setUint32(offset + 4, actualDataSize, true); // data chunk size
+            view.setUint32(4, bytes.length - 8, true); // RIFF chunk size
+            return buffer;
+        }
+        offset += 8 + chunkSize;
+    }
+    return buffer; // no data chunk found
+}
+
 export async function generateSpeech(opts: {
     modelName?: AudioModelName;
     text: string;
@@ -196,6 +235,21 @@ export async function generateSpeech(opts: {
     };
 
     log.info("TTS success: {chars} characters", { chars: text.length });
+
+    // WAV needs its RIFF header repaired (ElevenLabs ships a placeholder length),
+    // which requires buffering the body. Audio is small (input capped at 4096
+    // chars) so this is cheap; all other formats keep streaming.
+    if (responseFormat === "wav") {
+        const audioBuffer = fixWavHeader(await response.arrayBuffer());
+        return new Response(audioBuffer, {
+            status: 200,
+            headers: {
+                "Content-Type": contentType,
+                "Content-Length": String(audioBuffer.byteLength),
+                ...usageHeaders,
+            },
+        });
+    }
 
     return new Response(response.body, {
         status: 200,

--- a/gen.pollinations.ai/test/wav-header.test.ts
+++ b/gen.pollinations.ai/test/wav-header.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { fixWavHeader } from "../src/routes/audio.ts";
+
+/** Build a minimal RIFF/WAVE buffer: 44-byte header + `dataBytes` of payload,
+ *  with the data-chunk size and RIFF size set to `declared`. */
+function makeWav(dataBytes: number, declared: number): ArrayBuffer {
+    const buf = new ArrayBuffer(44 + dataBytes);
+    const view = new DataView(buf);
+    const ascii = (offset: number, s: string) => {
+        for (let i = 0; i < s.length; i++)
+            view.setUint8(offset + i, s.charCodeAt(i));
+    };
+    ascii(0, "RIFF");
+    view.setUint32(4, declared, true); // RIFF chunk size (intentionally wrong)
+    ascii(8, "WAVE");
+    ascii(12, "fmt ");
+    view.setUint32(16, 16, true); // fmt chunk size
+    ascii(36, "data");
+    view.setUint32(40, declared, true); // data chunk size (intentionally wrong)
+    return buf;
+}
+
+describe("fixWavHeader", () => {
+    it("rewrites the placeholder data/RIFF sizes to the real byte counts", () => {
+        const dataBytes = 1000;
+        const fixed = fixWavHeader(makeWav(dataBytes, 0x7fffffff));
+        const view = new DataView(fixed);
+        expect(view.getUint32(40, true)).toBe(dataBytes); // data chunk size
+        expect(view.getUint32(4, true)).toBe(44 + dataBytes - 8); // RIFF size
+    });
+
+    it("is a no-op when the header is already correct", () => {
+        const dataBytes = 512;
+        const correct = makeWav(dataBytes, dataBytes); // data size already right
+        const view = new DataView(correct);
+        view.setUint32(4, 44 + dataBytes - 8, true); // RIFF size already right too
+        const fixed = fixWavHeader(correct);
+        expect(new DataView(fixed).getUint32(40, true)).toBe(dataBytes);
+        expect(new DataView(fixed).getUint32(4, true)).toBe(44 + dataBytes - 8);
+    });
+
+    it("returns non-RIFF buffers unchanged", () => {
+        const buf = new TextEncoder().encode(
+            "not a wav file at all xxxxxxxxxx",
+        ).buffer;
+        expect(fixWavHeader(buf)).toBe(buf);
+    });
+
+    it("returns buffers shorter than a WAV header unchanged", () => {
+        const buf = new ArrayBuffer(10);
+        expect(fixWavHeader(buf)).toBe(buf);
+    });
+});


### PR DESCRIPTION
- ElevenLabs streams WAV with a placeholder length (`0x7FFFFFFF`) in the data-chunk and RIFF size fields, never back-patched — Python `wave`/ffmpeg then crash or truncate.
- Buffer the WAV body and rewrite both size fields to real byte counts; other formats keep streaming. Input is capped at 4096 chars so buffering is cheap; billing (from `text.length`) is unaffected.
- Adds `fixWavHeader` unit tests (gen's first audio test).

Supersedes #8930. Fixes #8929.