### PR TITLE
feat: Brainrot Merge — Italian brainrot edition (figures, hulls, voice)

### DIFF
--- a/apps/apps.json
+++ b/apps/apps.json
@@ -17,6 +17,13 @@
         "title": "Life Merge",
         "description": "A physics merge game about generated biological categories"
     },
+    "brainrot-merge": {
+        "subdomain": "brainrot-merge",
+        "buildCommand": "npm run build",
+        "outputDir": "dist",
+        "title": "Brainrot Merge",
+        "description": "A physics merge game that AI-generates Italian brainrot characters with voice"
+    },
     "catgpt": {
         "subdomain": "catgpt",
         "buildCommand": null,

--- a/apps/brainrot-merge/README.md
+++ b/apps/brainrot-merge/README.md
@@ -1,0 +1,76 @@
+# Brainrot Merge
+
+The Italian brainrot edition of SuikaCraft: Suika-style falling physics where
+merging two same-size pieces asks the AI to invent a brand-new Italian
+brainrot character — pseudo-Italian name, absurd lore, hyperreal image, and a
+dramatic Italian voice line spoken aloud on discovery.
+
+The famous brainrot creatures are themselves hybrids (shark + sneakers,
+crocodile + bomber, ballerina + cappuccino), so the seeds are the raw
+ingredients — Squalo, Sneakers, Cappuccino, Coccodrillo, Aereo, Banana,
+Scimmia, Ballerina — and characters emerge through play.
+
+## How it differs from SuikaCraft (`apps/life-merge`)
+
+- **One world, no presets.** The preset/style machinery is gone; the brainrot
+  grammar is hardcoded in `generation.ts`.
+- **Figure physics.** Generated images are requested on a plain white
+  background; `figure.ts` flood-fills the background away, cuts out the
+  sprite, and builds a simplified convex hull (≤12 vertices). The hull —
+  area-normalized to the tier circle so the size economy stays intact —
+  becomes the matter-js body. Shapes change how pieces rest, wedge, and
+  stack, never how much board space a tier is worth. Circle fallback when
+  extraction fails.
+- **Voice.** Each generated character comes with an Italian catchphrase
+  (blasphemy/profanity filtered, with prompt rules and a regex blocklist as
+  defense in depth). It is spoken via ElevenLabs TTS (`adam` — the canonical
+  brainrot narrator voice) on discovery, and replayed by clicking a piece.
+  The 🔊 Voce button mutes the narrator.
+
+## Stack
+
+- Vite, React, TypeScript
+- Matter.js — circles for placeholders, convex hulls for figures
+- `@pollinations/sdk/react` for BYOP login
+- `@pollinations/ui` for app chrome, wallet chips, and controls
+- Pollinations `claude` text generation for character name/lore/catchphrase
+- Pollinations `zimage` image generation for character art
+- Pollinations `elevenlabs` TTS for the narrator
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+Run from `apps/brainrot-merge`.
+
+No app key is committed. Without one, auth uses only the current
+`redirect_uri`, so requests are not attributed to a named app key. To enable
+app attribution, create a dedicated publishable App Key at
+`https://enter.pollinations.ai`, add the local or production redirect URL,
+and run/build with:
+
+```bash
+VITE_POLLINATIONS_APP_KEY=pk_your_publishable_key npm run build
+```
+
+## Scripts
+
+```bash
+npm run typecheck
+npm run build
+npm run preview
+```
+
+## Notes
+
+- Gameplay requires Pollinations login because playable pieces must be
+  generated.
+- Images and audio are fetched with the delegated key as blobs and rendered
+  from local object URLs, so the key never appears in media URLs.
+- Canonical brainrot characters are deliberately NOT reproduced: the prompt
+  instructs the model to invent new characters in the same naming grammar
+  (the canonical lines contain blasphemy, and some characters have
+  third-party IP claims).

--- a/apps/brainrot-merge/index.html
+++ b/apps/brainrot-merge/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Brainrot Merge</title>
+        <meta
+            name="description"
+            content="A Pollinations-powered physics merge game — fuse ingredients into AI-generated Italian brainrot characters, with voice."
+        />
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/apps/brainrot-merge/package.json
+++ b/apps/brainrot-merge/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "brainrot-merge.pollinations.ai",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "predev": "npm run build --prefix ../../packages/sdk && npm run build --prefix ../../packages/ui",
+        "build": "vite build",
+        "prebuild": "npm run build --prefix ../../packages/sdk && npm run build --prefix ../../packages/ui",
+        "preview": "vite preview",
+        "pretypecheck": "npm run build --prefix ../../packages/sdk && npm run build --prefix ../../packages/ui",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@pollinations/sdk": "*",
+        "@pollinations/ui": "*",
+        "matter-js": "^0.20.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+    },
+    "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/matter-js": "^0.19.8",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.7.2",
+        "vite": "^7.0.0"
+    }
+}

--- a/apps/brainrot-merge/src/App.tsx
+++ b/apps/brainrot-merge/src/App.tsx
@@ -1,0 +1,609 @@
+import { PolliProvider, useAuthState } from "@pollinations/sdk/react";
+import { Button, Chip } from "@pollinations/ui";
+import { AppUserMenu } from "@pollinations/ui/app-user-menu/sdk";
+import logoWordmarkUrl from "@pollinations/ui/assets/logo-wordmark.svg";
+import { type CSSProperties, useState } from "react";
+import { figureScale, type GamePiece, type LineageNode } from "./brainrot";
+import type { FigureData } from "./figure";
+import {
+    BOARD_ASPECT_RATIO,
+    BOARD_MAX_WIDTH,
+    BOARD_WIDTH_FROM_HEIGHT,
+    DROP_Y,
+    LOSS_LINE,
+    useGameEngine,
+} from "./useGameEngine";
+
+const APP_THEME = "green";
+
+const brandWordmarkMask: CSSProperties = {
+    WebkitMask: `url(${logoWordmarkUrl}) center / contain no-repeat`,
+    mask: `url(${logoWordmarkUrl}) center / contain no-repeat`,
+};
+
+function pieceTitle(
+    piece: Pick<GamePiece, "name" | "description" | "lineage">,
+) {
+    const parents = piece.lineage.parents
+        ? ` Parents: ${piece.lineage.parents[0].name} + ${piece.lineage.parents[1].name}.`
+        : "";
+    return `${piece.name}: ${piece.description}.${parents}`;
+}
+
+function parentTitle(parents: [LineageNode, LineageNode]) {
+    return [
+        `${parents[0].name}: ${parents[0].description}.`,
+        `${parents[1].name}: ${parents[1].description}.`,
+    ].join(" ");
+}
+
+// Only a real generated image (a blob:/http URL) is rendered. The coloured
+// circle stands in until the real image arrives.
+function realImage(imageUrl?: string): string | undefined {
+    return imageUrl && !imageUrl.startsWith("data:") ? imageUrl : undefined;
+}
+
+// Prefer the background-free cutout wherever a sprite is shown.
+function spriteImage(piece: {
+    imageUrl?: string;
+    figure?: FigureData;
+}): string | undefined {
+    return piece.figure?.cutoutUrl ?? realImage(piece.imageUrl);
+}
+
+// CSS vars aligning a cutout sprite with its physics hull: the element is
+// centered on the hull centroid, the sprite shifted by the centroid→sprite
+// offset, all in board pixels.
+function figureVars(
+    figure: FigureData,
+    radius: number,
+    viewScale: number,
+): CSSProperties {
+    const scale = figureScale(radius, figure) * viewScale;
+    return {
+        "--figure-w": `${figure.spriteSize.width * scale}px`,
+        "--figure-h": `${figure.spriteSize.height * scale}px`,
+        "--figure-dx": `${figure.spriteOffset.x * scale}px`,
+        "--figure-dy": `${figure.spriteOffset.y * scale}px`,
+    } as CSSProperties;
+}
+
+function App() {
+    return (
+        <PolliProvider
+            appKey=""
+            permissions={["profile", "usage"]}
+            models={["claude", "zimage", "elevenlabs"]}
+            budget={6}
+            expiry={7}
+        >
+            <BrainrotMergeApp />
+        </PolliProvider>
+    );
+}
+
+function BrainrotMergeApp() {
+    const { apiKey, isLoggedIn, isHydrated } = useAuthState();
+    const game = useGameEngine({ apiKey, isLoggedIn, isHydrated });
+    const generationFocusId = game.generationFocus?.id ?? null;
+    const [inspectorOverride, setInspectorOverride] = useState<{
+        generationFocusId: string | null;
+        pieceId: string;
+    } | null>(null);
+    const inspectorOverrideId =
+        inspectorOverride?.generationFocusId === generationFocusId
+            ? inspectorOverride.pieceId
+            : null;
+    const showInspectorOverride = (pieceId: string) =>
+        setInspectorOverride({ generationFocusId, pieceId });
+    const visibleGenerationFocus =
+        game.generationFocus &&
+        (!inspectorOverrideId || inspectorOverrideId === generationFocusId)
+            ? game.generationFocus
+            : null;
+    const scaled = (value: number) => `${value * game.viewScale}px`;
+
+    return (
+        <div data-theme={APP_THEME} className="app-shell">
+            <header className="topbar">
+                <a
+                    href="https://pollinations.ai"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="brand-mark"
+                    aria-label="Pollinations"
+                >
+                    <span className="sr-only">Pollinations</span>
+                    <span aria-hidden="true" style={brandWordmarkMask} />
+                </a>
+                <div className="topbar-actions">
+                    <Chip theme="teal" size="sm">
+                        Brainrot Merge
+                    </Chip>
+                    {game.hasStarted ? (
+                        <span className="topbar-score" aria-live="polite">
+                            <strong>{game.score}</strong>
+                            <small>
+                                {game.highestTier + 1}/{game.rungs.length} ·{" "}
+                                {game.pieces.length} in play
+                            </small>
+                        </span>
+                    ) : null}
+                    <Button
+                        theme="teal"
+                        size="sm"
+                        onClick={game.toggleVoice}
+                        aria-pressed={game.voiceEnabled}
+                        title={
+                            game.voiceEnabled
+                                ? "Mute the narrator"
+                                : "Unmute the narrator"
+                        }
+                    >
+                        {game.voiceEnabled ? "🔊 Voce" : "🔇 Voce"}
+                    </Button>
+                    {game.hasStarted ? (
+                        <Button
+                            theme="amber"
+                            size="sm"
+                            onClick={game.resetGame}
+                        >
+                            Reset
+                        </Button>
+                    ) : null}
+                    <AppUserMenu dashboardHref="https://enter.pollinations.ai" />
+                </div>
+            </header>
+
+            <main className="game-layout">
+                <section className="play-column">
+                    <div className="board-frame">
+                        <div
+                            className="board-stack"
+                            style={
+                                {
+                                    "--board-aspect-ratio": BOARD_ASPECT_RATIO,
+                                    "--board-max-width": BOARD_MAX_WIDTH,
+                                    "--board-width-from-height":
+                                        BOARD_WIDTH_FROM_HEIGHT,
+                                } as CSSProperties
+                            }
+                        >
+                            <div
+                                ref={game.boardRef}
+                                className={`merge-board ${
+                                    game.isCrowded ? "is-crowded" : ""
+                                }`}
+                                onPointerMove={game.updateAim}
+                                onPointerDown={game.handleBoardPointerDown}
+                            >
+                                <div
+                                    className="loss-line"
+                                    style={{ top: scaled(LOSS_LINE) }}
+                                >
+                                    <span />
+                                </div>
+                                {game.hasStarted ? (
+                                    <div
+                                        className="aim-line"
+                                        style={{
+                                            left: scaled(game.dropPreviewX),
+                                        }}
+                                    />
+                                ) : null}
+                                <div
+                                    className={`drop-preview ${
+                                        game.canDrop ? "" : "is-waiting"
+                                    } ${game.hasStarted ? "" : "is-hidden"} ${
+                                        game.nextPiece.figure ? "is-figure" : ""
+                                    }`}
+                                    title={pieceTitle(game.nextPiece)}
+                                    style={
+                                        {
+                                            "--piece-x": scaled(
+                                                game.dropPreviewX,
+                                            ),
+                                            "--piece-y": scaled(DROP_Y),
+                                            "--piece-size": scaled(
+                                                game.nextPiece.radius * 2,
+                                            ),
+                                            "--piece-color":
+                                                game.nextPiece.color,
+                                            "--piece-ink": game.nextPiece.ink,
+                                            ...(game.nextPiece.figure
+                                                ? figureVars(
+                                                      game.nextPiece.figure,
+                                                      game.nextPiece.radius,
+                                                      game.viewScale,
+                                                  )
+                                                : {}),
+                                        } as CSSProperties
+                                    }
+                                >
+                                    {game.nextPiece.pending ? (
+                                        <span
+                                            className="piece-spinner"
+                                            aria-hidden="true"
+                                        />
+                                    ) : spriteImage(game.nextPiece) ? (
+                                        <img
+                                            src={spriteImage(game.nextPiece)}
+                                            alt=""
+                                            draggable={false}
+                                        />
+                                    ) : null}
+                                </div>
+                                {game.pieces.map((piece) => (
+                                    <button
+                                        type="button"
+                                        key={piece.id}
+                                        className={`life-piece ${
+                                            piece.pending ? "is-pending" : ""
+                                        } ${
+                                            piece.generated
+                                                ? "is-generated"
+                                                : ""
+                                        } ${
+                                            piece.id === game.activeLabelId
+                                                ? "is-labeled"
+                                                : ""
+                                        } ${piece.figure ? "is-figure" : ""}`}
+                                        title={pieceTitle(piece)}
+                                        onPointerEnter={() => {
+                                            showInspectorOverride(piece.id);
+                                            game.showDiscovery(piece);
+                                        }}
+                                        onPointerLeave={(event) => {
+                                            if (event.pointerType !== "touch") {
+                                                setInspectorOverride(null);
+                                            }
+                                        }}
+                                        onClick={() => {
+                                            showInspectorOverride(piece.id);
+                                            game.showDiscovery(piece);
+                                            void game.speakCatchphrase(
+                                                piece.catchphrase,
+                                            );
+                                        }}
+                                        style={
+                                            {
+                                                "--piece-x": scaled(piece.x),
+                                                "--piece-y": scaled(piece.y),
+                                                "--piece-size": scaled(
+                                                    piece.radius * 2,
+                                                ),
+                                                "--piece-rotate": `${piece.angle}rad`,
+                                                "--piece-color": piece.color,
+                                                "--piece-ink": piece.ink,
+                                                ...(piece.figure
+                                                    ? figureVars(
+                                                          piece.figure,
+                                                          piece.radius,
+                                                          game.viewScale,
+                                                      )
+                                                    : {}),
+                                            } as CSSProperties
+                                        }
+                                    >
+                                        {piece.pending ? (
+                                            <span
+                                                className="piece-spinner"
+                                                aria-hidden="true"
+                                            />
+                                        ) : spriteImage(piece) ? (
+                                            <img
+                                                src={spriteImage(piece)}
+                                                alt=""
+                                                draggable={false}
+                                            />
+                                        ) : null}
+                                    </button>
+                                ))}
+                                {!game.hasStarted ? (
+                                    <div className="board-start">
+                                        <div className="board-start-card">
+                                            <span
+                                                className="board-start-emoji"
+                                                aria-hidden="true"
+                                            >
+                                                🦈👟☕🐊
+                                            </span>
+                                            <strong>Brainrot Merge</strong>
+                                            <small>
+                                                Drop ingredients, merge equals,
+                                                and let the AI invent absurd
+                                                Italian brainrot characters —
+                                                with voice.
+                                            </small>
+                                            <Button
+                                                theme="teal"
+                                                disabled={!game.canUseAi}
+                                                onClick={() =>
+                                                    game.dropNextPiece()
+                                                }
+                                            >
+                                                Andiamo!
+                                            </Button>
+                                            {!game.canUseAi ? (
+                                                <span className="board-start-hint">
+                                                    Authorize above to start
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                    </div>
+                                ) : game.pieces.length === 0 ? (
+                                    <div className="board-empty">
+                                        <span>Click the board to drop</span>
+                                    </div>
+                                ) : null}
+                            </div>
+                            <div
+                                className="piece-label-layer"
+                                aria-hidden="true"
+                            >
+                                {game.hasStarted ? (
+                                    <FloatingPieceLabel
+                                        name={game.nextPiece.name}
+                                        pending={game.nextPiece.pending}
+                                        active
+                                        x={game.dropPreviewX * game.viewScale}
+                                        y={
+                                            (DROP_Y -
+                                                game.nextPiece.radius -
+                                                10) *
+                                            game.viewScale
+                                        }
+                                    />
+                                ) : null}
+                                {game.pieces.map((piece) => (
+                                    <FloatingPieceLabel
+                                        key={piece.id}
+                                        name={piece.name}
+                                        pending={piece.pending}
+                                        active={piece.id === game.activeLabelId}
+                                        x={piece.x * game.viewScale}
+                                        y={
+                                            (piece.y - piece.radius - 10) *
+                                            game.viewScale
+                                        }
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <aside className="side-panel">
+                    {visibleGenerationFocus ? (
+                        <output
+                            className={`generation-focus is-${visibleGenerationFocus.status}`}
+                        >
+                            <div className="generation-focus-head">
+                                <span>
+                                    {visibleGenerationFocus.status === "result"
+                                        ? "New character"
+                                        : "Fusing"}
+                                </span>
+                            </div>
+                            <div className="generation-parents">
+                                {visibleGenerationFocus.parents.map(
+                                    (parent, index) => (
+                                        <div
+                                            className="generation-parent"
+                                            key={parent.id}
+                                        >
+                                            {index === 1 ? (
+                                                <span className="generation-plus">
+                                                    +
+                                                </span>
+                                            ) : null}
+                                            <img
+                                                src={
+                                                    spriteImage(parent) ??
+                                                    parent.imageUrl
+                                                }
+                                                alt=""
+                                            />
+                                            <div className="generation-parent-text">
+                                                <strong>{parent.name}</strong>
+                                                <p>{parent.description}</p>
+                                            </div>
+                                        </div>
+                                    ),
+                                )}
+                            </div>
+                            {visibleGenerationFocus.result ? (
+                                <div className="generation-result">
+                                    <span className="generation-arrow">↓</span>
+                                    <img
+                                        src={
+                                            visibleGenerationFocus.result
+                                                .imageUrl
+                                        }
+                                        alt=""
+                                    />
+                                    <div className="generation-result-text">
+                                        <strong>
+                                            {visibleGenerationFocus.result.name}
+                                        </strong>
+                                        <p>
+                                            {
+                                                visibleGenerationFocus.result
+                                                    .description
+                                            }
+                                        </p>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="generation-pulse">
+                                    <span />
+                                </div>
+                            )}
+                        </output>
+                    ) : (
+                        /* Inspector: the focused piece's sprite, name,
+                           description, catchphrase, and immediate parents. */
+                        <section className="selected-card">
+                            <div
+                                className="selected-icon"
+                                style={
+                                    {
+                                        "--piece-color":
+                                            game.selectedView.color,
+                                        "--piece-ink": game.selectedView.ink,
+                                    } as CSSProperties
+                                }
+                            >
+                                {spriteImage(game.selectedView) ? (
+                                    <img
+                                        src={spriteImage(game.selectedView)}
+                                        alt=""
+                                        draggable={false}
+                                    />
+                                ) : null}
+                            </div>
+                            <div className="selected-text">
+                                <strong>{game.selectedView.name}</strong>
+                                <p>{game.selectedView.description}</p>
+                                {game.selectedView.catchphrase ? (
+                                    <button
+                                        type="button"
+                                        className="selected-catchphrase"
+                                        title="Play the catchphrase"
+                                        onClick={() =>
+                                            void game.speakCatchphrase(
+                                                game.selectedView.catchphrase,
+                                            )
+                                        }
+                                    >
+                                        “{game.selectedView.catchphrase}”
+                                    </button>
+                                ) : null}
+                                {game.selectedView.lineage.parents ? (
+                                    <small
+                                        className="selected-parents"
+                                        title={parentTitle(
+                                            game.selectedView.lineage.parents,
+                                        )}
+                                    >
+                                        <span>from</span>
+                                        <b>
+                                            {
+                                                game.selectedView.lineage
+                                                    .parents[0].name
+                                            }
+                                        </b>
+                                        <span>+</span>
+                                        <b>
+                                            {
+                                                game.selectedView.lineage
+                                                    .parents[1].name
+                                            }
+                                        </b>
+                                    </small>
+                                ) : null}
+                            </div>
+                        </section>
+                    )}
+
+                    {game.legendEntries.length > 0 ? (
+                        <section className="legend-card">
+                            <header>
+                                <strong>In play</strong>
+                                <small>{game.legendEntries.length}</small>
+                            </header>
+                            <ul className="legend-list">
+                                {game.legendEntries.map((entry) => (
+                                    <li key={entry.name}>
+                                        <button
+                                            type="button"
+                                            className="legend-row"
+                                            title={pieceTitle(entry)}
+                                            onPointerEnter={() => {
+                                                showInspectorOverride(entry.id);
+                                                game.selectPiece(entry);
+                                            }}
+                                            onPointerLeave={(event) => {
+                                                if (
+                                                    event.pointerType !==
+                                                    "touch"
+                                                ) {
+                                                    setInspectorOverride(null);
+                                                }
+                                            }}
+                                            onClick={() => {
+                                                showInspectorOverride(entry.id);
+                                                game.showDiscovery(entry);
+                                                void game.speakCatchphrase(
+                                                    entry.catchphrase,
+                                                );
+                                            }}
+                                        >
+                                            <span
+                                                className="legend-icon"
+                                                style={
+                                                    {
+                                                        "--piece-color":
+                                                            entry.color,
+                                                        "--piece-ink":
+                                                            entry.ink,
+                                                    } as CSSProperties
+                                                }
+                                            >
+                                                {spriteImage(entry) ? (
+                                                    <img
+                                                        src={spriteImage(entry)}
+                                                        alt=""
+                                                        draggable={false}
+                                                    />
+                                                ) : null}
+                                            </span>
+                                            <span className="legend-name">
+                                                {entry.name}
+                                            </span>
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ) : null}
+                </aside>
+            </main>
+        </div>
+    );
+}
+
+function FloatingPieceLabel({
+    name,
+    pending,
+    active,
+    x,
+    y,
+}: {
+    name: string;
+    pending?: boolean;
+    active?: boolean;
+    x: number;
+    y: number;
+}) {
+    return (
+        <span
+            className={`piece-label ${pending ? "is-pending" : ""} ${
+                active ? "is-active" : ""
+            }`}
+            style={
+                {
+                    "--label-x": `${x}px`,
+                    "--label-y": `${y}px`,
+                } as CSSProperties
+            }
+        >
+            <span className="piece-label-name">{name}</span>
+            {pending ? (
+                <span className="piece-label-status">Making…</span>
+            ) : null}
+        </span>
+    );
+}
+
+export default App;

--- a/apps/brainrot-merge/src/app.css
+++ b/apps/brainrot-merge/src/app.css
@@ -1,0 +1,840 @@
+@import "@pollinations/ui/app.css";
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+    min-height: 100%;
+}
+
+body {
+    margin: 0;
+    background: #edf7ef;
+    color: #182317;
+    font-family:
+        "Uncut Sans",
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        sans-serif;
+}
+
+button,
+input,
+textarea,
+select {
+    font: inherit;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+}
+
+.app-shell {
+    min-height: 100vh;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.72), transparent 34%),
+        radial-gradient(circle at 12% 8%, rgba(94, 199, 178, 0.18), transparent 28%),
+        linear-gradient(180deg, #f5fbf4 0%, #e8f3ec 100%);
+}
+
+/* ---- Topbar ---------------------------------------------------------- */
+
+.topbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 20px;
+    border-bottom: 1px solid rgba(29, 74, 33, 0.12);
+    background: rgba(247, 251, 245, 0.92);
+    backdrop-filter: blur(14px);
+}
+
+.brand-mark {
+    display: inline-flex;
+    min-width: 0;
+    color: #173d22;
+}
+
+.brand-mark span {
+    display: block;
+    width: 200px;
+    max-width: 42vw;
+    height: 26px;
+    background: currentColor;
+}
+
+.topbar-actions {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+/* ---- Layout ---------------------------------------------------------- */
+
+.game-layout {
+    display: grid;
+    /* Fixed side column: selecting a piece changes the inspector text but must
+       never reflow the 1fr play column (that caused the board to resize). */
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 24px;
+    width: min(1240px, 100%);
+    margin: 0 auto;
+    padding: 22px 24px 28px;
+}
+
+.play-column,
+.side-panel {
+    min-width: 0;
+}
+
+.play-column {
+    /* dvh (not vh) so the board doesn't jump when a mobile URL bar shows/hides.
+       Only the topbar (~64px) + page padding sits outside the board now. */
+    --board-max-height: calc(100dvh - 120px);
+
+    display: grid;
+    min-height: 0;
+}
+
+/* The board centres itself; the frame just reserves the column space. */
+.board-frame {
+    display: flex;
+    justify-content: center;
+    min-height: 0;
+}
+
+.board-stack {
+    position: relative;
+    width: min(100%, var(--board-max-width), var(--board-width-from-height));
+    min-height: 0;
+    aspect-ratio: var(--board-aspect-ratio);
+    overflow: visible;
+}
+
+.merge-board {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    border: 1px solid rgba(29, 74, 33, 0.18);
+    border-radius: 18px;
+    background:
+        linear-gradient(90deg, rgba(25, 58, 48, 0.045) 1px, transparent 1px),
+        linear-gradient(rgba(25, 58, 48, 0.045) 1px, transparent 1px),
+        radial-gradient(circle at 50% 18%, rgba(137, 209, 127, 0.2), transparent 38%),
+        linear-gradient(180deg, #f9fcf6, #e0eddf);
+    background-size:
+        44px 44px,
+        44px 44px,
+        auto,
+        auto;
+    box-shadow:
+        0 24px 60px rgba(24, 35, 23, 0.1),
+        inset 0 -16px 0 rgba(29, 74, 33, 0.06);
+    cursor: crosshair;
+    touch-action: manipulation;
+}
+
+.merge-board.is-crowded {
+    border-color: rgba(178, 111, 47, 0.6);
+    box-shadow:
+        0 24px 60px rgba(178, 111, 47, 0.16),
+        inset 0 -16px 0 rgba(178, 111, 47, 0.12);
+}
+
+.loss-line {
+    position: absolute;
+    right: 18px;
+    left: 18px;
+    z-index: 1;
+    height: 1px;
+    border-top: 1px dashed rgba(100, 28, 56, 0.4);
+    pointer-events: none;
+}
+
+.aim-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 2;
+    width: 1px;
+    background: linear-gradient(
+        180deg,
+        rgba(29, 74, 33, 0.34),
+        rgba(29, 74, 33, 0)
+    );
+    pointer-events: none;
+}
+
+/* ---- Pieces ---------------------------------------------------------- */
+
+.life-piece {
+    position: absolute;
+    z-index: 8;
+    left: var(--piece-x);
+    top: var(--piece-y);
+    width: var(--piece-size);
+    height: var(--piece-size);
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    transform: translate(-50%, -50%) rotate(var(--piece-rotate));
+    transform-origin: center;
+    cursor: pointer;
+    pointer-events: auto;
+    user-select: none;
+}
+
+/*
+ * Each .life-piece is its own stacking context, so a later sibling piece can
+ * paint over an earlier piece's label. Lift hovered/focused/pending pieces
+ * above every other piece so their label is never covered.
+ */
+.life-piece:hover,
+.life-piece:focus-visible,
+.life-piece.is-pending,
+.life-piece.is-labeled {
+    z-index: 50;
+}
+
+.drop-preview {
+    position: absolute;
+    z-index: 6;
+    left: var(--piece-x);
+    top: var(--piece-y);
+    width: var(--piece-size);
+    height: var(--piece-size);
+    opacity: 0.7;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+    transition: opacity 120ms ease;
+    user-select: none;
+}
+
+.drop-preview.is-waiting {
+    opacity: 0.34;
+}
+
+.life-piece::before {
+    position: absolute;
+    inset: 0;
+    display: block;
+    border: 2px solid var(--piece-ink);
+    border-radius: 999px;
+    background:
+        radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.46), transparent 26%),
+        var(--piece-color);
+    box-shadow:
+        0 14px 28px rgba(24, 35, 23, 0.18),
+        inset 0 -10px 18px rgba(0, 0, 0, 0.12);
+    content: "";
+}
+
+.drop-preview::before {
+    position: absolute;
+    inset: 0;
+    display: block;
+    border: 2px dashed var(--piece-ink);
+    border-radius: 999px;
+    background:
+        radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.46), transparent 26%),
+        var(--piece-color);
+    box-shadow: 0 10px 24px rgba(24, 35, 23, 0.14);
+    content: "";
+}
+
+.life-piece img,
+.drop-preview img {
+    position: absolute;
+    inset: 3%;
+    z-index: 2;
+    width: 94%;
+    height: 94%;
+    border-radius: 999px;
+    object-fit: cover;
+}
+
+.life-piece.is-generated::after {
+    position: absolute;
+    right: 9%;
+    bottom: 9%;
+    z-index: 3;
+    width: 16%;
+    height: 16%;
+    border: 2px solid rgba(255, 255, 255, 0.82);
+    border-radius: 999px;
+    background: #5ec7b2;
+    box-shadow: 0 2px 8px rgba(22, 76, 68, 0.3);
+    content: "";
+}
+
+.piece-spinner {
+    position: absolute;
+    inset: 16%;
+    z-index: 5;
+    border: 3px solid rgba(255, 255, 255, 0.44);
+    border-top-color: var(--piece-ink);
+    border-radius: 999px;
+    animation: spin 0.8s linear infinite;
+}
+
+.piece-label {
+    position: absolute;
+    top: var(--label-y);
+    left: var(--label-x);
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    width: max-content;
+    max-width: 220px;
+    overflow: visible;
+    padding: 4px 11px 5px;
+    border: 1px solid rgba(20, 32, 22, 0.1);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 6px 16px rgba(24, 35, 23, 0.16);
+    color: #142016;
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 1.15;
+    text-align: center;
+    transform: translate(-50%, -100%);
+    white-space: normal;
+    pointer-events: none;
+    /* Reveal-on-demand: landed labels stay hidden so the board doesn't fill
+       with overlapping pills. Only the just-landed/hovered piece (is-active)
+       or one mid-generation (is-pending) shows its label. */
+    opacity: 0;
+    transition: opacity 130ms ease;
+}
+
+.piece-label.is-active,
+.piece-label.is-pending {
+    z-index: 2;
+    opacity: 1;
+}
+
+.piece-label-layer {
+    position: absolute;
+    inset: 0;
+    z-index: 70;
+    overflow: visible;
+    pointer-events: none;
+}
+
+.piece-label-name {
+    display: block;
+    max-width: 100%;
+    overflow: visible;
+    overflow-wrap: anywhere;
+}
+
+.piece-label-status {
+    color: rgba(20, 32, 22, 0.6);
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.board-empty {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    display: grid;
+    place-content: center;
+    gap: 10px;
+    color: rgba(20, 32, 22, 0.4);
+    font-weight: 700;
+    text-align: center;
+    pointer-events: none;
+}
+
+.board-empty svg {
+    width: 48px;
+    height: 48px;
+    margin: 0 auto;
+}
+
+.drop-preview.is-hidden {
+    display: none;
+}
+
+/* ---- Start screen (pre-game world chooser, on the empty board) ------- */
+
+.board-start {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    /* Clicks fall through to the board so the first click can start the
+       game — only the buttons inside the card capture pointer events. */
+    pointer-events: none;
+}
+
+.board-start-card {
+    display: grid;
+    justify-items: center;
+    gap: 12px;
+    width: min(320px, 100%);
+    padding: 22px 20px;
+    border: 1px solid rgba(29, 74, 33, 0.14);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 18px 44px rgba(24, 35, 23, 0.16);
+    text-align: center;
+    pointer-events: auto;
+}
+
+.board-start-card > strong {
+    color: #142016;
+    font-size: 17px;
+}
+
+.board-start-hint {
+    color: #4e6253;
+    font-size: 12px;
+    font-weight: 700;
+}
+
+/* ---- Generation focus ------------------------------------------------ */
+
+.generation-focus {
+    display: grid;
+    box-sizing: border-box;
+    width: 100%;
+    gap: 9px;
+    padding: 14px;
+    border: 1px solid rgba(20, 32, 22, 0.1);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.94);
+}
+
+.generation-focus-head span {
+    color: #3c6c45;
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.generation-parents {
+    display: grid;
+    gap: 6px;
+}
+
+.generation-parent {
+    position: relative;
+    display: grid;
+    grid-template-columns: 38px minmax(0, 1fr);
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+}
+
+.generation-plus {
+    position: absolute;
+    top: -10px;
+    left: 13px;
+    color: #3c6c45;
+    font-size: 13px;
+    font-weight: 800;
+}
+
+.generation-parent img {
+    width: 38px;
+    height: 38px;
+    border: 1.5px solid rgba(29, 74, 33, 0.2);
+    border-radius: 999px;
+    object-fit: cover;
+}
+
+.generation-parent-text {
+    min-width: 0;
+}
+
+.generation-parent-text strong {
+    display: block;
+    overflow: hidden;
+    color: #142016;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.generation-parent-text p {
+    display: -webkit-box;
+    margin: 1px 0 0;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    color: #536255;
+    font-size: 11px;
+    line-height: 1.25;
+}
+
+.generation-result {
+    display: grid;
+    grid-template-columns: 48px minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+    margin-top: 2px;
+    padding-top: 9px;
+    border-top: 1px solid rgba(29, 74, 33, 0.12);
+}
+
+.generation-arrow {
+    position: absolute;
+    align-self: start;
+    margin-top: -16px;
+    color: #3c6c45;
+    font-size: 13px;
+    font-weight: 800;
+}
+
+.generation-result img {
+    width: 48px;
+    height: 48px;
+    border: 2px solid rgba(29, 74, 33, 0.28);
+    border-radius: 999px;
+    object-fit: cover;
+}
+
+.generation-result-text strong {
+    display: block;
+    color: #142016;
+    font-size: 14px;
+}
+
+.generation-result-text p {
+    margin: 1px 0 0;
+    color: #536255;
+    font-size: 11px;
+    line-height: 1.3;
+}
+
+.generation-pulse {
+    position: relative;
+    height: 3px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(94, 199, 178, 0.2);
+}
+
+.generation-pulse span {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -35%;
+    width: 35%;
+    border-radius: inherit;
+    background: #5ec7b2;
+    animation: progress-sweep 1s ease-in-out infinite;
+}
+
+/* ---- Topbar score (score + progress, beside Reset) ------------------- */
+
+.topbar-score {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.topbar-score strong {
+    color: #142016;
+    font-size: 16px;
+    line-height: 1;
+}
+
+.topbar-score small {
+    color: #4e6253;
+    font-size: 12px;
+}
+
+/* ---- Sidebar cards --------------------------------------------------- */
+
+.side-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.selected-card,
+.legend-card {
+    padding: 14px;
+    border: 1px solid rgba(29, 74, 33, 0.12);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.78);
+}
+
+/* ---- Selected piece inspector (icon + name + description) ------------ */
+
+/* Stacked: a large image on its own line, name + description underneath. */
+.selected-card {
+    display: grid;
+    gap: 12px;
+}
+
+.selected-icon {
+    position: relative;
+    /* A big square that fills the card width — the image gets real space. */
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    overflow: hidden;
+    border: 2px solid var(--piece-ink);
+    border-radius: 18px;
+    background: var(--piece-color);
+}
+
+.selected-icon img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.selected-text {
+    min-width: 0;
+    text-align: center;
+}
+
+.selected-text strong {
+    display: block;
+    color: #142016;
+    font-size: 17px;
+}
+
+.selected-text p {
+    margin: 5px 0 0;
+    color: #4e6253;
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.selected-parents {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    margin-top: 8px;
+    color: #607164;
+    font-size: 12px;
+    line-height: 1.2;
+}
+
+.selected-parents b {
+    min-width: 0;
+    max-width: 42%;
+    overflow: hidden;
+    color: #2f6b3e;
+    font-weight: 800;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ---- Legend (icon → name for the objects in play) ------------------- */
+
+.legend-card header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.legend-card header strong {
+    color: #142016;
+    font-size: 15px;
+}
+
+.legend-card header small {
+    color: #4e6253;
+    font-size: 12px;
+}
+
+.legend-list {
+    display: grid;
+    gap: 2px;
+    max-height: 240px;
+    margin: 0;
+    overflow: auto;
+    padding: 0;
+    list-style: none;
+}
+
+.legend-row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    padding: 4px 6px;
+    border: 0;
+    border-radius: 9px;
+    background: transparent;
+    color: #142016;
+    cursor: pointer;
+    text-align: left;
+}
+
+.legend-row:hover,
+.legend-row:focus-visible {
+    background: rgba(47, 107, 62, 0.1);
+}
+
+.legend-icon {
+    position: relative;
+    flex: 0 0 auto;
+    width: 26px;
+    height: 26px;
+    overflow: hidden;
+    border: 1.5px solid var(--piece-ink);
+    border-radius: 999px;
+    background: var(--piece-color);
+}
+
+.legend-icon img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.legend-name {
+    min-width: 0;
+    overflow: hidden;
+    font-size: 13px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ---- Animations ------------------------------------------------------ */
+
+@keyframes spin {
+    to {
+        transform: rotate(1turn);
+    }
+}
+
+@keyframes progress-sweep {
+    to {
+        left: 100%;
+    }
+}
+
+/* ---- Responsive ------------------------------------------------------ */
+
+/* Same layout at every width — board left, cards right. The side column
+   just gets narrower; nothing reflows or stacks. */
+@media (max-width: 1040px) {
+    .game-layout {
+        grid-template-columns: minmax(0, 1fr) 260px;
+        gap: 16px;
+    }
+}
+
+@media (max-width: 640px) {
+    .topbar {
+        gap: 8px;
+        padding: 10px 12px;
+    }
+
+    .topbar-actions {
+        gap: 6px;
+    }
+
+    /* Drop the least-essential topbar items so it doesn't crowd on phones —
+       Reset, balance and the user menu stay. */
+    .topbar-score {
+        display: none;
+    }
+
+    .game-layout {
+        grid-template-columns: minmax(0, 1fr) 180px;
+        padding: 14px;
+        gap: 12px;
+    }
+
+    .piece-label {
+        max-width: 140px;
+        font-size: 13px;
+    }
+}
+
+/* ---- Figure pieces (cutout sprite + convex-hull physics) -------------- */
+
+/*
+ * A figure piece's element is centered on the physics hull centroid and
+ * sized to the scaled sprite; the sprite itself is shifted by the
+ * centroid→sprite-center offset so pixels line up with the hull.
+ */
+.life-piece.is-figure,
+.drop-preview.is-figure {
+    width: var(--figure-w);
+    height: var(--figure-h);
+}
+
+.life-piece.is-figure::before,
+.drop-preview.is-figure::before,
+.life-piece.is-figure.is-generated::after {
+    display: none;
+}
+
+.life-piece.is-figure img,
+.drop-preview.is-figure img {
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+    object-fit: fill;
+    transform: translate(var(--figure-dx), var(--figure-dy));
+    filter: drop-shadow(0 10px 14px rgba(24, 35, 23, 0.28));
+}
+
+/* ---- Brainrot chrome --------------------------------------------------- */
+
+.board-start-emoji {
+    font-size: 26px;
+    letter-spacing: 5px;
+}
+
+.selected-catchphrase {
+    display: block;
+    margin: 2px 0 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    font-style: italic;
+    font-size: 13px;
+    line-height: 1.35;
+    opacity: 0.85;
+    text-align: left;
+    cursor: pointer;
+}
+
+.selected-catchphrase:hover {
+    opacity: 1;
+}

--- a/apps/brainrot-merge/src/brainrot.ts
+++ b/apps/brainrot-merge/src/brainrot.ts
@@ -1,0 +1,225 @@
+import type { FigureData } from "./figure";
+
+export type Rung = {
+    id: string;
+    radius: number;
+    color: string;
+    ink: string;
+};
+
+export type LineageNode = {
+    name: string;
+    description: string;
+    parents?: [LineageNode, LineageNode];
+};
+
+export type Specimen = {
+    name: string;
+    description: string;
+    imagePrompt: string;
+    imageUrl?: string;
+    lineage?: LineageNode;
+    /** Dramatic Italian intro line, spoken aloud on discovery. */
+    catchphrase?: string;
+    /** Cutout sprite + convex hull; circle physics when absent. */
+    figure?: FigureData;
+};
+
+export type GamePiece = Specimen & {
+    id: string;
+    tier: number;
+    radius: number;
+    color: string;
+    ink: string;
+    x: number;
+    y: number;
+    angle: number;
+    pending: boolean;
+    generated: boolean;
+    lineage: LineageNode;
+    parents?: [string, string];
+};
+
+export type TierPhysics = {
+    density: number;
+    restitution: number;
+    friction: number;
+};
+
+export const SUIKA_RADII = [
+    16.5, 24, 30.5, 34.5, 44.5, 57, 64.5, 78, 88.5, 110, 129.5,
+] as const;
+
+const SUIKA_TIER_PHYSICS: TierPhysics[] = [
+    { density: 0.82, restitution: 0.08, friction: 0.32 },
+    { density: 0.86, restitution: 0.075, friction: 0.34 },
+    { density: 0.9, restitution: 0.07, friction: 0.36 },
+    { density: 0.94, restitution: 0.065, friction: 0.38 },
+    { density: 0.98, restitution: 0.06, friction: 0.4 },
+    { density: 1.02, restitution: 0.055, friction: 0.42 },
+    { density: 1.06, restitution: 0.05, friction: 0.44 },
+    { density: 1.1, restitution: 0.045, friction: 0.46 },
+    { density: 1.14, restitution: 0.04, friction: 0.48 },
+    { density: 1.18, restitution: 0.035, friction: 0.5 },
+    { density: 1.22, restitution: 0.03, friction: 0.52 },
+];
+
+// Tricolore-leaning ladder: greens → creams → reds as tiers climb.
+const LADDER_COLORS = [
+    ["#7fbf6c", "#1d4a21"],
+    ["#5ba85a", "#163d1c"],
+    ["#9ecf8a", "#2c4515"],
+    ["#e8dfc7", "#5d4a13"],
+    ["#f0e6cf", "#5d3613"],
+    ["#f3d9a8", "#594512"],
+    ["#e8b07a", "#5d3613"],
+    ["#dd8a66", "#641c1c"],
+    ["#d66c5c", "#681f1f"],
+    ["#c94f44", "#5e1414"],
+    ["#b8312e", "#4f0e0e"],
+] as const;
+
+// Base ingredients, not finished characters: famous brainrot creatures are
+// themselves hybrids (shark + sneakers, crocodile + bomber, ballerina +
+// cappuccino), so character discovery happens through play.
+export const BRAINROT_SEEDS: Specimen[] = [
+    {
+        name: "Squalo",
+        description: "A great white shark dreaming of dry land.",
+        imagePrompt: "a great white shark, full body side view",
+    },
+    {
+        name: "Sneakers",
+        description: "A pair of blue sneakers with nobody inside them.",
+        imagePrompt: "a pair of blue sneakers, side view",
+    },
+    {
+        name: "Cappuccino",
+        description: "A foamy cappuccino that refuses to be decaf.",
+        imagePrompt: "a cappuccino cup with thick milk foam",
+    },
+    {
+        name: "Coccodrillo",
+        description: "A crocodile with suspiciously big plans.",
+        imagePrompt: "a green crocodile, full body side view",
+    },
+    {
+        name: "Aereo",
+        description: "A propeller airplane looking for a new body.",
+        imagePrompt: "a vintage twin-propeller airplane, side view",
+    },
+    {
+        name: "Banana",
+        description: "A ripe banana of unusual confidence.",
+        imagePrompt: "a single ripe yellow banana",
+    },
+    {
+        name: "Scimmia",
+        description: "A chimpanzee ready to fuse with anything.",
+        imagePrompt: "a chimpanzee standing upright, full body",
+    },
+    {
+        name: "Ballerina",
+        description: "A ballerina spinning toward her destiny.",
+        imagePrompt: "a ballerina in a tutu mid-pirouette, full body",
+    },
+];
+
+export const RUNGS: Rung[] = SUIKA_RADII.map((radius, index) => ({
+    id: `layer-${index + 1}`,
+    radius,
+    color: LADDER_COLORS[index]?.[0] ?? LADDER_COLORS[0][0],
+    ink: LADDER_COLORS[index]?.[1] ?? LADDER_COLORS[0][1],
+}));
+
+export function createId(prefix = "piece") {
+    if (globalThis.crypto?.randomUUID) {
+        return `${prefix}-${globalThis.crypto.randomUUID()}`;
+    }
+    return `${prefix}-${Date.now().toString(36)}-${Math.random()
+        .toString(36)
+        .slice(2)}`;
+}
+
+export function sample<T>(items: readonly T[]): T {
+    return items[Math.floor(Math.random() * items.length)] ?? items[0];
+}
+
+export function tierPhysics(tier: number) {
+    const index = Math.min(Math.max(0, tier), SUIKA_TIER_PHYSICS.length - 1);
+    return SUIKA_TIER_PHYSICS[index] ?? SUIKA_TIER_PHYSICS[0];
+}
+
+/**
+ * Uniform scale from figure sprite space to board space so the hull's area
+ * equals the tier circle's area — shapes change how pieces rest and stack,
+ * never how much board space a tier is worth.
+ */
+export function figureScale(radius: number, figure: FigureData) {
+    return radius * Math.sqrt(Math.PI / figure.area);
+}
+
+export function lineageLeaf(specimen: Specimen): LineageNode {
+    return {
+        name: specimen.name,
+        description: specimen.description,
+    };
+}
+
+export function mergeLineage(
+    specimen: Specimen,
+    parents: [GamePiece, GamePiece],
+): LineageNode {
+    return {
+        name: specimen.name,
+        description: specimen.description,
+        parents: [parents[0].lineage, parents[1].lineage],
+    };
+}
+
+export function createSeedSpecimen(): Specimen {
+    return { ...sample(BRAINROT_SEEDS) };
+}
+
+export function createLoadingSpecimen(
+    name: string,
+    description: string,
+): Specimen {
+    return {
+        name,
+        description,
+        imagePrompt: name,
+    };
+}
+
+export function createGamePiece(
+    tier: number,
+    options: {
+        id?: string;
+        specimen: Specimen;
+        parents?: [string, string];
+        pending?: boolean;
+        generated?: boolean;
+        x?: number;
+        y?: number;
+        angle?: number;
+    },
+): GamePiece {
+    const rung = RUNGS[tier] ?? RUNGS[0];
+    const lineage = options.specimen.lineage ?? lineageLeaf(options.specimen);
+    return {
+        ...options.specimen,
+        id: options.id ?? createId(rung.id),
+        lineage,
+        tier,
+        radius: rung.radius,
+        color: rung.color,
+        ink: rung.ink,
+        x: options.x ?? 0,
+        y: options.y ?? 0,
+        angle: options.angle ?? 0,
+        pending: options.pending ?? false,
+        generated: options.generated ?? false,
+        parents: options.parents,
+    };
+}

--- a/apps/brainrot-merge/src/figure.ts
+++ b/apps/brainrot-merge/src/figure.ts
@@ -1,0 +1,269 @@
+// Figure extraction for "figure" piece styles (e.g. the Brainrot preset).
+//
+// Generated images arrive as photos of a single character on a plain white
+// background. This module turns one into:
+//   1. a cutout sprite (background made transparent) for rendering, and
+//   2. a simplified convex-hull polygon for the physics body.
+//
+// The hull is area-normalized by the caller (useGameEngine) so a piece's
+// physical footprint always matches its tier — shapes change how pieces
+// rest and stack, never how much space a tier is worth.
+
+export type FigureData = {
+    /** Object URL of the cutout sprite (transparent background PNG). */
+    cutoutUrl: string;
+    /**
+     * Convex hull of the figure in sprite pixel space, centered on the hull
+     * centroid (so the polygon's centroid is at 0,0), wound clockwise.
+     */
+    vertices: Array<{ x: number; y: number }>;
+    /** Hull area in sprite pixel space (for tier normalization). */
+    area: number;
+    /** Sprite size in pixels (square source images). */
+    spriteSize: { width: number; height: number };
+    /**
+     * Offset from the hull centroid to the sprite's center, in sprite pixel
+     * space. Lets the renderer align the sprite with the physics body.
+     */
+    spriteOffset: { x: number; y: number };
+};
+
+const BG_TOLERANCE = 42;
+const MAX_HULL_VERTICES = 12;
+// Reject extractions that are implausibly empty/full — likely a busy
+// background or a failed generation; the caller falls back to circles.
+const MIN_FG_FRACTION = 0.04;
+const MAX_FG_FRACTION = 0.82;
+const ANALYSIS_SIZE = 128;
+
+type Point = { x: number; y: number };
+
+function cross(o: Point, a: Point, b: Point) {
+    return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+}
+
+// Andrew's monotone chain. Input order does not matter.
+function convexHull(points: Point[]): Point[] {
+    const sorted = [...points].sort((p, q) => p.x - q.x || p.y - q.y);
+    if (sorted.length <= 3) return sorted;
+    const lower: Point[] = [];
+    for (const p of sorted) {
+        while (
+            lower.length >= 2 &&
+            cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0
+        ) {
+            lower.pop();
+        }
+        lower.push(p);
+    }
+    const upper: Point[] = [];
+    for (let i = sorted.length - 1; i >= 0; i -= 1) {
+        const p = sorted[i];
+        while (
+            upper.length >= 2 &&
+            cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0
+        ) {
+            upper.pop();
+        }
+        upper.push(p);
+    }
+    lower.pop();
+    upper.pop();
+    return [...lower, ...upper];
+}
+
+// Repeatedly drop the vertex whose removal loses the least area until the
+// hull is small enough for a stable physics body.
+function simplifyHull(hull: Point[], maxVertices: number): Point[] {
+    const poly = [...hull];
+    while (poly.length > maxVertices) {
+        let bestIndex = 0;
+        let bestLoss = Number.POSITIVE_INFINITY;
+        for (let i = 0; i < poly.length; i += 1) {
+            const a = poly[(i - 1 + poly.length) % poly.length];
+            const b = poly[i];
+            const c = poly[(i + 1) % poly.length];
+            const loss = Math.abs(cross(a, b, c)) / 2;
+            if (loss < bestLoss) {
+                bestLoss = loss;
+                bestIndex = i;
+            }
+        }
+        poly.splice(bestIndex, 1);
+    }
+    return poly;
+}
+
+function polygonArea(poly: Point[]) {
+    let sum = 0;
+    for (let i = 0; i < poly.length; i += 1) {
+        const a = poly[i];
+        const b = poly[(i + 1) % poly.length];
+        sum += a.x * b.y - b.x * a.y;
+    }
+    return Math.abs(sum) / 2;
+}
+
+function polygonCentroid(poly: Point[]): Point {
+    let area = 0;
+    let cx = 0;
+    let cy = 0;
+    for (let i = 0; i < poly.length; i += 1) {
+        const a = poly[i];
+        const b = poly[(i + 1) % poly.length];
+        const f = a.x * b.y - b.x * a.y;
+        area += f;
+        cx += (a.x + b.x) * f;
+        cy += (a.y + b.y) * f;
+    }
+    area /= 2;
+    if (area === 0) return poly[0] ?? { x: 0, y: 0 };
+    return { x: cx / (6 * area), y: cy / (6 * area) };
+}
+
+// Foreground mask via flood fill from the image borders over near-background
+// pixels. Filling from the borders (rather than thresholding everywhere)
+// keeps light areas inside the figure — a shark's white belly stays opaque.
+function buildForegroundMask(
+    data: Uint8ClampedArray,
+    width: number,
+    height: number,
+) {
+    const sampleBackground = () => {
+        let r = 0;
+        let g = 0;
+        let b = 0;
+        let count = 0;
+        const margin = Math.max(2, Math.floor(width * 0.02));
+        for (let y = 0; y < height; y += 1) {
+            const edgeRow = y < margin || y >= height - margin;
+            for (let x = 0; x < width; x += 1) {
+                if (!edgeRow && x >= margin && x < width - margin) continue;
+                const i = (y * width + x) * 4;
+                r += data[i];
+                g += data[i + 1];
+                b += data[i + 2];
+                count += 1;
+            }
+        }
+        return { r: r / count, g: g / count, b: b / count };
+    };
+
+    const bg = sampleBackground();
+    const isBackground = (index: number) => {
+        const i = index * 4;
+        const dr = data[i] - bg.r;
+        const dg = data[i + 1] - bg.g;
+        const db = data[i + 2] - bg.b;
+        return Math.sqrt(dr * dr + dg * dg + db * db) < BG_TOLERANCE;
+    };
+
+    const removed = new Uint8Array(width * height);
+    const queue: number[] = [];
+    const push = (index: number) => {
+        if (!removed[index] && isBackground(index)) {
+            removed[index] = 1;
+            queue.push(index);
+        }
+    };
+    for (let x = 0; x < width; x += 1) {
+        push(x);
+        push((height - 1) * width + x);
+    }
+    for (let y = 0; y < height; y += 1) {
+        push(y * width);
+        push(y * width + width - 1);
+    }
+    while (queue.length > 0) {
+        const index = queue.pop() as number;
+        const x = index % width;
+        const y = (index - x) / width;
+        if (x > 0) push(index - 1);
+        if (x < width - 1) push(index + 1);
+        if (y > 0) push(index - width);
+        if (y < height - 1) push(index + width);
+    }
+    return removed;
+}
+
+/**
+ * Extract a cutout sprite and a simplified convex-hull collider from a
+ * generated figure image. Returns null when the image does not look like a
+ * single figure on a plain background — callers then keep circle physics
+ * and token rendering.
+ */
+export async function extractFigure(
+    imageBlob: Blob,
+): Promise<FigureData | null> {
+    try {
+        const bitmap = await createImageBitmap(imageBlob);
+        const width = bitmap.width;
+        const height = bitmap.height;
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const context = canvas.getContext("2d");
+        if (!context) return null;
+        context.drawImage(bitmap, 0, 0);
+        bitmap.close();
+
+        const image = context.getImageData(0, 0, width, height);
+        const removed = buildForegroundMask(image.data, width, height);
+
+        // Hull from a downsampled grid of foreground pixels — the hull of a
+        // sparse sample is visually identical and far cheaper than using
+        // every pixel.
+        const step = Math.max(1, Math.floor(width / ANALYSIS_SIZE));
+        const samples: Point[] = [];
+        let foregroundCount = 0;
+        for (let y = 0; y < height; y += 1) {
+            for (let x = 0; x < width; x += 1) {
+                if (removed[y * width + x]) continue;
+                foregroundCount += 1;
+                if (x % step === 0 && y % step === 0) {
+                    samples.push({ x, y });
+                }
+            }
+        }
+        const foregroundFraction = foregroundCount / (width * height);
+        if (
+            foregroundFraction < MIN_FG_FRACTION ||
+            foregroundFraction > MAX_FG_FRACTION ||
+            samples.length < 8
+        ) {
+            return null;
+        }
+
+        const hull = simplifyHull(convexHull(samples), MAX_HULL_VERTICES);
+        if (hull.length < 3) return null;
+        const area = polygonArea(hull);
+        if (area <= 0) return null;
+        const centroid = polygonCentroid(hull);
+
+        for (let index = 0; index < removed.length; index += 1) {
+            if (removed[index]) image.data[index * 4 + 3] = 0;
+        }
+        context.putImageData(image, 0, 0);
+        const cutoutBlob = await new Promise<Blob | null>((resolve) => {
+            canvas.toBlob(resolve, "image/png");
+        });
+        if (!cutoutBlob) return null;
+
+        return {
+            cutoutUrl: URL.createObjectURL(cutoutBlob),
+            vertices: hull.map((p) => ({
+                x: p.x - centroid.x,
+                y: p.y - centroid.y,
+            })),
+            area,
+            spriteSize: { width, height },
+            spriteOffset: {
+                x: width / 2 - centroid.x,
+                y: height / 2 - centroid.y,
+            },
+        };
+    } catch {
+        return null;
+    }
+}

--- a/apps/brainrot-merge/src/generation.ts
+++ b/apps/brainrot-merge/src/generation.ts
@@ -1,0 +1,256 @@
+import type { Specimen } from "./brainrot";
+import { extractFigure } from "./figure";
+
+const API_BASE = "https://gen.pollinations.ai";
+const TEXT_MODEL = "claude";
+const IMAGE_MODEL = "zimage";
+const VOICE_MODEL = "elevenlabs";
+// The canonical brainrot narrator: a deep, theatrical Italian male delivery.
+const VOICE_NAME = "adam";
+const TEXT_THINKING_BUDGET = 1024;
+
+type GeneratedPayload = {
+    name?: unknown;
+    description?: unknown;
+    imagePrompt?: unknown;
+    catchphrase?: unknown;
+};
+
+// The meme's canonical lines are blasphemous; generated ones must not be.
+// Defense in depth on top of the prompt instructions: a flagged catchphrase
+// is replaced, never spoken.
+const CATCHPHRASE_BLOCKLIST =
+    /porco\s*dio|porco\s*all|dio\s+(cane|porco)|porca\s+madonna|madonna\s+(cane|porca)|cazz|fottut|stronz|merd|vaffancul|puttan|bestemmi|gaza|palestin/i;
+
+function textValue(value: unknown, maxLength: number) {
+    if (typeof value !== "string") return null;
+    const cleaned = value.replace(/\s+/g, " ").trim();
+    if (!cleaned) return null;
+    return cleaned.slice(0, maxLength);
+}
+
+function catchphraseValue(value: unknown, name: string) {
+    const text = textValue(value, 140);
+    if (!text || CATCHPHRASE_BLOCKLIST.test(text)) {
+        return `Mamma mia! ${name}!`;
+    }
+    return text;
+}
+
+function nameValue(value: unknown) {
+    const text = textValue(value, 36);
+    if (!text) return null;
+    const cleaned = text
+        .replace(/[^a-zA-ZÀ-ÿ0-9 -]/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+    if (!cleaned) return null;
+    const words = cleaned
+        .split(/[\s-]+/)
+        .filter(Boolean)
+        .slice(0, 4);
+    if (words.length === 0 || words.some((word) => word.length > 14)) {
+        return null;
+    }
+    return words.join(" ");
+}
+
+function buildUserPrompt(args: {
+    left: Pick<Specimen, "name" | "description">;
+    right: Pick<Specimen, "name" | "description">;
+}) {
+    return [
+        `Parent A: ${args.left.name} — ${args.left.description}`,
+        `Parent B: ${args.right.name} — ${args.right.description}`,
+        "Invent one NEW Italian brainrot character by fusing the two parents into a single absurd hybrid creature.",
+        "The order of the parents does not matter; both must be physically visible in the hybrid.",
+        "Name grammar (follow exactly): 2-3 pseudo-Italian words. The main words must rhyme or share their final syllable. Italianize every word: end in a vowel, double a consonant, use suffixes like -ino, -ini, -ina, -ello, -illo, -oni, -etto. Optionally start with a repeated onomatopoeia of the sound it makes.",
+        "Good name shapes: Bombardiro Crocodilo, Chimpanzini Bananini, Trippi Troppi, Brr Brr Patapim.",
+        "Do NOT copy existing famous brainrot character names; invent a new one in the same style.",
+        "The description is one absurd deadpan English sentence of lore about the character, under 80 chars.",
+        "The catchphrase is its dramatic Italian intro line, 6-16 words: start by chanting the name, then describe the creature with total operatic seriousness. It may declare its parentage (figlio di ... e ...). Simple Italian, present tense.",
+        "The catchphrase must be family-friendly: absolutely no blasphemy, profanity, religion, war, real people, or real brands.",
+        "The imagePrompt describes the hybrid creature plainly in English: which animal and object are fused, body parts, what it wears. 10-18 words.",
+        'Return JSON: {"name":"2-3 pseudo-Italian words","description":"one absurd English sentence under 80 chars","imagePrompt":"plain visual description of the hybrid creature, 10-18 words","catchphrase":"dramatic Italian intro, 6-16 words"}',
+    ].join("\n");
+}
+
+function promptSeed(value: string) {
+    let hash = 0;
+    for (let index = 0; index < value.length; index += 1) {
+        hash = Math.imul(31, hash) + value.charCodeAt(index);
+    }
+    return String(Math.abs(hash) % 2147483647);
+}
+
+function parseJsonObject(text: string): GeneratedPayload {
+    try {
+        return JSON.parse(text) as GeneratedPayload;
+    } catch {
+        const match = text.match(/\{[\s\S]*\}/);
+        if (!match) return {};
+        try {
+            return JSON.parse(match[0]) as GeneratedPayload;
+        } catch {
+            return {};
+        }
+    }
+}
+
+async function apiError(response: Response) {
+    try {
+        const payload = (await response.json()) as {
+            error?: { message?: string };
+            message?: string;
+        };
+        return (
+            payload.error?.message ??
+            payload.message ??
+            `${response.status} ${response.statusText}`
+        );
+    } catch {
+        return `${response.status} ${response.statusText}`;
+    }
+}
+
+export async function generateSpecimen(args: {
+    apiKey: string;
+    parents: [
+        Pick<Specimen, "name" | "description">,
+        Pick<Specimen, "name" | "description">,
+    ];
+}): Promise<Specimen> {
+    const [left, right] = args.parents;
+
+    const textResponse = await fetch(`${API_BASE}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${args.apiKey}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model: TEXT_MODEL,
+            response_format: { type: "json_object" },
+            temperature: 0,
+            max_tokens: 1800,
+            thinking: {
+                type: "enabled",
+                budget_tokens: TEXT_THINKING_BUDGET,
+            },
+            thinking_budget: TEXT_THINKING_BUDGET,
+            messages: [
+                {
+                    role: "system",
+                    content:
+                        "You invent Italian brainrot characters for a physics merge game. Return only valid JSON.",
+                },
+                {
+                    role: "user",
+                    content: buildUserPrompt({ left, right }),
+                },
+            ],
+        }),
+    });
+
+    if (!textResponse.ok) {
+        throw new Error(await apiError(textResponse));
+    }
+
+    const textPayload = (await textResponse.json()) as {
+        choices?: Array<{ message?: { content?: string | null } }>;
+    };
+    const payload = parseJsonObject(
+        textPayload.choices?.[0]?.message?.content ?? "",
+    );
+    const name = nameValue(payload.name);
+    const description = textValue(payload.description, 80);
+    const imagePrompt = textValue(payload.imagePrompt, 360);
+    if (!name || !description || !imagePrompt) {
+        throw new Error("Model returned incomplete character details.");
+    }
+
+    return generateImageSpecimen({
+        apiKey: args.apiKey,
+        specimen: {
+            name,
+            description,
+            imagePrompt,
+            catchphrase: catchphraseValue(payload.catchphrase, name),
+        },
+    });
+}
+
+export async function generateImageSpecimen(args: {
+    apiKey: string;
+    specimen: Specimen;
+}): Promise<Specimen> {
+    // Subject first so the diffusion model anchors on the creature. The plain
+    // white background is load-bearing: figure.ts cuts the sprite out of it
+    // and builds the physics hull from the silhouette.
+    const subject = args.specimen.imagePrompt || args.specimen.name;
+    const imagePrompt = [
+        subject,
+        `a depiction of ${args.specimen.name}`,
+        "one single character, whole figure fully visible",
+        "full body shot, centered, feet and all extremities inside the frame",
+        "isolated on a plain solid white background",
+        "hyperrealistic photo, glossy 3d-render look, oversaturated colors",
+        "bright studio lighting, slightly uncanny viral AI meme aesthetic",
+        "no text, no watermark",
+    ].join(", ");
+
+    const imageParams = new URLSearchParams({
+        model: IMAGE_MODEL,
+        width: "512",
+        height: "512",
+        nologo: "true",
+        safe: "true",
+        seed: promptSeed(imagePrompt),
+    });
+    const imageResponse = await fetch(
+        `${API_BASE}/image/${encodeURIComponent(imagePrompt)}?${imageParams}`,
+        {
+            headers: {
+                Authorization: `Bearer ${args.apiKey}`,
+            },
+        },
+    );
+
+    if (!imageResponse.ok) {
+        throw new Error(await apiError(imageResponse));
+    }
+
+    const imageBlob = await imageResponse.blob();
+    const figure = await extractFigure(imageBlob);
+
+    return {
+        ...args.specimen,
+        imagePrompt,
+        imageUrl: URL.createObjectURL(imageBlob),
+        figure: figure ?? undefined,
+    };
+}
+
+/** Speak a catchphrase aloud: resolves to an object URL of the mp3. */
+export async function generateVoiceLine(args: {
+    apiKey: string;
+    text: string;
+}): Promise<string> {
+    const voiceParams = new URLSearchParams({
+        model: VOICE_MODEL,
+        voice: VOICE_NAME,
+    });
+    const response = await fetch(
+        `${API_BASE}/audio/${encodeURIComponent(`[dramatic] ${args.text}`)}?${voiceParams}`,
+        {
+            headers: {
+                Authorization: `Bearer ${args.apiKey}`,
+            },
+        },
+    );
+    if (!response.ok) {
+        throw new Error(await apiError(response));
+    }
+    const blob = await response.blob();
+    return URL.createObjectURL(blob);
+}

--- a/apps/brainrot-merge/src/generation.ts
+++ b/apps/brainrot-merge/src/generation.ts
@@ -18,9 +18,16 @@ type GeneratedPayload = {
 
 // The meme's canonical lines are blasphemous; generated ones must not be.
 // Defense in depth on top of the prompt instructions: a flagged catchphrase
-// is replaced, never spoken.
+// is replaced and a flagged name is rejected, never spoken. \W* tolerates
+// hyphens/punctuation between tokens and d?dio catches compound spellings
+// like "porcoddio"; isBlocked strips diacritics first ("pòrco dìo").
 const CATCHPHRASE_BLOCKLIST =
-    /porco\s*dio|porco\s*all|dio\s+(cane|porco)|porca\s+madonna|madonna\s+(cane|porca)|cazz|fottut|stronz|merd|vaffancul|puttan|bestemmi|gaza|palestin/i;
+    /porco\W*d?dio|porco\W*all|d?dio\W*(cane|porco|bestia|boia)|porca\W*(madonna|troia)|madonna\W*(cane|porca|troia)|troi|cazz|fottut|stronz|merd|vaffancul|puttan|coglion|minchi|bestemmi|gaza|palestin/i;
+
+function isBlocked(value: string) {
+    const probe = value.normalize("NFD").replace(/[̀-ͯ]/g, "");
+    return CATCHPHRASE_BLOCKLIST.test(probe);
+}
 
 function textValue(value: unknown, maxLength: number) {
     if (typeof value !== "string") return null;
@@ -31,7 +38,7 @@ function textValue(value: unknown, maxLength: number) {
 
 function catchphraseValue(value: unknown, name: string) {
     const text = textValue(value, 140);
-    if (!text || CATCHPHRASE_BLOCKLIST.test(text)) {
+    if (!text || isBlocked(text)) {
         return `Mamma mia! ${name}!`;
     }
     return text;
@@ -44,7 +51,7 @@ function nameValue(value: unknown) {
         .replace(/[^a-zA-ZÀ-ÿ0-9 -]/g, "")
         .replace(/\s+/g, " ")
         .trim();
-    if (!cleaned) return null;
+    if (!cleaned || isBlocked(cleaned)) return null;
     const words = cleaned
         .split(/[\s-]+/)
         .filter(Boolean)

--- a/apps/brainrot-merge/src/main.tsx
+++ b/apps/brainrot-merge/src/main.tsx
@@ -1,0 +1,16 @@
+import "./app.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+    throw new Error("Missing #root element");
+}
+
+createRoot(rootElement).render(
+    <StrictMode>
+        <App />
+    </StrictMode>,
+);

--- a/apps/brainrot-merge/src/useGameEngine.ts
+++ b/apps/brainrot-merge/src/useGameEngine.ts
@@ -1,0 +1,1000 @@
+import {
+    Bodies,
+    Body,
+    Composite,
+    Engine,
+    Events,
+    type IEventCollision,
+    Runner,
+} from "matter-js";
+import {
+    type PointerEvent as ReactPointerEvent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import {
+    createGamePiece,
+    createLoadingSpecimen,
+    createSeedSpecimen,
+    figureScale,
+    type GamePiece,
+    type LineageNode,
+    mergeLineage,
+    RUNGS,
+    type Specimen,
+    sample,
+    tierPhysics,
+} from "./brainrot";
+import type { FigureData } from "./figure";
+import {
+    generateImageSpecimen,
+    generateSpecimen,
+    generateVoiceLine,
+} from "./generation";
+
+// Matter runs in this fixed logical space. The rendered board may be smaller;
+// App.tsx scales positions/radii with `viewScale` instead of resizing physics.
+const BOARD_LOGICAL_SIZE = { width: 600, height: 900 };
+const BOARD_FALLBACK = BOARD_LOGICAL_SIZE;
+export const BOARD_ASPECT_RATIO = `${BOARD_LOGICAL_SIZE.width} / ${BOARD_LOGICAL_SIZE.height}`;
+export const BOARD_MAX_WIDTH = `${BOARD_LOGICAL_SIZE.width}px`;
+export const BOARD_WIDTH_FROM_HEIGHT = `calc(var(--board-max-height) * ${
+    BOARD_LOGICAL_SIZE.width / BOARD_LOGICAL_SIZE.height
+})`;
+export const LOSS_LINE = 100;
+export const DROP_Y = 70;
+const MAX_PIECES = 50;
+const MAX_SPAWN_TIER = 4;
+const MIN_SPAWN_VARIANTS_PER_TIER = 2;
+const SPAWN_TIER_WEIGHTS = [55, 30, 12, 3, 1] as const;
+const WALL_THICKNESS = 180;
+const FLOOR_THICKNESS = 240;
+const BOARD_EDGE_GAP = 2;
+
+function uniqueSpecimensByName(specimens: Specimen[]) {
+    const seen = new Set<string>();
+    return specimens.filter((specimen) => {
+        const key = specimen.name.trim().toLowerCase();
+        if (!key || seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+}
+
+function weightedTierSample(tiers: number[]) {
+    const total = tiers.reduce(
+        (sum, tier) => sum + (SPAWN_TIER_WEIGHTS[tier] ?? 1),
+        0,
+    );
+    let roll = Math.random() * total;
+    for (const tier of tiers) {
+        roll -= SPAWN_TIER_WEIGHTS[tier] ?? 1;
+        if (roll <= 0) return tier;
+    }
+    return tiers[0] ?? 0;
+}
+
+function clampCenter(value: number, radius: number, extent: number) {
+    const min = radius + BOARD_EDGE_GAP;
+    const max = extent - radius - BOARD_EDGE_GAP;
+    if (max <= min) return extent / 2;
+    return Math.min(Math.max(value, min), max);
+}
+
+function clampPieceCenter(
+    piece: Pick<GamePiece, "radius">,
+    x: number,
+    y: number,
+    size: { width: number; height: number },
+) {
+    return {
+        x: clampCenter(x, piece.radius, size.width),
+        y: clampCenter(y, piece.radius, size.height),
+    };
+}
+
+function cacheText(value: string) {
+    return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function canonicalParents<T extends Pick<Specimen, "name" | "description">>(
+    parents: [T, T],
+): [T, T] {
+    const [left, right] = parents;
+    const leftKey = `${cacheText(left.name)}\n${cacheText(left.description)}`;
+    const rightKey = `${cacheText(right.name)}\n${cacheText(right.description)}`;
+    return leftKey.localeCompare(rightKey) <= 0 ? parents : [right, left];
+}
+
+// Image generation can lag behind play; only merge placeholders are unknown.
+function isResolvingIdentity(piece: Pick<GamePiece, "pending" | "parents">) {
+    return piece.pending && Boolean(piece.parents);
+}
+
+function mergeCacheKey(args: {
+    targetTier: number;
+    parents: [
+        Pick<Specimen, "name" | "description">,
+        Pick<Specimen, "name" | "description">,
+    ];
+}) {
+    const parentInputs = canonicalParents(args.parents).map((parent) => [
+        cacheText(parent.name),
+        cacheText(parent.description),
+    ]);
+    return JSON.stringify(["brainrot-v1", args.targetTier, parentInputs]);
+}
+
+type PieceBody = Body & { plugin: { pieceId: string } };
+
+export type GenerationResult = {
+    name: string;
+    description: string;
+    imageUrl?: string;
+};
+
+export type GenerationFocus = {
+    id: string;
+    parents: [GamePiece, GamePiece];
+    status: "generating" | "result";
+    result?: GenerationResult;
+};
+
+// What the inspector card shows: the focused piece's icon + identity + its
+// lineage (the recursive tree is currently hidden in the UI but kept here).
+export type SelectedView = {
+    id: string;
+    name: string;
+    description: string;
+    imageUrl?: string;
+    catchphrase?: string;
+    figure?: FigureData;
+    color: string;
+    ink: string;
+    lineage: LineageNode;
+};
+
+function toSelectedView(
+    piece: Pick<
+        GamePiece,
+        | "id"
+        | "name"
+        | "description"
+        | "imageUrl"
+        | "catchphrase"
+        | "figure"
+        | "color"
+        | "ink"
+        | "lineage"
+    >,
+): SelectedView {
+    return {
+        id: piece.id,
+        name: piece.name,
+        description: piece.description,
+        imageUrl: piece.imageUrl,
+        catchphrase: piece.catchphrase,
+        figure: piece.figure,
+        color: piece.color,
+        ink: piece.ink,
+        lineage: piece.lineage,
+    };
+}
+
+export type GameEngine = ReturnType<typeof useGameEngine>;
+
+export function useGameEngine({
+    apiKey,
+    isLoggedIn,
+    isHydrated,
+}: {
+    apiKey: string | null;
+    isLoggedIn: boolean;
+    isHydrated: boolean;
+}) {
+    const boardRef = useRef<HTMLDivElement | null>(null);
+    const engineRef = useRef<Engine | null>(null);
+    const runnerRef = useRef<Runner | null>(null);
+    const wallsRef = useRef<Body[]>([]);
+    const bodiesRef = useRef<Map<string, Body>>(new Map());
+    const piecesRef = useRef<GamePiece[]>([]);
+    const mergingIdsRef = useRef<Set<string>>(new Set());
+    const objectUrlsRef = useRef<Set<string>>(new Set());
+    const apiKeyRef = useRef<string | null>(apiKey);
+    const highestTierRef = useRef(0);
+    const hasStartedRef = useRef(false);
+    const generatedPoolRef = useRef<Map<number, Specimen[]>>(new Map());
+    const generatedCacheRef = useRef<Map<string, Specimen>>(new Map());
+    const voiceCacheRef = useRef<Map<string, string>>(new Map());
+    const voiceEnabledRef = useRef(true);
+    const audioRef = useRef<HTMLAudioElement | null>(null);
+    const nextPieceRef = useRef<GamePiece>(
+        createGamePiece(0, { specimen: createSeedSpecimen() }),
+    );
+    const mergePieceRef = useRef<(leftId: string, rightId: string) => void>(
+        () => undefined,
+    );
+
+    const [viewScale, setViewScale] = useState(1);
+    const [pieces, setPieces] = useState<GamePiece[]>([]);
+    const [nextPiece, setNextPiece] = useState<GamePiece>(nextPieceRef.current);
+    const [aimX, setAimX] = useState(BOARD_FALLBACK.width / 2);
+    const [score, setScore] = useState(0);
+    const [highestTier, setHighestTier] = useState(0);
+    const [hasStarted, setHasStarted] = useState(false);
+    const [isCrowded, setIsCrowded] = useState(false);
+    const [voiceEnabled, setVoiceEnabled] = useState(true);
+    // The most-recently created/changed piece — its label is revealed briefly
+    // so you can read what just landed/merged without hovering.
+    const [activeLabelId, setActiveLabelId] = useState<string | null>(null);
+    const [generationFocus, setGenerationFocus] =
+        useState<GenerationFocus | null>(null);
+    // The piece the inspector is focused on: its icon, name, description and
+    // lineage. Hovering/tapping a board piece or legend row updates it.
+    const [selectedView, setSelectedView] = useState<SelectedView>(() =>
+        toSelectedView(nextPieceRef.current),
+    );
+
+    const canUseAi = isHydrated && isLoggedIn && Boolean(apiKey);
+    const canDrop =
+        canUseAi && hasStarted && !isResolvingIdentity(nextPiece) && !isCrowded;
+    useEffect(() => {
+        apiKeyRef.current = apiKey;
+    }, [apiKey]);
+
+    useEffect(() => {
+        highestTierRef.current = highestTier;
+    }, [highestTier]);
+
+    useEffect(() => {
+        if (!activeLabelId) return undefined;
+        const timeout = window.setTimeout(() => setActiveLabelId(null), 4000);
+        return () => window.clearTimeout(timeout);
+    }, [activeLabelId]);
+
+    const setPieceList = (nextPieces: GamePiece[]) => {
+        piecesRef.current = nextPieces;
+        setPieces(nextPieces);
+        setIsCrowded(nextPieces.length >= MAX_PIECES);
+    };
+
+    const addWalls = useCallback(() => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        if (wallsRef.current.length > 0) {
+            Composite.remove(engine.world, wallsRef.current);
+        }
+        const { width, height } = BOARD_LOGICAL_SIZE;
+        const wallOptions = {
+            isStatic: true,
+            friction: 0.18,
+            render: { visible: false },
+        };
+        const walls = [
+            Bodies.rectangle(
+                width / 2,
+                height + FLOOR_THICKNESS / 2,
+                width + WALL_THICKNESS * 2,
+                FLOOR_THICKNESS,
+                wallOptions,
+            ),
+            Bodies.rectangle(
+                -WALL_THICKNESS / 2,
+                height / 2,
+                WALL_THICKNESS,
+                height + FLOOR_THICKNESS * 2,
+                wallOptions,
+            ),
+            Bodies.rectangle(
+                width + WALL_THICKNESS / 2,
+                height / 2,
+                WALL_THICKNESS,
+                height + FLOOR_THICKNESS * 2,
+                wallOptions,
+            ),
+        ];
+        wallsRef.current = walls;
+        Composite.add(engine.world, walls);
+    }, []);
+
+    useEffect(() => {
+        const engine = Engine.create();
+        engine.enableSleeping = true;
+        engine.gravity.y = 1.15;
+        engineRef.current = engine;
+        addWalls();
+
+        const runner = Runner.create();
+        runnerRef.current = runner;
+        Runner.run(runner, engine);
+
+        const onCollision = (event: IEventCollision<Engine>) => {
+            for (const pair of event.pairs) {
+                const leftId = (pair.bodyA as PieceBody).plugin?.pieceId;
+                const rightId = (pair.bodyB as PieceBody).plugin?.pieceId;
+                if (!leftId || !rightId || leftId === rightId) continue;
+                mergePieceRef.current(leftId, rightId);
+            }
+        };
+
+        Events.on(engine, "collisionStart", onCollision);
+
+        let animationFrame = 0;
+        const syncFrame = () => {
+            const nextPieces = piecesRef.current.map((piece) => {
+                const body = bodiesRef.current.get(piece.id);
+                if (!body) return piece;
+                return {
+                    ...piece,
+                    x: body.position.x,
+                    y: body.position.y,
+                    angle: body.angle,
+                };
+            });
+            piecesRef.current = nextPieces;
+            setPieces(nextPieces);
+            setIsCrowded(nextPieces.length >= MAX_PIECES);
+            animationFrame = requestAnimationFrame(syncFrame);
+        };
+        animationFrame = requestAnimationFrame(syncFrame);
+
+        return () => {
+            cancelAnimationFrame(animationFrame);
+            Events.off(engine, "collisionStart", onCollision);
+            Runner.stop(runner);
+            Composite.clear(engine.world, false);
+            Engine.clear(engine);
+            audioRef.current?.pause();
+            for (const url of objectUrlsRef.current) URL.revokeObjectURL(url);
+            objectUrlsRef.current.clear();
+            voiceCacheRef.current.clear();
+            bodiesRef.current.clear();
+            piecesRef.current = [];
+        };
+    }, [addWalls]);
+
+    useEffect(() => {
+        const node = boardRef.current;
+        if (!node) return;
+        const updateScale = (width: number, height: number) => {
+            const widthScale = width / BOARD_LOGICAL_SIZE.width;
+            const heightScale = height / BOARD_LOGICAL_SIZE.height;
+            const nextScale = Math.max(0.1, Math.min(widthScale, heightScale));
+            setViewScale(nextScale);
+            setAimX((current) =>
+                Math.min(Math.max(current, 44), BOARD_LOGICAL_SIZE.width - 44),
+            );
+        };
+        updateScale(node.clientWidth, node.clientHeight);
+        const observer = new ResizeObserver(([entry]) => {
+            updateScale(entry.contentRect.width, entry.contentRect.height);
+        });
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, []);
+
+    // A figure piece gets its convex hull as the physics body, scaled so the
+    // hull area matches the tier circle's area. Circle fallback otherwise.
+    const buildPieceBody = (piece: GamePiece, x: number, y: number) => {
+        const physics = tierPhysics(piece.tier);
+        const options = {
+            restitution: physics.restitution,
+            friction: physics.friction,
+            frictionAir: 0.01,
+            density: 0.0016 * physics.density,
+            sleepThreshold: 45,
+            label: "brainrot-piece",
+        };
+        if (piece.figure) {
+            const scale = figureScale(piece.radius, piece.figure);
+            const vertices = piece.figure.vertices.map((vertex) => ({
+                x: vertex.x * scale,
+                y: vertex.y * scale,
+            }));
+            const body = Bodies.fromVertices(x, y, [vertices], options);
+            if (body) return body;
+        }
+        return Bodies.circle(x, y, piece.radius, options);
+    };
+
+    const addPieceToWorld = (piece: GamePiece, x: number, y: number) => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        const center = clampPieceCenter(piece, x, y, BOARD_LOGICAL_SIZE);
+        const body = buildPieceBody(piece, center.x, center.y) as PieceBody;
+        body.plugin = { pieceId: piece.id };
+        bodiesRef.current.set(piece.id, body);
+        Composite.add(engine.world, body);
+        setPieceList([
+            ...piecesRef.current,
+            {
+                ...piece,
+                x: center.x,
+                y: center.y,
+                angle: body.angle,
+            },
+        ]);
+    };
+
+    const removePieceFromWorld = (pieceId: string) => {
+        const engine = engineRef.current;
+        const body = bodiesRef.current.get(pieceId);
+        if (engine && body) Composite.remove(engine.world, body);
+        bodiesRef.current.delete(pieceId);
+    };
+
+    // A merge placeholder starts as a circle; once its generated specimen
+    // arrives with a figure, swap in the hull body, keeping the motion state.
+    const swapPieceBody = (piece: GamePiece) => {
+        const engine = engineRef.current;
+        const oldBody = bodiesRef.current.get(piece.id);
+        if (!engine || !oldBody || !piece.figure) return;
+        const newBody = buildPieceBody(
+            piece,
+            oldBody.position.x,
+            oldBody.position.y,
+        ) as PieceBody;
+        Body.setAngle(newBody, oldBody.angle);
+        Body.setVelocity(newBody, oldBody.velocity);
+        Body.setAngularVelocity(newBody, oldBody.angularVelocity);
+        newBody.plugin = { pieceId: piece.id };
+        Composite.remove(engine.world, oldBody);
+        bodiesRef.current.set(piece.id, newBody);
+        Composite.add(engine.world, newBody);
+    };
+
+    // Focus the inspector on a piece (no label reveal) — used on hover.
+    const selectPiece = (
+        piece: Pick<
+            GamePiece,
+            | "id"
+            | "name"
+            | "description"
+            | "imageUrl"
+            | "catchphrase"
+            | "figure"
+            | "color"
+            | "ink"
+            | "lineage"
+        >,
+    ) => {
+        setSelectedView(toSelectedView(piece));
+    };
+
+    // Reveal a piece: briefly show its board label AND focus the inspector on
+    // it. Used for fresh discoveries and deliberate taps/clicks.
+    const showDiscovery = (
+        piece: Pick<
+            GamePiece,
+            | "id"
+            | "name"
+            | "description"
+            | "imageUrl"
+            | "catchphrase"
+            | "figure"
+            | "color"
+            | "ink"
+            | "lineage"
+        >,
+    ) => {
+        setActiveLabelId(piece.id);
+        setSelectedView(toSelectedView(piece));
+    };
+
+    const rememberObjectUrl = (specimen: Specimen) => {
+        if (specimen.imageUrl?.startsWith("blob:")) {
+            objectUrlsRef.current.add(specimen.imageUrl);
+        }
+        if (specimen.figure?.cutoutUrl.startsWith("blob:")) {
+            objectUrlsRef.current.add(specimen.figure.cutoutUrl);
+        }
+    };
+
+    // The narrator is garnish: failures and mid-flight mutes never block play.
+    const speakCatchphrase = async (catchphrase?: string) => {
+        const apiKey = apiKeyRef.current;
+        if (!apiKey || !catchphrase || !voiceEnabledRef.current) return;
+        try {
+            let url = voiceCacheRef.current.get(catchphrase);
+            if (!url) {
+                url = await generateVoiceLine({ apiKey, text: catchphrase });
+                voiceCacheRef.current.set(catchphrase, url);
+                objectUrlsRef.current.add(url);
+            }
+            if (!voiceEnabledRef.current) return;
+            const audio = audioRef.current ?? new Audio();
+            audioRef.current = audio;
+            audio.pause();
+            audio.src = url;
+            audio.currentTime = 0;
+            await audio.play();
+        } catch {
+            // Silence is acceptable; the discovery card still shows the line.
+        }
+    };
+
+    const toggleVoice = () => {
+        const next = !voiceEnabledRef.current;
+        voiceEnabledRef.current = next;
+        setVoiceEnabled(next);
+        if (!next) audioRef.current?.pause();
+    };
+
+    const hasPiece = (pieceId: string) =>
+        nextPieceRef.current.id === pieceId ||
+        piecesRef.current.some((piece) => piece.id === pieceId);
+
+    const stopImagePending = (pieceId: string) => {
+        if (nextPieceRef.current.id === pieceId) {
+            const stoppedPiece = {
+                ...nextPieceRef.current,
+                pending: false,
+                generated: false,
+            };
+            nextPieceRef.current = stoppedPiece;
+            setNextPiece(stoppedPiece);
+        }
+
+        if (piecesRef.current.some((piece) => piece.id === pieceId)) {
+            setPieceList(
+                piecesRef.current.map((piece) =>
+                    piece.id === pieceId
+                        ? {
+                              ...piece,
+                              pending: false,
+                              generated: false,
+                          }
+                        : piece,
+                ),
+            );
+        }
+    };
+
+    const applyGeneratedSpecimen = (pieceId: string, specimen: Specimen) => {
+        if (nextPieceRef.current.id === pieceId) {
+            const updated: GamePiece = {
+                ...nextPieceRef.current,
+                ...specimen,
+                lineage: specimen.lineage ?? nextPieceRef.current.lineage,
+                pending: false,
+                generated: true,
+            };
+            nextPieceRef.current = updated;
+            setNextPiece(updated);
+        }
+
+        if (piecesRef.current.some((piece) => piece.id === pieceId)) {
+            let updatedPiece: GamePiece | null = null;
+            setPieceList(
+                piecesRef.current.map((piece) => {
+                    if (piece.id !== pieceId) return piece;
+                    updatedPiece = {
+                        ...piece,
+                        ...specimen,
+                        lineage: specimen.lineage ?? piece.lineage,
+                        pending: false,
+                        generated: true,
+                    };
+                    return updatedPiece;
+                }),
+            );
+            if (updatedPiece) swapPieceBody(updatedPiece);
+        }
+    };
+
+    const hydrateSeedPiece = async (piece: GamePiece) => {
+        const apiKey = apiKeyRef.current;
+        if (!apiKey) {
+            return;
+        }
+
+        if (nextPieceRef.current.id === piece.id) {
+            const pendingPiece = { ...nextPieceRef.current, pending: true };
+            nextPieceRef.current = pendingPiece;
+            setNextPiece(pendingPiece);
+        }
+
+        const cacheKey = `seed:${piece.name.toLowerCase()}`;
+        const cached = generatedCacheRef.current.get(cacheKey);
+        if (cached) {
+            if (!hasPiece(piece.id)) return;
+            const enriched = {
+                ...cached,
+                lineage: piece.lineage,
+            };
+            applyGeneratedSpecimen(piece.id, enriched);
+            showDiscovery({ ...piece, ...enriched });
+            return;
+        }
+
+        try {
+            const generated = await generateImageSpecimen({
+                apiKey,
+                specimen: {
+                    name: piece.name,
+                    description: piece.description,
+                    imagePrompt: piece.imagePrompt,
+                },
+            });
+            if (!hasPiece(piece.id)) {
+                if (generated.imageUrl?.startsWith("blob:")) {
+                    URL.revokeObjectURL(generated.imageUrl);
+                }
+                if (generated.figure?.cutoutUrl.startsWith("blob:")) {
+                    URL.revokeObjectURL(generated.figure.cutoutUrl);
+                }
+                return;
+            }
+            rememberObjectUrl(generated);
+            generatedCacheRef.current.set(cacheKey, generated);
+            const enriched = {
+                ...generated,
+                lineage: piece.lineage,
+            };
+            applyGeneratedSpecimen(piece.id, enriched);
+            showDiscovery({ ...piece, ...enriched });
+        } catch {
+            stopImagePending(piece.id);
+        }
+    };
+
+    const createNextDrop = (currentHighestTier = highestTierRef.current) => {
+        const maxSpawnTier = Math.min(
+            MAX_SPAWN_TIER,
+            Math.max(0, currentHighestTier),
+        );
+        const availableTiers = [0];
+        const eligiblePools = new Map<number, Specimen[]>();
+        for (let tier = 1; tier <= maxSpawnTier; tier += 1) {
+            const pool = generatedPoolRef.current.get(tier) ?? [];
+            const uniquePool = uniqueSpecimensByName(pool);
+            if (uniquePool.length >= MIN_SPAWN_VARIANTS_PER_TIER) {
+                availableTiers.push(tier);
+                eligiblePools.set(tier, uniquePool);
+            }
+        }
+        const tier = weightedTierSample(availableTiers);
+        const pool = eligiblePools.get(tier) ?? [];
+        const specimen = tier === 0 ? createSeedSpecimen() : sample(pool);
+        const piece = createGamePiece(tier, {
+            specimen,
+            generated: tier > 0,
+        });
+        nextPieceRef.current = piece;
+        setNextPiece(piece);
+        if (piecesRef.current.length === 0) {
+            selectPiece(piece);
+        }
+        // Don't generate the seed image until the player has started — the
+        // first seed is generated by startGame(). Mid-game tier-0 refills
+        // still hydrate normally.
+        if (tier === 0 && hasStartedRef.current) void hydrateSeedPiece(piece);
+    };
+
+    // First board click: start the game and generate the first seed. The seed
+    // appears at the top to aim; the next click drops it.
+    const startGame = () => {
+        if (hasStartedRef.current) return;
+        if (!apiKeyRef.current) {
+            return;
+        }
+        hasStartedRef.current = true;
+        setHasStarted(true);
+        const piece = createGamePiece(0, { specimen: createSeedSpecimen() });
+        nextPieceRef.current = piece;
+        setNextPiece(piece);
+        selectPiece(piece);
+        void hydrateSeedPiece(piece);
+    };
+
+    const dropNextPiece = (x = aimX) => {
+        if (!canUseAi) {
+            return;
+        }
+        if (!hasStartedRef.current) {
+            startGame();
+            return;
+        }
+        if (isResolvingIdentity(nextPieceRef.current)) {
+            return;
+        }
+        if (isCrowded) return;
+        const clampedX = Math.min(
+            Math.max(x, nextPieceRef.current.radius + 8),
+            BOARD_LOGICAL_SIZE.width - nextPieceRef.current.radius - 8,
+        );
+        addPieceToWorld(nextPieceRef.current, clampedX, DROP_Y);
+        setActiveLabelId(nextPieceRef.current.id);
+        createNextDrop();
+    };
+
+    const resetGame = () => {
+        for (const piece of piecesRef.current) removePieceFromWorld(piece.id);
+        audioRef.current?.pause();
+        for (const url of objectUrlsRef.current) URL.revokeObjectURL(url);
+        objectUrlsRef.current.clear();
+        generatedPoolRef.current.clear();
+        generatedCacheRef.current.clear();
+        voiceCacheRef.current.clear();
+        setGenerationFocus(null);
+        mergingIdsRef.current.clear();
+        setPieceList([]);
+        setScore(0);
+        setHighestTier(0);
+        highestTierRef.current = 0;
+        hasStartedRef.current = false;
+        setHasStarted(false);
+        // Build a placeholder aim piece but DON'T generate — startGame()
+        // hydrates the first seed on the next board click.
+        createNextDrop(0);
+    };
+
+    // Briefly reveal the freshly-created character in the generation popover,
+    // then dismiss it. Replaces the "generating" state for that piece.
+    const revealResult = (
+        pieceId: string,
+        result: GenerationResult,
+        origin: "generated" | "cached",
+    ) => {
+        setGenerationFocus((current) =>
+            current?.id === pieceId
+                ? {
+                      ...current,
+                      status: "result",
+                      result: {
+                          name: result.name,
+                          description: result.description,
+                          imageUrl: result.imageUrl,
+                      },
+                  }
+                : current,
+        );
+        const holdMs = origin === "cached" ? 2200 : 3200;
+        window.setTimeout(() => {
+            setGenerationFocus((current) =>
+                current?.id === pieceId ? null : current,
+            );
+        }, holdMs);
+    };
+
+    const hydrateGeneratedPiece = async (
+        pieceId: string,
+        targetTier: number,
+        parents: [GamePiece, GamePiece],
+    ) => {
+        const apiKey = apiKeyRef.current;
+        if (!apiKey) {
+            removePieceFromWorld(pieceId);
+            setPieceList(
+                piecesRef.current.filter((piece) => piece.id !== pieceId),
+            );
+            return;
+        }
+
+        const generationParents = canonicalParents(parents);
+        const cacheKey = mergeCacheKey({ targetTier, parents });
+        const cached = generatedCacheRef.current.get(cacheKey);
+        if (cached) {
+            const enriched = {
+                ...cached,
+                lineage: mergeLineage(cached, parents),
+            };
+            applyGeneratedSpecimen(pieceId, enriched);
+            showDiscovery({
+                id: pieceId,
+                ...enriched,
+                color: RUNGS[targetTier].color,
+                ink: RUNGS[targetTier].ink,
+            });
+            revealResult(pieceId, enriched, "cached");
+            void speakCatchphrase(enriched.catchphrase);
+            return;
+        }
+
+        try {
+            const generated = await generateSpecimen({
+                apiKey,
+                parents: generationParents,
+            });
+            rememberObjectUrl(generated);
+            generatedCacheRef.current.set(cacheKey, generated);
+            if (!piecesRef.current.some((piece) => piece.id === pieceId)) {
+                return;
+            }
+            const currentPool = generatedPoolRef.current.get(targetTier) ?? [];
+            const enriched = {
+                ...generated,
+                lineage: mergeLineage(generated, parents),
+            };
+            generatedPoolRef.current.set(
+                targetTier,
+                [enriched, ...currentPool].slice(0, 18),
+            );
+            applyGeneratedSpecimen(pieceId, enriched);
+            showDiscovery({
+                id: pieceId,
+                ...enriched,
+                color: RUNGS[targetTier].color,
+                ink: RUNGS[targetTier].ink,
+            });
+            revealResult(pieceId, enriched, "generated");
+            void speakCatchphrase(enriched.catchphrase);
+        } catch {
+            removePieceFromWorld(pieceId);
+            setPieceList(
+                piecesRef.current.filter((piece) => piece.id !== pieceId),
+            );
+            setGenerationFocus((current) =>
+                current?.id === pieceId ? null : current,
+            );
+        }
+    };
+
+    const mergePieces = (leftId: string, rightId: string) => {
+        const left = piecesRef.current.find((piece) => piece.id === leftId);
+        const right = piecesRef.current.find((piece) => piece.id === rightId);
+        if (!left || !right) return;
+        if (left.tier !== right.tier) return;
+        if (left.tier >= RUNGS.length - 1) return;
+        if (isResolvingIdentity(left) || isResolvingIdentity(right)) return;
+        if (!apiKeyRef.current) {
+            return;
+        }
+        if (
+            mergingIdsRef.current.has(leftId) ||
+            mergingIdsRef.current.has(rightId)
+        ) {
+            return;
+        }
+
+        mergingIdsRef.current.add(leftId);
+        mergingIdsRef.current.add(rightId);
+        const leftBody = bodiesRef.current.get(leftId);
+        const rightBody = bodiesRef.current.get(rightId);
+        const center = {
+            x:
+                ((leftBody?.position.x ?? left.x) +
+                    (rightBody?.position.x ?? right.x)) /
+                2,
+            y:
+                ((leftBody?.position.y ?? left.y) +
+                    (rightBody?.position.y ?? right.y)) /
+                2,
+        };
+        removePieceFromWorld(leftId);
+        removePieceFromWorld(rightId);
+        setPieceList(
+            piecesRef.current.filter(
+                (piece) => piece.id !== leftId && piece.id !== rightId,
+            ),
+        );
+
+        const targetTier = left.tier + 1;
+        const parents: [string, string] = [left.name, right.name];
+        const loadingSpecimen = createLoadingSpecimen(
+            `${left.name} + ${right.name}`,
+            `Generating from ${left.name} and ${right.name}.`,
+        );
+        const specimen = {
+            ...loadingSpecimen,
+            lineage: mergeLineage(loadingSpecimen, [left, right]),
+        };
+        const result = createGamePiece(targetTier, {
+            specimen,
+            parents,
+            pending: true,
+            generated: false,
+        });
+
+        addPieceToWorld(result, center.x, center.y);
+        setGenerationFocus({
+            id: result.id,
+            parents: [left, right],
+            status: "generating",
+        });
+        setScore((current) => current + (targetTier + 1) * 10);
+        if (targetTier > highestTierRef.current) {
+            highestTierRef.current = targetTier;
+            setHighestTier(targetTier);
+        }
+        selectPiece(result);
+
+        window.setTimeout(() => {
+            mergingIdsRef.current.delete(leftId);
+            mergingIdsRef.current.delete(rightId);
+        }, 250);
+
+        void hydrateGeneratedPiece(result.id, targetTier, [left, right]);
+    };
+
+    // Assigned every render so the collision handler always calls the latest
+    // closure (with current refs). Do NOT move this into an effect.
+    mergePieceRef.current = mergePieces;
+
+    const updateAim = (event: ReactPointerEvent<HTMLDivElement>) => {
+        const bounds = event.currentTarget.getBoundingClientRect();
+        const scale = bounds.width / BOARD_LOGICAL_SIZE.width || 1;
+        setAimX((event.clientX - bounds.left) / scale);
+    };
+
+    const handleBoardPointerDown = (
+        event: ReactPointerEvent<HTMLDivElement>,
+    ) => {
+        if (event.button !== 0) return;
+        if (event.target !== event.currentTarget) return;
+        const bounds = event.currentTarget.getBoundingClientRect();
+        const scale = bounds.width / BOARD_LOGICAL_SIZE.width || 1;
+        const x = (event.clientX - bounds.left) / scale;
+        setAimX(x);
+        if (!hasStartedRef.current) {
+            startGame();
+            return;
+        }
+        dropNextPiece(x);
+    };
+
+    // No dependency array on purpose: re-binds every render so the handlers
+    // close over fresh dropNextPiece/resetGame.
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.code === "Space") {
+                event.preventDefault();
+                dropNextPiece();
+            }
+            if (event.key.toLowerCase() === "r") {
+                resetGame();
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    });
+
+    // Minimal legend: the distinct characters currently on the board (icon →
+    // name), collapsed by name and ordered biggest-tier first.
+    const legendEntries = useMemo(() => {
+        const seen = new Map<string, GamePiece>();
+        for (const piece of pieces) {
+            if (piece.pending) continue;
+            const existing = seen.get(piece.name);
+            if (!existing || piece.tier > existing.tier) {
+                seen.set(piece.name, piece);
+            }
+        }
+        return Array.from(seen.values()).sort((a, b) => b.tier - a.tier);
+    }, [pieces]);
+    const dropPreviewX = Math.min(
+        Math.max(aimX, nextPiece.radius + 8),
+        BOARD_LOGICAL_SIZE.width - nextPiece.radius - 8,
+    );
+
+    return {
+        boardRef,
+        pieces,
+        nextPiece,
+        score,
+        highestTier,
+        isCrowded,
+        activeLabelId,
+        generationFocus,
+        selectedView,
+        rungs: RUNGS,
+        canUseAi,
+        canDrop,
+        hasStarted,
+        voiceEnabled,
+        legendEntries,
+        dropPreviewX,
+        viewScale,
+        selectPiece,
+        showDiscovery,
+        speakCatchphrase,
+        toggleVoice,
+        dropNextPiece,
+        resetGame,
+        updateAim,
+        handleBoardPointerDown,
+    };
+}

--- a/apps/brainrot-merge/src/useGameEngine.ts
+++ b/apps/brainrot-merge/src/useGameEngine.ts
@@ -84,14 +84,26 @@ function clampCenter(value: number, radius: number, extent: number) {
     return Math.min(Math.max(value, min), max);
 }
 
+// Area normalization fixes a hull's area, not its extent: an elongated
+// figure reaches further than the tier radius, so x-clamps must use the
+// hull's real half-width or pieces spawn intersecting the walls.
+function pieceHalfWidth(piece: Pick<GamePiece, "radius" | "figure">) {
+    if (!piece.figure) return piece.radius;
+    const scale = figureScale(piece.radius, piece.figure);
+    return Math.max(
+        piece.radius,
+        ...piece.figure.vertices.map((vertex) => Math.abs(vertex.x * scale)),
+    );
+}
+
 function clampPieceCenter(
-    piece: Pick<GamePiece, "radius">,
+    piece: Pick<GamePiece, "radius" | "figure">,
     x: number,
     y: number,
     size: { width: number; height: number },
 ) {
     return {
-        x: clampCenter(x, piece.radius, size.width),
+        x: clampCenter(x, pieceHalfWidth(piece), size.width),
         y: clampCenter(y, piece.radius, size.height),
     };
 }
@@ -207,10 +219,15 @@ export function useGameEngine({
     const highestTierRef = useRef(0);
     const hasStartedRef = useRef(false);
     const generatedPoolRef = useRef<Map<number, Specimen[]>>(new Map());
-    const generatedCacheRef = useRef<Map<string, Specimen>>(new Map());
-    const voiceCacheRef = useRef<Map<string, string>>(new Map());
+    // Both caches store in-flight promises, set BEFORE the await: concurrent
+    // identical requests (same merge pair, same seed, same catchphrase) must
+    // share one paid generation instead of all missing the cache.
+    const generatedCacheRef = useRef<Map<string, Promise<Specimen>>>(new Map());
+    const voiceCacheRef = useRef<Map<string, Promise<string>>>(new Map());
     const voiceEnabledRef = useRef(true);
     const audioRef = useRef<HTMLAudioElement | null>(null);
+    // Monotonic token so a slow TTS fetch can't interrupt a newer line.
+    const speakRequestRef = useRef(0);
     const nextPieceRef = useRef<GamePiece>(
         createGamePiece(0, { specimen: createSeedSpecimen() }),
     );
@@ -228,8 +245,9 @@ export function useGameEngine({
     const [isCrowded, setIsCrowded] = useState(false);
     const [voiceEnabled, setVoiceEnabled] = useState(true);
     // The most-recently created/changed piece — its label is revealed briefly
-    // so you can read what just landed/merged without hovering.
-    const [activeLabelId, setActiveLabelId] = useState<string | null>(null);
+    // so you can read what just landed/merged without hovering. Wrapped in an
+    // object so re-revealing the same piece restarts the hide timer.
+    const [activeLabel, setActiveLabel] = useState<{ id: string } | null>(null);
     const [generationFocus, setGenerationFocus] =
         useState<GenerationFocus | null>(null);
     // The piece the inspector is focused on: its icon, name, description and
@@ -250,10 +268,10 @@ export function useGameEngine({
     }, [highestTier]);
 
     useEffect(() => {
-        if (!activeLabelId) return undefined;
-        const timeout = window.setTimeout(() => setActiveLabelId(null), 4000);
+        if (!activeLabel) return undefined;
+        const timeout = window.setTimeout(() => setActiveLabel(null), 4000);
         return () => window.clearTimeout(timeout);
-    }, [activeLabelId]);
+    }, [activeLabel]);
 
     const setPieceList = (nextPieces: GamePiece[]) => {
         piecesRef.current = nextPieces;
@@ -438,6 +456,19 @@ export function useGameEngine({
             oldBody.position.y,
         ) as PieceBody;
         Body.setAngle(newBody, oldBody.angle);
+        // The placeholder circle may rest flush against a wall or the floor;
+        // an elongated hull reaches further than the circle radius, so clamp
+        // by the hull's real extents or it spawns embedded in the statics
+        // and the penetration correction shoves the settled stack.
+        const halfW = (newBody.bounds.max.x - newBody.bounds.min.x) / 2;
+        const halfH = (newBody.bounds.max.y - newBody.bounds.min.y) / 2;
+        Body.setPosition(newBody, {
+            x: clampCenter(newBody.position.x, halfW, BOARD_LOGICAL_SIZE.width),
+            y: Math.min(
+                newBody.position.y,
+                BOARD_LOGICAL_SIZE.height - halfH - BOARD_EDGE_GAP,
+            ),
+        });
         Body.setVelocity(newBody, oldBody.velocity);
         Body.setAngularVelocity(newBody, oldBody.angularVelocity);
         newBody.plugin = { pieceId: piece.id };
@@ -480,7 +511,7 @@ export function useGameEngine({
             | "lineage"
         >,
     ) => {
-        setActiveLabelId(piece.id);
+        setActiveLabel({ id: piece.id });
         setSelectedView(toSelectedView(piece));
     };
 
@@ -497,14 +528,23 @@ export function useGameEngine({
     const speakCatchphrase = async (catchphrase?: string) => {
         const apiKey = apiKeyRef.current;
         if (!apiKey || !catchphrase || !voiceEnabledRef.current) return;
+        const requestId = ++speakRequestRef.current;
         try {
-            let url = voiceCacheRef.current.get(catchphrase);
-            if (!url) {
-                url = await generateVoiceLine({ apiKey, text: catchphrase });
-                voiceCacheRef.current.set(catchphrase, url);
-                objectUrlsRef.current.add(url);
+            let pending = voiceCacheRef.current.get(catchphrase);
+            if (!pending) {
+                pending = generateVoiceLine({
+                    apiKey,
+                    text: catchphrase,
+                }).then((url) => {
+                    objectUrlsRef.current.add(url);
+                    return url;
+                });
+                pending.catch(() => voiceCacheRef.current.delete(catchphrase));
+                voiceCacheRef.current.set(catchphrase, pending);
             }
+            const url = await pending;
             if (!voiceEnabledRef.current) return;
+            if (requestId !== speakRequestRef.current) return;
             const audio = audioRef.current ?? new Audio();
             audioRef.current = audio;
             audio.pause();
@@ -598,38 +638,29 @@ export function useGameEngine({
         }
 
         const cacheKey = `seed:${piece.name.toLowerCase()}`;
-        const cached = generatedCacheRef.current.get(cacheKey);
-        if (cached) {
-            if (!hasPiece(piece.id)) return;
-            const enriched = {
-                ...cached,
-                lineage: piece.lineage,
-            };
-            applyGeneratedSpecimen(piece.id, enriched);
-            showDiscovery({ ...piece, ...enriched });
-            return;
-        }
-
-        try {
-            const generated = await generateImageSpecimen({
+        let pending = generatedCacheRef.current.get(cacheKey);
+        if (!pending) {
+            pending = generateImageSpecimen({
                 apiKey,
                 specimen: {
                     name: piece.name,
                     description: piece.description,
                     imagePrompt: piece.imagePrompt,
                 },
+            }).then((generated) => {
+                // The cache keeps the specimen alive for future same-name
+                // seeds, so its URLs stay registered even if this piece is
+                // gone by the time the image lands.
+                rememberObjectUrl(generated);
+                return generated;
             });
-            if (!hasPiece(piece.id)) {
-                if (generated.imageUrl?.startsWith("blob:")) {
-                    URL.revokeObjectURL(generated.imageUrl);
-                }
-                if (generated.figure?.cutoutUrl.startsWith("blob:")) {
-                    URL.revokeObjectURL(generated.figure.cutoutUrl);
-                }
-                return;
-            }
-            rememberObjectUrl(generated);
-            generatedCacheRef.current.set(cacheKey, generated);
+            pending.catch(() => generatedCacheRef.current.delete(cacheKey));
+            generatedCacheRef.current.set(cacheKey, pending);
+        }
+
+        try {
+            const generated = await pending;
+            if (!hasPiece(piece.id)) return;
             const enriched = {
                 ...generated,
                 lineage: piece.lineage,
@@ -702,12 +733,13 @@ export function useGameEngine({
             return;
         }
         if (isCrowded) return;
+        const halfWidth = pieceHalfWidth(nextPieceRef.current);
         const clampedX = Math.min(
-            Math.max(x, nextPieceRef.current.radius + 8),
-            BOARD_LOGICAL_SIZE.width - nextPieceRef.current.radius - 8,
+            Math.max(x, halfWidth + 8),
+            BOARD_LOGICAL_SIZE.width - halfWidth - 8,
         );
         addPieceToWorld(nextPieceRef.current, clampedX, DROP_Y);
-        setActiveLabelId(nextPieceRef.current.id);
+        setActiveLabel({ id: nextPieceRef.current.id });
         createNextDrop();
     };
 
@@ -776,43 +808,39 @@ export function useGameEngine({
 
         const generationParents = canonicalParents(parents);
         const cacheKey = mergeCacheKey({ targetTier, parents });
-        const cached = generatedCacheRef.current.get(cacheKey);
-        if (cached) {
-            const enriched = {
-                ...cached,
-                lineage: mergeLineage(cached, parents),
-            };
-            applyGeneratedSpecimen(pieceId, enriched);
-            showDiscovery({
-                id: pieceId,
-                ...enriched,
-                color: RUNGS[targetTier].color,
-                ink: RUNGS[targetTier].ink,
+        let pending = generatedCacheRef.current.get(cacheKey);
+        const isCreator = !pending;
+        if (!pending) {
+            pending = generateSpecimen({
+                apiKey,
+                parents: generationParents,
+            }).then((generated) => {
+                rememberObjectUrl(generated);
+                return generated;
             });
-            revealResult(pieceId, enriched, "cached");
-            void speakCatchphrase(enriched.catchphrase);
-            return;
+            pending.catch(() => generatedCacheRef.current.delete(cacheKey));
+            generatedCacheRef.current.set(cacheKey, pending);
         }
 
         try {
-            const generated = await generateSpecimen({
-                apiKey,
-                parents: generationParents,
-            });
-            rememberObjectUrl(generated);
-            generatedCacheRef.current.set(cacheKey, generated);
+            const generated = await pending;
             if (!piecesRef.current.some((piece) => piece.id === pieceId)) {
                 return;
             }
-            const currentPool = generatedPoolRef.current.get(targetTier) ?? [];
             const enriched = {
                 ...generated,
                 lineage: mergeLineage(generated, parents),
             };
-            generatedPoolRef.current.set(
-                targetTier,
-                [enriched, ...currentPool].slice(0, 18),
-            );
+            // Only the call that created the generation feeds the spawn
+            // pool; concurrent same-key merges would duplicate the entry.
+            if (isCreator) {
+                const currentPool =
+                    generatedPoolRef.current.get(targetTier) ?? [];
+                generatedPoolRef.current.set(
+                    targetTier,
+                    [enriched, ...currentPool].slice(0, 18),
+                );
+            }
             applyGeneratedSpecimen(pieceId, enriched);
             showDiscovery({
                 id: pieceId,
@@ -820,7 +848,7 @@ export function useGameEngine({
                 color: RUNGS[targetTier].color,
                 ink: RUNGS[targetTier].ink,
             });
-            revealResult(pieceId, enriched, "generated");
+            revealResult(pieceId, enriched, isCreator ? "generated" : "cached");
             void speakCatchphrase(enriched.catchphrase);
         } catch {
             removePieceFromWorld(pieceId);
@@ -942,6 +970,8 @@ export function useGameEngine({
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.code === "Space") {
                 event.preventDefault();
+                // OS key-repeat would machine-gun paid generations.
+                if (event.repeat) return;
                 dropNextPiece();
             }
             if (event.key.toLowerCase() === "r") {
@@ -965,9 +995,10 @@ export function useGameEngine({
         }
         return Array.from(seen.values()).sort((a, b) => b.tier - a.tier);
     }, [pieces]);
+    const previewHalfWidth = pieceHalfWidth(nextPiece);
     const dropPreviewX = Math.min(
-        Math.max(aimX, nextPiece.radius + 8),
-        BOARD_LOGICAL_SIZE.width - nextPiece.radius - 8,
+        Math.max(aimX, previewHalfWidth + 8),
+        BOARD_LOGICAL_SIZE.width - previewHalfWidth - 8,
     );
 
     return {
@@ -977,7 +1008,7 @@ export function useGameEngine({
         score,
         highestTier,
         isCrowded,
-        activeLabelId,
+        activeLabelId: activeLabel?.id ?? null,
         generationFocus,
         selectedView,
         rungs: RUNGS,

--- a/apps/brainrot-merge/src/vite-env.d.ts
+++ b/apps/brainrot-merge/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/brainrot-merge/tsconfig.json
+++ b/apps/brainrot-merge/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "useDefineForClassFields": true,
+        "lib": ["DOM", "DOM.Iterable", "ES2022"],
+        "allowJs": false,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx"
+    },
+    "include": ["src"],
+    "references": []
+}

--- a/apps/brainrot-merge/vite.config.ts
+++ b/apps/brainrot-merge/vite.config.ts
@@ -1,0 +1,10 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+    plugins: [react(), tailwindcss()],
+    resolve: {
+        dedupe: ["react", "react-dom"],
+    },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "packages/ui",
         "apps/react",
         "apps/life-merge",
+        "apps/brainrot-merge",
         "tools/icons"
       ],
       "dependencies": {
@@ -23,6 +24,27 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",
         "concurrently": "^9.2.1"
+      }
+    },
+    "apps/brainrot-merge": {
+      "name": "brainrot-merge.pollinations.ai",
+      "version": "0.0.0",
+      "dependencies": {
+        "@pollinations/sdk": "*",
+        "@pollinations/ui": "*",
+        "matter-js": "^0.20.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/matter-js": "^0.19.8",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.7.2",
+        "vite": "^7.0.0"
       }
     },
     "apps/life-merge": {
@@ -4251,7 +4273,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4268,7 +4289,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4285,7 +4305,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4302,7 +4321,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4319,7 +4337,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4336,7 +4353,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4353,7 +4369,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4370,7 +4385,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4387,7 +4401,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4404,7 +4417,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4421,7 +4433,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4438,7 +4449,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4455,7 +4465,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4472,7 +4481,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4489,7 +4497,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4506,7 +4513,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4523,7 +4529,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4540,7 +4545,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4557,7 +4561,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4574,7 +4577,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4591,7 +4593,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4608,7 +4609,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5692,7 +5692,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -5703,7 +5703,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -5745,7 +5745,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -5756,7 +5756,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -6272,7 +6272,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6286,7 +6285,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6300,7 +6298,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6314,7 +6311,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6328,7 +6324,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6342,7 +6337,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6356,7 +6350,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6370,7 +6363,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6384,7 +6376,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6398,7 +6389,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6412,7 +6402,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6426,7 +6415,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6440,7 +6428,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6454,7 +6441,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6468,7 +6454,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6482,7 +6467,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6496,7 +6480,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6523,7 +6506,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6537,7 +6519,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6551,7 +6532,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6565,7 +6545,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6579,7 +6558,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6593,7 +6571,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6607,7 +6584,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10343,7 +10319,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -10807,6 +10783,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/brainrot-merge.pollinations.ai": {
+      "resolved": "apps/brainrot-merge",
+      "link": true
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
@@ -11645,7 +11625,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11662,7 +11641,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11679,7 +11657,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11696,7 +11673,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11713,7 +11689,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11730,7 +11705,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11747,7 +11721,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11764,7 +11737,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11781,7 +11753,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11798,7 +11769,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11815,7 +11785,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11832,7 +11801,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11849,7 +11817,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11866,7 +11833,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11883,7 +11849,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11900,7 +11865,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11917,7 +11881,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11934,7 +11897,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11951,7 +11913,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11968,7 +11929,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11985,7 +11945,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12002,7 +11961,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12019,7 +11977,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12036,7 +11993,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12053,7 +12009,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12070,7 +12025,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13615,7 +13569,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13887,11 +13841,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/life-merge.pollinations.ai": {
+      "resolved": "apps/life-merge",
+      "link": true
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -13924,7 +13882,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13945,7 +13902,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13966,7 +13922,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13987,7 +13942,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14008,7 +13962,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14029,7 +13982,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14050,7 +14002,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14071,7 +14022,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14092,7 +14042,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14113,7 +14062,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14134,7 +14082,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15610,8 +15557,7 @@
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
@@ -17371,7 +17317,7 @@
       "version": "5.46.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
       "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -17390,7 +17336,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -17760,7 +17706,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/ui",
     "apps/react",
     "apps/life-merge",
+    "apps/brainrot-merge",
     "tools/icons"
   ],
   "scripts": {


### PR DESCRIPTION
Builds on #11632 (Suikacraft demo). Draft while we decide the game-design direction (suika hybrid vs infinite-craft-style fusion dex).

- Adds `apps/brainrot-merge`: standalone Italian brainrot version of SuikaCraft, single hardcoded world (no presets)
- Merging two same-tier pieces asks claude to invent a NEW brainrot character: pseudo-Italian rhyming name, deadpan lore, Italian catchphrase
- Figure physics: zimage renders on white background; client cuts out the sprite (border flood-fill) and uses its convex hull (≤12 verts, area-normalized to tier circle) as the matter-js body; circle fallback
- Voice: catchphrase spoken on discovery via elevenlabs (`adam`, the canonical brainrot narrator voice); click a piece to replay; 🔊 mute toggle; blasphemy/profanity blocklist with diacritic stripping (canonical meme lines are blasphemous — generated ones are not)
- Hardened after multi-agent adversarial review: in-flight promise caches (no duplicate paid generations), stale-audio token, hull-aware wall clamps, Space auto-repeat guard
- Verified live: typecheck, build, real gameplay with cascading merges (Squalo+Scimmia→tier-1→+Sneakers→"Scarpallino Pinnellino"), all API calls 200, TTS cached per line

🤖 Generated with [Claude Code](https://claude.com/claude-code)