### PR TITLE
add enter test snapshots and agents.md snapshot note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ npx vitest run test/file.test.ts
 - API docs: strictly technical, no marketing; link dynamic endpoints (e.g. `/models`) vs hardcoded lists; no internal impl/env vars; minimal examples for both simplified and OpenAI-compatible endpoints.
 - Security: never expose keys/secrets; use env vars; validate input.
 - Temp scratch files go in `temp/` clearly labeled.
+- Shrinking large snapshots: video/image snapshots can be 10–30 MB because stream chunks store raw binary as text (`TextDecoder` output in `vcr.ts:289`). To shrink: replace `response.body.data` array with one tiny chunk `[{"data": "<minimal-bytes>", "delay": 1}]`. For mp4, a valid 20-byte ftyp box is `\x00\x00\x00\x14ftypisom\x00\x00\x00\x00isom` (use `bytes.decode('latin-1')` in Python). Tests only check headers/status, not media content.
 
 ## Workflow Orchestration
 

--- a/enter.pollinations.ai/test/mocks/snapshots/image-a528700650e95b3066fc7f97e833b738.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/image-a528700650e95b3066fc7f97e833b738.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16384/prompt/animate%20this%20image?model=seedance&duration=2&image=https%3A%2F%2Fimage.pollinations.ai%2Fprompt%2Fa%2520cat%3Fwidth%3D512%26height%3D512%26nologo%3Dtrue%26seed%3D42",
+    "method": "GET",
+    "body": {
+      "type": "empty",
+      "data": null
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 400,
+    "statusText": "Bad Request",
+    "headers": {
+      "access-control-allow-headers": "Content-Type",
+      "access-control-allow-methods": "GET, POST, OPTIONS",
+      "access-control-allow-origin": "*",
+      "access-control-expose-headers": "Content-Length",
+      "connection": "keep-alive",
+      "content-type": "application/json",
+      "date": "Tue, 02 Dec 2025 14:58:39 GMT",
+      "keep-alive": "timeout=5",
+      "transfer-encoding": "chunked",
+      "x-error-type": "Bad Request"
+    },
+    "body": {
+      "type": "stream",
+      "data": [
+        {
+          "data": "{\"error\":\"Bad Request\",\"message\":\"Seedance API request failed: {\\\"error\\\":{\\\"code\\\":\\\"InvalidParameter\\\",\\\"message\\\":\\\"The parameter `contents` specified in the request is not valid: text to video models do not support image in content. Request id: 021764687518769c799e7b290acded99bf6695874956a9f59130b\\\",\\\"param\\\":\\\"contents\\\",\\\"type\\\":\\\"BadRequest\\\"}}\",\"timingInfo\":[{\"step\":\"Request received.\",\"timestamp\":0}],\"requestId\":\"f18lrs\",\"requestParameters\":{\"prompt\":\"animate this image\",\"seed\":42,\"model\":\"seedance\",\"enhance\":false,\"nologo\":false,\"negative_prompt\":\"undefined\",\"nofeed\":false,\"safe\":false,\"quality\":\"medium\",\"image\":[\"https://image.pollinations.ai/prompt/a%20cat?width=512&height=512&nologo=true&seed=42\"],\"transparent\":false,\"audio\":false,\"width\":1024,\"height\":1024},\"queueInfo\":null}",
+          "delay": 0
+        }
+      ]
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-0458b94433a957475062bc4404de5e58.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-0458b94433a957475062bc4404de5e58.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771006174220"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1582",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:09:54 GMT",
+      "etag": "W/\"62e-7hlK+Dq7w0daQXRFkT19Uqn9h10\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1728",
+      "x-usage-completion-text-tokens": "103",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "That string looks like a label plus a big number — that number reads like a Unix timestamp in milliseconds. Converted to UTC it is:\n\n2026-02-13 18:09:34.220 UTC\n\nWant that converted to your local timezone? Or should I do something else with \"Different message 1 - 1771006174220\" (rename it, strip the timestamp, make alternative message text, parse it as an ID, etc.)?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771006174,
+        "id": "pllns_2bd10a6c2127891097517c9d30296cc3",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1831,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1728,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 2089
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-077dc2775a22dcbd921148f95fe4f242.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-077dc2775a22dcbd921148f95fe4f242.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771029839807"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1801",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 00:44:05 GMT",
+      "etag": "W/\"709-2jZiq4/NtzAUFSAp0R+dC3+v2+M\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "320",
+      "x-usage-completion-text-tokens": "149",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got the test ID: 1771029839807 — message received.\n\nDo you want me to actually deduplicate something, or was this just a connectivity/test ping? If you need dedup help, tell me:\n- data type (CSV, SQL table, plaintext, images, etc.)\n- how you define a \"duplicate\" (exact match, fuzzy name/email, same phone, near-duplicate images)\n- size of the dataset\n\nQuick options I can run through or explain: exact hashing (fast), pandas drop_duplicates or SQL DISTINCT, fuzzy matching / record linkage (dedupe library, fuzzywuzzy), or blocking/indexing for large datasets. Which do you want to try?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771029840,
+        "id": "pllns_f79287ed335b89b9ccd55caa0679c181",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 469,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 320,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 725
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-1172b01c5b3a34469aa1e498fdc896a1.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-1172b01c5b3a34469aa1e498fdc896a1.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771029779667"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1680",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 00:43:12 GMT",
+      "etag": "W/\"690-j/05KPeOEm50uqkOCgCprb8udjU\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1216",
+      "x-usage-completion-text-tokens": "128",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you want me to do something with that string (rewrite it, decode the number, turn it into a timestamp, etc.)?\n\nIf the numeric part (1771029779667) is a Unix timestamp in milliseconds, it converts to:\n- 2026-02-14 00:42:59.667 UTC\n\nI can:\n- Convert that to any timezone you want,\n- Format it in a human-friendly way,\n- Generate alternate \"Different message\" variants,\n- Or treat the number as an ID and embed it into a message template.\n\nWhich would you like?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771029780,
+        "id": "pllns_a1b19821656c26cd624b5af9f764f6a2",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1344,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1216,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1602
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-19a94ea4e7026b3c3e52a4778d592c9a.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-19a94ea4e7026b3c3e52a4778d592c9a.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771033637100"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2706",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:47:24 GMT",
+      "etag": "W/\"a92-qksAatVqY/uDIiv9YVqgRBF0soQ\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "384",
+      "x-usage-completion-text-tokens": "363",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Are you running a duplicate-check on that ID (1771033637100) or asking for general dedup help? I can do either — here are quick options depending on what you mean.\n\nIf you just want to check whether that exact value appears more than once:\n- Python (simple count):\n  items.count(\"1771033637100\")  # >0 means present, >1 means duplicated\n- Unix shell (count occurrences in a file):\n  grep -c \"1771033637100\" filename\n- SQL (find duplicates of a column named val):\n  SELECT val, COUNT(*) c FROM table GROUP BY val HAVING c>1;\n\nIf you want to remove duplicates from a list while preserving order:\n- Python:\n  deduped = list(dict.fromkeys(items))\n\nIf you want to remove duplicates from tabular data:\n- pandas:\n  df = df.drop_duplicates(subset=[\"column_name\"])  # or drop_duplicates() for whole rows\n\nIf you want to find all duplicated values (not just that one):\n- SQL:\n  SELECT val, COUNT(*) c FROM table GROUP BY val HAVING c>1;\n- Unix:\n  sort file | uniq -d  # prints values that are duplicated\n  sort file | uniq -c | sort -nr  # shows counts sorted descending\n\nIf you meant fuzzy/near-duplicate detection (e.g., similar strings, near-duplicate records), say so and I’ll outline approaches (fingerprinting, locality-sensitive hashing, similarity thresholds).\n\nTell me which format you’ve got (plain list, CSV, database, file path) and what outcome you want (report duplicates, delete duplicates, keep latest/earliest), and I’ll give the exact command or script.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033637,
+        "id": "pllns_d962a0c56acb906014acb2bb50d7beb1",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 747,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 384,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1003
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-1b206fdf609e146e82bc673c4d41f4dc.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-1b206fdf609e146e82bc673c4d41f4dc.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771033908187"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2080",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:52:02 GMT",
+      "etag": "W/\"820-jRH8RJjGyttgU1ksYsI6KuoP1NM\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1536",
+      "x-usage-completion-text-tokens": "273",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Looks like a label with a timestamp. If that’s a Unix millisecond value (1771033908187), it converts to:\n\n- 2026-02-14 01:51:48.187 UTC\n\nWant it shown in a different timezone? Or did you mean something else by that string?\n\nIf you want alternate versions of the message text, here are a few options you can pick from or tweak:\n\n1) Plain label: \"Different message 1 — 2026-02-14 01:51:48 UTC\"  \n2) Human-friendly: \"Message 1 (sent on Feb 14, 2026 at 01:51:48 UTC)\"  \n3) Log-style: \"[2026-02-14T01:51:48.187Z] Different message #1\"  \n4) File-name safe: \"Different_message_1_20260214_015148\"  \n5) Short/SMS: \"Msg1 — Feb 14 01:51\"  \n6) Friendly note: \"Different message 1 — captured on Valentine’s Day, 2026 at 01:51:48 UTC 🕒\"\n\nWhich direction do you want — convert to local time, rename a file, or produce different wording or formats?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033909,
+        "id": "pllns_b95cb68c3728b94b0fc8392d948756bc",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1809,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1536,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 2067
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-310a6b1889938756cbd6f7dbc0347fde.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-310a6b1889938756cbd6f7dbc0347fde.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771026649306"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1325",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 23:50:52 GMT",
+      "etag": "W/\"52d-ik4GEbkwNk6Ec4JYy5OA6Dvooho\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "128",
+      "x-usage-completion-text-tokens": "45",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got it — dedup test received: 1771026649306. Want me to check for duplicates, run a de-dup process, or just log this ID?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771026650,
+        "id": "pllns_575e7a7a6ad71a02ae7b247deffd0447",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 173,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 128,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 429
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-3e2f812a259a25337858426312d6004e.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-3e2f812a259a25337858426312d6004e.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771004545895"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1316",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 17:42:28 GMT",
+      "etag": "W/\"524-JvPBU1EtsByC5vmyKem9b3gzfbs\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "64",
+      "x-usage-completion-text-tokens": "43",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got it — dedup test ID 1771004545895 received. Want me to log it, run a check, or do anything else with that ID?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771004546,
+        "id": "pllns_3b19946596bdc2d4b43162ef8da67570",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 107,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 64,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 363
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-48f797053be11603993d3523970b27eb.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-48f797053be11603993d3523970b27eb.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771033644303"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1864",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:47:38 GMT",
+      "etag": "W/\"748-Wo1g4XAZ4mCM8WyzVubZLIIWFj4\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1344",
+      "x-usage-completion-text-tokens": "173",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you want me to do something with that string (parse it, turn it into alternate messages, look up what the number might mean)? A couple of quick possibilities:\n\n- If the 1771033644303 is an epoch timestamp in milliseconds, it converts to 2024-03-18 12:10:44.303 UTC. I can convert that to your local time zone if you tell me where you are.  \n- If you want different phrasing, I can generate variants for \"Different message 2\" (short, casual, formal, urgent, playful, etc.).  \n- If it’s an ID/filename and you want suggestions for naming, organizing, or decoding, I can help with that too.\n\nWhich of those (or something else) did you have in mind?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033645,
+        "id": "pllns_45a731c40989de780c55afcd08df812e",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1517,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1344,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1775
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-5656f8f1c43017f67be76f3175aab3d7.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-5656f8f1c43017f67be76f3175aab3d7.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771033658553"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1418",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:47:56 GMT",
+      "etag": "W/\"58a-ZcxvjYGSmJ7AzeI2QfKgddktogk\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "2048",
+      "x-usage-completion-text-tokens": "68",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "That looks like a Unix timestamp in milliseconds. 1771033658553 ms → 2026-02-14 01:47:38.553 UTC.\n\nDo you want it converted to a specific timezone/format, checked for a sequence pattern, or used in some test?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033659,
+        "id": "pllns_82f2239a14803f7035097465a67ec668",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 2116,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 2048,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 2371
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-570eb8cff08903c87ee991cb1858ab78.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-570eb8cff08903c87ee991cb1858ab78.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771004548478"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2202",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 17:42:39 GMT",
+      "etag": "W/\"89a-+JL2hHk51MXBvekU7hnWhQTeaQs\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "448",
+      "x-usage-completion-text-tokens": "258",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "I’m not sure what you mean by “Different message 2 - 1771004548478.” Do you want me to: recreate that label, decode it, write a set of alternative messages using that ID, or something else?\n\nIf you want alternative message texts, here are a few tones you can pick from (all include the ID):\n\n1) Formal: \"Different message 2 (ID 1771004548478): Please review the attached changes and confirm by end of day.\"\n2) Casual: \"Different message 2 — update for 1771004548478: everything’s on track for tomorrow.\"\n3) Playful: \"Different message 2 — mission 1771004548478 engaged. Adventure awaits.\"\n4) Technical/log: \"Different message 2 [1771004548478]: Build completed. All unit tests passed.\"\n5) Ultra-brief: \"Diff msg 2 — 1771004548478: ACK.\"\n6) Customer-service: \"Different message 2 — reference 1771004548478. We’re looking into this and will update you within 48 hours.\"\n\nWant any of these tweaked, more options, or did you mean something else with that string?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771004548,
+        "id": "pllns_298307c989e2172b3937751647dc44ce",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 706,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 448,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 964
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-607bb306c1f64ea7b4e6e5c3949536fc.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-607bb306c1f64ea7b4e6e5c3949536fc.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771029792058"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1611",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 00:43:35 GMT",
+      "etag": "W/\"64b-sCZd9xmCKySMpuLHB/ltqJQO6mQ\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1536",
+      "x-usage-completion-text-tokens": "115",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you mean that number as a Unix timestamp or just testing the connection? A couple quick possibilities:\n\n- As a Unix timestamp in milliseconds (1771029792058 ms) → 2026-02-14 00:43:12.058 UTC.\n- If you meant something else (an ID, a serial for a test run, want it converted to hex/base64, factored, or used to generate a sequence), tell me which and I’ll do it.\n\nWhich one did you have in mind?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771029792,
+        "id": "pllns_d9629858e05e75d9efc9d89b18a81fbb",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1651,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1536,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1906
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-7298957f95823145a66d6cb953e4fca5.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-7298957f95823145a66d6cb953e4fca5.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771005708474"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1718",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:02:03 GMT",
+      "etag": "W/\"6b6-HwINEQG7iqKhEGcfirqlST7ZiW8\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1216",
+      "x-usage-completion-text-tokens": "126",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Looks like a short tag — could be a filename, an identifier, or a Unix timestamp in milliseconds (1,771,005,708,474). What do you want me to do with it?\n\nOptions I can do right away:\n- Convert that number to a human-readable date/time (I can give exact UTC/local time).\n- Make different message variations that include it (formal, casual, log entry, etc.).\n- Explain or guess what it might represent (ID format, logging pattern).\n- Use it in a little script or filename template.\n\nWhich would you like?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771005709,
+        "id": "pllns_6954c144ac98b2741575141f4fd13fd6",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1342,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1216,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1600
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-797097b1ae01326c845855652d9a9a75.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-797097b1ae01326c845855652d9a9a75.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771029776105"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1437",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 00:42:59 GMT",
+      "etag": "W/\"59d-PnDYuz7m5HKmYQaCjPHWWM6KyhQ\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "192",
+      "x-usage-completion-text-tokens": "73",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got it — Dedup test 1771029776105 received. Do you want me to run a deduplication, check results, or just log this? If you want a dedup, paste the data and tell me the criteria (exact match, case-insensitive, fuzzy, by field, etc.).",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771029777,
+        "id": "pllns_b5fea6f894c3b5fc06bc5ae63e3a6468",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 265,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 192,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 521
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-7c07337954ecec7a5163800adae9175b.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-7c07337954ecec7a5163800adae9175b.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771005708474"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1574",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:01:59 GMT",
+      "etag": "W/\"626-izRlaTyvQqvtB9lnREDTmesmHHw\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "896",
+      "x-usage-completion-text-tokens": "108",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Looks like a label plus a Unix epoch in milliseconds. That timestamp (1771005708474 ms) = 2026-02-13 18:01:48.474 UTC.\n\nIf that’s a log line, an ID, or something else, tell me the context and I can:\n- convert it to any timezone you want,\n- reformat it,\n- extract or batch-convert more timestamps,\n- or help parse the whole message pattern. Which would you like?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771005708,
+        "id": "pllns_cc8c2946e9abb64d01db2522fba0a62c",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1004,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 896,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1262
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-8c573d6f03e44109c71bfb06bdb2c1c5.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-8c573d6f03e44109c71bfb06bdb2c1c5.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771006174221"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1622",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:09:51 GMT",
+      "etag": "W/\"656-g/LBZt2RYXLpaOxLDU8I+UgE8mQ\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1216",
+      "x-usage-completion-text-tokens": "115",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you want me to do something with that line — decode the number, rewrite the message, or something else?\n\nQuick decode in case that number is a Unix-milliseconds timestamp:\n- 1771006174221 ms since epoch = 2026-02-14 18:09:34.221 UTC.\n\nIf you want a rewritten \"Different message 2\", tell me the audience and tone (friendly, formal, funny, short, long) and I’ll draft a few options. Which would you like?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771006174,
+        "id": "pllns_7963c27497f954191c9d71bd18e85f0d",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1331,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1216,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1589
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-93bb931d798811f6dc02ff4d4c8a5d40.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-93bb931d798811f6dc02ff4d4c8a5d40.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771033900118"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2306",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:51:48 GMT",
+      "etag": "W/\"902-+5ncLk80g6qSzZjF/H3F8xIhq8E\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "512",
+      "x-usage-completion-text-tokens": "287",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got the test ID: 1771033900118. What do you want me to do with it?\n\nOptions I can help with:\n- Check or interpret a deduplication result if you paste it here.\n- Run a dedup on a dataset (upload or paste the data).\n- Show quick dedup examples (Python, SQL, shell) you can run locally.\n- Troubleshoot a dedup pipeline that’s failing or producing unexpected results.\n\nQuick examples you can use right away\n\n- Python (pandas, exact dedupe)\nimport pandas as pd\ndf = pd.read_csv('data.csv')\ndeduped = df.drop_duplicates()  # remove exact duplicate rows\ndeduped.to_csv('deduped.csv', index=False)\n\n- SQL (keep newest row per key)\nSELECT * FROM (\n  SELECT *, ROW_NUMBER() OVER (PARTITION BY key_column ORDER BY updated_at DESC) rn\n  FROM my_table\n) t\nWHERE rn = 1;\n\n- Shell (simple line dedupe)\nsort input.txt | uniq > deduped.txt\n\nIf you need fuzzy deduplication (typos, name/address matching), I can show a dedupe library example or a rules-based approach.\n\nTell me which path you want (check results, run dedup, show code), and drop the data or error messages if you have them.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033901,
+        "id": "pllns_d67caa329a3001a67196ef787c386087",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 799,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 512,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1055
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-95a63b8deae73a29df9a5bd2fe70ab1e.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-95a63b8deae73a29df9a5bd2fe70ab1e.json
@@ -1,0 +1,127 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "claude-legacy",
+        "messages": [
+          {
+            "role": "user",
+            "content": "What is 5 + 3? You must use the calculator tool to compute this."
+          },
+          {
+            "role": "assistant",
+            "tool_calls": [
+              {
+                "id": "tooluse_n6k60mHtnaQFkTlipLno8h",
+                "type": "function",
+                "function": {
+                  "name": "calculator",
+                  "arguments": "{\"operation\":\"add\",\"a\":5,\"b\":3}"
+                }
+              }
+            ]
+          },
+          {
+            "role": "tool",
+            "tool_call_id": "tooluse_n6k60mHtnaQFkTlipLno8h",
+            "content": "{\"result\":8}"
+          }
+        ],
+        "tools": [
+          {
+            "type": "function",
+            "function": {
+              "name": "calculator",
+              "description": "Perform basic arithmetic operations",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "enum": [
+                      "add",
+                      "subtract",
+                      "multiply",
+                      "divide"
+                    ],
+                    "description": "The arithmetic operation to perform"
+                  },
+                  "a": {
+                    "type": "number",
+                    "description": "First operand"
+                  },
+                  "b": {
+                    "type": "number",
+                    "description": "Second operand"
+                  }
+                },
+                "required": [
+                  "operation",
+                  "a",
+                  "b"
+                ]
+              }
+            }
+          }
+        ],
+        "seed": 42,
+        "max_tokens": 4096
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "449",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 17:47:06 GMT",
+      "etag": "W/\"1c1-plSf2ZoJV4KiCu1/KOqWRZyxiy0\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+      "x-powered-by": "Express",
+      "x-usage-completion-text-tokens": "12",
+      "x-usage-prompt-text-tokens": "1013"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "id": "pllns_824a2ad34f3c036c7ea5126d77eaa087",
+        "object": "chat.completion",
+        "created": 1771004826,
+        "model": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+        "provider": "bedrock",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "5 + 3 = 8",
+              "content_blocks": [
+                {
+                  "type": "text",
+                  "text": "5 + 3 = 8"
+                }
+              ]
+            },
+            "finish_reason": "end_turn"
+          }
+        ],
+        "usage": {
+          "prompt_tokens": 1013,
+          "completion_tokens": 12,
+          "total_tokens": 1025,
+          "prompt_tokens_details": {
+            "cached_tokens": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-98dc5c7cdd78566cb608defd3ffe7498.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-98dc5c7cdd78566cb608defd3ffe7498.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771033908187"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2097",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:52:00 GMT",
+      "etag": "W/\"831-mepJNVisHB9K4ZAMC0IAdV7pHQ4\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "896",
+      "x-usage-completion-text-tokens": "226",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Looks like a short label — maybe a filename, log entry, or a timestamp. What do you want me to do with it?\n\nHere are a few things I can do right away; tell me which one you want (or something else):\n\n- Interpret 1771033908187 as a Unix timestamp in milliseconds and convert it to a human date/time.\n- Treat it as a message/ID and help rename or reformat it.\n- Search for patterns or produce a cleaned/shortened version.\n- Explain how to convert it yourself (commands/snippets for Python, JavaScript, or shell).\n\nQuick conversion snippets you can run:\n\n- JavaScript:\n  - console.log(new Date(1771033908187))\n- Python:\n  - import datetime; print(datetime.datetime.utcfromtimestamp(1771033908187/1000))\n- Unix (if you have coreutils date that accepts seconds):\n  - date -d @1771033908   (use 1771033908 if your date wants seconds, not milliseconds)\n\nWhich option do you want?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033909,
+        "id": "pllns_7b44b018530039b68407a879aa3b24c4",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1122,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 896,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1380
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-9c1b2865fadf5bd85f334cbc13ba2c05.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-9c1b2865fadf5bd85f334cbc13ba2c05.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771033644303"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2047",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:47:30 GMT",
+      "etag": "W/\"7ff-QvMCeQzxxddHGP2f2IMVtrnGllI\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "320",
+      "x-usage-completion-text-tokens": "228",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "I’m not sure what you mean by \"Different message 1 - 1771033644303.\" Do you want me to:\n\n- Reword that exact line?\n- Create a new message using that ID?\n- Produce several alternative messages (different tones/purposes)?\n- Translate or summarize something else?\n\nIf you want alternatives right away, here are five short rewrites in different tones you can pick from or tell me to expand on:\n\n1) Formal: \"Alternate Notification 1 — Reference: 1771033644303.\"  \n2) Casual: \"New message #1 (ID: 1771033644303).\"  \n3) Friendly/Helpful: \"Heads up — different message 1 | ID 1771033644303.\"  \n4) Urgent/Direct: \"Alert: Different Message 1 — 1771033644303.\"  \n5) Technical/logging: \"diff_msg_1: id=1771033644303, status=pending.\"\n\nTell me which direction you want, or paste the original content if you want it edited.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033645,
+        "id": "pllns_71df242ffc2fc3f50dfa844ab4a1a1e3",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 548,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 320,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 806
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-a2e9d8e96876feda6bbb170c7dd4a909.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-a2e9d8e96876feda6bbb170c7dd4a909.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771026652180"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1648",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 23:51:03 GMT",
+      "etag": "W/\"670-tc2pHNvkoYdnUwcrAwLeTjT5pPg\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "896",
+      "x-usage-completion-text-tokens": "151",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Looks like a label plus a Unix-milliseconds timestamp. The number 1771026652180 ms converts to:\n\n- 2026-02-12 23:50:52.180 UTC\n\nIf you want it in a different timezone, for example:\n- UTC-5 (EST): 2026-02-12 18:50:52.180\n- UTC-8 (PST): 2026-02-12 15:50:52.180\n\nDo you want me to:\n- rename/format this into a friendlier string,\n- parse more of a batch of similar filenames,\n- or did you mean something else by \"Different message 2\"?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771026652,
+        "id": "pllns_eb8fef067500222a221fd30830105437",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1047,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 896,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1305
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-a4d4b4e7462da35330084d877c37aa0b.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-a4d4b4e7462da35330084d877c37aa0b.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771026652180"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2004",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 23:51:00 GMT",
+      "etag": "W/\"7d4-sAXzTW2gbkCKuMmd0UijSwW+96w\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "576",
+      "x-usage-completion-text-tokens": "214",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you want that line rewritten, explained, or transformed into something else? I’m guessing you either want an alternative phrasing or you’re showing a label with an ID/timestamp.\n\nHere are a few quick rewrites in different tones — tell me which fits or what you actually need:\n\n- Neutral: Different message 1 — 1771026652180\n- Formal: Message variant #1 — ID: 1771026652180\n- Casual: Here’s a different message (1) — 1771026652180\n- Concise: Alt msg 1: 1771026652180\n- Playful: Switching it up: Different message #1 ✨ 1771026652180\n- Technical: Alternate payload[1] = 1771026652180\n\nIf that number is a timestamp and you want it converted to a date/time (or explained), say so and I’ll convert it. Or tell me the tone/length/context and I’ll craft something specific.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771026652,
+        "id": "pllns_bd7c93439c6bbaec056e061bdf959697",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 790,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 576,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1048
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-a8d7d7a62722f551b2abf643e1079e2d.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-a8d7d7a62722f551b2abf643e1079e2d.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771005705097"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1341",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:01:48 GMT",
+      "etag": "W/\"53d-OtkaXqSzCp3pIqiNNNyvmjXoO9U\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "128",
+      "x-usage-completion-text-tokens": "50",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got it — \"Dedup test 1771005705097\". Do you want me to run a dedup check, explain dedup methods, or just record/acknowledge this test?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771005705,
+        "id": "pllns_265f322f997530072d58f35745307211",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 178,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 128,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 434
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-bb10fa57ceaff31e29c861715218bd35.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-bb10fa57ceaff31e29c861715218bd35.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771006194471"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2085",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:10:26 GMT",
+      "etag": "W/\"825-+KSDuy9YLE/VRfM1vnNjHyCfAdU\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "2240",
+      "x-usage-completion-text-tokens": "281",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you mean you want a mathematical/sequence analysis of the number 1771006194471? I can run several kinds of checks (primality/factoring, digit-patterns, randomness/run tests, OEIS search, base conversions, checksum tests, etc.). Quick findings to start with:\n\n- It's a 13-digit integer.\n- Sum of digits = 48, so it's divisible by 3. Indeed\n  1771006194471 = 3 × 590335398157\n- Not divisible by 2 or 5 (doesn't end in 0/2/4/6/8 or 0/5). The alternating-sum test for 11 gives 8, so not divisible by 11.\n- Digit frequencies: 0:2, 1:4, 4:2, 6:1, 7:3, 9:1 (other digits 2,3,5,8 absent).\n- Short repeats present: \"77\", \"00\", \"44\" (longest immediate repeat length = 2).\n\nWhat would you like next — try to factor the leftover 590,335,398,157, run a Miller–Rabin primality check, convert to binary/hex, search OEIS, or run randomness/run tests on the digit sequence?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771006194,
+        "id": "pllns_2f78ffe208c4b8edeadb6f75722353ad",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 2521,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 2240,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 2776
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-d085ff61bf3ccdd32b74295f82d22a7e.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-d085ff61bf3ccdd32b74295f82d22a7e.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771033922567"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1879",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 01:52:10 GMT",
+      "etag": "W/\"757-HnIwcplC2kAP3NuD4ce9GZC5UNk\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "448",
+      "x-usage-completion-text-tokens": "209",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got this: \"Sequential test 1771033922567.\" What do you want me to do with that?\n\nOptions I can help with right away:\n- Generate the next N sequential numbers (example next 10: 1771033922567, 1771033922568, 1771033922569, 1771033922570, 1771033922571, 1771033922572, 1771033922573, 1771033922574, 1771033922575, 1771033922576).\n- Treat the number as a seed and produce a pseudo-random sequence.\n- Explain or run a statistical sequential test (e.g., Wald SPRT) — I’ll need H0/H1, alpha/beta or your observed data.\n- Look up or diagnose a test run with that ID — tell me the system, logs, or paste the output.\n\nOr tell me what you actually meant and I’ll do it.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771033923,
+        "id": "pllns_3d253759341c60bd7937e23942281d92",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 657,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 448,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 912
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-d6241ecd0b61ab68a28637e61f4190db.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-d6241ecd0b61ab68a28637e61f4190db.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Dedup test 1771006170874"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1333",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:09:33 GMT",
+      "etag": "W/\"535-oxph9JIqz8HP9Vq2yyu/Dr2GdV0\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "128",
+      "x-usage-completion-text-tokens": "45",
+      "x-usage-prompt-text-tokens": "256"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got it — dedup test 1771006170874 received. Want me to run the dedup check, log this as completed, or do something else with it?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771006171,
+        "id": "pllns_7d40a49ac302544fa7a95c857ab80c88",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 173,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 128,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 256,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 429
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-e935c7b07a5ba4c33dd0c412b267f3ee.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-e935c7b07a5ba4c33dd0c412b267f3ee.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771004559777"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1982",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 17:42:55 GMT",
+      "etag": "W/\"7be-rOSlVXCuAY5MMOHEg7MCjVVAB0g\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "1408",
+      "x-usage-completion-text-tokens": "205",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you mean “run a test on this number”? I can do several different checks — tell me which you want, or pick one below and I’ll run it:\n\nQuick observations right away\n- Number: 1,771,004,559,777 (13 digits)\n- Digit sum = 60 → divisible by 3, so the number is composite (3 × 590,334,853,259).\n- Digits are not an increasing/decreasing sequential run.\n\nOptions I can do next (pick one or ask for something else)\n- Full prime factorization (continue factoring 590,334,853,259)\n- Primality test only (confirm composite/prime)\n- Interpret as a Unix timestamp (ms or s) and convert to human date/time\n- Check checksum algorithms (Luhn, ISBN-style, etc.)\n- Convert to binary/hex/base64 or do statistical/digit-pattern analysis\n\nWhich would you like me to do?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771004560,
+        "id": "pllns_5888e9f7c416ce7fd8c0d81ef74d4dd2",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 1613,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 1408,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1868
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-ec94addd6f4db3ebe865c1873c569f28.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-ec94addd6f4db3ebe865c1873c569f28.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 2 - 1771029779667"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2287",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Sat, 14 Feb 2026 00:43:06 GMT",
+      "etag": "W/\"8ef-I+/uji3wqQ73aSC9ILPpgpx1ceU\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "320",
+      "x-usage-completion-text-tokens": "296",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Hey — can you tell me what you want me to do with \"Different message 2 - 1771029779667\"? A few quick possibilities I can help with:\n\n- Rewrite it (shorter, clearer, fancier)\n- Turn it into an email subject, push notification, or SMS\n- Generate multiple alternative messages with that ID included or removed\n- Explain or reformat the numeric ID (timestamp, UUID-style, etc.)\n- Localize/translate it into another language\n- Use it as a log entry or commit message and make it more descriptive\n\nIf any of those match, pick one. If you want me to just produce a handful of alternate phrasings right away, here are eight options in different tones:\n\n1. Different message #2 — 1771029779667\n2. Alternate message 2 (ID: 1771029779667)\n3. Message variant 2 — 1771029779667\n4. Different Message 2 — Reference: 1771029779667\n5. Diff Msg 2 | 1771029779667\n6. New version 2 — 1771029779667\n7. Update: Different message 2 — 1771029779667\n8. Different Msg 2 — UID 1771029779667\n\nWant more options tailored to a specific use (subject line, log, user-facing text)?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771029780,
+        "id": "pllns_4dcc249d4ec9dcd6824cddad00e84ea8",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 616,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 320,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 874
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-eef6d47cf04e137461fbd3790e3fb259.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-eef6d47cf04e137461fbd3790e3fb259.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Different message 1 - 1771004548478"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1801",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 17:42:39 GMT",
+      "etag": "W/\"709-JJX8geKSla1n+6V/tZFXPYoa+/Y\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "704",
+      "x-usage-completion-text-tokens": "153",
+      "x-usage-prompt-text-tokens": "258"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "I’m missing context — what would you like me to do with \"Different message 1 - 1771004548478\"?\n\nHere are a few things I can do. Pick one (or tell me something else):\n\n- Convert the number (1771004548478) to a human date/time (it looks like a Unix timestamp in milliseconds).\n- Produce alternate phrasings of “Different message 1” (e.g., for UI labels or log entries).\n- Treat it as an ID and generate metadata or a short description.\n- Decode or analyze it for patterns (is it a timestamp, hash, serial, etc.).\n- Something else — tell me what you need.\n\nWhich would you like?",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771004548,
+        "id": "pllns_aab45679ab757daf35b59f72edcd3e44",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 857,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 704,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 258,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 1115
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-ef96107436771421a45bc50d002ecddf.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-ef96107436771421a45bc50d002ecddf.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771005723984"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "1642",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 18:02:12 GMT",
+      "etag": "W/\"66a-qb4ew+frwkALRPUeQGP5zEq/yS8\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "576",
+      "x-usage-completion-text-tokens": "121",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "detected": false,
+                "filtered": false
+              },
+              "protected_material_text": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Got it: \"Sequential test 1771005723984.\"\n\nWhat would you like me to do with that? A few quick options I can do right away:\n- Return the next number: 1771005723985\n- Generate a sequence (tell me count and step)\n- Factorize or check primality\n- Convert to binary/hex/base64\n- Interpret as a Unix timestamp (ms) and convert to a human date\n- Create test payloads or formatted IDs\n\nWhich one do you want, or tell me something else.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771005724,
+        "id": "pllns_b0a3d9b2d1ad09e54b7a368f63929d01",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "detected": false,
+                "filtered": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 697,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 576,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 952
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/test/mocks/snapshots/text-f699d649da3e4b3b60fbf0e09f1e05c5.json
+++ b/enter.pollinations.ai/test/mocks/snapshots/text-f699d649da3e4b3b60fbf0e09f1e05c5.json
@@ -1,0 +1,128 @@
+{
+  "request": {
+    "url": "http://ec2-3-80-56-235.compute-1.amazonaws.com:16385/openai",
+    "method": "POST",
+    "body": {
+      "type": "json",
+      "data": {
+        "model": "openai",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Sequential test 1771026663274"
+          }
+        ]
+      }
+    },
+    "params": {}
+  },
+  "response": {
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "access-control-allow-origin": "*",
+      "connection": "keep-alive",
+      "content-length": "2054",
+      "content-type": "application/json; charset=utf-8",
+      "date": "Fri, 13 Feb 2026 23:51:37 GMT",
+      "etag": "W/\"806-+7wFLgUVpzPvAb+T30tfCLiUuBY\"",
+      "keep-alive": "timeout=5",
+      "x-model-used": "gpt-5-mini-2025-08-07",
+      "x-powered-by": "Express",
+      "x-usage-completion-reasoning-tokens": "3200",
+      "x-usage-completion-text-tokens": "257",
+      "x-usage-prompt-text-tokens": "255"
+    },
+    "body": {
+      "type": "json",
+      "data": {
+        "choices": [
+          {
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "protected_material_code": {
+                "filtered": false,
+                "detected": false
+              },
+              "protected_material_text": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            },
+            "finish_reason": "stop",
+            "index": 0,
+            "logprobs": null,
+            "message": {
+              "annotations": [],
+              "content": "Do you mean that as a test ID you want looked up, or do you want some numeric/sequence analysis of the number 1771026663274? I can do either — quick breakdown below in case you meant the latter.\n\nQuick numeric facts about 1771026663274\n- Digits: 13\n- Even (ends with 4)\n- Sum of digits: 52\n- Not divisible by 3 or 9 (sum 52)\n- Divisible by 11 (alternating sum = 0), and by 2 — so divisible by 22\n- Further factorization so far: 1771026663274 = 2 × 11 × 11 × 7,318,291,997 = 242 × 7,318,291,997\n- Not a palindrome\n- Longest repeated run: three 6s in a row (…666…)\n- No strictly increasing or decreasing consecutive-digit run of length >2\n\nIf you meant something else by “Sequential test 1771026663274” (a lookup, a log ID, run a specific statistical or cryptographic test, etc.), tell me what you want and I’ll run it.",
+              "refusal": null,
+              "role": "assistant"
+            }
+          }
+        ],
+        "created": 1771026663,
+        "id": "pllns_4f151ac1b6f2e936c7c2140cad33cbd8",
+        "model": "gpt-5-mini-2025-08-07",
+        "object": "chat.completion",
+        "prompt_filter_results": [
+          {
+            "prompt_index": 0,
+            "content_filter_results": {
+              "hate": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "jailbreak": {
+                "filtered": false,
+                "detected": false
+              },
+              "self_harm": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "sexual": {
+                "filtered": false,
+                "severity": "safe"
+              },
+              "violence": {
+                "filtered": false,
+                "severity": "safe"
+              }
+            }
+          }
+        ],
+        "system_fingerprint": null,
+        "usage": {
+          "completion_tokens": 3457,
+          "completion_tokens_details": {
+            "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 3200,
+            "rejected_prediction_tokens": 0
+          },
+          "prompt_tokens": 255,
+          "prompt_tokens_details": {
+            "audio_tokens": 0,
+            "cached_tokens": 0
+          },
+          "total_tokens": 3712
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adds 31 recorded mock snapshots under `enter.pollinations.ai/test/mocks/snapshots` that currently exist only on `production`
- Adds the AGENTS.md note on shrinking large video/image test snapshots (also production-only)
- Reconciles `main` with `production` so the two branches stop diverging on these files