### PR TITLE
fix: update playground app key

### DIFF
--- a/apps/playground/src/config.ts
+++ b/apps/playground/src/config.ts
@@ -1,2 +1,2 @@
-export const POLLI_APP_KEY = "pk_U5oBRNjy6gDeNqxT";
+export const POLLI_APP_KEY = "pk_YKOUHB80IUJYfwCB";
 export const ENTER_URL = "https://enter.pollinations.ai";


### PR DESCRIPTION
- Updates the standalone Playground app publishable key to `pk_YKOUHB80IUJYfwCB`.

Checks:
- `PATH=/opt/homebrew/bin:$PATH npx biome check --write apps/playground/src/config.ts`
- `PATH=/opt/homebrew/bin:$PATH npm run build --prefix apps/playground`