### PR TITLE
fix: install monorepo deps for app deploys

### DIFF
--- a/apps/_scripts/deploy.sh
+++ b/apps/_scripts/deploy.sh
@@ -50,6 +50,11 @@ echo "📦 Installing dependencies..."
 cd "$APP_PATH"
 if [ -f "package.json" ]; then
     npm install --silent
+
+    if grep -qF "../../packages/" package.json; then
+        echo "📦 Installing monorepo package dependencies..."
+        npm install --silent --prefix "$REPO_ROOT"
+    fi
 fi
 
 # Step 3: Build


### PR DESCRIPTION
- Installs root workspace dependencies when an app references ../../packages/*\n- Fixes model-monitor deploys after moving to @pollinations/sdk/@pollinations/ui source builds\n- Verified with bash -n and local model-monitor production build