### PR TITLE
fix: enforce Polly API PR read-only actions

### DIFF
--- a/apps/polly/src/services/github_pr.py
+++ b/apps/polly/src/services/github_pr.py
@@ -1662,6 +1662,12 @@ async def tool_github_pr(
         else:
             logger.info(f"PR admin action '{action}' authorized for {context_user_name} (id={context_user_id})")
 
+    if _context and _context.get("is_http_api") and action in {"comment", "review"}:
+        logger.warning(
+            f"SECURITY: Blocked API PR write action '{action}' for user {context_user_name} (id={context_user_id})"
+        )
+        return {"error": f"The '{action}' action is not available from the HTTP API."}
+
     # READ ACTIONS
     if action == "get":
         if not pr_number:


### PR DESCRIPTION
## Summary
- block `github_pr` comment/review actions when Polly is running in HTTP API mode
- keep the server-side handler aligned with the API tool policy, where PR tools are read-only

## Security impact
Low / defense-in-depth. API mode already filters these actions out of the exposed tool schema, but the handler should enforce the same policy if an unexpected tool call reaches it.

## Testing
- `python -m py_compile apps\polly\src\services\github_pr.py`