### PR TITLE
refactor(registry): point clean model slugs at newest versions

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -52,7 +52,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000005,
     },
   },
-  "claude-opus-4.7": {
+  "claude-opus-4.6": {
     "cost": {
       "completionTextTokens": 0.000025,
       "promptCacheWriteTokens": 0.00000625,
@@ -66,7 +66,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000005,
     },
   },
-  "claude-opus-4.8": {
+  "claude-opus-4.7": {
     "cost": {
       "completionTextTokens": 0.000025,
       "promptCacheWriteTokens": 0.00000625,
@@ -146,16 +146,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "gemini": {
     "cost": {
-      "completionTextTokens": 0.000003,
-      "promptAudioTokens": 0.000001,
-      "promptCachedTokens": 0.00000005,
-      "promptTextTokens": 0.0000005,
+      "completionTextTokens": 0.000009,
+      "promptAudioTokens": 0.0000015,
+      "promptCachedTokens": 0.00000015,
+      "promptTextTokens": 0.0000015,
     },
     "price": {
-      "completionTextTokens": 0.000003,
-      "promptAudioTokens": 0.000001,
-      "promptCachedTokens": 0.00000005,
-      "promptTextTokens": 0.0000005,
+      "completionTextTokens": 0.000009,
+      "promptAudioTokens": 0.0000015,
+      "promptCachedTokens": 0.00000015,
+      "promptTextTokens": 0.0000015,
     },
   },
   "gemini-2": {
@@ -172,18 +172,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptVideoTokens": 0.000012,
     },
   },
-  "gemini-3.5-flash": {
+  "gemini-3-flash": {
     "cost": {
-      "completionTextTokens": 0.000009,
-      "promptAudioTokens": 0.0000015,
-      "promptCachedTokens": 0.00000015,
-      "promptTextTokens": 0.0000015,
+      "completionTextTokens": 0.000003,
+      "promptAudioTokens": 0.000001,
+      "promptCachedTokens": 0.00000005,
+      "promptTextTokens": 0.0000005,
     },
     "price": {
-      "completionTextTokens": 0.000009,
-      "promptAudioTokens": 0.0000015,
-      "promptCachedTokens": 0.00000015,
-      "promptTextTokens": 0.0000015,
+      "completionTextTokens": 0.000003,
+      "promptAudioTokens": 0.000001,
+      "promptCachedTokens": 0.00000005,
+      "promptTextTokens": 0.0000005,
     },
   },
   "gemini-fast": {
@@ -290,6 +290,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000014,
     },
   },
+  "gpt-5.4": {
+    "cost": {
+      "completionTextTokens": 0.000015,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.0000025,
+    },
+    "price": {
+      "completionTextTokens": 0.000015,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.0000025,
+    },
+  },
   "gpt-5.4-mini": {
     "cost": {
       "completionTextTokens": 0.0000045,
@@ -300,18 +312,6 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionTextTokens": 0.000003375,
       "promptCachedTokens": 0.00000005625,
       "promptTextTokens": 0.0000005625,
-    },
-  },
-  "gpt-5.5": {
-    "cost": {
-      "completionTextTokens": 0.00003,
-      "promptCachedTokens": 0.0000005,
-      "promptTextTokens": 0.000005,
-    },
-    "price": {
-      "completionTextTokens": 0.00003,
-      "promptCachedTokens": 0.0000005,
-      "promptTextTokens": 0.000005,
     },
   },
   "gpt-image-2": {
@@ -390,18 +390,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000002,
     },
   },
-  "grok-4.3": {
+  "grok-4-20-reasoning": {
     "cost": {
-      "completionTextTokens": 0.0000025,
+      "completionTextTokens": 0.000006,
       "promptCachedTokens": 0.0000002,
-      "promptImageTokens": 0.00000125,
-      "promptTextTokens": 0.00000125,
+      "promptImageTokens": 0.000002,
+      "promptTextTokens": 0.000002,
     },
     "price": {
-      "completionTextTokens": 0.0000025,
+      "completionTextTokens": 0.000006,
       "promptCachedTokens": 0.0000002,
-      "promptImageTokens": 0.00000125,
-      "promptTextTokens": 0.00000125,
+      "promptImageTokens": 0.000002,
+      "promptTextTokens": 0.000002,
     },
   },
   "grok-imagine": {
@@ -422,16 +422,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "grok-large": {
     "cost": {
-      "completionTextTokens": 0.000006,
+      "completionTextTokens": 0.0000025,
       "promptCachedTokens": 0.0000002,
-      "promptImageTokens": 0.000002,
-      "promptTextTokens": 0.000002,
+      "promptImageTokens": 0.00000125,
+      "promptTextTokens": 0.00000125,
     },
     "price": {
-      "completionTextTokens": 0.000006,
+      "completionTextTokens": 0.0000025,
       "promptCachedTokens": 0.0000002,
-      "promptImageTokens": 0.000002,
-      "promptTextTokens": 0.000002,
+      "promptImageTokens": 0.00000125,
+      "promptTextTokens": 0.00000125,
     },
   },
   "grok-video-pro": {
@@ -468,18 +468,6 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "kimi": {
     "cost": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.0000001,
-      "promptTextTokens": 0.0000006,
-    },
-    "price": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.0000001,
-      "promptTextTokens": 0.0000006,
-    },
-  },
-  "kimi-k2.6": {
-    "cost": {
       "completionTextTokens": 0.000004,
       "promptCachedTokens": 0.00000016,
       "promptTextTokens": 0.00000095,
@@ -490,7 +478,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000095,
     },
   },
-  "kimi-k2.7-code": {
+  "kimi-code": {
     "cost": {
       "completionTextTokens": 0.000004,
       "promptCachedTokens": 0.00000019,
@@ -500,6 +488,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionTextTokens": 0.000004,
       "promptCachedTokens": 0.00000019,
       "promptTextTokens": 0.00000095,
+    },
+  },
+  "kimi-k2.5": {
+    "cost": {
+      "completionTextTokens": 0.000003,
+      "promptCachedTokens": 0.0000001,
+      "promptTextTokens": 0.0000006,
+    },
+    "price": {
+      "completionTextTokens": 0.000003,
+      "promptCachedTokens": 0.0000001,
+      "promptTextTokens": 0.0000006,
     },
   },
   "klein": {
@@ -592,7 +592,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000003,
     },
   },
-  "minimax-m3": {
+  "minimax-m2.7": {
     "cost": {
       "completionTextTokens": 0.0000012,
       "promptCachedTokens": 0.00000006,
@@ -605,18 +605,6 @@ exports[`effective cost and price per model — snapshot 1`] = `
     },
   },
   "mistral": {
-    "cost": {
-      "completionTextTokens": 0.0000002,
-      "promptCachedTokens": 0.000000075,
-      "promptTextTokens": 0.000000075,
-    },
-    "price": {
-      "completionTextTokens": 0.0000002,
-      "promptCachedTokens": 0.000000075,
-      "promptTextTokens": 0.000000075,
-    },
-  },
-  "mistral-4": {
     "cost": {
       "completionTextTokens": 0.0000006,
       "promptCachedTokens": 0.00000015,
@@ -638,6 +626,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionTextTokens": 0.000001125,
       "promptCachedTokens": 0.0000000375,
       "promptTextTokens": 0.000000375,
+    },
+  },
+  "mistral-small-3.2": {
+    "cost": {
+      "completionTextTokens": 0.0000002,
+      "promptCachedTokens": 0.000000075,
+      "promptTextTokens": 0.000000075,
+    },
+    "price": {
+      "completionTextTokens": 0.0000002,
+      "promptCachedTokens": 0.000000075,
+      "promptTextTokens": 0.000000075,
     },
   },
   "nanobanana": {
@@ -786,14 +786,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "openai-large": {
     "cost": {
-      "completionTextTokens": 0.000015,
-      "promptCachedTokens": 0.00000025,
-      "promptTextTokens": 0.0000025,
+      "completionTextTokens": 0.00003,
+      "promptCachedTokens": 0.0000005,
+      "promptTextTokens": 0.000005,
     },
     "price": {
-      "completionTextTokens": 0.000015,
-      "promptCachedTokens": 0.00000025,
-      "promptTextTokens": 0.0000025,
+      "completionTextTokens": 0.00003,
+      "promptCachedTokens": 0.0000005,
+      "promptTextTokens": 0.000005,
     },
   },
   "p-image": {

--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -73,7 +73,9 @@ test("calculatePrice derives the total from cost via priceMultiplier", () => {
 });
 
 test("GPT-5.5 is available on the free tier", () => {
-    const definition = getModelDefinition("gpt-5.5");
+    // GPT-5.5 is the flagship behind the `openai-large` clean slug; `gpt-5.5`
+    // remains a back-compat alias. Resolve before the direct registry lookup.
+    const definition = getModelDefinition(resolveModelName("gpt-5.5"));
 
     expect(definition.paidOnly).toBeUndefined();
 });

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -117,12 +117,15 @@ test("Grok 4.20 registry metadata covers verified modalities and costs", () => {
     };
 
     const grok = getModelDefinition("grok");
-    const grokLarge = getModelDefinition("grok-large");
+    // `grok-large` now points at the newer Grok 4.3 (clean slug = newest);
+    // the 4.20 reasoning model keeps the versioned slug `grok-4-20-reasoning`.
+    const grokReasoning = getModelDefinition("grok-4-20-reasoning");
 
-    for (const model of ["grok", "grok-large"] as const) {
+    for (const model of ["grok", "grok-4-20-reasoning"] as const) {
         const definition = getModelDefinition(model);
         const priceDefinition = getPriceDefinition(model);
-        const usage = model === "grok-large" ? reasoningUsage : inputUsage;
+        const usage =
+            model === "grok-4-20-reasoning" ? reasoningUsage : inputUsage;
         const cost = calculateCost(model, usage);
         const price = calculatePrice(model, usage);
 
@@ -143,12 +146,11 @@ test("Grok 4.20 registry metadata covers verified modalities and costs", () => {
     expect(grok.reasoning).toBeUndefined();
     expect(calculateCost("grok", inputUsage).totalCost).toBeCloseTo(10.2, 8);
 
-    expect(grokLarge.modelId).toBe("grok-4-20-reasoning");
-    expect(grokLarge.reasoning).toBe(true);
-    expect(calculateCost("grok-large", reasoningUsage).totalCost).toBeCloseTo(
-        16.2,
-        8,
-    );
+    expect(grokReasoning.modelId).toBe("grok-4-20-reasoning");
+    expect(grokReasoning.reasoning).toBe(true);
+    expect(
+        calculateCost("grok-4-20-reasoning", reasoningUsage).totalCost,
+    ).toBeCloseTo(16.2, 8);
 });
 
 test("registry cost blocks contain no sentinel/placeholder negative values", () => {

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -30,7 +30,7 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["gpt-5-nano-2025-08-07"],
     },
     {
-        name: "openai-large",
+        name: "gpt-5.4",
         config: portkeyConfig["gpt-5.4"],
     },
     {
@@ -38,7 +38,7 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["gpt-5.4-mini"],
     },
     {
-        name: "gpt-5.5",
+        name: "openai-large",
         config: portkeyConfig["gpt-5.5"],
     },
     {
@@ -72,12 +72,12 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["stepfun/step-3.7-flash"],
     },
     {
-        name: "mistral",
+        name: "mistral-small-3.2",
         config: portkeyConfig["mistral-small-2503"],
         transform: stripCacheControl,
     },
     {
-        name: "mistral-4",
+        name: "mistral",
         config: portkeyConfig["mistral-small-2603"],
         transform: stripCacheControl,
     },
@@ -100,12 +100,12 @@ const models: ModelDefinition[] = [
         transform: pipe(stripCacheControl, stripReasoningEffort),
     },
     {
-        name: "grok-large",
+        name: "grok-4-20-reasoning",
         config: portkeyConfig["grok-4-20-reasoning"],
         transform: stripCacheControl,
     },
     {
-        name: "grok-4.3",
+        name: "grok-large",
         config: portkeyConfig["grok-4.3"],
         transform: stripCacheControl,
     },
@@ -126,7 +126,7 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["claude-sonnet-4-6"],
     },
     {
-        name: "claude-large",
+        name: "claude-opus-4.6",
         config: portkeyConfig["claude-opus-4-6"],
     },
     {
@@ -134,11 +134,11 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["claude-opus-4-7"],
     },
     {
-        name: "claude-opus-4.8",
+        name: "claude-large",
         config: portkeyConfig["claude-opus-4-8"],
     },
     {
-        name: "gemini",
+        name: "gemini-3-flash",
         config: portkeyConfig["gemini-3-flash-preview"],
         transform: pipe(
             sanitizeToolSchemas,
@@ -148,7 +148,7 @@ const models: ModelDefinition[] = [
         ),
     },
     {
-        name: "gemini-3.5-flash",
+        name: "gemini",
         config: portkeyConfig["gemini-3.5-flash"],
         transform: pipe(
             sanitizeToolSchemas,
@@ -231,17 +231,17 @@ const models: ModelDefinition[] = [
         transform: createPerplexitySearchTransform("high"),
     },
     {
-        name: "kimi",
+        name: "kimi-k2.5",
         config: portkeyConfig["accounts/fireworks/models/kimi-k2p5"],
         transform: stripCacheControl,
     },
     {
-        name: "kimi-k2.6",
+        name: "kimi",
         config: portkeyConfig["accounts/fireworks/models/kimi-k2p6"],
         transform: stripCacheControl,
     },
     {
-        name: "kimi-k2.7-code",
+        name: "kimi-code",
         config: portkeyConfig["accounts/fireworks/models/kimi-k2p7-code"],
         transform: stripCacheControl,
     },
@@ -269,11 +269,11 @@ const models: ModelDefinition[] = [
         transform: stripCacheControl,
     },
     {
-        name: "minimax",
+        name: "minimax-m2.7",
         config: portkeyConfig["accounts/fireworks/models/minimax-m2p7"],
     },
     {
-        name: "minimax-m3",
+        name: "minimax",
         config: portkeyConfig["accounts/fireworks/models/minimax-m3"],
     },
     {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -67,14 +67,8 @@ export const TEXT_SERVICES = {
         contextLength: 400000,
         isSpecialized: false,
     },
-    "openai-large": {
-        aliases: [
-            "gpt-5.4",
-            "gpt-5.4-reasoning",
-            "gpt-5.2",
-            "openai-reasoning",
-            "gpt-5.2-reasoning",
-        ],
+    "gpt-5.4": {
+        aliases: ["gpt-5.4-reasoning", "gpt-5.2", "gpt-5.2-reasoning"],
         modelId: "gpt-5.4",
         provider: "azure",
         brand: "OpenAI",
@@ -118,8 +112,8 @@ export const TEXT_SERVICES = {
         contextLength: 400000,
         isSpecialized: false,
     },
-    "gpt-5.5": {
-        aliases: ["gpt-5.5-reasoning"],
+    "openai-large": {
+        aliases: ["gpt-5.5", "gpt-5.5-reasoning", "openai-reasoning"],
         modelId: "gpt-5.5",
         provider: "azure",
         brand: "OpenAI",
@@ -161,12 +155,10 @@ export const TEXT_SERVICES = {
         contextLength: 262144,
         isSpecialized: false,
     },
-    "mistral": {
+    "mistral-small-3.2": {
         aliases: [
-            "mistral-small",
             "mistral-small-3.1",
             "mistral-small-2503",
-            "mistral-small-3.2",
             "mistral-small-3.2-24b-instruct-2506",
         ],
         modelId: "mistral-small-2503",
@@ -190,8 +182,13 @@ export const TEXT_SERVICES = {
         contextLength: 128000,
         isSpecialized: false,
     },
-    "mistral-4": {
-        aliases: ["mistral-small-4", "mistral-small-2603"],
+    "mistral": {
+        aliases: [
+            "mistral-4",
+            "mistral-small",
+            "mistral-small-4",
+            "mistral-small-2603",
+        ],
         modelId: "mistral-small-2603",
         provider: "openrouter",
         brand: "Mistral",
@@ -264,8 +261,8 @@ export const TEXT_SERVICES = {
         contextLength: 128000,
         isSpecialized: false,
     },
-    "gemini": {
-        aliases: ["gemini-3-flash", "gemini-3-flash-preview"],
+    "gemini-3-flash": {
+        aliases: ["gemini-3-flash-preview"],
         modelId: "gemini-3-flash-preview",
         provider: "google",
         brand: "Google",
@@ -291,7 +288,7 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
-    "gemini-3.5-flash": {
+    "gemini": {
         aliases: ["gemini-3.5-flash"],
         modelId: "gemini-3.5-flash",
         provider: "google",
@@ -490,13 +487,8 @@ export const TEXT_SERVICES = {
         contextLength: 262144,
         isSpecialized: false,
     },
-    "grok-large": {
-        aliases: [
-            "grok-4-20",
-            "grok-4-20-reasoning",
-            "grok-reasoning",
-            "grok-4-1-fast-reasoning",
-        ],
+    "grok-4-20-reasoning": {
+        aliases: ["grok-4-20", "grok-4-1-fast-reasoning"],
         modelId: "grok-4-20-reasoning",
         provider: "azure",
         brand: "xAI",
@@ -520,8 +512,8 @@ export const TEXT_SERVICES = {
         contextLength: 262144,
         isSpecialized: false,
     },
-    "grok-4.3": {
-        aliases: ["grok-4-3"],
+    "grok-large": {
+        aliases: ["grok-4.3", "grok-4-3", "grok-reasoning"],
         modelId: "grok-4.3",
         provider: "azure",
         brand: "xAI",
@@ -727,8 +719,8 @@ export const TEXT_SERVICES = {
         contextLength: 1000000, // Bedrock global Claude Sonnet 4.6 context window.
         isSpecialized: false,
     },
-    "claude-large": {
-        aliases: ["claude-opus-4.6", "claude-opus", "claude-opus-4.5"],
+    "claude-opus-4.6": {
+        aliases: ["claude-opus-4.5"],
         modelId: "claude-opus-4-6",
         provider: "bedrock",
         brand: "Anthropic",
@@ -777,8 +769,8 @@ export const TEXT_SERVICES = {
         contextLength: 1000000, // Bedrock global Claude Opus 4.7 context window.
         isSpecialized: false,
     },
-    "claude-opus-4.8": {
-        aliases: [],
+    "claude-large": {
+        aliases: ["claude-opus-4.8", "claude-opus"],
         modelId: "claude-opus-4-8",
         provider: "bedrock",
         brand: "Anthropic",
@@ -897,15 +889,8 @@ export const TEXT_SERVICES = {
         contextLength: 128000,
         isSpecialized: false,
     },
-    "kimi": {
-        aliases: [
-            "kimi-k2.5",
-            "kimi-k2p5",
-            "kimi-reasoning",
-            "kimi-large",
-            "kimi-k2-thinking",
-            "kimi-thinking",
-        ],
+    "kimi-k2.5": {
+        aliases: ["kimi-k2p5", "kimi-k2-thinking"],
         modelId: "accounts/fireworks/models/kimi-k2p5",
         provider: "fireworks",
         brand: "Moonshot AI",
@@ -928,8 +913,14 @@ export const TEXT_SERVICES = {
         contextLength: 262000,
         isSpecialized: false,
     },
-    "kimi-k2.6": {
-        aliases: ["kimi-k2p6"],
+    "kimi": {
+        aliases: [
+            "kimi-k2.6",
+            "kimi-k2p6",
+            "kimi-reasoning",
+            "kimi-large",
+            "kimi-thinking",
+        ],
         modelId: "accounts/fireworks/models/kimi-k2p6",
         provider: "fireworks",
         brand: "Moonshot AI",
@@ -952,8 +943,8 @@ export const TEXT_SERVICES = {
         contextLength: 262000,
         isSpecialized: false,
     },
-    "kimi-k2.7-code": {
-        aliases: ["kimi-k2.7", "kimi-k2p7"],
+    "kimi-code": {
+        aliases: ["kimi-k2.7-code", "kimi-k2.7", "kimi-k2p7"],
         modelId: "accounts/fireworks/models/kimi-k2p7-code",
         provider: "fireworks",
         brand: "Moonshot AI",
@@ -1146,13 +1137,8 @@ export const TEXT_SERVICES = {
         contextLength: 327680,
         isSpecialized: false,
     },
-    "minimax": {
-        aliases: [
-            "minimax-m2.7",
-            "minimax-m2p7",
-            "minimax-m2.5",
-            "minimax-m2p5",
-        ],
+    "minimax-m2.7": {
+        aliases: ["minimax-m2p7", "minimax-m2.5", "minimax-m2p5"],
         modelId: "accounts/fireworks/models/minimax-m2p7",
         provider: "fireworks",
         brand: "MiniMax",
@@ -1173,8 +1159,8 @@ export const TEXT_SERVICES = {
         contextLength: 200000,
         isSpecialized: false,
     },
-    "minimax-m3": {
-        aliases: ["minimax3", "minimax-3"],
+    "minimax": {
+        aliases: ["minimax-m3", "minimax3", "minimax-3"],
         modelId: "accounts/fireworks/models/minimax-m3",
         provider: "fireworks",
         brand: "MiniMax",


### PR DESCRIPTION
Restores the convention that **unversioned clean slugs always point at the newest model** in their family. Newer versions had been added as standalone version-named slugs, so the clean slugs had quietly drifted (e.g. `claude-large` was 2 Opus versions behind).

**Naming only — no model added or removed (55→55).** Every slug/alias callable today still resolves; displaced older versions keep a versioned slug.

| Clean slug | now → | old version kept as |
|---|---|---|
| `openai-large` | GPT-5.5 | `gpt-5.4` |
| `claude-large` | Opus 4.8 | `claude-opus-4.6` |
| `grok-large` | Grok 4.3 (reasoning) | `grok-4-20-reasoning` |
| `kimi` | K2.6 (general) | `kimi-k2.5` |
| `kimi-code` | K2.7 Code | (renamed from `kimi-k2.7-code`) |
| `minimax` | M3 | `minimax-m2.7` |
| `mistral` | Small 4 | `mistral-small-3.2` |
| `gemini` | 3.5 Flash | `gemini-3-flash` |

Bare `grok` (4.20 non-reasoning) unchanged — no newer non-reasoning model exists.

### Behavior notes (intended)
- Clean family/reasoning aliases follow to newest: `openai-reasoning`→5.5, `claude-opus`→4.8, `grok-reasoning`→4.3, `mistral-small`→Small 4, `kimi-reasoning`/`kimi-large`/`kimi-thinking`→K2.6. Version-specific `kimi-k2-thinking` stays on K2.5.
- Callers on bare slugs get the newer model (and its pricing) automatically — same policy as the GLM-5.2 bump.

### Verification
- 55→55 entries; diff is pure key rename (no key dropped without a replacement)
- 38/38 resolve checks pass (every new clean name + every old back-compat name)
- aliases.test (212), pricing-data, effective-prices snapshot, gen transforms + model-permissions green
- `availableModels.ts` `name` mapping updated in lockstep (resolver requires name==registry key); backend `portkeyConfig`/modelId layer untouched
- biome + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)