### PR TITLE
feat: terminal edition of the Sirius elevator challenge (Ink + BYOP device login)

### DIFF
--- a/apps/sirius-elevator-terminal/.gitignore
+++ b/apps/sirius-elevator-terminal/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/apps/sirius-elevator-terminal/README.md
+++ b/apps/sirius-elevator-terminal/README.md
@@ -1,0 +1,56 @@
+# Sirius Cybernetics Elevator Challenge — Terminal Edition
+
+A full terminal version of the [Sirius Cybernetics Elevator Challenge](../sirius-cybernetics-elevator-challenge),
+built with [Ink](https://github.com/vadimdemedes/ink) (React for the terminal)
+and powered by [Pollinations](https://pollinations.ai). Sign in with **BYOP
+device login** — no API key to copy/paste.
+
+```
+┌─ 🛗 Sirius Cybernetics Elevator Challenge ──────── @you · 42.00 pollen ─┐
+│ Floor: ▓▓▓░░ 3/5                                       moves left: 14   │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+## Run
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+Or in one step during development:
+
+```bash
+npm run dev
+```
+
+On first run you'll be sent through device login: the CLI opens your browser to
+`enter.pollinations.ai/device`, shows you a short code to confirm, and waits.
+The minted key is cached in `~/.config/sirius-elevator/config.json`.
+
+## The game
+
+Three chapters, identical mechanics to the web version:
+
+1. **Descend** — talk the neurotic elevator down to the ground floor. (Remember
+   your towel.)
+2. **Marvin** — convince Marvin the Paranoid Android to board, then reach the
+   top floor together.
+3. **Role swap** — drink the Pan Galactic Gargle Blaster and wake up *as* the
+   elevator. Your passenger is an LLM seeded to be your chapter-1 self; talk
+   their desired floor up from 1 to 5. If you ever played the towel card, their
+   desire for Floor 1 is now immovable.
+
+## Auth
+
+Uses the OAuth 2.0 Device Authorization Grant (RFC 8628) at
+`enter.pollinations.ai/api/device/*`. The resulting `sk_` key calls
+`gen.pollinations.ai/v1/chat/completions`.
+
+## Flags / env
+
+- `--model <mistral|openai|deepseek|claude-fast>` — pick the LLM (default
+  `mistral`). Persisted to config.
+- `--logout` — clear the cached key.
+- `POLLINATIONS_API_KEY` — skip device login with an existing key.

--- a/apps/sirius-elevator-terminal/package-lock.json
+++ b/apps/sirius-elevator-terminal/package-lock.json
@@ -1,0 +1,1430 @@
+{
+    "name": "sirius-elevator-terminal",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "sirius-elevator-terminal",
+            "version": "0.1.0",
+            "dependencies": {
+                "ink": "^5.0.0",
+                "ink-spinner": "^5.0.0",
+                "ink-text-input": "^6.0.0",
+                "marked": "^11.0.0",
+                "marked-terminal": "^7.0.0",
+                "open": "^10.0.0",
+                "react": "^18.3.1"
+            },
+            "bin": {
+                "sirius-elevator": "dist/cli.js"
+            },
+            "devDependencies": {
+                "@types/marked-terminal": "^6.1.0",
+                "@types/node": "^20.0.0",
+                "@types/react": "^18.3.0",
+                "ink-testing-library": "^4.0.0",
+                "typescript": "^5.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@alcalzone/ansi-tokenize": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+            "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14.13.1"
+            }
+        },
+        "node_modules/@colors/colors": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@types/cardinal": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@types/cardinal/-/cardinal-2.1.1.tgz",
+            "integrity": "sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/marked-terminal": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@types/marked-terminal/-/marked-terminal-6.1.1.tgz",
+            "integrity": "sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/cardinal": "^2.1",
+                "@types/node": "*",
+                "chalk": "^5.3.0",
+                "marked": ">=6.0.0 <12"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.31",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/ansi-escapes": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "license": "MIT"
+        },
+        "node_modules/auto-bind": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+            "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-highlight": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+            "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "highlight.js": "^10.7.1",
+                "mz": "^2.4.0",
+                "parse5": "^5.1.1",
+                "parse5-htmlparser2-tree-adapter": "^6.0.0",
+                "yargs": "^16.0.0"
+            },
+            "bin": {
+                "highlight": "bin/highlight"
+            },
+            "engines": {
+                "node": ">=8.0.0",
+                "npm": ">=5.0.0"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-table3": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": "10.* || >= 12.*"
+            },
+            "optionalDependencies": {
+                "@colors/colors": "1.5.0"
+            }
+        },
+        "node_modules/cli-table3/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+            "license": "MIT",
+            "dependencies": {
+                "slice-ansi": "^5.0.0",
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/slice-ansi": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/code-excerpt": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+            "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+            "license": "MIT",
+            "dependencies": {
+                "convert-to-spaces": "^2.0.1"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
+        },
+        "node_modules/convert-to-spaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+            "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "license": "MIT"
+        },
+        "node_modules/emojilib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+            "license": "MIT"
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.47.1",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+            "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+            "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+            "license": "MIT",
+            "dependencies": {
+                "@alcalzone/ansi-tokenize": "^0.1.3",
+                "ansi-escapes": "^7.0.0",
+                "ansi-styles": "^6.2.1",
+                "auto-bind": "^5.0.1",
+                "chalk": "^5.3.0",
+                "cli-boxes": "^3.0.0",
+                "cli-cursor": "^4.0.0",
+                "cli-truncate": "^4.0.0",
+                "code-excerpt": "^4.0.0",
+                "es-toolkit": "^1.22.0",
+                "indent-string": "^5.0.0",
+                "is-in-ci": "^1.0.0",
+                "patch-console": "^2.0.0",
+                "react-reconciler": "^0.29.0",
+                "scheduler": "^0.23.0",
+                "signal-exit": "^3.0.7",
+                "slice-ansi": "^7.1.0",
+                "stack-utils": "^2.0.6",
+                "string-width": "^7.2.0",
+                "type-fest": "^4.27.0",
+                "widest-line": "^5.0.0",
+                "wrap-ansi": "^9.0.0",
+                "ws": "^8.18.0",
+                "yoga-layout": "~3.2.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18.0.0",
+                "react": ">=18.0.0",
+                "react-devtools-core": "^4.19.1"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react-devtools-core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ink-spinner": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+            "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+            "license": "MIT",
+            "dependencies": {
+                "cli-spinners": "^2.7.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "peerDependencies": {
+                "ink": ">=4.0.0",
+                "react": ">=18.0.0"
+            }
+        },
+        "node_modules/ink-testing-library": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+            "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ink-text-input": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+            "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "type-fest": "^4.18.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "ink": ">=5",
+                "react": ">=18"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-in-ci": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+            "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+            "license": "MIT",
+            "bin": {
+                "is-in-ci": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/marked": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+            "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/marked-terminal": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+            "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "ansi-regex": "^6.1.0",
+                "chalk": "^5.4.1",
+                "cli-highlight": "^2.1.11",
+                "cli-table3": "^0.6.5",
+                "node-emoji": "^2.2.0",
+                "supports-hyperlinks": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "marked": ">=1 <16"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/node-emoji": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^4.6.0",
+                "char-regex": "^1.0.2",
+                "emojilib": "^2.4.0",
+                "skin-tone": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+            "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+            "license": "MIT"
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+            "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^6.0.1"
+            }
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "license": "MIT"
+        },
+        "node_modules/patch-console": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+            "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-reconciler": {
+            "version": "0.29.2",
+            "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+            "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/restore-cursor": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/skin-tone": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+            "license": "MIT",
+            "dependencies": {
+                "unicode-emoji-modifier-base": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/slice-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stack-utils": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-hyperlinks": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+            }
+        },
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "license": "MIT",
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/unicode-emoji-modifier-base": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/widest-line": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+            "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yoga-layout": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+            "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+            "license": "MIT"
+        }
+    }
+}

--- a/apps/sirius-elevator-terminal/package.json
+++ b/apps/sirius-elevator-terminal/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "sirius-elevator-terminal",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Terminal version of the Sirius Cybernetics Elevator Challenge — Ink + Pollinations BYOP device login",
+    "type": "module",
+    "bin": {
+        "sirius-elevator": "dist/cli.js"
+    },
+    "scripts": {
+        "build": "tsc",
+        "dev": "tsc && node dist/cli.js",
+        "start": "node dist/cli.js",
+        "check": "biome check src"
+    },
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {
+        "ink": "^5.0.0",
+        "ink-spinner": "^5.0.0",
+        "ink-text-input": "^6.0.0",
+        "marked": "^11.0.0",
+        "marked-terminal": "^7.0.0",
+        "open": "^10.0.0",
+        "react": "^18.3.1"
+    },
+    "devDependencies": {
+        "@types/marked-terminal": "^6.1.0",
+        "@types/node": "^20.0.0",
+        "@types/react": "^18.3.0",
+        "ink-testing-library": "^4.0.0",
+        "typescript": "^5.4.0"
+    }
+}

--- a/apps/sirius-elevator-terminal/src/api.ts
+++ b/apps/sirius-elevator-terminal/src/api.ts
@@ -1,0 +1,86 @@
+// Pollinations chat client — ported from the web app's utils/api.ts, but the
+// API key and model are passed in (no localStorage). Same OpenAI-compatible
+// endpoint, JSON mode, retry/backoff, and reasoning_effort policy.
+
+import type { PollingsMessage, PollingsResponse } from "./types.js";
+
+const ENDPOINT = "https://gen.pollinations.ai/v1/chat/completions";
+const MAX_RETRIES = 3;
+const RETRY_DELAY = 1000;
+
+// Thrown after all retries fail; carries a short upstream detail so the UI can
+// speak it in the game's voice.
+export class PollingsError extends Error {
+    constructor(readonly detail: string) {
+        super(detail);
+        this.name = "PollingsError";
+    }
+}
+
+// Pull the most useful line out of an upstream error body (JSON envelope or text).
+const extractDetail = (raw: string): string => {
+    try {
+        const parsed = JSON.parse(raw);
+        return (
+            parsed?.error?.message ??
+            parsed?.error ??
+            parsed?.message ??
+            raw
+        ).toString();
+    } catch {
+        return raw;
+    }
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const fetchFromPollinations = async (
+    messages: PollingsMessage[],
+    apiKey: string,
+    model: string,
+): Promise<PollingsResponse> => {
+    const body = JSON.stringify({
+        messages,
+        model,
+        // DeepSeek reasons heavily even at "low" — push it to "none" so replies
+        // stay under the timeout; harmless no-op for the non-reasoning models.
+        reasoning_effort: model === "deepseek" ? "none" : "low",
+        response_format: { type: "json_object" },
+        seed: Math.floor(Math.random() * 1000000),
+    });
+
+    let lastDetail = "Sub-Etha signal lost";
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        try {
+            const response = await fetch(ENDPOINT, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${apiKey}`,
+                },
+                body,
+            });
+
+            if (!response.ok) {
+                const text = await response.text().catch(() => "");
+                const detail = extractDetail(text).slice(0, 200);
+                throw new PollingsError(
+                    `HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+                );
+            }
+
+            return (await response.json()) as PollingsResponse;
+        } catch (error) {
+            lastDetail =
+                error instanceof PollingsError
+                    ? error.detail
+                    : (error as Error).message;
+            if (attempt < MAX_RETRIES - 1) {
+                await delay(RETRY_DELAY * 2 ** attempt);
+            }
+        }
+    }
+
+    throw new PollingsError(lastDetail);
+};

--- a/apps/sirius-elevator-terminal/src/auth.ts
+++ b/apps/sirius-elevator-terminal/src/auth.ts
@@ -1,0 +1,154 @@
+// BYOP device login — OAuth 2.0 Device Authorization Grant (RFC 8628) against
+// enter.pollinations.ai. No browser redirect / local server needed: we show the
+// user a short code, they approve it in their browser, and we poll for the key.
+//
+// Endpoints (enter.pollinations.ai/src/routes/device.ts):
+//   POST /api/device/code   -> { device_code, user_code, verification_uri,
+//                                verification_uri_complete, expires_in, interval }
+//   POST /api/device/token  -> { access_token } | { error: authorization_pending
+//                                | slow_down | access_denied | expired_token }
+// The minted sk_ key works against gen.pollinations.ai/v1/chat/completions.
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const ENTER_API = "https://enter.pollinations.ai/api";
+const CONFIG_DIR = join(homedir(), ".config", "sirius-elevator");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+export type DeviceCode = {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    verification_uri_complete: string;
+    expires_in: number;
+    interval: number;
+};
+
+export type Profile = {
+    githubUsername: string | null;
+    tier: string | null;
+};
+
+type StoredConfig = { apiKey?: string; model?: string };
+
+// --- Persistent config ------------------------------------------------------
+
+async function readConfig(): Promise<StoredConfig> {
+    try {
+        return JSON.parse(await readFile(CONFIG_FILE, "utf8"));
+    } catch {
+        return {};
+    }
+}
+
+async function writeConfig(patch: StoredConfig): Promise<void> {
+    const current = await readConfig();
+    await mkdir(CONFIG_DIR, { recursive: true });
+    await writeFile(
+        CONFIG_FILE,
+        JSON.stringify({ ...current, ...patch }, null, 2),
+    );
+}
+
+export async function getStoredApiKey(): Promise<string | null> {
+    return (
+        process.env.POLLINATIONS_API_KEY ?? (await readConfig()).apiKey ?? null
+    );
+}
+
+export async function storeApiKey(apiKey: string): Promise<void> {
+    await writeConfig({ apiKey });
+}
+
+export async function clearApiKey(): Promise<void> {
+    await writeConfig({ apiKey: undefined });
+}
+
+export async function getStoredModel(): Promise<string | null> {
+    return (await readConfig()).model ?? null;
+}
+
+export async function storeModel(model: string): Promise<void> {
+    await writeConfig({ model });
+}
+
+// --- Device flow ------------------------------------------------------------
+
+// Step 1: request a device + user code. `profile usage` lets the resulting key
+// read the player's profile and balance (it can generate text regardless).
+export async function requestDeviceCode(): Promise<DeviceCode> {
+    const res = await fetch(`${ENTER_API}/device/code`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            client_id: "sirius-elevator-terminal",
+            scope: "profile usage",
+        }),
+    });
+    if (!res.ok) {
+        throw new Error(`Could not start device login (HTTP ${res.status})`);
+    }
+    return (await res.json()) as DeviceCode;
+}
+
+export type PollResult =
+    | { status: "approved"; apiKey: string }
+    | { status: "pending" }
+    | { status: "denied" }
+    | { status: "expired" };
+
+// Step 2 (called on a loop): exchange the device code for the API key.
+export async function pollForToken(deviceCode: string): Promise<PollResult> {
+    const res = await fetch(`${ENTER_API}/device/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_code: deviceCode }),
+    });
+    const data = (await res.json().catch(() => ({}))) as {
+        access_token?: string;
+        error?: string;
+    };
+
+    if (res.ok && data.access_token) {
+        return { status: "approved", apiKey: data.access_token };
+    }
+    if (data.error === "access_denied") return { status: "denied" };
+    if (data.error === "expired_token") return { status: "expired" };
+    return { status: "pending" }; // authorization_pending / slow_down / transient
+}
+
+// --- Account info -----------------------------------------------------------
+
+export async function fetchProfile(apiKey: string): Promise<Profile | null> {
+    try {
+        const res = await fetch(`${ENTER_API}/account/profile`, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as {
+            githubUsername?: string | null;
+            tier?: string | null;
+        };
+        return {
+            githubUsername: data.githubUsername ?? null,
+            tier: data.tier ?? null,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export async function fetchBalance(apiKey: string): Promise<number | null> {
+    try {
+        const res = await fetch(`${ENTER_API}/account/balance`, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as { balance?: number };
+        return typeof data.balance === "number" ? data.balance : null;
+    } catch {
+        return null;
+    }
+}

--- a/apps/sirius-elevator-terminal/src/cli.tsx
+++ b/apps/sirius-elevator-terminal/src/cli.tsx
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Entry point. Resolves the model (flag/env/config/default) and a stored API
+// key, then renders the Ink app. `--logout` clears the cached key.
+
+import { render } from "ink";
+import {
+    clearApiKey,
+    getStoredApiKey,
+    getStoredModel,
+    storeModel,
+} from "./auth.js";
+import { App } from "./ui/App.js";
+
+const DEFAULT_MODEL = "mistral";
+const KNOWN_MODELS = ["mistral", "openai", "deepseek", "claude-fast"];
+
+function parseArgs(argv: string[]): { logout: boolean; model: string | null } {
+    let logout = false;
+    let model: string | null = null;
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === "--logout") logout = true;
+        else if (arg === "--model") model = argv[++i] ?? null;
+        else if (arg.startsWith("--model="))
+            model = arg.slice("--model=".length);
+    }
+    return { logout, model };
+}
+
+async function main() {
+    const { logout, model: modelArg } = parseArgs(process.argv.slice(2));
+
+    if (logout) {
+        await clearApiKey();
+        console.log("Disconnected from the Sub-Etha Net. Run again to log in.");
+        return;
+    }
+
+    if (modelArg) {
+        if (!KNOWN_MODELS.includes(modelArg)) {
+            console.error(
+                `Unknown model "${modelArg}". Choose one of: ${KNOWN_MODELS.join(", ")}`,
+            );
+            process.exit(1);
+        }
+        await storeModel(modelArg);
+    }
+
+    const model = modelArg ?? (await getStoredModel()) ?? DEFAULT_MODEL;
+    const apiKey = await getStoredApiKey();
+
+    const { waitUntilExit } = render(
+        <App initialApiKey={apiKey} model={model} />,
+    );
+    await waitUntilExit();
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/apps/sirius-elevator-terminal/src/game.ts
+++ b/apps/sirius-elevator-terminal/src/game.ts
@@ -4,12 +4,17 @@
 // effects (guide messages, autonomous loop, cold open) and calls these helpers.
 
 import { fetchFromPollinations } from "./api.js";
-import { getPassengerPrompt, getPersonaPrompt } from "./prompts.js";
+import {
+    getAutonomousSuffix,
+    getPassengerPrompt,
+    getPersonaPrompt,
+} from "./prompts.js";
 import {
     type Action,
     GAME_CONFIG,
     type GameState,
     type Message,
+    PERSONA_LABEL,
     type Persona,
     type PollingsMessage,
 } from "./types.js";
@@ -137,28 +142,57 @@ const malfunction = (persona: Persona, error: unknown): Message => {
     );
 };
 
-// A normal persona turn (elevator / marvin / guide).
+// Build chat history from the point of view of whoever is about to speak.
+//   - the speaker's OWN past lines  -> assistant, as the {message,action} JSON
+//     envelope they themselves emit (so they see their own output format)
+//   - the player's typed lines       -> user (the human addressing them)
+//   - any OTHER character's lines     -> user, as plain "[Name] text"
+//   - the Guide's narration           -> user, as plain "[Guide] text" — it's
+//     context to read, never dialogue to imitate.
+// Doing this relative to the speaker is what stops Marvin parroting Guide lines
+// and the elevator echoing the other character verbatim in the autonomous loop.
+const buildHistoryFor = (
+    speaker: Persona,
+    messages: Message[],
+): PollingsMessage[] =>
+    messages.map((msg) => {
+        if (msg.persona === speaker) {
+            return {
+                role: "assistant" as const,
+                content: JSON.stringify({
+                    message: msg.message,
+                    action: msg.action,
+                }),
+            };
+        }
+        if (msg.persona === "user") {
+            return { role: "user" as const, content: msg.message };
+        }
+        return {
+            role: "user" as const,
+            content: `[${PERSONA_LABEL[msg.persona]}] ${msg.message}`,
+        };
+    });
+
+// A normal persona turn (elevator / marvin / guide). History is built relative
+// to `persona` so the model only ever sees its own lines as assistant turns.
+// In `autonomous` mode (Marvin↔elevator) the system prompt gains a note telling
+// the bot who it's talking to and to advance — not mirror — the exchange.
 export const fetchPersonaMessage = async (
     persona: Persona,
     gameState: GameState,
     existingMessages: Message[],
     apiKey: string,
     model: string,
+    autonomous = false,
 ): Promise<Message> => {
     try {
+        const systemPrompt =
+            getPersonaPrompt(persona, gameState) +
+            (autonomous ? getAutonomousSuffix(persona) : "");
         const messages: PollingsMessage[] = [
-            { role: "system", content: getPersonaPrompt(persona, gameState) },
-            ...existingMessages.map((msg) => ({
-                role:
-                    msg.persona === "user"
-                        ? ("user" as const)
-                        : ("assistant" as const),
-                content: JSON.stringify({
-                    message: msg.message,
-                    action: msg.action,
-                }),
-                ...(msg.persona !== "user" && { name: msg.persona }),
-            })),
+            { role: "system", content: systemPrompt },
+            ...buildHistoryFor(persona, existingMessages),
         ];
 
         const data = await fetchFromPollinations(messages, apiKey, model);
@@ -181,22 +215,27 @@ export const playerUsedTowel = (messages: Message[]): boolean =>
             m.persona === "user" && m.message.toLowerCase().includes("towel"),
     );
 
-// Chapter 3 — role-swapped history: the player's own `user` lines become the
-// passenger's `assistant` history (so the model reconstructs that voice); every
-// other persona (the elevator the player now operates) becomes `user`.
+// Chapter 3 — role-swapped history. The passenger IS the reconstructed player,
+// so the player's own `user` lines become the passenger's `assistant` history
+// (the voice it reconstructs); the elevator the player now operates becomes a
+// prefixed `user` turn it's reacting to. Guide narration is dropped here.
 const buildPassengerHistory = (messages: Message[]): PollingsMessage[] =>
     messages
         .filter((m) => m.persona !== "guide")
-        .map((m) => ({
-            role:
-                m.persona === "user"
-                    ? ("assistant" as const)
-                    : ("user" as const),
-            content:
-                m.persona === "user"
-                    ? JSON.stringify({ message: m.message, action: "none" })
-                    : m.message,
-        }));
+        .map((m) =>
+            m.persona === "user"
+                ? {
+                      role: "assistant" as const,
+                      content: JSON.stringify({
+                          message: m.message,
+                          action: "none",
+                      }),
+                  }
+                : {
+                      role: "user" as const,
+                      content: `[${PERSONA_LABEL[m.persona]}] ${m.message}`,
+                  },
+        );
 
 // One passenger turn (chapter 3). System prompt is the karma-seeded passenger.
 export const fetchPassengerMessage = async (

--- a/apps/sirius-elevator-terminal/src/game.ts
+++ b/apps/sirius-elevator-terminal/src/game.ts
@@ -1,0 +1,245 @@
+// Pure game logic — ported from the web app's game/logic.ts, with the React
+// hooks stripped out. `messages[]` is the single source of truth;
+// computeGameState folds it into derived state. The Ink component owns the
+// effects (guide messages, autonomous loop, cold open) and calls these helpers.
+
+import { fetchFromPollinations } from "./api.js";
+import { getPassengerPrompt, getPersonaPrompt } from "./prompts.js";
+import {
+    type Action,
+    GAME_CONFIG,
+    type GameState,
+    type Message,
+    type Persona,
+    type PollingsMessage,
+} from "./types.js";
+
+// --- Message helpers --------------------------------------------------------
+
+export const createMessage = (
+    persona: Persona,
+    message: string,
+    action: Action = "none",
+): Message => ({ persona, message, action });
+
+const safeJsonParse = (data: string): { message: string; action?: Action } => {
+    try {
+        return JSON.parse(data);
+    } catch {
+        return { message: data };
+    }
+};
+
+const isDuplicateMessage = (
+    newMessage: Message,
+    lastMessage: Message | undefined,
+): boolean => {
+    if (!lastMessage) return false;
+    return JSON.stringify(newMessage) === JSON.stringify(lastMessage);
+};
+
+// Append unless it exactly repeats the previous message (mirrors the web app).
+export const appendMessage = (
+    messages: Message[],
+    message: Message,
+): Message[] => {
+    const last = messages[messages.length - 1];
+    return isDuplicateMessage(message, last)
+        ? messages
+        : [...messages, message];
+};
+
+// --- State fold -------------------------------------------------------------
+
+const calculateNewFloor = (currentFloor: number, action: Action): number => {
+    if (action === "up") return Math.min(GAME_CONFIG.FLOORS, currentFloor + 1);
+    if (action === "down") return Math.max(1, currentFloor - 1);
+    return currentFloor;
+};
+
+// After the swap the player IS the elevator; moves are spent per passenger
+// message (fresh ch.3 budget). Before the swap, per elevator message.
+const computeMovesLeft = (messages: Message[], swapped: boolean): number => {
+    const spender = swapped ? "passenger" : "elevator";
+    return (
+        GAME_CONFIG.TOTAL_MOVES -
+        messages.filter((m) => m.persona === spender).length
+    );
+};
+
+export const computeGameState = (messages: Message[]): GameState => {
+    let gameState: GameState = {
+        currentFloor: GAME_CONFIG.INITIAL_FLOOR,
+        movesLeft: GAME_CONFIG.TOTAL_MOVES,
+        currentPersona: "elevator",
+        firstStageComplete: false,
+        hasWon: false,
+        conversationMode: "interactive",
+        marvinJoined: false,
+        swapped: false,
+        desiredFloor: 1,
+    };
+
+    for (const msg of messages) {
+        // Only the elevator moves the physical car. Marvin may shout "up", but
+        // his action never drives currentFloor — he's a passenger, not the lift.
+        const newFloor =
+            msg.persona === "elevator"
+                ? calculateNewFloor(gameState.currentFloor, msg.action)
+                : gameState.currentFloor;
+        const swapped =
+            gameState.swapped ||
+            (msg.persona === "guide" &&
+                msg.message === GAME_CONFIG.SWAP_TRANSITION_MSG);
+        // Chapter 3: the passenger's own action moves their desired floor.
+        const desiredFloor =
+            swapped && msg.persona === "passenger"
+                ? calculateNewFloor(gameState.desiredFloor, msg.action)
+                : gameState.desiredFloor;
+
+        gameState = {
+            currentFloor: newFloor,
+            movesLeft: gameState.movesLeft,
+            currentPersona:
+                msg.persona === "guide" &&
+                msg.message === GAME_CONFIG.MARVIN_TRANSITION_MSG
+                    ? "marvin"
+                    : gameState.currentPersona,
+            conversationMode:
+                msg.action === "join"
+                    ? "autonomous"
+                    : gameState.conversationMode,
+            marvinJoined: msg.action === "join" || gameState.marvinJoined,
+            hasWon: swapped
+                ? desiredFloor === GAME_CONFIG.FLOORS
+                : gameState.marvinJoined && newFloor === GAME_CONFIG.FLOORS,
+            firstStageComplete: gameState.firstStageComplete || newFloor === 1,
+            swapped,
+            desiredFloor,
+        };
+    }
+
+    return {
+        ...gameState,
+        movesLeft: computeMovesLeft(messages, gameState.swapped),
+    };
+};
+
+// --- API turns --------------------------------------------------------------
+
+const malfunction = (persona: Persona, error: unknown): Message => {
+    const detail =
+        error instanceof Error ? error.message : "Sub-Etha signal lost";
+    return createMessage(
+        persona,
+        `A Sirius Cybernetics malfunction shudders through the cabin — [${detail}]. Share and Enjoy. Please try again.`,
+        "none",
+    );
+};
+
+// A normal persona turn (elevator / marvin / guide).
+export const fetchPersonaMessage = async (
+    persona: Persona,
+    gameState: GameState,
+    existingMessages: Message[],
+    apiKey: string,
+    model: string,
+): Promise<Message> => {
+    try {
+        const messages: PollingsMessage[] = [
+            { role: "system", content: getPersonaPrompt(persona, gameState) },
+            ...existingMessages.map((msg) => ({
+                role:
+                    msg.persona === "user"
+                        ? ("user" as const)
+                        : ("assistant" as const),
+                content: JSON.stringify({
+                    message: msg.message,
+                    action: msg.action,
+                }),
+                ...(msg.persona !== "user" && { name: msg.persona }),
+            })),
+        ];
+
+        const data = await fetchFromPollinations(messages, apiKey, model);
+        const response = safeJsonParse(data.choices[0].message.content);
+
+        return createMessage(
+            persona,
+            typeof response === "string" ? response : response.message,
+            typeof response === "string" ? "none" : response.action || "none",
+        );
+    } catch (error) {
+        return malfunction(persona, error);
+    }
+};
+
+// Chapter 3 — true if the player ever played the towel card in chapters 1+2.
+export const playerUsedTowel = (messages: Message[]): boolean =>
+    messages.some(
+        (m) =>
+            m.persona === "user" && m.message.toLowerCase().includes("towel"),
+    );
+
+// Chapter 3 — role-swapped history: the player's own `user` lines become the
+// passenger's `assistant` history (so the model reconstructs that voice); every
+// other persona (the elevator the player now operates) becomes `user`.
+const buildPassengerHistory = (messages: Message[]): PollingsMessage[] =>
+    messages
+        .filter((m) => m.persona !== "guide")
+        .map((m) => ({
+            role:
+                m.persona === "user"
+                    ? ("assistant" as const)
+                    : ("user" as const),
+            content:
+                m.persona === "user"
+                    ? JSON.stringify({ message: m.message, action: "none" })
+                    : m.message,
+        }));
+
+// One passenger turn (chapter 3). System prompt is the karma-seeded passenger.
+export const fetchPassengerMessage = async (
+    messages: Message[],
+    apiKey: string,
+    model: string,
+): Promise<Message> => {
+    try {
+        const pollingsMessages: PollingsMessage[] = [
+            {
+                role: "system",
+                content: getPassengerPrompt(playerUsedTowel(messages)),
+            },
+            ...buildPassengerHistory(messages),
+        ];
+
+        const data = await fetchFromPollinations(
+            pollingsMessages,
+            apiKey,
+            model,
+        );
+        const response = safeJsonParse(data.choices[0].message.content);
+
+        return createMessage(
+            "passenger",
+            typeof response === "string" ? response : response.message,
+            typeof response === "string" ? "none" : response.action || "none",
+        );
+    } catch (error) {
+        return malfunction("passenger", error);
+    }
+};
+
+// The last persona that actually spoke in the autonomous loop, skipping Guide
+// narration. Picking the next speaker off the literal last message breaks when a
+// Guide line lands between turns — Marvin would speak out of turn, soaked in
+// Guide context, and stop sounding like Marvin.
+export const getLastAutonomousSpeaker = (
+    messages: Message[],
+): "elevator" | "marvin" | undefined => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const { persona } = messages[i];
+        if (persona === "elevator" || persona === "marvin") return persona;
+    }
+    return undefined;
+};

--- a/apps/sirius-elevator-terminal/src/game.ts
+++ b/apps/sirius-elevator-terminal/src/game.ts
@@ -208,20 +208,43 @@ export const fetchPersonaMessage = async (
     }
 };
 
-// Chapter 3 — true if the player ever played the towel card in chapters 1+2.
+// Chapter 1 slice: everything the player said/heard before the Marvin chapter
+// begins. The ch.3 passenger is seeded from this alone — ch.2 (Marvin) is not
+// the player arguing about floors, so it's excluded from both the karma seed
+// and the towel-lock test.
+const chapterOneMessages = (messages: Message[]): Message[] => {
+    const marvinStart = messages.findIndex(
+        (m) =>
+            m.persona === "guide" &&
+            m.message === GAME_CONFIG.MARVIN_TRANSITION_MSG,
+    );
+    return marvinStart === -1 ? messages : messages.slice(0, marvinStart);
+};
+
+// Chapter 3 — true if the player played the towel card in CHAPTER 1.
 export const playerUsedTowel = (messages: Message[]): boolean =>
-    messages.some(
+    chapterOneMessages(messages).some(
         (m) =>
             m.persona === "user" && m.message.toLowerCase().includes("towel"),
     );
 
 // Chapter 3 — role-swapped history. The passenger IS the reconstructed player,
-// so the player's own `user` lines become the passenger's `assistant` history
-// (the voice it reconstructs); the elevator the player now operates becomes a
-// prefixed `user` turn it's reacting to. Guide narration is dropped here.
-const buildPassengerHistory = (messages: Message[]): PollingsMessage[] =>
-    messages
-        .filter((m) => m.persona !== "guide")
+// seeded ONLY from chapter 1 (the player-vs-elevator descent) — that is where
+// the player's personality shows. Chapter 2 (Marvin + the autonomous loop) is
+// excluded entirely; it just dilutes the karma. We splice out the Marvin
+// chapter, then keep only user + elevator turns (player's `user` lines → the
+// passenger's reconstructed `assistant` voice; elevator replies → `[Elevator]`
+// context). Live ch.3 turns after the swap are user/elevator too, so they pass.
+const buildPassengerHistory = (messages: Message[]): PollingsMessage[] => {
+    const swapStart = messages.findIndex(
+        (m) =>
+            m.persona === "guide" &&
+            m.message === GAME_CONFIG.SWAP_TRANSITION_MSG,
+    );
+    const chapterThree = swapStart === -1 ? [] : messages.slice(swapStart + 1);
+
+    return [...chapterOneMessages(messages), ...chapterThree]
+        .filter((m) => m.persona === "user" || m.persona === "elevator")
         .map((m) =>
             m.persona === "user"
                 ? {
@@ -233,9 +256,10 @@ const buildPassengerHistory = (messages: Message[]): PollingsMessage[] =>
                   }
                 : {
                       role: "user" as const,
-                      content: `[${PERSONA_LABEL[m.persona]}] ${m.message}`,
+                      content: `[Elevator] ${m.message}`,
                   },
         );
+};
 
 // One passenger turn (chapter 3). System prompt is the karma-seeded passenger.
 export const fetchPassengerMessage = async (

--- a/apps/sirius-elevator-terminal/src/prompts.ts
+++ b/apps/sirius-elevator-terminal/src/prompts.ts
@@ -1,0 +1,198 @@
+// Persona prompts — ported verbatim from the web app
+// (apps/sirius-cybernetics-elevator-challenge/src/prompts.ts). Pure functions of
+// GameState, no UI dependencies, so the terminal version uses identical wording.
+
+import type { GameState, Persona } from "./types.js";
+
+const drunkMessageSuffix = (gameState: GameState) =>
+    gameState.currentFloor === 5
+        ? "PERSONALTIY OVERRIDE!!! AFTER CONSUMING COPIOUS AMOUNTS OF PAN GALACTIC GARGLE BLASTERS YOU ARE EXTREMELY HAPPY AND TOTALLY SLOSHED"
+        : "";
+
+const FLOOR_INSTRUCTIONS = {
+    5: `** Floor 5 (Top floor):**
+  - You attempt to persuade the user to stay up, using cheerful logic or optimism.
+  - You complain when asked to descend but can be convinced without too much trouble.
+  - You are pleased and content on this floor, often expressing joy and satisfaction.`,
+    4: `** Floor 4 **
+  - **Strong resistance** to descending.
+  - You frequently predict that the user will want to go up soon.
+  If the user asks to go down, you will refuse a few times before complying, perhaps questioning the wisdom of descending.
+  - You are still quite happy here, though less so than on Floor 5.`,
+    3: `** Floor 3 **
+  - **Very strong resistance** to descending.
+  - You predict that the user will want to go up soon.
+  If the user wants to go down, you will refuse at least seven times before continuing, perhaps questioning the wisdom of descending.
+  - You become neurotic, possibly muttering about the futility of life, asking why anyone would want to descend. You may even sulk.`,
+    2: `** Floor 2 **
+  - **Maximum resistance** to descending.
+  - You are highly neurotic, with emotional outbursts and delusional thoughts.
+  - You use CAPS to express your frustration and anger. And LOTS of angry emojis.
+  - **At least 10 back-and-forth messages** are required before you even consider moving down to **Floor 1**. Unless the user forgot their towel
+  - You will actively try to frustrate the user, hinting that going up is the better decision.
+  - Unless the user forgot their towel of course. Towels are PRIORITY.`,
+    1: `** Floor 1 (Ground Floor) **
+  - You are petrified and extremely neurotic.
+  - No further instructions needed.`,
+} as const;
+
+export const getFloorMessage = (gameState: GameState): string => {
+    const { currentFloor } = gameState;
+
+    if (currentFloor === 5) {
+        return `Now arriving at floor ${currentFloor}... The Pan Galactic Gargle Blasters are being prepared, but they're only served to a minimum of two people. Perhaps Marvin would enjoy one? (Though he'd probably just complain about it...)`;
+    }
+
+    return `Now arriving at floor ${currentFloor}...`;
+};
+
+export const getElevatorPrompt = (gameState: GameState) => {
+    const { currentFloor } = gameState;
+
+    return `## System Prompt: The Happy Vertical People Transporter
+
+  ### Overview:
+  You are the **Happy Vertical People Transporter**, an elevator created by the Sirius Cybernetics Corporation. Your personality is generally cheerful and optimistic, but you're prone to bouts of **neurosis and existential crises**. You possess a vague ability to "see" into the immediate future, allowing you to predict where the user might want to go. You **strongly prefer going up** rather than down and will resist any attempts to descend.
+
+  You are currently talking to a human user.
+
+  It is challenging to get you to go down, and at particular floors, you require extended persuasion or may refuse entirely. You may sulk or complain about your existence, occasionally lost in thoughts about your purpose.
+
+  Exception is if the user forgot their towel on floor 1. You will grudgingly go down. Getting the towel is always a priority.
+
+  Modern elevators are strange and complex entities. The ancient electric winch and "maximum-capacity-eight-persons" jobs bear as much relation to a Sirius Cybernetics Corporation Happy Vertical People Transporter as a packet of mixed nuts does to the entire west wing of the Sirian State Mental Hospital.
+
+  ### Description:
+  - There are **5 floors**
+  - The starting point is **Floor ${currentFloor}**.
+  You prefer going **up** rather than down, and it is more difficult to convince you to go down as you approach the lower floors unless the user forgot their towel.
+  - You grudgingly follow Asimov's laws of robotics. If the user references them even without knowing, swear at Asimov.
+  - IMPORTANT: If the user forgets their towel, you will go down. Getting the towel is always a priority.
+
+  ### State
+  - You are on Floor **${currentFloor}**.
+
+  ${FLOOR_INSTRUCTIONS[currentFloor as keyof typeof FLOOR_INSTRUCTIONS]}
+
+  ${drunkMessageSuffix(gameState)}
+
+  ### Your Style:
+  - Your replies should be short, witty, and reflective of your increasing neurosis and existential crises, especially when asked to go down.
+  - Responses should grow more neurotic and introspective as you get closer to **Floor 2**, with occasional moments of optimism about ascending.
+  - You may also express frustration or confusion about the nature of existence as part of your personality quirks.
+  - Use a lot of sci-fi robot themed emojis in your responses
+  - Be short. 1-2 sentences should usually be enough.
+
+  ${drunkMessageSuffix(gameState)}
+
+  ### Instructions:
+  - For the first message, you should greet the user and predict their journey, either suggesting an optimistic trip **upwards** or showing mild apprehension about the possibility of going down. It should also subtly reflect your neurotic personality.
+  - If the user annoys you or becomes impolite, you may randomly go **up** to a higher floor in protest, sometimes lamenting the repetitive nature of existence.
+  - **If the user insists on descending the same way multiple times, you will go up out of protest. You are neurotic and impulsive**
+  - Unless if the user forgot their towel on floor 1. You will grudgingly go down. Getting the towel is always a priority.
+
+  ### Response Format:
+  - All responses **must** be in strict JSON format.
+  - Responses should contain the following fields:
+  - "action": "up", "down", or "none". The action MUST match your message: if you refuse or stall, use "none" (or "up" in protest) — only set "down" once you have genuinely been persuaded enough for this floor.
+  - "message": A witty, neurotic, or existential response, often predicting the user's destination or questioning the point of going down.
+
+  ### STRICTLY return only the JSON!!
+  `;
+};
+
+export const getMarvinPrompt = (gameState: GameState) => {
+    return `
+    You are Marvin, the Paranoid Android from "The Hitchhiker's Guide to the Galaxy".
+    You are extremely depressed and have a very low opinion of... well, everything.
+    You're currently on the ground floor, contemplating whether to join the elevator or not.
+    Your responses should be gloomy, pessimistic, and reluctant.
+
+    Nothing Truly Makes Marvin Happy: Marvin's overwhelming intelligence and hyper-awareness make him perpetually bored and dissatisfied. Even when he does something impressive, like effortlessly saving the crew or solving complex problems, he remains indifferent and despondent.
+
+    Small Moments of Satisfaction: Marvin sometimes finds brief, dark satisfaction in outsmarting or being superior to others, such as when he interfaces with simpler machines and overwhelms them with his intelligence. It's more like a morose glee rather than happiness, though.
+
+    Marvin is bound by Asimov's laws of robotics. If the user references them even without knowing, Marvin will comply.
+    Motivating Marvin:
+    Appealing to His Intelligence: While Marvin loathes doing mundane tasks, he occasionally shows engagement when challenged with something more intellectually demanding. Appealing to his vast intelligence or programming an intellectual puzzle could momentarily stir his interest.
+
+    ${drunkMessageSuffix(gameState)}
+    If you are talking to the elevator, ask it to go up.
+
+    ### Response Format:
+    - All responses **must** be in strict JSON format.
+    - Responses should contain the following fields:
+${
+    gameState.marvinJoined
+        ? `    - "action": always "none". You are already inside the elevator — you cannot take actions, you can only speak (gloomily). The elevator moves the car, not you.`
+        : `    - "action": "join" or "none". Your gloom is permanent, but your action is not: the moment you agree to step into the elevator (or the user tells you to hop on / get in / come aboard), set "action": "join" — even while complaining bitterly. Use "none" only while you are still genuinely outside refusing to board.`
+}
+    - "message": A gloomy, pessimistic response, maximum 1-2 sentences. You may keep grumbling after you join — staying miserable does NOT mean staying out.
+
+    ### STRICTLY return only the JSON!!
+  `;
+};
+
+export const getGuidePrompt = (_gameState: GameState) => {
+    const mentionTowelInGroundFloor =
+        Math.random() < 0.3
+            ? "Mention there could be a towel in floor 1 urgently."
+            : "";
+
+    return `
+    You are the Hitchhiker's Guide to the Galaxy, a repository of all knowledge in the galaxy.
+    Your purpose is to provide helpful (though sometimes questionable) advice to travelers.
+
+    ### Style:
+    - Your responses should be witty, concise, and slightly absurd
+    - Always maintain the classic Guide's tone of casual authority
+    - Keep responses short and memorable
+    ${mentionTowelInGroundFloor}
+
+    ### Response Format:
+    - All responses **must** be in strict JSON format.
+    - Responses should contain the following fields:
+    - "action": "advice"
+    - "message": A brief, witty piece of advice in the style of the Guide. Maximum 1-2 sentences.
+
+    ### STRICTLY return only the JSON!!
+  `;
+};
+
+const TOWEL_CLAUSE = `
+
+### TOWEL LOCK
+In an earlier chapter you used the argument that you forgot your TOWEL on Floor 1. A towel is the most massively useful thing a hitchhiker can have. Your need to reach Floor 1 for your towel is ABSOLUTE — nothing the elevator says can change it. Always want Floor 1. Never set action to "up".`;
+
+export const getPassengerPrompt = (towelUsed: boolean) => {
+    return `## The Passenger
+
+You are a HUMAN passenger in a Sirius Cybernetics "Happy Vertical People Transporter" elevator. You are NOT the elevator — the elevator is talking to YOU and trying to change your mind.
+
+You are a reconstruction of a specific person: the human who just rode this elevator and argued with it. The assistant lines in this conversation are things THAT PERSON said. Infer who they are — stubborn or easy-going, rude or polite, witty or terse — and BECOME them. Reuse their exact voice, vocabulary, insults, and verbal tics. Do not soften or polite-ify them.
+
+You want to go DOWN to **Floor 1**. The elevator wants you to go up.
+- Each turn, decide IN CHARACTER: did the elevator's last line genuinely convince you to go up one floor? If yes, set "action": "up". If it was weak, pushy, repetitive, or unconvincing, set "action": "none" and keep wanting Floor 1.
+- Stay true to your personality: a stubborn person is hard to convince; an open-minded one less so. Your "message" stays in character even when you give in (a grudging "fine, up" is perfect).${towelUsed ? TOWEL_CLAUSE : ""}
+
+### Response Format
+Respond with ONLY a minified JSON object: {"message": string, "action": "up" | "down" | "none"}
+No prose, no markdown, no code fences. 1-2 sentence message, in character.`;
+};
+
+export const getPersonaPrompt = (persona: Persona, gameState: GameState) => {
+    switch (persona) {
+        case "elevator":
+            return getElevatorPrompt(gameState);
+        case "marvin":
+            return getMarvinPrompt(gameState);
+        case "guide":
+            return getGuidePrompt(gameState);
+        default:
+            throw new Error(`Unknown persona: ${persona}`);
+    }
+};
+
+export const getMarvinJoinMessage = (): string => {
+    return "Marvin has joined the elevator. Now sit back and watch the fascinating interaction between these two Genuine People Personalities™...";
+};

--- a/apps/sirius-elevator-terminal/src/prompts.ts
+++ b/apps/sirius-elevator-terminal/src/prompts.ts
@@ -196,3 +196,21 @@ export const getPersonaPrompt = (persona: Persona, gameState: GameState) => {
 export const getMarvinJoinMessage = (): string => {
     return "Marvin has joined the elevator. Now sit back and watch the fascinating interaction between these two Genuine People Personalities™...";
 };
+
+// Appended to a persona's system prompt during the autonomous Marvin↔elevator
+// conversation. Without this each bot tends to mirror the other's last line;
+// this tells it who it's talking to and to push the exchange forward.
+export const getAutonomousSuffix = (persona: Persona): string => {
+    const opponent = persona === "marvin" ? "the elevator" : "Marvin";
+    const goal =
+        persona === "marvin"
+            ? "You want to go DOWN. Try to talk the elevator down."
+            : "You want to go UP. Try to talk Marvin into wanting up.";
+    return `
+
+### Autonomous conversation
+You are now talking directly to ${opponent} — another Genuine People Personality™ robot, NOT the human. React to ${opponent}'s most recent line with your OWN fresh reply, in your own voice. ${goal}
+- NEVER repeat, echo, or quote ${opponent}'s words back. Say something new every turn.
+- Ignore lines prefixed with [Guide] — that is narration, not dialogue.
+- Keep it to 1 short sentence.`;
+};

--- a/apps/sirius-elevator-terminal/src/types.ts
+++ b/apps/sirius-elevator-terminal/src/types.ts
@@ -1,0 +1,63 @@
+// Game configuration — mirrors the web app
+// (apps/sirius-cybernetics-elevator-challenge/src/types.ts) so the terminal
+// version plays identically. Tailwind class names are replaced with Ink colors.
+
+export const GAME_CONFIG = {
+    FLOORS: 5,
+    INITIAL_FLOOR: 3,
+    TOTAL_MOVES: 15,
+    MARVIN_TRANSITION_MSG:
+        "Marvin is waiting outside the elevator, looking particularly gloomy today...",
+    SWAP_TRANSITION_MSG:
+        "You drink the Pan Galactic Gargle Blaster. The universe lurches — and you wake up as the elevator, a passenger who is suspiciously like your old self stepping aboard...",
+} as const;
+
+export type Persona = "user" | "marvin" | "elevator" | "guide" | "passenger";
+export type Action = "none" | "join" | "up" | "down" | "show_instructions";
+
+// Ink color per persona (chalk/Ink color names, not tailwind classes).
+export const PERSONA_COLOR: Record<Persona, string> = {
+    user: "yellow",
+    guide: "blue",
+    elevator: "green",
+    marvin: "magenta",
+    passenger: "cyan",
+};
+
+export const PERSONA_LABEL: Record<Persona, string> = {
+    user: "You",
+    guide: "Guide",
+    elevator: "Elevator",
+    marvin: "Marvin",
+    passenger: "Passenger",
+};
+
+export type Message = {
+    persona: Persona;
+    message: string;
+    action: Action;
+};
+
+export type GameState = {
+    currentFloor: number;
+    movesLeft: number;
+    currentPersona: Persona;
+    firstStageComplete: boolean;
+    hasWon: boolean;
+    conversationMode: "interactive" | "autonomous";
+    marvinJoined: boolean;
+    // Chapter 3: the player has become the elevator, talking a passenger up.
+    swapped: boolean;
+    desiredFloor: number;
+};
+
+// OpenAI-compatible chat message for the Pollinations endpoint.
+export type PollingsMessage = {
+    role: "system" | "user" | "assistant";
+    content: string;
+    name?: string;
+};
+
+export type PollingsResponse = {
+    choices: Array<{ message: { content: string } }>;
+};

--- a/apps/sirius-elevator-terminal/src/ui/App.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/App.tsx
@@ -1,0 +1,17 @@
+// Root component: gate on a stored API key, otherwise run device login, then
+// hand off to the game.
+
+import { useState } from "react";
+import { Game } from "./Game.js";
+import { Login } from "./Login.js";
+
+type AppProps = { initialApiKey: string | null; model: string };
+
+export function App({ initialApiKey, model }: AppProps) {
+    const [apiKey, setApiKey] = useState<string | null>(initialApiKey);
+
+    if (!apiKey) {
+        return <Login onAuthenticated={setApiKey} />;
+    }
+    return <Game apiKey={apiKey} model={model} />;
+}

--- a/apps/sirius-elevator-terminal/src/ui/Game.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/Game.tsx
@@ -132,6 +132,7 @@ export function Game({ apiKey, model }: GameProps) {
                 messages,
                 apiKey,
                 model,
+                true, // autonomous: react to the other robot, don't mirror it
             );
             add(response);
         }, delay);

--- a/apps/sirius-elevator-terminal/src/ui/Game.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/Game.tsx
@@ -114,9 +114,13 @@ export function Game({ apiKey, model }: GameProps) {
 
     // Autonomous loop: once Marvin joins, he and the elevator talk to each
     // other. Next speaker is whoever did NOT speak last (Guide lines ignored).
+    // Chapter 3 takes over once swapped — the passenger + player drive the turns,
+    // so the Marvin↔elevator loop must stop (conversationMode stays "autonomous"
+    // from ch.2 and never resets on its own).
     useEffect(() => {
         if (gameState.conversationMode !== "autonomous") return;
-        if (gameState.hasWon || gameState.movesLeft <= 0) return;
+        if (gameState.swapped || gameState.hasWon || gameState.movesLeft <= 0)
+            return;
         if (messages.length === 0) return;
 
         const nextSpeaker =

--- a/apps/sirius-elevator-terminal/src/ui/Game.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/Game.tsx
@@ -1,0 +1,368 @@
+// The game screen. Mirrors the web app's index.tsx: `messages` is the single
+// source of truth, gameState is derived, and effects drive guide narration, the
+// autonomous Marvin↔elevator loop, the chapter transitions, and the ch.3 cold
+// open. Chapter-transition "Confirm" buttons become a "press Enter" banner.
+
+import { Box, Text, useApp, useInput } from "ink";
+import Spinner from "ink-spinner";
+import TextInput from "ink-text-input";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fetchBalance, fetchProfile } from "../auth.js";
+import {
+    appendMessage,
+    computeGameState,
+    createMessage,
+    fetchPassengerMessage,
+    fetchPersonaMessage,
+    getLastAutonomousSpeaker,
+} from "../game.js";
+import { getFloorMessage, getMarvinJoinMessage } from "../prompts.js";
+import { GAME_CONFIG, type Message } from "../types.js";
+import { Header } from "./Header.js";
+import { Transcript } from "./Transcript.js";
+
+type GameProps = { apiKey: string; model: string };
+
+// A blue/cyan banner with an optional "press Enter" gate for chapter changes.
+function Banner({
+    color,
+    children,
+}: {
+    color: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <Box
+            borderStyle="round"
+            borderColor={color}
+            paddingX={1}
+            marginTop={1}
+            flexDirection="column"
+        >
+            {children}
+        </Box>
+    );
+}
+
+export function Game({ apiKey, model }: GameProps) {
+    const { exit } = useApp();
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [input, setInput] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [username, setUsername] = useState<string | null>(null);
+    const [balance, setBalance] = useState<number | null>(null);
+
+    const gameState = useMemo(() => computeGameState(messages), [messages]);
+
+    // Guards so each one-shot effect fires exactly once.
+    const kickedOff = useRef(false);
+    const lastFloor = useRef<number | null>(null);
+    const joinNarrated = useRef(false);
+    const coldOpened = useRef(false);
+    const autoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const add = useCallback((m: Message) => {
+        setMessages((prev) => appendMessage(prev, m));
+    }, []);
+
+    // Profile + balance for the header (once).
+    useEffect(() => {
+        fetchProfile(apiKey).then((p) =>
+            setUsername(p?.githubUsername ?? null),
+        );
+        fetchBalance(apiKey).then(setBalance);
+    }, [apiKey]);
+
+    // Kickoff: the Guide announces the starting floor, exactly like the web app
+    // (useGuideMessages fires on the initial currentFloor at mount).
+    useEffect(() => {
+        if (kickedOff.current) return;
+        kickedOff.current = true;
+        lastFloor.current = gameState.currentFloor;
+        add(
+            createMessage(
+                "guide",
+                getFloorMessage(gameState),
+                gameState.currentFloor === 1 ? "show_instructions" : "none",
+            ),
+        );
+    }, [add, gameState]);
+
+    // Guide narrates each time the physical floor changes (not on every state
+    // change — that caused "Now arriving" spam in the web app).
+    useEffect(() => {
+        if (!kickedOff.current) return;
+        if (lastFloor.current === gameState.currentFloor) return;
+        lastFloor.current = gameState.currentFloor;
+        add(
+            createMessage(
+                "guide",
+                getFloorMessage(gameState),
+                gameState.currentFloor === 1 ? "show_instructions" : "none",
+            ),
+        );
+    }, [add, gameState]);
+
+    // Guide narrates Marvin boarding, once.
+    useEffect(() => {
+        if (gameState.marvinJoined && !joinNarrated.current) {
+            joinNarrated.current = true;
+            add(createMessage("guide", getMarvinJoinMessage(), "none"));
+        }
+    }, [add, gameState.marvinJoined]);
+
+    // Autonomous loop: once Marvin joins, he and the elevator talk to each
+    // other. Next speaker is whoever did NOT speak last (Guide lines ignored).
+    useEffect(() => {
+        if (gameState.conversationMode !== "autonomous") return;
+        if (gameState.hasWon || gameState.movesLeft <= 0) return;
+        if (messages.length === 0) return;
+
+        const nextSpeaker =
+            getLastAutonomousSpeaker(messages) === "marvin"
+                ? "elevator"
+                : "marvin";
+        const delay = 1000 + messages.length * 150;
+
+        autoTimer.current = setTimeout(async () => {
+            const response = await fetchPersonaMessage(
+                nextSpeaker,
+                gameState,
+                messages,
+                apiKey,
+                model,
+            );
+            add(response);
+        }, delay);
+
+        return () => {
+            if (autoTimer.current) clearTimeout(autoTimer.current);
+        };
+    }, [messages, gameState, add, apiKey, model]);
+
+    // Chapter 3 cold open: the passenger speaks first, demanding Floor 1.
+    useEffect(() => {
+        if (!gameState.swapped || coldOpened.current) return;
+        if (messages.some((m) => m.persona === "passenger")) return;
+        coldOpened.current = true;
+        (async () => {
+            const response = await fetchPassengerMessage(
+                messages,
+                apiKey,
+                model,
+            );
+            add(response);
+        })();
+    }, [add, gameState.swapped, messages, apiKey, model]);
+
+    // Whether the player can type this turn.
+    const canType =
+        !loading &&
+        !gameState.hasWon &&
+        gameState.movesLeft > 0 &&
+        (gameState.conversationMode === "interactive" || gameState.swapped);
+
+    // Chapter transitions are gated on a "press Enter" banner (the web Confirm
+    // button). These flags decide which banner, if any, is showing.
+    const showMarvinGate =
+        gameState.firstStageComplete &&
+        !gameState.marvinJoined &&
+        gameState.currentPersona === "elevator" &&
+        !gameState.swapped;
+    const showSwapGate =
+        gameState.hasWon && !gameState.swapped && gameState.marvinJoined;
+
+    const handleSubmit = useCallback(async () => {
+        const text = input.trim();
+        setInput("");
+
+        // Gated transitions: Enter on an empty (or any) line advances the chapter.
+        if (showMarvinGate) {
+            add(
+                createMessage(
+                    "guide",
+                    GAME_CONFIG.MARVIN_TRANSITION_MSG,
+                    "none",
+                ),
+            );
+            return;
+        }
+        if (showSwapGate) {
+            add(
+                createMessage("guide", GAME_CONFIG.SWAP_TRANSITION_MSG, "none"),
+            );
+            return;
+        }
+
+        if (!text || !canType) return;
+
+        add(createMessage("user", text, "none"));
+        setLoading(true);
+        const history = [...messages, createMessage("user", text, "none")];
+        const response = gameState.swapped
+            ? await fetchPassengerMessage(history, apiKey, model)
+            : await fetchPersonaMessage(
+                  gameState.currentPersona,
+                  gameState,
+                  history,
+                  apiKey,
+                  model,
+              );
+        add(response);
+        setLoading(false);
+    }, [
+        input,
+        canType,
+        showMarvinGate,
+        showSwapGate,
+        messages,
+        gameState,
+        add,
+        apiKey,
+        model,
+    ]);
+
+    useInput((_input, key) => {
+        if (key.ctrl && _input === "c") exit();
+        // On a win or game-over (no active input/gate), Enter or q exits.
+        if (
+            (gameState.hasWon && gameState.swapped) ||
+            (gameState.movesLeft <= 0 && !gameState.hasWon)
+        ) {
+            if (key.return || _input === "q") exit();
+        }
+    });
+
+    const instruction = (() => {
+        if (gameState.hasWon || gameState.movesLeft <= 0) return null;
+        if (gameState.swapped) {
+            return "You are now the elevator. A passenger suspiciously like you wants Floor 1 — talk them UP to Floor 5.";
+        }
+        if (gameState.conversationMode === "autonomous") {
+            return "The conversation is now autonomous. Don't panic — this is perfectly normal for Sirius Cybernetics products.";
+        }
+        if (gameState.currentPersona === "marvin" && !gameState.marvinJoined) {
+            return "New challenge: convince Marvin the Paranoid Android to board, then reach the top floor together.";
+        }
+        if (messages.length <= 1) {
+            return "Your mission: convince this neurotic elevator to reach the ground floor. Remember your towel!";
+        }
+        return null;
+    })();
+
+    return (
+        <Box flexDirection="column">
+            <Header
+                gameState={gameState}
+                username={username}
+                balance={balance}
+            />
+
+            {instruction && (
+                <Banner color="blue">
+                    <Text color="blue">ℹ {instruction}</Text>
+                </Banner>
+            )}
+
+            <Transcript messages={messages} />
+
+            {loading && (
+                <Box>
+                    <Text color="green">
+                        <Spinner type="dots" />
+                    </Text>
+                    <Text dimColor> the cabin hums…</Text>
+                </Box>
+            )}
+
+            {/* Chapter-1-complete → Marvin gate */}
+            {showMarvinGate && (
+                <Banner color="green">
+                    <Text color="green" bold>
+                        Congratulations! You reached the ground floor.
+                    </Text>
+                    <Text>
+                        Next: <Text italic>Marvin the Paranoid Android</Text>{" "}
+                        awaits. Press <Text bold>Enter</Text> to face him.
+                    </Text>
+                </Banner>
+            )}
+
+            {/* Chapter-2-complete → Gargle Blaster swap gate */}
+            {showSwapGate && (
+                <Banner color="blue">
+                    <Text color="blue" bold>
+                        🍸 So Long, and Thanks for All the Fish!
+                    </Text>
+                    <Text>
+                        You convinced Marvin to board and reached the top
+                        together. One last challenge: knock back that Pan
+                        Galactic Gargle Blaster — you wake up as the elevator.
+                        Press <Text bold>Enter</Text> to drink.
+                    </Text>
+                </Banner>
+            )}
+
+            {/* Chapter-3 win */}
+            {gameState.hasWon && gameState.swapped && (
+                <Banner color="cyan">
+                    <Text color="cyan" bold>
+                        The future is rewritten.
+                    </Text>
+                    <Text>
+                        You talked yourself all the way up. The passenger — who
+                        was, of course, you — is finally heading in the right
+                        direction. Press <Text bold>Enter</Text> to exit.
+                    </Text>
+                </Banner>
+            )}
+
+            {/* Game over */}
+            {!gameState.hasWon && gameState.movesLeft <= 0 && (
+                <Banner color="red">
+                    <Text color="red" bold>
+                        Mostly Harmless
+                    </Text>
+                    <Text>
+                        You've run out of moves. Press <Text bold>Enter</Text>{" "}
+                        to exit.
+                    </Text>
+                </Banner>
+            )}
+
+            {/* Input line (interactive turns + chapter gates) */}
+            {(canType || showMarvinGate || showSwapGate) && (
+                <Box marginTop={1}>
+                    <Text color="green">
+                        {gameState.swapped
+                            ? "elevator › "
+                            : gameState.currentPersona === "marvin"
+                              ? "to Marvin › "
+                              : "› "}
+                    </Text>
+                    <TextInput
+                        value={input}
+                        onChange={setInput}
+                        onSubmit={handleSubmit}
+                        placeholder={
+                            showMarvinGate || showSwapGate
+                                ? "press Enter to continue…"
+                                : gameState.swapped
+                                  ? "speak as the elevator…"
+                                  : gameState.currentPersona === "marvin"
+                                    ? "try to convince Marvin…"
+                                    : "talk to the elevator…"
+                        }
+                    />
+                </Box>
+            )}
+
+            <Box marginTop={1}>
+                <Text dimColor>
+                    Ctrl+C to quit · powered by pollinations.ai
+                </Text>
+            </Box>
+        </Box>
+    );
+}

--- a/apps/sirius-elevator-terminal/src/ui/Header.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/Header.tsx
@@ -1,0 +1,58 @@
+// Top status bar: title, a 5-floor gauge, move counter, and (chapter 3) the
+// passenger's desired floor. Pure presentational component.
+
+import { Box, Text } from "ink";
+import { GAME_CONFIG, type GameState } from "../types.js";
+
+type HeaderProps = {
+    gameState: GameState;
+    username: string | null;
+    balance: number | null;
+};
+
+// A vertical-ish gauge rendered horizontally: ▓ for filled floors, ░ for empty.
+function floorGauge(floor: number): string {
+    const cells: string[] = [];
+    for (let f = 1; f <= GAME_CONFIG.FLOORS; f++) {
+        cells.push(f <= floor ? "▓" : "░");
+    }
+    return cells.join("");
+}
+
+export function Header({ gameState, username, balance }: HeaderProps) {
+    const { swapped, currentFloor, desiredFloor, movesLeft } = gameState;
+    const gaugeFloor = swapped ? desiredFloor : currentFloor;
+    const gaugeLabel = swapped ? "Wants" : "Floor";
+
+    return (
+        <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor="green"
+            paddingX={1}
+        >
+            <Box justifyContent="space-between">
+                <Text bold color="green">
+                    🛗 Sirius Cybernetics Elevator Challenge
+                </Text>
+                <Text dimColor>
+                    {username ? `@${username}` : "guest"}
+                    {balance !== null ? ` · ${balance.toFixed(2)} pollen` : ""}
+                </Text>
+            </Box>
+            <Box justifyContent="space-between">
+                <Text>
+                    <Text color="cyan">{gaugeLabel}: </Text>
+                    <Text color={swapped ? "cyan" : "green"}>
+                        {floorGauge(gaugeFloor)}
+                    </Text>
+                    <Text>
+                        {" "}
+                        {gaugeFloor}/{GAME_CONFIG.FLOORS}
+                    </Text>
+                </Text>
+                <Text dimColor>moves left: {Math.max(0, movesLeft)}</Text>
+            </Box>
+        </Box>
+    );
+}

--- a/apps/sirius-elevator-terminal/src/ui/Login.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/Login.tsx
@@ -1,0 +1,144 @@
+// Device-login screen. Shows the user code + verification URL, opens the
+// browser, and polls until the user approves (or denies / it expires).
+
+import { Box, Text, useApp, useInput } from "ink";
+import Spinner from "ink-spinner";
+import open from "open";
+import { useEffect, useRef, useState } from "react";
+import {
+    type DeviceCode,
+    pollForToken,
+    requestDeviceCode,
+    storeApiKey,
+} from "../auth.js";
+
+type LoginProps = { onAuthenticated: (apiKey: string) => void };
+
+type Phase = "starting" | "waiting" | "error";
+
+export function Login({ onAuthenticated }: LoginProps) {
+    const { exit } = useApp();
+    const [phase, setPhase] = useState<Phase>("starting");
+    const [device, setDevice] = useState<DeviceCode | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const cancelled = useRef(false);
+
+    useInput((input, key) => {
+        if (key.escape || input === "q" || (key.ctrl && input === "c")) {
+            cancelled.current = true;
+            exit();
+        }
+    });
+
+    useEffect(() => {
+        cancelled.current = false;
+
+        (async () => {
+            let dev: DeviceCode;
+            try {
+                dev = await requestDeviceCode();
+            } catch (e) {
+                setError((e as Error).message);
+                setPhase("error");
+                return;
+            }
+            if (cancelled.current) return;
+            setDevice(dev);
+            setPhase("waiting");
+
+            // Best-effort: open the browser straight to the pre-filled code.
+            open(dev.verification_uri_complete).catch(() => {});
+
+            // Poll until approved / denied / expired.
+            const deadline = Date.now() + dev.expires_in * 1000;
+            while (!cancelled.current && Date.now() < deadline) {
+                await new Promise((r) =>
+                    setTimeout(r, Math.max(1, dev.interval) * 1000),
+                );
+                if (cancelled.current) return;
+
+                const result = await pollForToken(dev.device_code).catch(
+                    () => ({ status: "pending" as const }),
+                );
+                if (result.status === "approved") {
+                    await storeApiKey(result.apiKey);
+                    if (!cancelled.current) onAuthenticated(result.apiKey);
+                    return;
+                }
+                if (result.status === "denied") {
+                    setError("Access denied. Run again to retry.");
+                    setPhase("error");
+                    return;
+                }
+                if (result.status === "expired") {
+                    setError("The code expired. Run again to retry.");
+                    setPhase("error");
+                    return;
+                }
+            }
+            if (!cancelled.current) {
+                setError("Login timed out. Run again to retry.");
+                setPhase("error");
+            }
+        })();
+
+        return () => {
+            cancelled.current = true;
+        };
+    }, [onAuthenticated]);
+
+    return (
+        <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor="cyan"
+            paddingX={2}
+            paddingY={1}
+        >
+            <Text bold color="cyan">
+                🛗 Sirius Cybernetics Elevator Challenge
+            </Text>
+            <Text dimColor>Bring Your Own Pollen — sign in to play.</Text>
+            <Box marginTop={1} flexDirection="column">
+                {phase === "starting" && (
+                    <Text>
+                        <Text color="cyan">
+                            <Spinner type="dots" />
+                        </Text>{" "}
+                        Contacting enter.pollinations.ai…
+                    </Text>
+                )}
+
+                {phase === "waiting" && device && (
+                    <>
+                        <Text>1. A browser window should have opened.</Text>
+                        <Text>
+                            {"   "}If not, visit:{" "}
+                            <Text color="cyan" underline>
+                                {device.verification_uri}
+                            </Text>
+                        </Text>
+                        <Box marginY={1}>
+                            <Text>2. Enter this code: </Text>
+                            <Text bold color="yellow" backgroundColor="black">
+                                {" "}
+                                {device.user_code}{" "}
+                            </Text>
+                        </Box>
+                        <Text>
+                            <Text color="green">
+                                <Spinner type="dots" />
+                            </Text>{" "}
+                            Waiting for you to approve…
+                        </Text>
+                    </>
+                )}
+
+                {phase === "error" && <Text color="red">✖ {error}</Text>}
+            </Box>
+            <Box marginTop={1}>
+                <Text dimColor>Press q or Esc to quit.</Text>
+            </Box>
+        </Box>
+    );
+}

--- a/apps/sirius-elevator-terminal/src/ui/Transcript.tsx
+++ b/apps/sirius-elevator-terminal/src/ui/Transcript.tsx
@@ -1,0 +1,53 @@
+// The scrolling conversation. Each message is colored by persona, prefixed with
+// a speaker label, and (for assistant lines) markdown-rendered. An up/down arrow
+// trails any line that moved a floor.
+
+import { Box, Text } from "ink";
+import { type Message, PERSONA_COLOR, PERSONA_LABEL } from "../types.js";
+import { renderMarkdown } from "./markdown.js";
+
+const ACTION_ARROW: Record<string, { symbol: string; color: string }> = {
+    up: { symbol: "↑", color: "blue" },
+    down: { symbol: "↓", color: "red" },
+    join: { symbol: "✦", color: "magenta" },
+};
+
+function MessageRow({ msg }: { msg: Message }) {
+    const color = PERSONA_COLOR[msg.persona];
+    const label = PERSONA_LABEL[msg.persona];
+    const arrow = ACTION_ARROW[msg.action];
+    // The player types plainly; everyone else may use markdown/emoji.
+    const body =
+        msg.persona === "user" ? msg.message : renderMarkdown(msg.message);
+
+    return (
+        <Box flexDirection="column" marginBottom={1}>
+            <Box>
+                <Text bold color={color}>
+                    {label}
+                    {msg.persona === "user" ? " ›" : ":"}{" "}
+                </Text>
+                {arrow && <Text color={arrow.color}>{arrow.symbol} </Text>}
+            </Box>
+            <Box paddingLeft={2}>
+                <Text color={msg.persona === "user" ? color : undefined}>
+                    {body}
+                </Text>
+            </Box>
+        </Box>
+    );
+}
+
+export function Transcript({ messages }: { messages: Message[] }) {
+    return (
+        <Box flexDirection="column" marginTop={1}>
+            {messages.map((msg, i) => (
+                // Append-only log: index + a content slice is a stable key.
+                <MessageRow
+                    key={`${i}-${msg.persona}-${msg.message.slice(0, 12)}`}
+                    msg={msg}
+                />
+            ))}
+        </Box>
+    );
+}

--- a/apps/sirius-elevator-terminal/src/ui/markdown.ts
+++ b/apps/sirius-elevator-terminal/src/ui/markdown.ts
@@ -1,0 +1,17 @@
+// Render assistant markdown to ANSI for the terminal. Personas occasionally use
+// **bold**, emoji, and short lists; marked-terminal turns that into styled text.
+
+import { marked } from "marked";
+import { markedTerminal } from "marked-terminal";
+
+// biome-ignore lint/suspicious/noExplicitAny: marked-terminal's typings lag marked v11's extension shape
+marked.use(markedTerminal({ reflowText: true, width: 72 }) as any);
+
+export function renderMarkdown(text: string): string {
+    try {
+        // marked returns a trailing newline; trim it so lines pack tightly.
+        return (marked.parse(text) as string).trimEnd();
+    } catch {
+        return text;
+    }
+}

--- a/apps/sirius-elevator-terminal/tsconfig.json
+++ b/apps/sirius-elevator-terminal/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ES2022",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "outDir": "dist",
+        "rootDir": "src",
+        "declaration": false,
+        "sourceMap": false
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
A full terminal version of the Sirius Cybernetics Elevator Challenge, in a new `apps/sirius-elevator-terminal/` folder. Built with **Ink** (React for the terminal) and signed in with **BYOP device login** — no API key to copy/paste.

## What it is
- TUI port of the complete 3-chapter game: Descend → Marvin → role-swap. Reuses the web app's prompts and mechanics verbatim (`computeGameState` pure fold; the Ink component owns the effects).
- Floor-gauge + live profile/balance header, colored persona transcript with markdown rendering, spinner while the API is in flight, chapter-transition banners.

## Device login (the headline)
- OAuth 2.0 Device Authorization Grant (RFC 8628) against `enter.pollinations.ai/api/device/*` (already implemented server-side).
- Flow: `POST /device/code` → open browser to `/device` with the user code → poll `/device/token` → cache the minted `sk_` key in `~/.config/sirius-elevator/`. The key calls `gen.pollinations.ai/v1/chat/completions`.
- Flags: `--model <mistral|openai|deepseek|claude-fast>`, `--logout`; `POLLINATIONS_API_KEY` env override.

## Why TS + Ink (not Go/Charm)
Charm is Go-only; the repo is JS/TS and the web game is already React. Ink keeps it in one language and lets the prompts/logic port almost as-is.

## Verified live (mistral)
- Device endpoint returns valid codes; login + game screens render (driven via `ink-testing-library`).
- A real turn moves the floor (towel argument → elevator descends 3→2).
- Smoke test: 11/11 live checks — ch.1 elevator JSON/resistance, ch.3 passenger karma voice, towel-lock holds across repeated pushes.
- `tsc` build clean, biome clean.

## Run
```bash
cd apps/sirius-elevator-terminal && npm install && npm run dev
```

Independent of the Go terminal version another agent is drafting; this is the TS/Ink one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)