### PR TITLE
Fix SEO meta rewriting on pollinations.ai (run worker on navigations)

### DIFF
--- a/pollinations.ai/wrangler.toml
+++ b/pollinations.ai/wrangler.toml
@@ -7,6 +7,11 @@ account_id = "b6ec751c0862027ba269faf7029b2501"
 directory = "dist"
 binding = "ASSETS"
 not_found_handling = "single-page-application"
+# Run the worker on every request so the SEO HTMLRewriter fires on navigations.
+# Without this, compatibility_date >= 2025-04-01 serves navigation requests as
+# static assets and skips the worker, so per-route meta never gets rewritten.
+# Non-HTML responses are passed through unchanged (see src/worker.ts).
+run_worker_first = true
 
 # Public hostname is pollinations.ai, served by the pollinations-myceli-proxy
 # worker in the old account, which forwards to pollinations.myceli.ai (below).


### PR DESCRIPTION
The `pollinations-ai` worker rewrites per-route SEO tags via HTMLRewriter, but with `compatibility_date >= 2025-04-01` navigation requests are served the static asset directly and skip the worker — so the rewriting never fired (`/play` showed the default `pollinations.ai` title instead of `Play — pollinations.ai`).

- Sets `run_worker_first = true` so the worker runs on all requests; non-HTML responses pass through unchanged.
- Verified on `staging.pollinations.myceli.ai` (with `Sec-Fetch-Mode: navigate`): `/play` → `Play — pollinations.ai`, `/apps` → `Apps — pollinations.ai`, canonical `https://pollinations.ai/play`, og:title + JSON-LD present.

Tradeoff: the worker now runs on every request (incl. static assets), but it only transforms HTML and passes the rest through unchanged; assets stay browser-cached after first load. Can scope with negative globs later if invocation cost matters.

Fixes #11466