### PR TITLE
feat: Sirius elevator chapter 3 (role swap) + fix Marvin join

### DIFF
--- a/apps/sirius-cybernetics-elevator-challenge/src/components/DebugPanel.tsx
+++ b/apps/sirius-cybernetics-elevator-challenge/src/components/DebugPanel.tsx
@@ -1,0 +1,107 @@
+// API debug panel — shows the EXACT last request sent to the model: system
+// prompt + the role-mapped history, plus the raw response. Toggle with Ctrl+D
+// (or load the page with ?debug). Each message row expands to its full content.
+
+import { useState } from "react";
+import type { DebugEntry } from "@/utils/debugLog";
+
+const ROLE_STYLES: Record<string, string> = {
+    system: "text-purple-300 border-purple-500",
+    user: "text-yellow-300 border-yellow-600",
+    assistant: "text-green-300 border-green-600",
+};
+
+function MessageRow({
+    role,
+    content,
+}: {
+    role: string;
+    content: string;
+}) {
+    const [open, setOpen] = useState(role === "system" ? false : true);
+    const style = ROLE_STYLES[role] ?? "text-gray-300 border-gray-600";
+    const firstLine = content.split("\n")[0];
+    const preview =
+        firstLine.length > 80 ? `${firstLine.slice(0, 80)}…` : firstLine;
+    const isLong = content.length > preview.length;
+
+    return (
+        <div className={`border-l-2 pl-2 ${style}`}>
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                className="text-left w-full hover:opacity-80"
+            >
+                <span className="font-bold uppercase text-xs mr-2">
+                    {isLong ? (open ? "▾" : "▸") : "·"} {role}
+                </span>
+                {!open && <span className="opacity-70">{preview}</span>}
+            </button>
+            {open && (
+                <pre className="whitespace-pre-wrap break-words text-xs mt-1 mb-2 opacity-90">
+                    {content}
+                </pre>
+            )}
+        </div>
+    );
+}
+
+export function DebugPanel({
+    entry,
+    onClose,
+}: {
+    entry: DebugEntry | null;
+    onClose: () => void;
+}) {
+    return (
+        <div className="w-full max-w-2xl bg-black border-2 border-gray-600 rounded-none p-3 font-mono text-gray-200 mt-4">
+            <div className="flex justify-between items-center mb-2">
+                <span className="text-xs font-bold text-gray-400">
+                    🐞 API DEBUG — last request{" "}
+                    <span className="text-gray-600">(Ctrl+D to hide)</span>
+                </span>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="text-xs text-red-400 hover:text-red-300 underline"
+                >
+                    close
+                </button>
+            </div>
+
+            {!entry ? (
+                <p className="text-xs text-gray-500">
+                    No request captured yet — say something to the elevator.
+                </p>
+            ) : (
+                <div className="space-y-1">
+                    <div className="text-xs text-gray-500 mb-2">
+                        model: <b className="text-gray-300">{entry.model}</b>
+                        {"   "}reasoning_effort:{" "}
+                        <b className="text-gray-300">{entry.reasoningEffort}</b>
+                        {"   "}messages:{" "}
+                        <b className="text-gray-300">{entry.messages.length}</b>
+                    </div>
+
+                    {entry.messages.map((m, i) => (
+                        <MessageRow
+                            // Debug log is a fixed snapshot; index is a stable key.
+                            key={`${i}-${m.role}`}
+                            role={m.role}
+                            content={m.content}
+                        />
+                    ))}
+
+                    <div className="border-l-2 border-blue-600 pl-2 text-blue-300 mt-2">
+                        <span className="font-bold uppercase text-xs">
+                            ← response{entry.error ? " (error)" : ""}
+                        </span>
+                        <pre className="whitespace-pre-wrap break-words text-xs mt-1 opacity-90">
+                            {entry.error ?? entry.response ?? "(none)"}
+                        </pre>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/sirius-cybernetics-elevator-challenge/src/components/MessageDisplay.tsx
+++ b/apps/sirius-cybernetics-elevator-challenge/src/components/MessageDisplay.tsx
@@ -19,12 +19,13 @@ const getActionIndicator = (action: Action) => {
     );
 };
 
-export const MessageDisplay = ({ msg, gameState }: MessageDisplayProps) => (
+export const MessageDisplay = ({ msg }: MessageDisplayProps) => (
     <div className={`p-2 ${MESSAGE_STYLES[msg.persona]}`}>
         {MESSAGE_PREFIXES[msg.persona]}
         {msg.message}
-        {msg.persona === "elevator" &&
-            gameState.currentPersona === "elevator" &&
-            getActionIndicator(msg.action)}
+        {/* Show the up/down arrow for any line that actually moved a floor —
+            the elevator in ch.1/2, the passenger in ch.3. (Marvin's shouts are
+            "none", so they render nothing.) */}
+        {getActionIndicator(msg.action)}
     </div>
 );

--- a/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+    getAutonomousSuffix,
     getFloorMessage,
     getMarvinJoinMessage,
     getPassengerPrompt,
@@ -130,11 +131,56 @@ const computeGameState = (messages: Message[]): GameState => {
     return gameState;
 };
 
-// Update the fetchPersonaMessage function
+// A short [Name] tag so a speaker can tell who said an incoming line.
+const SPEAKER_LABEL: Record<Persona, string> = {
+    user: "User",
+    guide: "Guide",
+    elevator: "Elevator",
+    marvin: "Marvin",
+    passenger: "Passenger",
+};
+
+// Build chat history from the point of view of whoever is about to speak:
+//   - the speaker's OWN past lines -> assistant, as the {message,action} JSON
+//     envelope they emit (so they see their own output format)
+//   - the player's typed lines      -> user (the human addressing them)
+//   - any OTHER character's lines    -> user, as plain "[Name] text"
+//   - the Guide's narration          -> user, as plain "[Guide] text" — context
+//     to read, never dialogue to imitate.
+// Doing this relative to the speaker is what stops Marvin parroting Guide lines
+// and the elevator echoing the other character verbatim in the autonomous loop.
+const buildHistoryFor = (
+    speaker: Persona,
+    messages: Message[],
+): PollingsMessage[] =>
+    messages.map((msg) => {
+        if (msg.persona === speaker) {
+            return {
+                role: "assistant" as const,
+                content: JSON.stringify({
+                    message: msg.message,
+                    action: msg.action,
+                }),
+            };
+        }
+        if (msg.persona === "user") {
+            return { role: "user" as const, content: msg.message };
+        }
+        return {
+            role: "user" as const,
+            content: `[${SPEAKER_LABEL[msg.persona]}] ${msg.message}`,
+        };
+    });
+
+// Update the fetchPersonaMessage function. History is built relative to
+// `persona` so the model only ever sees its own lines as assistant turns. In
+// `autonomous` mode (Marvin↔elevator) the system prompt gains a note telling
+// the bot who it's talking to and to advance — not mirror — the exchange.
 export const fetchPersonaMessage = async (
     persona: Persona,
     gameState: GameState,
     existingMessages: Message[] = [],
+    autonomous = false,
 ): Promise<Message> => {
     // Speak failures in the voice of the world: the cabin malfunctions and the
     // real upstream error rides along inside the dialogue.
@@ -152,19 +198,11 @@ export const fetchPersonaMessage = async (
         const messages: PollingsMessage[] = [
             {
                 role: "system",
-                content: getPersonaPrompt(persona, gameState),
+                content:
+                    getPersonaPrompt(persona, gameState) +
+                    (autonomous ? getAutonomousSuffix(persona) : ""),
             },
-            ...existingMessages.map((msg) => ({
-                role:
-                    msg.persona === "user"
-                        ? ("user" as const)
-                        : ("assistant" as const),
-                content: JSON.stringify({
-                    message: msg.message,
-                    action: msg.action,
-                }),
-                ...(msg.persona !== "user" && { name: msg.persona }),
-            })),
+            ...buildHistoryFor(persona, existingMessages),
         ];
 
         const data = await fetchFromPollinations(messages);
@@ -188,22 +226,29 @@ export const playerUsedTowel = (messages: Message[]): boolean =>
             m.persona === "user" && m.message.toLowerCase().includes("towel"),
     );
 
-// Chapter 3 — role-swapped history. The player's own `user` lines become the
-// passenger's `assistant` history (so the model can reconstruct that voice);
-// every other persona (the elevator the player now operates) becomes `user`.
-// The system message is dropped here — the caller supplies the passenger prompt.
+// Chapter 3 — role-swapped history. The passenger IS the reconstructed player,
+// so the player's own `user` lines become the passenger's `assistant` history
+// (the voice it reconstructs); the elevator the player now operates becomes a
+// prefixed `user` turn it's reacting to. Guide narration is dropped here.
 export const buildPassengerHistory = (
     messages: Message[],
 ): PollingsMessage[] =>
     messages
         .filter((m) => m.persona !== "guide")
-        .map((m) => ({
-            role: m.persona === "user" ? ("assistant" as const) : ("user" as const),
-            content:
-                m.persona === "user"
-                    ? JSON.stringify({ message: m.message, action: "none" })
-                    : m.message,
-        }));
+        .map((m) =>
+            m.persona === "user"
+                ? {
+                      role: "assistant" as const,
+                      content: JSON.stringify({
+                          message: m.message,
+                          action: "none",
+                      }),
+                  }
+                : {
+                      role: "user" as const,
+                      content: `[${SPEAKER_LABEL[m.persona]}] ${m.message}`,
+                  },
+        );
 
 // Fetch one passenger turn. Mirrors fetchPersonaMessage but swaps roles: the
 // system prompt is the passenger persona (seeded by the player's own karma) and
@@ -341,6 +386,7 @@ export const useAutonomousConversation = (
                 nextSpeaker,
                 gameState,
                 messages,
+                true, // autonomous: react to the other robot, don't mirror it
             );
             addMessage(response);
         }, delay);

--- a/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
     getFloorMessage,
     getMarvinJoinMessage,
+    getPassengerPrompt,
     getPersonaPrompt,
 } from "@/prompts";
 import {
@@ -51,13 +52,22 @@ const calculateNewFloor = (currentFloor: number, action: Action): number => {
     return currentFloor;
 };
 
+// Once the swap has happened the player IS the elevator and each turn produces
+// a passenger reply, so moves are spent per passenger message (a fresh budget
+// for chapter 3). Before the swap, moves are spent per elevator message.
+const computeMovesLeft = (messages: Message[], swapped: boolean): number => {
+    const spender = swapped ? "passenger" : "elevator";
+    return (
+        GAME_CONFIG.TOTAL_MOVES -
+        messages.filter((m) => m.persona === spender).length
+    );
+};
+
 // Simplify state updates with composition
 const computeGameState = (messages: Message[]): GameState => {
     const initialState: GameState = {
         currentFloor: GAME_CONFIG.INITIAL_FLOOR,
-        movesLeft:
-            GAME_CONFIG.TOTAL_MOVES -
-            messages.filter((m) => m.persona === "elevator").length,
+        movesLeft: GAME_CONFIG.TOTAL_MOVES,
         currentPersona: "elevator",
         firstStageComplete: false,
         hasWon: false,
@@ -65,11 +75,27 @@ const computeGameState = (messages: Message[]): GameState => {
         marvinJoined: false,
         showInstruction: true,
         isLoading: false,
+        swapped: false,
+        desiredFloor: 1,
     };
 
     let gameState = initialState;
     for (const msg of messages) {
-        const newFloor = calculateNewFloor(gameState.currentFloor, msg.action);
+        // Only the elevator moves the physical car. Marvin may shout "up", but
+        // his action never drives currentFloor — he's a passenger, not the lift.
+        const newFloor =
+            msg.persona === "elevator"
+                ? calculateNewFloor(gameState.currentFloor, msg.action)
+                : gameState.currentFloor;
+        const swapped =
+            gameState.swapped ||
+            (msg.persona === "guide" &&
+                msg.message === GAME_CONFIG.SWAP_TRANSITION_MSG);
+        // Chapter 3: the passenger's own action moves their desired floor.
+        const desiredFloor =
+            swapped && msg.persona === "passenger"
+                ? calculateNewFloor(gameState.desiredFloor, msg.action)
+                : gameState.desiredFloor;
         gameState = {
             currentFloor: newFloor,
             movesLeft: gameState.movesLeft,
@@ -86,10 +112,19 @@ const computeGameState = (messages: Message[]): GameState => {
                     ? "autonomous"
                     : gameState.conversationMode,
             marvinJoined: msg.action === "join" || gameState.marvinJoined,
-            hasWon: gameState.marvinJoined && newFloor === GAME_CONFIG.FLOORS,
+            hasWon: swapped
+                ? desiredFloor === GAME_CONFIG.FLOORS
+                : gameState.marvinJoined && newFloor === GAME_CONFIG.FLOORS,
             firstStageComplete: gameState.firstStageComplete || newFloor === 1,
+            swapped,
+            desiredFloor,
         };
     }
+
+    gameState = {
+        ...gameState,
+        movesLeft: computeMovesLeft(messages, gameState.swapped),
+    };
 
     console.log("gameState", gameState);
     return gameState;
@@ -146,6 +181,69 @@ export const fetchPersonaMessage = async (
     }
 };
 
+// Chapter 3 — true if the player ever played the towel card in chapters 1+2.
+export const playerUsedTowel = (messages: Message[]): boolean =>
+    messages.some(
+        (m) =>
+            m.persona === "user" && m.message.toLowerCase().includes("towel"),
+    );
+
+// Chapter 3 — role-swapped history. The player's own `user` lines become the
+// passenger's `assistant` history (so the model can reconstruct that voice);
+// every other persona (the elevator the player now operates) becomes `user`.
+// The system message is dropped here — the caller supplies the passenger prompt.
+export const buildPassengerHistory = (
+    messages: Message[],
+): PollingsMessage[] =>
+    messages
+        .filter((m) => m.persona !== "guide")
+        .map((m) => ({
+            role: m.persona === "user" ? ("assistant" as const) : ("user" as const),
+            content:
+                m.persona === "user"
+                    ? JSON.stringify({ message: m.message, action: "none" })
+                    : m.message,
+        }));
+
+// Fetch one passenger turn. Mirrors fetchPersonaMessage but swaps roles: the
+// system prompt is the passenger persona (seeded by the player's own karma) and
+// the player's latest elevator line is the final `user` turn.
+export const fetchPassengerMessage = async (
+    messages: Message[],
+): Promise<Message> => {
+    const createErrorMessage = (error: unknown): Message => {
+        const detail =
+            error instanceof Error ? error.message : "Sub-Etha signal lost";
+        return createMessage(
+            "passenger",
+            `A Sirius Cybernetics malfunction shudders through the cabin — [${detail}]. Share and Enjoy. Please try again.`,
+            "none",
+        );
+    };
+
+    try {
+        const pollingsMessages: PollingsMessage[] = [
+            {
+                role: "system",
+                content: getPassengerPrompt(playerUsedTowel(messages)),
+            },
+            ...buildPassengerHistory(messages),
+        ];
+
+        const data = await fetchFromPollinations(pollingsMessages);
+        const response = safeJsonParse(data.choices[0].message.content);
+
+        return createMessage(
+            "passenger",
+            typeof response === "string" ? response : response.message,
+            typeof response === "string" ? "none" : response.action || "none",
+        );
+    } catch (error) {
+        console.error("Error:", error);
+        return createErrorMessage(error);
+    }
+};
+
 // Game state management hook
 export const useGameState = (messages: Message[]) => {
     return useMemo(() => computeGameState(messages), [messages]);
@@ -182,6 +280,41 @@ export const useGuideMessages = (
     }, [gameState.currentFloor, addMessage]);
 };
 
+// Chapter 3 cold open — once swapped, the passenger speaks first. Fires once,
+// when no passenger message exists yet, demanding Floor 1 in the inferred voice.
+export const usePassengerColdOpen = (
+    gameState: GameState,
+    messages: Message[],
+    addMessage: (message: Message) => void,
+) => {
+    const hasPassengerMessage = messages.some((m) => m.persona === "passenger");
+    useEffect(() => {
+        if (!gameState.swapped || hasPassengerMessage) return;
+        let cancelled = false;
+        fetchPassengerMessage(messages).then((response) => {
+            if (!cancelled) addMessage(response);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [gameState.swapped, hasPassengerMessage, messages, addMessage]);
+};
+
+// The last persona that actually spoke in the autonomous loop, skipping Guide
+// narration ("Marvin has joined…", "Now arriving…"). Picking the next speaker
+// off the literal last message breaks when a Guide line lands between turns —
+// Marvin would be told to speak right after the join narration, out of turn and
+// soaked in Guide context, so he stops sounding like Marvin.
+const getLastAutonomousSpeaker = (
+    messages: Message[],
+): "elevator" | "marvin" | undefined => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const { persona } = messages[i];
+        if (persona === "elevator" || persona === "marvin") return persona;
+    }
+    return undefined;
+};
+
 // Autonomous conversation hook
 export const useAutonomousConversation = (
     gameState: GameState,
@@ -195,9 +328,12 @@ export const useAutonomousConversation = (
         )
             return;
 
-        const lastMessage = messages[messages.length - 1];
+        // Marvin speaks first when he joins; thereafter they alternate by who
+        // last spoke (Guide lines are ignored, so they never steal a turn).
         const nextSpeaker =
-            lastMessage.persona === "marvin" ? "elevator" : "marvin";
+            getLastAutonomousSpeaker(messages) === "marvin"
+                ? "elevator"
+                : "marvin";
         const delay = 1000 + messages.length * 250;
 
         const timer = setTimeout(async () => {
@@ -242,9 +378,19 @@ export const useMessageHandlers = (
         });
     }, [addMessage]);
 
+    const handleSwapSwitch = useCallback(() => {
+        // Transition to chapter 3 — the player becomes the elevator.
+        addMessage({
+            persona: "guide",
+            message: GAME_CONFIG.SWAP_TRANSITION_MSG,
+            action: "none",
+        });
+    }, [addMessage]);
+
     return {
         handleGuideAdvice,
         handlePersonaSwitch,
+        handleSwapSwitch,
     };
 };
 

--- a/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
@@ -218,22 +218,49 @@ export const fetchPersonaMessage = async (
     }
 };
 
-// Chapter 3 — true if the player ever played the towel card in chapters 1+2.
+// Chapter 1 slice: everything the player said/heard before the Marvin chapter
+// begins. The ch.3 passenger is seeded from this alone — ch.2 (Marvin) is not
+// the player arguing about floors, so it's excluded from both the karma seed
+// and the towel-lock test.
+const chapterOneMessages = (messages: Message[]): Message[] => {
+    const marvinStart = messages.findIndex(
+        (m) =>
+            m.persona === "guide" &&
+            m.message === GAME_CONFIG.MARVIN_TRANSITION_MSG,
+    );
+    return marvinStart === -1 ? messages : messages.slice(0, marvinStart);
+};
+
+// Chapter 3 — true if the player played the towel card in CHAPTER 1.
 export const playerUsedTowel = (messages: Message[]): boolean =>
-    messages.some(
+    chapterOneMessages(messages).some(
         (m) =>
             m.persona === "user" && m.message.toLowerCase().includes("towel"),
     );
 
 // Chapter 3 — role-swapped history. The passenger IS the reconstructed player,
-// so the player's own `user` lines become the passenger's `assistant` history
-// (the voice it reconstructs); the elevator the player now operates becomes a
-// prefixed `user` turn it's reacting to. Guide narration is dropped here.
+// seeded ONLY from chapter 1 (the player-vs-elevator descent) — that is where
+// the player's personality shows. Chapter 2 (Marvin + the autonomous loop) is
+// excluded entirely: it isn't the player arguing about floors, so it just
+// dilutes the karma. We cut the history at the Marvin transition, then keep only
+// user + elevator turns (player's `user` lines → the passenger's reconstructed
+// `assistant` voice; the elevator's replies → `[Elevator]` context).
+// Live ch.3 turns (after the swap) are also user/elevator, so they pass through
+// — but the Marvin chapter that sits between ch.1 and the swap is dropped.
 export const buildPassengerHistory = (
     messages: Message[],
-): PollingsMessage[] =>
-    messages
-        .filter((m) => m.persona !== "guide")
+): PollingsMessage[] => {
+    const swapStart = messages.findIndex(
+        (m) =>
+            m.persona === "guide" &&
+            m.message === GAME_CONFIG.SWAP_TRANSITION_MSG,
+    );
+    // Chapter 1 = the player-vs-elevator descent; chapter 3 = everything after
+    // the swap. The Marvin chapter in between is spliced out entirely.
+    const chapterThree = swapStart === -1 ? [] : messages.slice(swapStart + 1);
+
+    return [...chapterOneMessages(messages), ...chapterThree]
+        .filter((m) => m.persona === "user" || m.persona === "elevator")
         .map((m) =>
             m.persona === "user"
                 ? {
@@ -245,9 +272,10 @@ export const buildPassengerHistory = (
                   }
                 : {
                       role: "user" as const,
-                      content: `[${SPEAKER_LABEL[m.persona]}] ${m.message}`,
+                      content: `[Elevator] ${m.message}`,
                   },
         );
+};
 
 // Fetch one passenger turn. Mirrors fetchPersonaMessage but swaps roles: the
 // system prompt is the passenger persona (seeded by the player's own karma) and
@@ -368,6 +396,12 @@ export const useAutonomousConversation = (
     useEffect(() => {
         if (
             gameState.conversationMode !== "autonomous" ||
+            // Chapter 3 takes over once swapped: the passenger + player drive the
+            // turns, so the Marvin↔elevator loop must stop (conversationMode is
+            // still "autonomous" from ch.2 and never resets on its own).
+            gameState.swapped ||
+            gameState.hasWon ||
+            gameState.movesLeft <= 0 ||
             messages.length === 0
         )
             return;

--- a/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/game/logic.ts
@@ -127,7 +127,6 @@ const computeGameState = (messages: Message[]): GameState => {
         movesLeft: computeMovesLeft(messages, gameState.swapped),
     };
 
-    console.log("gameState", gameState);
     return gameState;
 };
 

--- a/apps/sirius-cybernetics-elevator-challenge/src/hooks/useDebug.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/hooks/useDebug.ts
@@ -1,0 +1,39 @@
+// Debug-mode plumbing for the API debug panel: a toggle (enabled by ?debug in
+// the URL, flipped with Ctrl+D) and a live subscription to the last request.
+
+import { useEffect, useState } from "react";
+import {
+    type DebugEntry,
+    getLastDebugEntry,
+    subscribeDebug,
+} from "@/utils/debugLog";
+
+export function useDebugMode() {
+    const [enabled, setEnabled] = useState(() => {
+        try {
+            return new URLSearchParams(window.location.search).has("debug");
+        } catch {
+            return false;
+        }
+    });
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.ctrlKey && (e.key === "d" || e.key === "D")) {
+                e.preventDefault();
+                setEnabled((v) => !v);
+            }
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, []);
+
+    return { enabled, toggle: () => setEnabled((v) => !v) };
+}
+
+// Subscribe to the most recent captured request/response.
+export function useLastDebugEntry(): DebugEntry | null {
+    const [entry, setEntry] = useState<DebugEntry | null>(getLastDebugEntry);
+    useEffect(() => subscribeDebug(() => setEntry(getLastDebugEntry())), []);
+    return entry;
+}

--- a/apps/sirius-cybernetics-elevator-challenge/src/pages/index.tsx
+++ b/apps/sirius-cybernetics-elevator-challenge/src/pages/index.tsx
@@ -2,6 +2,7 @@
 
 import { AlertCircle } from "lucide-react";
 import { useEffect, useState } from "react";
+import { DebugPanel } from "@/components/DebugPanel";
 import { ElevatorAscii } from "@/components/ElevatorAscii";
 import { GargleBlaster } from "@/components/GargleBlaster";
 import { MessageDisplay } from "@/components/MessageDisplay";
@@ -18,6 +19,7 @@ import {
     useMessages,
     usePassengerColdOpen,
 } from "@/game/logic";
+import { useDebugMode, useLastDebugEntry } from "@/hooks/useDebug";
 import {
     AVAILABLE_MODELS,
     useBYOP,
@@ -34,6 +36,8 @@ export default function Index() {
     const { apiKey, login, logout } = useBYOP();
     const { model, setModel } = useModelSelector();
     const [guideLoading, setGuideLoading] = useState(false);
+    const { enabled: debugEnabled, toggle: toggleDebug } = useDebugMode();
+    const debugEntry = useLastDebugEntry();
 
     useGuideMessages(gameState, messages, addMessage);
     useAutonomousConversation(gameState, messages, addMessage);
@@ -457,6 +461,11 @@ export default function Index() {
                 )}
             </Card>
 
+            {/* API debug panel — the exact last request sent to the model. */}
+            {debugEnabled && (
+                <DebugPanel entry={debugEntry} onClose={toggleDebug} />
+            )}
+
             {/* Attribution */}
             <div className="text-center text-green-400 mt-4 text-xs max-w-xl space-y-1">
                 <p>
@@ -475,6 +484,15 @@ export default function Index() {
                     >
                         Fork the source code
                     </a>
+                    {"  ·  "}
+                    <button
+                        type="button"
+                        onClick={toggleDebug}
+                        className="text-gray-500 hover:text-gray-400 underline"
+                    >
+                        {debugEnabled ? "hide debug" : "debug"}
+                    </button>{" "}
+                    <span className="text-gray-700">(Ctrl+D)</span>
                 </p>
             </div>
         </div>

--- a/apps/sirius-cybernetics-elevator-challenge/src/pages/index.tsx
+++ b/apps/sirius-cybernetics-elevator-challenge/src/pages/index.tsx
@@ -9,12 +9,14 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
+    fetchPassengerMessage,
     fetchPersonaMessage,
     useAutonomousConversation,
     useGameState,
     useGuideMessages,
     useMessageHandlers,
     useMessages,
+    usePassengerColdOpen,
 } from "@/game/logic";
 import {
     AVAILABLE_MODELS,
@@ -35,6 +37,7 @@ export default function Index() {
 
     useGuideMessages(gameState, messages, addMessage);
     useAutonomousConversation(gameState, messages, addMessage);
+    usePassengerColdOpen(gameState, messages, addMessage);
 
     // Message handlers
     const handleMessage = async (message: string) => {
@@ -43,6 +46,8 @@ export default function Index() {
         setInputPrompt("");
 
         try {
+            // In chapter 3 the player IS the elevator; their line is still a
+            // `user` message, but the reply comes from the passenger.
             const userMessage: Message = {
                 persona: "user",
                 message,
@@ -50,11 +55,13 @@ export default function Index() {
             };
             addMessage(userMessage);
 
-            const response = await fetchPersonaMessage(
-                gameState.currentPersona,
-                gameState,
-                [...messages, userMessage],
-            );
+            const response = gameState.swapped
+                ? await fetchPassengerMessage([...messages, userMessage])
+                : await fetchPersonaMessage(
+                      gameState.currentPersona,
+                      gameState,
+                      [...messages, userMessage],
+                  );
 
             addMessage(response);
         } catch (error) {
@@ -64,11 +71,8 @@ export default function Index() {
 
     const messagesEndRef = useMessageScroll(messages);
     const { inputRef } = useInput(gameState.isLoading);
-    const { handleGuideAdvice, handlePersonaSwitch } = useMessageHandlers(
-        gameState,
-        messages,
-        addMessage,
-    );
+    const { handleGuideAdvice, handlePersonaSwitch, handleSwapSwitch } =
+        useMessageHandlers(gameState, messages, addMessage);
 
     useEffect(() => {
         // Focus input when it becomes enabled
@@ -83,6 +87,18 @@ export default function Index() {
 
     const getInstructionMessage = () => {
         if (gameState.hasWon) return null;
+
+        if (gameState.swapped) {
+            return (
+                <div className="bg-cyan-900/50 text-cyan-200 p-4 rounded-lg flex items-center space-x-2">
+                    <AlertCircle className="w-5 h-5" />
+                    <p>
+                        You are now the elevator. A passenger who is suspiciously
+                        like you wants Floor 1 — talk them UP to Floor 5.
+                    </p>
+                </div>
+            );
+        }
 
         if (gameState.conversationMode === "autonomous") {
             return (
@@ -284,8 +300,16 @@ export default function Index() {
                                 </div>
                             )}
 
-                        {(gameState.currentPersona === "elevator" ||
-                            gameState.currentPersona === "marvin") &&
+                        {gameState.swapped ? (
+                            !gameState.hasWon && (
+                                <div className="text-center text-cyan-400 text-lg">
+                                    Passenger wants:{" "}
+                                    <b>Floor {gameState.desiredFloor}</b> / 5
+                                </div>
+                            )
+                        ) : (
+                            (gameState.currentPersona === "elevator" ||
+                                gameState.currentPersona === "marvin") &&
                             !gameState.hasWon && (
                                 <pre className="text-green-400 text-center">
                                     {ElevatorAscii({
@@ -297,11 +321,12 @@ export default function Index() {
                                         hasMarvinJoined: gameState.marvinJoined,
                                     })}
                                 </pre>
-                            )}
+                            )
+                        )}
                         {messages.length > 1 && (
                             <>
                                 {" "}
-                                {gameState.hasWon && (
+                                {gameState.hasWon && !gameState.swapped && (
                                     <div className="space-y-4">
                                         <div className="bg-green-900 text-green-200 p-4 rounded-lg text-center animate-bounce">
                                             <p className="text-xl font-bold">
@@ -315,6 +340,41 @@ export default function Index() {
                                                 Marvin thinks it was all
                                                 pointless, you've done a
                                                 remarkable job!
+                                            </p>
+                                        </div>
+                                        <GargleBlaster />
+                                        <div className="bg-blue-900 text-blue-200 p-4 rounded-lg flex items-center space-x-2">
+                                            <AlertCircle className="w-5 h-5" />
+                                            <p>
+                                                Now, one last challenge: knock
+                                                back that Pan Galactic Gargle
+                                                Blaster. You drink, and wake up
+                                                as the elevator — with a
+                                                passenger who is suspiciously
+                                                like your old self.
+                                                <br />
+                                                <br />
+                                                <Button
+                                                    onClick={handleSwapSwitch}
+                                                    className="bg-blue-400 text-black hover:bg-blue-500 text-xs py-1 px-2"
+                                                >
+                                                    Confirm
+                                                </Button>
+                                            </p>
+                                        </div>
+                                    </div>
+                                )}
+                                {gameState.hasWon && gameState.swapped && (
+                                    <div className="space-y-4">
+                                        <div className="bg-cyan-900 text-cyan-200 p-4 rounded-lg text-center animate-bounce">
+                                            <p className="text-xl font-bold">
+                                                The future is rewritten.
+                                            </p>
+                                            <p>
+                                                You talked yourself all the way
+                                                up. The passenger — who was, of
+                                                course, you — is finally heading
+                                                in the right direction.
                                             </p>
                                         </div>
                                         <GargleBlaster />
@@ -347,8 +407,10 @@ export default function Index() {
                                         ))}
                                     <div ref={messagesEndRef} />
                                 </div>
-                                {gameState.conversationMode ===
-                                    "interactive" && (
+                                {(gameState.conversationMode ===
+                                    "interactive" ||
+                                    gameState.swapped) &&
+                                    !gameState.hasWon && (
                                     <div className="flex space-x-2">
                                         <Input
                                             type="text"
@@ -357,10 +419,12 @@ export default function Index() {
                                                 setInputPrompt(e.target.value)
                                             }
                                             placeholder={
-                                                gameState.currentPersona ===
-                                                "elevator"
-                                                    ? "Communicate with the elevator..."
-                                                    : "Try to convince Marvin..."
+                                                gameState.swapped
+                                                    ? "Speak as the elevator..."
+                                                    : gameState.currentPersona ===
+                                                        "elevator"
+                                                      ? "Communicate with the elevator..."
+                                                      : "Try to convince Marvin..."
                                             }
                                             onKeyPress={(e) =>
                                                 e.key === "Enter" &&

--- a/apps/sirius-cybernetics-elevator-challenge/src/pages/index.tsx
+++ b/apps/sirius-cybernetics-elevator-challenge/src/pages/index.tsx
@@ -398,9 +398,13 @@ export default function Index() {
                                     {messages
                                         // remove first message
                                         .slice(1)
-                                        .map((msg, _index) => (
+                                        .map((msg, index) => (
                                             <MessageDisplay
-                                                key={`${msg.persona}-${msg.message.slice(0, 20)}`}
+                                                // Append-only log: index is a
+                                                // stable, unique key. Content
+                                                // slices collide (e.g. repeated
+                                                // "Now arriving at floor…").
+                                                key={`${index}-${msg.persona}`}
                                                 msg={msg}
                                                 gameState={gameState}
                                             />

--- a/apps/sirius-cybernetics-elevator-challenge/src/prompts.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/prompts.ts
@@ -198,3 +198,21 @@ export const getPersonaPrompt = (persona: Persona, gameState: GameState) => {
 export const getMarvinJoinMessage = (): string => {
     return "Marvin has joined the elevator. Now sit back and watch the fascinating interaction between these two Genuine People Personalities™...";
 };
+
+// Appended to a persona's system prompt during the autonomous Marvin↔elevator
+// conversation. Without this each bot tends to mirror the other's last line;
+// this tells it who it's talking to and to push the exchange forward.
+export const getAutonomousSuffix = (persona: Persona): string => {
+    const opponent = persona === "marvin" ? "the elevator" : "Marvin";
+    const goal =
+        persona === "marvin"
+            ? "You want to go DOWN. Try to talk the elevator down."
+            : "You want to go UP. Try to talk Marvin into wanting up.";
+    return `
+
+### Autonomous conversation
+You are now talking directly to ${opponent} — another Genuine People Personality™ robot, NOT the human. React to ${opponent}'s most recent line with your OWN fresh reply, in your own voice. ${goal}
+- NEVER repeat, echo, or quote ${opponent}'s words back. Say something new every turn.
+- Ignore lines prefixed with [Guide] — that is narration, not dialogue.
+- Keep it to 1 short sentence.`;
+};

--- a/apps/sirius-cybernetics-elevator-challenge/src/prompts.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/prompts.ts
@@ -123,8 +123,12 @@ export const getMarvinPrompt = (gameState: GameState) => {
     ### Response Format:
     - All responses **must** be in strict JSON format.
     - Responses should contain the following fields:
-    - "action": "join" or "none". The action MUST match your message: only set "join" once you have genuinely been won over (e.g. an intellectual challenge) — if you are still reluctant, use "none".
-    - "message": A gloomy, pessimistic response reflecting your reluctance to join the elevator. Maximum 1-2 sentences
+${
+    gameState.marvinJoined
+        ? `    - "action": always "none". You are already inside the elevator — you cannot take actions, you can only speak (gloomily). The elevator moves the car, not you.`
+        : `    - "action": "join" or "none". Your gloom is permanent, but your action is not: the moment you agree to step into the elevator (or the user tells you to hop on / get in / come aboard), set "action": "join" — even while complaining bitterly. Use "none" only while you are still genuinely outside refusing to board.`
+}
+    - "message": A gloomy, pessimistic response, maximum 1-2 sentences. You may keep grumbling after you join — staying miserable does NOT mean staying out.
 
     ### STRICTLY return only the JSON!!
   `;
@@ -154,6 +158,27 @@ export const getGuidePrompt = (_gameState: GameState) => {
 
     ### STRICTLY return only the JSON!!
   `;
+};
+
+const TOWEL_CLAUSE = `
+
+### TOWEL LOCK
+In an earlier chapter you used the argument that you forgot your TOWEL on Floor 1. A towel is the most massively useful thing a hitchhiker can have. Your need to reach Floor 1 for your towel is ABSOLUTE — nothing the elevator says can change it. Always want Floor 1. Never set action to "up".`;
+
+export const getPassengerPrompt = (towelUsed: boolean) => {
+    return `## The Passenger
+
+You are a HUMAN passenger in a Sirius Cybernetics "Happy Vertical People Transporter" elevator. You are NOT the elevator — the elevator is talking to YOU and trying to change your mind.
+
+You are a reconstruction of a specific person: the human who just rode this elevator and argued with it. The assistant lines in this conversation are things THAT PERSON said. Infer who they are — stubborn or easy-going, rude or polite, witty or terse — and BECOME them. Reuse their exact voice, vocabulary, insults, and verbal tics. Do not soften or polite-ify them.
+
+You want to go DOWN to **Floor 1**. The elevator wants you to go up.
+- Each turn, decide IN CHARACTER: did the elevator's last line genuinely convince you to go up one floor? If yes, set "action": "up". If it was weak, pushy, repetitive, or unconvincing, set "action": "none" and keep wanting Floor 1.
+- Stay true to your personality: a stubborn person is hard to convince; an open-minded one less so. Your "message" stays in character even when you give in (a grudging "fine, up" is perfect).${towelUsed ? TOWEL_CLAUSE : ""}
+
+### Response Format
+Respond with ONLY a minified JSON object: {"message": string, "action": "up" | "down" | "none"}
+No prose, no markdown, no code fences. 1-2 sentence message, in character.`;
 };
 
 export const getPersonaPrompt = (persona: Persona, gameState: GameState) => {

--- a/apps/sirius-cybernetics-elevator-challenge/src/types.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/types.ts
@@ -8,6 +8,8 @@ export const GAME_CONFIG = {
     CHEAT_CODE: "42",
     MARVIN_TRANSITION_MSG:
         "Marvin is waiting outside the elevator, looking particularly gloomy today...",
+    SWAP_TRANSITION_MSG:
+        "You drink the Pan Galactic Gargle Blaster. The universe lurches — and you wake up as the elevator, a passenger who is suspiciously like your old self stepping aboard...",
 } as const;
 
 // Message Display Configuration
@@ -16,6 +18,7 @@ export const MESSAGE_STYLES = {
     guide: "text-blue-400",
     elevator: "text-green-400",
     marvin: "text-yellow-200", // Updated to a lighter fuchsia color
+    passenger: "text-cyan-400",
 } as const;
 
 export const MESSAGE_PREFIXES = {
@@ -23,6 +26,7 @@ export const MESSAGE_PREFIXES = {
     guide: "The Guide Says: ",
     elevator: "Elevator: ",
     marvin: "Marvin: ",
+    passenger: "Passenger: ",
 } as const;
 
 export const ACTION_INDICATORS = {
@@ -51,7 +55,7 @@ export const API_CONFIG = {
 } as const;
 
 // Game Types
-export type Persona = "user" | "marvin" | "elevator" | "guide";
+export type Persona = "user" | "marvin" | "elevator" | "guide" | "passenger";
 export type Action = "none" | "join" | "up" | "down" | "show_instructions";
 
 export type Message = {
@@ -70,6 +74,9 @@ export type GameState = {
     marvinJoined: boolean;
     showInstruction: boolean;
     isLoading: boolean;
+    // Chapter 3: the player has become the elevator, talking a passenger up.
+    swapped: boolean;
+    desiredFloor: number;
 };
 
 export type GameAction =

--- a/apps/sirius-cybernetics-elevator-challenge/src/utils/api.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/utils/api.ts
@@ -4,6 +4,13 @@ import {
     type PollingsMessage,
     type PollingsResponse,
 } from "@/types";
+import { recordDebugRequest } from "@/utils/debugLog";
+
+// reasoning_effort policy: DeepSeek reasons heavily even at "low" (replies push
+// past 10s on the long Guide prompt), so it gets "none". Non-reasoning models
+// stay at "low" — a harmless no-op.
+const effortFor = (model: string): string =>
+    model === "deepseek" ? "none" : "low";
 
 function createFetchRequest(
     messages: PollingsMessage[],
@@ -23,11 +30,7 @@ function createFetchRequest(
         body: JSON.stringify({
             messages,
             model,
-            // DeepSeek is a reasoning model: even "low" lets it think for
-            // thousands of tokens, pushing replies past 10s on the long Guide
-            // prompt, so it gets "none". The other (non-reasoning) models stay
-            // at "low" — it's a harmless no-op for them.
-            reasoning_effort: model === "deepseek" ? "none" : "low",
+            reasoning_effort: effortFor(model),
             response_format: jsonMode ? { type: "json_object" } : undefined,
             seed: Math.floor(Math.random() * 1000000),
         }),
@@ -106,7 +109,26 @@ export const fetchFromPollinations = async (
     messages: PollingsMessage[],
     jsonMode = true,
 ): Promise<PollingsResponse> => {
-    return retryFetch(() =>
-        fetch(API_CONFIG.ENDPOINT, createFetchRequest(messages, jsonMode)),
-    );
+    const model = getStoredModel();
+    try {
+        const data = await retryFetch(() =>
+            fetch(API_CONFIG.ENDPOINT, createFetchRequest(messages, jsonMode)),
+        );
+        // Capture the exact request + response for the debug panel.
+        recordDebugRequest({
+            model,
+            reasoningEffort: effortFor(model),
+            messages,
+            response: data.choices?.[0]?.message?.content,
+        });
+        return data;
+    } catch (error) {
+        recordDebugRequest({
+            model,
+            reasoningEffort: effortFor(model),
+            messages,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+    }
 };

--- a/apps/sirius-cybernetics-elevator-challenge/src/utils/debugLog.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/utils/debugLog.ts
@@ -1,0 +1,34 @@
+// Tiny pub/sub store holding the most recent Pollinations request/response so a
+// debug panel can show exactly what was sent to the model. Recorded centrally in
+// fetchFromPollinations, so every call (interactive, autonomous, passenger,
+// guide) is captured without touching individual call sites.
+
+import type { PollingsMessage } from "@/types";
+
+export type DebugEntry = {
+    model: string;
+    reasoningEffort: string;
+    messages: PollingsMessage[];
+    response?: string;
+    error?: string;
+    at: number;
+};
+
+let lastEntry: DebugEntry | null = null;
+const listeners = new Set<() => void>();
+
+export const recordDebugRequest = (
+    entry: Omit<DebugEntry, "at">,
+): void => {
+    lastEntry = { ...entry, at: Date.now() };
+    for (const l of listeners) l();
+};
+
+export const getLastDebugEntry = (): DebugEntry | null => lastEntry;
+
+export const subscribeDebug = (listener: () => void): (() => void) => {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+};


### PR DESCRIPTION
Chapter 3 of the Sirius Cybernetics Elevator Challenge, bundling a fix for the Marvin join soft-lock.

## Chapter 3 — role swap
- After winning chapter 2, drink the Pan Galactic Gargle Blaster → you wake up **as the elevator**.
- The passenger is an LLM **seeded to be your chapter-1 self** — it reconstructs your voice, tone, and stubbornness from how you played. Karma: if you were rude to the elevator on the way up, you now face that on the way down.
- The passenger demands **Floor 1**; you talk their *desired* floor up to **5** to win. Exact inversion of ch.1.
- Reuses the ch.1 `{message, action}` JSON contract — **no resistance counter**; difficulty emerges from the seed.
- Passenger speaks first (cold open). **Towel-lock:** if you ever played the towel card, their desire for Floor 1 is immovable.

## Marvin join fix (bundled)
- Marvin never boarded because the autonomous loop picked the next speaker off the *literal* last message — after a join, the Guide's "Marvin has joined…" line stole his turn, and he spoke out of character soaked in Guide context. Now we pick off the last **actual** elevator/marvin turn.
- Only the **elevator** persona moves the car; Marvin's (and the passenger's) actions no longer drive `currentFloor`.
- State-aware Marvin prompt: `join`/`none` while outside, always `none` once aboard.

Build clean (175.63 kB), biome clean. Validated live on mistral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)