### PR TITLE
feat(gen): serve OpenAPI spec at /openapi.json

### DIFF
--- a/gen.pollinations.ai/src/index.ts
+++ b/gen.pollinations.ai/src/index.ts
@@ -25,7 +25,7 @@ import { requestId } from "hono/request-id";
 import type { Env } from "@/env.ts";
 import { logger } from "@/middleware/logger.ts";
 import { audioRoutes } from "./routes/audio.ts";
-import { createDocsRoutes } from "./routes/docs.ts";
+import { buildMergedOpenApiSpec, createDocsRoutes } from "./routes/docs.ts";
 import { proxyRoutes } from "./routes/proxy.ts";
 
 export { PollenRateLimiter } from "./durable-objects/PollenRateLimiter.ts";
@@ -85,7 +85,11 @@ function stripTrailingSlash(path: string): string {
 }
 
 function isDocsPath(path: string): boolean {
-    return path === "/docs" || path.startsWith("/docs/");
+    return (
+        path === "/docs" ||
+        path.startsWith("/docs/") ||
+        path === "/openapi.json"
+    );
 }
 
 function redirectLegacyDocs(c: Context<Env>): Response {
@@ -125,6 +129,13 @@ app.use("*", cors(PERMISSIVE_CORS_OPTIONS))
     })
     .route("/docs", createDocsRoutes(app))
     .route("/v1/audio", audioRoutes)
+    // Conventional, discoverable alias for the merged OpenAPI spec. JSON-only;
+    // the ?format=yaml passthrough stays on /docs/open-api/generate-schema.
+    // Must be registered before the "/" proxy catch-all or it gets shadowed.
+    .get("/openapi.json", async (c) => {
+        const merged = await buildMergedOpenApiSpec(c, app);
+        return c.json(merged);
+    })
     .route("/", proxyRoutes);
 
 app.notFound(async (c: Context<Env>) => {

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -739,6 +739,25 @@ function guideHtml(guide: Guide): string {
     return guidesPage(rendered);
 }
 
+/**
+ * Build the merged OpenAPI spec (generation + public account + media storage,
+ * with code samples injected). Single source of truth for both the docs
+ * Scalar route and the conventional /openapi.json alias.
+ */
+export async function buildMergedOpenApiSpec(
+    c: Context<Env>,
+    genApp: Hono<Env>,
+): Promise<OpenApiSchema> {
+    const [generationSchema, enterSchema, mediaSchema] = await Promise.all([
+        getGenerationSchema(genApp),
+        fetchEnterSchema(c).catch(() => undefined),
+        fetchMediaSchema().catch(() => undefined),
+    ]);
+    return injectSamples(
+        mergeSchemas(generationSchema, enterSchema, mediaSchema),
+    );
+}
+
 export function createDocsRoutes(genApp: Hono<Env>): Hono<Env> {
     return new Hono<Env>()
         .get("/", async (c, next) => {
@@ -799,16 +818,7 @@ export function createDocsRoutes(genApp: Hono<Env>): Hono<Env> {
             return c.html(guideHtml(guide));
         })
         .get("/open-api/generate-schema", async (c) => {
-            const [generationSchema, enterSchema, mediaSchema] =
-                await Promise.all([
-                    getGenerationSchema(genApp),
-                    fetchEnterSchema(c).catch(() => undefined),
-                    fetchMediaSchema().catch(() => undefined),
-                ]);
-            const merged = injectSamples(
-                mergeSchemas(generationSchema, enterSchema, mediaSchema),
-            );
-
+            const merged = await buildMergedOpenApiSpec(c, genApp);
             if (c.req.query("format") === "yaml") {
                 c.header("Content-Type", "application/yaml; charset=utf-8");
                 return c.body(yamlStringify(merged));

--- a/gen.pollinations.ai/test/openapi-json.test.ts
+++ b/gen.pollinations.ai/test/openapi-json.test.ts
@@ -1,0 +1,103 @@
+import {
+    createExecutionContext,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index.ts";
+
+function envWithEnterSchema(schema: unknown): CloudflareBindings {
+    return {
+        ENTER: {
+            fetch: async () =>
+                new Response(JSON.stringify(schema), {
+                    headers: { "Content-Type": "application/json" },
+                }),
+        } as unknown as Fetcher,
+        ENVIRONMENT: "test",
+        LOG_LEVEL: "debug",
+        LOG_FORMAT: "text",
+    } as CloudflareBindings;
+}
+
+function mockMediaSchema() {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+            JSON.stringify({ paths: {}, components: { schemas: {} } }),
+            { headers: { "Content-Type": "application/json" } },
+        ),
+    );
+}
+
+const ENTER_SCHEMA = {
+    openapi: "3.1.0",
+    info: { title: "Enter", version: "0.0.0" },
+    paths: { "/account/key": { get: { tags: ["Account"] } } },
+};
+
+describe("/openapi.json", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("serves the merged OpenAPI spec as JSON at a discoverable URL", async () => {
+        const ctx = createExecutionContext();
+        mockMediaSchema();
+
+        const response = await worker.fetch(
+            new Request("https://gen.pollinations.ai/openapi.json"),
+            envWithEnterSchema(ENTER_SCHEMA),
+            ctx,
+        );
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Type")).toContain(
+            "application/json",
+        );
+        // Discoverable: the spec must stay indexable (no noindex robots tag).
+        expect(response.headers.get("X-Robots-Tag")).toBeNull();
+        const schema = (await response.json()) as {
+            openapi: string;
+            paths: Record<string, unknown>;
+        };
+        expect(schema.openapi).toBe("3.1.0");
+        expect(Object.keys(schema.paths).length).toBeGreaterThan(0);
+        // Gen-owned merged paths prove the real merge ran (not a stub/404).
+        expect(schema.paths["/v1/chat/completions"]).toBeDefined();
+        expect(schema.paths["/image/{prompt}"]).toBeDefined();
+        expect(schema.paths["/account/key"]).toBeDefined();
+    });
+
+    it("returns the same spec as /docs/open-api/generate-schema", async () => {
+        const aliasCtx = createExecutionContext();
+        mockMediaSchema();
+        const aliasRes = await worker.fetch(
+            new Request("https://gen.pollinations.ai/openapi.json"),
+            envWithEnterSchema(ENTER_SCHEMA),
+            aliasCtx,
+        );
+        await waitOnExecutionContext(aliasCtx);
+        const aliasSchema = (await aliasRes.json()) as Record<string, unknown>;
+        vi.restoreAllMocks();
+
+        const canonicalCtx = createExecutionContext();
+        mockMediaSchema();
+        const canonicalRes = await worker.fetch(
+            new Request(
+                "https://gen.pollinations.ai/docs/open-api/generate-schema",
+            ),
+            envWithEnterSchema(ENTER_SCHEMA),
+            canonicalCtx,
+        );
+        await waitOnExecutionContext(canonicalCtx);
+        const canonicalSchema = (await canonicalRes.json()) as Record<
+            string,
+            unknown
+        >;
+
+        expect(Object.keys(aliasSchema).sort()).toEqual(
+            Object.keys(canonicalSchema).sort(),
+        );
+        expect(aliasSchema).toEqual(canonicalSchema);
+    });
+});


### PR DESCRIPTION
- The OpenAPI spec already existed (served at `/docs/open-api/generate-schema`); this just exposes it at the conventional `/openapi.json` path
- Extracts `buildMergedOpenApiSpec` so both routes share one source of truth (no logic duplication)
- Keeps `/openapi.json` indexable (excluded from the noindex middleware)
- Test asserts JSON output + parity with the canonical route

Pure routing change. Tests 8/8 green; reviewed by adversarial workflow + Codex (both APPROVE).

Addresses #11894