### PR TITLE
feat(quests): reward_grants snapshot + accounting pipe + read route [Plan B]

### DIFF
--- a/enter.pollinations.ai/observability/datasources/d1_reward_grants.datasource
+++ b/enter.pollinations.ai/observability/datasources/d1_reward_grants.datasource
@@ -1,0 +1,22 @@
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+    Daily snapshot of the D1 reward_grants table (discrete pollen grants:
+    code quests, product quests, onboarding, referrals, manual credits).
+    Source of truth stays in D1; this snapshot makes grants queryable for
+    accounting/analytics pipes alongside the other d1_* snapshots.
+
+SCHEMA >
+    `id` String `json:$.id`,
+    `user_id` String `json:$.user_id`,
+    `source` String `json:$.source`,
+    `quest_id` Nullable(String) `json:$.quest_id`,
+    `pollen_credited` Float64 `json:$.pollen_credited`,
+    `balance_bucket` String `json:$.balance_bucket`,
+    `source_ref` Nullable(String) `json:$.source_ref`,
+    `created_at` Nullable(Int64) `json:$.created_at`,
+    `synced_at` DateTime `json:$.synced_at`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(synced_at)"
+ENGINE_SORTING_KEY "id"

--- a/enter.pollinations.ai/observability/endpoints/reward_grants_summary.pipe
+++ b/enter.pollinations.ai/observability/endpoints/reward_grants_summary.pipe
@@ -1,0 +1,38 @@
+DESCRIPTION >
+    Per-user grant-style reward totals (quests, onboarding, referrals, manual
+    credits) from the latest d1_reward_grants snapshot. Returns one row per
+    (source, balance_bucket) with grant count and pollen totals, plus a global
+    rollup row (empty source). Pairs with developer_earnings (generation-tied
+    BYOP/community earnings) to give a complete "all rewards" accounting view.
+    Required param: user_id.
+
+TOKEN tinybird_read READ
+
+NODE latest_grants
+SQL >
+    %
+    SELECT
+        source,
+        balance_bucket,
+        pollen_credited
+    FROM d1_reward_grants
+    WHERE user_id = {{String(user_id, '')}}
+      AND synced_at = (SELECT max(synced_at) FROM d1_reward_grants)
+
+# GROUPING SETS emits, in one scan:
+#   (source, balance_bucket) -> per-source/per-bucket totals
+#   ()                       -> global rollup (source='', balance_bucket='')
+NODE reward_grants_summary_node
+SQL >
+    SELECT
+        source,
+        balance_bucket,
+        count() AS grants,
+        sum(pollen_credited) AS pollen_total
+    FROM latest_grants
+    GROUP BY GROUPING SETS (
+        (source, balance_bucket),
+        ()
+    )
+
+TYPE endpoint

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1293,6 +1293,87 @@ export const accountRoutes = new Hono<Env>()
         },
     )
     .get(
+        "/quests",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "Get Reward Grant Totals",
+            description:
+                "Returns grant-style reward totals for the current user (code quests, product quests, onboarding, referrals, manual credits) grouped by source and balance bucket, plus a global rollup. Reads the daily d1_reward_grants snapshot, so totals lag live grants by up to ~24h (the credited balance itself is always live). Cached for 1 hour.",
+            responses: {
+                200: {
+                    description:
+                        "Per-source reward grant totals + global rollup",
+                },
+                401: { description: "Unauthorized" },
+            },
+        }),
+        async (c) => {
+            const log = c.get("log").getChild("quests");
+
+            await c.var.auth.requireAuthorization({
+                message: "Authentication required to view quest rewards",
+            });
+            const user = c.var.auth.requireUser();
+
+            type RewardGrantsSummaryRow = {
+                source: string;
+                balance_bucket: string;
+                grants: number;
+                pollen_total: number;
+            };
+            type QuestRewardsPayload = {
+                bySource: RewardGrantsSummaryRow[];
+                global: RewardGrantsSummaryRow | null;
+            };
+
+            const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
+            const tinybirdToken = requireTinybirdReadToken(c.env);
+            const kv = c.env.KV;
+            const cacheKey = `quests:v1:${user.id}`;
+
+            try {
+                let payload = await kv
+                    .get<QuestRewardsPayload>(cacheKey, "json")
+                    .catch((err) => {
+                        log.trace("KV get error: {err}", { err });
+                        return null;
+                    });
+
+                if (!payload) {
+                    const rows =
+                        await fetchTinybirdRows<RewardGrantsSummaryRow>(
+                            tinybirdOrigin,
+                            "/v0/pipes/reward_grants_summary.json",
+                            tinybirdToken,
+                            { user_id: user.id },
+                        );
+                    // Global rollup row has empty source (and empty bucket).
+                    const global = rows.find((r) => r.source === "") ?? null;
+                    const bySource = rows
+                        .filter((r) => r.source !== "")
+                        .sort((a, b) => b.pollen_total - a.pollen_total);
+                    payload = { bySource, global };
+
+                    try {
+                        await kv.put(cacheKey, JSON.stringify(payload), {
+                            expirationTtl: CACHE_TTL,
+                        });
+                    } catch (err) {
+                        log.trace("KV put error: {err}", { err });
+                    }
+                }
+
+                return c.json(payload);
+            } catch (error) {
+                log.error("Error fetching quest rewards: {error}", { error });
+                return c.json(
+                    { error: "Failed to fetch quest reward data" },
+                    500,
+                );
+            }
+        },
+    )
+    .get(
         "/keys",
         describeRoute({
             tags: ["👤 Account"],

--- a/enter.pollinations.ai/src/services/d1-tinybird-sync.ts
+++ b/enter.pollinations.ai/src/services/d1-tinybird-sync.ts
@@ -52,6 +52,12 @@ const TABLES: TableConfig[] = [
                        refresh_token_expires_at, scope, created_at, updated_at
                 FROM account`,
     },
+    {
+        datasource: "d1_reward_grants",
+        query: `SELECT id, user_id, source, quest_id, pollen_credited, balance_bucket,
+                       source_ref, created_at
+                FROM reward_grants`,
+    },
 ];
 
 /** Delete rows matching a condition from a Tinybird datasource. */


### PR DESCRIPTION
**Stacked PR 2 of 3** — base is **Plan A (#11850)**, not main. Review/merge A first.

> ⚠️ Independent voodoo/ track (a separate agent explores `codex/quest-reward-grants-floor`).

## Why
Plan A records grants in D1 (balance is live). Plan B makes them **queryable/visible** for accounting + dashboards — reusing the existing daily `d1_*` snapshot mechanism, so **no new ingest path and no real-time dual-write**.

## What
- Add `reward_grants` to `d1-tinybird-sync.ts` `TABLES` (safe columns + injected `synced_at`) → 03:00 UTC cron snapshots it append-then-delete like `d1_user`.
- Add **`d1_reward_grants.datasource`** (MergeTree, `partition toYYYYMM(synced_at)`).
- Add **`reward_grants_summary.pipe`**: per-user totals by `source`/`balance_bucket` + global rollup (GROUPING SETS), parameterized by `user_id` — mirrors `developer_earnings`. Pairs with `developer_earnings` (generation-tied BYOP/community) for a full "all rewards" view.
- Add **`GET /account/quests`** read route: auth + fetch pipe + KV-cache 1h (mirrors `/account/earnings`).

## Tests
`npx vitest run test/account-earnings.test.ts test/integration/grant-reward.test.ts` → **6/6 pass**. Worker typechecks clean (pre-existing `@pollinations/ui` frontend errors are unrelated).

## Deploy note
The `.datasource` + `.pipe` must deploy to **staging first, then prod, both workspaces** (`pollinations_enter` + `pollinations_enter_staging`) per the Tinybird safety rules — no CI auto-deploy yet.

## Tradeoff
Up to ~24h analytics latency (the daily snapshot). The **credited balance is always live** in D1; only the accounting view lags. Plan C adds real-time `reward_grant` events if live quest UI is needed.

Addresses #11377, #11109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)