### PR TITLE
feat: log whether a Portkey fallback target served the request

### DIFF
--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -48,6 +48,7 @@ SCHEMA >
 `resolved_model_requested`  LowCardinality(String) `json:$.resolvedModelRequested` DEFAULT 'undefined',
 `model_used`                LowCardinality(String) `json:$.modelUsed` DEFAULT 'undefined',
 `model_provider_used`       LowCardinality(String) `json:$.modelProviderUsed` DEFAULT 'undefined',
+`fallback_used`             Bool                   `json:$.fallbackUsed` DEFAULT false,
 `is_billed_usage`           Bool                   `json:$.isBilledUsage`,
 
 -- Pricing

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -33,6 +33,7 @@ import {
     type UsagePrice,
 } from "@shared/registry/registry.ts";
 import {
+    FALLBACK_TARGET_HEADER,
     openaiUsageToUsage,
     parseUsageHeaders,
 } from "@shared/registry/usage-headers.ts";
@@ -94,6 +95,7 @@ type ResponseTrackingData = {
     responseOk: boolean;
     cacheData: CacheData;
     isBilledUsage: boolean;
+    fallbackUsed: boolean;
     modelUsed?: string;
     usage?: Usage;
     cost?: UsageCost;
@@ -391,6 +393,7 @@ async function trackResponse(
     const log = getLogger(["hono", "track", "response"]);
     const { resolvedModelRequested } = requestTracking;
     const cacheInfo = extractCacheHeaders(response);
+    const fallbackUsed = parseFallbackUsed(response);
     const notBilled = (
         extra?: Partial<ResponseTrackingData>,
     ): ResponseTrackingData => ({
@@ -398,6 +401,7 @@ async function trackResponse(
         responseStatus: response.status,
         cacheData: cacheInfo,
         isBilledUsage: false,
+        fallbackUsed,
         ...extra,
     });
 
@@ -446,12 +450,23 @@ async function trackResponse(
         responseStatus: response.status,
         cacheData: cacheInfo,
         isBilledUsage: true,
+        fallbackUsed,
         cost,
         price,
         modelUsed: modelUsage.model,
         usage: modelUsage.usage,
         contentFilterResults,
     };
+}
+
+// Portkey reports the served target as "config.targets[N]" via the
+// x-fallback-target header (re-emitted from x-portkey-last-used-option-index).
+// A fallback fired whenever the served target is not the primary (index 0).
+function parseFallbackUsed(response: Response): boolean {
+    const target = response.headers.get(FALLBACK_TARGET_HEADER);
+    if (!target) return false;
+    const match = target.match(/\[(\d+)\]/);
+    return match ? Number(match[1]) > 0 : false;
 }
 
 // Resolve the per-event content-type expectation for billing. Returns null
@@ -603,6 +618,7 @@ function createTrackingEvent({
         resolvedModelRequested: requestTracking.resolvedModelRequested,
         modelUsed: responseTracking.modelUsed,
         modelProviderUsed: requestTracking.modelProvider,
+        fallbackUsed: responseTracking.fallbackUsed,
 
         isBilledUsage: responseTracking.isBilledUsage,
 

--- a/gen.pollinations.ai/src/text/genericOpenAIClient.ts
+++ b/gen.pollinations.ai/src/text/genericOpenAIClient.ts
@@ -172,6 +172,13 @@ export async function genericOpenAIClient(
             throw createApiError(response, errorDetails, modelName);
         }
 
+        // Portkey reports which fallback target served the call via this header
+        // (e.g. "config.targets[0]" = primary, "config.targets[1]" = first
+        // fallback). Surface it so tracking can record whether a fallback fired.
+        const fallbackTarget =
+            response.headers.get("x-portkey-last-used-option-index") ??
+            undefined;
+
         if (normalizedOptions.stream) {
             log(
                 `[${requestId}] Streaming response, status: ${response.status}`,
@@ -185,6 +192,7 @@ export async function genericOpenAIClient(
                 model: modelName,
                 stream: true,
                 responseStream: streamToReturn,
+                fallbackTarget,
                 choices: [
                     { delta: { content: "" }, finish_reason: null, index: 0 },
                 ],
@@ -208,6 +216,7 @@ export async function genericOpenAIClient(
             ...data,
             id: data.id || `genericopenai-${requestId}`,
             object: data.object || "chat.completion",
+            fallbackTarget,
             choices: [formattedChoice],
         };
     } catch (thrown: unknown) {

--- a/gen.pollinations.ai/src/text/genericOpenAIClient.ts
+++ b/gen.pollinations.ai/src/text/genericOpenAIClient.ts
@@ -18,6 +18,24 @@ const log = debug("pollinations:genericopenai");
 const errorLog = debug("pollinations:error");
 const DONE_EVENT_PATTERN = /data:\s*\[DONE\]/;
 
+// Attach Portkey's served fallback target as internal, non-enumerable metadata
+// so tracking can read completion.fallbackTarget while it stays out of every
+// JSON.stringify({ ...completion }) response body (the OpenAI-compatible body
+// has no such field).
+function withFallbackTarget(
+    completion: ChatCompletion,
+    fallbackTarget: string | undefined,
+): ChatCompletion {
+    if (fallbackTarget === undefined) return completion;
+    Object.defineProperty(completion, "fallbackTarget", {
+        value: fallbackTarget,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+    });
+    return completion;
+}
+
 function ensureOpenAISseDone(
     source: ReadableStream<Uint8Array> | null,
 ): ReadableStream<Uint8Array> | null {
@@ -185,18 +203,24 @@ export async function genericOpenAIClient(
             );
 
             const streamToReturn = ensureOpenAISseDone(response.body);
-            return {
-                id: `genericopenai-${requestId}`,
-                object: "chat.completion.chunk",
-                created: Math.floor(startTime / 1000),
-                model: modelName,
-                stream: true,
-                responseStream: streamToReturn,
+            return withFallbackTarget(
+                {
+                    id: `genericopenai-${requestId}`,
+                    object: "chat.completion.chunk",
+                    created: Math.floor(startTime / 1000),
+                    model: modelName,
+                    stream: true,
+                    responseStream: streamToReturn,
+                    choices: [
+                        {
+                            delta: { content: "" },
+                            finish_reason: null,
+                            index: 0,
+                        },
+                    ],
+                },
                 fallbackTarget,
-                choices: [
-                    { delta: { content: "" }, finish_reason: null, index: 0 },
-                ],
-            };
+            );
         }
 
         const data = (await response.json()) as ChatCompletion;
@@ -212,13 +236,15 @@ export async function genericOpenAIClient(
             formattedChoice.finish_reason = "tool_calls";
         }
 
-        return {
-            ...data,
-            id: data.id || `genericopenai-${requestId}`,
-            object: data.object || "chat.completion",
+        return withFallbackTarget(
+            {
+                ...data,
+                id: data.id || `genericopenai-${requestId}`,
+                object: data.object || "chat.completion",
+                choices: [formattedChoice],
+            },
             fallbackTarget,
-            choices: [formattedChoice],
-        };
+        );
     } catch (thrown: unknown) {
         const error = thrown as ServiceError;
         errorLog(`[${requestId}] Error:`, {

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -6,6 +6,7 @@ import {
 } from "@shared/registry/registry.ts";
 import {
     buildUsageHeaders,
+    FALLBACK_TARGET_HEADER,
     openaiUsageToUsage,
 } from "@shared/registry/usage-headers.ts";
 import type { Context } from "hono";
@@ -118,6 +119,9 @@ function usageHeaders(completion: ChatCompletion): Headers {
             headers.set(key, String(value));
         }
     }
+    if (completion?.fallbackTarget) {
+        headers.set(FALLBACK_TARGET_HEADER, completion.fallbackTarget);
+    }
     return headers;
 }
 
@@ -188,6 +192,11 @@ function sendTextStreamResponse(completion: ChatCompletion): Response {
         "Cache-Control": "no-cache",
         Connection: "keep-alive",
     });
+    // sendTextStreamResponse bypasses usageHeaders(), so set the fallback
+    // header here too — tracking reads it off the worker response for streams.
+    if (completion.fallbackTarget) {
+        headers.set(FALLBACK_TARGET_HEADER, completion.fallbackTarget);
+    }
 
     if (completion.responseStream instanceof ReadableStream) {
         return new Response(completion.responseStream, { headers });

--- a/gen.pollinations.ai/src/text/types.ts
+++ b/gen.pollinations.ai/src/text/types.ts
@@ -80,6 +80,8 @@ export interface ChatCompletion {
     stream?: boolean;
     responseStream?: ReadableStream | null;
     requestData?: unknown;
+    /** Portkey fallback target that served the call, e.g. "config.targets[1]". */
+    fallbackTarget?: string;
     [key: string]: unknown;
 }
 

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -406,6 +406,17 @@ describe("genericOpenAIClient", () => {
         );
 
         expect(completion.fallbackTarget).toBe("config.targets[1]");
+        // Internal metadata must stay out of the OpenAI-compatible body: it is
+        // non-enumerable, so JSON.stringify({ ...completion }) never includes it.
+        expect(
+            Object.prototype.propertyIsEnumerable.call(
+                completion,
+                "fallbackTarget",
+            ),
+        ).toBe(false);
+        expect(JSON.stringify({ ...completion })).not.toContain(
+            "fallbackTarget",
+        );
     });
 
     it("captures the Portkey fallback target header on streaming responses", async () => {

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -374,4 +374,91 @@ describe("genericOpenAIClient", () => {
         expect(text).toContain('"content":"ok"');
         expect(text).toContain("data: [DONE]\n\n");
     });
+
+    it("captures the Portkey fallback target header on non-streaming responses", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json(
+                {
+                    id: "chatcmpl_test",
+                    object: "chat.completion",
+                    model: "provider-model",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: { prompt_tokens: 1, completion_tokens: 1 },
+                },
+                {
+                    headers: {
+                        "x-portkey-last-used-option-index": "config.targets[1]",
+                    },
+                },
+            ),
+        );
+
+        const completion = await genericOpenAIClient(
+            [{ role: "user", content: "hello" }],
+            { model: "provider-model" },
+            { endpoint: "https://portkey.test/chat" },
+        );
+
+        expect(completion.fallbackTarget).toBe("config.targets[1]");
+    });
+
+    it("captures the Portkey fallback target header on streaming responses", async () => {
+        vi.spyOn(globalThis, "fetch").mockImplementationOnce(async () => {
+            const encoder = new TextEncoder();
+            return new Response(
+                new ReadableStream({
+                    start(controller) {
+                        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                        controller.close();
+                    },
+                }),
+                {
+                    headers: {
+                        "content-type": "text/event-stream; charset=utf-8",
+                        "x-portkey-last-used-option-index": "config.targets[1]",
+                    },
+                },
+            );
+        });
+
+        const completion = await genericOpenAIClient(
+            [{ role: "user", content: "hello" }],
+            { model: "provider-model", stream: true },
+            { endpoint: "https://portkey.test/chat" },
+        );
+
+        expect(completion.fallbackTarget).toBe("config.targets[1]");
+    });
+
+    it("leaves fallbackTarget undefined when the header is absent", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json({
+                id: "chatcmpl_test",
+                object: "chat.completion",
+                model: "provider-model",
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: "assistant", content: "ok" },
+                        finish_reason: "stop",
+                    },
+                ],
+                usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }),
+        );
+
+        const completion = await genericOpenAIClient(
+            [{ role: "user", content: "hello" }],
+            { model: "provider-model" },
+            { endpoint: "https://portkey.test/chat" },
+        );
+
+        expect(completion.fallbackTarget).toBeUndefined();
+    });
 });

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -111,6 +111,82 @@ function createWrongContentTypeApp(
     return app;
 }
 
+// App whose text response carries caller-supplied headers, used to assert that
+// the x-fallback-target worker header propagates into the Tinybird event.
+function createHeaderApp(extraHeaders: Record<string, string>) {
+    const app = new Hono<Env>();
+
+    app.use("*", requestId());
+    app.use("*", logger);
+    app.use("*", async (c, next) => {
+        c.set("auth", {
+            user: undefined,
+            requireAuthorization: async () => {},
+            requireUser: () => {
+                throw new Error("user should not be required in this test");
+            },
+            requireModelAccess: () => {},
+        });
+        c.set("balance", {
+            getBalance: async () => ({ tierBalance: 1, packBalance: 0 }),
+        });
+        c.set("frontendKeyRateLimit", { consumePollen: async () => {} });
+        c.set("model", { requested: "openai", resolved: "openai" });
+        await next();
+    });
+    app.post(
+        "/v1/chat/completions",
+        track("generate.text"),
+        () =>
+            new Response(JSON.stringify({ choices: [{ message: {} }] }), {
+                headers: {
+                    "content-type": "application/json",
+                    "x-model-used": "gpt-5-nano-2025-08-07",
+                    "x-usage-prompt-text-tokens": "10",
+                    "x-usage-completion-text-tokens": "5",
+                    ...extraHeaders,
+                },
+            }),
+    );
+
+    return app;
+}
+
+async function captureFallbackEvent(extraHeaders: Record<string, string>) {
+    const tinybirdRequests: Request[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        tinybirdRequests.push(new Request(input, init));
+        return new Response("ok");
+    });
+
+    const ctx = createExecutionContext();
+    await createHeaderApp(extraHeaders).fetch(
+        new Request("https://gen.pollinations.ai/v1/chat/completions", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                model: "openai",
+                stream: false,
+                messages: [{ role: "user", content: "test" }],
+            }),
+        }),
+        {
+            ENVIRONMENT: "test",
+            LOG_LEVEL: "debug",
+            LOG_FORMAT: "text",
+            BETTER_AUTH_SECRET: "test_secret",
+            TINYBIRD_INGEST_URL:
+                "https://tinybird.test/v0/events?name=generation_event",
+            TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+        } as CloudflareBindings,
+        ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(tinybirdRequests).toHaveLength(1);
+    return (await tinybirdRequests[0].json()) as { fallbackUsed?: boolean };
+}
+
 describe("tracking observability", () => {
     it("emits Tinybird generation events for successful gen requests", async () => {
         const tinybirdRequests: Request[] = [];
@@ -356,5 +432,24 @@ describe("tracking observability", () => {
             isBilledUsage: false,
         });
         expect(consumePollen).toHaveBeenCalledWith(0);
+    });
+
+    it("records fallbackUsed=true when Portkey served a non-primary target", async () => {
+        const event = await captureFallbackEvent({
+            "x-fallback-target": "config.targets[1]",
+        });
+        expect(event.fallbackUsed).toBe(true);
+    });
+
+    it("records fallbackUsed=false when Portkey served the primary target", async () => {
+        const event = await captureFallbackEvent({
+            "x-fallback-target": "config.targets[0]",
+        });
+        expect(event.fallbackUsed).toBe(false);
+    });
+
+    it("records fallbackUsed=false when no fallback header is present", async () => {
+        const event = await captureFallbackEvent({});
+        expect(event.fallbackUsed).toBe(false);
     });
 });

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -21,6 +21,13 @@ export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
 };
 
 /**
+ * Internal worker header carrying Portkey's served fallback target (e.g.
+ * "config.targets[1]"), re-emitted from x-portkey-last-used-option-index so
+ * tracking can read it off the worker response like the other usage headers.
+ */
+export const FALLBACK_TARGET_HEADER = "x-fallback-target";
+
+/**
  * Convert OpenAI usage format to Usage format.
  *
  * The OpenAI spec defines `completion_tokens` (and `prompt_tokens`) as the

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -56,6 +56,8 @@ export type TinybirdEvent = {
     resolvedModelRequested?: string;
     modelUsed?: string;
     modelProviderUsed?: string;
+    /** True when Portkey served from a non-primary fallback target. */
+    fallbackUsed?: boolean;
     isBilledUsage: boolean;
 
     // Pricing


### PR DESCRIPTION
Records, per text request, whether Portkey served from a non-primary fallback target (e.g. Airforce→Vertex on the public `gemini` model). Today nothing captures this — `model_provider_used` is the static registry provider, and the gateway's `x-portkey-*` headers are discarded in `genericOpenAIClient` before tracking sees them.

## Approach (mirrors the existing `x-model-used` flow)
- `genericOpenAIClient` reads `x-portkey-last-used-option-index` off the gateway response (stream + non-stream) → `ChatCompletion.fallbackTarget`
- `handler.ts` re-emits it as the internal `x-fallback-target` worker header (in `usageHeaders` + explicitly in `sendTextStreamResponse`, which bypasses `usageHeaders`)
- `track.ts` parses `"config.targets[N]"` → `fallbackUsed` (true when N > 0), recorded before the cache/billing branch so streaming and non-streaming both work
- New `fallback_used` Bool on the `generation_event` datasource + `fallbackUsed` on the event schema

Verified against the live gateway: happy path returns `config.targets[0]` (`x-portkey-provider: openai`), forced fallback returns `config.targets[1]` (`vertex-ai`). The header value is the string `config.targets[N]`, not a bare int — parser handles that.

## Why not reuse `model_provider_used`
Semantically tempting, but it's consumed by ~45 sites (4 Grafana economics dashboards, alerting rules, a billing test) that assume the static registry provider. Notably `daily-spending.json` filters paid-inference by `model_provider_used IN ('google',...)`; flipping it to `airforce` would silently move billed Gemini out of the paid bucket. A dedicated bool is lower-risk and leaves all of that untouched.

## Query
```sql
SELECT countIf(fallback_used)/count() AS fallback_rate
FROM generation_event WHERE model_requested = 'gemini'
```

## Tests
- `genericOpenAIClient`: captures `fallbackTarget` on stream + non-stream; undefined when header absent
- `tracking-observability`: `fallbackUsed` true (`config.targets[1]`), false (`config.targets[0]`), false (absent)

## Tinybird deploy (manual, not in this PR)
`fallback_used` column ADD is non-destructive (backfills existing rows as `false`). Deploy to **both** workspaces, staging first: `tb --cloud deploy --wait` from `enter.pollinations.ai/observability` (override `TB_TOKEN` for staging). Validate with `--check` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)