### PR TITLE
perf: reduce Tinybird vCPU pressure on developer earnings

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/developer_earnings.pipe
+++ b/enter.pollinations.ai/observability/endpoints/developer_earnings.pipe
@@ -28,7 +28,11 @@ SQL >
     SELECT
         ge.api_key_client_id AS app_key_id,
         ge.user_id AS user_id,
-        ge.start_time AS start_time,
+        if(
+            {{String(grain, 'day')}} = 'hour',
+            formatDateTime(toStartOfHour(ge.start_time), '%F %T'),
+            formatDateTime(toStartOfDay(ge.start_time), '%F')
+        ) AS date,
         ge.dev_price AS baseline_price,
         ge.total_price AS cost_usd,
         ge.total_price - ge.dev_price AS earned,
@@ -49,61 +53,30 @@ SQL >
     AND ge.api_key_client_id IN {{Array(api_key_ids, 'String')}}
     {% end %}
 
-NODE daily_buckets
+# Single pass over dev_events. GROUPING SETS emits, in one scan, the three row
+# kinds the old pipe produced via three separate scans + UNION ALL:
+#   (date, app_key_id, app_name) -> daily/hourly buckets (date non-empty)
+#   (app_key_id, app_name)       -> per-app rollup (date='')
+#   ()                           -> global rollup (date='', app_key_id='')
+# Columns outside a set default to '' (String), matching the old '' literals.
+# GROUPING(date)=0 only on daily rows, preserving their unique_users=0.
+NODE developer_earnings_node
 SQL >
-    %
     SELECT
-        if(
-            {{String(grain, 'day')}} = 'hour',
-            formatDateTime(toStartOfHour(start_time), '%F %T'),
-            formatDateTime(toStartOfDay(start_time), '%F')
-        ) AS date,
+        date,
         app_key_id,
-        any(app_name) AS app_name,
-        count() AS requests,
-        sum(baseline_price) AS baseline_price,
-        sum(earned) AS pollen_earned,
-        sum(cost_usd) AS cost_usd,
-        avg(markup_rate) AS markup_rate,
-        toUInt64(0) AS unique_users
-    FROM dev_events
-    GROUP BY date, app_key_id
-
-NODE per_app_rollup
-SQL >
-    SELECT
-        '' AS date,
-        app_key_id,
-        any(app_name) AS app_name,
-        count() AS requests,
-        sum(baseline_price) AS baseline_price,
-        sum(earned) AS pollen_earned,
-        sum(cost_usd) AS cost_usd,
-        avg(markup_rate) AS markup_rate,
-        uniq(user_id) AS unique_users
-    FROM dev_events
-    GROUP BY app_key_id
-
-NODE global_rollup
-SQL >
-    SELECT
-        '' AS date,
-        '' AS app_key_id,
-        '' AS app_name,
+        app_name,
         count() AS requests,
         sum(baseline_price) AS baseline_price,
         sum(earned) AS pollen_earned,
         sum(cost_usd) AS cost_usd,
         if(count() = 0, toFloat64(0), avg(markup_rate)) AS markup_rate,
-        uniq(user_id) AS unique_users
+        if(GROUPING(date) = 0, toUInt64(0), uniq(user_id)) AS unique_users
     FROM dev_events
-
-NODE developer_earnings_node
-SQL >
-    SELECT * FROM daily_buckets
-    UNION ALL
-    SELECT * FROM per_app_rollup
-    UNION ALL
-    SELECT * FROM global_rollup
+    GROUP BY GROUPING SETS (
+        (date, app_key_id, app_name),
+        (app_key_id, app_name),
+        ()
+    )
 
 TYPE endpoint

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -355,6 +355,18 @@ function buildUsageWindows(
     return newestFirst ? windows.reverse() : windows;
 }
 
+/**
+ * Thrown when Tinybird returns 429 (rate limit / vCPU budget exceeded). This is
+ * transient, so read-only usage endpoints should degrade gracefully rather than
+ * surface it as a 5xx with the raw upstream message.
+ */
+export class TinybirdRateLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TinybirdRateLimitError";
+    }
+}
+
 export async function fetchTinybirdRows<T>(
     origin: string,
     path: string,
@@ -376,9 +388,11 @@ export async function fetchTinybirdRows<T>(
 
     if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(
-            `Tinybird error: ${response.status} ${errorText || "(empty response)"}`,
-        );
+        const message = `Tinybird error: ${response.status} ${errorText || "(empty response)"}`;
+        if (response.status === 429) {
+            throw new TinybirdRateLimitError(message);
+        }
+        throw new Error(message);
     }
 
     const data = (await response.json()) as { data: T[] };

--- a/enter.pollinations.ai/src/routes/customer.ts
+++ b/enter.pollinations.ai/src/routes/customer.ts
@@ -11,12 +11,25 @@ import {
     fetchTinybirdRows,
     requireTinybirdReadToken,
     resolveUsageTargetUserId,
+    TinybirdRateLimitError,
 } from "./account.ts";
 
 type EarningsTodayRow = {
     paid_week: number;
     tier_week: number;
 };
+
+type EarningsTodayResponse = {
+    paidWeek: number;
+    tierWeek: number;
+};
+
+// Short TTL: the pipe scans 7 days of `generation_event` filtered to one dev
+// (no index on `api_key_created_for_user_id`), so it's expensive and was
+// uncached — unlike the sibling /usage and /earnings endpoints. 60s keeps the
+// "this week so far" number near-live while collapsing per-dashboard-load
+// bursts that were tripping Tinybird's per-minute vCPU budget.
+const BALANCE_TODAY_CACHE_TTL = 60; // seconds
 
 /**
  * Customer routes - Internal endpoints for the frontend
@@ -64,6 +77,7 @@ export const customerRoutes = new Hono<Env>()
             hide: ({ c }) => c?.env.ENVIRONMENT === "production",
         }),
         async (c) => {
+            const log = c.get("log").getChild("balance-today");
             const user = c.var.auth.requireUser();
             const token = requireTinybirdReadToken(c.env);
             const { userId: devUserId } = resolveUsageTargetUserId(
@@ -71,6 +85,22 @@ export const customerRoutes = new Hono<Env>()
                 user.id,
                 c.var.auth.apiKey,
             );
+
+            const kv = c.env.KV;
+            const cacheKey = `balance-today:${devUserId}`;
+
+            try {
+                const cached = await kv.get<EarningsTodayResponse>(
+                    cacheKey,
+                    "json",
+                );
+                if (cached) {
+                    return c.json(cached);
+                }
+            } catch (err) {
+                log.trace("KV get error: {err}", { err });
+            }
+
             const origin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
             let rows: EarningsTodayRow[];
             try {
@@ -81,15 +111,35 @@ export const customerRoutes = new Hono<Env>()
                     { dev_user_id: devUserId },
                 );
             } catch (error) {
+                // Tinybird 429s (vCPU budget) are transient — degrade to empty
+                // earnings instead of surfacing a 502 with the raw message.
+                if (error instanceof TinybirdRateLimitError) {
+                    log.warn(
+                        "Tinybird rate limit on /balance/today, returning empty earnings: {error}",
+                        { error },
+                    );
+                    return c.json({ paidWeek: 0, tierWeek: 0 });
+                }
                 throw new HTTPException(502, {
                     message:
                         error instanceof Error ? error.message : String(error),
                 });
             }
+
             const row = rows[0];
-            return c.json({
+            const response: EarningsTodayResponse = {
                 paidWeek: row?.paid_week ?? 0,
                 tierWeek: row?.tier_week ?? 0,
-            });
+            };
+
+            try {
+                await kv.put(cacheKey, JSON.stringify(response), {
+                    expirationTtl: BALANCE_TODAY_CACHE_TTL,
+                });
+            } catch (err) {
+                log.trace("KV put error: {err}", { err });
+            }
+
+            return c.json(response);
         },
     );


### PR DESCRIPTION
Reduces Tinybird vCPU-budget pressure behind intermittent 429s on account endpoints (a peak minute hit 246s vs the 180s/min budget, surfacing to users as 502s).

- Rewrite the `developer_earnings` pipe to a single `GROUPING SETS` pass instead of scanning `dev_events` 3×, cutting rows read ~3× (~795M → ~265M per call on a 90-day window). Output is byte-identical — validated against prod data across multiple devs (day/hour grain) and already deployed to both Tinybird workspaces.
- Map Tinybird 429s (vCPU budget) to a typed error so `/balance/today` degrades to empty earnings instead of leaking a raw 502.
- Cache `/balance/today` for 60s, matching the sibling usage/earnings endpoints — it was the only one uncached.