### PR TITLE
feat: add @pollinations/ui browser bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - Before implementing: verify assumptions on web (APIs change), read related files, check related PRs/issues, check existing utilities in `shared/` before writing new ones (auth, queue, registry, SSE parsing, retry wrappers), confirm branch via `git branch --show-current`.
 - When continuing prior work: read relevant code first; identify clear next steps.
 - Don't reimplement existing logic — search first.
+- When adding a React browser/IIFE bundle, grep bundled dependencies'
+  published dist for `react/jsx-runtime` and `react-dom` imports before
+  choosing shim vs external; transitive deps such as `@ark-ui/react` Portal can
+  reintroduce externals the package source does not import.
 
 ## Common Mistakes to Avoid
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -40,6 +40,54 @@ export function App() {
 }
 ```
 
+### CDN / `<script>` Tag
+
+The root `@pollinations/ui` entry also ships a browser IIFE bundle for
+no-build pages. It exposes SDK-free primitives and compositions on
+`window.PollinationsUI`. Non-root subpaths such as `@pollinations/ui/auth`,
+`@pollinations/ui/wallet`, `@pollinations/ui/gen`, and
+`@pollinations/ui/app-user-menu/sdk` remain ESM/CJS-only.
+
+React 19 no longer ships UMD builds, so load React from an ESM CDN first, set
+the globals expected by the IIFE bundle, then load `@pollinations/ui`:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@pollinations/ui@alpha/styles.css"
+/>
+<div id="root"></div>
+<script type="module">
+  import React from "https://esm.sh/react@19";
+  import * as ReactDOM from "https://esm.sh/react-dom@19";
+  import * as ReactDOMClient from "https://esm.sh/react-dom@19/client";
+
+  window.React = React;
+  window.ReactDOM = { ...ReactDOM, ...ReactDOMClient };
+
+  await new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = "https://cdn.jsdelivr.net/npm/@pollinations/ui@alpha";
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+
+  const { Button } = window.PollinationsUI;
+
+  window.ReactDOM.createRoot(document.getElementById("root")).render(
+    React.createElement(Button, null, "Generate"),
+  );
+</script>
+```
+
+The browser bundle keeps React and ReactDOM external via those globals, but it
+does bundle the root entry's package dependencies, including Ark UI,
+react-markdown, remark, and rehype.
+
+React's guidance on loading React 19 without UMD builds:
+https://react.dev/blog/2024/04/25/react-19-upgrade-guide#umd-builds-removed
+
 For Pollinations apps that use unprefixed Tailwind utilities, import the
 package-owned app stylesheet instead:
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,12 +7,15 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "unpkg": "./dist/index.browser.min.js",
+  "jsdelivr": "./dist/index.browser.min.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./umd": "./dist/index.browser.min.js",
     "./auth": {
       "types": "./dist/auth/index.d.ts",
       "import": "./dist/auth/index.js",

--- a/packages/ui/src/browser/react-dom-global.ts
+++ b/packages/ui/src/browser/react-dom-global.ts
@@ -1,0 +1,22 @@
+import type * as ReactDOMModule from "react-dom";
+
+type ReactDOMGlobal = typeof ReactDOMModule;
+
+function getReactDOM(): ReactDOMGlobal {
+    const ReactDOM = (
+        globalThis as typeof globalThis & { ReactDOM?: ReactDOMGlobal }
+    ).ReactDOM;
+
+    if (!ReactDOM) {
+        throw new Error(
+            "@pollinations/ui browser bundle requires globalThis.ReactDOM. Load ReactDOM before @pollinations/ui.",
+        );
+    }
+
+    return ReactDOM;
+}
+
+const ReactDOM = getReactDOM();
+
+export default ReactDOM;
+export const { createPortal, flushSync } = ReactDOM;

--- a/packages/ui/src/browser/react-global.ts
+++ b/packages/ui/src/browser/react-global.ts
@@ -1,0 +1,59 @@
+import type * as ReactModule from "react";
+
+type ReactGlobal = typeof ReactModule;
+
+function getReact(): ReactGlobal {
+    const React = (globalThis as typeof globalThis & { React?: ReactGlobal })
+        .React;
+
+    if (!React) {
+        throw new Error(
+            "@pollinations/ui browser bundle requires globalThis.React. Load React before @pollinations/ui.",
+        );
+    }
+
+    return React;
+}
+
+const React = getReact();
+
+export default React;
+export const {
+    Children,
+    Component,
+    Fragment,
+    Profiler,
+    PureComponent,
+    StrictMode,
+    Suspense,
+    cache,
+    cloneElement,
+    createContext,
+    createElement,
+    createRef,
+    forwardRef,
+    isValidElement,
+    lazy,
+    memo,
+    startTransition,
+    use,
+    useActionState,
+    useCallback,
+    useContext,
+    useDebugValue,
+    useDeferredValue,
+    useEffect,
+    useEffectEvent,
+    useId,
+    useImperativeHandle,
+    useInsertionEffect,
+    useLayoutEffect,
+    useMemo,
+    useOptimistic,
+    useReducer,
+    useRef,
+    useState,
+    useSyncExternalStore,
+    useTransition,
+    version,
+} = React;

--- a/packages/ui/src/browser/react-jsx-runtime-global.ts
+++ b/packages/ui/src/browser/react-jsx-runtime-global.ts
@@ -1,0 +1,18 @@
+import { createElement, Fragment } from "./react-global.ts";
+
+type PropsWithKey = Record<string, unknown> | null | undefined;
+const createElementFromRuntime = createElement as (
+    type: unknown,
+    props?: Record<string, unknown> | null,
+) => unknown;
+
+export function jsx(type: unknown, props: PropsWithKey, key?: unknown) {
+    const nextProps =
+        key === undefined ? props : { ...(props ?? {}), key: String(key) };
+
+    return createElementFromRuntime(type, nextProps);
+}
+
+export const jsxs = jsx;
+export const jsxDEV = jsx;
+export { Fragment };

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,35 +1,67 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-    entry: {
-        index: "src/index.ts",
-        "auth/index": "src/modules/auth/index.ts",
-        "auth/sdk": "src/modules/auth/sdk.ts",
-        "app-user-menu/sdk": "src/modules/app-user-menu/sdk.ts",
-        "gen/index": "src/modules/gen/index.ts",
-        "wallet/index": "src/modules/wallet/index.ts",
+export default defineConfig([
+    {
+        entry: {
+            index: "src/index.ts",
+            "auth/index": "src/modules/auth/index.ts",
+            "auth/sdk": "src/modules/auth/sdk.ts",
+            "app-user-menu/sdk": "src/modules/app-user-menu/sdk.ts",
+            "gen/index": "src/modules/gen/index.ts",
+            "wallet/index": "src/modules/wallet/index.ts",
+        },
+        format: ["esm", "cjs"],
+        dts: true,
+        splitting: false,
+        sourcemap: true,
+        // Scoped clean: remove tsup's own JS/dts outputs (incl. stale ones from
+        // renamed modules) but PRESERVE the static files copied by the later build
+        // steps (fonts, assets, licenses, css). A blanket `clean: true` wipes all of
+        // dist/ first, leaving a window where the fonts + logo don't exist — consumers
+        // that serve them from this symlinked dist (e.g. the website in dev) then 404
+        // and cache the miss. Preserving them removes that window entirely.
+        clean: [
+            "**/*",
+            "!fonts/**",
+            "!assets/**",
+            "!licenses/**",
+            "!styles.css",
+            "!app.css",
+            "!index.browser.min.js",
+            "!index.browser.min.js.map",
+        ],
+        minify: false,
+        external: ["@pollinations/sdk", "@pollinations/sdk/react", "react"],
+        loader: {
+            ".svg": "dataurl",
+        },
     },
-    format: ["esm", "cjs"],
-    dts: true,
-    splitting: false,
-    sourcemap: true,
-    // Scoped clean: remove tsup's own JS/dts outputs (incl. stale ones from
-    // renamed modules) but PRESERVE the static files copied by the later build
-    // steps (fonts, assets, licenses, css). A blanket `clean: true` wipes all of
-    // dist/ first, leaving a window where the fonts + logo don't exist — consumers
-    // that serve them from this symlinked dist (e.g. the website in dev) then 404
-    // and cache the miss. Preserving them removes that window entirely.
-    clean: [
-        "**/*",
-        "!fonts/**",
-        "!assets/**",
-        "!licenses/**",
-        "!styles.css",
-        "!app.css",
-    ],
-    minify: false,
-    external: ["@pollinations/sdk", "@pollinations/sdk/react", "react"],
-    loader: {
-        ".svg": "dataurl",
+    {
+        entry: {
+            index: "src/index.ts",
+        },
+        format: ["iife"],
+        globalName: "PollinationsUI",
+        outDir: "dist",
+        platform: "browser",
+        splitting: false,
+        sourcemap: true,
+        minify: true,
+        dts: false,
+        clean: false,
+        outExtension: () => ({ js: ".browser.min.js" }),
+        loader: {
+            ".svg": "dataurl",
+        },
+        esbuildOptions(options) {
+            options.alias = {
+                react: "./src/browser/react-global.ts",
+                "react-dom": "./src/browser/react-dom-global.ts",
+                "react/jsx-runtime":
+                    "./src/browser/react-jsx-runtime-global.ts",
+                "react/jsx-dev-runtime":
+                    "./src/browser/react-jsx-runtime-global.ts",
+            };
+        },
     },
-});
+]);


### PR DESCRIPTION
Adds a browser IIFE build for the root `@pollinations/ui` entry so primitives + tokens load via a plain `<script>` tag in no-build pages (standalone HTML, CodePen, prototypes).

- Root-only IIFE tsup build exposing `window.PollinationsUI`; existing ESM/CJS entries unchanged
- Keeps React/ReactDOM external via `globalThis` shims (incl. `react/jsx-runtime` and `react-dom` `createPortal` for Ark Portal) — no bundled React
- Adds `unpkg`/`jsdelivr` + `./umd` export; ships `styles.css` alongside
- Documents React 19 CDN setup (esm.sh; React 19 dropped UMD) with reliable script ordering
- SDK-backed subpaths stay ESM/CJS only

Verified: build, typecheck, tests, biome; bundle has no `Dynamic require` / no bundled React; real no-build page renders and exercises the portal path.

Fixes #11574
