### PR TITLE
feat(enter): pre-fill localhost redirect URI for new app keys

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
@@ -21,6 +21,13 @@ import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
 import type { CreateApiKey, CreateApiKeyResponse } from "./types.ts";
 
+/**
+ * Pre-filled callback for app keys so local dev works out of the box. Loopback
+ * ports are wildcarded (RFC 8252 §7.3), so only the path needs editing. The
+ * dev sees it in the editor and should remove it before production.
+ */
+const DEFAULT_LOCALHOST_REDIRECT = "http://localhost/callback";
+
 type ApiKeyDialogProps = {
     onSubmit: (state: CreateApiKey) => Promise<CreateApiKeyResponse>;
     onComplete: () => void;
@@ -53,7 +60,9 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
     const keyType: "secret" | "publishable" = simplified
         ? "publishable"
         : "secret";
-    const [redirectUris, setRedirectUris] = useState<string[]>([]);
+    const [redirectUris, setRedirectUris] = useState<string[]>(
+        simplified ? [DEFAULT_LOCALHOST_REDIRECT] : [],
+    );
     const [earningsEnabled, setEarningsEnabled] = useState(true);
     const keyPermissions = useKeyPermissions(
         simplified
@@ -158,7 +167,9 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                     setCreatedKey(null);
                     setError(null);
                     setName(generateFunName());
-                    setRedirectUris([]);
+                    setRedirectUris(
+                        simplified ? [DEFAULT_LOCALHOST_REDIRECT] : [],
+                    );
                     setEarningsEnabled(true);
                     const dateStr = new Date().toLocaleDateString("en-US", {
                         day: "2-digit",

--- a/enter.pollinations.ai/frontend/src/components/keys/publishable-key-settings.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/publishable-key-settings.tsx
@@ -46,6 +46,11 @@ export const PublishableKeySettings: FC<PublishableKeySettingsProps> = ({
                         Redirect URIs
                     </Field.Label>
                 </div>
+                <p className="text-xs text-theme-text-soft">
+                    A localhost callback is pre-filled for local development —
+                    edit the path to match your dev server, and remove it before
+                    going to production.
+                </p>
                 {redirectUris.map((uri, index) => (
                     <div
                         // biome-ignore lint/suspicious/noArrayIndexKey: stable enough for a small editable list


### PR DESCRIPTION
- Seeds `http://localhost/callback` into the app-key creation dialog (simplified/app-key mode only)
- Removes the friction of manually registering a localhost redirect just to develop locally
- Keeps the per-app allowlist gate intact (no blanket localhost allow) — avoids the open-redirect/token-theft class that "allow any URL + warn" would open
- Loopback ports are already wildcarded (RFC 8252 §7.3), so only the path needs editing for most dev servers
- Adds a dev note in the editor: edit the path to match your dev server, remove before production

🤖 Generated with [Claude Code](https://claude.com/claude-code)