### PR TITLE
fix(ui): export @pollinations/ui/auth/sdk subpath

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,11 @@
       "import": "./dist/auth/index.js",
       "require": "./dist/auth/index.cjs"
     },
+    "./auth/sdk": {
+      "types": "./dist/auth/sdk.d.ts",
+      "import": "./dist/auth/sdk.js",
+      "require": "./dist/auth/sdk.cjs"
+    },
     "./app-user-menu/sdk": {
       "types": "./dist/app-user-menu/sdk.d.ts",
       "import": "./dist/app-user-menu/sdk.js",

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
     entry: {
         index: "src/index.ts",
         "auth/index": "src/modules/auth/index.ts",
+        "auth/sdk": "src/modules/auth/sdk.ts",
         "app-user-menu/sdk": "src/modules/app-user-menu/sdk.ts",
         "gen/index": "src/modules/gen/index.ts",
         "wallet/index": "src/modules/wallet/index.ts",


### PR DESCRIPTION
PR #11697 added the `auth/sdk` module and an `apps/react` consumer (`UserAvatar`) but never wired the subpath, so the `react.pollinations.ai` vite build failed on main with `Missing "./auth/sdk" specifier in "@pollinations/ui"` ([run](https://github.com/pollinations/pollinations/actions/runs/27461729232)).

- Add `auth/sdk` entry to `packages/ui/tsup.config.ts` so `dist/auth/sdk.*` is built
- Add `./auth/sdk` export to `packages/ui/package.json` (matches sibling subpaths + the README)

Verified locally: `packages/ui` build emits `dist/auth/sdk.{js,cjs,d.ts}`; the `react.pollinations.ai` build now succeeds.