### PR TITLE
fix(gen-text): strip reasoning_effort for non-reasoning grok via transform

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -11,6 +11,7 @@ import { pipe } from "./transforms/pipe.js";
 import { removeToolsForJsonResponse } from "./transforms/removeToolsForJsonResponse.ts";
 import { sanitizeToolSchemas } from "./transforms/sanitizeToolSchemas.js";
 import { stripCacheControl } from "./transforms/stripCacheControl.js";
+import { stripReasoningEffort } from "./transforms/stripReasoningEffort.js";
 import type { TransformFn } from "./types.js";
 
 interface ModelDefinition {
@@ -95,6 +96,8 @@ const models: ModelDefinition[] = [
     {
         name: "grok",
         config: portkeyConfig["grok-4-20-non-reasoning"],
+        // Non-reasoning deployment 500s if reasoning_effort is forwarded.
+        transform: stripReasoningEffort,
     },
     {
         name: "grok-large",

--- a/gen.pollinations.ai/src/text/transforms/stripReasoningEffort.ts
+++ b/gen.pollinations.ai/src/text/transforms/stripReasoningEffort.ts
@@ -1,0 +1,25 @@
+import type {
+    ChatMessage,
+    TransformOptions,
+    TransformResult,
+} from "../types.js";
+
+/**
+ * Strips the `reasoning_effort` option from the request.
+ *
+ * The non-reasoning Grok deployment (`grok-4-20-non-reasoning`) returns an
+ * opaque upstream 500 instead of ignoring `reasoning_effort` when it's
+ * forwarded (verified on prod: 5/5 with the param → 500, 5/5 without → 200).
+ * Apply this only on model entries whose upstream rejects it.
+ */
+export function stripReasoningEffort(
+    messages: ChatMessage[],
+    options: TransformOptions,
+): TransformResult {
+    if (options.reasoning_effort === undefined) {
+        return { messages, options };
+    }
+
+    const { reasoning_effort: _dropped, ...rest } = options;
+    return { messages, options: rest };
+}

--- a/gen.pollinations.ai/test/text/transforms/stripReasoningEffort.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/stripReasoningEffort.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { findModelByName } from "../../../src/text/availableModels.js";
+import { stripReasoningEffort } from "../../../src/text/transforms/stripReasoningEffort.js";
+
+describe("stripReasoningEffort", () => {
+    it("drops reasoning_effort from options", () => {
+        const { options } = stripReasoningEffort([], {
+            reasoning_effort: "high",
+            temperature: 0.5,
+        });
+
+        expect(options.reasoning_effort).toBeUndefined();
+        expect(options.temperature).toBe(0.5);
+    });
+
+    it("preserves options when reasoning_effort is absent (identity preserved)", () => {
+        const original = { temperature: 0.5 };
+
+        const { options } = stripReasoningEffort([], original);
+
+        expect(options).toBe(original);
+    });
+
+    it("passes messages through untouched", () => {
+        const messages = [{ role: "user" as const, content: "hi" }];
+
+        const { messages: result } = stripReasoningEffort(messages, {
+            reasoning_effort: "high",
+        });
+
+        expect(result).toBe(messages);
+    });
+});
+
+describe("stripReasoningEffort model wiring", () => {
+    // Only the non-reasoning Grok deployment (grok-4-20-non-reasoning) 500s on
+    // reasoning_effort; the reasoning variants must keep accepting it.
+    it("wires stripReasoningEffort onto grok (non-reasoning)", () => {
+        expect(findModelByName("grok")?.transform).toBe(stripReasoningEffort);
+    });
+
+    it.each([
+        "grok-large",
+        "grok-4.3",
+    ])("does not strip reasoning_effort on %s (reasoning model)", (modelName) => {
+        expect(findModelByName(modelName)?.transform).not.toBe(
+            stripReasoningEffort,
+        );
+    });
+});


### PR DESCRIPTION
Alternative to #11431 — same fix, via the per-model transform system instead of a handler-level strip.

**Root cause (same as #11431):** non-reasoning Grok (`grok-4-20-non-reasoning`) returns an opaque upstream 500 when `reasoning_effort` is forwarded (5/5 with → 500, 5/5 without → 200).

**Approach:** adds a `stripReasoningEffort` transform and applies it to the `grok` entry only — the same pattern as `stripCacheControl` / `createGeminiThinkingTransform`.

**Why this vs #11431's handler strip:**
- **Consistent** — lives in `transforms/`, composed via the existing per-model `transform:` field; matches how every other model-specific quirk is handled.
- **Scoped** — targets the one broken deployment. `grok-large` / `grok-4.3` are `reasoning: true` and keep accepting the param. #11431 keys on `reasoning: true` registry-wide, which also reaches into Gemini (`gemini` isn't `reasoning: true`, so #11431 strips the user value and relies on the Gemini thinking transform re-injecting it afterward — works, but coupled).
- **No new handler plumbing** — all grok traffic already flows handler → `generateTextResponse` → `generateTextPortkey`, where transforms run (verified), so coverage is identical.

**Tests:** transform unit tests + wiring assertion (attached to `grok`, not to the reasoning variants). 6/6 pass, biome clean, tsc clean.

Pick whichever fits the codebase direction; close the other. Fixes the Grok-500 outage cluster either way.

Fixes #11167
Fixes #11089
