### PR TITLE
fix: route Opus 4.7/4.8 via us.* Bedrock profile

### DIFF
--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -209,14 +209,16 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "global.anthropic.claude-opus-4-6-v1",
             defaultOptions: { max_tokens: 128000 },
         }),
+    // global.* inference profiles for Opus 4.7/4.8 return Bedrock-side
+    // Internal/ServiceUnavailable errors; the us.* profiles are healthy.
     "claude-opus-4-7": () =>
         createBedrockNativeConfig({
-            model: "global.anthropic.claude-opus-4-7",
+            model: "us.anthropic.claude-opus-4-7",
             defaultOptions: { max_tokens: 128000 },
         }),
     "claude-opus-4-8": () =>
         createBedrockNativeConfig({
-            model: "global.anthropic.claude-opus-4-8",
+            model: "us.anthropic.claude-opus-4-8",
             defaultOptions: { max_tokens: 128000 },
         }),
     "claude-haiku-4-5": () =>


### PR DESCRIPTION
- `claude-opus-4.7`/`4.8` were failing nearly every request (monitor showed them "Off")
- Root cause: the `global.anthropic.claude-opus-4-7`/`4-8` Bedrock inference profiles return `InternalServerException`/`ServiceUnavailableException` at invoke time
- The `us.anthropic.claude-opus-4-7`/`4-8` profiles are healthy — verified directly against the Bedrock runtime (both return real responses; `global.*` both fail)
- Switches both models to the `us.*` profile; `opus-4-6` left on `global.*` (still works)
- Note: the inflated 4xx in the monitor is separate — 402 (out-of-pollen spore users) + 401 (anon), expected traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)