### PR TITLE
chore(enter-tierprog): remove dead flows code and fix stale README

### DIFF
--- a/enter.pollinations.ai/src/tier-progression/README.md
+++ b/enter.pollinations.ai/src/tier-progression/README.md
@@ -15,8 +15,10 @@ these flows, but the business logic lives here.
 ## Layout
 
 - `flows/spore_to_seed.py`: upgrade spore users to seed based on GitHub activity
-- `flows/spore-to-microbe-scan.ts`: LLM-based abuse detection and scoring
-- `flows/apply-abuse-blocks.ts`: apply tier downgrades from abuse report
+- `flows/spore-to-microbe-scan.ts`: LLM-based abuse detection and scoring (outputs CSV)
+- `flows/spore-to-microbe-enrich.ts`: enrich the scan CSV with Tinybird consumption data
+- `flows/spore-to-microbe-review.ts`: apply usage-based rules to adjust block actions
+- `flows/spore-to-microbe-apply.ts`: apply tier downgrades from the reviewed report
 - `flows/cleanup-github-users.ts`: audit D1 users against GitHub API (renamed/deleted accounts)
 - `shared/github_profile.py`: GitHub identity lookup and scoring logic
 - `shared/d1_updates.py`: shared D1 query and mutation helpers
@@ -42,19 +44,26 @@ This flow is triggered by:
 
 ### spore → microbe (abuse downgrade)
 
-The downgrade flow is `spore-to-microbe-scan.ts` + `apply-abuse-blocks.ts`.
+The downgrade pipeline is `spore-to-microbe-scan.ts` → `spore-to-microbe-enrich.ts`
+→ `spore-to-microbe-review.ts` → `spore-to-microbe-apply.ts`.
 
 High-level behavior:
 
 1. Find the most recent microbe user's registration date as cutoff (`--since-last-block`).
 2. Fetch users created after that cutoff from D1.
-3. Score users via LLM (Gemini) in overlapping chunks, looking for coordinated abuse patterns.
-4. Users scoring >= 70 are flagged for blocking.
-5. Blocked users are downgraded to `microbe` tier with 0.1 pollen balance.
+3. Score users via LLM (Gemini) in overlapping chunks, looking for coordinated abuse patterns (`scan`, outputs CSV).
+4. Enrich the CSV with Tinybird consumption data (`enrich`).
+5. Apply usage-based rules to adjust block actions (`review`).
+6. Downgrade users with a `block` action to `microbe` tier with 0.1 pollen balance (`apply`).
 
-This flow is triggered by:
+There is no scheduled workflow for this pipeline. Run the steps manually:
 
-- `.github/workflows/user-downgrade-spore-to-microbe.yml`
+```bash
+npx tsx src/tier-progression/flows/spore-to-microbe-scan.ts
+npx tsx src/tier-progression/flows/spore-to-microbe-enrich.ts
+npx tsx src/tier-progression/flows/spore-to-microbe-review.ts
+npx tsx src/tier-progression/flows/spore-to-microbe-apply.ts
+```
 
 ## Entry Point
 

--- a/enter.pollinations.ai/src/tier-progression/README.md
+++ b/enter.pollinations.ai/src/tier-progression/README.md
@@ -56,13 +56,14 @@ High-level behavior:
 5. Apply usage-based rules to adjust block actions (`review`).
 6. Downgrade users with a `block` action to `microbe` tier with 0.1 pollen balance (`apply`).
 
-There is no scheduled workflow for this pipeline. Run the steps manually:
+There is no scheduled workflow for this pipeline. Run the steps manually from
+`enter.pollinations.ai/`:
 
 ```bash
 npx tsx src/tier-progression/flows/spore-to-microbe-scan.ts
 npx tsx src/tier-progression/flows/spore-to-microbe-enrich.ts
 npx tsx src/tier-progression/flows/spore-to-microbe-review.ts
-npx tsx src/tier-progression/flows/spore-to-microbe-apply.ts
+npx tsx src/tier-progression/flows/spore-to-microbe-apply.ts apply-blocks
 ```
 
 ## Entry Point

--- a/enter.pollinations.ai/src/tier-progression/flows/cleanup-github-users.ts
+++ b/enter.pollinations.ai/src/tier-progression/flows/cleanup-github-users.ts
@@ -16,12 +16,9 @@
  *   CLOUDFLARE_API_TOKEN  - Required for D1 access via wrangler
  *   CLOUDFLARE_ACCOUNT_ID - Required for D1 access via wrangler
  *   GITHUB_TOKEN          - Required for GitHub API (5000 req/hr)
- *   GITHUB_APP_ID         - GitHub App ID (for 15k/hr Enterprise rate limit)
- *   GITHUB_APP_PRIVATE_KEY_PATH - Path to .pem private key
  */
 
 import { execSync } from "node:child_process";
-import * as crypto from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { boolean, command, number, run, string } from "@drizzle-team/brocli";
 
@@ -158,126 +155,23 @@ function saveReport(report: AuditReport, path: string): void {
     writeFileSync(path, JSON.stringify(report, null, 2));
 }
 
-// ── GitHub App auth (15k/hr on Enterprise Cloud) ─────────────
-
-function generateJWT(appId: string, privateKey: string): string {
-    const header = Buffer.from(
-        JSON.stringify({ alg: "RS256", typ: "JWT" }),
-    ).toString("base64url");
-    const now = Math.floor(Date.now() / 1000);
-    const payload = Buffer.from(
-        JSON.stringify({ iat: now - 60, exp: now + 10 * 60, iss: appId }),
-    ).toString("base64url");
-    const signature = crypto
-        .sign("SHA256", Buffer.from(`${header}.${payload}`), privateKey)
-        .toString("base64url");
-    return `${header}.${payload}.${signature}`;
-}
-
-async function getInstallationToken(
-    appId: string,
-    privateKey: string,
-): Promise<{ token: string; expiresAt: number }> {
-    const jwt = generateJWT(appId, privateKey);
-
-    // Find first installation
-    const installRes = await fetch("https://api.github.com/app/installations", {
-        headers: {
-            Authorization: `Bearer ${jwt}`,
-            Accept: "application/vnd.github+json",
-            "User-Agent": "pollinations-audit",
-        },
-    });
-    const installations = (await installRes.json()) as {
-        id: number;
-        account: { login: string };
-    }[];
-    if (installations.length === 0) {
-        throw new Error(
-            "No installations found — install the app on an org first",
-        );
-    }
-    const installationId = installations[0].id;
-
-    // Get token
-    const tokenRes = await fetch(
-        `https://api.github.com/app/installations/${installationId}/access_tokens`,
-        {
-            method: "POST",
-            headers: {
-                Authorization: `Bearer ${jwt}`,
-                Accept: "application/vnd.github+json",
-                "User-Agent": "pollinations-audit",
-            },
-        },
-    );
-    const tokenData = (await tokenRes.json()) as {
-        token: string;
-        expires_at: string;
-    };
-    // Refresh 5 min before expiry
-    const expiresAt = new Date(tokenData.expires_at).getTime() - 5 * 60 * 1000;
-    return { token: tokenData.token, expiresAt };
-}
-
 interface TokenProvider {
     getToken: () => Promise<string>;
     label: string;
 }
 
-async function createTokenProvider(): Promise<TokenProvider> {
-    const appId = process.env.GITHUB_APP_ID;
-    const keyPath = process.env.GITHUB_APP_PRIVATE_KEY_PATH;
-
-    // Prefer GitHub App (15k/hr) over PAT (5k/hr)
-    if (appId && keyPath && existsSync(keyPath)) {
-        const privateKey = readFileSync(keyPath, "utf-8");
-        let current = await getInstallationToken(appId, privateKey);
-        console.log(
-            `🔑 GitHub App auth (15k/hr) — token expires ${new Date(current.expiresAt + 5 * 60 * 1000).toISOString()}`,
-        );
-
-        return {
-            label: "GitHub App (15k/hr)",
-            getToken: async () => {
-                if (Date.now() >= current.expiresAt) {
-                    console.log("  🔄 Refreshing installation token...");
-                    current = await getInstallationToken(appId, privateKey);
-                    console.log(
-                        `  ✅ New token expires ${new Date(current.expiresAt + 5 * 60 * 1000).toISOString()}`,
-                    );
-                }
-                return current.token;
-            },
-        };
-    }
-
-    // Fallback: PAT(s)
-    const tokenStr = process.env.GITHUB_TOKENS || process.env.GITHUB_TOKEN;
-    if (!tokenStr) {
-        console.error(
-            "❌ Set GITHUB_APP_ID+GITHUB_APP_PRIVATE_KEY_PATH (15k/hr) or GITHUB_TOKEN (5k/hr)",
-        );
+function createTokenProvider(): TokenProvider {
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+        console.error("❌ Set GITHUB_TOKEN (5k/hr)");
         process.exit(1);
     }
-    const tokens = tokenStr
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean);
-    let tokenIndex = 0;
-    const label =
-        tokens.length > 1
-            ? `${tokens.length} PATs (~${tokens.length * 5000}/hr)`
-            : "PAT (5k/hr)";
+    const label = "PAT (5k/hr)";
     console.log(`🔑 Using ${label}`);
 
     return {
         label,
-        getToken: async () => {
-            const t = tokens[tokenIndex % tokens.length];
-            tokenIndex++;
-            return t;
-        },
+        getToken: async () => token,
     };
 }
 
@@ -305,7 +199,7 @@ const auditCommand = command({
     handler: async (opts) => {
         const env = opts.env as Environment;
 
-        const tokenProvider = await createTokenProvider();
+        const tokenProvider = createTokenProvider();
 
         const reportPath = getReportPath(env);
         let report: AuditReport;
@@ -684,127 +578,4 @@ const applyCommand = command({
     },
 });
 
-// ── Split command ──────────────────────────────────────────────
-
-const splitCommand = command({
-    name: "split",
-    desc: "Split audit report into separate files (renamed, deleted, errors)",
-    options: {
-        env: string().enum("staging", "production").default("production"),
-    },
-    handler: async (opts) => {
-        const env = opts.env as Environment;
-        const report = loadReport(env);
-
-        const renamed = report.results.filter((r) => r.status === "renamed");
-        const deleted = report.results.filter((r) => r.status === "deleted");
-        const errors = report.results.filter((r) => r.status === "error");
-
-        const dir = `${process.cwd()}/scripts`;
-
-        writeFileSync(
-            `${dir}/audit-renamed.json`,
-            JSON.stringify(renamed, null, 2),
-        );
-        writeFileSync(
-            `${dir}/audit-deleted.json`,
-            JSON.stringify(deleted, null, 2),
-        );
-        writeFileSync(
-            `${dir}/audit-errors.json`,
-            JSON.stringify(errors, null, 2),
-        );
-
-        console.log(`📂 Split audit report into:`);
-        console.log(
-            `   scripts/audit-renamed.json  (${renamed.length} entries)`,
-        );
-        console.log(
-            `   scripts/audit-deleted.json  (${deleted.length} entries)`,
-        );
-        console.log(
-            `   scripts/audit-errors.json   (${errors.length} entries)`,
-        );
-    },
-});
-
-// ── Retry command ──────────────────────────────────────────────
-
-const retryCommand = command({
-    name: "retry",
-    desc: "Retry errored entries from the audit report",
-    options: {
-        env: string().enum("staging", "production").default("production"),
-    },
-    handler: async (opts) => {
-        const env = opts.env as Environment;
-        const reportPath = getReportPath(env);
-        const report = loadReport(env);
-        const errors = report.results.filter((r) => r.status === "error");
-
-        if (errors.length === 0) {
-            console.log("✅ No errors to retry!");
-            return;
-        }
-
-        console.log(`🔄 Retrying ${errors.length} errored entries...\n`);
-
-        const tokenProvider = await createTokenProvider();
-        let fixed = 0;
-
-        for (const entry of errors) {
-            const result = await checkGitHubUser(
-                entry.githubId,
-                await tokenProvider.getToken(),
-            );
-
-            if (result.status === 200 && result.login) {
-                if (
-                    result.login.toLowerCase() ===
-                    (entry.d1Username || "").toLowerCase()
-                ) {
-                    entry.status = "ok";
-                    entry.currentUsername = result.login;
-                    delete entry.error;
-                    console.log(
-                        `   ✅ OK: ${entry.d1Username} (${entry.githubId})`,
-                    );
-                } else {
-                    entry.status = "renamed";
-                    entry.currentUsername = result.login;
-                    delete entry.error;
-                    console.log(
-                        `   🔄 Renamed: ${entry.d1Username} → ${result.login} (${entry.githubId})`,
-                    );
-                }
-                fixed++;
-            } else if (result.status === 404) {
-                entry.status = "deleted";
-                delete entry.error;
-                console.log(
-                    `   ❌ Deleted: ${entry.d1Username} (${entry.githubId})`,
-                );
-                fixed++;
-            } else {
-                console.log(
-                    `   ⚠️  Still error: ${entry.d1Username} (${entry.githubId}) → HTTP ${result.status}`,
-                );
-                entry.error = `HTTP ${result.status}`;
-            }
-
-            await sleep(750);
-        }
-
-        saveReport(report, reportPath);
-
-        const remaining = report.results.filter(
-            (r) => r.status === "error",
-        ).length;
-        console.log(
-            `\n📊 Retry results: ${fixed} resolved, ${remaining} still errored`,
-        );
-        console.log(`📄 Updated report: ${reportPath}`);
-    },
-});
-
-run([auditCommand, applyCommand, splitCommand, retryCommand]);
+run([auditCommand, applyCommand]);

--- a/enter.pollinations.ai/src/tier-progression/shared/d1_updates.py
+++ b/enter.pollinations.ai/src/tier-progression/shared/d1_updates.py
@@ -91,34 +91,3 @@ def batch_upgrade_users(
         )
 
     return total_upgraded, total_skipped, failed
-
-
-def ban_deleted_accounts(
-    github_ids: list[int], env: str = "production"
-) -> tuple[int, bool]:
-    """Ban users whose GitHub accounts were deleted."""
-    batch_sql_size = 500
-    total_banned = 0
-    failed = False
-
-    for index in range(0, len(github_ids), batch_sql_size):
-        batch = github_ids[index : index + batch_sql_size]
-        safe_batch = [gid for gid in batch if isinstance(gid, int) and gid > 0]
-        if not safe_batch:
-            continue
-        id_list = ", ".join(str(gid) for gid in safe_batch)
-
-        query = f"""
-            UPDATE user SET banned = 1, ban_reason = 'github_account_deleted'
-            WHERE github_id IN ({id_list})
-            AND (banned = 0 OR banned IS NULL)
-        """
-        result = run_d1_query(query, env)
-        if result is not None:
-            total_banned += len(safe_batch)
-        else:
-            failed = True
-            print(f"   ❌ Ban batch {index // batch_sql_size + 1} failed")
-
-    return total_banned, failed
-


### PR DESCRIPTION
Dead-code cleanup in tier-progression maintenance scripts (no production path, no tests):

- Delete the never-called `ban_deleted_accounts` function (d1_updates.py)
- Remove the dead `split` / `retry` CLI subcommands (cleanup-github-users.ts) — only `audit`/`apply` are used
- Collapse the speculative, never-configured GitHub-App JWT auth path down to a single `GITHUB_TOKEN` PAT (kept the `TokenProvider` interface so call sites/log lines are unchanged)
- Fix the stale README: drop 3 referenced files that don't exist, correct the spore-to-microbe pipeline (scan → enrich → review → apply), remove the false workflow trigger

Net −251 lines. biome clean; cleanup-github-users.ts type-checks; no test references any deleted symbol. Skipped the queryD1/CSV dedups (held for separate review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
