### PR TITLE
feat: make playground and websim embed-friendly

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -11,17 +11,22 @@ export function App() {
 
     return (
         <div className="relative flex min-h-dvh flex-col bg-app-bg font-body text-theme-text-base">
-            <div className="fixed top-4 right-4 z-40 flex items-center gap-2">
+            <div
+                className={cn(
+                    "fixed right-4 z-40 flex items-center gap-2",
+                    isEmbedded ? "top-2" : "top-4",
+                )}
+            >
                 {!isEmbedded && <ColorModeToggle />}
-                <AppUserMenu dashboardHref={ENTER_URL} hiddenWhenEmbedded />
+                <AppUserMenu dashboardHref={ENTER_URL} />
             </div>
             <main
                 className={cn(
                     "mx-auto flex w-full max-w-5xl flex-1 flex-col gap-5 px-4 pb-5 sm:px-6",
-                    isEmbedded ? "pt-5" : "pt-16",
+                    isEmbedded ? "pt-2" : "pt-16",
                 )}
             >
-                <Playground />
+                <Playground showTitle={!isEmbedded} />
             </main>
         </div>
     );

--- a/apps/playground/src/Playground.tsx
+++ b/apps/playground/src/Playground.tsx
@@ -65,6 +65,7 @@ type PlaygroundResult =
 export type PlaygroundProps = {
     title?: string;
     subtitle?: string;
+    showTitle?: boolean;
     className?: string;
 };
 
@@ -303,6 +304,7 @@ async function uploadReferenceImages(
 export function Playground({
     title = "Playground",
     subtitle = "Create and refine images, text, audio, and video from one focused workspace.",
+    showTitle = true,
     className,
 }: PlaygroundProps) {
     const { apiKey, isLoggedIn, isHydrated } = useAuthState();
@@ -543,13 +545,15 @@ export function Playground({
             )}
         >
             <section className="polli:flex polli:flex-col polli:gap-1">
-                <Heading
-                    as="h1"
-                    size="title"
-                    className="polli-playground-title polli:m-0 polli:text-theme-text-strong"
-                >
-                    {title}
-                </Heading>
+                {showTitle && (
+                    <Heading
+                        as="h1"
+                        size="title"
+                        className="polli-playground-title polli:m-0 polli:text-theme-text-strong"
+                    >
+                        {title}
+                    </Heading>
+                )}
                 <p className="polli:m-0 polli:max-w-3xl polli:text-base polli:leading-relaxed polli:text-theme-text-base">
                     {subtitle}
                 </p>

--- a/apps/websim/src/App.tsx
+++ b/apps/websim/src/App.tsx
@@ -221,30 +221,37 @@ export function App() {
             data-theme="accent"
             className="relative flex min-h-dvh flex-col bg-app-bg font-body text-theme-text-base"
         >
-            <div className="fixed top-4 right-4 z-40 flex items-center gap-2">
+            <div
+                className={cn(
+                    "fixed right-4 z-40 flex items-center gap-2",
+                    isEmbedded ? "top-2" : "top-4",
+                )}
+            >
                 {!isEmbedded && <ColorModeToggle />}
-                <AppUserMenu dashboardHref={ENTER_URL} hiddenWhenEmbedded />
+                <AppUserMenu dashboardHref={ENTER_URL} />
             </div>
 
             <main
                 className={cn(
                     "mx-auto flex w-full max-w-5xl flex-1 flex-col gap-5 px-4 pb-5 sm:px-6",
-                    isEmbedded ? "pt-5" : "pt-16",
+                    isEmbedded ? "pt-2" : "pt-16",
                 )}
             >
                 <section className="flex flex-col gap-2">
-                    <div className="flex items-center gap-3">
-                        <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-theme-bg-active text-theme-text-strong">
-                            <AppIcon className="h-6 w-6" />
-                        </span>
-                        <Heading
-                            as="h1"
-                            size="title"
-                            className="websim-title m-0 text-theme-text-strong"
-                        >
-                            Websim
-                        </Heading>
-                    </div>
+                    {!isEmbedded && (
+                        <div className="flex items-center gap-3">
+                            <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-theme-bg-active text-theme-text-strong">
+                                <AppIcon className="h-6 w-6" />
+                            </span>
+                            <Heading
+                                as="h1"
+                                size="title"
+                                className="websim-title m-0 text-theme-text-strong"
+                            >
+                                Websim
+                            </Heading>
+                        </div>
+                    )}
                     <Text as="p" className="m-0 max-w-3xl">
                         Generate shareable single-file web pages with
                         Pollinations.


### PR DESCRIPTION
Makes the Playground and Websim apps render correctly when embedded in the pollinations.ai `/play` iframe — the reference implementation of the self-contained embeddable-app pattern.

- Show the BYOP auth menu when embedded (previously hidden via `hiddenWhenEmbedded`); each app keeps its own auth on its own origin.
- Hide the app title when embedded — the host tab selector already names the app; the subtitle stays.
- Tighten top spacing in embed mode (`pt-2`, menu `top-2`); standalone unchanged.

CatGPT gets the same treatment in #11614.