### PR TITLE
classify qwen-image NSFW rejections as 422, not 500

### DIFF
--- a/gen.pollinations.ai/src/image/utils/contentModeration.ts
+++ b/gen.pollinations.ai/src/image/utils/contentModeration.ts
@@ -30,6 +30,7 @@ const MODERATION_PATTERNS = [
     "flagged", // Replicate "Content flagged for ...", "flagged as sensitive"
     "illegal material",
     "unsafe content", // Azure Content Safety "contains unsafe content"
+    "nsfw", // Replicate Qwen Image Edit "... contained NSFW content ..."
 ];
 
 /** True when an upstream error message indicates a content-policy rejection. */

--- a/gen.pollinations.ai/test/image/contentModeration.test.ts
+++ b/gen.pollinations.ai/test/image/contentModeration.test.ts
@@ -25,6 +25,8 @@ const REAL_MODERATION_MESSAGES = [
     "Seedream 4.5 Pro generation failed: Prediction failed: Async prediction failed: ContentModerationError: Content flagged for: sexual",
     "Seedream 4.0 generation failed: Content flagged for: sexual",
     "Seedream 4.0 generation failed: Content flagged and reported for containing illegal material",
+    // Replicate Qwen Image Edit (qwen-image, qwen-image-plus)
+    "Qwen Image Edit generation failed: All generated images contained NSFW content. Try running it again with a different prompt.",
     // Vertex AI Gemini (nanobanana)
     "Vertex AI Gemini image generation failed: Content policy violation detected in response",
     // Azure Content Safety (kontext, gpt-image)


### PR DESCRIPTION
qwen-image / qwen-image-plus showed a high failure rate on the model monitor. All the 5xx are the same Replicate safety-filter rejection:

`Qwen Image Edit generation failed: All generated images contained NSFW content...`

These are content-policy rejections, not backend failures, but they leaked through the moderation funnel as raw 500s because `MODERATION_PATTERNS` had no `nsfw` entry — so they polluted `errors_5xx` and tripped false "degraded" alarms.

- Adds `nsfw` to `MODERATION_PATTERNS` so these surface as `422 content_policy_violation` (same path as DashScope/Replicate/Vertex/Azure rejections)
- Adds the real Qwen message to the moderation test corpus

Impact (prod, last 24h): 34 NSFW-worded 5xx, all from qwen-image/qwen-image-plus, one identical message, none matched by existing patterns — and none of the other ~900 5xx mention nsfw, so no genuine backend failure is reclassified. These flip 500 → 422, drop out of `emitServerError`/`errors_5xx`, and users get a clear "adjust your input" message.

Tests: `contentModeration.test.ts` (34) pass.