### PR TITLE
fix: faster Sirius elevator models + in-character LLM errors

### DIFF
--- a/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
@@ -101,12 +101,17 @@ export const fetchPersonaMessage = async (
     gameState: GameState,
     existingMessages: Message[] = [],
 ): Promise<Message> => {
-    const createErrorMessage = (_error: unknown): Message =>
-        createMessage(
+    // Speak failures in the voice of the world: the cabin malfunctions and the
+    // real upstream error rides along inside the dialogue.
+    const createErrorMessage = (error: unknown): Message => {
+        const detail =
+            error instanceof Error ? error.message : "Sub-Etha signal lost";
+        return createMessage(
             persona,
-            "Apologies, I'm experiencing some difficulties.",
+            `A Sirius Cybernetics malfunction shudders through the cabin — [${detail}]. Share and Enjoy. Please try again.`,
             "none",
         );
+    };
 
     try {
         const messages: PollingsMessage[] = [

--- a/apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/hooks/ui.ts
@@ -7,13 +7,16 @@ const ENTER_URL = "https://enter.pollinations.ai";
 const API_BASE = "https://enter.pollinations.ai/api";
 const API_KEY_PREFIX = /^(sk_|plln_pk_|pk_)/;
 
-// deepseek best respects the elevator/Marvin resistance (keeps the game
-// challenging); reasoning_effort:"low" on each request keeps it responsive.
-export const DEFAULT_MODEL = "deepseek";
+// mistral is the default: fast (~1.2s) and reliably returns valid game JSON
+// on the real prompts. DeepSeek is kept as an option for its stubborn
+// in-character resistance, but it reasons heavily — on the long Guide prompt
+// "reasoning_effort: low" pushed replies past 10s, so api.ts now sends "none".
+export const DEFAULT_MODEL = "mistral";
 
 export const AVAILABLE_MODELS = [
-    { id: "deepseek", label: "DeepSeek" },
+    { id: "mistral", label: "Mistral" },
     { id: "openai", label: "OpenAI" },
+    { id: "deepseek", label: "DeepSeek" },
     { id: "claude-fast", label: "Claude" },
 ] as const;
 

--- a/apps/sirius-cybernetics-elevator-challenge/src/utils/api.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/utils/api.ts
@@ -15,33 +15,48 @@ function createFetchRequest(
     };
     if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
+    const model = getStoredModel();
+
     return {
         method: "POST",
         headers,
         body: JSON.stringify({
             messages,
-            model: getStoredModel(),
-            // Cap reasoning so replies stay snappy. Harmless for non-reasoning
-            // models (openai); keeps reasoning models (deepseek) usable.
-            reasoning_effort: "low",
+            model,
+            // DeepSeek is a reasoning model: even "low" lets it think for
+            // thousands of tokens, pushing replies past 10s on the long Guide
+            // prompt, so it gets "none". The other (non-reasoning) models stay
+            // at "low" — it's a harmless no-op for them.
+            reasoning_effort: model === "deepseek" ? "none" : "low",
             response_format: jsonMode ? { type: "json_object" } : undefined,
             seed: Math.floor(Math.random() * 1000000),
         }),
     };
 }
 
-const FALLBACK_RESPONSE: PollingsResponse = {
-    choices: [
-        {
-            message: {
-                content: JSON.stringify({
-                    message:
-                        "I apologize, but I'm having trouble processing your request right now.",
-                    action: "none",
-                }),
-            },
-        },
-    ],
+// Thrown after all retries fail. Carries a short upstream detail (e.g.
+// "HTTP 429: rate limit exceeded") so the UI can speak it in the game's voice.
+export class PollingsError extends Error {
+    constructor(readonly detail: string) {
+        super(detail);
+        this.name = "PollingsError";
+    }
+}
+
+// Pull the most useful line out of an upstream error body, which may be a JSON
+// envelope ({error:{message}} / {message}) or plain text.
+const extractDetail = (raw: string): string => {
+    try {
+        const parsed = JSON.parse(raw);
+        return (
+            parsed?.error?.message ??
+            parsed?.error ??
+            parsed?.message ??
+            raw
+        ).toString();
+    } catch {
+        return raw;
+    }
 };
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -50,17 +65,25 @@ export const retryFetch = async (
     operation: () => Promise<Response>,
     maxAttempts = API_CONFIG.MAX_RETRIES,
 ): Promise<PollingsResponse> => {
-    let lastError: Error | null = null;
+    let lastDetail = "Sub-Etha signal lost";
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
         try {
             const response = await operation();
-            if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+            if (!response.ok) {
+                const body = await response.text().catch(() => "");
+                const detail = extractDetail(body).slice(0, 200);
+                throw new PollingsError(
+                    `HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+                );
+            }
 
-            const data = await response.json();
-            return data as PollingsResponse;
+            return (await response.json()) as PollingsResponse;
         } catch (error) {
-            lastError = error as Error;
+            lastDetail =
+                error instanceof PollingsError
+                    ? error.detail
+                    : (error as Error).message;
             console.warn(
                 `Attempt ${attempt + 1}/${maxAttempts} failed:`,
                 error,
@@ -72,20 +95,18 @@ export const retryFetch = async (
         }
     }
 
-    console.error(`All ${maxAttempts} attempts failed. Last error:`, lastError);
-    return FALLBACK_RESPONSE;
+    console.error(
+        `All ${maxAttempts} attempts failed. Last error:`,
+        lastDetail,
+    );
+    throw new PollingsError(lastDetail);
 };
 
 export const fetchFromPollinations = async (
     messages: PollingsMessage[],
     jsonMode = true,
 ): Promise<PollingsResponse> => {
-    try {
-        return await retryFetch(() =>
-            fetch(API_CONFIG.ENDPOINT, createFetchRequest(messages, jsonMode)),
-        );
-    } catch (error) {
-        console.error("Error in fetchFromPollinations:", error);
-        return FALLBACK_RESPONSE;
-    }
+    return retryFetch(() =>
+        fetch(API_CONFIG.ENDPOINT, createFetchRequest(messages, jsonMode)),
+    );
 };


### PR DESCRIPTION
The elevator game felt "awfully slow". Root cause: DeepSeek (the default) is a reasoning model, and `reasoning_effort: "low"` still let it think for thousands of tokens — on the long Guide prompt (the game's first request) replies went **past 10s** in benchmarks against `gen.pollinations.ai`.

Benchmarked the free models on the game's **real** prompts (Guide + elevator floor-3 mid-game), 3 runs each, 10s cap:

- `deepseek` + `low` (shipped): **timed out 3/3** on the Guide prompt
- `mistral` / `openai` / `gemini-fast`: ~1.0–1.4s, 3/3 valid JSON

Changes:
- Default model → `mistral` (fast, reliable JSON); dropdown trimmed to mistral / openai / deepseek / claude-fast
- `reasoning_effort: "none"` for `deepseek` (kept as an option for its in-character resistance); `"low"` for the others (no-op for non-reasoning models)
- LLM errors now surface the **real upstream error** inside an in-character elevator line instead of a generic apology

Verified: tsc + vite build pass (170kB), biome clean, mistral returns valid JSON live, error extraction pulls the clean `error.message` from a real gateway 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)