### PR TITLE
fix(media): force active content downloads

### DIFF
--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -17,6 +17,15 @@ const KEY_VERIFY_URL = "https://gen.pollinations.ai/account/key";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
 const HASH_PATTERN = /^[a-f0-9]{16}$/i;
 const DEFAULT_MAX_SIZE = 52428800; // 50 MB
+const ACTIVE_CONTENT_TYPES = new Set([
+    "application/javascript",
+    "application/xhtml+xml",
+    "application/xml",
+    "image/svg+xml",
+    "text/html",
+    "text/javascript",
+    "text/xml",
+]);
 
 interface Env {
     MEDIA_BUCKET: R2Bucket;
@@ -56,6 +65,44 @@ function fileTooLargeError(maxSize: number): { error: string } {
 
 function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
+}
+
+function normalizeContentType(contentType?: string): string {
+    return (contentType || "application/octet-stream")
+        .split(";")[0]
+        .trim()
+        .toLowerCase();
+}
+
+function isActiveContentType(contentType?: string): boolean {
+    const normalized = normalizeContentType(contentType);
+    return ACTIVE_CONTENT_TYPES.has(normalized) || normalized.endsWith("+xml");
+}
+
+function setContentHeaders(
+    headers: Headers,
+    contentType: string | undefined,
+    originalName?: string,
+) {
+    const resolvedType = contentType || "application/octet-stream";
+    const active = isActiveContentType(resolvedType);
+    headers.set("Content-Type", resolvedType);
+    headers.set("X-Content-Type-Options", "nosniff");
+
+    if (active) {
+        headers.set("Content-Security-Policy", "default-src 'none'; sandbox");
+    }
+
+    if (originalName) {
+        const sanitized = encodeURIComponent(originalName);
+        const disposition = active ? "attachment" : "inline";
+        headers.set(
+            "Content-Disposition",
+            `${disposition}; filename*=UTF-8''${sanitized}`,
+        );
+    } else if (active) {
+        headers.set("Content-Disposition", "attachment");
+    }
 }
 
 const UploadResponseSchema = z.object({
@@ -294,23 +341,14 @@ api.get(
             }
 
             const headers = new Headers();
-            headers.set(
-                "Content-Type",
+            setContentHeaders(
+                headers,
                 object.httpMetadata?.contentType || "application/octet-stream",
+                object.customMetadata?.originalName,
             );
             headers.set("Cache-Control", CACHE_CONTROL);
             headers.set("X-Content-Hash", hash);
             headers.set("X-Content-Size", object.size.toString());
-
-            const originalName = object.customMetadata?.originalName;
-            if (originalName) {
-                // RFC 5987: use filename* with UTF-8 encoding to safely handle any characters
-                const sanitized = encodeURIComponent(originalName);
-                headers.set(
-                    "Content-Disposition",
-                    `inline; filename*=UTF-8''${sanitized}`,
-                );
-            }
 
             const responseBody = refreshR2ObjectTtl(
                 c.env.MEDIA_BUCKET,
@@ -426,9 +464,10 @@ api.on(
             }
 
             const headers = new Headers();
-            headers.set(
-                "Content-Type",
+            setContentHeaders(
+                headers,
                 object.httpMetadata?.contentType || "application/octet-stream",
+                object.customMetadata?.originalName,
             );
             headers.set("Content-Length", object.size.toString());
             headers.set("Cache-Control", CACHE_CONTROL);

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -109,6 +109,7 @@ describe("media.pollinations.ai", () => {
         expect(getRes.headers.get("cache-control")).toBe(
             "public, max-age=31536000, immutable",
         );
+        expect(getRes.headers.get("x-content-type-options")).toBe("nosniff");
         expect(getRes.headers.get("content-disposition")).toContain("test.png");
         const body = new Uint8Array(await getRes.arrayBuffer());
         expect(body.length).toBe(TINY_PNG.length);
@@ -138,6 +139,56 @@ describe("media.pollinations.ai", () => {
         const dup = (await dupRes.json()) as UploadResponse;
         expect(dup.id).toBe(upload.id);
         expect(dup.duplicate).toBe(true);
+    });
+
+    it("serves active document types as downloads", async () => {
+        const html = "<!doctype html><script>globalThis.executed=true</script>";
+        const uploadRes = await SELF.fetch(
+            "https://media.pollinations.ai/upload",
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    data: btoa(html),
+                    contentType: "text/html",
+                    name: "proof.html",
+                }),
+                headers: {
+                    Authorization: `Bearer ${VALID_KEY}`,
+                    "Content-Type": "application/json",
+                },
+            },
+        );
+        expect(uploadRes.status).toBe(200);
+        const upload = (await uploadRes.json()) as UploadResponse;
+        expect(upload.contentType).toBe("text/html");
+
+        const getRes = await SELF.fetch(
+            `https://media.pollinations.ai/${upload.id}`,
+        );
+        expect(getRes.status).toBe(200);
+        expect(getRes.headers.get("content-type")).toBe("text/html");
+        expect(getRes.headers.get("content-disposition")).toContain(
+            "attachment",
+        );
+        expect(getRes.headers.get("content-disposition")).toContain(
+            "proof.html",
+        );
+        expect(getRes.headers.get("content-security-policy")).toBe(
+            "default-src 'none'; sandbox",
+        );
+        expect(getRes.headers.get("x-content-type-options")).toBe("nosniff");
+        expect(await getRes.text()).toBe(html);
+
+        const headRes = await SELF.fetch(
+            `https://media.pollinations.ai/${upload.id}`,
+            { method: "HEAD" },
+        );
+        expect(headRes.headers.get("content-disposition")).toContain(
+            "attachment",
+        );
+        expect(headRes.headers.get("content-security-policy")).toBe(
+            "default-src 'none'; sandbox",
+        );
     });
 
     it("refreshes uploaded media TTL on aged GET", async () => {


### PR DESCRIPTION
## Summary
- keep media uploads working, but force scriptable document types like HTML/SVG/XML to download instead of rendering inline
- add nosniff on served media and CSP sandbox headers for active document responses
- cover GET and HEAD responses with a regression test

## Why
media.pollinations.ai is documented as image/audio/video storage, but uploaded active document types were served inline from the public Pollinations media origin.

## Test plan
- npm --prefix media.pollinations.ai test
- npx tsc --noEmit -p media.pollinations.ai/tsconfig.json