### PR TITLE
fix: clean package publish follow-up

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -18,7 +18,7 @@ jobs:
       sdk: ${{ steps.changes.outputs.sdk }}
       ui: ${{ steps.changes.outputs.ui }}
       mcp: ${{ steps.changes.outputs.mcp }}
-      polli-cli: ${{ steps.changes.outputs.polli-cli }}
+      cli: ${{ steps.changes.outputs.cli }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,7 +36,7 @@ jobs:
           echo "sdk=$(echo "$changed" | grep -q '^packages/sdk/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "ui=$(echo "$changed" | grep -q '^packages/ui/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "mcp=$(echo "$changed" | grep -q '^packages/mcp/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "polli-cli=$(echo "$changed" | grep -q '^packages/polli-cli/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "cli=$(echo "$changed" | grep -q '^packages/polli-cli/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$changed" | grep '^packages/' || true
 
@@ -158,9 +158,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-polli-cli:
+  publish-cli:
     needs: detect-changes
-    if: needs.detect-changes.outputs.polli-cli == 'true'
+    if: needs.detect-changes.outputs.cli == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -4,7 +4,7 @@
     "description": "Model Context Protocol (MCP) server for pollinations.ai - image, text, audio & video generation",
     "type": "module",
     "bin": {
-        "pollinations-mcp": "./pollinations-mcp.js"
+        "pollinations-mcp": "pollinations-mcp.js"
     },
     "files": [
         "src/**/*",
@@ -32,12 +32,12 @@
     "author": "pollinations.ai <hello@pollinations.ai>",
     "contributors": [
         {
-        "name": "Circuit-Overtime",
-        "email": "ayushman@myceli.ai"
+            "name": "Circuit-Overtime",
+            "email": "ayushman@myceli.ai"
         },
         {
-        "name": "ElliotEtag",
-        "email": "elliot@myceli.ai"
+            "name": "ElliotEtag",
+            "email": "elliot@myceli.ai"
         }
     ],
     "license": "MIT",
@@ -49,7 +49,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/pollinations/pollinations.git",
+        "url": "git+https://github.com/pollinations/pollinations.git",
         "directory": "packages/mcp"
     },
     "bugs": {
@@ -63,7 +63,7 @@
         "access": "public"
     },
     "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/pollinations"
+        "type": "github",
+        "url": "https://github.com/sponsors/pollinations"
     }
 }


### PR DESCRIPTION
- Renames the CLI package publish job from `publish-polli-cli` to `publish-cli`.
- Keeps the path/output detection pointed at `packages/polli-cli`, only changing the CI-facing job name.
- Normalizes `@pollinations/mcp` package metadata so npm does not auto-correct bin/repository fields during publish.

Validation:
- YAML parse check for `.github/workflows/publish-packages.yml`
- `git diff --check`
- `npx biome check --write .github/workflows/publish-packages.yml packages/mcp/package.json`
- `npm publish --dry-run --access public` from `packages/mcp`

Note:
- This does not fix the current npm 403. That requires replacing `NPM_TOKEN` with a granular token that has read/write access and bypass 2FA enabled, then rerunning the failed publish jobs.