### PR TITLE
add seed:local to fix local e2e auth

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -85,13 +85,33 @@ For pure model work (modelId, provider, registry modalities/aliases/description,
 
 ```bash
 # (Optional) Terminal 1 — Enter on 3000 — ONLY when your change touches Enter surfaces
-(cd enter.pollinations.ai && npm run decrypt-vars && npm run dev)
+(cd enter.pollinations.ai && npm run dev)
 
-# Terminal 2 — Gen on 8788 — required for all model tests
-(cd gen.pollinations.ai && npm run decrypt-vars && npx wrangler dev --port 8788)
+# Terminal 2 — Gen on 8788 — required for all model tests.
+# USE `npm run dev`, NOT bare `npx wrangler dev`. The dev script runs
+# `vite build` first; bare wrangler serves a STALE bundle (your registry/config
+# edits won't show — /v1/models returns old pricing) and skips
+# `--persist-to .wrangler/state` (so the seeded D1 below isn't used).
+(cd gen.pollinations.ai && npm run dev)
 
-# Terminal 3 — your tests
+# Terminal 3 — seed a known API key into gen's local D1, then source tokens.
+# Without this, e2e curls 401: gen validates Bearer tokens against its own local
+# D1, and better-auth stores keys hashed (base64url(sha256(key))) — it never
+# stores the plaintext of secret keys, so a token in _local/.env only works if
+# its hash is in THIS D1. `seed:local` inserts a key whose plaintext = your
+# _local/.env POLLINATIONS_TOKEN_LOCAL (idempotent; re-run after any D1 reset).
+(cd gen.pollinations.ai && npm run seed:local)
 source _local/.env
+```
+
+**End-to-end smoke test (must pass before any model PR):**
+```bash
+source _local/.env
+curl -s "http://localhost:8788/v1/chat/completions" \
+  -H "Authorization: Bearer $POLLINATIONS_TOKEN_LOCAL" -H "Content-Type: application/json" \
+  -d '{"model":"<your-model>","max_tokens":200,"messages":[{"role":"user","content":"Reply: OK"}]}' \
+  | jq '{finish:.choices[0].finish_reason, content:.choices[0].message.content}'
+# 200 + content → wiring + auth + billing path all live. 401 → re-run seed:local.
 ```
 
 ---
@@ -107,19 +127,18 @@ source _local/.env
 | Var | Purpose |
 |---|---|
 | `POLLINATIONS_TOKEN_PROD` | Prod enter `sk_` — calls against `gen.pollinations.ai` |
-| `POLLINATIONS_TOKEN_LOCAL` | Local enter `sk_` (seeded into local KV) — calls against `localhost:8788` |
+| `POLLINATIONS_TOKEN_LOCAL` | `sk_` for `localhost:8788`. **NOT auto-seeded** — its hash must be inserted into gen's local D1 via `cd gen.pollinations.ai && npm run seed:local` (seeds this exact token). Re-run after any D1 reset. |
 | `POLLINATIONS_TOKEN_STAGING` | Staging enter `sk_` — calls against staging deploys |
 | `TINYBIRD_READ_PROD` | Read token, prod workspace |
 | `TINYBIRD_READ_STAGING` | Read token, staging workspace — **also covers DEV** (local gen writes to the staging workspace via its `TINYBIRD_INGEST_URL` binding) |
 
 > **There are no "free" vs "paid" keys.** A key is a key. The `paidOnly` gate checks the user's `packBalance` (purchased Pollen pack balance), not the key prefix. To exercise the gate, use a token whose **owning user has `packBalance == 0`** — typically a freshly minted key (signup grants free Pollen, no pack) or one whose pack has been depleted. Don't confuse "free Pollen remaining" (signup grant, doesn't unlock paidOnly) with "pack balance" (purchased, does unlock).
 
-> **`_local/.env` token labels are not guaranteed to match where they actually validate.** Before assuming a 401 means "wrong/expired token," verify the token against gen's local D1 — only keys seeded in *gen's* `apikey` table validate there (enter's D1 is a separate sqlite, not shared with gen in local). Quick lookup (no secrets printed):
+> **A 401 on `localhost:8788` almost always means the local D1 has no row for your token — run `cd gen.pollinations.ai && npm run seed:local`.** Root cause: gen validates `Bearer` tokens against its OWN local D1 `apikey` table (`shared/auth/api-key.ts` → better-auth `verifyApiKey`; enter's D1 is a separate sqlite, not shared). better-auth stores keys hashed as `base64url(sha256(key))` and never stores the plaintext of secret keys, so a dashboard-minted key is unrecoverable and a `_local/.env` token only validates if its hash is in THIS D1. The D1 gets recreated (or came from another clone), so the hash is usually absent → 401. `seed:local` inserts a key whose plaintext = your `_local/.env` `POLLINATIONS_TOKEN_LOCAL` (and a flower-tier user with large balances, so paid-only + spend both pass). It's idempotent — re-run any time. Inspect what's seeded (no secrets printed):
 > ```bash
 > GEN_DB=gen.pollinations.ai/.wrangler/state/v3/d1/miniflare-D1DatabaseObject/*.sqlite
-> sqlite3 $GEN_DB "SELECT name, start, prefix FROM apikey;"
+> sqlite3 $GEN_DB "SELECT name, start, enabled FROM apikey WHERE id='local-e2e-key';"
 > ```
-> Match each `POLLINATIONS_TOKEN_*` env var's first 6 chars against the `start` column — the env var named `_LOCAL` is not necessarily the one seeded locally. Pick whichever env var matches a row whose `name` looks like a local test key (e.g., `local-battle-test`, `local-e2e-test-key`).
 
 Provider/runtime secrets (Azure, OpenAI, OpenRouter API keys, etc.) belong in `gen.pollinations.ai/secrets/{dev,staging,prod}.vars.json` via SOPS — never in `_local/.env`. See §11.
 

--- a/gen.pollinations.ai/package.json
+++ b/gen.pollinations.ai/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "decrypt-vars": "sops exec-file --no-fifo secrets/dev.vars.json 'node scripts/push-generation-secrets.mjs {} local'",
         "dev": "npm run decrypt-vars && vite build --mode=development && wrangler dev --port 8788 --local --persist-to .wrangler/state --show-interactive-dev-session false",
+        "seed:local": "node scripts/seed-local-key.mjs",
         "build:staging": "CLOUDFLARE_ENV=staging vite build --mode=staging",
         "build:production": "CLOUDFLARE_ENV=production vite build --mode=production",
         "deploy:staging": "npm run build:staging && wrangler deploy --env staging",

--- a/gen.pollinations.ai/scripts/seed-local-key.mjs
+++ b/gen.pollinations.ai/scripts/seed-local-key.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Seed a known API key into gen's LOCAL D1 so local end-to-end tests work.
+ *
+ * Why this exists
+ * ---------------
+ * gen validates `Authorization: Bearer sk_…` against its own local D1 `apikey`
+ * table via better-auth `verifyApiKey`. better-auth stores keys hashed as
+ * `base64url(sha256(plaintext))` and NEVER stores the plaintext of secret keys.
+ * So a key minted via the dashboard is unrecoverable, and a token sitting in
+ * `_local/.env` only authenticates if ITS hash happens to be in THIS D1 — which
+ * it usually isn't (the D1 gets recreated, or the token came from another clone).
+ * That's why curl-based e2e against `npm run dev` 401s "almost every day".
+ *
+ * This script computes the same hash better-auth uses and upserts a key whose
+ * plaintext we control. Idempotent — safe to re-run after any D1 reset.
+ *
+ * Usage
+ * -----
+ *   npm run seed:local                          # seed POLLINATIONS_TOKEN_LOCAL from _local/.env
+ *   POLLINATIONS_TOKEN_LOCAL=sk_xxx npm run seed:local
+ *
+ * If no token is found it generates one, seeds it, and appends it to _local/.env.
+ * Boot the worker first (`npm run dev`) so the D1 + schema exist.
+ */
+import { execFileSync } from "node:child_process";
+import { createHash, getRandomValues } from "node:crypto";
+import {
+    appendFileSync,
+    existsSync,
+    readdirSync,
+    readFileSync,
+    statSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const GEN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = resolve(GEN_ROOT, "..");
+const ENV_FILE = join(REPO_ROOT, "_local", ".env");
+const D1_DIR = join(
+    GEN_ROOT,
+    ".wrangler/state/v3/d1/miniflare-D1DatabaseObject",
+);
+const USER_ID = "local-e2e-user";
+const KEY_ID = "local-e2e-key";
+
+const die = (msg) => {
+    console.error(`\n✖ ${msg}\n`);
+    process.exit(1);
+};
+
+// better-auth apiKey plugin hashing: base64url(sha256(utf8(key))), no padding.
+// Mirrors defaultKeyHasher in better-auth/dist/plugins/api-key/index.mjs.
+const hashKey = (key) =>
+    createHash("sha256").update(key, "utf8").digest("base64url");
+
+function readEnvToken() {
+    if (process.env.POLLINATIONS_TOKEN_LOCAL)
+        return process.env.POLLINATIONS_TOKEN_LOCAL.trim();
+    if (!existsSync(ENV_FILE)) return null;
+    for (const line of readFileSync(ENV_FILE, "utf8").split("\n")) {
+        const m = line.match(/^\s*POLLINATIONS_TOKEN_LOCAL\s*=\s*(.+?)\s*$/);
+        if (m) return m[1].replace(/^["']|["']$/g, "").trim();
+    }
+    return null;
+}
+
+function generateToken() {
+    const chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    const bytes = getRandomValues(new Uint8Array(32));
+    return `sk_${Array.from(bytes, (b) => chars[b % chars.length]).join("")}`;
+}
+
+function findDb() {
+    if (!existsSync(D1_DIR))
+        die(
+            `No local D1 found at ${D1_DIR}\n  Boot the worker once first: npm run dev`,
+        );
+    const files = readdirSync(D1_DIR)
+        .filter((f) => f.endsWith(".sqlite"))
+        .map((f) => join(D1_DIR, f))
+        .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+    if (!files.length)
+        die(
+            `No .sqlite in ${D1_DIR}\n  Boot the worker once first: npm run dev`,
+        );
+    return files[0];
+}
+
+function sql(db, statement) {
+    try {
+        return execFileSync("sqlite3", [db, statement], {
+            encoding: "utf8",
+        }).trim();
+    } catch (err) {
+        if (err.code === "ENOENT")
+            die(
+                "`sqlite3` CLI not found — install it (macOS: preinstalled; Debian: apt install sqlite3).",
+            );
+        die(`sqlite3 failed: ${err.stderr || err.message}`);
+    }
+}
+
+// --- main ---------------------------------------------------------------
+const db = findDb();
+
+const hasTable = sql(
+    db,
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='apikey';",
+);
+if (!hasTable)
+    die(
+        "Local D1 has no `apikey` table yet.\n  Boot the worker once first: npm run dev",
+    );
+
+let token = readEnvToken();
+let generated = false;
+if (!token) {
+    token = generateToken();
+    generated = true;
+}
+
+const keyHash = hashKey(token);
+const start = token.slice(0, 10);
+const esc = (s) => s.replace(/'/g, "''");
+
+// Self-contained: a dedicated user with generous balances so paid-only gates
+// and spend both pass. Fixed ids → INSERT OR REPLACE is a clean upsert.
+sql(
+    db,
+    `INSERT OR REPLACE INTO user
+       (id, name, email, email_verified, tier, tier_balance, pack_balance,
+        created_at, updated_at, auto_top_up_enabled)
+     VALUES
+       ('${USER_ID}', 'Local E2E', 'local-e2e@test.local', 1, 'flower',
+        1000000, 1000000, strftime('%s','now'), strftime('%s','now'), 0);`,
+);
+sql(
+    db,
+    `INSERT OR REPLACE INTO apikey
+       (id, name, start, prefix, key, user_id, enabled, rate_limit_enabled,
+        request_count, created_at, updated_at)
+     VALUES
+       ('${KEY_ID}', 'local-e2e', '${esc(start)}', 'sk', '${esc(keyHash)}',
+        '${USER_ID}', 1, 0, 0, strftime('%s','now'), strftime('%s','now'));`,
+);
+
+if (generated && existsSync(ENV_FILE)) {
+    appendFileSync(ENV_FILE, `\nPOLLINATIONS_TOKEN_LOCAL=${token}\n`);
+}
+
+console.log(`
+✔ Seeded local API key into gen's D1
+  db:    ${db}
+  user:  ${USER_ID} (tier=flower, balances=1,000,000)
+  key:   ${KEY_ID} (enabled, no expiry, full access)
+  token: ${token}${generated ? "  (generated → appended to _local/.env)" : "  (from _local/.env)"}
+
+Test it:
+  curl "http://localhost:8788/v1/chat/completions" \\
+    -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" \\
+    -d '{"model":"minimax-m3","max_tokens":20,"messages":[{"role":"user","content":"hi"}]}'
+`);


### PR DESCRIPTION
**Problem:** end-to-end curls against local `npm run dev` 401 constantly. Gen validates `Bearer` tokens against its **own local D1** `apikey` table (better-auth `verifyApiKey`), which stores keys hashed as `base64url(sha256(key))` and never stores the plaintext of secret keys. So a token in `_local/.env` only authenticates if its hash is in *that* D1 — which it usually isn't after the D1 is recreated or when it came from another clone. There was no step to guarantee a known key exists.

**Fix:**
- Adds `npm run seed:local` (gen) — inserts a key whose plaintext = `_local/.env` `POLLINATIONS_TOKEN_LOCAL`, plus a flower-tier user with large balances (so paid-only gates + spend both pass). Idempotent; re-run after any D1 reset. If no token is set it generates one and appends it to `_local/.env`.
- Updates the `model-management` skill: boot gen with `npm run dev` (not bare `wrangler dev`, which serves a stale bundle and skips the persisted D1), run `seed:local`, and adds an e2e smoke-test snippet + root-cause note.

**Verified:** bogus token → 401; seeded `_local/.env` token → real `minimax-m3` generation through `localhost:8788` (`finish:stop`, content returned, usage billed).
