### PR TITLE
fix: stabilize transaction history pagination

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/activity/transaction-history.tsx
+++ b/enter.pollinations.ai/frontend/src/components/activity/transaction-history.tsx
@@ -12,17 +12,24 @@ const PAGE_SIZE_COMPACT = 5;
 
 type UsageRecord = {
     timestamp: string;
+    cursor_event_id: string;
     model: string;
+    api_key_id: string | null;
     api_key: string | null;
     meter_source: string | null;
     cost_usd: number;
+};
+
+type UsageCursor = {
+    timestamp: string;
+    eventId: string;
 };
 
 type FetchState = {
     rows: UsageRecord[];
     loading: boolean;
     error: string | null;
-    nextCursor: string | null;
+    nextCursor: UsageCursor | null;
     hasMore: boolean;
 };
 
@@ -34,8 +41,17 @@ const INITIAL_STATE: FetchState = {
     hasMore: true,
 };
 
+function parseTimestamp(value: string): Date {
+    const normalizedUtcTimestamp = value.match(
+        /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+    )
+        ? `${value.replace(" ", "T")}Z`
+        : value;
+    return new Date(normalizedUtcTimestamp);
+}
+
 function formatTimestamp(value: string, mode: Mode): string {
-    const date = new Date(value);
+    const date = parseTimestamp(value);
     if (Number.isNaN(date.getTime())) return value;
     if (mode === "compact") {
         // Relative-ish short form: "Mar 14, 14:05"
@@ -70,17 +86,15 @@ function MeterSourceChip({ source }: { source: string | null }) {
 }
 
 function rowKey(row: UsageRecord): string {
-    return `${row.timestamp}-${row.model}-${row.cost_usd}`;
+    return row.cursor_event_id;
 }
 
-function buildKeyNameLookup(
-    keys: ApiKeyInfo[] | undefined,
-): (id: string | null) => string {
+function buildKeyNameLookup(keys: ApiKeyInfo[] | undefined) {
     const map = new Map<string, string>();
     for (const k of keys ?? []) map.set(k.id, k.name);
-    return (id) => {
+    return (id: string | null, fallbackName?: string | null) => {
         if (!id) return "—";
-        return map.get(id) ?? `${id.slice(0, 8)}…`;
+        return map.get(id) ?? fallbackName ?? `${id.slice(0, 8)}…`;
     };
 }
 
@@ -101,12 +115,19 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
     const lookupKeyName = useMemo(() => buildKeyNameLookup(apiKeys), [apiKeys]);
 
     const loadPage = useCallback(
-        async (before: string | null): Promise<void> => {
+        async (cursor: UsageCursor | null): Promise<void> => {
             setState((prev) => ({ ...prev, loading: true, error: null }));
-            const query: { limit: string; before?: string } = {
+            const query: {
+                limit: string;
+                before?: string;
+                before_event_id?: string;
+            } = {
                 limit: pageSize.toString(),
             };
-            if (before) query.before = before;
+            if (cursor) {
+                query.before = cursor.timestamp;
+                query.before_event_id = cursor.eventId;
+            }
 
             const response = await apiClient.account.usage.$get({ query });
             if (!response.ok) {
@@ -122,10 +143,16 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
             const rows = data.usage ?? [];
             const hasMore = mode === "full" && rows.length >= pageSize;
             const last = rows[rows.length - 1];
-            const nextCursor = hasMore && last ? last.timestamp : null;
+            const nextCursor =
+                hasMore && last
+                    ? {
+                          timestamp: last.timestamp,
+                          eventId: last.cursor_event_id,
+                      }
+                    : null;
 
             setState((prev) => ({
-                rows: before ? [...prev.rows, ...rows] : rows,
+                rows: cursor ? [...prev.rows, ...rows] : rows,
                 loading: false,
                 error: null,
                 nextCursor,
@@ -162,6 +189,7 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
                 <p className="text-sm text-ink-700">
                     Each row is one billed request — when it happened, which API
                     key and model were used, and how much pollen was deducted.
+                    Times are shown in your local timezone.
                 </p>
             )}
 
@@ -203,7 +231,10 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
                                 </div>
                                 {!isCompact && (
                                     <div className="text-xs text-ink-500 truncate">
-                                        {lookupKeyName(row.api_key)}
+                                        {lookupKeyName(
+                                            row.api_key_id,
+                                            row.api_key,
+                                        )}
                                     </div>
                                 )}
                             </li>
@@ -251,7 +282,10 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
                                         </td>
                                         {!isCompact && (
                                             <td className="px-3 py-2 text-ink-700 max-w-[12rem] truncate">
-                                                {lookupKeyName(row.api_key)}
+                                                {lookupKeyName(
+                                                    row.api_key_id,
+                                                    row.api_key,
+                                                )}
                                             </td>
                                         )}
                                         <td className="px-3 py-2">

--- a/enter.pollinations.ai/frontend/src/components/activity/transaction-history.tsx
+++ b/enter.pollinations.ai/frontend/src/components/activity/transaction-history.tsx
@@ -85,8 +85,11 @@ function MeterSourceChip({ source }: { source: string | null }) {
     return <PaidChip>paid</PaidChip>;
 }
 
-function rowKey(row: UsageRecord): string {
-    return row.cursor_event_id;
+function rowKey(row: UsageRecord, index: number): string {
+    if (row.cursor_event_id) return row.cursor_event_id;
+    return `${row.timestamp}-${row.api_key_id ?? row.api_key ?? "key"}-${
+        row.model || "model"
+    }-${row.cost_usd}-${index}`;
 }
 
 function buildKeyNameLookup(keys: ApiKeyInfo[] | undefined) {
@@ -208,9 +211,9 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
                 <>
                     {/* Mobile: stacked cards */}
                     <ul className="flex flex-col gap-2 sm:hidden">
-                        {state.rows.map((row) => (
+                        {state.rows.map((row, index) => (
                             <li
-                                key={rowKey(row)}
+                                key={rowKey(row, index)}
                                 className="rounded-lg border border-theme-border p-3 flex flex-col gap-1.5"
                             >
                                 <div className="flex items-center justify-between gap-2">
@@ -266,9 +269,9 @@ export const TransactionHistory: FC<TransactionHistoryProps> = ({
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-theme-border">
-                                {state.rows.map((row) => (
+                                {state.rows.map((row, index) => (
                                     <tr
-                                        key={rowKey(row)}
+                                        key={rowKey(row, index)}
                                         className="hover:bg-ink-50"
                                     >
                                         <td className="px-3 py-2 whitespace-nowrap text-ink-800 tabular-nums">

--- a/enter.pollinations.ai/frontend/src/routes/index.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/index.tsx
@@ -323,7 +323,8 @@ function RouteComponent() {
                             minDate={ACTIVITY_MIN_DATE}
                         />
                         <p className="text-micro text-theme-text-muted">
-                            Data refreshes every hour. Times shown in UTC.
+                            Usage data refreshes every hour. Chart buckets use
+                            UTC; transactions use your local time.
                         </p>
                     </div>
                     <UsageGraph

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -420,6 +420,7 @@ const usageQuerySchema = z.object({
         .optional()
         .default(100),
     before: z.string().optional(), // ISO timestamp cursor for pagination
+    before_event_id: z.string().optional(), // Stable tie-breaker for same-second timestamps
     days: z.coerce
         .number()
         .int()
@@ -637,8 +638,8 @@ function stripUsageCursor(row: UsageRecordWithCursor): UsageRecord {
 }
 
 // Shared tail for the detailed-usage endpoints (/usage, /key/usage):
-// fetch a page from the user_usage pipe, strip the cursor, then return CSV
-// (with a per-route filename prefix) or JSON, or a 500 on upstream error.
+// fetch a page from the user_usage pipe, return the cursor for JSON pagination,
+// but keep CSV output on its established public columns.
 async function respondDetailedUsage(
     c: Pick<Context<Env>, "env" | "json">,
     log: Logger,
@@ -652,25 +653,29 @@ async function respondDetailedUsage(
         since: string;
         until: string;
         before?: string;
+        beforeEventId?: string;
     },
 ): Promise<Response> {
     const tinybirdOrigin = new URL(c.env.TINYBIRD_INGEST_URL).origin;
     const tinybirdToken = requireTinybirdReadToken(c.env);
 
     try {
-        const usage = (
-            await fetchDetailedUsagePage(tinybirdOrigin, tinybirdToken, {
+        const usage = await fetchDetailedUsagePage(
+            tinybirdOrigin,
+            tinybirdToken,
+            {
                 userId: params.userId,
                 apiKeyId: params.apiKeyId,
                 limit: params.limit,
                 since: params.since,
                 until: params.until,
                 before: params.before,
-            })
-        ).map(stripUsageCursor);
+                beforeEventId: params.beforeEventId,
+            },
+        );
 
         if (params.format === "csv") {
-            const rows = usage.map(usageRecordToCsvRow);
+            const rows = usage.map(stripUsageCursor).map(usageRecordToCsvRow);
             const csv = [USAGE_CSV_HEADER, ...rows].join("\n");
             return new Response(csv, {
                 headers: {
@@ -731,11 +736,18 @@ const usageRecordSchema = z.object({
     timestamp: z
         .string()
         .describe("Request timestamp (YYYY-MM-DD HH:mm:ss format)"),
+    cursor_event_id: z
+        .string()
+        .describe("Event id used with `before_event_id` for stable pagination"),
     type: z
         .string()
         .describe("Request type (e.g., 'generate.image', 'generate.text')"),
     model: z.string().nullable().describe("Model used for generation"),
-    api_key: z.string().nullable().describe("API key identifier used (masked)"),
+    api_key_id: z
+        .string()
+        .nullable()
+        .describe("API key id used for generation"),
+    api_key: z.string().nullable().describe("API key display name"),
     api_key_type: z
         .string()
         .nullable()
@@ -908,7 +920,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Usage History",
             description:
-                "Returns your request history with per-request details: model used, token counts, cost, and response time. Defaults to the last 30 days, supports up to 90 days via `days`, or exact day/week/month periods via `granularity` and `period`. Supports JSON and CSV export. Each response is capped at 50,000 rows. Use `before` for cursor-based pagination. Requires `account:usage` permission when using API keys.",
+                "Returns your request history with per-request details: model used, token counts, cost, and response time. Defaults to the last 30 days, supports up to 90 days via `days`, or exact day/week/month periods via `granularity` and `period`. Supports JSON and CSV export. Each response is capped at 50,000 rows. Use `before` with `before_event_id` for stable cursor-based pagination. Requires `account:usage` permission when using API keys.",
             responses: {
                 200: {
                     description: "Usage records",
@@ -943,8 +955,15 @@ export const accountRoutes = new Hono<Env>()
                 });
             }
 
-            const { format, limit, before, days, granularity, period } =
-                c.req.valid("query");
+            const {
+                format,
+                limit,
+                before,
+                before_event_id: beforeEventId,
+                days,
+                granularity,
+                period,
+            } = c.req.valid("query");
             const { userId: usageUserId, overridden: usageUserOverridden } =
                 resolveUsageTargetUserId(c.env, user.id, apiKey);
             const usageWindow = formatUsageWindow(
@@ -959,7 +978,7 @@ export const accountRoutes = new Hono<Env>()
             });
 
             log.debug(
-                "Fetching usage: requesterUserId={requesterUserId} targetUserId={targetUserId} override={override} format={format} limit={limit} before={before} days={days}",
+                "Fetching usage: requesterUserId={requesterUserId} targetUserId={targetUserId} override={override} format={format} limit={limit} before={before} beforeEventId={beforeEventId} days={days}",
                 {
                     requesterUserId: user.id,
                     targetUserId: usageUserId,
@@ -967,6 +986,7 @@ export const accountRoutes = new Hono<Env>()
                     format,
                     limit,
                     before,
+                    beforeEventId,
                     days,
                 },
             );
@@ -980,6 +1000,7 @@ export const accountRoutes = new Hono<Env>()
                 since: usageWindow.since,
                 until: usageWindow.until,
                 before,
+                beforeEventId,
             });
         },
     )
@@ -1617,7 +1638,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get API Key Usage",
             description:
-                "Returns usage history for the API key used in the request. No scope required — a key can always read its own usage. For account-wide usage across all keys, use `/account/usage` with the `account:usage` scope.",
+                "Returns usage history for the API key used in the request. No scope required — a key can always read its own usage. Use `before` with `before_event_id` for stable cursor-based pagination. For account-wide usage across all keys, use `/account/usage` with the `account:usage` scope.",
             responses: {
                 200: {
                     description: "Usage records for this key",
@@ -1645,8 +1666,15 @@ export const accountRoutes = new Hono<Env>()
             }
             const user = c.var.auth.requireUser();
 
-            const { format, limit, before, days, granularity, period } =
-                c.req.valid("query");
+            const {
+                format,
+                limit,
+                before,
+                before_event_id: beforeEventId,
+                days,
+                granularity,
+                period,
+            } = c.req.valid("query");
             const usageWindow = formatUsageWindow(
                 resolveUsageWindow(days, {
                     granularity,
@@ -1673,6 +1701,7 @@ export const accountRoutes = new Hono<Env>()
                 since: usageWindow.since,
                 until: usageWindow.until,
                 before,
+                beforeEventId,
             });
         },
     );

--- a/enter.pollinations.ai/test/account-usage.test.ts
+++ b/enter.pollinations.ai/test/account-usage.test.ts
@@ -142,6 +142,58 @@ test("GET /api/account/usage/daily rejects periods outside supported bounds", as
     expect(future.status).toBe(400);
 });
 
+test("GET /api/account/usage forwards stable cursor and returns event cursor", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    mocks.tinybird.state.usageResponse = [
+        {
+            cursor_event_id: "event-2",
+            timestamp: "2026-04-14 12:10:00",
+            type: "generate.text",
+            model: "openai-fast",
+            api_key_id: "key_abc123",
+            api_key: "alpha",
+            api_key_type: "secret",
+            meter_source: "tier",
+            input_text_tokens: 10,
+            input_cached_tokens: 0,
+            input_audio_tokens: 0,
+            input_audio_seconds: 0,
+            input_image_tokens: 0,
+            output_text_tokens: 20,
+            output_reasoning_tokens: 0,
+            output_audio_tokens: 0,
+            output_audio_seconds: 0,
+            output_image_tokens: 0,
+            output_video_seconds: 0,
+            cost_usd: 1,
+            response_time_ms: 123,
+        },
+    ];
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/usage?days=30&limit=25&before=2026-04-14%2012%3A10%3A00&before_event_id=event-1",
+        { headers: authHeaders(sessionToken) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+        usage: Array<Record<string, unknown>>;
+    };
+    expect(body.usage[0].cursor_event_id).toBe("event-2");
+    expect(body.usage[0].api_key_id).toBe("key_abc123");
+
+    const usageCalls = mocks.tinybird.state.pipeCalls.filter((call) =>
+        call.url.includes("user_usage.json"),
+    );
+    expect(usageCalls).toHaveLength(1);
+    expect(usageCalls[0].query.before).toBe("2026-04-14 12:10:00");
+    expect(usageCalls[0].query.before_event_id).toBe("event-1");
+});
+
 test("GET /api/account/usage?format=csv renders rows and sets filename from limit", async ({
     sessionToken,
     mocks,
@@ -188,6 +240,7 @@ test("GET /api/account/usage?format=csv renders rows and sets filename from limi
     const lines = csv.trim().split("\n");
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain("timestamp,type,model");
+    expect(lines[0]).not.toContain("cursor_event_id");
     expect(lines[1]).toContain("2026-04-14 12:10:00");
     expect(lines[1]).toContain("alpha");
 


### PR DESCRIPTION
- Fixes transaction history pagination by using the Tinybird event id tie-breaker with the timestamp cursor.
- Returns `cursor_event_id` in JSON usage rows while keeping CSV columns unchanged.
- Displays API key names by resolving `api_key_id`, with the returned key name as fallback.
- Clarifies that activity charts use UTC buckets while transaction rows use local time.

Checks:
- `npx biome check --write enter.pollinations.ai/src/routes/account.ts enter.pollinations.ai/frontend/src/components/activity/transaction-history.tsx enter.pollinations.ai/frontend/src/routes/index.tsx enter.pollinations.ai/test/account-usage.test.ts`
- `npx tsc --noEmit -p enter.pollinations.ai/frontend/src/tsconfig.json`
- `npm run decrypt-vars && npx vitest run test/account-usage.test.ts`
- `npm run typecheck`