### PR TITLE
feat(quests): real-time reward_grant events + quest_definitions catalog [Plan C]

### DIFF
--- a/enter.pollinations.ai/drizzle/0028_icy_rick_jones.sql
+++ b/enter.pollinations.ai/drizzle/0028_icy_rick_jones.sql
@@ -5,7 +5,7 @@ CREATE TABLE `quest_definitions` (
 	`category` text,
 	`trigger_type` text NOT NULL,
 	`reward_amount` real NOT NULL,
-	`balance_bucket` text DEFAULT 'tier' NOT NULL,
+	`balance_bucket` text DEFAULT 'pack' NOT NULL,
 	`repeatability` text DEFAULT 'once' NOT NULL,
 	`active` integer DEFAULT true NOT NULL,
 	`criteria_json` text,

--- a/enter.pollinations.ai/drizzle/0028_ordinary_proteus.sql
+++ b/enter.pollinations.ai/drizzle/0028_ordinary_proteus.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `quest_definitions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`key` text NOT NULL,
+	`title` text NOT NULL,
+	`category` text,
+	`trigger_type` text NOT NULL,
+	`reward_amount` real NOT NULL,
+	`balance_bucket` text DEFAULT 'tier' NOT NULL,
+	`repeatability` text DEFAULT 'once' NOT NULL,
+	`active` integer DEFAULT true NOT NULL,
+	`criteria_json` text,
+	`created_at` integer DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `quest_definitions_key_unique` ON `quest_definitions` (`key`);--> statement-breakpoint
+CREATE INDEX `idx_quest_definitions_trigger_type` ON `quest_definitions` (`trigger_type`);

--- a/enter.pollinations.ai/drizzle/meta/0028_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0028_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "10f18b3b-413f-4c45-b033-7bf924fddbce",
+  "id": "dddff182-50d9-4af8-b5d4-4ce9d3131778",
   "prevId": "8f529aac-b0c1-41a3-8b67-681ccebcd264",
   "tables": {
     "account": {
@@ -493,7 +493,7 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "'tier'"
+          "default": "'pack'"
         },
         "repeatability": {
           "name": "repeatability",

--- a/enter.pollinations.ai/drizzle/meta/0028_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,1311 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "10f18b3b-413f-4c45-b033-7bf924fddbce",
+  "prevId": "8f529aac-b0c1-41a3-8b67-681ccebcd264",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quest_definitions": {
+      "name": "quest_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reward_amount": {
+          "name": "reward_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'tier'"
+        },
+        "repeatability": {
+          "name": "repeatability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'once'"
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "criteria_json": {
+          "name": "criteria_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "quest_definitions_key_unique": {
+          "name": "quest_definitions_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_quest_definitions_trigger_type": {
+          "name": "idx_quest_definitions_trigger_type",
+          "columns": [
+            "trigger_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quest_payout_credits": {
+      "name": "quest_payout_credits",
+      "columns": {
+        "payout_key": {
+          "name": "payout_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_issue_number": {
+          "name": "quest_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_quest_payout_credits_user_id": {
+          "name": "idx_quest_payout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_quest_payout_credits_quest_issue": {
+          "name": "idx_quest_payout_credits_quest_issue",
+          "columns": [
+            "quest_issue_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "quest_payout_credits_user_id_user_id_fk": {
+          "name": "quest_payout_credits_user_id_user_id_fk",
+          "tableFrom": "quest_payout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reward_grants": {
+      "name": "reward_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "reward_grants_idempotency_key_unique": {
+          "name": "reward_grants_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_reward_grants_user_id": {
+          "name": "idx_reward_grants_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reward_grants_source": {
+          "name": "idx_reward_grants_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reward_grants_user_id_user_id_fk": {
+          "name": "reward_grants_user_id_user_id_fk",
+          "tableFrom": "reward_grants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -201,8 +201,8 @@
     {
       "idx": 28,
       "version": "6",
-      "when": 1781658408930,
-      "tag": "0028_ordinary_proteus",
+      "when": 1781661072650,
+      "tag": "0028_icy_rick_jones",
       "breakpoints": true
     }
   ]

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1781657696502,
       "tag": "0027_whole_tomas",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1781658408930,
+      "tag": "0028_ordinary_proteus",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/observability/datasources/reward_grant.datasource
+++ b/enter.pollinations.ai/observability/datasources/reward_grant.datasource
@@ -1,0 +1,21 @@
+TOKEN tinybird_ingest APPEND
+
+DESCRIPTION >
+    Real-time reward grant events (analytics only). Emitted from worker context
+    after grantReward() succeeds, so live quest dashboards don't wait for the
+    daily d1_reward_grants snapshot. The authoritative grant lives in D1
+    reward_grants; this is a derived, append-only event log.
+
+SCHEMA >
+    `environment` LowCardinality(String) `json:$.environment` DEFAULT 'undefined',
+    `user_id` String `json:$.user_id`,
+    `source` String `json:$.source`,
+    `quest_id` Nullable(String) `json:$.quest_id`,
+    `pollen_credited` Float64 `json:$.pollen_credited`,
+    `balance_bucket` String `json:$.balance_bucket`,
+    `source_ref` Nullable(String) `json:$.source_ref`,
+    `timestamp` DateTime `json:$.timestamp`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "timestamp, environment, source"

--- a/enter.pollinations.ai/test/integration/check-and-grant-quest.test.ts
+++ b/enter.pollinations.ai/test/integration/check-and-grant-quest.test.ts
@@ -136,6 +136,40 @@ describe("checkAndGrantQuest", () => {
         expect(balance.tierBalance).toBe(0);
     });
 
+    test("credits the pack bucket by default (no explicit balance_bucket)", async () => {
+        const db = drizzle(env.DB);
+        const userId = "cq-user-default-bucket";
+        await seedUser(db, userId);
+        // seedDef sets balanceBucket: "tier" by default in this helper, so
+        // override it to undefined to exercise the column default ("pack").
+        await db
+            .insert(questDefinitions)
+            .values({
+                id: "def-default-bucket",
+                key: "default_bucket_quest",
+                title: "default bucket",
+                triggerType: "first_top_up",
+                rewardAmount: 1,
+            })
+            .onConflictDoNothing();
+
+        const results = await checkAndGrantQuest(
+            db,
+            userId,
+            "first_top_up",
+            ctx,
+        );
+
+        expect(
+            results.some(
+                (r) => r.questKey === "default_bucket_quest" && r.granted,
+            ),
+        ).toBe(true);
+        const balance = await getUserBalance(db, userId);
+        expect(balance.packBalance).toBe(1);
+        expect(balance.tierBalance).toBe(0);
+    });
+
     test("skips non-once repeatability (not yet supported) without granting", async () => {
         const db = drizzle(env.DB);
         const userId = "cq-user-4";

--- a/enter.pollinations.ai/test/integration/check-and-grant-quest.test.ts
+++ b/enter.pollinations.ai/test/integration/check-and-grant-quest.test.ts
@@ -1,0 +1,156 @@
+import { env } from "cloudflare:test";
+import { getUserBalance } from "@shared/billing/balance.ts";
+import { checkAndGrantQuest } from "@shared/billing/check-and-grant-quest.ts";
+import { questDefinitions, user as userTable } from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
+
+// Minimal logger stub matching the Logger surface checkAndGrantQuest uses.
+const log = {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    trace() {},
+    getChild() {
+        return log;
+    },
+} as unknown as Parameters<typeof checkAndGrantQuest>[3]["log"];
+
+const ctx = { environment: "test", log };
+
+async function seedUser(db: ReturnType<typeof drizzle>, id: string) {
+    await db
+        .insert(userTable)
+        .values({
+            id,
+            email: `${id}@test.com`,
+            name: id,
+            tier: "seed",
+            tierBalance: 0,
+            packBalance: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+            target: userTable.id,
+            set: { tierBalance: 0, packBalance: 0 },
+        });
+}
+
+async function seedDef(
+    db: ReturnType<typeof drizzle>,
+    overrides: Partial<typeof questDefinitions.$inferInsert> & {
+        key: string;
+        triggerType: string;
+        rewardAmount: number;
+    },
+) {
+    await db
+        .insert(questDefinitions)
+        .values({
+            id: `def-${overrides.key}`,
+            title: overrides.key,
+            balanceBucket: "tier",
+            repeatability: "once",
+            active: true,
+            ...overrides,
+        })
+        .onConflictDoNothing();
+}
+
+describe("checkAndGrantQuest", () => {
+    test("grants a matching active quest and credits the user", async () => {
+        const db = drizzle(env.DB);
+        const userId = "cq-user-1";
+        await seedUser(db, userId);
+        await seedDef(db, {
+            key: "first_image",
+            triggerType: "first_image",
+            rewardAmount: 0.5,
+        });
+
+        const results = await checkAndGrantQuest(
+            db,
+            userId,
+            "first_image",
+            ctx,
+        );
+
+        expect(results).toHaveLength(1);
+        expect(results[0]).toEqual({ questKey: "first_image", granted: true });
+
+        const balance = await getUserBalance(db, userId);
+        expect(balance.tierBalance).toBe(0.5);
+    });
+
+    test("is idempotent: re-firing the same trigger does not double-grant", async () => {
+        const db = drizzle(env.DB);
+        const userId = "cq-user-2";
+        await seedUser(db, userId);
+        await seedDef(db, {
+            key: "first_key",
+            triggerType: "key_created",
+            rewardAmount: 0.5,
+        });
+
+        const first = await checkAndGrantQuest(db, userId, "key_created", ctx);
+        const second = await checkAndGrantQuest(db, userId, "key_created", ctx);
+
+        expect(first[0].granted).toBe(true);
+        expect(second[0].granted).toBe(false);
+
+        const balance = await getUserBalance(db, userId);
+        expect(balance.tierBalance).toBe(0.5); // once, not twice
+    });
+
+    test("ignores inactive definitions and unknown triggers", async () => {
+        const db = drizzle(env.DB);
+        const userId = "cq-user-3";
+        await seedUser(db, userId);
+        await seedDef(db, {
+            key: "disabled_quest",
+            triggerType: "first_top_up",
+            rewardAmount: 2,
+            active: false,
+        });
+
+        const matched = await checkAndGrantQuest(
+            db,
+            userId,
+            "first_top_up",
+            ctx,
+        );
+        const unknown = await checkAndGrantQuest(
+            db,
+            userId,
+            "no_such_trigger",
+            ctx,
+        );
+
+        expect(matched).toHaveLength(0);
+        expect(unknown).toHaveLength(0);
+
+        const balance = await getUserBalance(db, userId);
+        expect(balance.tierBalance).toBe(0);
+    });
+
+    test("skips non-once repeatability (not yet supported) without granting", async () => {
+        const db = drizzle(env.DB);
+        const userId = "cq-user-4";
+        await seedUser(db, userId);
+        await seedDef(db, {
+            key: "weekly_streak",
+            triggerType: "streak",
+            rewardAmount: 1,
+            repeatability: "weekly",
+        });
+
+        const results = await checkAndGrantQuest(db, userId, "streak", ctx);
+
+        expect(results).toHaveLength(0);
+        const balance = await getUserBalance(db, userId);
+        expect(balance.tierBalance).toBe(0);
+    });
+});

--- a/shared/billing/check-and-grant-quest.ts
+++ b/shared/billing/check-and-grant-quest.ts
@@ -70,7 +70,7 @@ export async function checkAndGrantQuest(
             source: def.triggerType,
             questId: def.key,
             amount: def.rewardAmount,
-            bucket: (def.balanceBucket as Bucket) ?? "tier",
+            bucket: (def.balanceBucket as Bucket) ?? "pack",
             metadata: { title: def.title, category: def.category },
         });
 
@@ -84,7 +84,7 @@ export async function checkAndGrantQuest(
                     source: def.triggerType,
                     quest_id: def.key,
                     pollen_credited: def.rewardAmount,
-                    balance_bucket: def.balanceBucket ?? "tier",
+                    balance_bucket: def.balanceBucket ?? "pack",
                 },
                 ctx.tinybirdIngestUrl,
                 ctx.tinybirdIngestToken,

--- a/shared/billing/check-and-grant-quest.ts
+++ b/shared/billing/check-and-grant-quest.ts
@@ -1,0 +1,102 @@
+import type { Logger } from "@logtape/logtape";
+import { and, eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { questDefinitions } from "../db/better-auth.ts";
+import { sendRewardGrantEventToTinybird } from "../events.ts";
+import type { Bucket } from "./deduction.ts";
+import { grantReward } from "./grant-reward.ts";
+
+export interface QuestTriggerContext {
+    /** Worker execution context, used to fire the analytics event off the hot path. */
+    waitUntil?: (promise: Promise<unknown>) => void;
+    environment?: string;
+    /** Reference Tinybird ingest URL (the generation_event ingest URL works). */
+    tinybirdIngestUrl?: string;
+    tinybirdIngestToken?: string;
+    log: Logger;
+}
+
+export interface CheckAndGrantQuestResult {
+    questKey: string;
+    granted: boolean;
+}
+
+/**
+ * Data-driven product-quest evaluation: given a trigger signal (e.g.
+ * "first_image"), find the active quest definitions for it and grant any the
+ * user hasn't earned yet. Idempotency is enforced by grantReward() via a
+ * deterministic key "quest:{questKey}:{userId}", so re-firing the same signal
+ * is safe and "once" repeatability falls out for free.
+ *
+ * Worker context only. After a fresh grant, emits a real-time reward_grant
+ * event (via waitUntil, best-effort analytics) so live dashboards don't wait
+ * for the daily d1_reward_grants snapshot. The authoritative record is still
+ * the D1 reward_grants row written by grantReward().
+ */
+export async function checkAndGrantQuest(
+    db: DrizzleD1Database,
+    userId: string,
+    triggerType: string,
+    ctx: QuestTriggerContext,
+): Promise<CheckAndGrantQuestResult[]> {
+    const defs = await db
+        .select()
+        .from(questDefinitions)
+        .where(
+            and(
+                eq(questDefinitions.triggerType, triggerType),
+                eq(questDefinitions.active, true),
+            ),
+        );
+
+    const results: CheckAndGrantQuestResult[] = [];
+
+    for (const def of defs) {
+        // NOTE: this handles "once" repeatability via the deterministic
+        // idempotency key. weekly/streak/tiered quests need a window check
+        // against reward_grants history (or derivation from usage pipes)
+        // before granting — deferred until those quest types ship.
+        if (def.repeatability !== "once") {
+            ctx.log.debug(
+                "Skipping non-once quest {key} (repeatability={repeat} not yet supported)",
+                { key: def.key, repeat: def.repeatability },
+            );
+            continue;
+        }
+
+        const result = await grantReward(db, {
+            idempotencyKey: `quest:${def.key}:${userId}`,
+            userId,
+            source: def.triggerType,
+            questId: def.key,
+            amount: def.rewardAmount,
+            bucket: (def.balanceBucket as Bucket) ?? "tier",
+            metadata: { title: def.title, category: def.category },
+        });
+
+        results.push({ questKey: def.key, granted: result.granted });
+
+        if (result.granted) {
+            const emit = sendRewardGrantEventToTinybird(
+                {
+                    environment: ctx.environment ?? "undefined",
+                    user_id: userId,
+                    source: def.triggerType,
+                    quest_id: def.key,
+                    pollen_credited: def.rewardAmount,
+                    balance_bucket: def.balanceBucket ?? "tier",
+                },
+                ctx.tinybirdIngestUrl,
+                ctx.tinybirdIngestToken,
+                ctx.log,
+            );
+            if (ctx.waitUntil) {
+                ctx.waitUntil(emit);
+            } else {
+                await emit;
+            }
+        }
+    }
+
+    return results;
+}

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -282,3 +282,31 @@ export const rewardGrants = sqliteTable("reward_grants", {
   index("idx_reward_grants_user_id").on(table.userId),
   index("idx_reward_grants_source").on(table.source),
 ]);
+
+// Data-driven quest catalog. Adding a product quest = inserting a row here
+// instead of editing call sites. Config table (like community_endpoint), read
+// synchronously when evaluating a trigger signal. The actual grant still flows
+// through grantReward()/reward_grants; this only declares what can be earned.
+export const questDefinitions = sqliteTable("quest_definitions", {
+  id: text("id").primaryKey(),
+  // Stable catalog key referenced by reward_grants.quest_id, e.g. "first_image".
+  key: text("key").notNull().unique(),
+  title: text("title").notNull(),
+  category: text("category"),
+  // Signal that can complete this quest, e.g.
+  // first_image | first_top_up | key_created | streak | referral | spend_threshold.
+  triggerType: text("trigger_type").notNull(),
+  rewardAmount: real("reward_amount").notNull(),
+  // Which bucket to credit: "tier" or "pack".
+  balanceBucket: text("balance_bucket").notNull().default("tier"),
+  // once | weekly | streak | tiered — how often it can be earned.
+  repeatability: text("repeatability").notNull().default("once"),
+  active: integer("active", { mode: "boolean" }).notNull().default(true),
+  // Optional JSON criteria (thresholds, windows) evaluated by checkAndGrantQuest.
+  criteriaJson: text("criteria_json"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+}, (table) => [
+  index("idx_quest_definitions_trigger_type").on(table.triggerType),
+]);

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -297,8 +297,8 @@ export const questDefinitions = sqliteTable("quest_definitions", {
   // first_image | first_top_up | key_created | streak | referral | spend_threshold.
   triggerType: text("trigger_type").notNull(),
   rewardAmount: real("reward_amount").notNull(),
-  // Which bucket to credit: "tier" or "pack".
-  balanceBucket: text("balance_bucket").notNull().default("tier"),
+  // Which bucket to credit: "pack" (default) or "tier".
+  balanceBucket: text("balance_bucket").notNull().default("pack"),
   // once | weekly | streak | tiered — how often it can be earned.
   repeatability: text("repeatability").notNull().default("once"),
   active: integer("active", { mode: "boolean" }).notNull().default(true),

--- a/shared/events.ts
+++ b/shared/events.ts
@@ -226,6 +226,61 @@ export async function sendTierEventToTinybird(
     }
 }
 
+// Real-time event for the reward_grant Tinybird datasource — analytics only,
+// emitted (worker context, via waitUntil) after a grantReward() succeeds. The
+// authoritative grant lives in D1 reward_grants; this event just gives live
+// dashboards lower latency than the daily d1_reward_grants snapshot.
+export type RewardGrantEvent = {
+    environment: string;
+    user_id: string;
+    source: string;
+    quest_id?: string;
+    pollen_credited: number;
+    balance_bucket: string;
+    source_ref?: string;
+    timestamp: string;
+};
+
+export async function sendRewardGrantEventToTinybird(
+    event: Omit<RewardGrantEvent, "timestamp">,
+    referenceIngestUrl: string | undefined,
+    tinybirdIngestToken: string | undefined,
+    log: Logger,
+): Promise<void> {
+    if (!referenceIngestUrl || !tinybirdIngestToken) {
+        log.warn("Tinybird ingest not configured, skipping reward_grant event");
+        return;
+    }
+    const url = getTinybirdDatasourceIngestUrl(
+        referenceIngestUrl,
+        "reward_grant",
+    );
+    const rewardGrantEvent: RewardGrantEvent = {
+        ...event,
+        timestamp: new Date().toISOString(),
+    };
+    const body = JSON.stringify(removeUnset(rewardGrantEvent));
+
+    try {
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${tinybirdIngestToken}`,
+                "Content-Type": "application/x-ndjson",
+            },
+            body,
+            signal: AbortSignal.timeout(5000),
+        });
+        if (!response.ok) {
+            log.warn("Tinybird reward_grant ingest failed: status={status}", {
+                status: response.status,
+            });
+        }
+    } catch (error) {
+        log.warn("Tinybird reward_grant ingest failed: {error}", { error });
+    }
+}
+
 async function retryWithBackoff(
     attempt: number,
     log: Logger,


### PR DESCRIPTION
**Stacked PR 3 of 3** — base is **Plan B (#11852)**, not main. Review/merge A → B → C in order.

> ⚠️ Independent voodoo/ track (a separate agent explores `codex/quest-reward-grants-floor`).

## Why
Plan A+B credit and surface grants but each product quest is a hardcoded call site, and analytics lag ~24h. Plan C makes the catalog **data-driven** and adds **real-time** events for live quest UI — only worth it once the non-GitHub catalog grows (onboarding/spend/engage/referrals).

## What
- **`quest_definitions` D1 table** (migration `0028`): `key`, `title`, `category`, `trigger_type`, `reward_amount`, `balance_bucket`, `repeatability`, `active`, `criteria_json`. Adding a quest = inserting a row, not editing code. Config table like `community_endpoint`.
- **`checkAndGrantQuest()`**: given a trigger signal (`first_image`, `key_created`, …) grants matching active quests via `grantReward()` with a deterministic key `quest:{key}:{userId}`. `once` repeatability falls out of idempotency; `weekly/streak/tiered` are explicitly skipped until window-checks ship (logged, not silently granted).
- **`sendRewardGrantEventToTinybird()` + `reward_grant.datasource`** (real-time, append-only, modeled on `tier_event`). Emitted via `waitUntil` after a **fresh** grant — **worker context only**. GH-Action code quests keep using the daily snapshot (no `executionCtx`); the design never requires real-time emit for correctness.

## Tests
`npx vitest run test/integration/check-and-grant-quest.test.ts test/integration/grant-reward.test.ts` → **8/8 pass**: grant-on-match, idempotency (no double-grant), inactive/unknown ignored, non-once skipped.

## Deploy note
`reward_grant.datasource` deploys **staging→prod, both workspaces** per the Tinybird safety rules.

## Not in scope (deliberately)
- `weekly/streak/tiered` evaluation (needs a window check vs `reward_grants` history or derivation from usage pipes).
- Wiring `checkAndGrantQuest` into specific request paths (first-image, first-top-up) — that's the per-trigger rollout, gated on the launch quest set (#11677).

Addresses #11374, #11677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)