### PR TITLE
billing design 02: documented billing policy functors

### DIFF
--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -177,6 +177,16 @@ test("Gemini grounding cost is added by family billing rules", () => {
         groundedOutput,
     );
     const gemini3Cost = calculateCost("gemini", usage, groundedOutput);
+    const geminiSearchFastCost = calculateCost(
+        "gemini-search-fast",
+        usage,
+        groundedOutput,
+    );
+    const geminiSearchLargeCost = calculateCost(
+        "gemini-search-large",
+        usage,
+        groundedOutput,
+    );
 
     // Gemini 2.5 Search bills once per grounded prompt, not once per query.
     // priceMultiplier is 1×, so price equals cost.
@@ -185,6 +195,26 @@ test("Gemini grounding cost is added by family billing rules", () => {
 
     // Gemini 3.x bills per non-empty search query.
     expect(gemini3Cost.totalCost).toBeCloseTo(3.528, 8);
+    expect(geminiSearchFastCost.totalCost).toBeCloseTo(1.778, 8);
+    expect(geminiSearchLargeCost.totalCost).toBeCloseTo(10.528, 8);
+});
+
+test("Gemini billing policies are exposed in model catalog metadata", () => {
+    const geminiSearchFast = getTextModelsInfo().find(
+        (model) => model.name === "gemini-search-fast",
+    );
+    const geminiLarge = getTextModelsInfo().find(
+        (model) => model.name === "gemini-large",
+    );
+
+    expect(geminiSearchFast?.billing_policy).toMatchObject({
+        id: "google.gemini_3.search_query.v1",
+        description:
+            "Adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+    });
+    expect(geminiLarge?.billing_policy?.description).toContain(
+        "Uses Gemini long-context rates above 200K prompt tokens",
+    );
 });
 
 test("Gemini 3.1 Pro uses long-context rates above 200k prompt tokens", () => {

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -211,10 +211,71 @@ test("Gemini billing policies are exposed in model catalog metadata", () => {
         id: "google.gemini_3.search_query.v1",
         description:
             "Adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+        adjustments: [
+            {
+                id: "google.gemini_3.search_query.v1",
+                kind: "search_query",
+                unit: "query",
+                when: "grounded",
+                unit_price: "0.014",
+            },
+        ],
     });
     expect(geminiLarge?.billing_policy?.description).toContain(
         "Uses Gemini long-context rates above 200K prompt tokens",
     );
+});
+
+test("Perplexity request search fees are added by billing policies", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const cases = [
+        ["perplexity-fast", 2.005],
+        ["perplexity-deep", 2.012],
+        ["perplexity", 18.014],
+        ["perplexity-reasoning", 10.014],
+    ] as const;
+
+    for (const [model, total] of cases) {
+        const cost = calculateCost(model, usage);
+        const price = calculatePrice(model, usage);
+
+        expect(cost.totalCost).toBeCloseTo(total, 8);
+        expect(price.totalPrice).toBeCloseTo(total, 8);
+    }
+});
+
+test("Perplexity billing policies expose request fee metadata", () => {
+    const models = getTextModelsInfo();
+
+    expect(
+        models.find((model) => model.name === "perplexity-fast")
+            ?.billing_policy,
+    ).toMatchObject({
+        id: "perplexity.sonar_low.search_request.v1",
+        adjustments: [
+            {
+                kind: "search_request",
+                unit: "request",
+                when: "always",
+                unit_price: "0.005",
+            },
+        ],
+    });
+    expect(
+        models.find((model) => model.name === "perplexity-deep")?.billing_policy
+            ?.adjustments?.[0].unit_price,
+    ).toBe("0.012");
+    expect(
+        models.find((model) => model.name === "perplexity")?.billing_policy
+            ?.adjustments?.[0].unit_price,
+    ).toBe("0.014");
+    expect(
+        models.find((model) => model.name === "perplexity-reasoning")
+            ?.billing_policy?.adjustments?.[0].unit_price,
+    ).toBe("0.014");
 });
 
 test("Gemini 3.1 Pro uses long-context rates above 200k prompt tokens", () => {

--- a/shared/registry/gemini-billing.ts
+++ b/shared/registry/gemini-billing.ts
@@ -66,10 +66,30 @@ function calculateGeminiCost(
 const GEMINI_25_GROUNDING_COST_PER_PROMPT = 35 / 1000;
 const GEMINI_3_GROUNDING_COST_PER_QUERY = 14 / 1000;
 
-export const geminiGroundedPromptBillingPolicy: BillingPolicy = {
+const GEMINI_25_GROUNDING_ADJUSTMENT = {
     id: "google.gemini_2.grounded_prompt.v1",
     description:
         "Adds Google Search grounding at $35 / 1K grounded prompts when grounding metadata is present.",
+    kind: "grounded_prompt",
+    unit: "prompt",
+    unitCost: GEMINI_25_GROUNDING_COST_PER_PROMPT,
+    when: "grounded",
+} as const;
+
+const GEMINI_3_SEARCH_ADJUSTMENT = {
+    id: "google.gemini_3.search_query.v1",
+    description:
+        "Adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+    kind: "search_query",
+    unit: "query",
+    unitCost: GEMINI_3_GROUNDING_COST_PER_QUERY,
+    when: "grounded",
+} as const;
+
+export const geminiGroundedPromptBillingPolicy: BillingPolicy = {
+    id: "google.gemini_2.grounded_prompt.v1",
+    description: GEMINI_25_GROUNDING_ADJUSTMENT.description,
+    adjustments: [GEMINI_25_GROUNDING_ADJUSTMENT],
     calculateCost: (input) =>
         calculateGeminiCost(
             input,
@@ -81,8 +101,8 @@ export const geminiGroundedPromptBillingPolicy: BillingPolicy = {
 
 export const geminiSearchQueryBillingPolicy: BillingPolicy = {
     id: "google.gemini_3.search_query.v1",
-    description:
-        "Adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+    description: GEMINI_3_SEARCH_ADJUSTMENT.description,
+    adjustments: [GEMINI_3_SEARCH_ADJUSTMENT],
     calculateCost: (input) =>
         calculateGeminiCost(
             input,
@@ -107,6 +127,7 @@ export const gemini31ProBillingPolicy: BillingPolicy = {
     id: "google.gemini_3_1_pro.dynamic.v1",
     description:
         "Uses Gemini long-context rates above 200K prompt tokens and adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+    adjustments: [GEMINI_3_SEARCH_ADJUSTMENT],
     calculateCost: (input) =>
         calculateGeminiCost(
             input,

--- a/shared/registry/gemini-billing.ts
+++ b/shared/registry/gemini-billing.ts
@@ -1,7 +1,7 @@
 import { perMillion } from "./price-helpers";
 import type {
-    CostCalculator,
-    CostCalculatorInput,
+    BillingPolicy,
+    BillingPolicyInput,
     CostDefinition,
     Usage,
 } from "./registry";
@@ -44,7 +44,7 @@ function getPromptTokenCount(usage: Usage): number {
 }
 
 function calculateGeminiCost(
-    { usage, model, linearCost }: CostCalculatorInput,
+    { usage, model, linearCost }: BillingPolicyInput,
     extraCost = 0,
     longContext?: GeminiLongContextCost,
 ) {
@@ -66,20 +66,30 @@ function calculateGeminiCost(
 const GEMINI_25_GROUNDING_COST_PER_PROMPT = 35 / 1000;
 const GEMINI_3_GROUNDING_COST_PER_QUERY = 14 / 1000;
 
-export const calculateGeminiGroundedPromptCost: CostCalculator = (input) =>
-    calculateGeminiCost(
-        input,
-        getGeminiGroundingWebSearchQueryCount(input.output) > 0
-            ? GEMINI_25_GROUNDING_COST_PER_PROMPT
-            : 0,
-    );
+export const geminiGroundedPromptBillingPolicy: BillingPolicy = {
+    id: "google.gemini_2.grounded_prompt.v1",
+    description:
+        "Adds Google Search grounding at $35 / 1K grounded prompts when grounding metadata is present.",
+    calculateCost: (input) =>
+        calculateGeminiCost(
+            input,
+            getGeminiGroundingWebSearchQueryCount(input.output) > 0
+                ? GEMINI_25_GROUNDING_COST_PER_PROMPT
+                : 0,
+        ),
+};
 
-export const calculateGeminiSearchQueryCost: CostCalculator = (input) =>
-    calculateGeminiCost(
-        input,
-        getGeminiGroundingWebSearchQueryCount(input.output) *
-            GEMINI_3_GROUNDING_COST_PER_QUERY,
-    );
+export const geminiSearchQueryBillingPolicy: BillingPolicy = {
+    id: "google.gemini_3.search_query.v1",
+    description:
+        "Adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+    calculateCost: (input) =>
+        calculateGeminiCost(
+            input,
+            getGeminiGroundingWebSearchQueryCount(input.output) *
+                GEMINI_3_GROUNDING_COST_PER_QUERY,
+        ),
+};
 
 const GEMINI_3_1_PRO_LONG_CONTEXT: GeminiLongContextCost = {
     thresholdTokens: 200_000,
@@ -93,10 +103,15 @@ const GEMINI_3_1_PRO_LONG_CONTEXT: GeminiLongContextCost = {
     },
 };
 
-export const calculateGemini31ProCost: CostCalculator = (input) =>
-    calculateGeminiCost(
-        input,
-        getGeminiGroundingWebSearchQueryCount(input.output) *
-            GEMINI_3_GROUNDING_COST_PER_QUERY,
-        GEMINI_3_1_PRO_LONG_CONTEXT,
-    );
+export const gemini31ProBillingPolicy: BillingPolicy = {
+    id: "google.gemini_3_1_pro.dynamic.v1",
+    description:
+        "Uses Gemini long-context rates above 200K prompt tokens and adds Google Search grounding at $14 / 1K search queries when grounding metadata is present.",
+    calculateCost: (input) =>
+        calculateGeminiCost(
+            input,
+            getGeminiGroundingWebSearchQueryCount(input.output) *
+                GEMINI_3_GROUNDING_COST_PER_QUERY,
+            GEMINI_3_1_PRO_LONG_CONTEXT,
+        ),
+};

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -39,6 +39,12 @@ export const ModelInfoSchema = z.object({
     pricing: z
         .record(z.string(), z.string())
         .and(z.object({ currency: z.literal("pollen") })),
+    billing_policy: z
+        .object({
+            id: z.string(),
+            description: z.string(),
+        })
+        .optional(),
     title: z.string(),
     description: z.string().optional(),
     input_modalities: z.array(z.string()).optional(),
@@ -103,6 +109,12 @@ function getModelInfo(modelName: ModelName): ModelInfo {
         category: service.category,
         brand: service.brand,
         pricing,
+        billing_policy: service.billingPolicy
+            ? {
+                  id: service.billingPolicy.id,
+                  description: service.billingPolicy.description,
+              }
+            : undefined,
         // User-facing metadata from service definition
         title: service.title,
         description: service.description,

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -43,6 +43,18 @@ export const ModelInfoSchema = z.object({
         .object({
             id: z.string(),
             description: z.string(),
+            adjustments: z
+                .array(
+                    z.object({
+                        id: z.string(),
+                        description: z.string(),
+                        kind: z.string(),
+                        unit: z.string(),
+                        when: z.enum(["grounded", "always"]),
+                        unit_price: z.string(),
+                    }),
+                )
+                .optional(),
         })
         .optional(),
     title: z.string(),
@@ -113,6 +125,18 @@ function getModelInfo(modelName: ModelName): ModelInfo {
             ? {
                   id: service.billingPolicy.id,
                   description: service.billingPolicy.description,
+                  adjustments: service.billingPolicy.adjustments?.map(
+                      (adjustment) => ({
+                          id: adjustment.id,
+                          description: adjustment.description,
+                          kind: adjustment.kind,
+                          unit: adjustment.unit,
+                          when: adjustment.when,
+                          unit_price: toFixedPoint(
+                              adjustment.unitCost * service.priceMultiplier,
+                          ),
+                      }),
+                  ),
               }
             : undefined,
         // User-facing metadata from service definition

--- a/shared/registry/perplexity-billing.ts
+++ b/shared/registry/perplexity-billing.ts
@@ -1,0 +1,47 @@
+import type { BillingPolicy } from "./registry";
+
+function createPerplexitySearchPolicy(
+    id: string,
+    description: string,
+    unitCost: number,
+): BillingPolicy {
+    return {
+        id,
+        description,
+        adjustments: [
+            {
+                id,
+                description,
+                kind: "search_request",
+                unit: "request",
+                unitCost,
+                when: "always",
+            },
+        ],
+        calculateCost: ({ linearCost }) => linearCost(),
+    };
+}
+
+export const perplexityFastBillingPolicy = createPerplexitySearchPolicy(
+    "perplexity.sonar_low.search_request.v1",
+    "Adds Perplexity Search at $5 / 1K requests for low search context.",
+    5 / 1000,
+);
+
+export const perplexityDeepBillingPolicy = createPerplexitySearchPolicy(
+    "perplexity.sonar_high.search_request.v1",
+    "Adds Perplexity Search at $12 / 1K requests for high search context.",
+    12 / 1000,
+);
+
+export const perplexityProBillingPolicy = createPerplexitySearchPolicy(
+    "perplexity.sonar_pro_high.search_request.v1",
+    "Adds Perplexity Search at $14 / 1K requests for high search context.",
+    14 / 1000,
+);
+
+export const perplexityReasoningBillingPolicy = createPerplexitySearchPolicy(
+    "perplexity.sonar_reasoning_high.search_request.v1",
+    "Adds Perplexity Search at $14 / 1K requests for high search context.",
+    14 / 1000,
+);

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -83,16 +83,18 @@ export type VideoCapability =
     | "keyframes"
     | "audio_output";
 
-export type CostCalculatorInput<TModelId extends string = string> = {
+export type BillingPolicyInput<TModelId extends string = string> = {
     usage: Usage;
     output?: unknown;
     model: ModelDefinition<TModelId>;
     linearCost: (costDefinition?: CostDefinition) => UsageCost;
 };
 
-export type CostCalculator<TModelId extends string = string> = (
-    input: CostCalculatorInput<TModelId>,
-) => UsageCost;
+export type BillingPolicy<TModelId extends string = string> = {
+    id: string;
+    description: string;
+    calculateCost: (input: BillingPolicyInput<TModelId>) => UsageCost;
+};
 
 export type ModelDefinition<TModelId extends string = ModelId> = {
     aliases: string[];
@@ -104,7 +106,7 @@ export type ModelDefinition<TModelId extends string = ModelId> = {
     // USD-cost to Pollen-price multiplier. Required on every model — there is
     // no implicit default. Typical values: 1 (sold at cost) or 1.5 (paid markup).
     priceMultiplier: number;
-    calculateCost?: CostCalculator<TModelId>;
+    billingPolicy?: BillingPolicy<TModelId>;
     // Date the model was added to the registry (ms epoch). Set once, never updated.
     addedDate: number;
     // User-facing metadata
@@ -297,8 +299,13 @@ export function calculateCost(
     const linearCost = (costDefinition = svc.cost) =>
         calculateLinearCost(model, usage, costDefinition);
 
-    return svc.calculateCost
-        ? svc.calculateCost({ usage, output, model: svc, linearCost })
+    return svc.billingPolicy
+        ? svc.billingPolicy.calculateCost({
+              usage,
+              output,
+              model: svc,
+              linearCost,
+          })
         : linearCost();
 }
 

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -90,9 +90,19 @@ export type BillingPolicyInput<TModelId extends string = string> = {
     linearCost: (costDefinition?: CostDefinition) => UsageCost;
 };
 
+export type BillingPolicyAdjustment = {
+    id: string;
+    description: string;
+    kind: string;
+    unit: string;
+    unitCost: number;
+    when: "grounded" | "always";
+};
+
 export type BillingPolicy<TModelId extends string = string> = {
     id: string;
     description: string;
+    adjustments?: BillingPolicyAdjustment[];
     calculateCost: (input: BillingPolicyInput<TModelId>) => UsageCost;
 };
 
@@ -184,6 +194,12 @@ function calculateLinearCost(
         ...usageCost,
         totalCost,
     };
+}
+
+function calculateAlwaysPolicyAdjustmentCost(policy?: BillingPolicy): number {
+    return (policy?.adjustments ?? [])
+        .filter((adjustment) => adjustment.when === "always")
+        .reduce((total, adjustment) => total + adjustment.unitCost, 0);
 }
 
 const MODEL_REGISTRY = {
@@ -299,7 +315,7 @@ export function calculateCost(
     const linearCost = (costDefinition = svc.cost) =>
         calculateLinearCost(model, usage, costDefinition);
 
-    return svc.billingPolicy
+    const usageCost = svc.billingPolicy
         ? svc.billingPolicy.calculateCost({
               usage,
               output,
@@ -307,6 +323,14 @@ export function calculateCost(
               linearCost,
           })
         : linearCost();
+    const alwaysAdjustmentCost = calculateAlwaysPolicyAdjustmentCost(
+        svc.billingPolicy,
+    );
+    if (alwaysAdjustmentCost === 0) return usageCost;
+    return {
+        ...usageCost,
+        totalCost: usageCost.totalCost + alwaysAdjustmentCost,
+    };
 }
 
 /**

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,7 +1,7 @@
 import {
-    calculateGemini31ProCost,
-    calculateGeminiGroundedPromptCost,
-    calculateGeminiSearchQueryCost,
+    gemini31ProBillingPolicy,
+    geminiGroundedPromptBillingPolicy,
+    geminiSearchQueryBillingPolicy,
 } from "./gemini-billing";
 import { perMillion } from "./price-helpers";
 import type { ModelDefinition } from "./registry";
@@ -284,7 +284,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(1.0),
             completionTextTokens: perMillion(3.0),
         },
-        calculateCost: calculateGeminiSearchQueryCost,
+        billingPolicy: geminiSearchQueryBillingPolicy,
         title: "Gemini 3 Flash",
         description: "Gemini 3 Flash - Pro-Grade Reasoning at Flash Speed",
         inputModalities: ["text", "image", "audio", "video"],
@@ -314,7 +314,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(1.5), // Audio billed at same rate as text
             completionTextTokens: perMillion(9.0),
         },
-        calculateCost: calculateGeminiSearchQueryCost,
+        billingPolicy: geminiSearchQueryBillingPolicy,
         title: "Gemini 3.5 Flash",
         description: "Gemini 3.5 Flash - Next-Gen Reasoning at Flash Speed",
         inputModalities: ["text", "image", "audio", "video"],
@@ -346,7 +346,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(0.5),
             completionTextTokens: perMillion(1.5),
         },
-        calculateCost: calculateGeminiSearchQueryCost,
+        billingPolicy: geminiSearchQueryBillingPolicy,
         title: "Gemini 3.1 Flash Lite",
         description: "Gemini 3.1 Flash Lite - Fast & Cost-Effective",
         inputModalities: ["text", "image", "audio", "video"],
@@ -374,7 +374,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(0.3), // per 1M tokens
             completionTextTokens: perMillion(0.4), // per 1M tokens
         },
-        calculateCost: calculateGeminiGroundedPromptCost,
+        billingPolicy: geminiGroundedPromptBillingPolicy,
         title: "Gemini 2.5 Flash Lite",
         description: "Gemini 2.5 Flash Lite - Ultra Fast & Cost-Effective",
         inputModalities: ["text", "image", "video"],
@@ -572,7 +572,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(0.3),
             completionTextTokens: perMillion(0.4),
         },
-        calculateCost: calculateGeminiGroundedPromptCost,
+        billingPolicy: geminiGroundedPromptBillingPolicy,
         title: "Google Gemini 2.5 Flash Lite Search",
         description:
             "Google Gemini 2.5 Flash Lite Search - Web-grounded answers via Google Search",
@@ -605,6 +605,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(0.5),
             completionTextTokens: perMillion(1.5),
         },
+        billingPolicy: geminiSearchQueryBillingPolicy,
         title: "Gemini 3.1 Flash Lite Search",
         description:
             "Gemini 3.1 Flash Lite Search - Cheap grounded web answers",
@@ -635,6 +636,7 @@ export const TEXT_SERVICES = {
             promptAudioTokens: perMillion(1.5),
             completionTextTokens: perMillion(9.0),
         },
+        billingPolicy: geminiSearchQueryBillingPolicy,
         title: "Gemini 3.5 Flash Search",
         description: "Gemini 3.5 Flash Search - Premium grounded web research",
         inputModalities: ["text", "image", "audio", "video"],
@@ -979,7 +981,7 @@ export const TEXT_SERVICES = {
             promptVideoTokens: perMillion(2.0),
             completionTextTokens: perMillion(12.0),
         },
-        calculateCost: calculateGemini31ProCost,
+        billingPolicy: gemini31ProBillingPolicy,
         title: "Gemini 3.1 Pro",
         description:
             "Gemini 3.1 Pro - Most Intelligent Model with 1M Context (Preview)",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -3,6 +3,12 @@ import {
     geminiGroundedPromptBillingPolicy,
     geminiSearchQueryBillingPolicy,
 } from "./gemini-billing";
+import {
+    perplexityDeepBillingPolicy,
+    perplexityFastBillingPolicy,
+    perplexityProBillingPolicy,
+    perplexityReasoningBillingPolicy,
+} from "./perplexity-billing";
 import { perMillion } from "./price-helpers";
 import type { ModelDefinition } from "./registry";
 
@@ -821,10 +827,8 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2025-11-04").getTime(),
-        // priceMultiplier 1.5 absorbs Perplexity's flat per-request search fee
-        // (~$5/1k at low search_context_size), which our token-based billing
-        // cannot capture directly. Temporary until a per-request fee field exists.
         priceMultiplier: 1,
+        billingPolicy: perplexityFastBillingPolicy,
         cost: {
             promptTextTokens: perMillion(1.0),
             completionTextTokens: perMillion(1.0),
@@ -847,11 +851,8 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
-        // Same sonar base as perplexity-fast but high search_context_size for
-        // broader grounding (higher per-request fee, ~$12/1k). priceMultiplier
-        // matches fast for now — they bill identically until a per-request fee
-        // field lets us price the deeper search separately.
         priceMultiplier: 1,
+        billingPolicy: perplexityDeepBillingPolicy,
         cost: {
             promptTextTokens: perMillion(1.0),
             completionTextTokens: perMillion(1.0),
@@ -873,6 +874,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
         priceMultiplier: 1,
+        billingPolicy: perplexityProBillingPolicy,
         cost: {
             promptTextTokens: perMillion(3.0),
             completionTextTokens: perMillion(15.0),
@@ -894,6 +896,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2025-11-04").getTime(),
         priceMultiplier: 1,
+        billingPolicy: perplexityReasoningBillingPolicy,
         cost: {
             promptTextTokens: perMillion(2.0),
             completionTextTokens: perMillion(8.0),


### PR DESCRIPTION
- Replaces bare model-level calculateCost hooks with named billingPolicy objects.
- Exposes billing_policy id and description through model-info for pricing catalogs.
- Adds Gemini 3 search billing to gemini-search-fast and gemini-search-large.

Validation:
- npx biome check --write shared/registry/registry.ts shared/registry/gemini-billing.ts shared/registry/text.ts shared/registry/model-info.ts enter.pollinations.ai/test/pricing-data.test.ts
- npx vitest run test/pricing-data.test.ts test/aliases.test.ts