### PR TITLE
fix: preflight duration-based media charges

### DIFF
--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -14,7 +14,10 @@ import {
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
-import { checkBalance } from "@/utils/generation-access.ts";
+import {
+    checkBalance,
+    getDurationBasedEstimatedPrice,
+} from "@/utils/generation-access.ts";
 
 const db = drizzle(env.DB);
 
@@ -393,6 +396,63 @@ describe("BYOP markup", () => {
                 },
             } as unknown as D1Database,
         } as CloudflareBindings);
+    });
+
+    it("uses requested duration as a media preflight floor", () => {
+        expect(getDurationBasedEstimatedPrice("nova-reel", 120)).toBe(9.6);
+        expect(getDurationBasedEstimatedPrice("acestep", 300)).toBe(0.15);
+    });
+
+    it("rejects duration-billed media when balance only covers the historical average", async () => {
+        const vars = {
+            auth: {
+                user: { id: "duration-payer" },
+                apiKey: { id: "sk-test", pollenBalance: 10 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: 1,
+                    packBalance: 1,
+                }),
+            },
+            model: { requested: "nova-reel", resolved: "nova-reel" },
+            log: fakeLog(),
+        } as unknown as Parameters<typeof checkBalance>[0];
+
+        await expect(
+            checkBalance(vars, fakeStatsEnv(0.744, "nova-reel"), {
+                minimumEstimatedPrice: getDurationBasedEstimatedPrice(
+                    "nova-reel",
+                    120,
+                ),
+            }),
+        ).rejects.toMatchObject({ status: 402 });
+    });
+
+    it("rejects finite API key budgets below the requested duration price", async () => {
+        const vars = {
+            auth: {
+                user: { id: "duration-payer" },
+                apiKey: { id: "sk-test", pollenBalance: 1 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: 10,
+                    packBalance: 10,
+                }),
+            },
+            model: { requested: "nova-reel", resolved: "nova-reel" },
+            log: fakeLog(),
+        } as unknown as Parameters<typeof checkBalance>[0];
+
+        await expect(
+            checkBalance(vars, fakeStatsEnv(0.744, "nova-reel"), {
+                minimumEstimatedPrice: getDurationBasedEstimatedPrice(
+                    "nova-reel",
+                    120,
+                ),
+            }),
+        ).rejects.toMatchObject({ status: 402 });
     });
 
     it("does not credit or deduct for unbilled requests", async () => {

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -30,7 +30,10 @@ import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
 import { validator } from "@/middleware/validator.ts";
 import { errorResponseDescriptions } from "@/utils/api-docs.ts";
-import { requireGenerationAccess } from "@/utils/generation-access.ts";
+import {
+    getDurationBasedEstimatedPrice,
+    requireGenerationAccess,
+} from "@/utils/generation-access.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
 
 const CreateSpeechRequestSchema = z
@@ -1036,7 +1039,13 @@ export const audioRoutes = new Hono<Env>()
         track("generate.audio"),
         async (c) => {
             const log = c.get("log").getChild("tts");
-            await requireGenerationAccess(c.var, c.env);
+            const body = c.req.valid("json" as never) as CreateSpeechRequest;
+            await requireGenerationAccess(c.var, c.env, {
+                minimumEstimatedPrice: getDurationBasedEstimatedPrice(
+                    c.var.model.resolved,
+                    body.duration,
+                ),
+            });
 
             const {
                 input,
@@ -1048,7 +1057,7 @@ export const audioRoutes = new Hono<Env>()
                 seed,
                 style,
                 instruct,
-            } = c.req.valid("json" as never) as CreateSpeechRequest;
+            } = body;
             requireTextToAudioModel(c.var.model.resolved);
             const safeInput = await applySafety(c, input, safe);
 

--- a/gen.pollinations.ai/src/utils/generation-access.ts
+++ b/gen.pollinations.ai/src/utils/generation-access.ts
@@ -1,8 +1,15 @@
 import { createBalanceCheckResult } from "@shared/billing/balance.ts";
 import { canCoverEstimatedCharge } from "@shared/billing/bucket-selection.ts";
-import { getModelDefinition } from "@shared/registry/registry.ts";
+import {
+    calculatePrice,
+    getModelDefinition,
+    getPriceDefinition,
+    type ModelName,
+    type Usage,
+} from "@shared/registry/registry.ts";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
+import { IMAGE_CONFIG } from "@/image/models.ts";
 import type { AuthVariables } from "@/middleware/auth.ts";
 import type { BalanceVariables } from "@/middleware/balance.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
@@ -19,9 +26,91 @@ type GenerationAccessEnv = {
     Variables: GenerationAccessVariables;
 };
 
+type BalanceCheckOptions = {
+    minimumEstimatedPrice?: number;
+};
+
+type DurationModelConfig = {
+    isVideo?: boolean;
+    defaultDuration?: number;
+    maxDuration?: number;
+};
+
+function parseDuration(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) return parsed;
+    }
+    return undefined;
+}
+
+function getValidatedRequestDuration(c: {
+    req: { valid: (target: never) => unknown };
+}): unknown {
+    for (const target of ["query", "json"] as const) {
+        try {
+            const data = c.req.valid(target as never) as
+                | { duration?: unknown }
+                | undefined;
+            if (data?.duration !== undefined) return data.duration;
+        } catch {
+            // Some routes have no validator for this target.
+        }
+    }
+    return undefined;
+}
+
+function getVideoDurationEstimate(
+    model: ModelName,
+    duration: number | undefined,
+): number | undefined {
+    const config = IMAGE_CONFIG[model as keyof typeof IMAGE_CONFIG] as
+        | DurationModelConfig
+        | undefined;
+    if (!config?.isVideo) return undefined;
+
+    const requestedDuration = duration ?? config.defaultDuration;
+    if (!requestedDuration) return undefined;
+
+    const clamped = Math.min(
+        config.maxDuration ?? requestedDuration,
+        Math.max(1, requestedDuration),
+    );
+    if (model === "nova-reel") {
+        return Math.min(120, Math.max(6, Math.ceil(clamped / 6) * 6));
+    }
+    return clamped;
+}
+
+export function getDurationBasedEstimatedPrice(
+    model: ModelName,
+    rawDuration: unknown,
+): number {
+    const priceDefinition = getPriceDefinition(model);
+    if (!priceDefinition) return 0;
+
+    const requestedDuration = parseDuration(rawDuration);
+    const seconds =
+        getVideoDurationEstimate(model, requestedDuration) ?? requestedDuration;
+    if (!seconds || seconds <= 0) return 0;
+
+    const usage: Usage = {};
+    if (priceDefinition.completionVideoSeconds !== undefined) {
+        usage.completionVideoSeconds = seconds;
+    }
+    if (priceDefinition.completionAudioSeconds !== undefined) {
+        usage.completionAudioSeconds = seconds;
+    }
+    if (Object.keys(usage).length === 0) return 0;
+
+    return calculatePrice(model, usage).totalPrice;
+}
+
 export async function checkBalance(
     vars: GenerationAccessVariables,
     env: CloudflareBindings,
+    options: BalanceCheckOptions = {},
 ): Promise<void> {
     const { auth, balance, model, log } = vars;
     if (!auth.user?.id) return;
@@ -33,21 +122,25 @@ export async function checkBalance(
     const estimatedCost = getEstimatedPrice(stats, model.resolved);
 
     const apiKeyBudget = auth.apiKey?.pollenBalance;
-    const requiredBudget = Math.max(0, estimatedCost);
+    const requiredBudget = Math.max(
+        0,
+        estimatedCost,
+        options.minimumEstimatedPrice ?? 0,
+    );
     if (typeof apiKeyBudget === "number" && apiKeyBudget <= requiredBudget) {
         throw new HTTPException(402, {
-            message: `API key budget too low. This request costs ~${estimatedCost.toFixed(4)} pollen, but this key has ${Math.max(0, apiKeyBudget).toFixed(4)}.`,
+            message: `API key budget too low. This request costs ~${requiredBudget.toFixed(4)} pollen, but this key has ${Math.max(0, apiKeyBudget).toFixed(4)}.`,
         });
     }
 
     const userBalance = await balance.getBalance(auth.user.id);
 
-    if (!canCoverEstimatedCharge(userBalance, estimatedCost, isPaidOnly)) {
+    if (!canCoverEstimatedCharge(userBalance, requiredBudget, isPaidOnly)) {
         const available = isPaidOnly
             ? userBalance.packBalance
             : Math.max(userBalance.tierBalance, userBalance.packBalance);
         throw new HTTPException(402, {
-            message: `Insufficient balance. This request costs ~${estimatedCost.toFixed(4)} pollen, but your available balance is ${Math.max(0, available).toFixed(4)}.`,
+            message: `Insufficient balance. This request costs ~${requiredBudget.toFixed(4)} pollen, but your available balance is ${Math.max(0, available).toFixed(4)}.`,
         });
     }
 
@@ -60,15 +153,22 @@ export async function checkBalance(
 export async function requireGenerationAccess(
     vars: GenerationAccessVariables,
     env: CloudflareBindings,
+    options: BalanceCheckOptions = {},
 ): Promise<void> {
     await vars.auth.requireAuthorization();
     vars.auth.requireModelAccess();
-    await checkBalance(vars, env);
+    await checkBalance(vars, env, options);
 }
 
 export const generationAccess = createMiddleware<GenerationAccessEnv>(
     async (c, next) => {
-        await requireGenerationAccess(c.var, c.env);
+        const duration = getValidatedRequestDuration(c);
+        await requireGenerationAccess(c.var, c.env, {
+            minimumEstimatedPrice: getDurationBasedEstimatedPrice(
+                c.var.model.resolved,
+                duration,
+            ),
+        });
         await next();
     },
 );


### PR DESCRIPTION
## Summary

- Use requested duration as a preflight price floor for duration-billed media models
- Apply the floor to both user balance and finite API key budget checks
- Cover GET media generation plus OpenAI-compatible audio speech requests

## Why

The existing generation gate used the model historical average price before provider work starts. Duration-billed requests can be much more expensive than that average, for example nova-reel with duration=120 bills 120 * 0.08 = 9.6 pollen. This made a low balance or finite API key budget pass preflight and go negative after final billing.

This keeps the historical average as the fallback, but raises the required preflight amount when the current request has a duration-based price.

## Test plan

- npx vitest run src/byop-markup.test.ts
- npm run typecheck
- npx biome check gen.pollinations.ai/src/utils/generation-access.ts gen.pollinations.ai/src/routes/audio.ts gen.pollinations.ai/src/byop-markup.test.ts