### PR TITLE
fix: wan-pro image-to-video failing with 500

### DIFF
--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -27,6 +27,13 @@ interface WanModelConfig {
     trackingName: string;
     displayName: string;
     audioBundledWithVideo?: boolean;
+    /**
+     * wan2.7+ replaced the legacy `input.img_url` string with a unified
+     * `input.media` array of `{ type, url }` (type ∈ first_frame | last_frame |
+     * driving_audio | first_clip). When set, i2v sends the image as
+     * media[{type:"first_frame"}] instead of img_url.
+     */
+    usesMediaArray?: boolean;
 }
 
 const WAN_26_CONFIG: WanModelConfig = {
@@ -64,6 +71,7 @@ const WAN_27_CONFIG: WanModelConfig = {
     trackingName: "wan-pro",
     displayName: "Wan 2.7",
     audioBundledWithVideo: true,
+    usesMediaArray: true,
 };
 
 // kf2v uses a different DashScope endpoint than i2v/t2v
@@ -124,6 +132,7 @@ interface DashScopeRequest {
         img_url?: string;
         first_frame_url?: string;
         last_frame_url?: string;
+        media?: Array<{ type: string; url: string }>;
     };
     parameters: {
         resolution: string;
@@ -402,6 +411,31 @@ function buildDashScopeRequest(
             },
         };
     }
+    // wan2.7+ unified i2v inputs into an input.media[] array ({type, url});
+    // the legacy img_url string is accepted at submit but fails the task async
+    // with "Field required: input.media". Map the start image to first_frame.
+    if (config.usesMediaArray) {
+        return {
+            model: firstFrameUrl ? config.i2vModel : config.t2vModel,
+            input: firstFrameUrl
+                ? {
+                      prompt,
+                      media: [
+                          {
+                              type: "first_frame",
+                              url: prepareImageUrl(firstFrameUrl),
+                          },
+                      ],
+                  }
+                : { prompt },
+            parameters: {
+                resolution: videoParams.resolution,
+                duration: videoParams.durationSeconds,
+                prompt_extend: true,
+                audio: videoParams.generateAudio,
+            },
+        };
+    }
     return {
         model: firstFrameUrl ? config.i2vModel : config.t2vModel,
         input: firstFrameUrl
@@ -446,6 +480,10 @@ function logRequestSafely(requestBody: DashScopeRequest): void {
             img_url: mask(requestBody.input.img_url),
             first_frame_url: mask(requestBody.input.first_frame_url),
             last_frame_url: mask(requestBody.input.last_frame_url),
+            media: requestBody.input.media?.map((m) => ({
+                ...m,
+                url: mask(m.url),
+            })),
         },
     };
     logOps("DashScope API request:", JSON.stringify(safeRequest, null, 2));

--- a/gen.pollinations.ai/test/image/wanVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wanVideoModel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
 import {
     callWanAPI,
+    callWanFastAPI,
     callWanProAPI,
 } from "../../src/image/models/wanVideoModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
@@ -12,6 +13,10 @@ const DASHSCOPE_SUBMIT_URL =
 const DASHSCOPE_POLL_URL =
     "https://dashscope-intl.aliyuncs.com/api/v1/tasks/task-wan-test";
 const VIDEO_URL = "https://video.example.com/wan-output.mp4";
+const INPUT_IMAGE_URL = "https://img.example.com/first-frame.png";
+// PNG magic bytes so downloadUserImage's detectMimeType resolves to image/png.
+const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const EXPECTED_DATA_URI = /^data:image\/png;base64,/;
 
 interface DashScopeRequest {
     url: string;
@@ -90,6 +95,13 @@ function mockDashScopeFetch(requests: DashScopeRequest[], videoDuration = 2) {
                 });
             }
 
+            if (href === INPUT_IMAGE_URL) {
+                return new Response(PNG_BYTES, {
+                    status: 200,
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+
             return new Response("unexpected URL", { status: 404 });
         });
 }
@@ -159,5 +171,54 @@ describe("wanVideoModel billing usage", () => {
                 completionAudioSeconds: 3,
             },
         });
+    });
+});
+
+describe("wanVideoModel image-to-video input schema", () => {
+    it("wan-pro (wan2.7) i2v sends the image as input.media[].first_frame", async () => {
+        syncImageEnv(
+            { DASHSCOPE_API_KEY: "dashscope-test-key" } as CloudflareBindings,
+            ["DASHSCOPE_API_KEY"],
+        );
+        const requests: DashScopeRequest[] = [];
+        mockDashScopeFetch(requests);
+
+        await callWanProAPI(
+            "a cat walking",
+            { ...baseParams, image: [INPUT_IMAGE_URL] },
+            asProgress(makeProgress()),
+            "req-wan-pro-i2v",
+        );
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0].body.model).toBe("wan2.7-i2v");
+        const input = requests[0].body.input;
+        // wan2.7 uses the unified media array, NOT the legacy img_url string.
+        expect(input.img_url).toBeUndefined();
+        const media = input.media as Array<{ type: string; url: string }>;
+        expect(media).toHaveLength(1);
+        expect(media[0].type).toBe("first_frame");
+        expect(media[0].url).toMatch(EXPECTED_DATA_URI);
+    });
+
+    it("wan-fast (wan2.2) i2v still uses the legacy img_url string", async () => {
+        syncImageEnv(
+            { DASHSCOPE_API_KEY: "dashscope-test-key" } as CloudflareBindings,
+            ["DASHSCOPE_API_KEY"],
+        );
+        const requests: DashScopeRequest[] = [];
+        mockDashScopeFetch(requests);
+
+        await callWanFastAPI(
+            "a cat walking",
+            { ...baseParams, model: "wan-fast", image: [INPUT_IMAGE_URL] },
+            asProgress(makeProgress()),
+            "req-wan-fast-i2v",
+        );
+
+        expect(requests[0].body.model).toBe("wan2.2-i2v-flash");
+        const input = requests[0].body.input;
+        expect(input.media).toBeUndefined();
+        expect(input.img_url as string).toMatch(EXPECTED_DATA_URI);
     });
 });


### PR DESCRIPTION
wan-pro (wan2.7) image-to-video has been failing every request with a 500.

- Root cause: wan2.7 dropped the legacy `input.img_url` string for a unified `input.media[]` array (`{type, url}`). The handler still sent `img_url` — DashScope accepts it at submit but fails the task async with "Field required: input.media".
- Fix: wan2.7 i2v now maps the start image to `media:[{type:"first_frame", url}]`; wan2.2/2.6 keep `img_url` (unchanged).
- Also masks `media` URLs in the safe request logger.
- Tests: added i2v schema tests for wan-pro (media array) and wan-fast (legacy img_url regression guard). 4/4 wan tests pass, biome clean.
- Verified end-to-end through the gen worker: wan-pro i2v returns video/mp4 (was 500).