### PR TITLE
fix: refresh model monitor package lock

### DIFF
--- a/apps/model-monitor/package-lock.json
+++ b/apps/model-monitor/package-lock.json
@@ -22,14 +22,14 @@
     },
     "../../packages/sdk": {
       "name": "@pollinations/sdk",
-      "version": "4.4.0",
+      "version": "5.1.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",
-        "@types/react": "^18.3.12",
-        "@types/react-test-renderer": "^18.3.1",
-        "react": "^18.3.1",
-        "react-test-renderer": "^18.3.1",
+        "@types/react": "^19.2.15",
+        "@types/react-test-renderer": "^19.1.0",
+        "react": "^19.2.5",
+        "react-test-renderer": "^19.2.5",
         "tsup": "^8.0.0",
         "typescript": "^5.3.0",
         "vitest": "^2.1.0"
@@ -52,11 +52,14 @@
     },
     "../../packages/ui": {
       "name": "@pollinations/ui",
-      "version": "0.0.1",
+      "version": "0.1.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@ark-ui/react": "^5.29.1",
         "clsx": "^2.1.1",
+        "react-markdown": "^10.1.0",
+        "rehype-slug": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -72,7 +75,7 @@
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "@pollinations/sdk": "^4.4.0",
+        "@pollinations/sdk": "^5.0.0",
         "react": "^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -1500,6 +1503,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",


### PR DESCRIPTION
- Refreshes `apps/model-monitor/package-lock.json` so its local `@pollinations/sdk` and `@pollinations/ui` snapshots match current main.
- Leaves CatGPT PR #11614 untouched.
- Scope is limited to the active package consumer that still had SDK 4.4.0 / UI 0.0.1 lock metadata.

Verified:
- `npm run build --prefix apps/model-monitor`
- `git diff --check`
- package-consumer detector: `model-monitor`, `playground`, `react`

Note: `npx biome check --write apps/model-monitor/package-lock.json` processed no files because lockfiles are ignored by Biome config.