### PR TITLE
fix(gen-image): weight image LB by last latency

### DIFF
--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -176,7 +176,7 @@ export function __resetLatencyStateForTests(): void {
     recentWrites.clear();
 }
 
-export const fetchFromLeastBusyServer = async (
+export const fetchFromWeightedServer = async (
     type: ServerType = "flux",
     options: RequestInit,
 ): Promise<Response> => {
@@ -185,8 +185,12 @@ export const fetchFromLeastBusyServer = async (
     const response = await fetch(`${serverUrl}/generate`, options);
     // Record latency for successful responses only (a 5xx/timeout would record
     // the full timeout window and wrongly down-weight a recovering server).
+    // Awaited (not fire-and-forget): a floating promise can be cancelled when
+    // the Worker invocation completes, dropping the KV write. The cost is
+    // bounded — recordLatency hits the in-memory throttle and returns without
+    // any KV I/O on all but ~1 request per LATENCY_WRITE_THROTTLE_MS per server.
     if (response.ok) {
-        void recordLatency(type, serverUrl, Date.now() - startedAt);
+        await recordLatency(type, serverUrl, Date.now() - startedAt);
     }
     if (!response.ok) {
         let errorBody = "";

--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -9,15 +9,26 @@ export type ServerType = (typeof VALID_TYPES)[number];
 type ServerEntry = {
     url: string;
     lastHeartbeat: number;
+    // Last observed /generate latency (ms), measured by the gen worker. Used to
+    // weight load balancing toward faster backends so a slow GPU (e.g. a 3090
+    // next to a 4090) does not get an equal share and drown. Absent until the
+    // first request to that server has completed.
+    lastMs?: number;
 };
 
 const SERVER_TIMEOUT = 180000;
 const REGISTRY_TTL_SECONDS = 240;
 const REGISTRY_WRITE_THROTTLE_MS = 30_000;
+// Persist a server's latest latency at most this often (KV ~1 write/sec/key).
+const LATENCY_WRITE_THROTTLE_MS = 20_000;
+// Latency assumed for a server with no measurement yet, so it still gets
+// sampled (not starved or flooded) on cold start.
+const DEFAULT_LATENCY_MS = 8000;
 
 let serverRegistry: KVNamespace | null = null;
 let registryEnvironment = "development";
 const recentWrites = new Map<string, number>();
+const recentLatencyWrites = new Map<string, number>();
 
 export function setServerRegistryBinding(
     binding: KVNamespace,
@@ -68,7 +79,14 @@ export const registerServer = async (
         logServer(`Skipped throttled write for ${type} server ${url}`);
         return;
     }
-    const entry: ServerEntry = { url, lastHeartbeat: now };
+    // Preserve any latency previously recorded by recordLatency() so a heartbeat
+    // write does not wipe the routing weight.
+    const existing = await kv.get<ServerEntry>(key, "json");
+    const entry: ServerEntry = {
+        url,
+        lastHeartbeat: now,
+        ...(existing?.lastMs !== undefined && { lastMs: existing.lastMs }),
+    };
     await kv.put(key, JSON.stringify(entry), {
         expirationTtl: REGISTRY_TTL_SECONDS,
     });
@@ -93,6 +111,24 @@ export async function getRegisteredServers(
     );
 }
 
+// Weighted-random pick over active servers, weighted by 1/lastMs so faster
+// backends receive proportionally more traffic (a 3090 next to a 4090 gets a
+// smaller share instead of an equal one). Weighted rather than always-pick-the-
+// fastest to avoid herding every request onto one server between updates.
+// Unmeasured servers use a neutral default so they still get sampled. Pure
+// function — exported for testing.
+export function chooseWeightedServer(servers: ServerEntry[]): string {
+    if (servers.length === 1) return servers[0].url;
+    const weights = servers.map((s) => 1 / (s.lastMs ?? DEFAULT_LATENCY_MS));
+    const total = weights.reduce((a, b) => a + b, 0);
+    let r = Math.random() * total;
+    for (let i = 0; i < servers.length; i++) {
+        r -= weights[i];
+        if (r <= 0) return servers[i].url;
+    }
+    return servers[servers.length - 1].url;
+}
+
 export const getNextServerUrl = async (
     type: ServerType = "flux",
 ): Promise<string> => {
@@ -100,15 +136,58 @@ export const getNextServerUrl = async (
     if (activeServers.length === 0) {
         throw new Error(`No active ${type} servers available`);
     }
-    return activeServers[Math.floor(Math.random() * activeServers.length)].url;
+    return chooseWeightedServer(activeServers);
 };
+
+// Save the latency of the most recent successful /generate onto the server's
+// registry entry, so chooseWeightedServer can weight toward faster backends.
+// Throttled to one write per LATENCY_WRITE_THROTTLE_MS per server (KV caps at
+// ~1 write/sec/key). Best-effort: never throws into the request path.
+export const recordLatency = async (
+    type: ServerType,
+    url: string,
+    lastMs: number,
+): Promise<void> => {
+    if (!serverRegistry || !Number.isFinite(lastMs) || lastMs <= 0) return;
+    const key = prefix(type) + (await urlHash(url));
+    const now = Date.now();
+    const lastWrite = recentLatencyWrites.get(key);
+    if (lastWrite !== undefined && now - lastWrite < LATENCY_WRITE_THROTTLE_MS) {
+        return;
+    }
+    try {
+        const existing = await serverRegistry.get<ServerEntry>(key, "json");
+        if (!existing) return; // not registered / expired — nothing to update
+        await serverRegistry.put(
+            key,
+            JSON.stringify({ ...existing, lastMs }),
+            { expirationTtl: REGISTRY_TTL_SECONDS },
+        );
+        recentLatencyWrites.set(key, now);
+        logServer(`Recorded latency ${lastMs}ms for ${url}`);
+    } catch (err) {
+        logServer(`Failed to record latency for ${url}: ${err}`);
+    }
+};
+
+// Test-only: clear in-process throttle state between cases.
+export function __resetLatencyStateForTests(): void {
+    recentLatencyWrites.clear();
+    recentWrites.clear();
+}
 
 export const fetchFromLeastBusyServer = async (
     type: ServerType = "flux",
     options: RequestInit,
 ): Promise<Response> => {
     const serverUrl = await getNextServerUrl(type);
+    const startedAt = Date.now();
     const response = await fetch(`${serverUrl}/generate`, options);
+    // Record latency for successful responses only (a 5xx/timeout would record
+    // the full timeout window and wrongly down-weight a recovering server).
+    if (response.ok) {
+        void recordLatency(type, serverUrl, Date.now() - startedAt);
+    }
     if (!response.ok) {
         let errorBody = "";
         try {

--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -152,17 +152,18 @@ export const recordLatency = async (
     const key = prefix(type) + (await urlHash(url));
     const now = Date.now();
     const lastWrite = recentLatencyWrites.get(key);
-    if (lastWrite !== undefined && now - lastWrite < LATENCY_WRITE_THROTTLE_MS) {
+    if (
+        lastWrite !== undefined &&
+        now - lastWrite < LATENCY_WRITE_THROTTLE_MS
+    ) {
         return;
     }
     try {
         const existing = await serverRegistry.get<ServerEntry>(key, "json");
         if (!existing) return; // not registered / expired — nothing to update
-        await serverRegistry.put(
-            key,
-            JSON.stringify({ ...existing, lastMs }),
-            { expirationTtl: REGISTRY_TTL_SECONDS },
-        );
+        await serverRegistry.put(key, JSON.stringify({ ...existing, lastMs }), {
+            expirationTtl: REGISTRY_TTL_SECONDS,
+        });
         recentLatencyWrites.set(key, now);
         logServer(`Recorded latency ${lastMs}ms for ${url}`);
     } catch (err) {

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import { fetchFromLeastBusyServer } from "./availableServers.ts";
+import { fetchFromWeightedServer } from "./availableServers.ts";
 import { getImageEnv } from "./env.ts";
 import { HttpError } from "./httpError.ts";
 import { callAzureFluxKontext } from "./models/azureFluxKontextModel.js";
@@ -196,7 +196,7 @@ export const callSelfHostedServer = async (
 
         // Single attempt - no retry logic
         try {
-            response = await fetchFromLeastBusyServer("zimage", {
+            response = await fetchFromWeightedServer("zimage", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/gen.pollinations.ai/test/image/availableServers.test.ts
+++ b/gen.pollinations.ai/test/image/availableServers.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    __resetLatencyStateForTests,
+    chooseWeightedServer,
+    getRegisteredServers,
+    recordLatency,
+    registerServer,
+    setServerRegistryBinding,
+} from "../../src/image/availableServers.ts";
+
+// Minimal in-memory KV stub matching the subset of KVNamespace we use.
+function makeKv() {
+    const store = new Map<string, string>();
+    return {
+        store,
+        async get(key: string, _type?: "json") {
+            const raw = store.get(key);
+            if (raw === undefined) return null;
+            return JSON.parse(raw);
+        },
+        async put(key: string, value: string) {
+            store.set(key, value);
+        },
+        async list({ prefix }: { prefix: string }) {
+            const keys = [...store.keys()]
+                .filter((k) => k.startsWith(prefix))
+                .map((name) => ({ name }));
+            return { keys };
+        },
+        async delete(key: string) {
+            store.delete(key);
+        },
+    } as unknown as KVNamespace;
+}
+
+describe("chooseWeightedServer", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns the only server when there is one", () => {
+        const url = chooseWeightedServer([
+            { url: "https://a", lastHeartbeat: 0 },
+        ]);
+        expect(url).toBe("https://a");
+    });
+
+    it("favours the faster (lower lastMs) server", () => {
+        // Fast lastMs=1000 (weight 1.0), slow lastMs=5000 (weight 0.2).
+        const servers = [
+            { url: "https://fast", lastHeartbeat: 0, lastMs: 1000 },
+            { url: "https://slow", lastHeartbeat: 0, lastMs: 5000 },
+        ];
+        const picks = { fast: 0, slow: 0 };
+        // Deterministic sweep across [0,1) instead of real randomness.
+        let i = 0;
+        vi.spyOn(Math, "random").mockImplementation(() => {
+            const v = i / 100;
+            i = (i + 1) % 100;
+            return v;
+        });
+        for (let n = 0; n < 100; n++) {
+            if (chooseWeightedServer(servers) === "https://fast") picks.fast++;
+            else picks.slow++;
+        }
+        // weight ratio 1.0 : 0.2 => fast should get ~5x the slow server's share.
+        expect(picks.fast).toBeGreaterThan(picks.slow * 3);
+    });
+
+    it("gives unmeasured servers a neutral (non-zero) share so they get sampled", () => {
+        const servers = [
+            { url: "https://measured", lastHeartbeat: 0, lastMs: 1000 },
+            { url: "https://new", lastHeartbeat: 0 },
+        ];
+        let i = 0;
+        vi.spyOn(Math, "random").mockImplementation(() => {
+            const v = i / 100;
+            i = (i + 1) % 100;
+            return v;
+        });
+        const seen = new Set<string>();
+        for (let n = 0; n < 100; n++) seen.add(chooseWeightedServer(servers));
+        // The new, unmeasured server must still be reachable (not starved).
+        expect(seen.has("https://new")).toBe(true);
+    });
+});
+
+describe("recordLatency", () => {
+    beforeEach(() => {
+        setServerRegistryBinding(makeKv(), "test");
+        __resetLatencyStateForTests();
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("stores the last latency on the server entry", async () => {
+        await registerServer("https://w1", "zimage");
+        await recordLatency("zimage", "https://w1", 2000);
+        const w1 = (await getRegisteredServers("zimage")).find(
+            (s) => s.url === "https://w1",
+        );
+        expect(w1?.lastMs).toBe(2000);
+    });
+
+    it("throttles repeated writes (keeps the first, ignores the immediate second)", async () => {
+        await registerServer("https://w1", "zimage");
+        await recordLatency("zimage", "https://w1", 2000);
+        await recordLatency("zimage", "https://w1", 9000); // within throttle window
+        const w1 = (await getRegisteredServers("zimage")).find(
+            (s) => s.url === "https://w1",
+        );
+        expect(w1?.lastMs).toBe(2000);
+    });
+
+    it("does nothing for an unregistered server", async () => {
+        await recordLatency("zimage", "https://ghost", 1234);
+        const servers = await getRegisteredServers("zimage");
+        expect(servers).toHaveLength(0);
+    });
+});

--- a/gen.pollinations.ai/test/image/availableServers.test.ts
+++ b/gen.pollinations.ai/test/image/availableServers.test.ts
@@ -118,4 +118,27 @@ describe("recordLatency", () => {
         const servers = await getRegisteredServers("zimage");
         expect(servers).toHaveLength(0);
     });
+
+    it("ignores invalid latency values (0, negative, NaN)", async () => {
+        await registerServer("https://w1", "zimage");
+        for (const bad of [0, -5, Number.NaN]) {
+            await recordLatency("zimage", "https://w1", bad);
+        }
+        const w1 = (await getRegisteredServers("zimage")).find(
+            (s) => s.url === "https://w1",
+        );
+        expect(w1?.lastMs).toBeUndefined();
+    });
+
+    it("records a new latency once the throttle window has passed", async () => {
+        await registerServer("https://w1", "zimage");
+        await recordLatency("zimage", "https://w1", 2000);
+        // Advance time past the 20s throttle window.
+        vi.spyOn(Date, "now").mockReturnValue(Date.now() + 21_000);
+        await recordLatency("zimage", "https://w1", 3500);
+        const w1 = (await getRegisteredServers("zimage")).find(
+            (s) => s.url === "https://w1",
+        );
+        expect(w1?.lastMs).toBe(3500);
+    });
 });


### PR DESCRIPTION
- Routes image requests weighted by `1/lastMs` instead of uniform random, so a fast 4090 gets a larger share than a slow 3090 (which drowned at an equal split → 524 timeouts)
- Gen worker measures `/generate` latency itself and stores the last value on the registry entry; no worker/backend changes
- Latency writes throttled to 20s/server (KV ~1 write/sec/key); recorded on success only so timeouts don't poison the weight
- Unmeasured servers use a neutral default so they still get sampled
- Weighted-random (not always-pick-fastest) to avoid herding requests onto one server between updates
- Adds unit tests for `chooseWeightedServer` + `recordLatency`

🤖 Generated with [Claude Code](https://claude.com/claude-code)