### PR TITLE
add claude fable 5 on bedrock

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -24,6 +24,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000003,
     },
   },
+  "claude-fable-5": {
+    "cost": {
+      "completionTextTokens": 0.00005,
+      "promptCacheWriteTokens": 0.0000125,
+      "promptCachedTokens": 0.000001,
+      "promptTextTokens": 0.00001,
+    },
+    "price": {
+      "completionTextTokens": 0.00005,
+      "promptCacheWriteTokens": 0.0000125,
+      "promptCachedTokens": 0.000001,
+      "promptTextTokens": 0.00001,
+    },
+  },
   "claude-fast": {
     "cost": {
       "completionTextTokens": 0.000005,
@@ -776,12 +790,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.01,
     },
   },
-  "p-video": {
+  "p-video-1080p": {
     "cost": {
-      "completionVideoSeconds": 0.024,
+      "completionVideoSeconds": 0.04,
     },
     "price": {
-      "completionVideoSeconds": 0.024,
+      "completionVideoSeconds": 0.04,
+    },
+  },
+  "p-video-720p": {
+    "cost": {
+      "completionVideoSeconds": 0.02,
+    },
+    "price": {
+      "completionVideoSeconds": 0.02,
     },
   },
   "perplexity": {

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -138,6 +138,10 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["claude-opus-4-8"],
     },
     {
+        name: "claude-fable-5",
+        config: portkeyConfig["claude-fable-5"],
+    },
+    {
         name: "gemini",
         config: portkeyConfig["gemini-3-flash-preview"],
         transform: pipe(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -177,6 +177,11 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "global.anthropic.claude-opus-4-8",
             defaultOptions: { max_tokens: 128000 },
         }),
+    "claude-fable-5": () =>
+        createBedrockNativeConfig({
+            model: "global.anthropic.claude-fable-5",
+            defaultOptions: { max_tokens: 128000 },
+        }),
     "claude-haiku-4-5": () =>
         createBedrockNativeConfig({
             model: "global.anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -802,6 +802,31 @@ export const TEXT_SERVICES = {
         contextLength: 1000000,
         isSpecialized: false,
     },
+    "claude-fable-5": {
+        aliases: [],
+        modelId: "claude-fable-5",
+        provider: "bedrock",
+        brand: "Anthropic",
+        category: "text",
+        addedDate: new Date("2026-06-11").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // Bedrock global.anthropic.claude-fable-5 global standard rates.
+            promptTextTokens: perMillion(10),
+            promptCachedTokens: perMillion(1),
+            promptCacheWriteTokens: perMillion(12.5),
+            completionTextTokens: perMillion(50),
+        },
+        title: "Claude Fable 5",
+        description: "Claude Fable 5 - Frontier reasoning & agentic work",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 20, // Bedrock Converse image limit.
+        tools: true,
+        contextLength: 1000000,
+        isSpecialized: false,
+    },
     "perplexity-fast": {
         aliases: ["sonar"],
         modelId: "sonar",


### PR DESCRIPTION
Adds Claude Fable 5 as a text model, served via the existing Bedrock global inference profile `global.anthropic.claude-fable-5`.

- Slug `claude-fable-5`; `$10`/`$50` per M input/output (2× Opus 4.8), standard Anthropic cache ratios ($1 read / $12.5 write), 1M context, text+image input, tools. `priceMultiplier: 1` (at-cost, matching the Claude family).
- Reuses existing Bedrock wiring/creds — no new provider integration.
- Regenerated `effective-prices` snapshot. It also absorbs pre-existing `p-video` → `p-video-720p`/`p-video-1080p` drift that was already failing on `main`.

Operational note — Fable 5 is a Mythos-class model and on Bedrock only runs under `provider_data_share` data-retention (30-day retention, shared with Anthropic for trust & safety; no ZDR, applies on every surface incl. the direct Anthropic API). The Bedrock account is already configured for this; other models keep AWS-only retention.

Verified e2e through local gen against real Bedrock (us-east-1): basic, streaming, `max_tokens` edge, reasoning, tools, vision; error paths return 4xx; Tinybird billing rows correct ($10/$50 math, markup 0); no missing-conversion-rate warnings.