### PR TITLE
[codex] fix: repair auth modal theme and focus

### DIFF
--- a/packages/ui/src/modules/auth/AuthModal.tsx
+++ b/packages/ui/src/modules/auth/AuthModal.tsx
@@ -2,9 +2,17 @@ import type { CSSProperties, ReactNode } from "react";
 import logoUrl from "../../assets/logo.svg";
 import { Dialog } from "../../primitives/Dialog.tsx";
 
+const authLogoMaskUrl = `url('${logoUrl}')`;
+
 const authLogoMask: CSSProperties = {
-    WebkitMask: `url(${logoUrl}) center / contain no-repeat`,
-    mask: `url(${logoUrl}) center / contain no-repeat`,
+    WebkitMaskImage: authLogoMaskUrl,
+    WebkitMaskPosition: "center",
+    WebkitMaskRepeat: "no-repeat",
+    WebkitMaskSize: "contain",
+    maskImage: authLogoMaskUrl,
+    maskPosition: "center",
+    maskRepeat: "no-repeat",
+    maskSize: "contain",
 };
 
 export type AuthModalProps = {
@@ -50,7 +58,7 @@ export function AuthModalHeader({ children }: AuthModalHeaderProps) {
             href="https://pollinations.ai"
             target="_blank"
             rel="noopener noreferrer"
-            className="polli:block polli:shrink-0 polli:text-theme-text-strong"
+            className="polli:block polli:shrink-0 polli:text-theme-text-strong polli:focus:outline-none polli:focus-visible:outline-none"
             aria-label="pollinations.ai"
         >
             <span className="polli:sr-only">pollinations.ai</span>

--- a/packages/ui/src/primitives/Dialog.tsx
+++ b/packages/ui/src/primitives/Dialog.tsx
@@ -69,6 +69,7 @@ export const Dialog: FC<DialogProps> = ({
                 />
             )}
             <ArkDialog.Positioner
+                data-theme={theme}
                 className={cn(
                     "polli:fixed polli:inset-0 polli:z-[110] polli:flex polli:h-dvh polli:items-start polli:justify-center polli:overflow-hidden polli:p-4",
                     positionerClassName,
@@ -79,7 +80,7 @@ export const Dialog: FC<DialogProps> = ({
                     aria-label={ariaLabel}
                     aria-labelledby={labelledBy}
                     className={cn(
-                        "polli:my-auto polli:w-full polli:overflow-hidden polli:rounded-lg polli:border-2 polli:border-theme-border polli:bg-white polli:shadow-lg",
+                        "polli:my-auto polli:w-full polli:overflow-hidden polli:rounded-lg polli:border-2 polli:border-theme-border polli:bg-white polli:shadow-lg polli:outline-none polli:focus:outline-none polli:focus-visible:outline-none",
                         sizeClasses[size],
                         contentClassName,
                     )}


### PR DESCRIPTION
- Adds the dialog theme boundary to the positioner so auth backgrounds resolve to amber.
- Replaces the logo mask shorthand with explicit quoted mask properties so the built SVG data URL renders correctly.
- Suppresses default browser focus outlines on the dialog/logo containers without changing tab order or control focus.
- Root cause: themed classes were resolving outside `data-theme`, and the inlined SVG mask URL could fail CSS parsing.
- Verified with `biome`, `@pollinations/ui` typecheck/build, Enter typecheck, and local auth/key-dialog checks.