### PR TITLE
fix: route Websim through app proxy

### DIFF
--- a/apps/_scripts/deploy.sh
+++ b/apps/_scripts/deploy.sh
@@ -34,12 +34,15 @@ CONFIG=$(node -e "
 OUTPUT_DIR=$(echo "$CONFIG" | node -e "const c=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(c.outputDir || 'dist')")
 BUILD_CMD=$(echo "$CONFIG" | node -e "const c=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(c.buildCommand || '')")
 SUBDOMAIN=$(echo "$CONFIG" | node -e "const c=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(c.subdomain || process.argv[1])" "$APP_NAME")
+DEPLOY_TARGET=$(echo "$CONFIG" | node -e "const c=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(c.deployTarget || 'pages')")
+WORKER_ENTRYPOINT=$(echo "$CONFIG" | node -e "const c=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(c.workerEntrypoint || 'worker.js')")
 PROJECT_NAME="apps-$SUBDOMAIN"
 
 echo "📦 App: $APP_NAME"
 echo "📋 Project: $PROJECT_NAME"
 echo "🌐 Subdomain: $SUBDOMAIN"
 echo "📁 Output: $OUTPUT_DIR"
+echo "🎯 Target: $DEPLOY_TARGET"
 
 # Apps ship committed brand assets (favicons/icons/OG/manifest). After an app
 # migrates to the design-system logo, regenerate them via tools/icons.
@@ -64,20 +67,27 @@ if [ -n "$BUILD_CMD" ] && [ "$BUILD_CMD" != "null" ]; then
     eval "$BUILD_CMD"
 fi
 
-# Step 4: Provision the Myceli origin before upload
-echo ""
-echo "☁️ Provisioning Myceli origin..."
-node "$SCRIPT_DIR/deploy-app.js" "$APP_NAME" --phase=origin
+if [ "$DEPLOY_TARGET" = "worker" ]; then
+    # Worker-backed apps define their Myceli origin route in wrangler.toml.
+    echo ""
+    echo "🚀 Deploying Cloudflare Worker..."
+    npx wrangler deploy "$WORKER_ENTRYPOINT"
+else
+    # Step 4: Provision the Myceli origin before upload
+    echo ""
+    echo "☁️ Provisioning Myceli origin..."
+    node "$SCRIPT_DIR/deploy-app.js" "$APP_NAME" --phase=origin
 
-# Step 5: Upload content to Cloudflare Pages
-echo ""
-echo "🚀 Uploading to Cloudflare Pages..."
-npx wrangler pages deploy "$APP_PATH/$OUTPUT_DIR" \
-    --project-name="$PROJECT_NAME" \
-    --branch=production \
-    --commit-dirty=true
+    # Step 5: Upload content to Cloudflare Pages
+    echo ""
+    echo "🚀 Uploading to Cloudflare Pages..."
+    npx wrangler pages deploy "$APP_PATH/$OUTPUT_DIR" \
+        --project-name="$PROJECT_NAME" \
+        --branch=production \
+        --commit-dirty=true
+fi
 
-# Step 6: Gate on the Myceli origin before public cutover
+# Gate on the Myceli origin before public cutover
 echo ""
 echo "⏳ Waiting for https://$SUBDOMAIN.myceli.ai to serve..."
 for i in $(seq 1 30); do

--- a/apps/apps.json
+++ b/apps/apps.json
@@ -13,6 +13,14 @@
         "title": "Playground | pollinations.ai",
         "description": "Generate images, text, audio and video with Pollinations AI"
     },
+    "websim": {
+        "subdomain": "websim",
+        "deployTarget": "worker",
+        "buildCommand": "npm run build",
+        "workerEntrypoint": "worker.js",
+        "title": "Websim | pollinations.ai",
+        "description": "Generate shareable single-file web pages with Pollinations"
+    },
     "catgpt": {
         "subdomain": "catgpt",
         "buildCommand": null,

--- a/apps/websim/index.html
+++ b/apps/websim/index.html
@@ -32,12 +32,12 @@
       property="og:description"
       content="Generate shareable single-file HTML pages with Pollinations Websim."
     />
-    <meta property="og:image" content="https://websim.myceli.ai/og-image.png" />
+    <meta property="og:image" content="https://websim.pollinations.ai/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="pollinations.ai logo" />
     <meta property="og:locale" content="en_US" />
-    <meta property="og:url" content="https://websim.myceli.ai" />
+    <meta property="og:url" content="https://websim.pollinations.ai" />
     <meta property="og:site_name" content="pollinations.ai" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -47,7 +47,7 @@
       name="twitter:description"
       content="Generate shareable single-file HTML pages with Pollinations Websim."
     />
-    <meta name="twitter:image" content="https://websim.myceli.ai/og-image.png" />
+    <meta name="twitter:image" content="https://websim.pollinations.ai/og-image.png" />
     <meta name="twitter:image:alt" content="pollinations.ai logo" />
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
@@ -57,7 +57,7 @@
     <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
     <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="canonical" href="https://websim.myceli.ai" />
+    <link rel="canonical" href="https://websim.pollinations.ai" />
 
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
- Registers Websim in apps.json so the app proxy source of truth includes websim.pollinations.ai.\n- Adds a Worker deploy target to apps/_scripts/deploy.sh, keeping Pages as the default for existing apps.\n- Points Websim canonical/OG metadata at websim.pollinations.ai.\n\nChecks:\n- npx biome check --write apps/apps.json apps/websim/index.html\n- bash -n apps/_scripts/deploy.sh\n- npm run build --prefix apps/websim\n- npm run typecheck --prefix apps/websim\n- npx wrangler deploy worker.js --dry-run\n- npm test --prefix pollinations-myceli-proxy