### PR TITLE
feat: report embed height from playground and websim

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -3,14 +3,21 @@ import {
     AppUserMenu,
     isEmbeddedContext,
 } from "@pollinations/ui/app-user-menu/sdk";
+import { useReportEmbedHeight } from "@pollinations/ui/embed";
 import { ENTER_URL } from "./config";
 import { Playground } from "./Playground";
 
 export function App() {
     const isEmbedded = isEmbeddedContext();
+    useReportEmbedHeight(isEmbedded);
 
     return (
-        <div className="relative flex min-h-dvh flex-col bg-app-bg font-body text-theme-text-base">
+        <div
+            className={cn(
+                "relative flex flex-col bg-app-bg font-body text-theme-text-base",
+                !isEmbedded && "min-h-dvh",
+            )}
+        >
             <div
                 className={cn(
                     "fixed right-4 z-40 flex items-center gap-2",

--- a/apps/websim/src/App.tsx
+++ b/apps/websim/src/App.tsx
@@ -21,6 +21,7 @@ import {
     AppUserMenu,
     isEmbeddedContext,
 } from "@pollinations/ui/app-user-menu/sdk";
+import { useReportEmbedHeight } from "@pollinations/ui/embed";
 import { useEffect, useRef, useState } from "react";
 import {
     DEFAULT_MODEL,
@@ -141,6 +142,7 @@ export function App() {
     const { apiKey, isHydrated } = useAuthState();
     const { login } = useAuthActions();
     const isEmbedded = isEmbeddedContext();
+    useReportEmbedHeight(isEmbedded);
     const [prompt, setPrompt] = useState(INITIAL_PROMPT);
     const [model, setModel] = useState<WebsimModelId>(DEFAULT_MODEL);
     const [html, setHtml] = useState("");
@@ -219,7 +221,10 @@ export function App() {
     return (
         <div
             data-theme="accent"
-            className="relative flex min-h-dvh flex-col bg-app-bg font-body text-theme-text-base"
+            className={cn(
+                "relative flex flex-col bg-app-bg font-body text-theme-text-base",
+                !isEmbedded && "min-h-dvh",
+            )}
         >
             <div
                 className={cn(


### PR DESCRIPTION
Makes the `/play` iframe size to its app's content so there's no scrollbar inside the iframe.

- Playground and Websim now call `useReportEmbedHeight` when embedded and drop `min-h-dvh`, so each reports its natural content height instead of padding to the iframe viewport.
- Standalone behavior unchanged — height reporting only fires inside a frame; `min-h-dvh` is kept when not embedded.

Depends on #11792, which adds `@pollinations/ui/embed` (the shared hook + the host-side listener in `/play`). No file overlap with #11792, so no merge conflict — but merge #11792 first; this won't build until that lands.
