### PR TITLE
fix: parse stream/json boolean query params correctly on text routes

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -65,7 +65,12 @@ import type { AuthVariables } from "@/middleware/auth.ts";
 import type { BalanceVariables } from "@/middleware/balance.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import type { FrontendKeyRateLimitVariables } from "@/middleware/rate-limit-durable.ts";
-import { generateRandomId, getRoutePath, removeUnset } from "@/util.ts";
+import {
+    generateRandomId,
+    getRoutePath,
+    parseBooleanLike,
+    removeUnset,
+} from "@/util.ts";
 
 type ModelVariables = {
     model: {
@@ -622,8 +627,8 @@ function createTrackingEvent({
 
 async function extractStreamRequested(request: HonoRequest): Promise<boolean> {
     if (request.method === "GET") {
-        const stream = request.param("stream");
-        return z.safeParse(z.coerce.boolean(), stream).data || false;
+        // "stream" is a query param, not a route param.
+        return parseBooleanLike(request.query("stream")) ?? false;
     }
     if (request.method === "POST") {
         const contentType = request.header("content-type") || "";
@@ -638,7 +643,7 @@ async function extractStreamRequested(request: HonoRequest): Promise<boolean> {
                     | undefined
             )?.stream;
             if (stream !== undefined) {
-                return z.safeParse(z.coerce.boolean(), stream).data || false;
+                return parseBooleanLike(stream) ?? false;
             }
         } catch {
             // Fall back to parsing a cloned raw body for routes without JSON validation.
@@ -647,7 +652,7 @@ async function extractStreamRequested(request: HonoRequest): Promise<boolean> {
             const stream = (
                 (await request.raw.clone().json()) as { stream?: unknown }
             ).stream;
-            return z.safeParse(z.coerce.boolean(), stream).data || false;
+            return parseBooleanLike(stream) ?? false;
         } catch {
             return false;
         }

--- a/gen.pollinations.ai/src/schemas/text.ts
+++ b/gen.pollinations.ai/src/schemas/text.ts
@@ -1,6 +1,14 @@
 import { DEFAULT_TEXT_MODEL, TEXT_SERVICES } from "@shared/registry/text.ts";
 import { SafeSchema } from "@shared/schemas/safety.ts";
 import { z } from "zod";
+import { parseBooleanLike } from "@/util.ts";
+
+// z.coerce.boolean() coerces the string "false" to true; parse boolean-ish
+// tokens instead and let unrecognized values fail validation.
+const BooleanQueryParamSchema = z.preprocess(
+    (value) => parseBooleanLike(value) ?? value,
+    z.boolean(),
+);
 
 const VALID_TEXT_MODELS = [
     ...Object.keys(TEXT_SERVICES),
@@ -23,7 +31,7 @@ export const GenerateTextRequestQueryParamsSchema = z.object({
         description:
             "System prompt to set the model's behavior and context. Acts as initial instructions before the user prompt.",
     }),
-    json: z.coerce.boolean().optional().default(false).meta({
+    json: BooleanQueryParamSchema.optional().default(false).meta({
         description:
             "When true, the model returns valid JSON. Useful for structured data extraction.",
     }),
@@ -31,7 +39,7 @@ export const GenerateTextRequestQueryParamsSchema = z.object({
         description:
             "Controls randomness. Lower values (e.g. 0.2) produce more focused output, higher values (e.g. 1.5) produce more creative output. Range: 0.0 to 2.0.",
     }),
-    stream: z.coerce.boolean().optional().default(false).meta({
+    stream: BooleanQueryParamSchema.optional().default(false).meta({
         description:
             "Stream the response as it's generated, using Server-Sent Events (SSE). Each chunk contains partial text.",
     }),

--- a/gen.pollinations.ai/src/util.ts
+++ b/gen.pollinations.ai/src/util.ts
@@ -120,3 +120,22 @@ const ansiColors: Record<AnsiColor, string> = {
 export function applyColor(color: AnsiColor, str: string): string {
     return `${ansiColors[color]}${str}${resetColor}`;
 }
+
+const TRUE_TOKENS = ["true", "1", "yes", "on"];
+const FALSE_TOKENS = ["false", "0", "no", "off", ""];
+
+/**
+ * Parse boolean-ish query/body values. Returns null when the value is not
+ * recognizably boolean, so callers decide between defaulting and rejecting.
+ * (z.coerce.boolean() treats the string "false" as true.)
+ */
+export function parseBooleanLike(value: unknown): boolean | null {
+    if (typeof value === "boolean") return value;
+    if (typeof value === "number") return value !== 0;
+    if (typeof value !== "string") return null;
+
+    const normalized = value.trim().toLowerCase();
+    if (TRUE_TOKENS.includes(normalized)) return true;
+    if (FALSE_TOKENS.includes(normalized)) return false;
+    return null;
+}

--- a/gen.pollinations.ai/test/boolean-param.test.ts
+++ b/gen.pollinations.ai/test/boolean-param.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
+import { parseBooleanLike } from "@/util.ts";
+
+describe("parseBooleanLike", () => {
+    it("parses boolean-ish tokens", () => {
+        expect(parseBooleanLike(true)).toBe(true);
+        expect(parseBooleanLike(false)).toBe(false);
+        expect(parseBooleanLike(1)).toBe(true);
+        expect(parseBooleanLike(0)).toBe(false);
+        expect(parseBooleanLike("true")).toBe(true);
+        expect(parseBooleanLike(" TRUE ")).toBe(true);
+        expect(parseBooleanLike("1")).toBe(true);
+        expect(parseBooleanLike("yes")).toBe(true);
+        expect(parseBooleanLike("on")).toBe(true);
+        expect(parseBooleanLike("false")).toBe(false);
+        expect(parseBooleanLike("0")).toBe(false);
+        expect(parseBooleanLike("no")).toBe(false);
+        expect(parseBooleanLike("off")).toBe(false);
+        expect(parseBooleanLike("")).toBe(false);
+    });
+
+    it("returns null for unrecognized values", () => {
+        expect(parseBooleanLike("banana")).toBeNull();
+        expect(parseBooleanLike(undefined)).toBeNull();
+        expect(parseBooleanLike(null)).toBeNull();
+        expect(parseBooleanLike({})).toBeNull();
+    });
+});
+
+describe("GenerateTextRequestQueryParamsSchema booleans", () => {
+    it('treats "false" as false for stream and json', () => {
+        const parsed = GenerateTextRequestQueryParamsSchema.parse({
+            stream: "false",
+            json: "false",
+        });
+        expect(parsed.stream).toBe(false);
+        expect(parsed.json).toBe(false);
+    });
+
+    it('treats "true"/"1" as true and defaults to false', () => {
+        const parsed = GenerateTextRequestQueryParamsSchema.parse({
+            stream: "true",
+            json: "1",
+        });
+        expect(parsed.stream).toBe(true);
+        expect(parsed.json).toBe(true);
+        const defaults = GenerateTextRequestQueryParamsSchema.parse({});
+        expect(defaults.stream).toBe(false);
+        expect(defaults.json).toBe(false);
+    });
+
+    it("rejects unrecognized boolean values", () => {
+        expect(() =>
+            GenerateTextRequestQueryParamsSchema.parse({ stream: "banana" }),
+        ).toThrow();
+    });
+});


### PR DESCRIPTION
- Fix GET stream detection reading `request.param("stream")` (nonexistent route param) instead of the query param — streaming was never tracked on GET text routes
- Fix `z.coerce.boolean()` treating the string `"false"` as `true` — `?stream=false` / `?json=false` behaved as `true`
- One shared `parseBooleanLike` helper used by both the request schema and the track middleware; unrecognized values fail schema validation with a 400
- Unit tests for the parser and the schema

Extracted from #11567 so it can land independently — both bugs reproduce on main today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)