### PR TITLE
feat(sdk): model catalog helper + client subpath

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,10 +5,23 @@ Official SDK for [pollinations.ai](https://pollinations.ai) - Generate images, t
 [![npm version](https://img.shields.io/npm/v/@pollinations/sdk.svg)](https://www.npmjs.com/package/@pollinations/sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+> [!WARNING]
+> **The `alpha` release line (`5.1.0-alpha.x`) is unstable and breakage-prone.**
+> It ships the in-progress rebuild (model-catalog helper, `./client` subpath, provider changes) and its API may change between alpha versions without notice. The stable `latest` line is `5.0.0`. Opt into the alpha only deliberately, and pin an exact version.
+
 ## Installation
+
+Stable (recommended):
 
 ```bash
 npm install @pollinations/sdk
+```
+
+Alpha (in-progress rebuild — pin an exact version):
+
+```bash
+npm install @pollinations/sdk@alpha
+# or pin exactly: npm install @pollinations/sdk@5.1.0-alpha.0
 ```
 
 ### CDN / `<script>` tag

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.0.0",
+  "version": "5.1.0-alpha.0",
   "description": "Official SDK for pollinations.ai - Generate images, videos, audio, and text with ease",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -13,6 +13,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/index.browser.min.js",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./client": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -66,6 +66,14 @@ export {
     validateKey,
     videoUrl,
 } from "./helpers.js";
+export {
+    type FetchModelCatalogOptions,
+    fetchModelCatalog,
+    type ModelCatalog,
+    type ModelCatalogCategory,
+    type ModelCatalogItem,
+    type ModelCatalogSource,
+} from "./models.js";
 
 // Export all types
 export type {

--- a/packages/sdk/src/models.ts
+++ b/packages/sdk/src/models.ts
@@ -168,12 +168,20 @@ async function fetchCatalogModels(
     return sortModels([...imageModels, ...textModels, ...audioModels]);
 }
 
+function trimTrailingSlashes(value: string): string {
+    let end = value.length;
+    while (end > 0 && value.charCodeAt(end - 1) === 47) {
+        end -= 1;
+    }
+    return value.slice(0, end);
+}
+
 export async function fetchModelCatalog({
     apiKey,
     baseUrl = DEFAULT_BASE_URL,
     signal,
 }: FetchModelCatalogOptions = {}): Promise<ModelCatalog> {
-    const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+    const normalizedBaseUrl = trimTrailingSlashes(baseUrl);
     const models = await fetchCatalogModels(normalizedBaseUrl, null, signal);
     const allowedModels = apiKey
         ? await fetchCatalogModels(normalizedBaseUrl, apiKey, signal)

--- a/packages/sdk/src/models.ts
+++ b/packages/sdk/src/models.ts
@@ -25,6 +25,7 @@ export interface ModelCatalog {
     models: ModelCatalogItem[];
     allowedModelIds: Set<string>;
     allowedImageModelIds: Set<string>;
+    allowedVideoModelIds: Set<string>;
     allowedTextModelIds: Set<string>;
     allowedAudioModelIds: Set<string>;
 }
@@ -184,10 +185,8 @@ export async function fetchModelCatalog({
         models,
         allowedModelIds,
         allowedImageModelIds: idsForCategory(allowedModels, "image"),
+        allowedVideoModelIds: idsForCategory(allowedModels, "video"),
         allowedTextModelIds: idsForCategory(allowedModels, "text"),
-        allowedAudioModelIds: new Set([
-            ...idsForCategory(allowedModels, "audio"),
-            ...idsForCategory(allowedModels, "video"),
-        ]),
+        allowedAudioModelIds: idsForCategory(allowedModels, "audio"),
     };
 }

--- a/packages/sdk/src/models.ts
+++ b/packages/sdk/src/models.ts
@@ -1,0 +1,193 @@
+import type { ModelInfo, RequestOptions } from "./types.js";
+import { PollinationsError } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://gen.pollinations.ai";
+
+export type ModelCatalogSource = "image" | "text" | "audio";
+export type ModelCatalogCategory = "image" | "video" | "text" | "audio";
+
+export interface ModelCatalogItem {
+    id: string;
+    name: string;
+    description?: string;
+    aliases: string[];
+    source: ModelCatalogSource;
+    category: ModelCatalogCategory;
+    inputModalities: string[];
+    outputModalities: string[];
+    voices: string[];
+    paidOnly: boolean;
+    tools: boolean;
+    reasoning: boolean;
+}
+
+export interface ModelCatalog {
+    models: ModelCatalogItem[];
+    allowedModelIds: Set<string>;
+    allowedImageModelIds: Set<string>;
+    allowedTextModelIds: Set<string>;
+    allowedAudioModelIds: Set<string>;
+}
+
+export interface FetchModelCatalogOptions extends RequestOptions {
+    apiKey?: string | null;
+    baseUrl?: string;
+}
+
+type RawModelInfo = ModelInfo & {
+    output_modalities?: string[];
+    input_modalities?: string[];
+    paid_only?: boolean;
+};
+
+function modelId(model: RawModelInfo): string {
+    return model.id || model.name;
+}
+
+function endpointFor(source: ModelCatalogSource): string {
+    return source === "image"
+        ? "/image/models"
+        : source === "text"
+          ? "/text/models"
+          : "/audio/models";
+}
+
+function categoryFor(
+    model: RawModelInfo,
+    source: ModelCatalogSource,
+): ModelCatalogCategory | null {
+    const output = model.output_modalities ?? [];
+    const input = model.input_modalities ?? [];
+
+    if (source === "image") {
+        if (output.includes("video")) return "video";
+        if (output.includes("image")) return "image";
+        return null;
+    }
+
+    if (source === "text") {
+        if (output.includes("audio")) return "audio";
+        if (output.includes("text")) return "text";
+        return null;
+    }
+
+    if (output.includes("audio") && input.includes("text")) return "audio";
+    return null;
+}
+
+function normalizeModel(
+    model: RawModelInfo,
+    source: ModelCatalogSource,
+): ModelCatalogItem | null {
+    const id = modelId(model);
+    const category = categoryFor(model, source);
+    if (!id || !category) return null;
+
+    return {
+        id,
+        name: model.name || id,
+        description: model.description,
+        aliases: model.aliases ?? [],
+        source,
+        category,
+        inputModalities: model.input_modalities ?? [],
+        outputModalities: model.output_modalities ?? [],
+        voices: model.voices ?? [],
+        paidOnly: model.paid_only ?? false,
+        tools: model.tools ?? false,
+        reasoning: model.reasoning ?? false,
+    };
+}
+
+function sortModels(models: ModelCatalogItem[]): ModelCatalogItem[] {
+    const order: Record<ModelCatalogCategory, number> = {
+        image: 0,
+        video: 1,
+        text: 2,
+        audio: 3,
+    };
+
+    return [...models].sort((a, b) => {
+        const categoryDelta = order[a.category] - order[b.category];
+        if (categoryDelta !== 0) return categoryDelta;
+        return a.id.localeCompare(b.id);
+    });
+}
+
+async function fetchModels(
+    baseUrl: string,
+    source: ModelCatalogSource,
+    apiKey: string | null | undefined,
+    signal?: AbortSignal,
+): Promise<ModelCatalogItem[]> {
+    const headers: Record<string, string> = {};
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+    const response = await fetch(`${baseUrl}${endpointFor(source)}`, {
+        headers,
+        signal,
+    });
+
+    if (!response.ok) {
+        throw new PollinationsError(
+            `Failed to fetch ${source} models`,
+            "MODEL_CATALOG",
+            response.status,
+        );
+    }
+
+    const rawModels = (await response.json()) as RawModelInfo[];
+    return rawModels
+        .map((model) => normalizeModel(model, source))
+        .filter((model): model is ModelCatalogItem => Boolean(model));
+}
+
+function idsForCategory(
+    models: ModelCatalogItem[],
+    category: ModelCatalogCategory,
+): Set<string> {
+    return new Set(
+        models
+            .filter((model) => model.category === category)
+            .map((model) => model.id),
+    );
+}
+
+async function fetchCatalogModels(
+    baseUrl: string,
+    apiKey: string | null | undefined,
+    signal?: AbortSignal,
+): Promise<ModelCatalogItem[]> {
+    const [imageModels, textModels, audioModels] = await Promise.all([
+        fetchModels(baseUrl, "image", apiKey, signal),
+        fetchModels(baseUrl, "text", apiKey, signal),
+        fetchModels(baseUrl, "audio", apiKey, signal),
+    ]);
+
+    return sortModels([...imageModels, ...textModels, ...audioModels]);
+}
+
+export async function fetchModelCatalog({
+    apiKey,
+    baseUrl = DEFAULT_BASE_URL,
+    signal,
+}: FetchModelCatalogOptions = {}): Promise<ModelCatalog> {
+    const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+    const models = await fetchCatalogModels(normalizedBaseUrl, null, signal);
+    const allowedModels = apiKey
+        ? await fetchCatalogModels(normalizedBaseUrl, apiKey, signal)
+        : [];
+
+    const allowedModelIds = new Set(allowedModels.map((model) => model.id));
+
+    return {
+        models,
+        allowedModelIds,
+        allowedImageModelIds: idsForCategory(allowedModels, "image"),
+        allowedTextModelIds: idsForCategory(allowedModels, "text"),
+        allowedAudioModelIds: new Set([
+            ...idsForCategory(allowedModels, "audio"),
+            ...idsForCategory(allowedModels, "video"),
+        ]),
+    };
+}

--- a/packages/sdk/src/react/PolliProvider.test.tsx
+++ b/packages/sdk/src/react/PolliProvider.test.tsx
@@ -1,0 +1,71 @@
+import { act, create } from "react-test-renderer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PolliProvider } from "./PolliProvider.js";
+import type { StorageAdapter } from "./storage.js";
+
+function memoryStorage(): StorageAdapter {
+    const values = new Map<string, string>();
+    return {
+        getItem: (key) => values.get(key) ?? null,
+        setItem: (key, value) => values.set(key, value),
+        removeItem: (key) => values.delete(key),
+    };
+}
+
+function stubWindow(href: string) {
+    const url = new URL(href);
+    vi.stubGlobal("window", {
+        location: {
+            href,
+            hash: url.hash,
+            pathname: url.pathname,
+            search: url.search,
+        },
+        history: {
+            replaceState: vi.fn(),
+        },
+    });
+}
+
+async function renderProvider(appKey: string) {
+    await act(async () => {
+        create(
+            <PolliProvider appKey={appKey} storage={memoryStorage()}>
+                <div />
+            </PolliProvider>,
+        );
+    });
+}
+
+describe("PolliProvider setup guidance", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it("warns when appKey is not a publishable key", async () => {
+        stubWindow("http://127.0.0.1:4178/");
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(console, "info").mockImplementation(() => {});
+
+        await renderProvider("sk_secret_test");
+
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining("publishable pk_ App Key"),
+        );
+        expect(warn.mock.calls[0][0]).not.toContain("sk_secret_test");
+    });
+
+    it("prints the local redirect URI used by login", async () => {
+        stubWindow("http://127.0.0.1:4178/apps?filter=image#ignored");
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+        await renderProvider("pk_test");
+
+        expect(info).toHaveBeenCalledWith(
+            expect.stringContaining("http://127.0.0.1:4178/apps?filter=image"),
+        );
+        expect(info.mock.calls[0][0]).not.toContain("#ignored");
+    });
+});

--- a/packages/sdk/src/react/PolliProvider.test.tsx
+++ b/packages/sdk/src/react/PolliProvider.test.tsx
@@ -56,16 +56,4 @@ describe("PolliProvider setup guidance", () => {
         expect(warn.mock.calls[0][0]).not.toContain("sk_secret_test");
     });
 
-    it("prints the local redirect URI used by login", async () => {
-        stubWindow("http://127.0.0.1:4178/apps?filter=image#ignored");
-        vi.spyOn(console, "warn").mockImplementation(() => {});
-        const info = vi.spyOn(console, "info").mockImplementation(() => {});
-
-        await renderProvider("pk_test");
-
-        expect(info).toHaveBeenCalledWith(
-            expect.stringContaining("http://127.0.0.1:4178/apps?filter=image"),
-        );
-        expect(info.mock.calls[0][0]).not.toContain("#ignored");
-    });
 });

--- a/packages/sdk/src/react/PolliProvider.test.tsx
+++ b/packages/sdk/src/react/PolliProvider.test.tsx
@@ -55,5 +55,4 @@ describe("PolliProvider setup guidance", () => {
         );
         expect(warn.mock.calls[0][0]).not.toContain("sk_secret_test");
     });
-
 });

--- a/packages/sdk/src/react/PolliProvider.tsx
+++ b/packages/sdk/src/react/PolliProvider.tsx
@@ -22,6 +22,8 @@ export type { AuthorizeRequest } from "./contexts.js";
 export type { StorageAdapter, StorageOption } from "./storage.js";
 
 export const DEFAULT_ENTER_URL = "https://enter.pollinations.ai";
+const BYOP_DOCS_URL =
+    "https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md";
 
 export interface PolliProviderProps {
     /** Publishable key (`pk_...`): the app identifier, not a user's API key. */
@@ -86,6 +88,58 @@ function buildAuthorizeUrl(args: {
     return `${args.enterUrl}/authorize?${params.toString()}`;
 }
 
+function currentRedirectUrl(): string | null {
+    if (typeof window === "undefined") return null;
+    return window.location.href.split("#")[0] ?? window.location.href;
+}
+
+function isProductionRuntime(): boolean {
+    return globalThis.process?.env?.NODE_ENV === "production";
+}
+
+function isLoopbackHttpUrl(value: string): boolean {
+    try {
+        const url = new URL(value);
+        if (url.protocol !== "http:") return false;
+        const hostname = url.hostname
+            .toLowerCase()
+            .replace(/^\[(.*)\]$/, "$1")
+            .replace(/\.$/, "");
+        return (
+            hostname === "localhost" ||
+            hostname === "0.0.0.0" ||
+            hostname === "::1" ||
+            /^127\.\d+\.\d+\.\d+$/.test(hostname)
+        );
+    } catch {
+        return false;
+    }
+}
+
+function describeAppKey(appKey: string): string {
+    if (!appKey) return "<empty>";
+    if (appKey.length <= 8) return `${appKey.slice(0, 3)}...`;
+    return `${appKey.slice(0, 3)}...${appKey.slice(-4)}`;
+}
+
+function warnAuthSetup(appKey: string, redirectUrl: string | null): void {
+    if (isProductionRuntime()) return;
+
+    if (!appKey || !appKey.startsWith("pk_")) {
+        console.warn(
+            `[PolliProvider] appKey should be a publishable pk_ App Key. Received ${describeAppKey(
+                appKey,
+            )}. Create one in Enter and pass it to <PolliProvider appKey="pk_..." />. ${BYOP_DOCS_URL}`,
+        );
+    }
+
+    if (redirectUrl && isLoopbackHttpUrl(redirectUrl)) {
+        console.info(
+            `[PolliProvider] Local auth redirect URI: ${redirectUrl}\nAdd this URI to your App Key redirectUris in Enter. ${BYOP_DOCS_URL}`,
+        );
+    }
+}
+
 /**
  * Provides Pollinations auth state to descendants. Wrap your app once at the
  * root. Holds the delegated API key, handles the OAuth callback, and exposes
@@ -120,6 +174,10 @@ export function PolliProvider({
     const [apiKey, setApiKey] = useState<string | null>(null);
     const [isHydrated, setIsHydrated] = useState(false);
     const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        warnAuthSetup(appKey, currentRedirectUrl());
+    }, [appKey]);
 
     const updateApiKey = useCallback(
         (nextApiKey: string | null) => {
@@ -178,8 +236,8 @@ export function PolliProvider({
     const login = useCallback(
         (request?: AuthorizeRequest) => {
             if (typeof window === "undefined") return;
-            const currentUrl =
-                window.location.href.split("#")[0] ?? window.location.href;
+            const currentUrl = currentRedirectUrl();
+            if (!currentUrl) return;
             const extraPermissions = request?.permissions;
             const perms: AccountPermission[] =
                 extraPermissions && extraPermissions.length > 0

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -799,6 +799,7 @@ export type VideoCapability =
 
 /** Model information */
 export interface ModelInfo {
+    id?: string;
     name: string;
     description?: string;
     aliases?: string[];
@@ -815,8 +816,10 @@ export interface ModelInfo {
     voices?: string[];
     maxInputChars?: number;
     context_length?: number;
+    supported_endpoints?: string[];
     supportsSystemMessages?: boolean;
     is_specialized?: boolean;
+    paid_only?: boolean;
     pricing?: {
         currency: "pollen";
         input_token_price?: number;


### PR DESCRIPTION
- Adds `fetchModelCatalog()` for normalized image/video/text/audio model metadata and allowed-model ID sets.
- Adds the `@pollinations/sdk/client` export subpath.
- Bumps `@pollinations/sdk` to `5.1.0-alpha.0` so PR6 publishes it under the `alpha` npm dist-tag.
- Adds PolliProvider setup guidance for non-`pk_` keys and local redirect URIs.
- Marks the SDK alpha release line as unstable in the README.

Validation:
- `npm run typecheck --workspace @pollinations/sdk`
- `npm test --workspace @pollinations/sdk`
- `npm run build --workspace @pollinations/sdk`
- `npm ci --dry-run` in `packages/sdk`
- `git diff --check origin/main...HEAD`
- Runtime import/smoke check for `@pollinations/sdk/client` and `fetchModelCatalog()`