### PR TITLE
Add Ideogram 4.0 image models (turbo/balanced/quality)

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -442,6 +442,30 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionVideoSeconds": 0.05,
     },
   },
+  "ideogram-v4-balanced": {
+    "cost": {
+      "completionImageTokens": 0.06,
+    },
+    "price": {
+      "completionImageTokens": 0.06,
+    },
+  },
+  "ideogram-v4-quality": {
+    "cost": {
+      "completionImageTokens": 0.1,
+    },
+    "price": {
+      "completionImageTokens": 0.1,
+    },
+  },
+  "ideogram-v4-turbo": {
+    "cost": {
+      "completionImageTokens": 0.03,
+    },
+    "price": {
+      "completionImageTokens": 0.03,
+    },
+  },
   "kimi": {
     "cost": {
       "completionTextTokens": 0.000003,

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -5,6 +5,11 @@ import { HttpError } from "./httpError.ts";
 import { callAzureFluxKontext } from "./models/azureFluxKontextModel.js";
 import { callFireworksFluxSchnellAPI } from "./models/fireworksFluxModel.ts";
 import { callFluxKleinAPI } from "./models/fluxKleinModel.ts";
+import {
+    callIdeogramBalancedAPI,
+    callIdeogramQualityAPI,
+    callIdeogramTurboAPI,
+} from "./models/ideogramReplicateModel.ts";
 import { callNovaCanvasAPI } from "./models/novaCanvasModel.ts";
 import {
     callPrunaImageAPI,
@@ -644,6 +649,15 @@ const generateImage = async (
 
         case "seedream-pro":
             return await callSeedreamProAPI(prompt, safeParams);
+
+        case "ideogram-v4-turbo":
+            return await callIdeogramTurboAPI(prompt, safeParams);
+
+        case "ideogram-v4-balanced":
+            return await callIdeogramBalancedAPI(prompt, safeParams);
+
+        case "ideogram-v4-quality":
+            return await callIdeogramQualityAPI(prompt, safeParams);
 
         case "klein":
             return await callFluxKleinAPI(prompt, safeParams);

--- a/gen.pollinations.ai/src/image/models.ts
+++ b/gen.pollinations.ai/src/image/models.ts
@@ -49,6 +49,21 @@ export const IMAGE_CONFIG = {
         minPixels: 3686400, // Seedream 4.5 requires at least 1920x1920 pixels
     },
 
+    // Ideogram 4.0 via Replicate (text-to-image; output resolution is preset,
+    // so width/height only signal the target aspect ratio). Default 1:1 → 2048².
+    "ideogram-v4-turbo": {
+        type: "replicate-ideogram-turbo",
+        defaultSideLength: 2048,
+    },
+    "ideogram-v4-balanced": {
+        type: "replicate-ideogram-balanced",
+        defaultSideLength: 2048,
+    },
+    "ideogram-v4-quality": {
+        type: "replicate-ideogram-quality",
+        defaultSideLength: 2048,
+    },
+
     // Gemini 2.5 Flash Image via Vertex AI - image-to-image generation
     nanobanana: {
         type: "vertex-ai",

--- a/gen.pollinations.ai/src/image/models/ideogramReplicateModel.ts
+++ b/gen.pollinations.ai/src/image/models/ideogramReplicateModel.ts
@@ -1,0 +1,225 @@
+/**
+ * Ideogram 4.0 (turbo / balanced / quality) image generation via Replicate.
+ *
+ * Replicate models (all three share an identical input schema):
+ *   - ideogram-v4-turbo    → ideogram-ai/ideogram-v4-turbo    ($0.03/img)
+ *   - ideogram-v4-balanced → ideogram-ai/ideogram-v4-balanced ($0.06/img)
+ *   - ideogram-v4-quality  → ideogram-ai/ideogram-v4-quality  ($0.10/img)
+ *
+ * Schema verified live against the Replicate model API:
+ *   prompt: string, json_prompt: string, resolution: <WxH enum>,
+ *   enable_copyright_detection: bool (default false).
+ * Output is a SINGLE image-URL string (not an array). There is no `seed` and
+ * no `image` input → these are text-to-image only. `resolution` is an explicit
+ * WxH preset enum, so we map the caller's aspectRatio / dimensions to the
+ * closest preset by log-space ratio distance.
+ */
+
+import debug from "debug";
+import type { ImageGenerationResult } from "../createAndReturnImages.ts";
+import { HttpError } from "../httpError.ts";
+import type { ImageParams } from "../params.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
+import {
+    ReplicateError,
+    runReplicatePrediction,
+} from "../utils/replicateClient.ts";
+
+const logOps = debug("pollinations:ideogram:ops");
+const logError = debug("pollinations:ideogram:error");
+
+// Supported output resolutions, verified live against the Replicate schema.
+// Identical across all three v4 variants. Each entry pairs the preset with its
+// numeric width/height so we can pick the closest match to the request.
+const IDEOGRAM_RESOLUTIONS = [
+    "2048x2048",
+    "1440x2880",
+    "2880x1440",
+    "1664x2496",
+    "2496x1664",
+    "1792x2240",
+    "2240x1792",
+    "1440x2560",
+    "2560x1440",
+    "1600x2560",
+    "2560x1600",
+    "1728x2304",
+    "2304x1728",
+    "1296x3168",
+    "3168x1296",
+    "1152x2944",
+    "2944x1152",
+    "1248x3328",
+    "3328x1248",
+    "1280x3072",
+    "3072x1280",
+] as const;
+type IdeogramResolution = (typeof IDEOGRAM_RESOLUTIONS)[number];
+
+interface IdeogramReplicateInput {
+    prompt: string;
+    resolution: IdeogramResolution;
+}
+
+interface IdeogramVariantConfig {
+    replicateModel: string;
+    displayName: string;
+    /** Tracking label persisted to billing — matches the registry slug. */
+    trackingLabel: string;
+}
+
+const IDEOGRAM_VARIANTS: Record<
+    "ideogram-v4-turbo" | "ideogram-v4-balanced" | "ideogram-v4-quality",
+    IdeogramVariantConfig
+> = {
+    "ideogram-v4-turbo": {
+        replicateModel: "ideogram-ai/ideogram-v4-turbo",
+        displayName: "Ideogram 4.0 Turbo",
+        trackingLabel: "ideogram-v4-turbo",
+    },
+    "ideogram-v4-balanced": {
+        replicateModel: "ideogram-ai/ideogram-v4-balanced",
+        displayName: "Ideogram 4.0 Balanced",
+        trackingLabel: "ideogram-v4-balanced",
+    },
+    "ideogram-v4-quality": {
+        replicateModel: "ideogram-ai/ideogram-v4-quality",
+        displayName: "Ideogram 4.0 Quality",
+        trackingLabel: "ideogram-v4-quality",
+    },
+};
+
+// Aspect-ratio enum entries map to a target W:H; "adaptive" has no image to
+// match here, so it falls through to the dimension-derived ratio (the default
+// 2048×2048 → 1:1 when the caller passed nothing).
+const ASPECT_RATIO_DIMS: Record<string, [number, number]> = {
+    "16:9": [16, 9],
+    "9:16": [9, 16],
+    "4:3": [4, 3],
+    "3:4": [3, 4],
+    "1:1": [1, 1],
+    "21:9": [21, 9],
+    "9:21": [9, 21],
+};
+
+/**
+ * Pick the resolution preset whose aspect ratio is closest to the request, by
+ * log-space distance (symmetric for landscape/portrait). Explicit aspectRatio
+ * wins; otherwise width/height (always populated via defaultSideLength) decides.
+ */
+function resolveResolution(safeParams: ImageParams): IdeogramResolution {
+    const ar = safeParams.aspectRatio;
+    const [w, h] =
+        ar && ar !== "adaptive" && ASPECT_RATIO_DIMS[ar]
+            ? ASPECT_RATIO_DIMS[ar]
+            : [safeParams.width || 1, safeParams.height || 1];
+
+    const target = Math.log(w / h);
+    let best: IdeogramResolution = IDEOGRAM_RESOLUTIONS[0];
+    let bestDist = Number.POSITIVE_INFINITY;
+    for (const res of IDEOGRAM_RESOLUTIONS) {
+        const [rw, rh] = res.split("x").map(Number);
+        const dist = Math.abs(Math.log(rw / rh) - target);
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = res;
+        }
+    }
+    return best;
+}
+
+async function callIdeogramReplicateAPI(
+    variantKey: keyof typeof IDEOGRAM_VARIANTS,
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    const variant = IDEOGRAM_VARIANTS[variantKey];
+
+    const input: IdeogramReplicateInput = {
+        prompt,
+        resolution: resolveResolution(safeParams),
+    };
+
+    logOps(`${variant.displayName} input:`, {
+        ...input,
+        prompt: prompt.slice(0, 80),
+    });
+
+    let outputUrl: string;
+    try {
+        const result = await runReplicatePrediction<
+            IdeogramReplicateInput,
+            string
+        >({
+            model: variant.replicateModel,
+            input,
+        });
+        outputUrl = result.output;
+        logOps(`${variant.displayName} prediction succeeded:`, {
+            id: result.id,
+            predict_time: result.predictTimeSeconds,
+        });
+    } catch (err) {
+        logError(`${variant.displayName} prediction call failed:`, err);
+        if (err instanceof ReplicateError) {
+            throw new HttpError(
+                `${variant.displayName} generation failed: ${err.message}`,
+                err.status ?? 500,
+            );
+        }
+        throw err;
+    }
+
+    if (!outputUrl) {
+        throw new HttpError(`${variant.displayName} returned no image`, 500);
+    }
+
+    const imageResponse = await fetchUpstream(outputUrl, {
+        errorLabel: `Failed to download ${variant.displayName} output image`,
+    });
+    const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+    logOps(
+        `${variant.displayName} image downloaded:`,
+        (imageBuffer.length / 1024).toFixed(1),
+        "KB",
+    );
+
+    return {
+        buffer: imageBuffer,
+        // Ideogram applies its own content moderation upstream.
+        isMature: false,
+        isChild: false,
+        trackingData: {
+            actualModel: variant.trackingLabel,
+            // Flat per-image pricing on Replicate; report 1 image token.
+            usage: {
+                completionImageTokens: 1,
+                totalTokenCount: 1,
+            },
+        },
+    };
+}
+
+/** Ideogram 4.0 Turbo via Replicate (ideogram-ai/ideogram-v4-turbo). */
+export function callIdeogramTurboAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    return callIdeogramReplicateAPI("ideogram-v4-turbo", prompt, safeParams);
+}
+
+/** Ideogram 4.0 Balanced via Replicate (ideogram-ai/ideogram-v4-balanced). */
+export function callIdeogramBalancedAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    return callIdeogramReplicateAPI("ideogram-v4-balanced", prompt, safeParams);
+}
+
+/** Ideogram 4.0 Quality via Replicate (ideogram-ai/ideogram-v4-quality). */
+export function callIdeogramQualityAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    return callIdeogramReplicateAPI("ideogram-v4-quality", prompt, safeParams);
+}

--- a/gen.pollinations.ai/test/image/ideogramModel.test.ts
+++ b/gen.pollinations.ai/test/image/ideogramModel.test.ts
@@ -1,0 +1,147 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { syncImageEnvironment } from "../../src/image/handler.ts";
+import {
+    callIdeogramBalancedAPI,
+    callIdeogramQualityAPI,
+    callIdeogramTurboAPI,
+} from "../../src/image/models/ideogramReplicateModel.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+
+interface ReplicateRequest {
+    url: string;
+    body: Record<string, unknown>;
+}
+
+const REPLICATE_IMAGE_URL = "https://replicate.delivery/x/ideogram-output.png";
+
+// Ideogram v4 returns a SINGLE image-URL string (not an array).
+function mockReplicateFetch(requests: ReplicateRequest[]) {
+    return vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (url, init) => {
+            const href = typeof url === "string" ? url : url.toString();
+            if (href === REPLICATE_IMAGE_URL) {
+                return new Response(
+                    new TextEncoder().encode("png-bytes").buffer,
+                    {
+                        status: 200,
+                    },
+                );
+            }
+            const body = init?.body
+                ? (JSON.parse(init.body as string) as Record<string, unknown>)
+                : {};
+            requests.push({ url: href, body });
+            return new Response(
+                JSON.stringify({
+                    id: "pred_ideogram_test",
+                    status: "succeeded",
+                    output: REPLICATE_IMAGE_URL,
+                    metrics: { predict_time: 5 },
+                }),
+                { status: 201 },
+            );
+        });
+}
+
+const baseParams: ImageParams = {
+    model: "ideogram-v4-balanced",
+    width: 2048,
+    height: 2048,
+    dimensionsExplicit: false,
+    seed: 42,
+    safe: false,
+    quality: "medium",
+    image: [],
+    transparent: false,
+    reasoning: "balanced",
+    audio: false,
+    duration: 0,
+};
+
+function inputOf(req: ReplicateRequest): Record<string, unknown> {
+    return (req.body as { input: Record<string, unknown> }).input;
+}
+
+beforeEach(() => {
+    syncImageEnvironment({
+        ...env,
+        REPLICATE_API_TOKEN: "r8_test_token",
+    } as CloudflareBindings);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("ideogramReplicateModel - routing & billing", () => {
+    it("turbo posts to ideogram-ai/ideogram-v4-turbo and bills 1 image token", async () => {
+        const requests: ReplicateRequest[] = [];
+        mockReplicateFetch(requests);
+
+        const result = await callIdeogramTurboAPI("a sign reading OPEN", {
+            ...baseParams,
+            model: "ideogram-v4-turbo",
+        });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0].url).toBe(
+            "https://api.replicate.com/v1/models/ideogram-ai/ideogram-v4-turbo/predictions",
+        );
+        expect(inputOf(requests[0]).prompt).toBe("a sign reading OPEN");
+        expect(result.trackingData?.actualModel).toBe("ideogram-v4-turbo");
+        expect(result.trackingData?.usage?.completionImageTokens).toBe(1);
+    });
+
+    it("balanced posts to ideogram-ai/ideogram-v4-balanced", async () => {
+        const requests: ReplicateRequest[] = [];
+        mockReplicateFetch(requests);
+        await callIdeogramBalancedAPI("x", baseParams);
+        expect(requests[0].url).toBe(
+            "https://api.replicate.com/v1/models/ideogram-ai/ideogram-v4-balanced/predictions",
+        );
+    });
+
+    it("quality posts to ideogram-ai/ideogram-v4-quality", async () => {
+        const requests: ReplicateRequest[] = [];
+        mockReplicateFetch(requests);
+        await callIdeogramQualityAPI("x", {
+            ...baseParams,
+            model: "ideogram-v4-quality",
+        });
+        expect(requests[0].url).toBe(
+            "https://api.replicate.com/v1/models/ideogram-ai/ideogram-v4-quality/predictions",
+        );
+    });
+});
+
+describe("ideogramReplicateModel - resolution mapping", () => {
+    const cases: Array<[Partial<ImageParams>, string, string]> = [
+        [{ aspectRatio: "1:1" }, "2048x2048", "1:1"],
+        [{ aspectRatio: "16:9" }, "2560x1440", "16:9 landscape"],
+        [{ aspectRatio: "9:16" }, "1440x2560", "9:16 portrait"],
+        // No aspectRatio → falls back to width/height (1920×1080 ≈ 16:9).
+        [
+            { aspectRatio: undefined, width: 1920, height: 1080 },
+            "2560x1440",
+            "1920×1080 dims",
+        ],
+        // Default square dims, nothing specified.
+        [
+            { aspectRatio: undefined, width: 2048, height: 2048 },
+            "2048x2048",
+            "default square",
+        ],
+    ];
+
+    for (const [override, expected, label] of cases) {
+        it(`maps ${label} → ${expected}`, async () => {
+            const requests: ReplicateRequest[] = [];
+            mockReplicateFetch(requests);
+            await callIdeogramBalancedAPI("x", { ...baseParams, ...override });
+            expect(inputOf(requests[0]).resolution).toBe(expected);
+        });
+    }
+});

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -148,6 +148,12 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations route cap from Replicate schema.
     },
+    // Ideogram 4.0 (turbo/balanced/quality) via Replicate. These are official
+    // Replicate models (is_official=true) → billed a FLAT price per output
+    // image set by the publisher, NOT per-second of GPU time. The price is
+    // therefore independent of the resolution preset the handler picks, and all
+    // v4 presets sit in a single 3.4–4.2 MP band (no 1K/2K/4K tier split). So a
+    // flat per-image cost is correct regardless of aspect ratio / resolution.
     "ideogram-v4-turbo": {
         aliases: [],
         modelId: "ideogram-v4-turbo",
@@ -158,7 +164,7 @@ export const IMAGE_SERVICES = {
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            completionImageTokens: 0.03, // per image — ideogram-ai/ideogram-v4-turbo
+            completionImageTokens: 0.03, // flat per image — ideogram-ai/ideogram-v4-turbo
         },
         title: "Ideogram 4.0 Turbo",
         description:
@@ -176,7 +182,7 @@ export const IMAGE_SERVICES = {
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            completionImageTokens: 0.06, // per image — ideogram-ai/ideogram-v4-balanced
+            completionImageTokens: 0.06, // flat per image — ideogram-ai/ideogram-v4-balanced
         },
         title: "Ideogram 4.0 Balanced",
         description:
@@ -194,7 +200,7 @@ export const IMAGE_SERVICES = {
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            completionImageTokens: 0.1, // per image — ideogram-ai/ideogram-v4-quality
+            completionImageTokens: 0.1, // flat per image — ideogram-ai/ideogram-v4-quality
         },
         title: "Ideogram 4.0 Quality",
         description:

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -148,6 +148,60 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations route cap from Replicate schema.
     },
+    "ideogram-v4-turbo": {
+        aliases: [],
+        modelId: "ideogram-v4-turbo",
+        provider: "replicate",
+        brand: "Ideogram",
+        category: "image",
+        addedDate: new Date("2026-06-15").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        cost: {
+            completionImageTokens: 0.03, // per image — ideogram-ai/ideogram-v4-turbo
+        },
+        title: "Ideogram 4.0 Turbo",
+        description:
+            "Ideogram 4.0 Turbo - Fast text-to-image with accurate typography",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
+    "ideogram-v4-balanced": {
+        aliases: [],
+        modelId: "ideogram-v4-balanced",
+        provider: "replicate",
+        brand: "Ideogram",
+        category: "image",
+        addedDate: new Date("2026-06-15").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        cost: {
+            completionImageTokens: 0.06, // per image — ideogram-ai/ideogram-v4-balanced
+        },
+        title: "Ideogram 4.0 Balanced",
+        description:
+            "Ideogram 4.0 Balanced - Text-to-image with accurate typography",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
+    "ideogram-v4-quality": {
+        aliases: [],
+        modelId: "ideogram-v4-quality",
+        provider: "replicate",
+        brand: "Ideogram",
+        category: "image",
+        addedDate: new Date("2026-06-15").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        cost: {
+            completionImageTokens: 0.1, // per image — ideogram-ai/ideogram-v4-quality
+        },
+        title: "Ideogram 4.0 Quality",
+        description:
+            "Ideogram 4.0 Quality - High-fidelity text-to-image with typography",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
     "gptimage": {
         aliases: ["gpt-image", "gpt-image-1-mini"],
         modelId: "gptimage",


### PR DESCRIPTION
Adds the three Ideogram 4.0 variants as image models, served via Replicate (same path as the seedream models).

- New models: \`ideogram-v4-turbo\` (\$0.03/img), \`ideogram-v4-balanced\` (\$0.06/img), \`ideogram-v4-quality\` (\$0.10/img)
- \`priceMultiplier: 1\` (at-cost, matching the other Replicate image models); \`paidOnly: true\`
- Text-to-image only — verified live the Replicate schema has no \`image\` input and no \`seed\`
- \`resolution\` is a fixed WxH preset enum, so the handler maps the caller's aspectRatio / dimensions to the nearest preset by log-space ratio distance
- Output is a single image-URL string (not an array)

Verified locally against gen :8788 (real Replicate calls):
- All 3 generate 200 + valid JPEG; usage header \`x-usage-completion-image-tokens: 1\`
- Aspect mapping correct: 1:1→2048², 16:9→2560×1440, 9:16→1440×2560
- Tinybird billing rows match (cost 0.03/0.06/0.10, price == cost), cache HIT not billed
- No \`Missing conversion rate\` warnings in worker tail
- Added \`test/image/ideogramModel.test.ts\` (routing + billing + resolution mapping); image suite + model-permissions + pricing snapshot all green