### PR TITLE
feat: add systematic quest rollout

### DIFF
--- a/enter.pollinations.ai/src/api.ts
+++ b/enter.pollinations.ai/src/api.ts
@@ -3,6 +3,7 @@ import { createAuth } from "./auth.ts";
 import type { Env } from "./env.ts";
 import { frontendApi } from "./frontend-api.ts";
 import { adminRoutes } from "./routes/admin.ts";
+import { questsRoutes } from "./routes/quests.ts";
 import { stripeWebhooksRoutes } from "./routes/stripe-webhooks.ts";
 
 const authRoutes = new Hono<Env>().on(["GET", "POST"], "*", async (c) => {
@@ -12,6 +13,7 @@ const authRoutes = new Hono<Env>().on(["GET", "POST"], "*", async (c) => {
 export const api = new Hono<Env>()
     .route("/auth", authRoutes)
     .route("/", frontendApi)
+    .route("/quests", questsRoutes)
     .route("/webhooks", stripeWebhooksRoutes)
     .route("/admin", adminRoutes);
 

--- a/enter.pollinations.ai/src/index.ts
+++ b/enter.pollinations.ai/src/index.ts
@@ -9,6 +9,7 @@ import { api } from "./api.ts";
 import type { Env } from "./env.ts";
 import { logger } from "./middleware/logger.ts";
 import { createDocsRoutes } from "./routes/docs.ts";
+import { runQuestEvaluator } from "./services/quest-evaluator.ts";
 import { runTierRefill } from "./services/tier-refill.ts";
 
 function stripTrailingSlash(path: string): string {
@@ -94,5 +95,10 @@ export default {
         ctx: ExecutionContext,
     ) {
         await runTierRefill(env, ctx);
+        ctx.waitUntil(
+            runQuestEvaluator(env).catch((error) => {
+                console.error("QUEST_EVALUATOR_FAILED", error);
+            }),
+        );
     },
 } satisfies ExportedHandler<CloudflareBindings>;

--- a/enter.pollinations.ai/src/routes/admin.ts
+++ b/enter.pollinations.ai/src/routes/admin.ts
@@ -12,6 +12,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "../env.ts";
 import { runD1TinybirdSync } from "../services/d1-tinybird-sync.ts";
+import { runQuestEvaluator } from "../services/quest-evaluator.ts";
 import { runTierRefill } from "../services/tier-refill.ts";
 
 const log = getLogger(["hono", "admin"]);
@@ -120,6 +121,10 @@ export const adminRoutes = new Hono<Env>()
     })
     .post("/trigger-refill", async (c) => {
         const result = await runTierRefill(c.env, c.executionCtx);
+        return c.json(result);
+    })
+    .post("/trigger-quest-evaluator", async (c) => {
+        const result = await runQuestEvaluator(c.env);
         return c.json(result);
     })
     .post("/trigger-d1-sync", async (c) => {

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,0 +1,42 @@
+import { QUEST_DEFINITIONS } from "@shared/quests/definitions.ts";
+import { Hono } from "hono";
+import { describeRoute, resolver } from "hono-openapi";
+import { z } from "zod";
+import type { Env } from "../env.ts";
+
+const questDefinitionSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    category: z.string(),
+    status: z.string(),
+    trigger: z.string(),
+    rewardAmount: z.number(),
+    balanceBucket: z.string(),
+    repeatability: z.string(),
+});
+
+const questCatalogResponseSchema = z.object({
+    quests: z.array(questDefinitionSchema),
+});
+
+export const questsRoutes = new Hono<Env>().get(
+    "/",
+    describeRoute({
+        tags: ["Quests"],
+        summary: "List Quests",
+        description:
+            "Returns the checked-in quest catalog. Active quests are grantable by the current evaluator; planned quests are visible but not yet auto-granted.",
+        responses: {
+            200: {
+                description: "Quest catalog",
+                content: {
+                    "application/json": {
+                        schema: resolver(questCatalogResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    (c) => c.json({ quests: QUEST_DEFINITIONS }),
+);

--- a/enter.pollinations.ai/src/services/quest-evaluator.ts
+++ b/enter.pollinations.ai/src/services/quest-evaluator.ts
@@ -1,0 +1,126 @@
+import { getLogger } from "@logtape/logtape";
+import { grantReward } from "@shared/billing/reward-grants.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { getQuestDefinition } from "@shared/quests/definitions.ts";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+
+const log = getLogger(["enter", "quest-evaluator"]);
+const MAX_GRANTS_PER_RUN = 500;
+
+type Candidate = {
+    user_id: string;
+    source_ref: string | null;
+};
+
+type QuestEvaluatorResult = {
+    questId: string;
+    scanned: number;
+    granted: number;
+};
+
+function questGrantKey(questId: string, userId: string): string {
+    return `quest:${questId}:user:${userId}`;
+}
+
+async function grantCandidates({
+    db,
+    questId,
+    source,
+    candidates,
+}: {
+    db: ReturnType<typeof drizzle<typeof schema>>;
+    questId: string;
+    source: "onboarding" | "spend";
+    candidates: Candidate[];
+}): Promise<QuestEvaluatorResult> {
+    const definition = getQuestDefinition(questId);
+    if (!definition) {
+        throw new Error(`Unknown quest definition: ${questId}`);
+    }
+
+    let granted = 0;
+    for (const candidate of candidates) {
+        const result = await grantReward(db, {
+            idempotencyKey: questGrantKey(questId, candidate.user_id),
+            userId: candidate.user_id,
+            source,
+            questId,
+            amount: definition.rewardAmount,
+            balanceBucket: definition.balanceBucket,
+            sourceRef: candidate.source_ref,
+            metadata: {
+                title: definition.title,
+                category: definition.category,
+                trigger: definition.trigger,
+            },
+        });
+        if (result.granted) granted += 1;
+    }
+
+    return {
+        questId,
+        scanned: candidates.length,
+        granted,
+    };
+}
+
+async function findFirstApiKeyCandidates(
+    db: ReturnType<typeof drizzle<typeof schema>>,
+): Promise<Candidate[]> {
+    return await db.all<Candidate>(
+        sql`
+        SELECT
+            apikey.user_id,
+            MIN(apikey.id) AS source_ref
+        FROM apikey
+        LEFT JOIN reward_grants
+            ON reward_grants.idempotency_key =
+                'quest:onboarding:first_api_key:user:' || apikey.user_id
+        WHERE reward_grants.id IS NULL
+        GROUP BY apikey.user_id
+        LIMIT ${MAX_GRANTS_PER_RUN}`,
+    );
+}
+
+async function findFirstTopUpCandidates(
+    db: ReturnType<typeof drizzle<typeof schema>>,
+): Promise<Candidate[]> {
+    return await db.all<Candidate>(
+        sql`
+        SELECT
+            stripe_checkout_credits.user_id,
+            MIN(stripe_checkout_credits.session_id) AS source_ref
+        FROM stripe_checkout_credits
+        LEFT JOIN reward_grants
+            ON reward_grants.idempotency_key =
+                'quest:spend:first_top_up:user:' ||
+                stripe_checkout_credits.user_id
+        WHERE reward_grants.id IS NULL
+        GROUP BY stripe_checkout_credits.user_id
+        LIMIT ${MAX_GRANTS_PER_RUN}`,
+    );
+}
+
+export async function runQuestEvaluator(
+    env: CloudflareBindings,
+): Promise<{ success: true; results: QuestEvaluatorResult[] }> {
+    const db = drizzle(env.DB, { schema });
+    const results = [
+        await grantCandidates({
+            db,
+            questId: "onboarding:first_api_key",
+            source: "onboarding",
+            candidates: await findFirstApiKeyCandidates(db),
+        }),
+        await grantCandidates({
+            db,
+            questId: "spend:first_top_up",
+            source: "spend",
+            candidates: await findFirstTopUpCandidates(db),
+        }),
+    ];
+
+    log.info("QUEST_EVALUATOR_COMPLETE: results={results}", { results });
+    return { success: true, results };
+}

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -1,0 +1,102 @@
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { runQuestEvaluator } from "@/services/quest-evaluator.ts";
+import { test } from "./fixtures.ts";
+
+async function getOnlyUser() {
+    const db = drizzle(env.DB, { schema });
+    const users = await db
+        .select({
+            id: schema.user.id,
+            packBalance: schema.user.packBalance,
+        })
+        .from(schema.user)
+        .limit(1);
+
+    const user = users[0];
+    if (!user) throw new Error("Expected fixture user");
+    return user;
+}
+
+test("GET /api/quests returns the checked-in quest catalog", async () => {
+    const response = await SELF.fetch("http://localhost:3000/api/quests");
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+        quests: {
+            id: string;
+            status: string;
+            rewardAmount: number;
+            balanceBucket: string;
+        }[];
+    };
+
+    expect(payload.quests.map((quest) => quest.id)).toEqual([
+        "onboarding:first_api_key",
+        "spend:first_top_up",
+        "onboarding:first_chat_completion",
+        "onboarding:first_image_generation",
+    ]);
+    expect(
+        payload.quests.filter((quest) => quest.status === "active"),
+    ).toHaveLength(2);
+});
+
+test("quest evaluator grants D1-backed product quests once", async ({
+    apiKey: _apiKey,
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await getOnlyUser();
+
+    await db.insert(schema.stripeCheckoutCredits).values({
+        sessionId: "cs_first_top_up",
+        eventId: "evt_first_top_up",
+        eventType: "checkout.session.completed",
+        userId: user.id,
+        pollenCredited: 10,
+        createdAt: new Date(),
+    });
+
+    const firstRun = await runQuestEvaluator(env);
+    expect(firstRun.results).toEqual([
+        { questId: "onboarding:first_api_key", scanned: 1, granted: 1 },
+        { questId: "spend:first_top_up", scanned: 1, granted: 1 },
+    ]);
+
+    const secondRun = await runQuestEvaluator(env);
+    expect(secondRun.results).toEqual([
+        { questId: "onboarding:first_api_key", scanned: 0, granted: 0 },
+        { questId: "spend:first_top_up", scanned: 0, granted: 0 },
+    ]);
+
+    const [balance] = await db
+        .select({ packBalance: schema.user.packBalance })
+        .from(schema.user)
+        .where(eq(schema.user.id, user.id));
+    expect(balance?.packBalance).toBeCloseTo((user.packBalance ?? 0) + 2.5);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/quests",
+        {
+            headers: {
+                cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+        totalPollen: number;
+        grants: { questId: string | null; amount: number }[];
+    };
+
+    expect(payload.totalPollen).toBeCloseTo(2.5);
+    expect(payload.grants.map((grant) => grant.questId).sort()).toEqual([
+        "onboarding:first_api_key",
+        "spend:first_top_up",
+    ]);
+});

--- a/shared/quests/definitions.ts
+++ b/shared/quests/definitions.ts
@@ -1,0 +1,81 @@
+import type { Bucket } from "../billing/deduction.ts";
+
+export type QuestCategory =
+    | "onboarding"
+    | "spend"
+    | "build"
+    | "grow"
+    | "engage";
+export type QuestStatus = "active" | "planned";
+export type QuestTrigger =
+    | "api_key_created"
+    | "first_top_up"
+    | "first_chat_completion"
+    | "first_image_generation";
+
+export type QuestDefinition = {
+    id: string;
+    title: string;
+    description: string;
+    category: QuestCategory;
+    status: QuestStatus;
+    trigger: QuestTrigger;
+    rewardAmount: number;
+    balanceBucket: Bucket;
+    repeatability: "once";
+};
+
+export const QUEST_DEFINITIONS: QuestDefinition[] = [
+    {
+        id: "onboarding:first_api_key",
+        title: "Create your first API key",
+        description: "Create a Pollinations API key from your account.",
+        category: "onboarding",
+        status: "active",
+        trigger: "api_key_created",
+        rewardAmount: 0.5,
+        balanceBucket: "pack",
+        repeatability: "once",
+    },
+    {
+        id: "spend:first_top_up",
+        title: "Make your first top-up",
+        description: "Buy your first Pollen pack.",
+        category: "spend",
+        status: "active",
+        trigger: "first_top_up",
+        rewardAmount: 2,
+        balanceBucket: "pack",
+        repeatability: "once",
+    },
+    {
+        id: "onboarding:first_chat_completion",
+        title: "Run your first chat completion",
+        description: "Send a successful chat completion request.",
+        category: "onboarding",
+        status: "planned",
+        trigger: "first_chat_completion",
+        rewardAmount: 0.5,
+        balanceBucket: "pack",
+        repeatability: "once",
+    },
+    {
+        id: "onboarding:first_image_generation",
+        title: "Generate your first image",
+        description: "Send a successful image generation request.",
+        category: "onboarding",
+        status: "planned",
+        trigger: "first_image_generation",
+        rewardAmount: 0.5,
+        balanceBucket: "pack",
+        repeatability: "once",
+    },
+];
+
+export function getQuestDefinition(id: string): QuestDefinition | undefined {
+    return QUEST_DEFINITIONS.find((quest) => quest.id === id);
+}
+
+export function activeQuestDefinitions(): QuestDefinition[] {
+    return QUEST_DEFINITIONS.filter((quest) => quest.status === "active");
+}


### PR DESCRIPTION
- Builds on #11849.
- Adds a checked-in quest catalog exposed at /api/quests.
- Adds an Enter-side quest evaluator for D1-backed product quests: first API key and first top-up.
- Wires the evaluator into the scheduled worker and adds an admin trigger.
- Keeps Tinybird usage-trigger automation deferred to the next stack layer.

Validation:
- npm run decrypt-vars && npx vitest run test/quests.test.ts test/reward-grants.test.ts
- npm run typecheck