### PR TITLE
fix: preflight transcription duration billing

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1,12 +1,17 @@
 import type { Logger } from "@logtape/logtape";
+import { createBalanceCheckResult } from "@shared/billing/balance.ts";
+import { canCoverEstimatedCharge } from "@shared/billing/bucket-selection.ts";
 import {
     type AudioModelName,
     ELEVENLABS_VOICES,
     resolveElevenLabsVoiceId,
 } from "@shared/registry/audio.ts";
 import {
+    calculatePrice,
     getModelDefinition,
+    getPriceDefinition,
     type ModelName,
+    type Usage,
 } from "@shared/registry/registry.ts";
 import {
     buildUsageHeaders,
@@ -33,6 +38,8 @@ import { errorResponseDescriptions } from "@/utils/api-docs.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
 import { buildTranscriptionResponse } from "./transcription-response.ts";
+
+export const MAX_TRANSCRIPTION_SECONDS = 60 * 60;
 
 const CreateSpeechRequestSchema = z
     .object({
@@ -568,6 +575,67 @@ function requireTextToAudioModel(model: ModelName): void {
 
     throw new UpstreamError(400 as ContentfulStatusCode, {
         message: `Model '${model}' is not supported on text-to-audio endpoints. Use /v1/audio/transcriptions for speech-to-text models.`,
+    });
+}
+
+export function getMaxTranscriptionPreflightPrice(
+    model: ModelName,
+    maxSeconds = MAX_TRANSCRIPTION_SECONDS,
+): number {
+    const priceDefinition = getPriceDefinition(model);
+    if (!priceDefinition?.promptAudioSeconds) return 0;
+
+    const usage: Usage = { promptAudioSeconds: maxSeconds };
+    return calculatePrice(model, usage).totalPrice;
+}
+
+export async function requireMaxTranscriptionBudget(
+    vars: Pick<Env["Variables"], "auth" | "balance" | "model">,
+    maxSeconds = MAX_TRANSCRIPTION_SECONDS,
+): Promise<void> {
+    const maxPrice = getMaxTranscriptionPreflightPrice(
+        vars.model.resolved,
+        maxSeconds,
+    );
+    if (maxPrice <= 0) return;
+
+    const userId = vars.auth.user?.id;
+    if (!userId) return;
+
+    const apiKeyBudget = vars.auth.apiKey?.pollenBalance;
+    if (typeof apiKeyBudget === "number" && apiKeyBudget <= maxPrice) {
+        throw new UpstreamError(402 as ContentfulStatusCode, {
+            message: `API key budget too low. Transcription requests must reserve up to ${maxSeconds}s (~${maxPrice.toFixed(4)} pollen), but this key has ${Math.max(0, apiKeyBudget).toFixed(4)}.`,
+        });
+    }
+
+    const balances = await vars.balance.getBalance(userId);
+    const isPaidOnly =
+        getModelDefinition(vars.model.resolved).paidOnly ?? false;
+
+    if (!canCoverEstimatedCharge(balances, maxPrice, isPaidOnly)) {
+        const available = isPaidOnly
+            ? balances.packBalance
+            : Math.max(balances.tierBalance, balances.packBalance);
+        throw new UpstreamError(402 as ContentfulStatusCode, {
+            message: `Insufficient balance. Transcription requests must reserve up to ${maxSeconds}s (~${maxPrice.toFixed(4)} pollen), but your available balance is ${Math.max(0, available).toFixed(4)}.`,
+        });
+    }
+
+    vars.balance.balanceCheckResult = createBalanceCheckResult(
+        balances,
+        isPaidOnly,
+        maxPrice,
+    );
+}
+
+export function assertTranscriptionDurationWithinLimit(
+    durationSeconds: number,
+    maxSeconds = MAX_TRANSCRIPTION_SECONDS,
+): void {
+    if (durationSeconds <= maxSeconds) return;
+    throw new UpstreamError(400 as ContentfulStatusCode, {
+        message: `Audio duration exceeds the ${maxSeconds}s transcription limit`,
     });
 }
 
@@ -1130,7 +1198,8 @@ export const audioRoutes = new Hono<Env>()
         track("generate.audio"),
         async (c) => {
             const log = c.get("log").getChild("transcription");
-            await requireGenerationAccess(c.var, c.env);
+            await c.var.auth.requireAuthorization();
+            c.var.auth.requireModelAccess();
 
             // Get formData from middleware or parse it
             let formData: FormData;
@@ -1176,6 +1245,8 @@ export const audioRoutes = new Hono<Env>()
                 });
             }
 
+            await requireMaxTranscriptionBudget(c.var);
+
             // Route to ElevenLabs Scribe or Whisper based on model
             if (c.var.model.resolved === "scribe") {
                 const elevenLabsApiKey = (
@@ -1189,6 +1260,12 @@ export const audioRoutes = new Hono<Env>()
                     log,
                     numSpeakers: speakersExpected,
                 });
+                const duration = Number(
+                    response.headers.get("x-usage-prompt-audio-seconds"),
+                );
+                if (Number.isFinite(duration)) {
+                    assertTranscriptionDurationWithinLimit(duration);
+                }
 
                 // Override tracking with final response
                 c.var.track.overrideResponseTracking(response.clone());
@@ -1213,6 +1290,12 @@ export const audioRoutes = new Hono<Env>()
                     log,
                     speakersExpected,
                 });
+                const duration = Number(
+                    response.headers.get("x-usage-prompt-audio-seconds"),
+                );
+                if (Number.isFinite(duration)) {
+                    assertTranscriptionDurationWithinLimit(duration);
+                }
 
                 c.var.track.overrideResponseTracking(response.clone());
                 return response;
@@ -1268,6 +1351,7 @@ export const audioRoutes = new Hono<Env>()
                 });
             }
             const duration = extractWhisperUsage(whisper, log);
+            assertTranscriptionDurationWithinLimit(duration);
             const usageHeaders = buildUsageHeaders(
                 c.var.model.resolved,
                 createAudioSecondsUsage(duration),

--- a/gen.pollinations.ai/test/transcription-param-parsing.test.ts
+++ b/gen.pollinations.ai/test/transcription-param-parsing.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { parsePositiveInt } from "../src/routes/audio.ts";
+import {
+    assertTranscriptionDurationWithinLimit,
+    getMaxTranscriptionPreflightPrice,
+    MAX_TRANSCRIPTION_SECONDS,
+    parsePositiveInt,
+    requireMaxTranscriptionBudget,
+} from "../src/routes/audio.ts";
 
 describe("parsePositiveInt", () => {
     it("returns undefined for null/empty input", () => {
@@ -20,5 +26,92 @@ describe("parsePositiveInt", () => {
                 /speakers_expected must be a positive integer/,
             );
         }
+    });
+});
+
+describe("transcription budget preflight", () => {
+    it("prices the maximum accepted transcription duration", () => {
+        expect(getMaxTranscriptionPreflightPrice("whisper")).toBeCloseTo(
+            0.1602,
+        );
+        expect(getMaxTranscriptionPreflightPrice("scribe")).toBeCloseTo(0.33);
+    });
+
+    it("rejects finite API key budgets below the maximum transcription price", async () => {
+        const vars = {
+            auth: {
+                user: { id: "transcription-user" },
+                apiKey: { id: "sk-test", pollenBalance: 0.01 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: 10,
+                    packBalance: 10,
+                }),
+            },
+            model: { requested: "whisper", resolved: "whisper" },
+        };
+
+        await expect(
+            requireMaxTranscriptionBudget(vars as never),
+        ).rejects.toMatchObject({
+            status: 402,
+        });
+    });
+
+    it("rejects paid-only transcription when pack balance cannot cover the maximum", async () => {
+        const vars = {
+            auth: {
+                user: { id: "transcription-user" },
+                apiKey: { id: "sk-test", pollenBalance: 1 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: 10,
+                    packBalance: 0.01,
+                }),
+            },
+            model: { requested: "scribe", resolved: "scribe" },
+        };
+
+        await expect(
+            requireMaxTranscriptionBudget(vars as never),
+        ).rejects.toMatchObject({
+            status: 402,
+        });
+    });
+
+    it("accepts transcription budgets that cover the maximum", async () => {
+        const vars = {
+            auth: {
+                user: { id: "transcription-user" },
+                apiKey: { id: "sk-test", pollenBalance: 1 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: 1,
+                    packBalance: 0,
+                }),
+            },
+            model: { requested: "whisper", resolved: "whisper" },
+        };
+
+        await expect(requireMaxTranscriptionBudget(vars as never)).resolves.toBe(
+            undefined,
+        );
+        expect(
+            (vars.balance as { balanceCheckResult?: unknown })
+                .balanceCheckResult,
+        ).toMatchObject({
+            selectedMeterSlug: "v1:meter:tier",
+        });
+    });
+
+    it("rejects provider-reported durations above the maximum", () => {
+        expect(() =>
+            assertTranscriptionDurationWithinLimit(
+                MAX_TRANSCRIPTION_SECONDS + 1,
+            ),
+        ).toThrow(/transcription limit/);
     });
 });


### PR DESCRIPTION
## Summary
- require transcription requests to reserve the maximum accepted transcription duration before calling the upstream provider
- enforce the same maximum against provider-reported transcription duration
- add regression coverage for finite API-key budgets, paid-only pack balance checks, and over-limit provider durations

## Why
The transcription route previously used the normal generation preflight before the uploaded audio duration was known. Actual billing is based on provider-reported audio seconds after the upstream transcription work has already completed, so a low-balance or finite-budget API key could pass preflight and then be charged more than it was allowed to spend.

This is separate from #11499: that PR covers request-provided duration for media/audio generation paths. This route learns duration only after the transcription provider responds.

## Tests
- `cd gen.pollinations.ai && npm run typecheck`
- `cd gen.pollinations.ai && npx vitest run test/transcription-param-parsing.test.ts`