### PR TITLE
fix(text): remove kimi-k2.5 (deprecated upstream by Fireworks)

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -490,18 +490,6 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000095,
     },
   },
-  "kimi-k2.5": {
-    "cost": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.0000001,
-      "promptTextTokens": 0.0000006,
-    },
-    "price": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.0000001,
-      "promptTextTokens": 0.0000006,
-    },
-  },
   "klein": {
     "cost": {
       "completionImageTokens": 0.01,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -231,11 +231,6 @@ const models: ModelDefinition[] = [
         transform: createPerplexitySearchTransform("high"),
     },
     {
-        name: "kimi-k2.5",
-        config: portkeyConfig["accounts/fireworks/models/kimi-k2p5"],
-        transform: stripCacheControl,
-    },
-    {
         name: "kimi",
         config: portkeyConfig["accounts/fireworks/models/kimi-k2p6"],
         transform: stripCacheControl,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -125,10 +125,6 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- Fireworks AI (Kimi, GLM, Qwen) --------------------------------------
-    "accounts/fireworks/models/kimi-k2p5": () =>
-        createFireworksModelConfig({
-            model: "accounts/fireworks/models/kimi-k2p5",
-        }),
     "accounts/fireworks/models/kimi-k2p6": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/kimi-k2p6",

--- a/packages/mcp/src/index.js
+++ b/packages/mcp/src/index.js
@@ -81,7 +81,7 @@ All requests go through: https://gen.pollinations.ai
 - Video generation: use listImageModels for live videoCapabilities, including start/end-frame and audio support
 - Web search: Use webSearch with perplexity-fast, perplexity-reasoning, or gemini-search
 - Audio transcription: Use transcribeAudio with gemini-large
-- Reasoning: Use kimi-k2-thinking, perplexity-reasoning, openai-large, gemini-large`;
+- Reasoning: Use kimi, perplexity-reasoning, openai-large, gemini-large`;
 
 /**
  * Start the MCP server with STDIO transport

--- a/packages/mcp/src/services/textService.js
+++ b/packages/mcp/src/services/textService.js
@@ -311,7 +311,7 @@ async function listTextModels(_params) {
                 advanced:
                     "Use chatCompletion for multi-turn conversations, tool calling, audio output",
                 reasoning:
-                    "True reasoning models: kimi-k2-thinking, perplexity-reasoning, openai-large, gemini-large. Use reasoning_effort or thinking params",
+                    "True reasoning models: kimi, perplexity-reasoning, openai-large, gemini-large. Use reasoning_effort or thinking params",
                 audio: "Use openai-audio with modalities=['text','audio'] for voice output",
             },
         };
@@ -673,13 +673,13 @@ const chatParamsSchema = {
     thinking: thinkingSchema
         .optional()
         .describe(
-            "Thinking mode for reasoning models. Use with kimi-k2-thinking, perplexity-reasoning, openai-large, gemini-large",
+            "Thinking mode for reasoning models. Use with kimi, perplexity-reasoning, openai-large, gemini-large",
         ),
     reasoning_effort: z
         .enum(["low", "medium", "high"])
         .optional()
         .describe(
-            "Reasoning effort level. Works with reasoning models like kimi-k2-thinking, openai-large",
+            "Reasoning effort level. Works with reasoning models like kimi, openai-large",
         ),
     thinking_budget: z
         .number()
@@ -770,7 +770,7 @@ export const textTools = [
     ],
     [
         "chatCompletion",
-        "OpenAI-compatible chat completions with ALL parameters. Supports:\n- Multi-turn conversations with message history\n- Function/tool calling for AI agents\n- Audio input/output (openai-audio model)\n- Reasoning mode (kimi-k2-thinking, perplexity-reasoning, openai-large, gemini-large)\n- JSON/structured output\n- Built-in Gemini tools (google_search, code_execution, etc.)\n- Perplexity web search with citations",
+        "OpenAI-compatible chat completions with ALL parameters. Supports:\n- Multi-turn conversations with message history\n- Function/tool calling for AI agents\n- Audio input/output (openai-audio model)\n- Reasoning mode (kimi, perplexity-reasoning, openai-large, gemini-large)\n- JSON/structured output\n- Built-in Gemini tools (google_search, code_execution, etc.)\n- Perplexity web search with citations",
         chatParamsSchema,
         chatCompletion,
     ],

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -889,30 +889,6 @@ export const TEXT_SERVICES = {
         contextLength: 128000,
         isSpecialized: false,
     },
-    "kimi-k2.5": {
-        aliases: ["kimi-k2p5", "kimi-k2-thinking"],
-        modelId: "accounts/fireworks/models/kimi-k2p5",
-        provider: "fireworks",
-        brand: "Moonshot AI",
-        category: "text",
-        addedDate: new Date("2026-01-10").getTime(),
-        priceMultiplier: 1,
-        cost: {
-            promptTextTokens: perMillion(0.6),
-            promptCachedTokens: perMillion(0.1),
-            completionTextTokens: perMillion(3.0),
-        },
-        title: "Moonshot Kimi K2.5",
-        description:
-            "Moonshot Kimi K2.5 - Flagship Agentic Model with CoT Reasoning",
-        inputModalities: ["text", "image"],
-        outputModalities: ["text"],
-        maxReferenceImages: 30, // Fireworks vision hard limit.
-        tools: true,
-        reasoning: true,
-        contextLength: 262000,
-        isSpecialized: false,
-    },
     "kimi": {
         aliases: [
             "kimi-k2.6",


### PR DESCRIPTION
## Why
`kimi-k2.5` returns HTTP 500 on every request. Root-caused to upstream: Fireworks **deprecated** `accounts/fireworks/models/kimi-k2p5` on **2026-06-16** and tore down its serverless deployment, so every inference 500s (`openai error: Internal server error`) even though the catalog still reports `state: READY`.

Verified by calling Fireworks directly (bypassing Portkey + our gateway): `kimi-k2p5` → 500 (3/3), sibling `kimi-k2p6` → 200. Same code path, so it's not our config. Production `model_health` showed kimi-k2.5 at 0/7 success.

## Changes
- Remove `kimi-k2.5` from `shared/registry/text.ts`, `availableModels.ts`, `modelConfigs.ts`
- Repoint the dead `kimi-k2-thinking` alias in MCP docstrings → `kimi` (k2.6, the live reasoning flagship)
- Update effective-prices snapshot

`kimi` (k2.6) and `kimi-code` (k2.7) are unaffected and remain healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)