### PR TITLE
[codex] feat: move model routes to Fireworks

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -898,14 +898,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "qwen-large": {
     "cost": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.0000001,
-      "promptTextTokens": 0.0000005,
+      "completionTextTokens": 0.0000016,
+      "promptCachedTokens": 0.00000008,
+      "promptTextTokens": 0.0000004,
     },
     "price": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.0000001,
-      "promptTextTokens": 0.0000005,
+      "completionTextTokens": 0.0000016,
+      "promptCachedTokens": 0.00000008,
+      "promptTextTokens": 0.0000004,
     },
   },
   "qwen-safety": {

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -53,7 +53,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "qwen-large",
-        config: portkeyConfig["accounts/fireworks/models/qwen3p6-plus"],
+        config: portkeyConfig["accounts/fireworks/models/qwen3p7-plus"],
     },
     {
         name: "qwen-vision",
@@ -246,7 +246,8 @@ const models: ModelDefinition[] = [
     },
     {
         name: "kimi-k2.7-code",
-        config: portkeyConfig["moonshotai/kimi-k2.7-code"],
+        config: portkeyConfig["accounts/fireworks/models/kimi-k2p7-code"],
+        transform: stripCacheControl,
     },
     {
         name: "gemini-large",
@@ -277,7 +278,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "minimax-m3",
-        config: portkeyConfig["minimax/minimax-m3"],
+        config: portkeyConfig["accounts/fireworks/models/minimax-m3"],
     },
     {
         name: "llama",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -133,6 +133,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/kimi-k2p6",
         }),
+    "accounts/fireworks/models/kimi-k2p7-code": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/kimi-k2p7-code",
+        }),
 
     // -- OpenRouter (Mistral Small 3.2, Mistral Small 4) ---------------------
     // Moved off Azure: Mistral Small was Marketplace SaaS pass-through on
@@ -219,9 +223,9 @@ export const portkeyConfig: PortkeyConfigMap = {
         createPerplexityModelConfig({ model: "sonar-reasoning-pro" }),
 
     // -- Fireworks AI (Qwen) -----------------------------------------------------
-    "accounts/fireworks/models/qwen3p6-plus": () =>
+    "accounts/fireworks/models/qwen3p7-plus": () =>
         createFireworksModelConfig({
-            model: "accounts/fireworks/models/qwen3p6-plus",
+            model: "accounts/fireworks/models/qwen3p7-plus",
         }),
     "accounts/fireworks/models/glm-5p1": () =>
         createFireworksModelConfig({
@@ -231,21 +235,9 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/minimax-m2p7",
         }),
-
-    // -- OpenRouter (MiniMax M3) ---------------------------------------------
-    // M3 is not on Fireworks/Bedrock yet (Bedrock tops out at M2.5); OpenRouter
-    // is the only route and also exposes image input.
-    "minimax/minimax-m3": () =>
-        createOpenRouterModelConfig({
-            model: "minimax/minimax-m3",
-        }),
-
-    // -- OpenRouter (Kimi K2.7 Code) -----------------------------------------
-    // K2.7 (Code variant) is not on Fireworks/Azure yet (both top out at K2.6);
-    // OpenRouter is the only route.
-    "moonshotai/kimi-k2.7-code": () =>
-        createOpenRouterModelConfig({
-            model: "moonshotai/kimi-k2.7-code",
+    "accounts/fireworks/models/minimax-m3": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/minimax-m3",
         }),
 
     // -- Azure (Myceli Prod — eastus, Meta Llama) ----------------------------

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -979,14 +979,14 @@ export const TEXT_SERVICES = {
     },
     "kimi-k2.7-code": {
         aliases: ["kimi-k2.7", "kimi-k2p7"],
-        modelId: "moonshotai/kimi-k2.7-code",
-        provider: "openrouter",
+        modelId: "accounts/fireworks/models/kimi-k2p7-code",
+        provider: "fireworks",
         brand: "Moonshot AI",
         category: "text",
         addedDate: new Date("2026-06-12").getTime(),
         priceMultiplier: 1,
         cost: {
-            // OpenRouter moonshotai/kimi-k2.7-code rates (2026-06-12):
+            // Fireworks accounts/fireworks/models/kimi-k2p7-code rates (2026-06-14):
             // prompt $0.95/M, completion $4.00/M, cache read $0.19/M.
             promptTextTokens: perMillion(0.95),
             promptCachedTokens: perMillion(0.19),
@@ -997,7 +997,7 @@ export const TEXT_SERVICES = {
             "Moonshot Kimi K2.7 Code - Agentic coding model with CoT reasoning",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
+        maxReferenceImages: 30, // Fireworks vision hard limit.
         tools: true,
         reasoning: true,
         contextLength: 262144,
@@ -1200,29 +1200,27 @@ export const TEXT_SERVICES = {
     },
     "minimax-m3": {
         aliases: ["minimax3", "minimax-3"],
-        modelId: "minimax/minimax-m3",
-        provider: "openrouter",
+        modelId: "accounts/fireworks/models/minimax-m3",
+        provider: "fireworks",
         brand: "MiniMax",
         category: "text",
         addedDate: new Date("2026-06-02").getTime(),
         priceMultiplier: 1,
         cost: {
-            // OpenRouter minimax/minimax-m3 effective rates (2026-06-02):
-            // currently a temporary 50% promo — prompt $0.30/M, completion
-            // $1.20/M, cache read $0.06/M. Base (post-promo) is double:
-            // $0.60/M, $2.40/M, $0.12/M — revisit when the promo ends.
+            // Fireworks accounts/fireworks/models/minimax-m3 rates (2026-06-14):
+            // prompt $0.30/M, completion $1.20/M, cache read $0.06/M.
             promptTextTokens: perMillion(0.3),
             promptCachedTokens: perMillion(0.06),
             completionTextTokens: perMillion(1.2),
         },
         title: "MiniMax M3",
-        description: "MiniMax M3 - Coding, agentic & 1M-context reasoning",
+        description: "MiniMax M3 - Coding, agentic & 512K-context reasoning",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
+        maxReferenceImages: 30, // Fireworks vision hard limit.
         tools: true,
         reasoning: true,
-        contextLength: 1048576,
+        contextLength: 524288,
         isSpecialized: false,
     },
     "mistral-large": {
@@ -1297,27 +1295,33 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "qwen-large": {
-        aliases: ["qwen3.6", "qwen3.6-plus", "qwen3p6-plus"],
-        modelId: "accounts/fireworks/models/qwen3p6-plus",
+        aliases: [
+            "qwen3.7",
+            "qwen3.7-plus",
+            "qwen3p7-plus",
+            "qwen3.6",
+            "qwen3.6-plus",
+            "qwen3p6-plus",
+        ],
+        modelId: "accounts/fireworks/models/qwen3p7-plus",
         provider: "fireworks",
         brand: "Qwen",
         category: "text",
-        addedDate: new Date("2026-03-22").getTime(),
+        addedDate: new Date("2026-06-12").getTime(),
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(0.5),
-            promptCachedTokens: perMillion(0.1),
-            completionTextTokens: perMillion(3.0),
+            promptTextTokens: perMillion(0.4),
+            promptCachedTokens: perMillion(0.08),
+            completionTextTokens: perMillion(1.6),
         },
-        title: "Qwen3.6 Plus",
-        description:
-            "Qwen3.6 Plus - 396B MoE Flagship with Reasoning (Fireworks)",
+        title: "Qwen3.7 Plus",
+        description: "Qwen3.7 Plus - Multimodal agent intelligence (Fireworks)",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 30, // Fireworks vision hard limit.
         tools: true,
         reasoning: true,
-        contextLength: 1048576,
+        contextLength: 262000,
         isSpecialized: false,
     },
     "qwen-vision": {


### PR DESCRIPTION
## Summary
- Moves Kimi K2.7 Code, MiniMax M3, and Qwen Large to Fireworks routes.
- Updates Qwen Large to Qwen3.7 Plus.
- Halves MiniMax M3 registered context from 1M to 512K for the Fireworks route.

| Model | Before | After | Price in/cache/out per 1M |
|---|---|---|---|
| Kimi K2.7 Code | OpenRouter `moonshotai/kimi-k2.7-code` | Fireworks `kimi-k2p7-code` | `$0.95/$0.19/$4.00` -> same |
| MiniMax M3 | OpenRouter `minimax/minimax-m3`, 1M ctx | Fireworks `minimax-m3`, 512K ctx | `$0.30/$0.06/$1.20` -> same |
| Qwen Large | Fireworks `qwen3p6-plus` | Fireworks `qwen3p7-plus` | `$0.50/$0.10/$3.00` -> `$0.40/$0.08/$1.60` |

## Checks
- `npx biome check --write gen.pollinations.ai/src/text/availableModels.ts gen.pollinations.ai/src/text/configs/modelConfigs.ts shared/registry/text.ts enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap`
- `npm run decrypt-vars` in `enter.pollinations.ai`
- `npx vitest run test/effective-prices.snapshot.test.ts test/aliases.test.ts test/pricing-data.test.ts`
- `npx vitest run test/text/transforms/stripCacheControl.test.ts`
- Local `/v1/chat/completions` smoke: `kimi-k2.7-code`, `qwen-large`, `minimax-m3` -> Fireworks upstream ids