### PR TITLE
billing design: multiplier functors for search fees

### DIFF
--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -4,6 +4,7 @@ import type { ModelDefinition } from "@shared/registry/registry.js";
 import {
     calculateCost,
     calculatePrice,
+    getBasePriceMultiplier,
     getCostDefinition,
     getModelDefinition,
     getModels,
@@ -42,14 +43,37 @@ test.for(
     expect(resolved).toBe(shouldResolveTo);
 });
 
-test("public price equals provider cost times priceMultiplier for every model", () => {
-    // Invariant: price = cost × priceMultiplier, for every model, no exceptions.
-    // Asserted per cost field so it holds at any multiplier (currently all 1×).
+test("gemini-search applies grounding cost on top of shared token rates", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const geminiFastCost = calculateCost("gemini-fast", usage);
+    const geminiSearchCost = calculateCost("gemini-search", usage, {
+        choices: [
+            {
+                groundingMetadata: {
+                    webSearchQueries: ["latest Gemini pricing"],
+                },
+            },
+        ],
+    });
+
+    expect(geminiSearchCost.totalCost).toBeGreaterThan(
+        geminiFastCost.totalCost,
+    );
+});
+
+test("public price equals provider cost times base priceMultiplier for every model", () => {
+    // The static price table is derived from base cost × base multiplier.
+    // Dynamic functors add runtime adjustments in calculateCost/calculatePrice.
     for (const model of getModels()) {
         const cost = getCostDefinition(model);
         const price = getPriceDefinition(model);
         if (!cost || !price) continue; // no cost block → nothing billed
-        const { priceMultiplier } = getModelDefinition(model);
+        const priceMultiplier = getBasePriceMultiplier(
+            getModelDefinition(model),
+        );
         for (const [field, rate] of Object.entries(cost)) {
             const priceRate = price[field as keyof typeof price] as number;
             expect(priceRate).toBeCloseTo(
@@ -65,7 +89,7 @@ test("calculatePrice derives the total from cost via priceMultiplier", () => {
     // cost × priceMultiplier. Assert the runtime aggregation honours that for a
     // single-field model, at whatever multiplier the model currently uses.
     const usage = { completionImageTokens: 1 };
-    const { priceMultiplier } = getModelDefinition("flux");
+    const priceMultiplier = getBasePriceMultiplier(getModelDefinition("flux"));
     const cost = calculateCost("flux", usage);
     const price = calculatePrice("flux", usage);
 

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -151,6 +151,259 @@ test("Grok 4.20 registry metadata covers verified modalities and costs", () => {
     );
 });
 
+test("Gemini grounding cost is added by multiplier functors", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const groundedOutput = {
+        choices: [
+            {
+                groundingMetadata: {
+                    webSearchQueries: ["weather in Berlin", "Berlin forecast"],
+                },
+            },
+        ],
+    };
+
+    const geminiSearchCost = calculateCost(
+        "gemini-search",
+        usage,
+        groundedOutput,
+    );
+    const geminiSearchPrice = calculatePrice(
+        "gemini-search",
+        usage,
+        groundedOutput,
+    );
+    const gemini3Cost = calculateCost("gemini", usage, groundedOutput);
+    const geminiSearchFastCost = calculateCost(
+        "gemini-search-fast",
+        usage,
+        groundedOutput,
+    );
+    const geminiSearchLargeCost = calculateCost(
+        "gemini-search-large",
+        usage,
+        groundedOutput,
+    );
+    const ungroundedGeminiSearchFastCost = calculateCost(
+        "gemini-search-fast",
+        usage,
+        { choices: [] },
+    );
+
+    // Gemini 2.5 Search bills once per grounded prompt, not once per query.
+    // priceMultiplier is 1×, so price equals cost.
+    expect(geminiSearchCost.totalCost).toBeCloseTo(0.535, 8);
+    expect(geminiSearchPrice.totalPrice).toBeCloseTo(0.535, 8);
+
+    // Gemini 3.x bills per non-empty search query.
+    expect(gemini3Cost.totalCost).toBeCloseTo(3.528, 8);
+    expect(geminiSearchFastCost.totalCost).toBeCloseTo(1.778, 8);
+    expect(geminiSearchLargeCost.totalCost).toBeCloseTo(10.528, 8);
+    expect(ungroundedGeminiSearchFastCost.totalCost).toBeCloseTo(1.75, 8);
+});
+
+test("Gemini multiplier billing metadata is exposed in model catalog metadata", () => {
+    const geminiSearchFast = getTextModelsInfo().find(
+        (model) => model.name === "gemini-search-fast",
+    );
+    const geminiLarge = getTextModelsInfo().find(
+        (model) => model.name === "gemini-large",
+    );
+
+    expect(geminiSearchFast?.billing?.adjustments?.[0]).toMatchObject({
+        id: "google.gemini_3.search_query.v1",
+        kind: "search_query",
+        unit: "query",
+        count: "geminiWebSearchQueries",
+        when: "grounded",
+        unit_price: "0.014",
+    });
+    expect(geminiSearchFast?.billing?.description).toContain(
+        "Gemini 3 Google Search fee",
+    );
+    expect(geminiLarge?.billing?.tiers?.[0]).toMatchObject({
+        id: "google.gemini_3_1_pro.long_context.v1",
+        description: "Prompts above 200K tokens use Gemini long-context rates.",
+    });
+});
+
+test("Perplexity request search fees are added by multiplier functors", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const cases = [
+        ["perplexity-fast", 2.005],
+        ["perplexity-deep", 2.012],
+        ["perplexity", 18.014],
+        ["perplexity-reasoning", 10.014],
+    ] as const;
+
+    for (const [model, total] of cases) {
+        const cost = calculateCost(model, usage);
+        const price = calculatePrice(model, usage);
+
+        expect(cost.totalCost).toBeCloseTo(total, 8);
+        expect(price.totalPrice).toBeCloseTo(total, 8);
+    }
+});
+
+test("Perplexity request search fee prefers provider-reported request cost", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const responseOutput = {
+        usage: {
+            cost: {
+                request_cost: 0.006,
+                total_cost: 0.0061,
+            },
+            search_context_size: "low",
+        },
+    };
+    const streamOutput = {
+        streamEvents: [
+            { choices: [{ delta: { content: "ok" } }] },
+            {
+                usage: {
+                    cost: {
+                        request_cost: 0.012,
+                    },
+                },
+                choices: [{ finish_reason: "stop" }],
+            },
+        ],
+    };
+
+    expect(
+        calculateCost("perplexity-fast", usage, responseOutput).totalCost,
+    ).toBeCloseTo(2.006, 8);
+    expect(
+        calculatePrice("perplexity-fast", usage, responseOutput).totalPrice,
+    ).toBeCloseTo(2.006, 8);
+    expect(
+        calculateCost("perplexity-fast", usage, streamOutput).totalCost,
+    ).toBeCloseTo(2.012, 8);
+});
+
+test("Perplexity provider-reported request cost is sanity bounded", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+
+    // Malformed or out-of-bound values fall back to the static $0.005 fee,
+    // never to 0: huge (>10x static), negative, and NaN are all rejected.
+    const rejected = [9.99, -0.5, Number.NaN];
+    for (const requestCost of rejected) {
+        const output = { usage: { cost: { request_cost: requestCost } } };
+        expect(
+            calculateCost("perplexity-fast", usage, output).totalCost,
+        ).toBeCloseTo(2.005, 8);
+        expect(
+            calculatePrice("perplexity-fast", usage, output).totalPrice,
+        ).toBeCloseTo(2.005, 8);
+    }
+
+    // The bound is inclusive: exactly 10x the static fee is still trusted.
+    const atBound = { usage: { cost: { request_cost: 0.05 } } };
+    expect(
+        calculateCost("perplexity-fast", usage, atBound).totalCost,
+    ).toBeCloseTo(2.05, 8);
+});
+
+test("Gemini grounding is detected on streamed chunk output", () => {
+    const usage = {
+        promptTextTokens: 1_000_000,
+        completionTextTokens: 1_000_000,
+    };
+    const streamOutput = {
+        streamEvents: [
+            { choices: [{ delta: { content: "searching" } }] },
+            {
+                choices: [
+                    {
+                        groundingMetadata: {
+                            webSearchQueries: [
+                                "weather in Berlin",
+                                "Berlin forecast",
+                            ],
+                        },
+                    },
+                ],
+            },
+        ],
+    };
+
+    // Same totals as the non-stream fixtures: grounding billed once per
+    // prompt for Gemini 2.5, per unique query for Gemini 3.x.
+    expect(
+        calculateCost("gemini-search", usage, streamOutput).totalCost,
+    ).toBeCloseTo(0.535, 8);
+    expect(
+        calculatePrice("gemini-search", usage, streamOutput).totalPrice,
+    ).toBeCloseTo(0.535, 8);
+    expect(
+        calculateCost("gemini-search-fast", usage, streamOutput).totalCost,
+    ).toBeCloseTo(1.778, 8);
+});
+
+test("Perplexity multiplier billing metadata exposes request fee metadata", () => {
+    const models = getTextModelsInfo();
+
+    expect(
+        models.find((model) => model.name === "perplexity-fast")?.billing
+            ?.adjustments?.[0],
+    ).toMatchObject({
+        id: "perplexity.sonar_low.search_request.v1",
+        kind: "search_request",
+        unit: "request",
+        count: "perplexityRequest",
+        when: "always",
+        unit_price: "0.005",
+    });
+    expect(
+        models.find((model) => model.name === "perplexity-fast")?.billing
+            ?.description,
+    ).toContain("Perplexity search request fee");
+    expect(
+        models.find((model) => model.name === "perplexity-deep")?.billing
+            ?.adjustments?.[0].unit_price,
+    ).toBe("0.012");
+    expect(
+        models.find((model) => model.name === "perplexity")?.billing
+            ?.adjustments?.[0].unit_price,
+    ).toBe("0.014");
+    expect(
+        models.find((model) => model.name === "perplexity-reasoning")?.billing
+            ?.adjustments?.[0].unit_price,
+    ).toBe("0.014");
+});
+
+test("Gemini 3.1 Pro uses long-context rates above 200k prompt tokens", () => {
+    const shortContextCost = calculateCost("gemini-large", {
+        promptTextTokens: 200_000,
+        completionTextTokens: 1_000,
+    });
+    const longContextCost = calculateCost("gemini-large", {
+        promptTextTokens: 200_001,
+        completionTextTokens: 1_000,
+    });
+    const longContextPrice = calculatePrice("gemini-large", {
+        promptTextTokens: 200_001,
+        completionTextTokens: 1_000,
+    });
+
+    // priceMultiplier is 1×, so price equals cost.
+    expect(shortContextCost.totalCost).toBeCloseTo(0.412, 8);
+    expect(longContextCost.totalCost).toBeCloseTo(0.818004, 8);
+    expect(longContextPrice.totalPrice).toBeCloseTo(0.818004, 8);
+});
+
 test("registry cost blocks contain no sentinel/placeholder negative values", () => {
     const registries = [
         ["text", TEXT_SERVICES],

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -13,7 +13,6 @@ import {
 } from "@shared/client-ip.ts";
 import { user as userTable } from "@shared/db/better-auth.ts";
 import { PUBLIC_URLS } from "@shared/public-urls.ts";
-import type { Usage } from "@shared/registry/registry.ts";
 import {
     calculateCost,
     calculatePrice,
@@ -21,6 +20,7 @@ import {
     getPriceDefinition,
     type ModelName,
     type PriceDefinition,
+    type Usage,
     type UsageCost,
     type UsagePrice,
 } from "@shared/registry/registry.ts";
@@ -77,6 +77,7 @@ type ModelVariables = {
 export type ModelUsage = {
     model: string;
     usage: Usage;
+    output?: unknown;
 };
 
 type RequestTrackingData = {
@@ -158,7 +159,7 @@ export const track = (eventType: EventType) =>
                 c.var.auth.apiKey?.byopClientUserId ?? undefined,
         } satisfies UserData;
 
-        let responseOverride = null;
+        let responseOverride: Response | null = null;
 
         c.set("track", {
             modelRequested: requestTracking.modelRequested,
@@ -175,7 +176,14 @@ export const track = (eventType: EventType) =>
 
         c.executionCtx.waitUntil(
             (async () => {
-                const response = responseOverride || c.res.clone();
+                // Routes attach telemetry headers (x-moderation-*, cache
+                // status) to the final response AFTER the override is
+                // captured, so read the body from the override but headers
+                // from c.res — keeping the override's content-type since it
+                // describes the body that usage extraction parses.
+                const response = responseOverride
+                    ? withFinalResponseHeaders(responseOverride, c.res)
+                    : c.res.clone();
                 const responseTracking = await trackResponse(
                     eventType,
                     requestTracking,
@@ -382,6 +390,24 @@ async function trackRequest(
     };
 }
 
+// Tracking overrides capture the upstream body before route handlers attach
+// telemetry headers to the final response. Combine the override body with the
+// final headers so header-based extraction (moderation, cache) stays intact.
+function withFinalResponseHeaders(
+    override: Response,
+    final: Response,
+): Response {
+    const headers = new Headers(final.headers);
+    const contentType = override.headers.get("content-type");
+    if (contentType) {
+        headers.set("content-type", contentType);
+    }
+    return new Response(override.body, {
+        status: override.status,
+        headers,
+    });
+}
+
 async function trackResponse(
     eventType: EventType,
     requestTracking: RequestTrackingData,
@@ -438,8 +464,16 @@ async function trackResponse(
         });
         return notBilled({ contentFilterResults });
     }
-    const cost = calculateCost(resolvedModelRequested, modelUsage.usage);
-    const price = calculatePrice(resolvedModelRequested, modelUsage.usage);
+    const cost = calculateCost(
+        resolvedModelRequested,
+        modelUsage.usage,
+        modelUsage.output,
+    );
+    const price = calculatePrice(
+        resolvedModelRequested,
+        modelUsage.usage,
+        modelUsage.output,
+    );
     return {
         responseOk: response.ok,
         responseStatus: response.status,
@@ -669,6 +703,18 @@ function extractUsageHeaders(response: Response): ModelUsage {
     };
 }
 
+async function extractResponseJsonOutput(
+    response: Response,
+): Promise<unknown | undefined> {
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) return undefined;
+    try {
+        return await response.clone().json();
+    } catch {
+        return undefined;
+    }
+}
+
 function extractContentFilterHeaders(
     response: Response,
 ): GenerationEventContentFilterParams {
@@ -678,12 +724,16 @@ function extractContentFilterHeaders(
     return parseResult.data || {};
 }
 
-function extractUsageAndContentFilterResultsHeaders(response: Response): {
+async function extractUsageAndContentFilterResultsHeaders(
+    response: Response,
+): Promise<{
     modelUsage: ModelUsage;
     contentFilterResults: GenerationEventContentFilterParams;
-} {
+}> {
+    const modelUsage = extractUsageHeaders(response);
+    modelUsage.output = await extractResponseJsonOutput(response);
     return {
-        modelUsage: extractUsageHeaders(response),
+        modelUsage,
         contentFilterResults: extractContentFilterHeaders(response),
     };
 }
@@ -716,9 +766,11 @@ async function extractUsageAndContentFilterResultsStream(
     let usage: CompletionUsage | undefined;
     let promptFilterResults: ContentFilterResult = {};
     let completionFilterResults: ContentFilterResult = {};
+    const streamEvents: unknown[] = [];
 
     for await (const event of events) {
         const parseResult = EventSchema.safeParse(event);
+        streamEvents.push(event);
 
         const incomingPromptFilterResults =
             parseResult.data?.prompt_filter_results?.map(
@@ -764,6 +816,7 @@ async function extractUsageAndContentFilterResultsStream(
         modelUsage: {
             model,
             usage: openaiUsageToUsage(usage),
+            output: streamEvents.length > 0 ? { streamEvents } : undefined,
         },
         contentFilterResults,
     };
@@ -787,7 +840,7 @@ async function extractUsageAndContentFilterResults(
         const eventStream = extractResponseStream(response);
         return await extractUsageAndContentFilterResultsStream(eventStream);
     }
-    return extractUsageAndContentFilterResultsHeaders(response);
+    return await extractUsageAndContentFilterResultsHeaders(response);
 }
 
 type CacheData = {

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -122,6 +122,38 @@ function usageHeaders(completion: ChatCompletion): Headers {
     return headers;
 }
 
+const PUBLIC_USAGE_FIELDS = new Set([
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "completion_tokens",
+    "completion_tokens_details",
+    "prompt_tokens",
+    "prompt_tokens_details",
+    "total_tokens",
+]);
+
+function publicCompletionUsage(
+    usage: ChatCompletion["usage"],
+): ChatCompletion["usage"] {
+    if (!usage || (!("cost" in usage) && !("search_context_size" in usage))) {
+        return usage;
+    }
+
+    return Object.fromEntries(
+        Object.entries(usage).filter(([key]) => PUBLIC_USAGE_FIELDS.has(key)),
+    );
+}
+
+function publicChatCompletion(completion: ChatCompletion): ChatCompletion {
+    const usage = publicCompletionUsage(completion.usage);
+    if (usage === completion.usage) return completion;
+
+    return {
+        ...completion,
+        usage,
+    };
+}
+
 function sendOpenAIResponse(completion: ChatCompletion): Response {
     const headers = usageHeaders(completion);
     headers.set("Content-Type", "application/json; charset=utf-8");
@@ -276,8 +308,14 @@ async function generateTextResponse(
         }
 
         if (requestData.stream) return sendTextStreamResponse(completion);
-        if (contentResponse) return sendTextContentResponse(completion);
-        return sendOpenAIResponse(completion);
+        const trackingResponse = sendOpenAIResponse(completion);
+        const publicCompletion = publicChatCompletion(completion);
+        if (contentResponse) {
+            c.var.track?.overrideResponseTracking(trackingResponse.clone());
+            return sendTextContentResponse(publicCompletion);
+        }
+        c.var.track?.overrideResponseTracking(trackingResponse.clone());
+        return sendOpenAIResponse(publicCompletion);
     } catch (thrown: unknown) {
         throwTextError(thrown as ServiceError, c);
     }

--- a/gen.pollinations.ai/src/text/transforms/createPerplexitySearchTransform.ts
+++ b/gen.pollinations.ai/src/text/transforms/createPerplexitySearchTransform.ts
@@ -7,7 +7,9 @@ export type SearchContextSize = "low" | "medium" | "high";
  * body. This controls how much web content Sonar retrieves to ground its answer —
  * and the per-request search fee scales with it (low < medium < high).
  *
- * Respects a caller-provided `web_search_options` if present (user intent wins).
+ * Always uses the registry-selected context size: the static billing fee in
+ * the registry assumes it, and callers cannot supply web_search_options
+ * through the public API anyway.
  */
 export function createPerplexitySearchTransform(
     searchContextSize: SearchContextSize,
@@ -16,7 +18,7 @@ export function createPerplexitySearchTransform(
         messages,
         options: {
             ...options,
-            web_search_options: options.web_search_options ?? {
+            web_search_options: {
                 search_context_size: searchContextSize,
             },
         },

--- a/gen.pollinations.ai/src/text/types.ts
+++ b/gen.pollinations.ai/src/text/types.ts
@@ -76,7 +76,7 @@ export interface ChatCompletion {
     created?: number;
     model?: string;
     choices?: CompletionChoice[];
-    usage?: Record<string, number>;
+    usage?: Record<string, unknown>;
     citations?: string[];
     error?: string | { message?: string; status?: number; details?: unknown };
     stream?: boolean;

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -171,6 +171,15 @@ async function fakePortkeyResponse(request: Request) {
         body.messages?.map((m) => contentToText(m.content)).join("\n") || "";
 
     if (body.stream) {
+        const streamUsageExtras = prompt.includes("vcr perplexity stream cost")
+            ? {
+                  search_context_size: "low",
+                  cost: {
+                      request_cost: 0.007,
+                      total_cost: 0.00701,
+                  },
+              }
+            : {};
         const streamEvent = {
             id: "chatcmpl_vcr_stream",
             object: "chat.completion.chunk",
@@ -196,6 +205,7 @@ async function fakePortkeyResponse(request: Request) {
                 prompt_tokens: 7,
                 completion_tokens: 3,
                 total_tokens: 10,
+                ...streamUsageExtras,
             },
         };
         return new Response(
@@ -242,6 +252,37 @@ async function fakePortkeyResponse(request: Request) {
             completionTokens: 2,
             citations: ["https://example.test/source"],
         },
+        {
+            matches: prompt.includes("vcr perplexity reported cost"),
+            content: "snapshot perplexity response",
+            promptTokens: 10,
+            completionTokens: 5,
+            usageExtras: {
+                search_context_size: "low",
+                cost: {
+                    request_cost: 0.006,
+                    total_cost: 0.00602,
+                },
+            },
+        },
+        {
+            matches: prompt.includes("vcr moderated text"),
+            content: "snapshot moderated response",
+            promptTokens: 6,
+            completionTokens: 4,
+            promptFilterResults: [
+                {
+                    prompt_index: 0,
+                    content_filter_results: {
+                        hate: { filtered: false, severity: "safe" },
+                        sexual: { filtered: false, severity: "safe" },
+                    },
+                },
+            ],
+            completionFilterResults: {
+                violence: { filtered: false, severity: "medium" },
+            },
+        },
     ];
     const selectedCase = cases.find((candidate) => candidate.matches);
     const isAudio =
@@ -284,6 +325,7 @@ async function fakePortkeyResponse(request: Request) {
             created: 1,
             model,
             citations: selectedCase?.citations,
+            prompt_filter_results: selectedCase?.promptFilterResults,
             choices: [
                 {
                     index: 0,
@@ -292,6 +334,8 @@ async function fakePortkeyResponse(request: Request) {
                         content: selectedCase?.content ?? "snapshot response",
                     },
                     finish_reason: selectedCase?.finishReason || "stop",
+                    content_filter_results:
+                        selectedCase?.completionFilterResults,
                 },
             ],
             usage: {
@@ -300,6 +344,7 @@ async function fakePortkeyResponse(request: Request) {
                 total_tokens:
                     (selectedCase?.promptTokens || 7) +
                     (selectedCase?.completionTokens || 3),
+                ...selectedCase?.usageExtras,
             },
         },
         { headers: usageHeaders({}) },
@@ -382,6 +427,120 @@ test("chat completions use local text generation with VCR-backed Portkey", async
         modelRequested: "openai-fast",
         tokenCountPromptText: 7,
         tokenCountCompletionText: 3,
+        isBilledUsage: true,
+    });
+});
+
+test("chat completions bill provider-reported Perplexity request cost without exposing it", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "portkeyDirect");
+
+    const { response, wait } = await fetchWorker("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${paidApiKey}`,
+        },
+        body: JSON.stringify({
+            model: "perplexity-fast",
+            messages: [
+                { role: "user", content: "vcr perplexity reported cost" },
+            ],
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+        usage?: Record<string, unknown>;
+    };
+    expect(body.usage).toMatchObject({
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+    });
+    expect(body.usage).not.toHaveProperty("cost");
+    expect(body.usage).not.toHaveProperty("search_context_size");
+    await wait();
+
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        eventType: "generate.text",
+        modelRequested: "perplexity-fast",
+        tokenCountPromptText: 10,
+        tokenCountCompletionText: 5,
+        isBilledUsage: true,
+    });
+    expect(mocks.tinybird.state.events[0].totalCost).toBeCloseTo(0.006015, 8);
+});
+
+test("streaming chat completions bill provider-reported Perplexity request cost", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "portkeyDirect");
+
+    const { response, wait } = await fetchWorker("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${paidApiKey}`,
+        },
+        body: JSON.stringify({
+            model: "perplexity-fast",
+            stream: true,
+            messages: [{ role: "user", content: "vcr perplexity stream cost" }],
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    await response.text();
+    await wait();
+
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        eventType: "generate.text",
+        modelRequested: "perplexity-fast",
+        tokenCountPromptText: 7,
+        tokenCountCompletionText: 3,
+        isBilledUsage: true,
+    });
+    // 0.007 provider-reported request fee + 0.00001 token cost.
+    expect(mocks.tinybird.state.events[0].totalCost).toBeCloseTo(0.00701, 8);
+});
+
+test("non-stream chat completions keep moderation telemetry in generation events", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "portkeyDirect");
+
+    const { response, wait } = await fetchWorker("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${paidApiKey}`,
+        },
+        body: JSON.stringify({
+            model: "openai-fast",
+            messages: [{ role: "user", content: "vcr moderated text" }],
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-moderation-prompt-hate-severity")).toBe(
+        "safe",
+    );
+    await wait();
+
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        eventType: "generate.text",
+        modelRequested: "openai-fast",
+        moderationPromptHateSeverity: "safe",
+        moderationPromptSexualSeverity: "safe",
+        moderationCompletionViolenceSeverity: "medium",
         isBilledUsage: true,
     });
 });

--- a/shared/registry/gemini-billing.ts
+++ b/shared/registry/gemini-billing.ts
@@ -1,0 +1,133 @@
+import { perMillion } from "./price-helpers";
+import type {
+    BillingRules,
+    CostDefinition,
+    PriceMultiplierContext,
+    PriceMultiplierFunctor,
+} from "./registry";
+
+const GEMINI_25_GROUNDING_COST_PER_PROMPT = 35 / 1000;
+const GEMINI_3_GROUNDING_COST_PER_QUERY = 14 / 1000;
+
+const GEMINI_3_1_PRO_LONG_CONTEXT_COST: CostDefinition = {
+    promptTextTokens: perMillion(4.0),
+    promptCachedTokens: perMillion(0.4),
+    promptAudioTokens: perMillion(4.0),
+    promptImageTokens: perMillion(4.0),
+    promptVideoTokens: perMillion(4.0),
+    completionTextTokens: perMillion(18.0),
+};
+
+type GroundedOutput = {
+    choices?: { groundingMetadata?: { webSearchQueries?: string[] } }[];
+    streamEvents?: GroundedOutput[];
+};
+
+function getPromptTokenCount(context: PriceMultiplierContext): number {
+    const { usage } = context;
+    return (
+        (usage.promptTextTokens ?? 0) +
+        (usage.promptCachedTokens ?? 0) +
+        (usage.promptAudioTokens ?? 0) +
+        (usage.promptImageTokens ?? 0) +
+        (usage.promptVideoTokens ?? 0)
+    );
+}
+
+function getGeminiGroundingWebSearchQueryCount(output: unknown): number {
+    const o = output as GroundedOutput | undefined;
+    const events = o?.streamEvents ?? (o ? [o] : []);
+    const queries = new Set<string>();
+    for (const event of events) {
+        for (const choice of event.choices ?? []) {
+            for (const q of choice.groundingMetadata?.webSearchQueries ?? []) {
+                if (q?.trim()) queries.add(q);
+            }
+        }
+    }
+    return queries.size;
+}
+
+const GEMINI_25_GROUNDING_BILLING: BillingRules = {
+    adjustments: [
+        {
+            id: "google.gemini_2.grounded_prompt.v1",
+            description:
+                "Google Search grounding adds $35 / 1K grounded prompts when grounding metadata is present.",
+            kind: "grounded_prompt",
+            unit: "prompt",
+            count: "geminiGroundedPrompt",
+            unitCost: GEMINI_25_GROUNDING_COST_PER_PROMPT,
+            when: "grounded",
+        },
+    ],
+};
+
+const GEMINI_3_SEARCH_BILLING: BillingRules = {
+    adjustments: [
+        {
+            id: "google.gemini_3.search_query.v1",
+            description:
+                "Google Search grounding adds $14 / 1K search queries when grounding metadata is present.",
+            kind: "search_query",
+            unit: "query",
+            count: "geminiWebSearchQueries",
+            unitCost: GEMINI_3_GROUNDING_COST_PER_QUERY,
+            when: "grounded",
+        },
+    ],
+};
+
+const GEMINI_31_PRO_BILLING: BillingRules = {
+    tiers: [
+        {
+            id: "google.gemini_3_1_pro.long_context.v1",
+            description:
+                "Prompts above 200K tokens use Gemini long-context rates.",
+            when: { promptTokensGt: 200_000 },
+            cost: GEMINI_3_1_PRO_LONG_CONTEXT_COST,
+        },
+    ],
+    adjustments: GEMINI_3_SEARCH_BILLING.adjustments,
+};
+
+export const GEMINI_25_GROUNDING_PRICE_MULTIPLIER: PriceMultiplierFunctor = {
+    multiplier: 1,
+    description:
+        "Uses 1x token pricing and adds the Gemini 2.5 Google Search grounded-prompt fee when grounding metadata is present.",
+    billing: GEMINI_25_GROUNDING_BILLING,
+    apply: ({ output }) => ({
+        costAdjustment:
+            getGeminiGroundingWebSearchQueryCount(output) > 0
+                ? GEMINI_25_GROUNDING_COST_PER_PROMPT
+                : 0,
+    }),
+};
+
+export const GEMINI_3_SEARCH_PRICE_MULTIPLIER: PriceMultiplierFunctor = {
+    multiplier: 1,
+    description:
+        "Uses 1x token pricing and adds the Gemini 3 Google Search fee per unique grounded web search query.",
+    billing: GEMINI_3_SEARCH_BILLING,
+    apply: ({ output }) => ({
+        costAdjustment:
+            getGeminiGroundingWebSearchQueryCount(output) *
+            GEMINI_3_GROUNDING_COST_PER_QUERY,
+    }),
+};
+
+export const GEMINI_31_PRO_PRICE_MULTIPLIER: PriceMultiplierFunctor = {
+    multiplier: 1,
+    description:
+        "Uses 1x token pricing, switches Gemini 3.1 Pro prompts above 200K tokens to long-context rates, and adds search query fees.",
+    billing: GEMINI_31_PRO_BILLING,
+    apply: (context) => ({
+        cost:
+            getPromptTokenCount(context) > 200_000
+                ? { ...context.baseCost, ...GEMINI_3_1_PRO_LONG_CONTEXT_COST }
+                : context.baseCost,
+        costAdjustment:
+            getGeminiGroundingWebSearchQueryCount(context.output) *
+            GEMINI_3_GROUNDING_COST_PER_QUERY,
+    }),
+};

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import {
+    getBasePriceMultiplier,
+    getBillingRules,
     getModelDefinition,
     getPriceDefinition,
     getVisibleAudioModels,
@@ -39,6 +41,36 @@ export const ModelInfoSchema = z.object({
     pricing: z
         .record(z.string(), z.string())
         .and(z.object({ currency: z.literal("pollen") })),
+    billing: z
+        .object({
+            description: z.string().optional(),
+            tiers: z
+                .array(
+                    z.object({
+                        id: z.string(),
+                        description: z.string(),
+                    }),
+                )
+                .optional(),
+            adjustments: z
+                .array(
+                    z.object({
+                        id: z.string(),
+                        description: z.string(),
+                        kind: z.string(),
+                        unit: z.string(),
+                        count: z.enum([
+                            "geminiGroundedPrompt",
+                            "geminiWebSearchQueries",
+                            "perplexityRequest",
+                        ]),
+                        when: z.enum(["grounded", "always"]),
+                        unit_price: z.string(),
+                    }),
+                )
+                .optional(),
+        })
+        .optional(),
     title: z.string(),
     description: z.string().optional(),
     input_modalities: z.array(z.string()).optional(),
@@ -96,6 +128,33 @@ function getModelInfo(modelName: ModelName): ModelInfo {
             pricing[key] = toFixedPoint(value);
         }
     }
+    const billingRules = getBillingRules(service);
+    const basePriceMultiplier = getBasePriceMultiplier(service);
+    const billingDescription =
+        typeof service.priceMultiplier === "number"
+            ? undefined
+            : service.priceMultiplier.description;
+    const billing = billingRules
+        ? {
+              description: billingDescription,
+              tiers: billingRules.tiers?.map((tier) => ({
+                  id: tier.id,
+                  description: tier.description,
+              })),
+              adjustments: billingRules.adjustments?.map((adjustment) => ({
+                  id: adjustment.id,
+                  description: adjustment.description,
+                  kind: adjustment.kind,
+                  unit: adjustment.unit,
+                  count: adjustment.count,
+                  when: adjustment.when ?? "grounded",
+                  unit_price: toFixedPoint(
+                      adjustment.unitCost *
+                          (adjustment.priceMultiplier ?? basePriceMultiplier),
+                  ),
+              })),
+          }
+        : undefined;
 
     return {
         name: modelName as string,
@@ -103,6 +162,7 @@ function getModelInfo(modelName: ModelName): ModelInfo {
         category: service.category,
         brand: service.brand,
         pricing,
+        billing,
         // User-facing metadata from service definition
         title: service.title,
         description: service.description,

--- a/shared/registry/perplexity-billing.ts
+++ b/shared/registry/perplexity-billing.ts
@@ -1,0 +1,118 @@
+import type {
+    BillingRules,
+    PriceMultiplierContext,
+    PriceMultiplierFunctor,
+} from "./registry";
+
+// Trust a provider-reported unit cost only up to this multiple of the static
+// registry fee — a malformed or hostile value beyond it bills the static fee.
+const PROVIDER_UNIT_COST_MAX_RATIO = 10;
+
+type PerplexityCostOutput = {
+    usage?: {
+        cost?: {
+            request_cost?: unknown;
+        };
+    };
+    streamEvents?: unknown[];
+};
+
+function asProviderUnitCost(value: unknown): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+        return undefined;
+    }
+    return value;
+}
+
+function getPerplexityReportedRequestCost(output: unknown): number | undefined {
+    const o = output as PerplexityCostOutput | undefined;
+    const events = o?.streamEvents ?? (o ? [o] : []);
+
+    for (const event of [...events].reverse()) {
+        const requestCost = (event as PerplexityCostOutput | undefined)?.usage
+            ?.cost?.request_cost;
+        const unitCost = asProviderUnitCost(requestCost);
+        if (unitCost !== undefined) return unitCost;
+    }
+
+    return undefined;
+}
+
+function getPerplexityRequestCost(
+    output: PriceMultiplierContext["output"],
+    staticUnitCost: number,
+): number {
+    const reported = getPerplexityReportedRequestCost(output);
+    if (
+        reported !== undefined &&
+        reported <= staticUnitCost * PROVIDER_UNIT_COST_MAX_RATIO
+    ) {
+        return reported;
+    }
+    return staticUnitCost;
+}
+
+function createPerplexitySearchBilling(
+    id: string,
+    description: string,
+    unitCost: number,
+): BillingRules {
+    return {
+        adjustments: [
+            {
+                id,
+                description,
+                kind: "search_request",
+                unit: "request",
+                count: "perplexityRequest",
+                unitCost,
+                providerReportedUnitCost: "perplexityUsageCostRequest",
+                when: "always",
+            },
+        ],
+    };
+}
+
+function createPerplexitySearchPriceMultiplier(
+    id: string,
+    description: string,
+    unitCost: number,
+): PriceMultiplierFunctor {
+    return {
+        multiplier: 1,
+        description:
+            "Uses 1x token pricing and adds the Perplexity search request fee, preferring bounded provider-reported usage.cost.request_cost when present.",
+        billing: createPerplexitySearchBilling(id, description, unitCost),
+        apply: ({ output }) => ({
+            costAdjustment: getPerplexityRequestCost(output, unitCost),
+        }),
+    };
+}
+
+export const PERPLEXITY_FAST_PRICE_MULTIPLIER =
+    createPerplexitySearchPriceMultiplier(
+        "perplexity.sonar_low.search_request.v1",
+        "Perplexity Search adds $5 / 1K requests for low search context.",
+        5 / 1000,
+    );
+
+export const PERPLEXITY_DEEP_PRICE_MULTIPLIER =
+    createPerplexitySearchPriceMultiplier(
+        "perplexity.sonar_high.search_request.v1",
+        "Perplexity Search adds $12 / 1K requests for high search context.",
+        12 / 1000,
+    );
+
+export const PERPLEXITY_PRO_PRICE_MULTIPLIER =
+    createPerplexitySearchPriceMultiplier(
+        "perplexity.sonar_pro_high.search_request.v1",
+        "Perplexity Search adds $14 / 1K requests for high search context.",
+        14 / 1000,
+    );
+
+export const PERPLEXITY_REASONING_PRICE_MULTIPLIER =
+    createPerplexitySearchPriceMultiplier(
+        "perplexity.sonar_reasoning_high.search_request.v1",
+        "Perplexity Search adds $14 / 1K requests for high search context.",
+        14 / 1000,
+    );

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -83,6 +83,62 @@ export type VideoCapability =
     | "keyframes"
     | "audio_output";
 
+export type BillingAdjustmentCounter =
+    | "geminiGroundedPrompt"
+    | "geminiWebSearchQueries"
+    | "perplexityRequest";
+
+export type ProviderReportedUnitCostSource = "perplexityUsageCostRequest";
+
+export type BillingTierRule = {
+    id: string;
+    description: string;
+    when: {
+        promptTokensGt: number;
+    };
+    cost: CostDefinition;
+};
+
+export type BillingAdjustmentRule = {
+    id: string;
+    description: string;
+    kind: string;
+    unit: string;
+    count: BillingAdjustmentCounter;
+    unitCost: number;
+    providerReportedUnitCost?: ProviderReportedUnitCostSource;
+    priceMultiplier?: number;
+    when?: "grounded" | "always";
+};
+
+export type BillingRules = {
+    tiers?: BillingTierRule[];
+    adjustments?: BillingAdjustmentRule[];
+};
+
+export type PriceMultiplierContext = {
+    model: ModelName;
+    usage: Usage;
+    output?: unknown;
+    baseCost: CostDefinition;
+};
+
+export type PriceMultiplierEffect = {
+    cost?: CostDefinition;
+    multiplier?: number;
+    costAdjustment?: number;
+    priceAdjustment?: number;
+};
+
+export type PriceMultiplierFunctor = {
+    multiplier: number;
+    description: string;
+    billing?: BillingRules;
+    apply: (context: PriceMultiplierContext) => PriceMultiplierEffect;
+};
+
+export type PriceMultiplier = number | PriceMultiplierFunctor;
+
 export type ModelDefinition<TModelId extends string = ModelId> = {
     aliases: string[];
     modelId: TModelId;
@@ -92,7 +148,12 @@ export type ModelDefinition<TModelId extends string = ModelId> = {
     cost: CostDefinition;
     // USD-cost to Pollen-price multiplier. Required on every model — there is
     // no implicit default. Typical values: 1 (sold at cost) or 1.5 (paid markup).
-    priceMultiplier: number;
+    // Dynamic models can provide a functor that adjusts rated cost/price from
+    // usage and provider output while still exposing a base multiplier.
+    priceMultiplier: PriceMultiplier;
+    // Static catalog metadata only. Dynamic runtime behavior belongs in a
+    // priceMultiplier functor; this is kept for compatibility with simple docs.
+    billing?: BillingRules;
     // Date the model was added to the registry (ms epoch). Set once, never updated.
     addedDate: number;
     // User-facing metadata
@@ -148,12 +209,89 @@ function convertUsage(
     return convertedUsage as Usage;
 }
 
+export function getBasePriceMultiplier(svc: ModelDefinition): number {
+    return typeof svc.priceMultiplier === "number"
+        ? svc.priceMultiplier
+        : svc.priceMultiplier.multiplier;
+}
+
 function derivePrice(svc: ModelDefinition): PriceDefinition {
-    const m = svc.priceMultiplier;
+    const m = getBasePriceMultiplier(svc);
     if (m === 1) return svc.cost;
     return Object.fromEntries(
         Object.entries(svc.cost).map(([k, v]) => [k, (v as number) * m]),
     ) as PriceDefinition;
+}
+
+function calculateLinearCost(
+    model: ModelName,
+    usage: Usage,
+    costDefinition: CostDefinition,
+): UsageCost {
+    const usageCost = convertUsage(usage, costDefinition, model);
+    const totalCost = Object.values(usageCost).reduce(
+        (total, cost) => total + cost,
+        0,
+    );
+    return {
+        ...usageCost,
+        totalCost,
+    };
+}
+
+export function getBillingRules(
+    svc: ModelDefinition,
+): BillingRules | undefined {
+    if (typeof svc.priceMultiplier === "number") return svc.billing;
+    if (!svc.billing) return svc.priceMultiplier.billing;
+    return {
+        tiers: [
+            ...(svc.billing.tiers ?? []),
+            ...(svc.priceMultiplier.billing?.tiers ?? []),
+        ],
+        adjustments: [
+            ...(svc.billing.adjustments ?? []),
+            ...(svc.priceMultiplier.billing?.adjustments ?? []),
+        ],
+    };
+}
+
+type EvaluatedPriceMultiplier = {
+    cost: CostDefinition;
+    multiplier: number;
+    costAdjustment: number;
+    priceAdjustment: number;
+};
+
+function evaluatePriceMultiplier(
+    model: ModelName,
+    svc: ModelDefinition,
+    usage: Usage,
+    output?: unknown,
+): EvaluatedPriceMultiplier {
+    if (typeof svc.priceMultiplier === "number") {
+        return {
+            cost: svc.cost,
+            multiplier: svc.priceMultiplier,
+            costAdjustment: 0,
+            priceAdjustment: 0,
+        };
+    }
+
+    const effect = svc.priceMultiplier.apply({
+        model,
+        usage,
+        output,
+        baseCost: svc.cost,
+    });
+    const multiplier = effect.multiplier ?? svc.priceMultiplier.multiplier;
+    const costAdjustment = effect.costAdjustment ?? 0;
+    return {
+        cost: effect.cost ?? svc.cost,
+        multiplier,
+        costAdjustment,
+        priceAdjustment: effect.priceAdjustment ?? costAdjustment * multiplier,
+    };
 }
 
 const MODEL_REGISTRY = {
@@ -256,38 +394,57 @@ export function getPriceDefinition(model: ModelName): PriceDefinition | null {
 /**
  * Calculate cost for a model based on usage
  */
-export function calculateCost(model: ModelName, usage: Usage): UsageCost {
-    const costDefinition = getCostDefinition(model);
-    if (!costDefinition)
+export function calculateCost(
+    model: ModelName,
+    usage: Usage,
+    output?: unknown,
+): UsageCost {
+    const svc = MODEL_REGISTRY[model];
+    if (!svc)
         throw new Error(
             `Failed to get current cost for model: ${model.toString()}`,
         );
-    const usageCost = convertUsage(usage, costDefinition, model);
-    const totalCost = Object.values(usageCost).reduce(
-        (total, cost) => total + cost,
-        0,
-    );
+    const evaluated = evaluatePriceMultiplier(model, svc, usage, output);
+    const usageCost = calculateLinearCost(model, usage, evaluated.cost);
+    const adjustmentCost = evaluated.costAdjustment;
+    if (adjustmentCost === 0) return usageCost;
     return {
         ...usageCost,
-        totalCost,
+        totalCost: usageCost.totalCost + adjustmentCost,
     };
 }
 
 /**
  * Calculate price for a model based on usage
  */
-export function calculatePrice(model: ModelName, usage: Usage): UsagePrice {
-    const priceDefinition = getPriceDefinition(model);
-    if (!priceDefinition)
+export function calculatePrice(
+    model: ModelName,
+    usage: Usage,
+    output?: unknown,
+): UsagePrice {
+    const svc = MODEL_REGISTRY[model];
+    if (!svc)
         throw new Error(
             `Failed to get current price for model: ${model.toString()}`,
         );
-    const usagePrice = convertUsage(usage, priceDefinition, model);
-    const totalPrice = roundPollenLedgerAmount(
-        Object.values(usagePrice).reduce((total, price) => total + price, 0),
+    const evaluated = evaluatePriceMultiplier(model, svc, usage, output);
+    const usageCost = calculateLinearCost(model, usage, evaluated.cost);
+    const usagePrice = Object.fromEntries(
+        Object.entries(usageCost)
+            .filter(([usageType]) => usageType !== "totalCost")
+            .map(([usageType, cost]) => [
+                usageType,
+                (cost as number) * evaluated.multiplier,
+            ]),
+    ) as Usage;
+    const tokenTotalPrice = Object.values(usagePrice).reduce(
+        (total, price) => total + price,
+        0,
     );
     return {
         ...usagePrice,
-        totalPrice,
+        totalPrice: roundPollenLedgerAmount(
+            tokenTotalPrice + evaluated.priceAdjustment,
+        ),
     };
 }

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,3 +1,14 @@
+import {
+    GEMINI_3_SEARCH_PRICE_MULTIPLIER,
+    GEMINI_25_GROUNDING_PRICE_MULTIPLIER,
+    GEMINI_31_PRO_PRICE_MULTIPLIER,
+} from "./gemini-billing";
+import {
+    PERPLEXITY_DEEP_PRICE_MULTIPLIER,
+    PERPLEXITY_FAST_PRICE_MULTIPLIER,
+    PERPLEXITY_PRO_PRICE_MULTIPLIER,
+    PERPLEXITY_REASONING_PRICE_MULTIPLIER,
+} from "./perplexity-billing";
 import { perMillion } from "./price-helpers";
 import type { ModelDefinition } from "./registry";
 
@@ -271,7 +282,7 @@ export const TEXT_SERVICES = {
         brand: "Google",
         category: "text",
         addedDate: new Date("2025-10-07").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_3_SEARCH_PRICE_MULTIPLIER,
         paidOnly: true,
         cost: {
             promptTextTokens: perMillion(0.5),
@@ -298,7 +309,7 @@ export const TEXT_SERVICES = {
         brand: "Google",
         category: "text",
         addedDate: new Date("2026-05-19").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_3_SEARCH_PRICE_MULTIPLIER,
         paidOnly: true,
         // Rates per https://ai.google.dev/gemini-api/docs/pricing (global region).
         // Non-global regions add ~10%; we route through global.
@@ -331,7 +342,7 @@ export const TEXT_SERVICES = {
         brand: "Google",
         category: "text",
         addedDate: new Date("2026-04-03").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_3_SEARCH_PRICE_MULTIPLIER,
         paidOnly: true,
         cost: {
             promptTextTokens: perMillion(0.25),
@@ -358,7 +369,7 @@ export const TEXT_SERVICES = {
         brand: "Google",
         category: "text",
         addedDate: new Date("2025-12-18").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_25_GROUNDING_PRICE_MULTIPLIER,
         paidOnly: true,
         cost: {
             promptTextTokens: perMillion(0.1), // per 1M tokens
@@ -554,9 +565,9 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2025-10-10").getTime(),
         paidOnly: true,
-        priceMultiplier: 1,
-        // Vertex base rates for gemini-2.5-flash-lite. Grounding fee ($0.035/grounded
-        // prompt after 1,500 RPD free) is not yet modeled; absorbed by Pollinations.
+        priceMultiplier: GEMINI_25_GROUNDING_PRICE_MULTIPLIER,
+        // Vertex base rates for gemini-2.5-flash-lite. Grounding is added by
+        // calculateCost when the response includes web search metadata.
         cost: {
             promptTextTokens: perMillion(0.1),
             promptCachedTokens: perMillion(0.01),
@@ -584,7 +595,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2026-05-26").getTime(),
         paidOnly: true,
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_3_SEARCH_PRICE_MULTIPLIER,
         // Vertex base rates for gemini-3.1-flash-lite-preview. Grounding fee
         // dropped to $14/1K queries on Gemini 3 (vs $35/1K on 2.x), with 5K
         // free queries/month shared across all Gemini 3 models; absorbed by
@@ -616,7 +627,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2026-05-26").getTime(),
         paidOnly: true,
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_3_SEARCH_PRICE_MULTIPLIER,
         // Vertex base rates for gemini-3.5-flash. Grounding fee $14/1K queries
         // with 5K/month free shared across Gemini 3; absorbed by Pollinations.
         cost: {
@@ -809,10 +820,7 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2025-11-04").getTime(),
-        // priceMultiplier 1.5 absorbs Perplexity's flat per-request search fee
-        // (~$5/1k at low search_context_size), which our token-based billing
-        // cannot capture directly. Temporary until a per-request fee field exists.
-        priceMultiplier: 1,
+        priceMultiplier: PERPLEXITY_FAST_PRICE_MULTIPLIER,
         cost: {
             promptTextTokens: perMillion(1.0),
             completionTextTokens: perMillion(1.0),
@@ -835,11 +843,7 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
-        // Same sonar base as perplexity-fast but high search_context_size for
-        // broader grounding (higher per-request fee, ~$12/1k). priceMultiplier
-        // matches fast for now — they bill identically until a per-request fee
-        // field lets us price the deeper search separately.
-        priceMultiplier: 1,
+        priceMultiplier: PERPLEXITY_DEEP_PRICE_MULTIPLIER,
         cost: {
             promptTextTokens: perMillion(1.0),
             completionTextTokens: perMillion(1.0),
@@ -860,7 +864,7 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: PERPLEXITY_PRO_PRICE_MULTIPLIER,
         cost: {
             promptTextTokens: perMillion(3.0),
             completionTextTokens: perMillion(15.0),
@@ -881,7 +885,7 @@ export const TEXT_SERVICES = {
         brand: "Perplexity",
         category: "text",
         addedDate: new Date("2025-11-04").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: PERPLEXITY_REASONING_PRICE_MULTIPLIER,
         cost: {
             promptTextTokens: perMillion(2.0),
             completionTextTokens: perMillion(8.0),
@@ -959,11 +963,14 @@ export const TEXT_SERVICES = {
         brand: "Google",
         category: "text",
         addedDate: new Date("2025-11-19").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: GEMINI_31_PRO_PRICE_MULTIPLIER,
         paidOnly: true,
         cost: {
             promptTextTokens: perMillion(2.0),
             promptCachedTokens: perMillion(0.2),
+            promptAudioTokens: perMillion(2.0),
+            promptImageTokens: perMillion(2.0),
+            promptVideoTokens: perMillion(2.0),
             completionTextTokens: perMillion(12.0),
         },
         title: "Gemini 3.1 Pro",


### PR DESCRIPTION
Multiplier-functor billing for Gemini and Perplexity, split out from #11683 for comparison.

- Moves dynamic billing into `priceMultiplier` functors with `multiplier`, `description`, catalog `billing` metadata, and `apply(context)` runtime logic
- Handles Gemini 2.5 grounded-prompt fee, Gemini 3.x per-query fee, and Gemini 3.1 Pro long-context rates above 200K prompt tokens
- Adds Perplexity per-request search fees ($5/$12/$14/$14 per 1K by model), preferring bounded provider-reported `usage.cost.request_cost` when present
- Exposes the functor description through `/models` billing metadata for pricing tables
- Sanitizes non-stream public usage and keeps moderation telemetry with tracking overrides
- Always uses registry-selected Perplexity `search_context_size`

Validation:
- enter: `npx vitest run test/pricing-data.test.ts test/aliases.test.ts` — 217 passed
- gen: targeted `npx vitest run test/generation-vcr.test.ts --testNamePattern='Perplexity request cost|provider-reported Perplexity|moderation telemetry|streaming chat completions bill'` — 3 passed
- gen: `npm run typecheck` clean
- `npx biome check` clean on changed files

Deploy: safe before pollinations/gateway#7 because static fees cover non-stream. Pin bump tracked in #11703.