### PR TITLE
fix: force static avatar in catgpt-bot

### DIFF
--- a/apps/catgpt-bot/bot.ts
+++ b/apps/catgpt-bot/bot.ts
@@ -127,6 +127,7 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
     const avatarUrl = msg.author.displayAvatarURL({
         size: 1024,
         extension: "png",
+        forceStatic: true, // animated avatars ignore `extension` and return .gif, which the API rejects (400)
     });
     const catReply = await generateCatReply(question, avatarUrl);
     const prompt = createPrompt(question, catReply, true);


### PR DESCRIPTION
Animated (.gif) avatars failed the text API with a 400 because the gateway rejects gif image input. `forceStatic: true` resolves them to .png.

🤖 Generated with [Claude Code](https://claude.com/claude-code)