### PR TITLE
ci: redeploy consumers on package changes

### DIFF
--- a/.github/workflows/app-deploy-automatic.yml
+++ b/.github/workflows/app-deploy-automatic.yml
@@ -30,22 +30,32 @@ jobs:
         id: app
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            APP_NAME="${{ github.event.inputs.app_name }}"
+            CANDIDATES="${{ github.event.inputs.app_name }}"
           else
             git fetch origin main --depth=2
-            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep '^apps/[^/]*/' | head -1 || \
-                      git diff --name-only origin/main~1 HEAD | grep '^apps/[^/]*/' | head -1)
-            APP_NAME=$(echo "$CHANGED" | sed 's|^apps/\([^/]*\)/.*|\1|')
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep '^apps/[^/]*/' || \
+                      git diff --name-only origin/main~1 HEAD | grep '^apps/[^/]*/')
+            CANDIDATES=$(echo "$CHANGED" | sed 's|^apps/\([^/]*\)/.*|\1|' | sort -u)
           fi
           
-          # Check if app is in apps.json (source of truth)
-          if [ -z "$APP_NAME" ] || ! node -e "const c=require('./apps/apps.json'); if(!c['$APP_NAME']) process.exit(1);" 2>/dev/null; then
-            echo "⏭️ $APP_NAME not in apps.json, skipping deploy"
+          # Keep only apps registered in apps.json (source of truth)
+          APPS=""
+          for app in $CANDIDATES; do
+            if [ -n "$app" ] && node -e "const c=require('./apps/apps.json'); if(!c['$app']) process.exit(1);" 2>/dev/null; then
+              APPS="$APPS $app"
+            else
+              echo "⏭️ $app not in apps.json, skipping"
+            fi
+          done
+          APPS=$(echo $APPS | xargs)
+
+          if [ -z "$APPS" ]; then
+            echo "No registered apps changed, nothing to deploy"
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           
-          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+          echo "apps=$APPS" >> $GITHUB_OUTPUT
           echo "skip=false" >> $GITHUB_OUTPUT
 
       - name: Deploy
@@ -55,4 +65,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
           CLOUDFLARE_API_TOKEN_OLD: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID_OLD: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: ./apps/_scripts/deploy.sh ${{ steps.app.outputs.app_name }}
+        run: |
+          for app in ${{ steps.app.outputs.apps }}; do
+            echo "::group::Deploy $app"
+            ./apps/_scripts/deploy.sh "$app"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/deploy-enter-cloudflare.yml
+++ b/.github/workflows/deploy-enter-cloudflare.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'enter.pollinations.ai/**'
       - 'shared/**'
+      - 'packages/sdk/**'
+      - 'packages/ui/**'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/deploy-enter-cloudflare.yml'

--- a/.github/workflows/deploy-pollinations-ai-cloudflare.yml
+++ b/.github/workflows/deploy-pollinations-ai-cloudflare.yml
@@ -8,6 +8,8 @@ on:
       - 'pollinations.ai/**'
       - 'apps/APPS.md'
       - 'shared/**'
+      - 'packages/sdk/**'
+      - 'packages/ui/**'
       - '.github/workflows/deploy-pollinations-ai-cloudflare.yml'
   workflow_dispatch:
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -76,7 +76,12 @@ jobs:
       - name: Publish to NPM
         if: steps.check.outputs.skip != 'true'
         working-directory: packages/sdk
-        run: npm publish --access public
+        run: |
+          v=$(node -p "require('./package.json').version")
+          tag=latest
+          case "$v" in *-*) tag="${v#*-}"; tag="${tag%%.*}";; esac
+          echo "Publishing $v under dist-tag: $tag"
+          npm publish --access public --tag "$tag"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -116,7 +121,12 @@ jobs:
       - name: Publish to NPM
         if: steps.check.outputs.skip != 'true'
         working-directory: packages/ui
-        run: npm publish --access public
+        run: |
+          v=$(node -p "require('./package.json').version")
+          tag=latest
+          case "$v" in *-*) tag="${v#*-}"; tag="${tag%%.*}";; esac
+          echo "Publishing $v under dist-tag: $tag"
+          npm publish --access public --tag "$tag"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
- Adds `packages/sdk/**` and `packages/ui/**` to enter and website production deploy path filters.
- Publishes SDK/UI prereleases under a version-derived npm dist-tag (`alpha` for prereleases, `latest` for stable versions); MCP/CLI publishing is unchanged.
- Updates automatic app deploys to deploy every changed registered app instead of only the first changed app.

Scope note:
- This PR intentionally does not add package README stability warnings. Those should ship in the SDK/UI package PRs together with the alpha version bumps, so npm users see the warning on the exact alpha package they install.

Validation:
- `git diff --cached --check`
- Ruby YAML parse for all four edited workflow files
- `gh auth status`

Note: `actionlint` is not installed locally, so workflow linting was limited to YAML parse and shell/diff review.