### PR TITLE
fix: inline embed-height in playground and websim

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -3,13 +3,32 @@ import {
     AppUserMenu,
     isEmbeddedContext,
 } from "@pollinations/ui/app-user-menu/sdk";
-import { useReportEmbedHeight } from "@pollinations/ui/embed";
+import { useEffect } from "react";
 import { ENTER_URL } from "./config";
 import { Playground } from "./Playground";
 
 export function App() {
     const isEmbedded = isEmbeddedContext();
-    useReportEmbedHeight(isEmbedded);
+
+    // Report content height to the embedding host (/play) so it can size the
+    // iframe to fit — no inner scroll. Message: { source, type, value }.
+    useEffect(() => {
+        if (!isEmbedded || window.parent === window.self) return;
+        const report = () => {
+            window.parent.postMessage(
+                {
+                    source: "polli-embed",
+                    type: "height",
+                    value: Math.ceil(document.documentElement.scrollHeight),
+                },
+                "*",
+            );
+        };
+        const observer = new ResizeObserver(report);
+        observer.observe(document.body);
+        report();
+        return () => observer.disconnect();
+    }, [isEmbedded]);
 
     return (
         <div

--- a/apps/websim/src/App.tsx
+++ b/apps/websim/src/App.tsx
@@ -21,7 +21,6 @@ import {
     AppUserMenu,
     isEmbeddedContext,
 } from "@pollinations/ui/app-user-menu/sdk";
-import { useReportEmbedHeight } from "@pollinations/ui/embed";
 import { useEffect, useRef, useState } from "react";
 import {
     DEFAULT_MODEL,
@@ -142,7 +141,6 @@ export function App() {
     const { apiKey, isHydrated } = useAuthState();
     const { login } = useAuthActions();
     const isEmbedded = isEmbeddedContext();
-    useReportEmbedHeight(isEmbedded);
     const [prompt, setPrompt] = useState(INITIAL_PROMPT);
     const [model, setModel] = useState<WebsimModelId>(DEFAULT_MODEL);
     const [html, setHtml] = useState("");
@@ -153,6 +151,26 @@ export function App() {
     useEffect(() => {
         return () => activeRequest.current?.abort();
     }, []);
+
+    // Report content height to the embedding host (/play) so it can size the
+    // iframe to fit — no inner scroll. Message: { source, type, value }.
+    useEffect(() => {
+        if (!isEmbedded || window.parent === window.self) return;
+        const report = () => {
+            window.parent.postMessage(
+                {
+                    source: "polli-embed",
+                    type: "height",
+                    value: Math.ceil(document.documentElement.scrollHeight),
+                },
+                "*",
+            );
+        };
+        const observer = new ResizeObserver(report);
+        observer.observe(document.body);
+        report();
+        return () => observer.disconnect();
+    }, [isEmbedded]);
 
     async function generate() {
         const trimmedPrompt = prompt.trim();


### PR DESCRIPTION
#11795 merged playground + websim importing `@pollinations/ui/embed`, but that module isn't on main (it only lives in the still-open #11792) — so both apps currently fail to build on main.

This drops the package import and inlines the height reporter directly in each app: a small `useEffect` that posts `{ source: "polli-embed", type: "height", value }` to the parent when embedded, via a `ResizeObserver` on `document.body`. The apps are now self-contained — no shared-package dependency for this.

- Fixes the broken main build for `apps/playground` and `apps/websim`.
- Behavior unchanged: `/play` still auto-sizes the iframe (the host listener lives in #11792).
