### PR TITLE
fix: update Sirius elevator app key (old key deactivated)

### DIFF
--- a/apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts
@@ -52,7 +52,7 @@ function extractApiKeyFromFragment(): string | null {
     }
 }
 
-const APP_KEY = "pk_vbqLj6cwn05D2v5B";
+const APP_KEY = "pk_nDXh3ryXfjTkirMB";
 
 function getAuthorizeUrl(): string {
     const redirect = window.location.href.split("#")[0];


### PR DESCRIPTION
The Sirius Cybernetics Elevator Challenge login broke — the `/authorize` consent screen showed **"This app key could not be verified. Authorization blocked."**

**Root cause:** the registered app key `pk_vbqLj6cwn05D2v5B` no longer resolves. `app-lookup` returns `{"found":false}`, which triggers that exact error in `authorize.tsx`.

**Fix:** swap to the re-issued key `pk_nDXh3ryXfjTkirMB`. Verified against the live endpoint:
- old key → `{"found":false}`
- new key → `{"found":true}`, app `"Sirius Cybernetics Elevator Challenge"`, owner `voodoohop`, redirect allowlist includes `sirius-cybernetics-elevator-challenge.pollinations.ai`, `earningsEnabled:true`

One-line change in `apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)