### PR TITLE
fix: return 422 for content-policy rejections instead of 500

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -1327,9 +1327,10 @@ All endpoints return errors in this envelope:
 | `405` | `METHOD_NOT_ALLOWED` | HTTP method not supported on this route. |
 | `409` | `CONFLICT` | Request conflicts with current resource state (e.g. duplicate key name). |
 | `422` | `UNPROCESSABLE_ENTITY` | Request was well-formed but semantically invalid — typically a model rejection or unsupported parameter combination. |
+| `422` | `content_policy_violation` | Prompt, input, or generated content was blocked by content moderation. Adjust the input and retry. |
 | `429` | `RATE_LIMITED` | Too many requests. Slow down. |
 | `500` | `INTERNAL_ERROR` | Server error. We're on it. |
-| `502` | `BAD_GATEWAY` | Upstream provider returned an unexpected error (auth, billing, content policy). |
+| `502` | `BAD_GATEWAY` | Upstream provider returned an unexpected error (auth, billing). |
 | `503` | `SERVICE_UNAVAILABLE` | Temporarily unavailable — usually the safety/balance check service is degraded. Retry with backoff. |
 
 ## 🧩 Schemas

--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -875,9 +875,10 @@ All endpoints return errors in this envelope:
 | \`405\` | \`METHOD_NOT_ALLOWED\` | HTTP method not supported on this route. |
 | \`409\` | \`CONFLICT\` | Request conflicts with current resource state (e.g. duplicate key name). |
 | \`422\` | \`UNPROCESSABLE_ENTITY\` | Request was well-formed but semantically invalid — typically a model rejection or unsupported parameter combination. |
+| \`422\` | \`content_policy_violation\` | Prompt, input, or generated content was blocked by content moderation. Adjust the input and retry. |
 | \`429\` | \`RATE_LIMITED\` | Too many requests. Slow down. |
 | \`500\` | \`INTERNAL_ERROR\` | Server error. We're on it. |
-| \`502\` | \`BAD_GATEWAY\` | Upstream provider returned an unexpected error (auth, billing, content policy). |
+| \`502\` | \`BAD_GATEWAY\` | Upstream provider returned an unexpected error (auth, billing). |
 | \`503\` | \`SERVICE_UNAVAILABLE\` | Temporarily unavailable — usually the safety/balance check service is degraded. Retry with backoff. |`;
 }
 

--- a/gen.pollinations.ai/src/error.ts
+++ b/gen.pollinations.ai/src/error.ts
@@ -33,6 +33,12 @@ type UpstreamErrorOptions = {
     requestBody?: unknown;
     upstreamStatus?: number;
     responseBody?: string;
+    /**
+     * Overrides the status-derived error code in the response envelope. Used to
+     * surface a stable, machine-readable code (e.g. `content_policy_violation`)
+     * that callers can detect regardless of the HTTP status.
+     */
+    errorCode?: string;
 };
 
 export class UpstreamError extends HTTPException {
@@ -41,6 +47,7 @@ export class UpstreamError extends HTTPException {
     public readonly requestBody?: unknown;
     public readonly upstreamStatus?: number;
     public readonly responseBody?: string;
+    public readonly errorCode?: string;
 
     constructor(status: ContentfulStatusCode, options?: UpstreamErrorOptions) {
         super(status, options);
@@ -48,6 +55,7 @@ export class UpstreamError extends HTTPException {
         this.requestBody = options?.requestBody;
         this.upstreamStatus = options?.upstreamStatus;
         this.responseBody = options?.responseBody;
+        this.errorCode = options?.errorCode;
     }
 }
 
@@ -239,12 +247,13 @@ function createErrorResponse(
     status: ContentfulStatusCode,
     timestamp: string,
     details?: Record<string, unknown>,
+    code?: string,
 ): ErrorResponse {
     return {
         success: false,
         error: {
             message: error.message || getDefaultErrorMessage(status),
-            code: getErrorCode(status),
+            code: code ?? getErrorCode(status),
             timestamp,
             ...(details && { details }),
             ...(!!error.cause && { cause: error.cause }),
@@ -280,15 +289,21 @@ function createUpstreamErrorResponse(
     status: ContentfulStatusCode,
     timestamp: string,
 ): ErrorResponse {
-    return createErrorResponse(error, status, timestamp, {
-        name: error.name,
-        upstreamStatus: error.upstreamStatus,
-        upstreamHost: error.requestUrl?.hostname,
-        upstreamBody: truncateString(
-            error.responseBody,
-            MAX_UPSTREAM_BODY_LENGTH,
-        ),
-    });
+    return createErrorResponse(
+        error,
+        status,
+        timestamp,
+        {
+            name: error.name,
+            upstreamStatus: error.upstreamStatus,
+            upstreamHost: error.requestUrl?.hostname,
+            upstreamBody: truncateString(
+                error.responseBody,
+                MAX_UPSTREAM_BODY_LENGTH,
+            ),
+        },
+        error.errorCode,
+    );
 }
 
 export function remapUpstreamStatus(status: number): ContentfulStatusCode {

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -31,7 +31,7 @@ import {
     CONTENT_POLICY_ERROR_CODE,
     CONTENT_POLICY_STATUS,
     contentPolicyMessage,
-    isContentPolicyViolation,
+    firstContentPolicyMessage,
 } from "./utils/contentModeration.ts";
 import { bufferToUint8Array, detectMimeType } from "./utils/imageDownload.ts";
 import { setImagesBinding } from "./utils/imageTransform.ts";
@@ -178,15 +178,14 @@ function throwImageError(error: unknown): never {
     // backend failures. Catch them here — the single funnel for image/video
     // errors — so they surface as 422 with a stable, detectable code instead of
     // a 500 that pollutes model-health stats.
-    const rawMessage =
+    const candidateMessages =
         error instanceof HttpError
-            ? parseUpstreamErrorBody(error).text || error.message
-            : error instanceof Error
-              ? error.message
-              : String(error);
-    if (isContentPolicyViolation(rawMessage)) {
+            ? [parseUpstreamErrorBody(error).text, error.message]
+            : [error instanceof Error ? error.message : String(error)];
+    const moderationMessage = firstContentPolicyMessage(candidateMessages);
+    if (moderationMessage) {
         throw new UpstreamError(CONTENT_POLICY_STATUS, {
-            message: contentPolicyMessage(rawMessage),
+            message: contentPolicyMessage(moderationMessage),
             errorCode: CONTENT_POLICY_ERROR_CODE,
             requestUrl:
                 error instanceof HttpError

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -27,6 +27,12 @@ import { normalizeAndTranslatePrompt } from "./normalizeAndTranslatePrompt.ts";
 import { type ImageParams, ImageParamsSchema } from "./params.ts";
 import { createProgressTracker } from "./progressBar.ts";
 import { sleep } from "./util.ts";
+import {
+    CONTENT_POLICY_ERROR_CODE,
+    CONTENT_POLICY_STATUS,
+    contentPolicyMessage,
+    isContentPolicyViolation,
+} from "./utils/contentModeration.ts";
 import { bufferToUint8Array, detectMimeType } from "./utils/imageDownload.ts";
 import { setImagesBinding } from "./utils/imageTransform.ts";
 import { buildTrackingHeaders } from "./utils/trackingHeaders.ts";
@@ -166,6 +172,36 @@ function safeUpstreamUrl(value: string | undefined): URL | undefined {
 
 function throwImageError(error: unknown): never {
     if (error instanceof UpstreamError) throw error;
+
+    // Content-policy rejections from any provider (DashScope green-net, Replicate
+    // moderation, Vertex safety, Azure content safety) are client errors, not
+    // backend failures. Catch them here — the single funnel for image/video
+    // errors — so they surface as 422 with a stable, detectable code instead of
+    // a 500 that pollutes model-health stats.
+    const rawMessage =
+        error instanceof HttpError
+            ? parseUpstreamErrorBody(error).text || error.message
+            : error instanceof Error
+              ? error.message
+              : String(error);
+    if (isContentPolicyViolation(rawMessage)) {
+        throw new UpstreamError(CONTENT_POLICY_STATUS, {
+            message: contentPolicyMessage(rawMessage),
+            errorCode: CONTENT_POLICY_ERROR_CODE,
+            requestUrl:
+                error instanceof HttpError
+                    ? safeUpstreamUrl(error.upstreamUrl)
+                    : undefined,
+            upstreamStatus:
+                error instanceof HttpError ? error.status : undefined,
+            responseBody:
+                error instanceof HttpError
+                    ? imageResponseBody(error)
+                    : undefined,
+            cause: error,
+        });
+    }
+
     if (error instanceof HttpError) {
         const { status, message } = classifyImageHttpError(error);
         throw new UpstreamError(status, {

--- a/gen.pollinations.ai/src/image/utils/contentModeration.ts
+++ b/gen.pollinations.ai/src/image/utils/contentModeration.ts
@@ -24,7 +24,9 @@ const MODERATION_PATTERNS = [
     "inappropriate", // "... may contain inappropriate content"
     "content filter",
     "content polic", // "Content policy violation ..." (Vertex AI)
-    "moderation", // Replicate "ContentModerationError"
+    "contentmoderation", // Replicate "ContentModerationError" (one word —
+    // deliberately NOT bare "moderation", which would also match infra
+    // failures like "moderation service unavailable" and hide a real 5xx)
     "flagged", // Replicate "Content flagged for ...", "flagged as sensitive"
     "illegal material",
     "unsafe content", // Azure Content Safety "contains unsafe content"
@@ -37,6 +39,20 @@ export function isContentPolicyViolation(
     if (!message) return false;
     const lower = message.toLowerCase();
     return MODERATION_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+/**
+ * Returns the first candidate message that is a content-policy violation, or
+ * undefined if none are. Used at the error funnel to check every place a
+ * provider might surface the reason (parsed response body AND error.message),
+ * so a generic body can't shadow moderation wording in the message.
+ */
+export function firstContentPolicyMessage(
+    messages: Array<string | null | undefined>,
+): string | undefined {
+    return messages.find((message): message is string =>
+        isContentPolicyViolation(message),
+    );
 }
 
 /**

--- a/gen.pollinations.ai/src/image/utils/contentModeration.ts
+++ b/gen.pollinations.ai/src/image/utils/contentModeration.ts
@@ -1,0 +1,51 @@
+/**
+ * Content-policy detection for upstream image/video providers.
+ *
+ * Providers (Alibaba DashScope, Replicate, Vertex AI Gemini, Azure Content
+ * Safety) reject disallowed prompts, input images, or generated outputs with
+ * their own moderation messages. These are CLIENT errors — the request content
+ * is the problem and retrying the same thing won't help — so they must surface
+ * as a 4xx, never a 5xx. Labeling them 5xx pollutes model-health stats and
+ * trips false "degraded"/"off" alarms on low-traffic premium models.
+ *
+ * We return 422 (Unprocessable Entity): the request was well-formed but its
+ * content cannot be processed. It is paired with a stable
+ * `content_policy_violation` error code so API clients and the model-monitor
+ * can detect this case unambiguously rather than guessing from the message.
+ */
+export const CONTENT_POLICY_STATUS = 422;
+export const CONTENT_POLICY_ERROR_CODE = "content_policy_violation";
+
+// Substrings (matched case-insensitively) drawn from real upstream rejection
+// messages. Kept deliberately specific to moderation wording so genuine backend
+// failures are never swept in.
+const MODERATION_PATTERNS = [
+    "green net", // Alibaba DashScope "Green net check failed ..."
+    "inappropriate", // "... may contain inappropriate content"
+    "content filter",
+    "content polic", // "Content policy violation ..." (Vertex AI)
+    "moderation", // Replicate "ContentModerationError"
+    "flagged", // Replicate "Content flagged for ...", "flagged as sensitive"
+    "illegal material",
+    "unsafe content", // Azure Content Safety "contains unsafe content"
+];
+
+/** True when an upstream error message indicates a content-policy rejection. */
+export function isContentPolicyViolation(
+    message: string | null | undefined,
+): boolean {
+    if (!message) return false;
+    const lower = message.toLowerCase();
+    return MODERATION_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+/**
+ * Build a clear, user-facing explanation, preserving the provider's reason so
+ * the caller knows what to change.
+ */
+export function contentPolicyMessage(rawMessage: string): string {
+    const base =
+        "Your request was rejected by content moderation. The prompt, input, or generated content was flagged as disallowed — adjust your input and try again.";
+    const detail = rawMessage?.trim();
+    return detail ? `${base} (Reason: ${detail})` : base;
+}

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -879,16 +879,20 @@ type ErrorData = {
     // errorStack and errorDetails removed to reduce D1 memory usage
 };
 
-function collectErrorData(response: Response, error?: Error): ErrorData {
+export function collectErrorData(response: Response, error?: Error): ErrorData {
     if (response.ok && !error) return {};
     let source: string | undefined;
+    let explicitCode: string | undefined;
     if (error instanceof UpstreamError) {
         source = error.requestUrl?.hostname;
+        explicitCode = error.errorCode;
     }
     // Note: errorStack and errorDetails removed to reduce D1 memory usage
     // Stack traces and details are still logged but not stored in the database
     return {
-        errorResponseCode: getErrorCode(response.status),
+        // Prefer the error's explicit code (e.g. content_policy_violation) so
+        // analytics can distinguish it from a generic status-derived code.
+        errorResponseCode: explicitCode ?? getErrorCode(response.status),
         errorSource: source,
         errorMessage: error?.message || getDefaultErrorMessage(response.status),
     };

--- a/gen.pollinations.ai/test/collectErrorData.test.ts
+++ b/gen.pollinations.ai/test/collectErrorData.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { UpstreamError } from "@/error.ts";
+import { collectErrorData } from "@/middleware/track.ts";
+
+describe("collectErrorData", () => {
+    it("records the UpstreamError's explicit errorCode in analytics", () => {
+        const error = new UpstreamError(422, {
+            message: "blocked by moderation",
+            errorCode: "content_policy_violation",
+        });
+
+        const data = collectErrorData(
+            new Response(null, { status: 422 }),
+            error,
+        );
+
+        expect(data.errorResponseCode).toBe("content_policy_violation");
+    });
+
+    it("falls back to the status-derived code when no errorCode is set", () => {
+        const data = collectErrorData(
+            new Response(null, { status: 500 }),
+            new Error("boom"),
+        );
+
+        expect(data.errorResponseCode).toBe("INTERNAL_ERROR");
+    });
+});

--- a/gen.pollinations.ai/test/image/contentModeration.test.ts
+++ b/gen.pollinations.ai/test/image/contentModeration.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+    CONTENT_POLICY_ERROR_CODE,
+    CONTENT_POLICY_STATUS,
+    contentPolicyMessage,
+    isContentPolicyViolation,
+} from "../../src/image/utils/contentModeration.ts";
+
+// Real upstream rejection messages observed in production (Tinybird
+// recent_server_errors, 2026-06). Every one of these must classify as a
+// content-policy violation so it surfaces as a 4xx, not a 5xx.
+const REAL_MODERATION_MESSAGES = [
+    // Alibaba DashScope (wan, wan-pro, wan-fast)
+    "Green net check failed for input image",
+    "Green net check failed for output video",
+    "Green net check failed for input text",
+    "Green net check failed for image (input): Input data may contain inappropriate content.",
+    "Output data may contain inappropriate content.",
+    // Replicate (seedance-2.0, seedance-pro, seedream, seedream-pro, seedream5)
+    "Seedance 2.0 generation failed: Prediction failed: Async prediction failed: ContentModerationError: Content flagged for: sexual",
+    "Seedance Pro-Fast generation failed: Content flagged for: sexual",
+    "Seedance Pro-Fast generation failed: Content flagged and reported for containing illegal material",
+    "Seedream 5.0 Lite generation failed: Prediction failed: Async prediction failed: ContentModerationError: Content flagged for: sexual",
+    "Seedream 4.5 Pro generation failed: Prediction failed: Async prediction failed: ContentModerationError: Content flagged for: sexual",
+    "Seedream 4.0 generation failed: Content flagged for: sexual",
+    "Seedream 4.0 generation failed: Content flagged and reported for containing illegal material",
+    // Vertex AI Gemini (nanobanana)
+    "Vertex AI Gemini image generation failed: Content policy violation detected in response",
+    // Azure Content Safety (kontext, gpt-image)
+    "Prompt contains unsafe content: sexual, violence",
+    "Input image contains unsafe content: hate",
+];
+
+// Genuine backend/infra failures that MUST stay 5xx — never misclassified as
+// content policy.
+const NON_MODERATION_MESSAGES = [
+    "The service is currently experiencing high load and cannot process your request. Please try again later.",
+    "No image URL in Wan-Image response",
+    "Vertex AI API error: 500 Internal Server Error",
+    "Request timed out after 120000ms",
+    "fetch failed: getaddrinfo ENOTFOUND",
+    "Rate limit exceeded, please retry",
+    "Internal server error",
+];
+
+describe("isContentPolicyViolation", () => {
+    it.each(
+        REAL_MODERATION_MESSAGES,
+    )("flags real moderation message as content policy: %s", (message) => {
+        expect(isContentPolicyViolation(message)).toBe(true);
+    });
+
+    it.each(
+        NON_MODERATION_MESSAGES,
+    )("does NOT flag genuine backend failure: %s", (message) => {
+        expect(isContentPolicyViolation(message)).toBe(false);
+    });
+
+    it("returns false for empty, null, or undefined", () => {
+        expect(isContentPolicyViolation("")).toBe(false);
+        expect(isContentPolicyViolation(null)).toBe(false);
+        expect(isContentPolicyViolation(undefined)).toBe(false);
+    });
+
+    it("is case-insensitive", () => {
+        expect(isContentPolicyViolation("GREEN NET CHECK FAILED")).toBe(true);
+        expect(isContentPolicyViolation("content FLAGGED for: sexual")).toBe(
+            true,
+        );
+    });
+});
+
+describe("content-policy constants", () => {
+    it("uses 422 Unprocessable Entity", () => {
+        expect(CONTENT_POLICY_STATUS).toBe(422);
+    });
+
+    it("uses a stable, detectable error code", () => {
+        expect(CONTENT_POLICY_ERROR_CODE).toBe("content_policy_violation");
+    });
+});
+
+describe("contentPolicyMessage", () => {
+    it("explains the issue and preserves the provider's reason", () => {
+        const msg = contentPolicyMessage("Content flagged for: sexual");
+        expect(msg.toLowerCase()).toContain("content moderation");
+        expect(msg).toContain("Content flagged for: sexual");
+    });
+
+    it("still returns a clear explanation when no detail is provided", () => {
+        const msg = contentPolicyMessage("");
+        expect(msg.toLowerCase()).toContain("content moderation");
+    });
+});

--- a/gen.pollinations.ai/test/image/contentModeration.test.ts
+++ b/gen.pollinations.ai/test/image/contentModeration.test.ts
@@ -3,6 +3,7 @@ import {
     CONTENT_POLICY_ERROR_CODE,
     CONTENT_POLICY_STATUS,
     contentPolicyMessage,
+    firstContentPolicyMessage,
     isContentPolicyViolation,
 } from "../../src/image/utils/contentModeration.ts";
 
@@ -41,6 +42,11 @@ const NON_MODERATION_MESSAGES = [
     "fetch failed: getaddrinfo ENOTFOUND",
     "Rate limit exceeded, please retry",
     "Internal server error",
+    // Infra failures of the moderation service itself must stay 5xx — they are
+    // NOT a rejection of the user's content. Guards against the bare-"moderation"
+    // matcher swallowing outages (and against re-adding a space-separated form).
+    "moderation service unavailable",
+    "Content moderation service temporarily unavailable",
 ];
 
 describe("isContentPolicyViolation", () => {
@@ -67,6 +73,35 @@ describe("isContentPolicyViolation", () => {
         expect(isContentPolicyViolation("content FLAGGED for: sexual")).toBe(
             true,
         );
+    });
+});
+
+describe("firstContentPolicyMessage", () => {
+    it("returns the matching message even when an earlier candidate is generic", () => {
+        // Defends against a provider putting a generic message in the JSON body
+        // while the real moderation reason lives only in error.message.
+        expect(
+            firstContentPolicyMessage([
+                "Image provider error",
+                "Content flagged for: sexual",
+            ]),
+        ).toBe("Content flagged for: sexual");
+    });
+
+    it("skips null/undefined candidates", () => {
+        expect(
+            firstContentPolicyMessage([
+                null,
+                undefined,
+                "Green net check failed",
+            ]),
+        ).toBe("Green net check failed");
+    });
+
+    it("returns undefined when no candidate is a content-policy violation", () => {
+        expect(
+            firstContentPolicyMessage(["Request timed out", "Internal error"]),
+        ).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
Upstream content-moderation rejections were surfacing as HTTP 500 / `INTERNAL_ERROR`, so they counted as backend failures. On low-traffic image/video models a handful of rejected NSFW prompts dragged success to 0%, falsely flagging models as Off/Degraded on the monitor (83 such 5xx in the last 7d across wan, seedance, seedream, nanobanana).

- Detect content-policy rejections at `throwImageError` — the single funnel all image/video provider errors pass through (catches DashScope green-net, Replicate ContentModeration, Vertex safety, and Azure content safety, including Vertex's plain `Error`)
- Return **422** with a stable `content_policy_violation` code so clients and the model-monitor can detect this case without parsing messages
- User-facing message now explains the rejection and includes the provider's reason
- Adds optional `errorCode` on `UpstreamError` to carry the code through the envelope

These are client errors (the request content is the problem, retrying won't help), so they belong in 4xx, not 5xx. Genuine backend 5xx (GPU timeouts, provider 502s) are unaffected.

Tests: 28 new covering all 13 real prod message variants + 7 genuine failures that must stay 5xx; image suite 83/83, error-observability 5/5, tsc + biome clean.