### PR TITLE
fix: default Enter dashboard to light mode

### DIFF
--- a/enter.pollinations.ai/frontend/index.html
+++ b/enter.pollinations.ai/frontend/index.html
@@ -9,11 +9,11 @@
     <script>
       (() => {
         try {
-          let mode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
+          const storedMode = (document.cookie.match(/(?:^|;\s*)polli-color-mode=(light|dark)(?:;|$)/) || [])[1] || localStorage.getItem("polli-color-mode");
+          let mode = storedMode;
           if (mode !== "light" && mode !== "dark") {
-            mode = matchMedia("(prefers-color-scheme: dark)").matches
-              ? "dark"
-              : "light";
+            mode = "light";
+            localStorage.setItem("polli-color-mode", mode);
           }
           if (mode === "dark") document.documentElement.classList.add("dark");
           // theme-color (browser chrome) is derived from the --polli-color-app-bg


### PR DESCRIPTION
- Defaults fresh Enter dashboard visits to light mode.
- Keeps saved light/dark cookie or localStorage choices unchanged.
- Validated with Biome, TypeScript, frontend build, local browser smoke, and inline bootstrap smoke.