### PR TITLE
add kimi k2.7 code via openrouter

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -480,6 +480,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 9.5e-7,
     },
   },
+  "kimi-k2.7-code": {
+    "cost": {
+      "completionTextTokens": 0.000004,
+      "promptCachedTokens": 1.9e-7,
+      "promptTextTokens": 9.5e-7,
+    },
+    "price": {
+      "completionTextTokens": 0.000004,
+      "promptCachedTokens": 1.9e-7,
+      "promptTextTokens": 9.5e-7,
+    },
+  },
   "klein": {
     "cost": {
       "completionImageTokens": 0.01,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -245,6 +245,10 @@ const models: ModelDefinition[] = [
         transform: stripCacheControl,
     },
     {
+        name: "kimi-k2.7-code",
+        config: portkeyConfig["moonshotai/kimi-k2.7-code"],
+    },
+    {
         name: "gemini-large",
         config: portkeyConfig["gemini-3.1-pro-preview"],
         transform: pipe(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -241,6 +241,14 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "minimax/minimax-m3",
         }),
 
+    // -- OpenRouter (Kimi K2.7 Code) -----------------------------------------
+    // K2.7 (Code variant) is not on Fireworks/Azure yet (both top out at K2.6);
+    // OpenRouter is the only route.
+    "moonshotai/kimi-k2.7-code": () =>
+        createOpenRouterModelConfig({
+            model: "moonshotai/kimi-k2.7-code",
+        }),
+
     // -- Azure (Myceli Prod — eastus, Meta Llama) ----------------------------
     "Llama-3.3-70B-Instruct": () =>
         createAzureModelConfig(

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -977,6 +977,32 @@ export const TEXT_SERVICES = {
         contextLength: 262000,
         isSpecialized: false,
     },
+    "kimi-k2.7-code": {
+        aliases: ["kimi-k2.7", "kimi-k2p7"],
+        modelId: "moonshotai/kimi-k2.7-code",
+        provider: "openrouter",
+        brand: "Moonshot AI",
+        category: "text",
+        addedDate: new Date("2026-06-12").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter moonshotai/kimi-k2.7-code rates (2026-06-12):
+            // prompt $0.95/M, completion $4.00/M, cache read $0.19/M.
+            promptTextTokens: perMillion(0.95),
+            promptCachedTokens: perMillion(0.19),
+            completionTextTokens: perMillion(4.0),
+        },
+        title: "Moonshot Kimi K2.7 Code",
+        description:
+            "Moonshot Kimi K2.7 Code - Agentic coding model with CoT reasoning",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
+        tools: true,
+        reasoning: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
     "gemini-large": {
         aliases: ["gemini-3.1-pro", "gemini-2.5-pro"],
         modelId: "gemini-3.1-pro-preview",


### PR DESCRIPTION
Adds **Kimi K2.7 Code** (Moonshot AI) as a text model via OpenRouter (`moonshotai/kimi-k2.7-code`) — K2.7 isn't on Fireworks or Azure AI Foundry yet (both top out at K2.6); OpenRouter is the only route we already integrate.

- Slug `kimi-k2.7-code` (aliases `kimi-k2.7`, `kimi-k2p7`). Wiring mirrors `minimax-m3`.
- `$0.95`/`$4.00` per M in/out, `$0.19`/M cache-read. **Free** (no `paidOnly`), `priceMultiplier: 1` — at-cost, matching the Kimi family.
- 256K context, tools, reasoning, text+image input.
- It's the **Code variant** (coding-specialized); there's no general K2.7 yet. Canonical `kimi` stays on K2.5.

Verified e2e through local gen against real OpenRouter: basic, streaming, tools, reasoning (correct CoT answer), error paths → 4xx. **Reasoning tokens bill correctly** at the `completionTextTokens` rate (Tinybird cost == price, markup 0, no missing-rate warnings). Vision is functional but imperfect on synthetic color swatches (blue ✓, pure-red read as "black") — kept `image` to stay consistent with the K2.5/K2.6 family and OpenRouter's advertised modality.