### PR TITLE
fix(community-models): format titles as name by @owner

### DIFF
--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -72,7 +72,7 @@ export async function getCommunityTextModelsInfo(
         }
 
         const name = communityModelId(row.ownerGithubUsername, row.name);
-        const title = row.description?.trim() || name;
+        const title = `${row.name} by @${row.ownerGithubUsername}`;
 
         return [
             {

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -158,6 +158,7 @@ export function communityPriceDefinition(
 export function communityModelDefinition(
     endpoint: CommunityEndpointRuntime,
 ): ModelDefinition<string> {
+    const parsed = parseCommunityModelId(endpoint.modelId);
     return {
         aliases: [],
         modelId: endpoint.modelId,
@@ -167,7 +168,9 @@ export function communityModelDefinition(
         cost: communityPriceDefinition(endpoint),
         priceMultiplier: 1,
         addedDate: 0,
-        title: endpoint.description?.trim() || endpoint.modelId,
+        title: parsed
+            ? `${parsed.modelName} by @${parsed.ownerGithubUsername}`
+            : endpoint.modelId,
         description: endpoint.description ?? undefined,
         inputModalities: ["text"],
         outputModalities: ["text"],


### PR DESCRIPTION
fixes the display name for community models where the description was overriding the title and preventing a clean "model by @user" format