### PR TITLE
fix: keep model category tabs stable

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -447,16 +447,10 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
     const sections: { type: SectionType; models: ModelPrice[] }[] = [
         { type: "image", models: imageModels },
         { type: "video", models: videoModels },
-        ...(audioModels.length > 0
-            ? [{ type: "audio" as const, models: audioModels }]
-            : []),
-        ...(realtimeModels.length > 0
-            ? [{ type: "realtime" as const, models: realtimeModels }]
-            : []),
+        { type: "audio", models: audioModels },
+        { type: "realtime", models: realtimeModels },
         { type: "text", models: textModels },
-        ...(embeddingModels.length > 0
-            ? [{ type: "embedding" as const, models: embeddingModels }]
-            : []),
+        { type: "embedding", models: embeddingModels },
     ];
 
     const [sortKey, setSortKey] = useState<SortKey>("perPollen");

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -62,10 +62,10 @@ export const Models: FC = () => {
     const availableSections: SectionType[] = [
         "image",
         "video",
-        ...(audioModels.length > 0 ? (["audio"] as SectionType[]) : []),
-        ...(realtimeModels.length > 0 ? (["realtime"] as SectionType[]) : []),
+        "audio",
+        "realtime",
         "text",
-        ...(embeddingModels.length > 0 ? (["embedding"] as SectionType[]) : []),
+        "embedding",
     ];
 
     return (


### PR DESCRIPTION
- Shows all built-in model category tabs immediately
- Keeps the table section list aligned with those tabs
- Prevents Audio/Realtime/Embedding tabs from appearing late after catalog load

Validation:
- npx biome check --write enter.pollinations.ai/frontend/src/components/models/models.tsx enter.pollinations.ai/frontend/src/components/models/model-table.tsx
- npm run typecheck (enter.pollinations.ai)