### PR TITLE
add minimax m3, move gemma 4 26b to openrouter

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -270,12 +270,12 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "gemma": {
     "cost": {
-      "completionTextTokens": 3.4e-7,
-      "promptTextTokens": 7e-8,
+      "completionTextTokens": 3.3e-7,
+      "promptTextTokens": 6e-8,
     },
     "price": {
-      "completionTextTokens": 3.4e-7,
-      "promptTextTokens": 7e-8,
+      "completionTextTokens": 3.3e-7,
+      "promptTextTokens": 6e-8,
     },
   },
   "glm": {
@@ -545,6 +545,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
     },
   },
   "minimax": {
+    "cost": {
+      "completionTextTokens": 0.0000012,
+      "promptCachedTokens": 6e-8,
+      "promptTextTokens": 3e-7,
+    },
+    "price": {
+      "completionTextTokens": 0.0000012,
+      "promptCachedTokens": 6e-8,
+      "promptTextTokens": 3e-7,
+    },
+  },
+  "minimax-m3": {
     "cost": {
       "completionTextTokens": 0.0000012,
       "promptCachedTokens": 6e-8,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -87,7 +87,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "gemma",
-        config: portkeyConfig["google/gemma-4-26B-A4B-it"],
+        config: portkeyConfig["google/gemma-4-26b-a4b-it"],
     },
     {
         name: "deepseek-pro",
@@ -266,6 +266,10 @@ const models: ModelDefinition[] = [
     {
         name: "minimax",
         config: portkeyConfig["accounts/fireworks/models/minimax-m2p7"],
+    },
+    {
+        name: "minimax-m3",
+        config: portkeyConfig["minimax/minimax-m3"],
     },
     {
         name: "llama",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -3,7 +3,6 @@ import {
     createAzureModelConfig,
     createBedrockNativeConfig,
     createDashScopeModelConfig,
-    createDeepInfraModelConfig,
     createFireworksModelConfig,
     createOpenRouterModelConfig,
     createOVHcloudMistralConfig,
@@ -108,10 +107,12 @@ export const portkeyConfig: PortkeyConfigMap = {
             "grok-4.3",
         ),
 
-    // -- DeepInfra (Gemma) ----------------------------------------------------
-    "google/gemma-4-26B-A4B-it": () =>
-        createDeepInfraModelConfig({
-            model: "google/gemma-4-26B-A4B-it",
+    // -- OpenRouter (Gemma) ---------------------------------------------------
+    // Moved off DeepInfra: OpenRouter serves the same SKU ~cheaper ($0.06/$0.33
+    // posted vs $0.07/$0.34) and is credit-eligible.
+    "google/gemma-4-26b-a4b-it": () =>
+        createOpenRouterModelConfig({
+            model: "google/gemma-4-26b-a4b-it",
         }),
 
     // -- Fireworks AI (DeepSeek) ---------------------------------------------
@@ -225,6 +226,14 @@ export const portkeyConfig: PortkeyConfigMap = {
     "accounts/fireworks/models/minimax-m2p7": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/minimax-m2p7",
+        }),
+
+    // -- OpenRouter (MiniMax M3) ---------------------------------------------
+    // M3 is not on Fireworks/Bedrock yet (Bedrock tops out at M2.5); OpenRouter
+    // is the only route and also exposes image input.
+    "minimax/minimax-m3": () =>
+        createOpenRouterModelConfig({
+            model: "minimax/minimax-m3",
         }),
 
     // -- Azure (Myceli Prod — eastus, Meta Llama) ----------------------------

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -383,15 +383,17 @@ export const TEXT_SERVICES = {
             "gemma-4-26b-a4b",
             "gemma-4-26b-a4b-it",
         ],
-        modelId: "google/gemma-4-26B-A4B-it",
-        provider: "deepinfra",
+        modelId: "google/gemma-4-26b-a4b-it",
+        provider: "openrouter",
         addedDate: new Date("2026-05-08").getTime(),
         brand: "Google",
         category: "text",
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(0.07),
-            completionTextTokens: perMillion(0.34),
+            // OpenRouter google/gemma-4-26b-a4b-it posted rates (2026-06-02):
+            // prompt $0.06/M, completion $0.33/M. No prompt caching upstream.
+            promptTextTokens: perMillion(0.06),
+            completionTextTokens: perMillion(0.33),
         },
         description:
             "Gemma 4 26B A4B - Open-source multimodal MoE for fast inference",
@@ -1057,6 +1059,31 @@ export const TEXT_SERVICES = {
         tools: true,
         reasoning: true,
         contextLength: 200000,
+        isSpecialized: false,
+    },
+    "minimax-m3": {
+        aliases: ["minimax3", "minimax-3"],
+        modelId: "minimax/minimax-m3",
+        provider: "openrouter",
+        brand: "MiniMax",
+        category: "text",
+        addedDate: new Date("2026-06-02").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter minimax/minimax-m3 effective rates (2026-06-02):
+            // currently a temporary 50% promo — prompt $0.30/M, completion
+            // $1.20/M, cache read $0.06/M. Base (post-promo) is double:
+            // $0.60/M, $2.40/M, $0.12/M — revisit when the promo ends.
+            promptTextTokens: perMillion(0.3),
+            promptCachedTokens: perMillion(0.06),
+            completionTextTokens: perMillion(1.2),
+        },
+        description: "MiniMax M3 - Coding, agentic & 1M-context reasoning",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
         isSpecialized: false,
     },
     "mistral-large": {


### PR DESCRIPTION
- Adds **MiniMax M3** (`minimax-m3`, aliases `minimax3`/`minimax-3`) via OpenRouter — text+image input, tools, reasoning, 1M context. Verified upstream: tool calls, image input, reasoning tokens, prompt caching all work.
- M3 priced at 1x markup using the current OpenRouter rate ($0.30/M in, $1.20/M out, $0.06/M cache). This is a temporary 50% promo; base is $0.60/$2.40 — flagged in a code comment to revisit when the promo ends.
- Moves **Gemma 4 26B-A4B** from DeepInfra → OpenRouter (same SKU, cheaper: $0.06/$0.33 vs $0.07/$0.34), keeps 1x markup, non-paid.
- Checked AWS Bedrock + Fireworks first: M3 isn't on either (Bedrock tops out at M2.5); Gemma 4 is OpenRouter-only (Bedrock has Gemma 3, Fireworks is on-demand only). **Voyage 4 dropped** — not served by Fireworks, Bedrock, or OpenRouter (would need Voyage's native API).
- Tests: aliases, pricing-data, usage-headers, model-permissions pass; effective-prices snapshot updated. Local gateway lists both with correct pricing/modalities. Live local generation not run (no seeded local key in this clone); upstream responses verified directly.
