### PR TITLE
fix: match the auth modal backdrop to the app background

### DIFF
--- a/packages/ui/src/modules/auth/AuthModal.tsx
+++ b/packages/ui/src/modules/auth/AuthModal.tsx
@@ -39,7 +39,7 @@ export function AuthModal({
             showBackdrop={false}
             ariaLabel={dialog?.label}
             labelledBy={dialog?.labelledBy}
-            positionerClassName="polli:items-start polli:overflow-y-auto polli:bg-theme-bg-pale"
+            positionerClassName="polli:items-start polli:overflow-y-auto polli:bg-app-bg"
             contentClassName={`polli:bg-surface-white polli:border-2 ${borderClass} polli:rounded-lg polli:shadow-lg polli:max-w-xl polli:w-full polli:my-auto`}
         >
             {children}


### PR DESCRIPTION
The `AuthModal` positioner painted its full-bleed backdrop with `bg-theme-bg-pale` — a warm, theme-tinted surface. Standalone that reads as a soft modal scrim, but embedded full-bleed in `/play` it fills the whole iframe and clashes with the website's neutral `bg-app-bg` page background (cream vs. gray).

- Switch the positioner backdrop to `bg-app-bg` — the same neutral, theme-independent token the website and apps use for their page background — so the auth surface matches the page everywhere (light and dark).
- The white card (`surface-white`) and the inner accent panels (the "Authorize" strip, info cards) are unchanged, so it doesn't go flat.

Verified: the generated `polli:bg-app-bg` utility resolves to `var(--polli-color-app-bg)` — identical to the website background — and biome/build are clean. Full visual confirmation lands once enter redeploys with this.