### PR TITLE
fix: share enter local D1 state in gen dev

### DIFF
--- a/gen.pollinations.ai/package.json
+++ b/gen.pollinations.ai/package.json
@@ -5,7 +5,7 @@
     "description": "Simplified API gateway for pollinations.ai",
     "scripts": {
         "decrypt-vars": "sops exec-file --no-fifo secrets/dev.vars.json 'node scripts/push-generation-secrets.mjs {} local'",
-        "dev": "npm run decrypt-vars && vite build --mode=development && wrangler dev --port 8788 --local --persist-to .wrangler/state --show-interactive-dev-session false",
+        "dev": "npm run decrypt-vars && vite build --mode=development && wrangler dev --port 8788 --local --persist-to ../enter.pollinations.ai/frontend/.wrangler/state --show-interactive-dev-session false",
         "seed:local": "node scripts/seed-local-key.mjs",
         "build:staging": "CLOUDFLARE_ENV=staging vite build --mode=staging",
         "build:production": "CLOUDFLARE_ENV=production vite build --mode=production",


### PR DESCRIPTION
- gen dev server persists to enter's frontend `.wrangler/state` so locally seeded users/api-keys work across both dev servers (gen's D1 binding already points at the enter database)
- Note: enter has two state dirs; this binds to the vite-dev one (`frontend/.wrangler/state`)

Extracted from #11567 — independent of community endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)