### PR TITLE
fix: override existing app proxy domains

### DIFF
--- a/apps/_scripts/deploy-app.js
+++ b/apps/_scripts/deploy-app.js
@@ -315,6 +315,7 @@ async function attachWorkerDomain(account, headers, hostname, zoneId) {
                 hostname,
                 service: PROXY_WORKER,
                 environment: "production",
+                override_existing_origin: true,
                 zone_id: zoneId,
             }),
         },


### PR DESCRIPTION
- Passes override_existing_origin when attaching app public domains to pollinations-proxy.\n- Handles cutovers where the public hostname is still attached to an older Worker or Pages custom domain.\n- Unblocks the Websim public-domain cutover.\n\nChecks:\n- npx biome check --write apps/_scripts/deploy-app.js\n- git diff --check