### PR TITLE
feat: embed bridge for host-shared auth (sdk/ui + playground/websim)

### DIFF
--- a/apps/playground/package-lock.json
+++ b/apps/playground/package-lock.json
@@ -78,7 +78,7 @@
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "@pollinations/sdk": "^5.0.0",
+        "@pollinations/sdk": "^5.1.0-alpha.1",
         "react": "^19.0.0"
       },
       "peerDependenciesMeta": {

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -1,75 +1,17 @@
-import { ColorModeToggle, cn, setColorMode } from "@pollinations/ui";
+import { ColorModeToggle, cn, useHostThemeSync } from "@pollinations/ui";
 import {
     AppUserMenu,
     isEmbeddedContext,
 } from "@pollinations/ui/app-user-menu/sdk";
-import { useEffect } from "react";
 import { ENTER_URL } from "./config";
 import { Playground } from "./Playground";
-
-// Origins allowed to push a live theme into this embedded app: the /play host
-// and same-site siblings. Theme is cosmetic, but we still gate on origin.
-function isTrustedHostOrigin(origin: string): boolean {
-    try {
-        const host = new URL(origin).hostname;
-        return (
-            host === "pollinations.ai" ||
-            host.endsWith(".pollinations.ai") ||
-            host === "localhost"
-        );
-    } catch {
-        return false;
-    }
-}
 
 export function App() {
     const isEmbedded = isEmbeddedContext();
 
-    // Report content height to the embedding host (/play) so it can size the
-    // iframe to fit — no inner scroll. Message: { source, type, value }.
-    useEffect(() => {
-        if (!isEmbedded || window.parent === window.self) return;
-        const report = () => {
-            window.parent.postMessage(
-                {
-                    source: "polli-embed",
-                    type: "height",
-                    value: Math.ceil(document.documentElement.scrollHeight),
-                },
-                "*",
-            );
-        };
-        const observer = new ResizeObserver(report);
-        observer.observe(document.body);
-        report();
-        return () => observer.disconnect();
-    }, [isEmbedded]);
-
-    // Apply a theme the host (/play) pushes when its toggle changes, so this
-    // already-loaded embed re-themes live. Message: { source, type, value }.
-    useEffect(() => {
-        if (!isEmbedded || window.parent === window.self) return;
-        const onMessage = (event: MessageEvent) => {
-            if (!isTrustedHostOrigin(event.origin)) return;
-            const data = event.data as {
-                source?: unknown;
-                type?: unknown;
-                value?: unknown;
-            } | null;
-            if (
-                !data ||
-                data.source !== "polli-embed" ||
-                data.type !== "theme"
-            ) {
-                return;
-            }
-            if (data.value === "dark" || data.value === "light") {
-                setColorMode(data.value);
-            }
-        };
-        window.addEventListener("message", onMessage);
-        return () => window.removeEventListener("message", onMessage);
-    }, [isEmbedded]);
+    // Sizing + the auth handshake are auto-wired by the SDK's PolliProvider.
+    // Theme application is UI-owned, so opt into the host's live theme here.
+    useHostThemeSync();
 
     return (
         <div

--- a/apps/websim/package-lock.json
+++ b/apps/websim/package-lock.json
@@ -79,7 +79,7 @@
                 "vitest": "^2.1.0"
             },
             "peerDependencies": {
-                "@pollinations/sdk": "^5.0.0",
+                "@pollinations/sdk": "^5.1.0-alpha.1",
                 "react": "^19.0.0"
             },
             "peerDependenciesMeta": {

--- a/apps/websim/src/App.tsx
+++ b/apps/websim/src/App.tsx
@@ -11,12 +11,12 @@ import {
     Heading,
     MediaPlaceholder,
     Surface,
-    setColorMode,
     TabButton,
     TerminalIcon,
     Text,
     Textarea,
     Tooltip,
+    useHostThemeSync,
 } from "@pollinations/ui";
 import {
     AppUserMenu,
@@ -138,21 +138,6 @@ function PreviewPanel({
     );
 }
 
-// Origins allowed to push a live theme into this embedded app: the /play host
-// and same-site siblings. Theme is cosmetic, but we still gate on origin.
-function isTrustedHostOrigin(origin: string): boolean {
-    try {
-        const host = new URL(origin).hostname;
-        return (
-            host === "pollinations.ai" ||
-            host.endsWith(".pollinations.ai") ||
-            host === "localhost"
-        );
-    } catch {
-        return false;
-    }
-}
-
 export function App() {
     const { apiKey, isHydrated } = useAuthState();
     const { login } = useAuthActions();
@@ -168,51 +153,9 @@ export function App() {
         return () => activeRequest.current?.abort();
     }, []);
 
-    // Report content height to the embedding host (/play) so it can size the
-    // iframe to fit — no inner scroll. Message: { source, type, value }.
-    useEffect(() => {
-        if (!isEmbedded || window.parent === window.self) return;
-        const report = () => {
-            window.parent.postMessage(
-                {
-                    source: "polli-embed",
-                    type: "height",
-                    value: Math.ceil(document.documentElement.scrollHeight),
-                },
-                "*",
-            );
-        };
-        const observer = new ResizeObserver(report);
-        observer.observe(document.body);
-        report();
-        return () => observer.disconnect();
-    }, [isEmbedded]);
-
-    // Apply a theme the host (/play) pushes when its toggle changes, so this
-    // already-loaded embed re-themes live. Message: { source, type, value }.
-    useEffect(() => {
-        if (!isEmbedded || window.parent === window.self) return;
-        const onMessage = (event: MessageEvent) => {
-            if (!isTrustedHostOrigin(event.origin)) return;
-            const data = event.data as {
-                source?: unknown;
-                type?: unknown;
-                value?: unknown;
-            } | null;
-            if (
-                !data ||
-                data.source !== "polli-embed" ||
-                data.type !== "theme"
-            ) {
-                return;
-            }
-            if (data.value === "dark" || data.value === "light") {
-                setColorMode(data.value);
-            }
-        };
-        window.addEventListener("message", onMessage);
-        return () => window.removeEventListener("message", onMessage);
-    }, [isEmbedded]);
+    // Sizing + the auth handshake are auto-wired by the SDK's PolliProvider.
+    // Theme application is UI-owned, so opt into the host's live theme here.
+    useHostThemeSync();
 
     async function generate() {
         const trimmedPrompt = prompt.trim();

--- a/package-lock.json
+++ b/package-lock.json
@@ -19084,7 +19084,7 @@
         "vitest": "^2.1.0"
       },
       "peerDependencies": {
-        "@pollinations/sdk": "^5.0.0",
+        "@pollinations/sdk": "^5.1.0-alpha.1",
         "react": "^19.0.0"
       },
       "peerDependenciesMeta": {

--- a/packages/sdk/src/react/PolliProvider.test.tsx
+++ b/packages/sdk/src/react/PolliProvider.test.tsx
@@ -1,5 +1,6 @@
 import { act, create } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAuthActions } from "./hooks.js";
 import { PolliProvider } from "./PolliProvider.js";
 import type { StorageAdapter } from "./storage.js";
 
@@ -14,7 +15,7 @@ function memoryStorage(): StorageAdapter {
 
 function stubWindow(href: string) {
     const url = new URL(href);
-    vi.stubGlobal("window", {
+    const win: Record<string, unknown> = {
         location: {
             href,
             hash: url.hash,
@@ -24,7 +25,12 @@ function stubWindow(href: string) {
         history: {
             replaceState: vi.fn(),
         },
-    });
+    };
+    // Top-level: parent/self/top all reference this window (isFramed() === false).
+    win.parent = win;
+    win.self = win;
+    win.top = win;
+    vi.stubGlobal("window", win);
 }
 
 async function renderProvider(appKey: string) {
@@ -54,5 +60,34 @@ describe("PolliProvider setup guidance", () => {
             expect.stringContaining("publishable pk_ App Key"),
         );
         expect(warn.mock.calls[0][0]).not.toContain("sk_secret_test");
+    });
+
+    it("persists the key to the provided storage at top level", async () => {
+        stubWindow("https://app.example/");
+        const spy: StorageAdapter = {
+            getItem: vi.fn(() => null),
+            setItem: vi.fn(),
+            removeItem: vi.fn(),
+        };
+        let setApiKey: ((key: string | null) => void) | null = null;
+        function Grab() {
+            setApiKey = useAuthActions().setApiKey;
+            return null;
+        }
+
+        await act(async () => {
+            create(
+                <PolliProvider appKey="pk_test" storage={spy}>
+                    <Grab />
+                </PolliProvider>,
+            );
+        });
+        act(() => setApiKey?.("sk_live"));
+
+        // Top level (not framed) → writes through to the real adapter.
+        expect(spy.setItem).toHaveBeenCalledWith(
+            "polli:pk_test:token",
+            "sk_live",
+        );
     });
 });

--- a/packages/sdk/src/react/PolliProvider.tsx
+++ b/packages/sdk/src/react/PolliProvider.tsx
@@ -11,8 +11,10 @@ import {
     type AuthContextValue,
     type AuthorizeRequest,
 } from "./contexts.js";
+import { EmbedBridge, requestHostLogin } from "./embed.js";
 import { consumeOAuthCallback } from "./oauth.js";
 import {
+    createMemoryStorage,
     resolveStorage,
     type StorageAdapter,
     type StorageOption,
@@ -93,6 +95,22 @@ function currentRedirectUrl(): string | null {
     return window.location.href.split("#")[0] ?? window.location.href;
 }
 
+/**
+ * True when running inside an iframe. Throw-free (cross-origin access to
+ * `window.top` throws → we're definitely framed). Deliberately ignores
+ * `?embed=1`: only real framing makes the session frame-local, so a standalone
+ * URL that happens to carry `?embed=1` still persists auth normally.
+ */
+function isFramed(): boolean {
+    if (typeof window === "undefined") return false;
+    if (window.parent !== window) return true;
+    try {
+        return window.self !== window.top;
+    } catch {
+        return true;
+    }
+}
+
 function isProductionRuntime(): boolean {
     return globalThis.process?.env?.NODE_ENV === "production";
 }
@@ -157,8 +175,12 @@ export function PolliProvider({
     enterUrl = DEFAULT_ENTER_URL,
     apiBaseUrl,
 }: PolliProviderProps) {
+    // Inside an iframe, keep the session frame-local: a borrowed/host-pushed key
+    // must never be written to (or cleared from) the app's own localStorage,
+    // which same-origin standalone tabs share. The host re-pushes on each load.
     const storage = useMemo<StorageAdapter>(
-        () => resolveStorage(storageOption),
+        () =>
+            isFramed() ? createMemoryStorage() : resolveStorage(storageOption),
         [storageOption],
     );
     const resolvedApiBaseUrl = apiBaseUrl ?? `${enterUrl}/api`;
@@ -236,6 +258,14 @@ export function PolliProvider({
     const login = useCallback(
         (request?: AuthorizeRequest) => {
             if (typeof window === "undefined") return;
+            // Embedded under a trusted host (e.g. /play)? Ask the host to log in
+            // top-level instead of redirecting this iframe — GitHub refuses to be
+            // framed, so an in-iframe OAuth redirect can't complete. The embedded
+            // app borrows the HOST's key and auth policy, so the per-call
+            // `request` (permissions/models/budget) is intentionally NOT
+            // forwarded — the host decides scope. The host's app key must cover
+            // what the embedded apps need.
+            if (requestHostLogin()) return;
             const currentUrl = currentRedirectUrl();
             if (!currentUrl) return;
             const extraPermissions = request?.permissions;
@@ -300,6 +330,7 @@ export function PolliProvider({
 
     return (
         <AuthContext.Provider value={authValue}>
+            <EmbedBridge />
             {children}
         </AuthContext.Provider>
     );

--- a/packages/sdk/src/react/embed-protocol.test.ts
+++ b/packages/sdk/src/react/embed-protocol.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+    EMBED_MESSAGE_SOURCE,
+    isTrustedHostOrigin,
+    parseHostMessage,
+    TRUSTED_HOST_ORIGINS,
+    validateHostMessage,
+} from "./embed-protocol.js";
+
+const PARENT = { id: "parent" }; // sentinel standing in for window.parent
+
+describe("isTrustedHostOrigin", () => {
+    it("accepts the built-in exact prod + staging origins", () => {
+        expect(isTrustedHostOrigin("https://pollinations.ai")).toBe(true);
+        expect(isTrustedHostOrigin("https://staging.pollinations.ai")).toBe(
+            true,
+        );
+        expect(TRUSTED_HOST_ORIGINS).toContain("https://pollinations.ai");
+    });
+
+    it("rejects arbitrary origins", () => {
+        expect(isTrustedHostOrigin("https://evil.com")).toBe(false);
+        expect(isTrustedHostOrigin("https://pollinations.ai.evil.com")).toBe(
+            false,
+        );
+    });
+
+    it("rejects *.pollinations.ai subdomains (exact match only)", () => {
+        expect(isTrustedHostOrigin("https://foo.pollinations.ai")).toBe(false);
+        expect(isTrustedHostOrigin("http://pollinations.ai")).toBe(false); // wrong scheme
+    });
+
+    it("allows loopback only when allowLoopback is set", () => {
+        expect(isTrustedHostOrigin("http://localhost:4178")).toBe(false);
+        expect(
+            isTrustedHostOrigin("http://localhost:4178", {
+                allowLoopback: true,
+            }),
+        ).toBe(true);
+        expect(
+            isTrustedHostOrigin("http://127.0.0.1:5173", {
+                allowLoopback: true,
+            }),
+        ).toBe(true);
+        expect(
+            isTrustedHostOrigin("https://localhost", { allowLoopback: true }),
+        ).toBe(false);
+    });
+
+    it("honours an explicit trustedOrigins override", () => {
+        expect(
+            isTrustedHostOrigin("https://x.test", {
+                trustedOrigins: ["https://x.test"],
+            }),
+        ).toBe(true);
+    });
+});
+
+describe("parseHostMessage", () => {
+    it("parses host-hello with capabilities", () => {
+        expect(
+            parseHostMessage({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "host-hello",
+                capabilities: { authControl: true },
+            }),
+        ).toEqual({
+            source: EMBED_MESSAGE_SOURCE,
+            type: "host-hello",
+            capabilities: { authControl: true },
+        });
+    });
+
+    it("parses auth with a string apiKey (the borrowed key)", () => {
+        expect(
+            parseHostMessage({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "auth",
+                apiKey: "sk_borrowed",
+            }),
+        ).toEqual({
+            source: EMBED_MESSAGE_SOURCE,
+            type: "auth",
+            apiKey: "sk_borrowed",
+        });
+    });
+
+    it("parses auth with a null apiKey (logout / signed out)", () => {
+        expect(
+            parseHostMessage({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "auth",
+                apiKey: null,
+            }),
+        ).toEqual({ source: EMBED_MESSAGE_SOURCE, type: "auth", apiKey: null });
+    });
+
+    it("rejects foreign / malformed messages", () => {
+        expect(parseHostMessage(null)).toBeNull();
+        expect(parseHostMessage("nope")).toBeNull();
+        expect(
+            parseHostMessage({ source: "other", type: "host-hello" }),
+        ).toBeNull();
+        expect(
+            parseHostMessage({ source: EMBED_MESSAGE_SOURCE, type: "unknown" }),
+        ).toBeNull();
+        expect(
+            parseHostMessage({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "host-hello",
+            }),
+        ).toBeNull(); // no caps
+        expect(
+            parseHostMessage({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "auth",
+                apiKey: 123,
+            }),
+        ).toBeNull(); // bad key type
+        expect(
+            parseHostMessage({ source: EMBED_MESSAGE_SOURCE, type: "auth" }),
+        ).toBeNull(); // missing key
+    });
+});
+
+describe("validateHostMessage", () => {
+    const ctx = { parentWindow: PARENT, allowLoopback: false };
+    const authMsg = {
+        source: EMBED_MESSAGE_SOURCE,
+        type: "auth",
+        apiKey: "sk_x",
+    };
+
+    it("accepts a valid message from a trusted origin + the real parent", () => {
+        expect(
+            validateHostMessage(
+                {
+                    origin: "https://pollinations.ai",
+                    source: PARENT,
+                    data: authMsg,
+                },
+                ctx,
+            ),
+        ).toEqual(authMsg);
+    });
+
+    it("rejects an untrusted origin even from the parent", () => {
+        expect(
+            validateHostMessage(
+                { origin: "https://evil.com", source: PARENT, data: authMsg },
+                ctx,
+            ),
+        ).toBeNull();
+    });
+
+    it("rejects a trusted origin when source is not the parent", () => {
+        expect(
+            validateHostMessage(
+                {
+                    origin: "https://pollinations.ai",
+                    source: { id: "other" },
+                    data: authMsg,
+                },
+                ctx,
+            ),
+        ).toBeNull();
+    });
+});

--- a/packages/sdk/src/react/embed-protocol.ts
+++ b/packages/sdk/src/react/embed-protocol.ts
@@ -1,0 +1,108 @@
+// Wire protocol for the /play embed bridge (host-shared auth). Pure + DOM-free
+// so the security-critical trust gate is unit-tested without faking a browser.
+// React/DOM glue lives in embed.tsx.
+//
+// Model: the host (the website) logs in top-level and pushes its API key DOWN
+// into the embedded app. The key crosses the boundary deliberately, so the trust
+// gate must be tight — only the genuine embedding host may push it.
+
+export const EMBED_MESSAGE_SOURCE = "polli-embed" as const;
+
+// Exact trusted host origins — NOT a *.pollinations.ai suffix. The gate controls
+// who may push the shared API key into the app, so it must be tight. Loopback is
+// dev-only (allowLoopback).
+export const TRUSTED_HOST_ORIGINS: readonly string[] = [
+    "https://pollinations.ai",
+    "https://staging.pollinations.ai",
+];
+
+export interface TrustOptions {
+    /** Allow any-port http://localhost / http://127.0.0.1 (dev only). */
+    allowLoopback?: boolean;
+    /** Override the built-in exact origins (tests / future config). */
+    trustedOrigins?: readonly string[];
+}
+
+export function isTrustedHostOrigin(
+    origin: string,
+    opts: TrustOptions = {},
+): boolean {
+    const list = opts.trustedOrigins ?? TRUSTED_HOST_ORIGINS;
+    if (list.includes(origin)) return true;
+    if (opts.allowLoopback) {
+        try {
+            const { protocol, hostname } = new URL(origin);
+            return (
+                protocol === "http:" &&
+                (hostname === "localhost" || hostname === "127.0.0.1")
+            );
+        } catch {
+            return false;
+        }
+    }
+    return false;
+}
+
+export interface HostCapabilities {
+    /** Host renders the account control in its own chrome → app hides its own. */
+    authControl: boolean;
+}
+
+// host -> app
+export type HostToAppMessage =
+    | {
+          source: typeof EMBED_MESSAGE_SOURCE;
+          type: "host-hello";
+          capabilities: HostCapabilities;
+      }
+    | {
+          source: typeof EMBED_MESSAGE_SOURCE;
+          type: "auth";
+          /** The host's API key, lent to the app. `null` = host signed out. */
+          apiKey: string | null;
+      };
+
+// (App -> host messages — app-ready / height / login-request — are built inline
+// in embed.tsx; the host re-declares its own view, so no shared type is needed.)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+export function parseHostMessage(data: unknown): HostToAppMessage | null {
+    if (!isRecord(data)) return null;
+    if (data.source !== EMBED_MESSAGE_SOURCE) return null;
+    if (data.type === "host-hello") {
+        const caps = data.capabilities;
+        if (!isRecord(caps) || typeof caps.authControl !== "boolean")
+            return null;
+        return {
+            source: EMBED_MESSAGE_SOURCE,
+            type: "host-hello",
+            capabilities: { authControl: caps.authControl },
+        };
+    }
+    if (data.type === "auth") {
+        const { apiKey } = data;
+        if (apiKey !== null && typeof apiKey !== "string") return null;
+        return { source: EMBED_MESSAGE_SOURCE, type: "auth", apiKey };
+    }
+    return null;
+}
+
+export interface IncomingEvent {
+    origin: string;
+    source: unknown;
+    data: unknown;
+}
+
+// Full trust gate for an incoming host->app message: exact origin AND the event
+// must originate from our actual parent window. Pure — caller supplies the ref.
+export function validateHostMessage(
+    event: IncomingEvent,
+    ctx: { parentWindow: unknown } & TrustOptions,
+): HostToAppMessage | null {
+    if (!isTrustedHostOrigin(event.origin, ctx)) return null;
+    if (event.source !== ctx.parentWindow) return null;
+    return parseHostMessage(event.data);
+}

--- a/packages/sdk/src/react/embed.test.tsx
+++ b/packages/sdk/src/react/embed.test.tsx
@@ -1,0 +1,383 @@
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthContext, type AuthContextValue } from "./contexts.js";
+import {
+    __setHostCapabilitiesForTest,
+    EmbedBridge,
+    requestHostLogin,
+    useEmbedHostCapabilities,
+} from "./embed.js";
+import { EMBED_MESSAGE_SOURCE } from "./embed-protocol.js";
+import { useAuthActions } from "./hooks.js";
+import { PolliProvider } from "./PolliProvider.js";
+import type { StorageAdapter } from "./storage.js";
+
+let renderer: ReactTestRenderer | null = null;
+
+afterEach(() => {
+    act(() => renderer?.unmount());
+    renderer = null;
+    __setHostCapabilitiesForTest(null);
+});
+
+function Probe({ onValue }: { onValue: (v: unknown) => void }) {
+    onValue(useEmbedHostCapabilities());
+    return null;
+}
+
+describe("useEmbedHostCapabilities", () => {
+    it("starts null and tracks the capability store", () => {
+        const seen: unknown[] = [];
+        act(() => {
+            renderer = create(<Probe onValue={(v) => seen.push(v)} />);
+        });
+        expect(seen.at(-1)).toBeNull();
+
+        act(() => __setHostCapabilitiesForTest({ authControl: true }));
+        expect(seen.at(-1)).toEqual({ authControl: true });
+    });
+});
+
+const PARENT = {
+    postMessage: vi.fn(),
+};
+
+function stubEmbedWindow() {
+    const handlers: Record<string, ((e: unknown) => void)[]> = {};
+    const win = {
+        parent: PARENT,
+        self: {} as unknown,
+        top: {} as unknown, // self !== top → looks embedded (not used by gate, but realistic)
+        // Full enough for PolliProvider's mount-time hydration as well.
+        location: {
+            href: "https://websim.pollinations.ai/",
+            origin: "https://websim.pollinations.ai",
+            protocol: "https:",
+            hostname: "websim.pollinations.ai",
+            pathname: "/",
+            hash: "",
+            search: "",
+        },
+        history: { replaceState: vi.fn() },
+        addEventListener: (type: string, fn: (e: unknown) => void) => {
+            handlers[type] ??= [];
+            handlers[type].push(fn);
+        },
+        removeEventListener: (type: string, fn: (e: unknown) => void) => {
+            handlers[type] = (handlers[type] ?? []).filter((h) => h !== fn);
+        },
+    };
+    vi.stubGlobal("window", win);
+    // ResizeObserver + document are optional; EmbedBridge guards their absence.
+    return {
+        emit: (event: unknown) => {
+            for (const fn of handlers.message ?? []) fn(event);
+        },
+    };
+}
+
+// Minimal in-memory storage (mirrors PolliProvider.test) for a clean provider mount.
+function memoryStorage(): StorageAdapter {
+    const values = new Map<string, string>();
+    return {
+        getItem: (key) => values.get(key) ?? null,
+        setItem: (key, value) => {
+            values.set(key, value);
+        },
+        removeItem: (key) => {
+            values.delete(key);
+        },
+    };
+}
+
+function authContext(over: Partial<AuthContextValue> = {}): AuthContextValue {
+    return {
+        apiKey: null,
+        isLoggedIn: false,
+        isHydrated: true,
+        error: null,
+        login: vi.fn(),
+        logout: vi.fn(),
+        setApiKey: vi.fn(),
+        enterUrl: "https://enter.pollinations.ai",
+        apiBaseUrl: "https://enter.pollinations.ai/api",
+        ...over,
+    };
+}
+
+const hostHello = {
+    origin: "https://pollinations.ai",
+    source: PARENT,
+    data: {
+        source: EMBED_MESSAGE_SOURCE,
+        type: "host-hello",
+        capabilities: { authControl: true },
+    },
+};
+
+function authMessage(apiKey: string | null) {
+    return {
+        origin: "https://pollinations.ai",
+        source: PARENT,
+        data: { source: EMBED_MESSAGE_SOURCE, type: "auth", apiKey },
+    };
+}
+
+describe("EmbedBridge", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        PARENT.postMessage.mockClear();
+        __setHostCapabilitiesForTest(null);
+    });
+
+    it("acks app-ready and publishes capabilities on a trusted host-hello", () => {
+        const win = stubEmbedWindow();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={authContext()}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+
+        act(() => win.emit(hostHello));
+
+        expect(PARENT.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "app-ready",
+            }),
+            "https://pollinations.ai",
+        );
+
+        const seen: unknown[] = [];
+        act(() => {
+            create(<Probe onValue={(v) => seen.push(v)} />);
+        });
+        expect(seen.at(-1)).toEqual({ authControl: true });
+    });
+
+    it("ignores an untrusted host-hello", () => {
+        const win = stubEmbedWindow();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={authContext()}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+        act(() => win.emit({ ...hostHello, origin: "https://evil.com" }));
+        expect(PARENT.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores a host-hello that disclaims authControl", () => {
+        const win = stubEmbedWindow();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={authContext()}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+        act(() =>
+            win.emit({
+                origin: "https://pollinations.ai",
+                source: PARENT,
+                data: {
+                    source: EMBED_MESSAGE_SOURCE,
+                    type: "host-hello",
+                    capabilities: { authControl: false },
+                },
+            }),
+        );
+        expect(PARENT.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("adopts the host's borrowed apiKey on a trusted auth message", () => {
+        const win = stubEmbedWindow();
+        const ctx = authContext();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={ctx}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+        act(() => win.emit(hostHello));
+        act(() => win.emit(authMessage("sk_borrowed")));
+        expect(ctx.setApiKey).toHaveBeenCalledWith("sk_borrowed");
+    });
+
+    it("clears the key on auth null (host signed out)", () => {
+        const win = stubEmbedWindow();
+        const ctx = authContext();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={ctx}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+        act(() => win.emit(hostHello));
+        act(() => win.emit(authMessage(null)));
+        expect(ctx.setApiKey).toHaveBeenLastCalledWith(null);
+    });
+
+    it("ignores an auth message received before a handshake", () => {
+        const win = stubEmbedWindow();
+        const ctx = authContext();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={ctx}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+        act(() => win.emit(authMessage("sk_borrowed")));
+        expect(ctx.setApiKey).not.toHaveBeenCalled();
+    });
+
+    it("reports height to '*' whenever embedded, without a handshake", () => {
+        stubEmbedWindow();
+        // Height is pure DOM transport, so it needs document + ResizeObserver.
+        vi.stubGlobal("document", {
+            documentElement: { scrollHeight: 1500 },
+            body: {},
+        });
+        class FakeResizeObserver {
+            observe() {}
+            disconnect() {}
+        }
+        vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={authContext()}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+
+        // No host-hello was emitted — height is decoupled from auth, and goes
+        // to "*" (the host re-validates the sender origin on its side).
+        expect(PARENT.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "height",
+                value: 1500,
+            }),
+            "*",
+        );
+    });
+
+    it("requestHostLogin posts login-request after handshake, false before", () => {
+        const win = stubEmbedWindow();
+        act(() => {
+            renderer = create(
+                <AuthContext.Provider value={authContext()}>
+                    <EmbedBridge />
+                </AuthContext.Provider>,
+            );
+        });
+        expect(requestHostLogin()).toBe(false); // no host yet
+        act(() => win.emit(hostHello));
+        expect(requestHostLogin()).toBe(true);
+        expect(PARENT.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "login-request",
+            }),
+            "https://pollinations.ai",
+        );
+    });
+});
+
+describe("login() is embed-aware", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        PARENT.postMessage.mockClear();
+    });
+
+    it("reroutes login to the host when embedded (no iframe redirect)", () => {
+        const win = stubEmbedWindow();
+        let login: (() => void) | null = null;
+        function Grab() {
+            login = useAuthActions().login;
+            return null;
+        }
+        act(() => {
+            renderer = create(
+                <PolliProvider appKey="pk_test" storage={memoryStorage()}>
+                    <Grab />
+                </PolliProvider>,
+            );
+        });
+        act(() => win.emit(hostHello)); // handshake → embed-host recorded
+        const hrefBefore = window.location.href;
+        PARENT.postMessage.mockClear();
+        act(() => login?.());
+        // No iframe redirect; instead a login-request to the host.
+        expect(window.location.href).toBe(hrefBefore);
+        expect(PARENT.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: EMBED_MESSAGE_SOURCE,
+                type: "login-request",
+            }),
+            "https://pollinations.ai",
+        );
+    });
+});
+
+describe("PolliProvider keeps the session frame-local when embedded", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        PARENT.postMessage.mockClear();
+    });
+
+    it("never touches the app's own storage on a host auth(null) (can't wipe a standalone session)", () => {
+        const win = stubEmbedWindow(); // framed: window.parent = PARENT !== window
+        const spy: StorageAdapter = {
+            getItem: vi.fn(() => "sk_standalone"),
+            setItem: vi.fn(),
+            removeItem: vi.fn(),
+        };
+        act(() => {
+            renderer = create(
+                <PolliProvider appKey="pk_test" storage={spy}>
+                    <div />
+                </PolliProvider>,
+            );
+        });
+        act(() => win.emit(hostHello));
+        act(() => win.emit(authMessage(null))); // host is logged out
+
+        // Framed → provider uses frame-local memory, so the real adapter passed
+        // in is never read, written, or cleared — the standalone session stands.
+        expect(spy.getItem).not.toHaveBeenCalled();
+        expect(spy.setItem).not.toHaveBeenCalled();
+        expect(spy.removeItem).not.toHaveBeenCalled();
+    });
+});
+
+describe("PolliProvider auto-wires the embed bridge", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        PARENT.postMessage.mockClear();
+    });
+
+    it("acks a trusted host-hello without any app-level embed code", () => {
+        const win = stubEmbedWindow();
+        act(() => {
+            renderer = create(
+                <PolliProvider appKey="pk_test" storage={memoryStorage()}>
+                    <div />
+                </PolliProvider>,
+            );
+        });
+        act(() => win.emit(hostHello));
+        expect(PARENT.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "app-ready" }),
+            "https://pollinations.ai",
+        );
+    });
+});

--- a/packages/sdk/src/react/embed.tsx
+++ b/packages/sdk/src/react/embed.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import {
+    EMBED_MESSAGE_SOURCE,
+    type HostCapabilities,
+    validateHostMessage,
+} from "./embed-protocol.js";
+import { useAuthActions } from "./hooks.js";
+
+// Module-level external store: the EmbedBridge writes the validated host's
+// capabilities here; UI (AppUserMenu) reads them via the hook below.
+let hostCapabilities: HostCapabilities | null = null;
+const capabilityListeners = new Set<() => void>();
+
+function setHostCapabilities(next: HostCapabilities | null): void {
+    if (next === hostCapabilities) return;
+    if (
+        next &&
+        hostCapabilities &&
+        next.authControl === hostCapabilities.authControl
+    ) {
+        return; // unchanged — avoid spurious notifies
+    }
+    hostCapabilities = next;
+    for (const listener of capabilityListeners) listener();
+}
+
+function subscribeCapabilities(listener: () => void): () => void {
+    capabilityListeners.add(listener);
+    return () => {
+        capabilityListeners.delete(listener);
+    };
+}
+
+/**
+ * The validated embedding host's capabilities, or `null` when the app is not
+ * embedded under a trusted Pollinations host. `AppUserMenu` reads this to hide
+ * its own controls — the host renders the account menu in its chrome.
+ */
+export function useEmbedHostCapabilities(): HostCapabilities | null {
+    return useSyncExternalStore(
+        subscribeCapabilities,
+        () => hostCapabilities,
+        () => null,
+    );
+}
+
+// Test-only hook into the store (not part of the public surface).
+export function __setHostCapabilitiesForTest(
+    next: HostCapabilities | null,
+): void {
+    setHostCapabilities(next);
+}
+
+// Set by the bridge on a successful handshake; read by `PolliProvider.login()`
+// so that an in-app login under a trusted host asks the host to log in
+// (top-level) instead of redirecting the iframe — which GitHub blocks.
+let embedHostOrigin: string | null = null;
+
+/**
+ * If the app is embedded under a trusted host, ask the host to run login
+ * (top-level) via `postMessage` and return `true`. Otherwise return `false` so
+ * the caller falls back to its normal redirect login.
+ */
+export function requestHostLogin(): boolean {
+    if (!embedHostOrigin || typeof window === "undefined") return false;
+    window.parent.postMessage(
+        { source: EMBED_MESSAGE_SOURCE, type: "login-request" },
+        embedHostOrigin,
+    );
+    return true;
+}
+
+function devLoopback(): boolean {
+    try {
+        const h = window.location.hostname;
+        return h === "localhost" || h === "127.0.0.1";
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Always mounted by `PolliProvider`. Reports its content height to the parent
+ * whenever embedded (cosmetic, no handshake needed). For auth it stays inert
+ * until a trusted host completes the handshake — then it adopts the host's
+ * borrowed API key (`setApiKey`) and flags the embed-host so `login()` reroutes
+ * to the host. Renders nothing.
+ */
+export function EmbedBridge(): null {
+    const { setApiKey } = useAuthActions();
+    const hostOriginRef = useRef<string | null>(null);
+    // Keep the latest setter in a ref so the message listener mounts once.
+    const setApiKeyRef = useRef(setApiKey);
+    setApiKeyRef.current = setApiKey;
+
+    // Handshake + key push (mount once). Capture the window up front so cleanup
+    // is robust if the global is torn down (test teardown / unmount).
+    useEffect(() => {
+        if (typeof window === "undefined" || window.parent === window) return;
+        const target = window;
+        // No listener API (SSR-ish / partial environment) → nothing to wire up.
+        if (typeof target.addEventListener !== "function") return;
+        const onMessage = (event: MessageEvent) => {
+            const msg = validateHostMessage(
+                {
+                    origin: event.origin,
+                    source: event.source,
+                    data: event.data,
+                },
+                { parentWindow: target.parent, allowLoopback: devLoopback() },
+            );
+            if (!msg) return;
+            if (msg.type === "host-hello") {
+                // The host must advertise that it manages the account control,
+                // else the app keeps its own menu and stays standalone.
+                if (!msg.capabilities.authControl) return;
+                hostOriginRef.current = event.origin;
+                embedHostOrigin = event.origin;
+                setHostCapabilities(msg.capabilities);
+                // Ack so the host stops its host-hello retry.
+                target.parent.postMessage(
+                    { source: EMBED_MESSAGE_SOURCE, type: "app-ready" },
+                    event.origin,
+                );
+                return;
+            }
+            // The key push only counts after a handshake, and only from the host
+            // that handshook (a different trusted origin must not drive this app).
+            if (
+                !hostOriginRef.current ||
+                event.origin !== hostOriginRef.current
+            ) {
+                return;
+            }
+            if (msg.type === "auth") {
+                // Adopt the host's borrowed key (or clear it on null = host logout).
+                setApiKeyRef.current(msg.apiKey);
+            }
+        };
+        target.addEventListener("message", onMessage);
+        return () => {
+            target.removeEventListener("message", onMessage);
+            setHostCapabilities(null);
+            embedHostOrigin = null;
+        };
+    }, []);
+
+    // Report content height to the embedding host whenever embedded, so it can
+    // size the iframe to fit. Cosmetic and independent of the auth handshake, so
+    // it posts to "*" (the host validates the sender's origin on its side) and
+    // runs even before a host-hello. Guarded — node/test env has no DOM.
+    useEffect(() => {
+        if (typeof window === "undefined" || window.parent === window) return;
+        if (
+            typeof ResizeObserver === "undefined" ||
+            typeof document === "undefined"
+        ) {
+            return;
+        }
+        const report = () => {
+            window.parent.postMessage(
+                {
+                    source: EMBED_MESSAGE_SOURCE,
+                    type: "height",
+                    value: Math.ceil(document.documentElement.scrollHeight),
+                },
+                "*",
+            );
+        };
+        const observer = new ResizeObserver(report);
+        observer.observe(document.body);
+        report();
+        return () => observer.disconnect();
+    }, []);
+
+    return null;
+}

--- a/packages/sdk/src/react/index.ts
+++ b/packages/sdk/src/react/index.ts
@@ -3,6 +3,8 @@ export type {
     AuthContextValue,
     AuthStateValue,
 } from "./contexts.js";
+export { useEmbedHostCapabilities } from "./embed.js";
+export type { HostCapabilities } from "./embed-protocol.js";
 export {
     type AccountResourceValue,
     type UseAccountBalanceValue,

--- a/packages/sdk/src/react/storage.ts
+++ b/packages/sdk/src/react/storage.ts
@@ -26,3 +26,24 @@ export function resolveStorage(
     if (option === "sessionStorage") return window.sessionStorage;
     return option;
 }
+
+/**
+ * In-memory, frame-local storage. Used by `PolliProvider` when it runs inside
+ * an iframe: a host-pushed (borrowed) session must never touch the app's own
+ * `localStorage`, because same-origin standalone tabs share it — persisting the
+ * borrowed key there would overwrite a standalone session, and clearing it on
+ * host logout would wipe one. The key lives only for this frame's lifetime; the
+ * host re-pushes it on every load, so nothing needs to persist in the frame.
+ */
+export function createMemoryStorage(): StorageAdapter {
+    const map = new Map<string, string>();
+    return {
+        getItem: (key) => map.get(key) ?? null,
+        setItem: (key, value) => {
+            map.set(key, value);
+        },
+        removeItem: (key) => {
+            map.delete(key);
+        },
+    };
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -75,7 +75,7 @@
     "directory": "packages/ui"
   },
   "peerDependencies": {
-    "@pollinations/sdk": "^5.0.0",
+    "@pollinations/sdk": "^5.1.0-alpha.1",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -60,6 +60,7 @@ export {
     ColorModeToggle,
     setColorMode,
     useColorMode,
+    useHostThemeSync,
 } from "./primitives/ColorModeToggle.tsx";
 export {
     Dialog,

--- a/packages/ui/src/modules/app-user-menu/AppUserMenu.tsx
+++ b/packages/ui/src/modules/app-user-menu/AppUserMenu.tsx
@@ -1,4 +1,7 @@
-import { useAuthActions } from "@pollinations/sdk/react";
+import {
+    useAuthActions,
+    useEmbedHostCapabilities,
+} from "@pollinations/sdk/react";
 import { ChevronIcon } from "../../primitives/ChevronIcon.tsx";
 import { Dropdown } from "../../primitives/Dropdown.tsx";
 import { DropdownItem } from "../../primitives/DropdownItem.tsx";
@@ -22,8 +25,6 @@ export type AppUserMenuLabels = {
 export type AppUserMenuProps = {
     dashboardHref: string;
     labels?: Partial<AppUserMenuLabels>;
-    hiddenWhenEmbedded?: boolean;
-    embedQueryParam?: string;
 };
 
 const defaultLabels: AppUserMenuLabels = {
@@ -47,10 +48,11 @@ export function isEmbeddedContext(embedQueryParam = "embed"): boolean {
 export function AppUserMenu({
     dashboardHref,
     labels: labelOverrides,
-    hiddenWhenEmbedded = false,
-    embedQueryParam = "embed",
 }: AppUserMenuProps) {
-    if (hiddenWhenEmbedded && isEmbeddedContext(embedQueryParam)) return null;
+    const hostCapabilities = useEmbedHostCapabilities();
+    // A trusted embedding host (e.g. /play) advertises that it renders the auth
+    // control in its own chrome — so don't render it inside the iframe too.
+    if (hostCapabilities?.authControl) return null;
 
     return (
         <AppUserMenuContent

--- a/packages/ui/src/primitives/ColorModeToggle.tsx
+++ b/packages/ui/src/primitives/ColorModeToggle.tsx
@@ -1,4 +1,4 @@
-import { type FC, useSyncExternalStore } from "react";
+import { type FC, useEffect, useSyncExternalStore } from "react";
 import { cn } from "../lib/cn.ts";
 import { MoonIcon, SunIcon } from "./icons/index.tsx";
 
@@ -187,6 +187,64 @@ export function useColorMode(): {
         isDark: mode === "dark",
         toggle: () => setColorMode(mode === "dark" ? "light" : "dark"),
     };
+}
+
+const EMBED_MESSAGE_SOURCE = "polli-embed";
+
+// Origins allowed to push a live theme into an embed: the Pollinations host
+// pages and same-site siblings, plus loopback for local dev. Theme is cosmetic,
+// so this gates on the message shape + a trusted host suffix — never auth.
+function isTrustedThemeOrigin(origin: string): boolean {
+    try {
+        const { hostname } = new URL(origin);
+        return (
+            hostname === "pollinations.ai" ||
+            hostname.endsWith(".pollinations.ai") ||
+            hostname === "localhost" ||
+            hostname === "127.0.0.1"
+        );
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Apply a color mode pushed by a trusted embedding host (e.g. /play) over
+ * `postMessage` (`{ source: "polli-embed", type: "theme", value: "light"|"dark" }`),
+ * so an already-loaded embed re-themes live when the host toggles. Initial paint
+ * is handled by the shared cross-subdomain cookie; this only covers live changes.
+ *
+ * Call once in an embeddable app. No-op when not embedded or off-DOM, so it is
+ * safe to call unconditionally. Theme application lives here (in the UI package,
+ * next to `setColorMode`) rather than in the SDK embed bridge, which is
+ * UI-agnostic and must not depend on the design system.
+ */
+export function useHostThemeSync(): void {
+    useEffect(() => {
+        if (typeof window === "undefined" || window.parent === window.self) {
+            return;
+        }
+        const onMessage = (event: MessageEvent) => {
+            if (!isTrustedThemeOrigin(event.origin)) return;
+            const data = event.data as {
+                source?: unknown;
+                type?: unknown;
+                value?: unknown;
+            } | null;
+            if (
+                !data ||
+                data.source !== EMBED_MESSAGE_SOURCE ||
+                data.type !== "theme"
+            ) {
+                return;
+            }
+            if (data.value === "dark" || data.value === "light") {
+                setColorMode(data.value);
+            }
+        };
+        window.addEventListener("message", onMessage);
+        return () => window.removeEventListener("message", onMessage);
+    }, []);
 }
 
 /**


### PR DESCRIPTION
Splits the SDK/UI foundation for the `/play` App Hub embed out of the website rebuild PR (#11792) so it can ship and be tested on staging independently. The `/play` host itself lands separately on that branch.

Any app on `PolliProvider` + `AppUserMenu` becomes embeddable under a trusted host with no per-app code:

- **sdk**: `EmbedBridge` (auto-mounted by `PolliProvider`) runs the host handshake, adopts a host-pushed API key, reports height, and reroutes login to the host top-level (OAuth providers refuse to be iframed).
- **ui**: `AppUserMenu` self-hides when a trusted host advertises it owns the account control; `useHostThemeSync` applies a host-pushed color mode.
- **apps**: playground/websim drop their inline height/theme glue — the packages provide it now.

Standalone apps are unchanged and the auth bridge stays dormant until a trusted host handshakes. One intentional change applies **only inside an iframe**: the session is kept frame-local (in memory), so a borrowed key never persists to — and a host logout never clears — the app's own localStorage. As a result an iframed app no longer inherits a standalone localStorage session; since in-iframe OAuth can't complete anyway (providers refuse to be framed), the practical effect is limited to first-party `/play` embeds.

Verified: biome, sdk 54/54, and playground/websim/react/model-monitor build clean.