### PR TITLE
fix: redeploy shared package app consumers

### DIFF
--- a/.github/scripts/detect-package-consumers.js
+++ b/.github/scripts/detect-package-consumers.js
@@ -10,21 +10,6 @@ const PACKAGE_PATHS = [
 
 const DEFAULT_REPO_ROOT = path.resolve(__dirname, "..", "..");
 
-function readChangedFiles() {
-    const args = process.argv.slice(2).filter(Boolean);
-    if (args.length > 0) return args;
-
-    if (process.env.CHANGED) {
-        return process.env.CHANGED.split(/\n+/).filter(Boolean);
-    }
-
-    if (!process.stdin.isTTY) {
-        return fs.readFileSync(0, "utf8").split(/\n+/).filter(Boolean);
-    }
-
-    return [];
-}
-
 function detectPackageConsumers(changedFiles, repoRoot = DEFAULT_REPO_ROOT) {
     const changedPackages = new Set(
         PACKAGE_PATHS.filter(([prefix]) =>
@@ -64,10 +49,10 @@ function detectPackageConsumers(changedFiles, repoRoot = DEFAULT_REPO_ROOT) {
 }
 
 if (require.main === module) {
-    for (const app of detectPackageConsumers(
-        readChangedFiles(),
-        process.env.REPO_ROOT || DEFAULT_REPO_ROOT,
-    )) {
+    const changedFiles = (process.env.CHANGED || "")
+        .split(/\n+/)
+        .filter(Boolean);
+    for (const app of detectPackageConsumers(changedFiles)) {
         console.log(app);
     }
 }

--- a/.github/scripts/detect-package-consumers.js
+++ b/.github/scripts/detect-package-consumers.js
@@ -8,6 +8,8 @@ const PACKAGE_PATHS = [
     ["packages/ui/", "@pollinations/ui"],
 ];
 
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, "..", "..");
+
 function readChangedFiles() {
     const args = process.argv.slice(2).filter(Boolean);
     if (args.length > 0) return args;
@@ -23,32 +25,51 @@ function readChangedFiles() {
     return [];
 }
 
-const changedFiles = readChangedFiles();
-const changedPackages = new Set(
-    PACKAGE_PATHS.filter(([prefix]) =>
-        changedFiles.some((file) => file.startsWith(prefix)),
-    ).map(([, packageName]) => packageName),
-);
+function detectPackageConsumers(changedFiles, repoRoot = DEFAULT_REPO_ROOT) {
+    const changedPackages = new Set(
+        PACKAGE_PATHS.filter(([prefix]) =>
+            changedFiles.some((file) => file.startsWith(prefix)),
+        ).map(([, packageName]) => packageName),
+    );
 
-if (changedPackages.size === 0) process.exit(0);
+    if (changedPackages.size === 0) return [];
 
-const apps = JSON.parse(fs.readFileSync("apps/apps.json", "utf8"));
+    const appsPath = path.join(repoRoot, "apps", "apps.json");
+    const apps = JSON.parse(fs.readFileSync(appsPath, "utf8"));
 
-for (const app of Object.keys(apps)
-    .filter((name) => name !== "_defaults")
-    .sort()) {
-    const packagePath = path.join("apps", app, "package.json");
-    if (!fs.existsSync(packagePath)) continue;
+    return Object.keys(apps)
+        .filter((name) => name !== "_defaults")
+        .sort()
+        .filter((app) => {
+            const packagePath = path.join(
+                repoRoot,
+                "apps",
+                app,
+                "package.json",
+            );
+            if (!fs.existsSync(packagePath)) return false;
 
-    const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
-    const dependencies = {
-        ...pkg.dependencies,
-        ...pkg.devDependencies,
-        ...pkg.peerDependencies,
-        ...pkg.optionalDependencies,
-    };
+            const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+            const dependencies = {
+                ...pkg.dependencies,
+                ...pkg.devDependencies,
+                ...pkg.peerDependencies,
+                ...pkg.optionalDependencies,
+            };
 
-    if ([...changedPackages].some((packageName) => dependencies[packageName])) {
+            return [...changedPackages].some(
+                (packageName) => dependencies[packageName],
+            );
+        });
+}
+
+if (require.main === module) {
+    for (const app of detectPackageConsumers(
+        readChangedFiles(),
+        process.env.REPO_ROOT || DEFAULT_REPO_ROOT,
+    )) {
         console.log(app);
     }
 }
+
+module.exports = { detectPackageConsumers };

--- a/.github/scripts/detect-package-consumers.js
+++ b/.github/scripts/detect-package-consumers.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PACKAGE_PATHS = [
+    ["packages/sdk/", "@pollinations/sdk"],
+    ["packages/ui/", "@pollinations/ui"],
+];
+
+function readChangedFiles() {
+    const args = process.argv.slice(2).filter(Boolean);
+    if (args.length > 0) return args;
+
+    if (process.env.CHANGED) {
+        return process.env.CHANGED.split(/\n+/).filter(Boolean);
+    }
+
+    if (!process.stdin.isTTY) {
+        return fs.readFileSync(0, "utf8").split(/\n+/).filter(Boolean);
+    }
+
+    return [];
+}
+
+const changedFiles = readChangedFiles();
+const changedPackages = new Set(
+    PACKAGE_PATHS.filter(([prefix]) =>
+        changedFiles.some((file) => file.startsWith(prefix)),
+    ).map(([, packageName]) => packageName),
+);
+
+if (changedPackages.size === 0) process.exit(0);
+
+const apps = JSON.parse(fs.readFileSync("apps/apps.json", "utf8"));
+
+for (const app of Object.keys(apps)
+    .filter((name) => name !== "_defaults")
+    .sort()) {
+    const packagePath = path.join("apps", app, "package.json");
+    if (!fs.existsSync(packagePath)) continue;
+
+    const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    const dependencies = {
+        ...pkg.dependencies,
+        ...pkg.devDependencies,
+        ...pkg.peerDependencies,
+        ...pkg.optionalDependencies,
+    };
+
+    if ([...changedPackages].some((packageName) => dependencies[packageName])) {
+        console.log(app);
+    }
+}

--- a/.github/scripts/detect-package-consumers.test.js
+++ b/.github/scripts/detect-package-consumers.test.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { detectPackageConsumers } = require("./detect-package-consumers.js");
+
+function writeJson(filePath, value) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("detects registered apps that consume changed shared packages", () => {
+    const repoRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "pollinations-apps-"),
+    );
+    writeJson(path.join(repoRoot, "apps", "apps.json"), {
+        _defaults: {},
+        "model-monitor": {},
+        playground: {},
+        react: {},
+        static: {},
+        missingPackage: {},
+    });
+    writeJson(path.join(repoRoot, "apps", "model-monitor", "package.json"), {
+        dependencies: { "@pollinations/ui": "file:../../packages/ui" },
+    });
+    writeJson(path.join(repoRoot, "apps", "playground", "package.json"), {
+        dependencies: { "@pollinations/sdk": "file:../../packages/sdk" },
+    });
+    writeJson(path.join(repoRoot, "apps", "react", "package.json"), {
+        devDependencies: { "@pollinations/ui": "*" },
+    });
+    writeJson(path.join(repoRoot, "apps", "static", "package.json"), {
+        dependencies: { react: "^19.0.0" },
+    });
+
+    assert.deepEqual(
+        detectPackageConsumers(["packages/ui/src/theme.ts"], repoRoot),
+        ["model-monitor", "react"],
+    );
+    assert.deepEqual(
+        detectPackageConsumers(
+            ["packages/sdk/src/models.ts", "packages/ui/src/theme.ts"],
+            repoRoot,
+        ),
+        ["model-monitor", "playground", "react"],
+    );
+    assert.deepEqual(
+        detectPackageConsumers(["apps/react/src/App.tsx"], repoRoot),
+        [],
+    );
+});

--- a/.github/workflows/app-deploy-automatic.yml
+++ b/.github/workflows/app-deploy-automatic.yml
@@ -11,6 +11,8 @@ on:
     branches: [main]
     paths:
       - 'apps/**'
+      - 'packages/sdk/**'
+      - 'packages/ui/**'
 
 jobs:
   deploy:
@@ -33,9 +35,32 @@ jobs:
             CANDIDATES="${{ github.event.inputs.app_name }}"
           else
             git fetch origin main --depth=2
-            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null | grep '^apps/[^/]*/' || \
-                      git diff --name-only origin/main~1 HEAD | grep '^apps/[^/]*/')
-            CANDIDATES=$(echo "$CHANGED" | sed 's|^apps/\([^/]*\)/.*|\1|' | sort -u)
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || \
+                      git diff --name-only origin/main~1 HEAD)
+            APP_CANDIDATES=$(echo "$CHANGED" | grep '^apps/[^/]*/' | sed 's|^apps/\([^/]*\)/.*|\1|' || true)
+            PACKAGE_CANDIDATES=$(CHANGED="$CHANGED" node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const changed = (process.env.CHANGED || "").split(/\n+/).filter(Boolean);
+            const changedPackages = new Set();
+            if (changed.some((file) => file.startsWith("packages/sdk/"))) changedPackages.add("@pollinations/sdk");
+            if (changed.some((file) => file.startsWith("packages/ui/"))) changedPackages.add("@pollinations/ui");
+            if (changedPackages.size === 0) process.exit(0);
+            const apps = JSON.parse(fs.readFileSync("apps/apps.json", "utf8"));
+            for (const app of Object.keys(apps).filter((name) => name !== "_defaults").sort()) {
+              const packagePath = path.join("apps", app, "package.json");
+              if (!fs.existsSync(packagePath)) continue;
+              const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+              const dependencies = {
+                ...pkg.dependencies,
+                ...pkg.devDependencies,
+                ...pkg.peerDependencies,
+                ...pkg.optionalDependencies,
+              };
+              if ([...changedPackages].some((packageName) => dependencies[packageName])) console.log(app);
+            }
+            ')
+            CANDIDATES=$(printf "%s\n%s\n" "$APP_CANDIDATES" "$PACKAGE_CANDIDATES" | sort -u)
           fi
           
           # Keep only apps registered in apps.json (source of truth)

--- a/.github/workflows/app-deploy-automatic.yml
+++ b/.github/workflows/app-deploy-automatic.yml
@@ -32,47 +32,27 @@ jobs:
         id: app
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            CANDIDATES="${{ github.event.inputs.app_name }}"
+            APP_CANDIDATES="${{ github.event.inputs.app_name }}"
+            PACKAGE_CANDIDATES=""
           else
             git fetch origin main --depth=2
             CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || \
                       git diff --name-only origin/main~1 HEAD)
             APP_CANDIDATES=$(echo "$CHANGED" | grep '^apps/[^/]*/' | sed 's|^apps/\([^/]*\)/.*|\1|' || true)
-            PACKAGE_CANDIDATES=$(CHANGED="$CHANGED" node -e '
-            const fs = require("fs");
-            const path = require("path");
-            const changed = (process.env.CHANGED || "").split(/\n+/).filter(Boolean);
-            const changedPackages = new Set();
-            if (changed.some((file) => file.startsWith("packages/sdk/"))) changedPackages.add("@pollinations/sdk");
-            if (changed.some((file) => file.startsWith("packages/ui/"))) changedPackages.add("@pollinations/ui");
-            if (changedPackages.size === 0) process.exit(0);
-            const apps = JSON.parse(fs.readFileSync("apps/apps.json", "utf8"));
-            for (const app of Object.keys(apps).filter((name) => name !== "_defaults").sort()) {
-              const packagePath = path.join("apps", app, "package.json");
-              if (!fs.existsSync(packagePath)) continue;
-              const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
-              const dependencies = {
-                ...pkg.dependencies,
-                ...pkg.devDependencies,
-                ...pkg.peerDependencies,
-                ...pkg.optionalDependencies,
-              };
-              if ([...changedPackages].some((packageName) => dependencies[packageName])) console.log(app);
-            }
-            ')
-            CANDIDATES=$(printf "%s\n%s\n" "$APP_CANDIDATES" "$PACKAGE_CANDIDATES" | sort -u)
+            PACKAGE_CANDIDATES=$(CHANGED="$CHANGED" node .github/scripts/detect-package-consumers.js)
           fi
           
-          # Keep only apps registered in apps.json (source of truth)
+          # Keep only directly changed apps registered in apps.json (source of truth).
+          # Package consumers are already emitted from apps.json by detect-package-consumers.js.
           APPS=""
-          for app in $CANDIDATES; do
+          for app in $APP_CANDIDATES; do
             if [ -n "$app" ] && node -e "const c=require('./apps/apps.json'); if(!c['$app']) process.exit(1);" 2>/dev/null; then
               APPS="$APPS $app"
             else
               echo "⏭️ $app not in apps.json, skipping"
             fi
           done
-          APPS=$(echo $APPS | xargs)
+          APPS=$(printf "%s\n%s\n" "$APPS" "$PACKAGE_CANDIDATES" | xargs -n1 | sort -u | xargs)
 
           if [ -z "$APPS" ]; then
             echo "No registered apps changed, nothing to deploy"

--- a/.github/workflows/biome-check.yml
+++ b/.github/workflows/biome-check.yml
@@ -59,6 +59,27 @@ jobs:
             echo "✅ All files are properly formatted"
           fi
 
+      - name: Get changed GitHub scripts
+        id: github-scripts
+        run: |
+          FILES=$(git diff --diff-filter=d --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^\.github/scripts/.*\.js$' || true)
+          echo "Changed GitHub scripts:"
+          echo "$FILES"
+          if [ -n "$FILES" ]; then
+            echo "any_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "any_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Test GitHub scripts
+        if: steps.github-scripts.outputs.any_changed == 'true'
+        run: |
+          if compgen -G ".github/scripts/*.test.js" > /dev/null; then
+            node --test .github/scripts/*.test.js
+          else
+            echo "No GitHub script tests found"
+          fi
+
       - name: Get changed TypeScript files in enter.pollinations.ai
         id: enter-ts-files
         run: |

--- a/.github/workflows/deploy-pollinations-ai-cloudflare.yml
+++ b/.github/workflows/deploy-pollinations-ai-cloudflare.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'pollinations.ai/**'
       - 'apps/APPS.md'
+      - 'apps/playground/**'
       - 'shared/**'
       - 'packages/sdk/**'
       - 'packages/ui/**'

--- a/.github/workflows/deploy-pollinations-ai-cloudflare.yml
+++ b/.github/workflows/deploy-pollinations-ai-cloudflare.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'pollinations.ai/**'
       - 'apps/APPS.md'
-      - 'apps/playground/**'
       - 'shared/**'
       - 'packages/sdk/**'
       - 'packages/ui/**'


### PR DESCRIPTION
- Redeploy registered app subdomains when `packages/sdk/**` or `packages/ui/**` changes by detecting apps that declare those package dependencies.
- Keep direct `apps/**` deploy behavior and `workflow_dispatch` unchanged.
- Move package-consumer detection into `.github/scripts/detect-package-consumers.js` so it can be linted and tested outside the workflow YAML.
- Add a fixture test for changed-files in -> app-list out, including missing `package.json` and non-package app changes.
- Run `.github/scripts/*.test.js` in the existing Biome Check workflow whenever `.github/scripts/*.js` changes.
- Keep the script minimal: CLI input is only the workflow-provided `CHANGED` env var; tests use the exported function.

Checks:
- `PATH=/opt/homebrew/bin:$PATH npx biome check --write .github/scripts/detect-package-consumers.js .github/scripts/detect-package-consumers.test.js .github/workflows/biome-check.yml .github/workflows/app-deploy-automatic.yml`
- `PATH=/opt/homebrew/bin:$PATH node --test .github/scripts/*.test.js`
- `git diff --check`
- Ruby YAML parse for changed workflow files
- Simulated package-change detection returns `model-monitor`, `playground`, `react`