### PR TITLE
feat: add reward grants quest floor

### DIFF
--- a/enter.pollinations.ai/drizzle/0027_curvy_the_captain.sql
+++ b/enter.pollinations.ai/drizzle/0027_curvy_the_captain.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `reward_grants` (
+	`id` text PRIMARY KEY NOT NULL,
+	`idempotency_key` text NOT NULL,
+	`user_id` text NOT NULL,
+	`source` text NOT NULL,
+	`quest_id` text,
+	`amount` real NOT NULL,
+	`balance_bucket` text NOT NULL,
+	`source_ref` text,
+	`metadata_json` text,
+	`created_at` integer DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_reward_grants_idempotency_key` ON `reward_grants` (`idempotency_key`);--> statement-breakpoint
+CREATE INDEX `idx_reward_grants_user_id` ON `reward_grants` (`user_id`);--> statement-breakpoint
+CREATE INDEX `idx_reward_grants_source` ON `reward_grants` (`source`);--> statement-breakpoint
+CREATE INDEX `idx_reward_grants_quest_id` ON `reward_grants` (`quest_id`);

--- a/enter.pollinations.ai/drizzle/meta/0027_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1212 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "78bef782-4123-42a7-a843-45ec9a8e6e38",
+  "prevId": "317c099f-1214-4f19-9b28-85e140ad29a1",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quest_payout_credits": {
+      "name": "quest_payout_credits",
+      "columns": {
+        "payout_key": {
+          "name": "payout_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_issue_number": {
+          "name": "quest_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_quest_payout_credits_user_id": {
+          "name": "idx_quest_payout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_quest_payout_credits_quest_issue": {
+          "name": "idx_quest_payout_credits_quest_issue",
+          "columns": [
+            "quest_issue_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "quest_payout_credits_user_id_user_id_fk": {
+          "name": "quest_payout_credits_user_id_user_id_fk",
+          "tableFrom": "quest_payout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reward_grants": {
+      "name": "reward_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_reward_grants_idempotency_key": {
+          "name": "idx_reward_grants_idempotency_key",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_reward_grants_user_id": {
+          "name": "idx_reward_grants_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reward_grants_source": {
+          "name": "idx_reward_grants_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "idx_reward_grants_quest_id": {
+          "name": "idx_reward_grants_quest_id",
+          "columns": [
+            "quest_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reward_grants_user_id_user_id_fk": {
+          "name": "reward_grants_user_id_user_id_fk",
+          "tableFrom": "reward_grants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1780419641045,
       "tag": "0026_reflective_kinsey_walden",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1781657718694,
+      "tag": "0027_curvy_the_captain",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -5,11 +5,13 @@ import {
 } from "@shared/auth/api-key-creation.ts";
 import {
     apikey as apikeyTable,
+    questPayoutCredits as questPayoutCreditsTable,
+    rewardGrants as rewardGrantsTable,
     user as userTable,
 } from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { getTierCadence, tierNames } from "@shared/tier-config.ts";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -38,6 +40,12 @@ const DEFAULT_DAILY_USAGE_DAYS = 90;
 const MAX_USAGE_DAYS = 90;
 const USAGE_CHUNK_DAYS = 30;
 const MAX_USAGE_EXPORT_ROWS = 50_000;
+const QUEST_REWARD_SOURCES = new Set([
+    "code_quest",
+    "quest",
+    "onboarding",
+    "spend",
+]);
 
 const SECONDS_PER_DAY = 86400;
 const USAGE_MIN_DATE = "2026-01-01";
@@ -151,6 +159,26 @@ const CreateKeySchema = z.object({
         ),
 });
 
+const accountQuestGrantSchema = z.object({
+    id: z.string(),
+    idempotencyKey: z.string(),
+    source: z.string(),
+    questId: z.string().nullable(),
+    amount: z.number(),
+    balanceBucket: z.string(),
+    sourceRef: z.string().nullable(),
+    metadata: z.record(z.string(), z.unknown()).nullable(),
+    createdAt: z.string(),
+    legacy: z.boolean(),
+    questIssueNumber: z.number().nullable(),
+    prNumber: z.number().nullable(),
+});
+
+const accountQuestResponseSchema = z.object({
+    totalPollen: z.number(),
+    grants: z.array(accountQuestGrantSchema),
+});
+
 // CSV escape helper
 const escapeCSV = (val: string | number | boolean | null) => {
     if (val === null || val === undefined) return "";
@@ -160,6 +188,37 @@ const escapeCSV = (val: string | number | boolean | null) => {
     }
     return str;
 };
+
+function parseGrantMetadata(
+    raw: string | null,
+): Record<string, unknown> | null {
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+    } catch {
+        return null;
+    }
+    return null;
+}
+
+function formatGrantTimestamp(value: Date | number | string): string {
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === "number") return new Date(value).toISOString();
+    return new Date(value).toISOString();
+}
+
+function requireUsagePermission(apiKey?: {
+    permissions?: Record<string, string[]>;
+}): void {
+    if (apiKey && !apiKey.permissions?.account?.includes("usage")) {
+        throw new HTTPException(403, {
+            message: "API key does not have 'account:usage' permission",
+        });
+    }
+}
 
 function formatTinybirdDateTime(date: Date): string {
     return date.toISOString().slice(0, 19).replace("T", " ");
@@ -1290,6 +1349,121 @@ export const accountRoutes = new Hono<Env>()
                 log.error("Error fetching earnings: {error}", { error });
                 return c.json({ error: "Failed to fetch earnings data" }, 500);
             }
+        },
+    )
+    .get(
+        "/quests",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "Get Completed Quest Rewards",
+            description:
+                "Returns completed quest-style reward grants for the authenticated account. Includes generic reward grant rows and legacy GitHub quest payouts that have not been dual-written yet. Requires `account:usage` permission when using API keys.",
+            responses: {
+                200: {
+                    description: "Completed quest rewards",
+                    content: {
+                        "application/json": {
+                            schema: resolver(accountQuestResponseSchema),
+                        },
+                    },
+                },
+                401: { description: "Unauthorized" },
+                403: {
+                    description:
+                        "Permission denied - API key missing `account:usage` permission",
+                },
+            },
+        }),
+        async (c) => {
+            await c.var.auth.requireAuthorization({
+                message: "Authentication required to view quest rewards",
+            });
+            const user = c.var.auth.requireUser();
+            requireUsagePermission(c.var.auth.apiKey);
+
+            const db = drizzle(c.env.DB);
+            const [rewardRows, legacyRows] = await Promise.all([
+                db
+                    .select({
+                        id: rewardGrantsTable.id,
+                        idempotencyKey: rewardGrantsTable.idempotencyKey,
+                        source: rewardGrantsTable.source,
+                        questId: rewardGrantsTable.questId,
+                        amount: rewardGrantsTable.amount,
+                        balanceBucket: rewardGrantsTable.balanceBucket,
+                        sourceRef: rewardGrantsTable.sourceRef,
+                        metadataJson: rewardGrantsTable.metadataJson,
+                        createdAt: rewardGrantsTable.createdAt,
+                    })
+                    .from(rewardGrantsTable)
+                    .where(eq(rewardGrantsTable.userId, user.id))
+                    .orderBy(desc(rewardGrantsTable.createdAt)),
+                db
+                    .select({
+                        payoutKey: questPayoutCreditsTable.payoutKey,
+                        questIssueNumber:
+                            questPayoutCreditsTable.questIssueNumber,
+                        prNumber: questPayoutCreditsTable.prNumber,
+                        role: questPayoutCreditsTable.role,
+                        githubUsername: questPayoutCreditsTable.githubUsername,
+                        pollenCredited: questPayoutCreditsTable.pollenCredited,
+                        createdAt: questPayoutCreditsTable.createdAt,
+                    })
+                    .from(questPayoutCreditsTable)
+                    .where(eq(questPayoutCreditsTable.userId, user.id))
+                    .orderBy(desc(questPayoutCreditsTable.createdAt)),
+            ]);
+
+            const rewardKeys = new Set(
+                rewardRows.map((row) => row.idempotencyKey),
+            );
+            const grants = [
+                ...rewardRows
+                    .filter((row) => QUEST_REWARD_SOURCES.has(row.source))
+                    .map((row) => ({
+                        id: row.id,
+                        idempotencyKey: row.idempotencyKey,
+                        source: row.source,
+                        questId: row.questId,
+                        amount: row.amount,
+                        balanceBucket: row.balanceBucket,
+                        sourceRef: row.sourceRef,
+                        metadata: parseGrantMetadata(row.metadataJson),
+                        createdAt: formatGrantTimestamp(row.createdAt),
+                        legacy: false,
+                        questIssueNumber: null,
+                        prNumber: null,
+                    })),
+                ...legacyRows
+                    .filter((row) => !rewardKeys.has(row.payoutKey))
+                    .map((row) => ({
+                        id: row.payoutKey,
+                        idempotencyKey: row.payoutKey,
+                        source: "code_quest",
+                        questId: `github:${row.questIssueNumber}`,
+                        amount: row.pollenCredited,
+                        balanceBucket: "pack",
+                        sourceRef: `pr:${row.prNumber}`,
+                        metadata: {
+                            role: row.role,
+                            githubUsername: row.githubUsername,
+                        },
+                        createdAt: formatGrantTimestamp(row.createdAt),
+                        legacy: true,
+                        questIssueNumber: row.questIssueNumber,
+                        prNumber: row.prNumber,
+                    })),
+            ].sort(
+                (left, right) =>
+                    Date.parse(right.createdAt) - Date.parse(left.createdAt),
+            );
+
+            const totalPollen = grants.reduce(
+                (total, grant) => total + grant.amount,
+                0,
+            );
+
+            return c.json({ totalPollen, grants });
         },
     )
     .get(

--- a/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
+++ b/enter.pollinations.ai/src/tier-progression/shared/quest-grant-pollen.ts
@@ -110,14 +110,47 @@ const grantCommand = command({
             UPDATE user
             SET pack_balance = COALESCE(pack_balance, 0) + ${amount}
             WHERE id = ${sqlString(user.id)} AND changes() = 1;
+            INSERT OR IGNORE INTO reward_grants (
+                id,
+                idempotency_key,
+                user_id,
+                source,
+                quest_id,
+                amount,
+                balance_bucket,
+                source_ref,
+                metadata_json,
+                created_at
+            )
+            SELECT
+                ${sqlString(crypto.randomUUID())},
+                ${sqlString(payoutKey)},
+                ${sqlString(user.id)},
+                'code_quest',
+                ${sqlString(`github:${questIssue}`)},
+                ${amount},
+                'pack',
+                ${sqlString(`pr:${prNumber}`)},
+                ${sqlString(
+                    JSON.stringify({
+                        questIssueNumber: questIssue,
+                        prNumber,
+                        role: "assignee",
+                        githubUsername: user.github_username,
+                    }),
+                )},
+                ${Date.now()}
+            WHERE changes() = 1;
         `;
 
         const raw = queryD1(env, sql);
         const result = JSON.parse(raw);
         const insertResult = Array.isArray(result) ? result[0] : result;
         const updateResult = Array.isArray(result) ? result[1] : null;
+        const grantResult = Array.isArray(result) ? result[2] : null;
         const inserted = Number(insertResult?.meta?.changes ?? 0);
         const updated = Number(updateResult?.meta?.changes ?? 0);
+        const grantInserted = Number(grantResult?.meta?.changes ?? 0);
         if (inserted === 0) {
             console.log(`DUPLICATE payout_key=${payoutKey}`);
             process.exit(3);
@@ -130,7 +163,7 @@ const grantCommand = command({
 
         const previous = user.pack_balance ?? 0;
         console.log(
-            `GRANTED payout_key=${payoutKey} user_id=${user.id} github_username=${user.github_username} previous=${previous} added=${amount} new=${previous + amount}`,
+            `GRANTED payout_key=${payoutKey} reward_grant=${grantInserted === 1 ? "inserted" : "skipped"} user_id=${user.id} github_username=${user.github_username} previous=${previous} added=${amount} new=${previous + amount}`,
         );
     },
 });

--- a/enter.pollinations.ai/test/reward-grants.test.ts
+++ b/enter.pollinations.ai/test/reward-grants.test.ts
@@ -1,0 +1,147 @@
+import { env, SELF } from "cloudflare:test";
+import { grantReward } from "@shared/billing/reward-grants.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+async function getOnlyUser() {
+    const db = drizzle(env.DB, { schema });
+    const users = await db
+        .select({
+            id: schema.user.id,
+            packBalance: schema.user.packBalance,
+        })
+        .from(schema.user)
+        .limit(1);
+
+    const user = users[0];
+    if (!user) throw new Error("Expected fixture user");
+    return user;
+}
+
+test("grantReward credits once and appears in account quest history", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await getOnlyUser();
+
+    const first = await grantReward(db, {
+        idempotencyKey: `quest:first_api_key:${user.id}`,
+        userId: user.id,
+        source: "onboarding",
+        questId: "onboarding:first_api_key",
+        amount: 0.5,
+        balanceBucket: "pack",
+        sourceRef: "apikey:test",
+        metadata: { title: "Create first API key" },
+    });
+    expect(first.granted).toBe(true);
+    expect(first.newBalance).toBeCloseTo((user.packBalance ?? 0) + 0.5);
+
+    const duplicate = await grantReward(db, {
+        idempotencyKey: `quest:first_api_key:${user.id}`,
+        userId: user.id,
+        source: "onboarding",
+        questId: "onboarding:first_api_key",
+        amount: 0.5,
+        balanceBucket: "pack",
+        sourceRef: "apikey:test",
+        metadata: { title: "Create first API key" },
+    });
+    expect(duplicate.granted).toBe(false);
+
+    const [balance] = await db
+        .select({ packBalance: schema.user.packBalance })
+        .from(schema.user)
+        .where(eq(schema.user.id, user.id));
+    expect(balance?.packBalance).toBeCloseTo((user.packBalance ?? 0) + 0.5);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/quests",
+        {
+            headers: {
+                cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+        totalPollen: number;
+        grants: {
+            idempotencyKey: string;
+            source: string;
+            questId: string | null;
+            amount: number;
+            balanceBucket: string;
+            metadata: { title?: string } | null;
+            legacy: boolean;
+        }[];
+    };
+
+    expect(payload.totalPollen).toBeCloseTo(0.5);
+    expect(payload.grants).toHaveLength(1);
+    expect(payload.grants[0]).toMatchObject({
+        idempotencyKey: `quest:first_api_key:${user.id}`,
+        source: "onboarding",
+        questId: "onboarding:first_api_key",
+        amount: 0.5,
+        balanceBucket: "pack",
+        legacy: false,
+    });
+    expect(payload.grants[0]?.metadata?.title).toBe("Create first API key");
+});
+
+test("account quest history includes legacy GitHub quest payouts", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await getOnlyUser();
+    const payoutKey = "quest:123:gh:456:role:assignee";
+
+    await db.insert(schema.questPayoutCredits).values({
+        payoutKey,
+        questIssueNumber: 123,
+        prNumber: 789,
+        role: "assignee",
+        githubUsername: "octocat",
+        userId: user.id,
+        pollenCredited: 5,
+        createdAt: new Date(),
+    });
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/quests",
+        {
+            headers: {
+                cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+        totalPollen: number;
+        grants: {
+            idempotencyKey: string;
+            questId: string | null;
+            amount: number;
+            legacy: boolean;
+            questIssueNumber: number | null;
+            prNumber: number | null;
+        }[];
+    };
+
+    expect(payload.totalPollen).toBe(5);
+    expect(payload.grants).toHaveLength(1);
+    expect(payload.grants[0]).toMatchObject({
+        idempotencyKey: payoutKey,
+        questId: "github:123",
+        amount: 5,
+        legacy: true,
+        questIssueNumber: 123,
+        prNumber: 789,
+    });
+});

--- a/shared/billing/reward-grants.ts
+++ b/shared/billing/reward-grants.ts
@@ -1,0 +1,106 @@
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type * as schema from "../db/better-auth.ts";
+import { rewardGrants as rewardGrantsTable } from "../db/better-auth.ts";
+import { atomicCreditUserBalance, type Bucket } from "./deduction.ts";
+
+export type RewardGrantSource =
+    | "code_quest"
+    | "quest"
+    | "onboarding"
+    | "spend"
+    | "manual";
+
+export type RewardGrantInput = {
+    idempotencyKey: string;
+    userId: string;
+    source: RewardGrantSource | string;
+    amount: number;
+    balanceBucket: Bucket;
+    questId?: string | null;
+    sourceRef?: string | null;
+    metadata?: Record<string, unknown> | null;
+};
+
+export type RewardGrantResult = {
+    granted: boolean;
+    idempotencyKey: string;
+    grantId?: string;
+    newBalance?: number | null;
+};
+
+type AuthDb = DrizzleD1Database<typeof schema>;
+
+function requireNonEmpty(value: string, name: string): void {
+    if (value.trim().length === 0) {
+        throw new Error(`${name} is required`);
+    }
+}
+
+function serializeMetadata(
+    metadata: RewardGrantInput["metadata"],
+): string | null {
+    if (!metadata) return null;
+    return JSON.stringify(metadata);
+}
+
+export async function grantReward(
+    db: AuthDb | DrizzleD1Database,
+    input: RewardGrantInput,
+): Promise<RewardGrantResult> {
+    requireNonEmpty(input.idempotencyKey, "idempotencyKey");
+    requireNonEmpty(input.userId, "userId");
+    requireNonEmpty(input.source, "source");
+
+    if (!Number.isFinite(input.amount) || input.amount <= 0) {
+        throw new Error(
+            `amount must be a positive number, got ${input.amount}`,
+        );
+    }
+
+    const grantId = crypto.randomUUID();
+    const rows = await (db as AuthDb)
+        .insert(rewardGrantsTable)
+        .values({
+            id: grantId,
+            idempotencyKey: input.idempotencyKey,
+            userId: input.userId,
+            source: input.source,
+            questId: input.questId ?? null,
+            amount: input.amount,
+            balanceBucket: input.balanceBucket,
+            sourceRef: input.sourceRef ?? null,
+            metadataJson: serializeMetadata(input.metadata),
+            createdAt: new Date(),
+        })
+        .onConflictDoNothing({
+            target: rewardGrantsTable.idempotencyKey,
+        })
+        .returning({ id: rewardGrantsTable.id });
+
+    if (rows.length === 0) {
+        return {
+            granted: false,
+            idempotencyKey: input.idempotencyKey,
+        };
+    }
+
+    const credit = await atomicCreditUserBalance(
+        db as DrizzleD1Database,
+        input.userId,
+        input.balanceBucket,
+        input.amount,
+    );
+
+    if (!credit.ok) {
+        throw new Error(
+            `Reward grant inserted but balance credit failed for user ${input.userId}`,
+        );
+    }
+
+    return {
+        granted: true,
+        idempotencyKey: input.idempotencyKey,
+        grantId,
+        newBalance: credit.newBalance,
+    };
+}

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -6,7 +6,14 @@
 // and re-generating the schema including the indexes.
 
 import { relations, sql } from "drizzle-orm";
-import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -250,3 +257,32 @@ export const questPayoutCredits = sqliteTable("quest_payout_credits", {
   index("idx_quest_payout_credits_user_id").on(table.userId),
   index("idx_quest_payout_credits_quest_issue").on(table.questIssueNumber),
 ]);
+
+export const rewardGrants = sqliteTable("reward_grants", {
+  id: text("id").primaryKey(),
+  idempotencyKey: text("idempotency_key").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  source: text("source").notNull(),
+  questId: text("quest_id"),
+  amount: real("amount").notNull(),
+  balanceBucket: text("balance_bucket").notNull(),
+  sourceRef: text("source_ref"),
+  metadataJson: text("metadata_json"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+}, (table) => [
+  uniqueIndex("idx_reward_grants_idempotency_key").on(table.idempotencyKey),
+  index("idx_reward_grants_user_id").on(table.userId),
+  index("idx_reward_grants_source").on(table.source),
+  index("idx_reward_grants_quest_id").on(table.questId),
+]);
+
+export const rewardGrantsRelations = relations(rewardGrants, ({ one }) => ({
+  user: one(user, {
+    fields: [rewardGrants.userId],
+    references: [user.id],
+  }),
+}));


### PR DESCRIPTION
- Adds a source-agnostic D1 reward_grants table and shared grantReward() helper for idempotent balance credits.
- Adds /api/account/quests to return generic quest grants plus legacy quest_payout_credits rows.
- Dual-writes GitHub code quest payouts into reward_grants while preserving the existing quest_payout_credits guard.
- Adds focused coverage for idempotent grants and legacy quest history.

Validation:
- npm run decrypt-vars && npx vitest run test/reward-grants.test.ts
- npm run typecheck