### PR TITLE
feat: share theme across *.pollinations.ai subdomains

### DIFF
--- a/apps/model-monitor/index.html
+++ b/apps/model-monitor/index.html
@@ -9,7 +9,7 @@
     <script>
       (() => {
         try {
-          let mode = localStorage.getItem("polli-color-mode");
+          let mode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
           if (mode !== "light" && mode !== "dark") {
             mode = matchMedia("(prefers-color-scheme: dark)").matches
               ? "dark"

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -9,7 +9,7 @@
     <script>
       (() => {
         try {
-          let mode = localStorage.getItem("polli-color-mode");
+          let mode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
           if (mode !== "light" && mode !== "dark") {
             mode = matchMedia("(prefers-color-scheme: dark)").matches
               ? "dark"

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -1,4 +1,4 @@
-import { ColorModeToggle, cn } from "@pollinations/ui";
+import { ColorModeToggle, cn, setColorMode } from "@pollinations/ui";
 import {
     AppUserMenu,
     isEmbeddedContext,
@@ -6,6 +6,21 @@ import {
 import { useEffect } from "react";
 import { ENTER_URL } from "./config";
 import { Playground } from "./Playground";
+
+// Origins allowed to push a live theme into this embedded app: the /play host
+// and same-site siblings. Theme is cosmetic, but we still gate on origin.
+function isTrustedHostOrigin(origin: string): boolean {
+    try {
+        const host = new URL(origin).hostname;
+        return (
+            host === "pollinations.ai" ||
+            host.endsWith(".pollinations.ai") ||
+            host === "localhost"
+        );
+    } catch {
+        return false;
+    }
+}
 
 export function App() {
     const isEmbedded = isEmbeddedContext();
@@ -28,6 +43,32 @@ export function App() {
         observer.observe(document.body);
         report();
         return () => observer.disconnect();
+    }, [isEmbedded]);
+
+    // Apply a theme the host (/play) pushes when its toggle changes, so this
+    // already-loaded embed re-themes live. Message: { source, type, value }.
+    useEffect(() => {
+        if (!isEmbedded || window.parent === window.self) return;
+        const onMessage = (event: MessageEvent) => {
+            if (!isTrustedHostOrigin(event.origin)) return;
+            const data = event.data as {
+                source?: unknown;
+                type?: unknown;
+                value?: unknown;
+            } | null;
+            if (
+                !data ||
+                data.source !== "polli-embed" ||
+                data.type !== "theme"
+            ) {
+                return;
+            }
+            if (data.value === "dark" || data.value === "light") {
+                setColorMode(data.value);
+            }
+        };
+        window.addEventListener("message", onMessage);
+        return () => window.removeEventListener("message", onMessage);
     }, [isEmbedded]);
 
     return (

--- a/apps/react/index.html
+++ b/apps/react/index.html
@@ -9,7 +9,7 @@
         <script>
             (() => {
                 try {
-                    let mode = localStorage.getItem("polli-color-mode");
+                    let mode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
                     if (mode !== "light" && mode !== "dark") {
                         mode = matchMedia("(prefers-color-scheme: dark)").matches
                             ? "dark"

--- a/apps/websim/index.html
+++ b/apps/websim/index.html
@@ -7,7 +7,7 @@
     <script>
       (() => {
         try {
-          let mode = localStorage.getItem("polli-color-mode");
+          let mode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
           if (mode !== "light" && mode !== "dark") {
             mode = matchMedia("(prefers-color-scheme: dark)").matches
               ? "dark"

--- a/apps/websim/src/App.tsx
+++ b/apps/websim/src/App.tsx
@@ -11,6 +11,7 @@ import {
     Heading,
     MediaPlaceholder,
     Surface,
+    setColorMode,
     TabButton,
     TerminalIcon,
     Text,
@@ -137,6 +138,21 @@ function PreviewPanel({
     );
 }
 
+// Origins allowed to push a live theme into this embedded app: the /play host
+// and same-site siblings. Theme is cosmetic, but we still gate on origin.
+function isTrustedHostOrigin(origin: string): boolean {
+    try {
+        const host = new URL(origin).hostname;
+        return (
+            host === "pollinations.ai" ||
+            host.endsWith(".pollinations.ai") ||
+            host === "localhost"
+        );
+    } catch {
+        return false;
+    }
+}
+
 export function App() {
     const { apiKey, isHydrated } = useAuthState();
     const { login } = useAuthActions();
@@ -170,6 +186,32 @@ export function App() {
         observer.observe(document.body);
         report();
         return () => observer.disconnect();
+    }, [isEmbedded]);
+
+    // Apply a theme the host (/play) pushes when its toggle changes, so this
+    // already-loaded embed re-themes live. Message: { source, type, value }.
+    useEffect(() => {
+        if (!isEmbedded || window.parent === window.self) return;
+        const onMessage = (event: MessageEvent) => {
+            if (!isTrustedHostOrigin(event.origin)) return;
+            const data = event.data as {
+                source?: unknown;
+                type?: unknown;
+                value?: unknown;
+            } | null;
+            if (
+                !data ||
+                data.source !== "polli-embed" ||
+                data.type !== "theme"
+            ) {
+                return;
+            }
+            if (data.value === "dark" || data.value === "light") {
+                setColorMode(data.value);
+            }
+        };
+        window.addEventListener("message", onMessage);
+        return () => window.removeEventListener("message", onMessage);
     }, [isEmbedded]);
 
     async function generate() {

--- a/enter.pollinations.ai/frontend/index.html
+++ b/enter.pollinations.ai/frontend/index.html
@@ -9,7 +9,7 @@
     <script>
       (() => {
         try {
-          let mode = localStorage.getItem("polli-color-mode");
+          let mode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
           if (mode !== "light" && mode !== "dark") {
             mode = matchMedia("(prefers-color-scheme: dark)").matches
               ? "dark"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -58,6 +58,7 @@ export { ChevronIcon } from "./primitives/ChevronIcon.tsx";
 export { Chip } from "./primitives/Chip.tsx";
 export {
     ColorModeToggle,
+    setColorMode,
     useColorMode,
 } from "./primitives/ColorModeToggle.tsx";
 export {

--- a/packages/ui/src/primitives/ColorModeToggle.tsx
+++ b/packages/ui/src/primitives/ColorModeToggle.tsx
@@ -9,8 +9,15 @@ import { MoonIcon, SunIcon } from "./icons/index.tsx";
  * `useColorMode()` consumer, so duplicate toggles never desync and changes
  * propagate across tabs.
  *
+ * The chosen mode is persisted to BOTH a cookie scoped to the registrable
+ * domain — so every `*.pollinations.ai` page reads the same value, including
+ * cross-origin embeds like the enter auth screen shown inside /play — AND
+ * localStorage, a same-origin mirror that powers the cross-tab `storage` sync
+ * below and migrates existing users. Read priority: cookie → localStorage →
+ * system preference.
+ *
  * Host apps should set the initial class pre-paint (a tiny inline script in the
- * document head, reading the same STORAGE_KEY) to avoid a flash of light before
+ * document head, reading the same cookie/key) to avoid a flash of light before
  * React mounts; this store is the source of truth after hydration.
  *
  * Side-effect-free on import: the <html> sync and the cross-tab listener are
@@ -30,6 +37,45 @@ function readStored(): ColorMode | null {
     }
 }
 
+// Persist the mode one year; refreshed on every write.
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Cookie domain for cross-subdomain sharing: the registrable domain (last two
+ * hostname labels), so e.g. `enter.pollinations.ai` and the website share one
+ * value. Returns null for localhost / bare IPs (host-only cookie — already
+ * shared across ports). Every host we serve uses a single-label TLD (`.ai`),
+ * so last-two-labels equals eTLD+1 — no public-suffix list needed.
+ */
+function cookieDomain(): string | null {
+    if (typeof location === "undefined") return null;
+    const host = location.hostname;
+    if (host === "localhost" || /^[0-9.]+$/.test(host) || !host.includes(".")) {
+        return null;
+    }
+    return host.split(".").slice(-2).join(".");
+}
+
+function readCookie(): ColorMode | null {
+    if (typeof document === "undefined") return null;
+    const match = document.cookie.match(
+        /(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/,
+    );
+    return match ? (match[1] as ColorMode) : null;
+}
+
+function writeCookie(mode: ColorMode): void {
+    if (typeof document === "undefined" || typeof location === "undefined") {
+        return;
+    }
+    const domain = cookieDomain();
+    const secure = location.protocol === "https:" ? "; Secure" : "";
+    // biome-ignore lint/suspicious/noDocumentCookie: first-party theme key; Cookie Store API lacks Firefox/older-Safari support
+    document.cookie = `${STORAGE_KEY}=${mode}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${
+        domain ? `; Domain=${domain}` : ""
+    }${secure}`;
+}
+
 function systemPrefersDark(): boolean {
     return (
         typeof window !== "undefined" &&
@@ -38,7 +84,7 @@ function systemPrefersDark(): boolean {
 }
 
 let current: ColorMode =
-    readStored() ?? (systemPrefersDark() ? "dark" : "light");
+    readCookie() ?? readStored() ?? (systemPrefersDark() ? "dark" : "light");
 const listeners = new Set<() => void>();
 
 function apply(): void {
@@ -80,6 +126,13 @@ function handleStorage(event: StorageEvent): void {
 
 function subscribe(listener: () => void): () => void {
     if (listeners.size === 0 && typeof window !== "undefined") {
+        // Migrate existing users: seed the cross-subdomain cookie from a
+        // same-origin localStorage preference so embeds share it without a
+        // re-toggle. No-op when the cookie already exists or only a system
+        // fallback is active (readStored() returns null).
+        if (!readCookie() && readStored()) {
+            writeCookie(current);
+        }
         apply(); // safety-net sync once a consumer mounts
         window.addEventListener("storage", handleStorage);
     }
@@ -100,10 +153,17 @@ function getServerSnapshot(): ColorMode {
     return "light";
 }
 
-function setColorMode(mode: ColorMode): void {
+/**
+ * Set the color mode programmatically. Updates the shared store (so every
+ * `useColorMode()` consumer re-renders), flips the `.dark` class, and persists
+ * to the cross-subdomain cookie + the localStorage mirror. Exported so embedded
+ * apps can apply a theme pushed by their host (see /play postMessage contract).
+ */
+export function setColorMode(mode: ColorMode): void {
     if (mode === current) return;
     current = mode;
     apply();
+    writeCookie(mode);
     try {
         localStorage.setItem(STORAGE_KEY, mode);
     } catch {


### PR DESCRIPTION
Theme choice didn't cross the origin boundary: the enter auth screen embedded in `/play` reads its own origin's `localStorage`, so on a dark site with a light device it rendered light (the "auth screen ignores dark mode on mobile" report).

- Persist color mode to a cookie scoped to the registrable domain (`Domain=pollinations.ai`) + a localStorage mirror, so every `*.pollinations.ai` page — website, playground, websim, react, model-monitor, and the embedded enter auth screen — reads one shared value. Same-site, so it works inside the iframe (no third-party storage partitioning).
- Pre-paint scripts read the cookie first → no flash. Existing users migrate automatically (cookie seeded from their localStorage on first mount).
- Embedded apps live-update via the existing `polli-embed` postMessage contract (`type: "theme"`); `setColorMode` is now exported for that.

Backward compatible — readers fall back to localStorage and listeners stay inert until a host posts — so this lands before the website `/play` host slice (pr-05) with no broken-main risk.

Verified: real-browser pre-paint (cookie beats system, system fallback intact), `cookieDomain()` across all hosts, package + both apps typecheck, biome clean.