### PR TITLE
fix: prevent auto top-up webhook double credit

### DIFF
--- a/enter.pollinations.ai/src/utils/stripe-billing.ts
+++ b/enter.pollinations.ai/src/utils/stripe-billing.ts
@@ -601,23 +601,7 @@ export async function creditAutoTopUpInvoice(
     }
 
     const now = Date.now();
-    const [attemptUpdate] = await env.DB.batch([
-        env.DB.prepare(
-            `UPDATE stripe_auto_top_up_attempt
-                SET status = ?,
-                    completed_at = ?,
-                    updated_at = ?,
-                    failure_reason = NULL
-                WHERE stripe_invoice_id = ?
-                    AND status IN (?, ?)`,
-        ).bind(
-            AUTO_TOP_UP_ATTEMPT_STATUS_PAID,
-            now,
-            now,
-            invoice.id,
-            AUTO_TOP_UP_ATTEMPT_STATUS_PENDING,
-            AUTO_TOP_UP_ATTEMPT_STATUS_FAILED,
-        ),
+    const [creditUpdate, attemptUpdate] = await env.DB.batch([
         env.DB.prepare(
             `UPDATE user
                 SET pack_balance = COALESCE(pack_balance, 0) + ?
@@ -627,22 +611,52 @@ export async function creditAutoTopUpInvoice(
                         FROM stripe_auto_top_up_attempt
                         WHERE stripe_invoice_id = ?
                             AND user_id = ?
-                            AND status = ?
-                            AND completed_at = ?
+                            AND status IN (?, ?)
                     )`,
         ).bind(
             attempt.pollenGrant,
             attempt.userId,
             invoice.id,
             attempt.userId,
+            AUTO_TOP_UP_ATTEMPT_STATUS_PENDING,
+            AUTO_TOP_UP_ATTEMPT_STATUS_FAILED,
+        ),
+        env.DB.prepare(
+            `UPDATE stripe_auto_top_up_attempt
+                SET status = ?,
+                    completed_at = ?,
+                    updated_at = ?,
+                    failure_reason = NULL
+                WHERE stripe_invoice_id = ?
+                    AND user_id = ?
+                    AND status IN (?, ?)
+                    AND EXISTS (
+                        SELECT 1
+                        FROM user
+                        WHERE id = ?
+                    )`,
+        ).bind(
             AUTO_TOP_UP_ATTEMPT_STATUS_PAID,
             now,
+            now,
+            invoice.id,
+            attempt.userId,
+            AUTO_TOP_UP_ATTEMPT_STATUS_PENDING,
+            AUTO_TOP_UP_ATTEMPT_STATUS_FAILED,
+            attempt.userId,
         ),
     ]);
 
     const attemptChanges = attemptUpdate.meta.changes ?? 0;
     if (attemptChanges === 0) {
         return { credited: false, reason: "invoice already credited" };
+    }
+
+    const creditChanges = creditUpdate.meta.changes ?? 0;
+    if (creditChanges !== 1) {
+        throw new Error(
+            `Auto top-up credit failed to update user ${attempt.userId} for invoice ${invoice.id}`,
+        );
     }
 
     return { credited: true, pollenCredited: attempt.pollenGrant };

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -4,7 +4,8 @@ import { user as userTable } from "@shared/db/better-auth.ts";
 import { getPollenPackByAmount } from "@shared/pollen-packs.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
+import { creditAutoTopUpInvoice } from "../../src/utils/stripe-billing.ts";
 import { test } from "../fixtures.ts";
 import { mockCardPaymentMethod, mockCustomer } from "../mocks/stripe.ts";
 
@@ -1945,6 +1946,71 @@ test("POST /api/webhooks/stripe credits paid auto top-up invoice once", async ({
         .first<{
             packBalance: number | null;
         }>();
+    const attempt = await env.DB.prepare(
+        `SELECT status, failure_reason AS failureReason
+        FROM stripe_auto_top_up_attempt
+        WHERE stripe_invoice_id = ?`,
+    )
+        .bind(invoiceId)
+        .first<{ status: string; failureReason: string | null }>();
+
+    expect(updatedUser?.packBalance).toBe(14);
+    expect(attempt?.status).toBe("paid");
+    expect(attempt?.failureReason).toBeNull();
+});
+
+test("creditAutoTopUpInvoice credits concurrent duplicate invoices once", async () => {
+    const userId = "user_auto_top_up_concurrent";
+    const now = Date.now();
+    await env.DB.prepare(
+        `INSERT INTO user (
+            id,
+            name,
+            email,
+            email_verified,
+            created_at,
+            updated_at,
+            pack_balance,
+            auto_top_up_enabled,
+            auto_top_up_amount_usd
+        ) VALUES (?, ?, ?, 1, ?, ?, 1, 1, 10)`,
+    )
+        .bind(
+            userId,
+            "Auto Top Up Concurrent",
+            "auto-top-up-concurrent@example.com",
+            now,
+            now,
+        )
+        .run();
+
+    const invoiceId = "in_concurrent_paid_once";
+    await insertAutoTopUpAttempt({ userId, invoiceId });
+    const invoice = createAutoTopUpInvoiceEvent(
+        "invoice.paid",
+        invoiceId,
+        userId,
+    ).data.object as Parameters<typeof creditAutoTopUpInvoice>[1];
+
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1780272000000);
+    try {
+        const results = await Promise.all([
+            creditAutoTopUpInvoice(env, invoice),
+            creditAutoTopUpInvoice(env, invoice),
+        ]);
+
+        expect(results.filter((result) => result.credited)).toHaveLength(1);
+    } finally {
+        dateNow.mockRestore();
+    }
+
+    const updatedUser = await env.DB.prepare(
+        `SELECT pack_balance AS packBalance
+        FROM user
+        WHERE id = ?`,
+    )
+        .bind(userId)
+        .first<{ packBalance: number | null }>();
     const attempt = await env.DB.prepare(
         `SELECT status, failure_reason AS failureReason
         FROM stripe_auto_top_up_attempt


### PR DESCRIPTION
## Summary
- Prevent concurrent duplicate Stripe auto top-up invoice deliveries from crediting pack balance twice.
- Make the credit update depend on the attempt still being pending/failed, then mark the attempt paid in the same D1 batch.
- Add a focused regression for two concurrent `creditAutoTopUpInvoice` calls for the same paid invoice.

## Context
This is separate from the older checkout-session idempotency fix in #10624. Auto top-up invoices use `stripe_auto_top_up_attempt`; the previous code could let two concurrent handlers both read `pending`, then the second handler could still increment `pack_balance` when the first handler set `status = paid` with the same millisecond `completed_at` marker.

## Checks
- `npx vitest run test/integration/stripe.test.ts -t "creditAutoTopUpInvoice credits concurrent duplicate invoices once"`
- `git diff --check`
- `npx biome check --formatter-enabled=false enter.pollinations.ai/src/utils/stripe-billing.ts enter.pollinations.ai/test/integration/stripe.test.ts`

Notes:
- `npx tsc --noEmit` still fails on existing frontend `@pollinations/ui` resolution / implicit-any errors outside this change.
- Full Stripe webhook-route tests are blocked in this local checkout because `npm run decrypt-vars` fails with missing `sops`, so `STRIPE_WEBHOOK_SECRET` is not available.
