### PR TITLE
feat(glm): set GLM-5.2 priceMultiplier to 0.5

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -285,9 +285,9 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000014,
     },
     "price": {
-      "completionTextTokens": 0.0000044,
-      "promptCachedTokens": 0.00000026,
-      "promptTextTokens": 0.0000014,
+      "completionTextTokens": 0.0000022,
+      "promptCachedTokens": 0.00000013,
+      "promptTextTokens": 0.0000007,
     },
   },
   "gpt-5.4": {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1046,7 +1046,7 @@ export const TEXT_SERVICES = {
         brand: "Z.ai",
         category: "text",
         addedDate: new Date("2026-01-06").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: 0.5,
         cost: {
             promptTextTokens: perMillion(1.4),
             promptCachedTokens: perMillion(0.26),


### PR DESCRIPTION
- Sets `glm` (GLM-5.2) `priceMultiplier` 1 → **0.5** — bills at half Fireworks cost as a deliberate subsidy
- Cost block unchanged ($1.4/$0.26/$4.4 per 1M); effective price drops to 0.5× (completion $4.4→$2.2/1M, prompt $1.4→$0.7/1M)
- New multiplier value (rest of registry is 1 or 1.5) — intentional
- Snapshot updated: GLM-only, price-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)