### PR TITLE
fix: use Connect as the account menu label, prevent wrapping

### DIFF
--- a/packages/ui/src/modules/app-user-menu/AppUserMenu.tsx
+++ b/packages/ui/src/modules/app-user-menu/AppUserMenu.tsx
@@ -28,7 +28,7 @@ export type AppUserMenuProps = {
 };
 
 const defaultLabels: AppUserMenuLabels = {
-    authorize: "Authorize app",
+    authorize: "Connect",
     appUserMenu: "App user menu",
     topUpAccount: "Top up account",
     logout: "Log out from this app",
@@ -70,9 +70,14 @@ function AppUserMenuContent({
     const { logout } = useAuthActions();
 
     return (
-        <div data-theme="accent" className="polli:flex polli:justify-end">
+        // shrink-0 so the account control never gets squeezed (and its label
+        // never wraps) when it sits next to flexible content in a header row.
+        <div
+            data-theme="accent"
+            className="polli:flex polli:shrink-0 polli:justify-end"
+        >
             <WhenLoggedOut>
-                <LoginButton className="polli:gap-1.5">
+                <LoginButton className="polli:gap-1.5 polli:whitespace-nowrap">
                     <LockIcon className="polli:h-4 polli:w-4 polli:shrink-0" />
                     {labels.authorize}
                 </LoginButton>


### PR DESCRIPTION
Unifies the account-control wording and fixes the label wrapping seen on narrow widths (e.g. standalone websim, /play on mobile).

- Shared `AppUserMenu` default label `Authorize app` → `Connect`, so standalone apps (playground, websim) and the `/play` host all show one consistent word. Previously it was split: `Authorize app` (default), `Log in` (/play override), `sign in` (site prose).
- Make the control `shrink-0` and the login label `whitespace-nowrap` so it keeps its full width in a header flex row instead of breaking onto two lines.
- Playground/websim pick this up via `app-deploy`. The website rebuild branch inherits it on the next `main` merge and can then drop its `labels={{ authorize: ... }}` override.