### PR TITLE
fix(tinybird): privatize d1_user_public pipe

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/d1_user_public.pipe
+++ b/enter.pollinations.ai/observability/endpoints/d1_user_public.pipe
@@ -1,7 +1,10 @@
 DESCRIPTION >
-    Restricted public view of D1 user table (no emails, no balances).
+    Restricted view of D1 user table (no emails, no balances).
+    Internal only: returns the full user roster (id, name, GitHub identity,
+    tier, ban status), so it is gated behind the private read token rather
+    than the public one.
 
-TOKEN tinybird_read_public READ
+TOKEN tinybird_read READ
 
 NODE d1_user_public_node
 SQL >


### PR DESCRIPTION
- Switches `d1_user_public` from the public read token (`tinybird_read_public`) to the private one (`tinybird_read`)
- The pipe returns the **full user roster** — `id`, `name`, GitHub identity, `tier`, and ban status incl. free-text `ban_reason` — with no pagination, readable by anyone holding the public token shipped in client code
- Stripping just the ban fields wouldn't fix it: the core problem is an unauthenticated, enumerable list linking internal user IDs to named individuals (PII linkage + customer list)
- No in-repo consumer reads this pipe (only its own definition referenced it); the two genuinely-public stats pipes (`public_model_stats`, `model_health`) are untouched
- Original pipe added in #9078 (@ElliotEtag) — if an out-of-repo dashboard reads it via the public token, it will need re-pointing at an authenticated endpoint

**Deploy status:** already deployed to prod (deployment #127) and verified:
- `d1_user_public` + public token → **403** (was 200, returning real user rows)
- `public_model_stats` / `model_health` + public token → **200** (unchanged)

> Needs the same deploy on the staging workspace (`pollinations_enter_staging`) — no CI auto-deploy yet (#11127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)