### PR TITLE
billing design 01: keep calculateCost with catalog notes

### DIFF
--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -215,6 +215,48 @@ test("Gemini dynamic billing notes are exposed in model catalog metadata", () =>
     );
 });
 
+test("Perplexity request search fees are added by the shared cost path", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const cases = [
+        ["perplexity-fast", 2.005],
+        ["perplexity-deep", 2.012],
+        ["perplexity", 18.014],
+        ["perplexity-reasoning", 10.014],
+    ] as const;
+
+    for (const [model, total] of cases) {
+        const cost = calculateCost(model, usage);
+        const price = calculatePrice(model, usage);
+
+        expect(cost.totalCost).toBeCloseTo(total, 8);
+        expect(price.totalPrice).toBeCloseTo(total, 8);
+    }
+});
+
+test("Perplexity request fees are exposed in model catalog metadata", () => {
+    const models = getTextModelsInfo();
+
+    expect(
+        models.find((model) => model.name === "perplexity-fast")
+            ?.search_fee_per_thousand_requests,
+    ).toBe(5);
+    expect(
+        models.find((model) => model.name === "perplexity-deep")
+            ?.search_fee_per_thousand_requests,
+    ).toBe(12);
+    expect(
+        models.find((model) => model.name === "perplexity")
+            ?.search_fee_per_thousand_requests,
+    ).toBe(14);
+    expect(
+        models.find((model) => model.name === "perplexity-reasoning")
+            ?.search_fee_per_thousand_requests,
+    ).toBe(14);
+});
+
 test("Gemini 3.1 Pro uses long-context rates above 200k prompt tokens", () => {
     const shortContextCost = calculateCost("gemini-large", {
         promptTextTokens: 200_000,

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -177,6 +177,16 @@ test("Gemini grounding cost is added by family billing rules", () => {
         groundedOutput,
     );
     const gemini3Cost = calculateCost("gemini", usage, groundedOutput);
+    const geminiSearchFastCost = calculateCost(
+        "gemini-search-fast",
+        usage,
+        groundedOutput,
+    );
+    const geminiSearchLargeCost = calculateCost(
+        "gemini-search-large",
+        usage,
+        groundedOutput,
+    );
 
     // Gemini 2.5 Search bills once per grounded prompt, not once per query.
     // priceMultiplier is 1×, so price equals cost.
@@ -185,6 +195,24 @@ test("Gemini grounding cost is added by family billing rules", () => {
 
     // Gemini 3.x bills per non-empty search query.
     expect(gemini3Cost.totalCost).toBeCloseTo(3.528, 8);
+    expect(geminiSearchFastCost.totalCost).toBeCloseTo(1.778, 8);
+    expect(geminiSearchLargeCost.totalCost).toBeCloseTo(10.528, 8);
+});
+
+test("Gemini dynamic billing notes are exposed in model catalog metadata", () => {
+    const geminiSearchFast = getTextModelsInfo().find(
+        (model) => model.name === "gemini-search-fast",
+    );
+    const geminiLarge = getTextModelsInfo().find(
+        (model) => model.name === "gemini-large",
+    );
+
+    expect(geminiSearchFast?.pricing_notes).toContain(
+        "Google Search grounding adds $14 / 1K search queries when grounding metadata is present.",
+    );
+    expect(geminiLarge?.pricing_notes).toContain(
+        "Prompts above 200K tokens use Gemini long-context rates.",
+    );
 });
 
 test("Gemini 3.1 Pro uses long-context rates above 200k prompt tokens", () => {

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -39,6 +39,7 @@ export const ModelInfoSchema = z.object({
     pricing: z
         .record(z.string(), z.string())
         .and(z.object({ currency: z.literal("pollen") })),
+    search_fee_per_thousand_requests: z.number().positive().optional(),
     pricing_notes: z.array(z.string()).optional(),
     title: z.string(),
     description: z.string().optional(),
@@ -104,6 +105,9 @@ function getModelInfo(modelName: ModelName): ModelInfo {
         category: service.category,
         brand: service.brand,
         pricing,
+        search_fee_per_thousand_requests: service.searchFeePerThousandRequests
+            ? service.searchFeePerThousandRequests * service.priceMultiplier
+            : undefined,
         pricing_notes: service.pricingNotes,
         // User-facing metadata from service definition
         title: service.title,

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -39,6 +39,7 @@ export const ModelInfoSchema = z.object({
     pricing: z
         .record(z.string(), z.string())
         .and(z.object({ currency: z.literal("pollen") })),
+    pricing_notes: z.array(z.string()).optional(),
     title: z.string(),
     description: z.string().optional(),
     input_modalities: z.array(z.string()).optional(),
@@ -103,6 +104,7 @@ function getModelInfo(modelName: ModelName): ModelInfo {
         category: service.category,
         brand: service.brand,
         pricing,
+        pricing_notes: service.pricingNotes,
         // User-facing metadata from service definition
         title: service.title,
         description: service.description,

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -105,6 +105,7 @@ export type ModelDefinition<TModelId extends string = ModelId> = {
     // no implicit default. Typical values: 1 (sold at cost) or 1.5 (paid markup).
     priceMultiplier: number;
     calculateCost?: CostCalculator<TModelId>;
+    pricingNotes?: string[];
     // Date the model was added to the registry (ms epoch). Set once, never updated.
     addedDate: number;
     // User-facing metadata

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -105,6 +105,9 @@ export type ModelDefinition<TModelId extends string = ModelId> = {
     // no implicit default. Typical values: 1 (sold at cost) or 1.5 (paid markup).
     priceMultiplier: number;
     calculateCost?: CostCalculator<TModelId>;
+    // Provider fee that is charged once per request, expressed as USD per
+    // 1,000 requests. Used for request-determined search fees such as Perplexity.
+    searchFeePerThousandRequests?: number;
     pricingNotes?: string[];
     // Date the model was added to the registry (ms epoch). Set once, never updated.
     addedDate: number;
@@ -298,9 +301,15 @@ export function calculateCost(
     const linearCost = (costDefinition = svc.cost) =>
         calculateLinearCost(model, usage, costDefinition);
 
-    return svc.calculateCost
+    const usageCost = svc.calculateCost
         ? svc.calculateCost({ usage, output, model: svc, linearCost })
         : linearCost();
+    if (!svc.searchFeePerThousandRequests) return usageCost;
+    return {
+        ...usageCost,
+        totalCost:
+            usageCost.totalCost + svc.searchFeePerThousandRequests / 1000,
+    };
 }
 
 /**

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -19,6 +19,14 @@ const GEMINI_31_PRO_PRICING_NOTES = [
     ...GEMINI_3_SEARCH_PRICING_NOTES,
 ];
 
+const PERPLEXITY_LOW_SEARCH_PRICING_NOTES = [
+    "Perplexity Search adds $5 / 1K requests for low search context.",
+];
+
+const PERPLEXITY_HIGH_SEARCH_PRICING_NOTES = [
+    "Perplexity Search adds a model-specific high-context request fee.",
+];
+
 // Voices available for openai-audio model - exported for schema validation
 export const AUDIO_VOICES = [
     "alloy",
@@ -841,10 +849,9 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2025-11-04").getTime(),
-        // priceMultiplier 1.5 absorbs Perplexity's flat per-request search fee
-        // (~$5/1k at low search_context_size), which our token-based billing
-        // cannot capture directly. Temporary until a per-request fee field exists.
         priceMultiplier: 1,
+        searchFeePerThousandRequests: 5,
+        pricingNotes: PERPLEXITY_LOW_SEARCH_PRICING_NOTES,
         cost: {
             promptTextTokens: perMillion(1.0),
             completionTextTokens: perMillion(1.0),
@@ -867,11 +874,9 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
-        // Same sonar base as perplexity-fast but high search_context_size for
-        // broader grounding (higher per-request fee, ~$12/1k). priceMultiplier
-        // matches fast for now — they bill identically until a per-request fee
-        // field lets us price the deeper search separately.
         priceMultiplier: 1,
+        searchFeePerThousandRequests: 12,
+        pricingNotes: PERPLEXITY_HIGH_SEARCH_PRICING_NOTES,
         cost: {
             promptTextTokens: perMillion(1.0),
             completionTextTokens: perMillion(1.0),
@@ -893,6 +898,8 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
         priceMultiplier: 1,
+        searchFeePerThousandRequests: 14,
+        pricingNotes: PERPLEXITY_HIGH_SEARCH_PRICING_NOTES,
         cost: {
             promptTextTokens: perMillion(3.0),
             completionTextTokens: perMillion(15.0),
@@ -914,6 +921,8 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2025-11-04").getTime(),
         priceMultiplier: 1,
+        searchFeePerThousandRequests: 14,
+        pricingNotes: PERPLEXITY_HIGH_SEARCH_PRICING_NOTES,
         cost: {
             promptTextTokens: perMillion(2.0),
             completionTextTokens: perMillion(8.0),

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -6,6 +6,19 @@ import {
 import { perMillion } from "./price-helpers";
 import type { ModelDefinition } from "./registry";
 
+const GEMINI_25_GROUNDING_PRICING_NOTES = [
+    "Google Search grounding adds $35 / 1K grounded prompts when grounding metadata is present.",
+];
+
+const GEMINI_3_SEARCH_PRICING_NOTES = [
+    "Google Search grounding adds $14 / 1K search queries when grounding metadata is present.",
+];
+
+const GEMINI_31_PRO_PRICING_NOTES = [
+    "Prompts above 200K tokens use Gemini long-context rates.",
+    ...GEMINI_3_SEARCH_PRICING_NOTES,
+];
+
 // Voices available for openai-audio model - exported for schema validation
 export const AUDIO_VOICES = [
     "alloy",
@@ -285,6 +298,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(3.0),
         },
         calculateCost: calculateGeminiSearchQueryCost,
+        pricingNotes: GEMINI_3_SEARCH_PRICING_NOTES,
         title: "Gemini 3 Flash",
         description: "Gemini 3 Flash - Pro-Grade Reasoning at Flash Speed",
         inputModalities: ["text", "image", "audio", "video"],
@@ -315,6 +329,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(9.0),
         },
         calculateCost: calculateGeminiSearchQueryCost,
+        pricingNotes: GEMINI_3_SEARCH_PRICING_NOTES,
         title: "Gemini 3.5 Flash",
         description: "Gemini 3.5 Flash - Next-Gen Reasoning at Flash Speed",
         inputModalities: ["text", "image", "audio", "video"],
@@ -347,6 +362,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.5),
         },
         calculateCost: calculateGeminiSearchQueryCost,
+        pricingNotes: GEMINI_3_SEARCH_PRICING_NOTES,
         title: "Gemini 3.1 Flash Lite",
         description: "Gemini 3.1 Flash Lite - Fast & Cost-Effective",
         inputModalities: ["text", "image", "audio", "video"],
@@ -375,6 +391,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.4), // per 1M tokens
         },
         calculateCost: calculateGeminiGroundedPromptCost,
+        pricingNotes: GEMINI_25_GROUNDING_PRICING_NOTES,
         title: "Gemini 2.5 Flash Lite",
         description: "Gemini 2.5 Flash Lite - Ultra Fast & Cost-Effective",
         inputModalities: ["text", "image", "video"],
@@ -573,6 +590,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.4),
         },
         calculateCost: calculateGeminiGroundedPromptCost,
+        pricingNotes: GEMINI_25_GROUNDING_PRICING_NOTES,
         title: "Google Gemini 2.5 Flash Lite Search",
         description:
             "Google Gemini 2.5 Flash Lite Search - Web-grounded answers via Google Search",
@@ -605,6 +623,8 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(0.5),
             completionTextTokens: perMillion(1.5),
         },
+        calculateCost: calculateGeminiSearchQueryCost,
+        pricingNotes: GEMINI_3_SEARCH_PRICING_NOTES,
         title: "Gemini 3.1 Flash Lite Search",
         description:
             "Gemini 3.1 Flash Lite Search - Cheap grounded web answers",
@@ -635,6 +655,8 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(1.5),
             completionTextTokens: perMillion(9.0),
         },
+        calculateCost: calculateGeminiSearchQueryCost,
+        pricingNotes: GEMINI_3_SEARCH_PRICING_NOTES,
         title: "Gemini 3.5 Flash Search",
         description: "Gemini 3.5 Flash Search - Premium grounded web research",
         inputModalities: ["text", "image", "audio", "video"],
@@ -980,6 +1002,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(12.0),
         },
         calculateCost: calculateGemini31ProCost,
+        pricingNotes: GEMINI_31_PRO_PRICING_NOTES,
         title: "Gemini 3.1 Pro",
         description:
             "Gemini 3.1 Pro - Most Intelligent Model with 1M Context (Preview)",


### PR DESCRIPTION
- Keeps the current calculateCost hook design.
- Adds Gemini 3 search billing to gemini-search-fast and gemini-search-large.
- Adds pricing_notes to model-info so catalogs can explain dynamic fees.

Validation:
- npx biome check --write shared/registry/registry.ts shared/registry/model-info.ts shared/registry/text.ts enter.pollinations.ai/test/pricing-data.test.ts
- npx vitest run test/pricing-data.test.ts test/aliases.test.ts