### PR TITLE
fix: enforce api key budget deductions atomically

### DIFF
--- a/gen.pollinations.ai/test/billing-deduction.test.ts
+++ b/gen.pollinations.ai/test/billing-deduction.test.ts
@@ -1,9 +1,16 @@
 import { env } from "cloudflare:test";
 import { getUserBalance } from "@shared/billing/balance.ts";
-import { atomicDeductUserBalance } from "@shared/billing/deduction.ts";
+import {
+    atomicDeductApiKeyBalance,
+    atomicDeductUserBalance,
+} from "@shared/billing/deduction.ts";
 import { handleBalanceDeduction } from "@shared/billing/track-helpers.ts";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    apikey as apikeyTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import { getModelDefinition } from "@shared/registry/registry.ts";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
 
@@ -28,6 +35,34 @@ async function createUser({
         updatedAt: new Date(),
     });
     return userId;
+}
+
+async function createApiKeyBudget(balance: number | null) {
+    const userId = await createUser({ tierBalance: 10, packBalance: 10 });
+    const keyId = `apikey-budget-${crypto.randomUUID()}`;
+    await db.insert(apikeyTable).values({
+        id: keyId,
+        name: "Budget Test Key",
+        start: "sk-test",
+        prefix: "sk",
+        key: `sk-test-${crypto.randomUUID()}`,
+        userId,
+        enabled: true,
+        metadata: JSON.stringify({ keyType: "secret" }),
+        pollenBalance: balance,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+    return { keyId, userId };
+}
+
+async function getApiKeyBudget(keyId: string) {
+    const [row] = await db
+        .select({ pollenBalance: apikeyTable.pollenBalance })
+        .from(apikeyTable)
+        .where(eq(apikeyTable.id, keyId))
+        .limit(1);
+    return row?.pollenBalance;
 }
 
 describe("billing deduction", () => {
@@ -128,5 +163,49 @@ describe("billing deduction", () => {
         balance = await getUserBalance(db, userId);
         expect(balance.tierBalance).toBeCloseTo(0.01, 10);
         expect(balance.packBalance).toBeCloseTo(-0.01, 10);
+    });
+
+    it("does not let finite API key budgets go negative", async () => {
+        const { keyId } = await createApiKeyBudget(1);
+
+        await expect(
+            atomicDeductApiKeyBalance(db, keyId, 0.75),
+        ).resolves.toEqual({ ok: true });
+        expect(await getApiKeyBudget(keyId)).toBeCloseTo(0.25, 10);
+
+        await expect(
+            atomicDeductApiKeyBalance(db, keyId, 0.5),
+        ).resolves.toEqual({ ok: false });
+        expect(await getApiKeyBudget(keyId)).toBeCloseTo(0.25, 10);
+    });
+
+    it("keeps unlimited API key budgets untouched", async () => {
+        const { keyId } = await createApiKeyBudget(null);
+
+        await expect(atomicDeductApiKeyBalance(db, keyId, 1)).resolves.toEqual({
+            ok: false,
+        });
+        expect(await getApiKeyBudget(keyId)).toBeNull();
+    });
+
+    it("does not debit user balance when finite API key budget settlement fails", async () => {
+        const { keyId, userId } = await createApiKeyBudget(0.25);
+
+        await expect(
+            handleBalanceDeduction({
+                db,
+                isBilledUsage: true,
+                totalPrice: 0.5,
+                userId,
+                apiKeyId: keyId,
+                apiKeyPollenBalance: 0.25,
+            }),
+        ).rejects.toThrow(/API key budget deduction affected 0 rows/);
+
+        expect(await getApiKeyBudget(keyId)).toBeCloseTo(0.25, 10);
+        expect(await getUserBalance(db, userId)).toEqual({
+            tierBalance: 10,
+            packBalance: 10,
+        });
     });
 });

--- a/shared/billing/deduction.ts
+++ b/shared/billing/deduction.ts
@@ -89,6 +89,7 @@ export async function atomicDeductApiKeyBalance(
 			SET pollen_balance = pollen_balance - ${amount}
 			WHERE id = ${apiKeyId}
 			AND pollen_balance IS NOT NULL
+			AND pollen_balance >= ${amount}
 		`);
 
     return { ok: (result.meta.changes ?? 0) > 0 };

--- a/shared/billing/track-helpers.ts
+++ b/shared/billing/track-helpers.ts
@@ -131,6 +131,12 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
     let postDeductionPackBalance: number | null = null;
 
     try {
+        // API key budgets are decremented by the amount the user authorized the
+        // app to spend, including BYOP markup when it applies.
+        if (apiKeyId && hasApiKeyBudget(apiKeyPollenBalance)) {
+            await deductApiKeyBalance(db, apiKeyId, billedPrice);
+        }
+
         if (userId) {
             const deduction = await deductUserBalance(
                 db,
@@ -140,12 +146,6 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
             );
             payerBucket = deduction.bucket;
             postDeductionPackBalance = deduction.postDeductionPackBalance;
-        }
-
-        // API key budgets are decremented by the amount the user authorized the
-        // app to spend, including BYOP markup when it applies.
-        if (apiKeyId && hasApiKeyBudget(apiKeyPollenBalance)) {
-            await deductApiKeyBalance(db, apiKeyId, billedPrice);
         }
 
         if (markup) {


### PR DESCRIPTION
## Summary
- require finite API key budgets to have enough remaining pollen at deduction time
- keep unlimited API key budgets (`NULL`) untouched
- add regression coverage for budget exhaustion during atomic deduction

## Why
API key budgets are checked before generation starts, but final billing is deducted after the response. The deduction query only required `pollen_balance IS NOT NULL`, so a finite-budget key could be decremented below zero if the remaining budget was already spent by another request between preflight and final billing.

Adding the remaining-budget predicate makes the spend limit atomic at the ledger update boundary instead of relying only on the earlier preflight snapshot.

## Tests
- `cd gen.pollinations.ai && npm run typecheck`
- `cd gen.pollinations.ai && npx vitest run test/billing-deduction.test.ts`