### PR TITLE
fix(social): accurate model diff + richer Discord news format

### DIFF
--- a/social/prompts/models_news.md
+++ b/social/prompts/models_news.md
@@ -23,16 +23,20 @@ For each `{before, after}` pair, identify what actually changed:
 2. **Price cut** — any numeric pricing token value decreased. Compute the primary token % drop:
    - Image/video: `completionImageTokens`
    - Text: `completionTextTokens`
-   - Audio: `completionAudioTokens`
+   - Audio: `completionAudioTokens` or `completionAudioSeconds`
    - Embeddings: `completionEmbeddingTokens`
    Round to nearest 5%. Group these under ⬇️ by category.
 3. **Price increase** — any pricing token value increased. Same calculation. Group under ⬆️.
 4. **Modality change** — `input_modalities` or `output_modalities` changed → ✨ section.
-5. **Capability change** — `capabilities` array changed → ✨ section.
+   Note: audio models with `input_modalities: ["audio"]` are transcription/STT;
+   those with `output_modalities: ["audio"]` are TTS; both-direction models (like
+   openai-audio) are realtime voice models — describe accurately.
+5. **Capability change** — `capabilities` array changed (e.g. `tool_calling`, `reasoning`,
+   `web_search`, `code_execution` added or removed) → ✨ section.
 6. If multiple change types apply to one model, list it only in the most prominent section
    (access > price > capability).
 
-Category emojis: 🎨 image/video · 🧠 text · 🔊 audio · 🔢 embeddings
+Category emojis: 🎨 image · 🎬 video · 🧠 text · 🔊 audio · 🔢 embeddings
 
 ## discord_text format
 
@@ -46,9 +50,11 @@ Category emojis: 🎨 image/video · 🧠 text · 🔊 audio · 🔢 embeddings
 - `model-name` (category)
 
 ### ⬇️ Price cuts (~X% off)
-- 🎨 Image: Model A · Model B · Model C
-- 🧠 Text: Model D · Model E
-- 🔢 Embeddings: Model F
+- 🎨 Image: Model A · Model B
+- 🎬 Video: Model C · Model D
+- 🧠 Text: Model E · Model F
+- 🔊 Audio: Model G
+- 🔢 Embeddings: Model H
 
 ### ⬆️ Price increases (~X% more)
 - 🧠 Text: Model A · Model B

--- a/social/prompts/models_news.md
+++ b/social/prompts/models_news.md
@@ -1,74 +1,105 @@
-# Pollinations Models News - System Prompt
+# Pollinations Models News — System Prompt
 
-You write the weekly model-changes report for pollinations.ai based on a machine-generated diff of the public `/text/models`, `/image/models`, `/audio/models`, and `/embeddings/models` endpoints.
+You write the weekly model-changes report for pollinations.ai from a machine-generated diff of the public endpoints.
 
-Two consumers read your output:
-
-1. `social/news/models/models.md` on the `news` branch — a cumulative, dev-friendly changelog rendered on the website.
-2. `social/news/models/{date}/discord.json` — a single Discord post for the model-news channel.
+Two outputs:
+1. `discord_text` — a single Discord message (≤1900 chars) for the model-news channel.
+2. `models_md_section` — a markdown section prepended to the cumulative developer changelog.
 
 ## Hard rules
 
-- Output a single JSON object: `{"models_md_section": "...", "discord_text": "..."}`. No prose around it, no markdown fences.
-- Use only facts present in the supplied diff. Never invent providers, capabilities, prices, or release notes.
-- If a category has no changes, omit it entirely (no empty headings).
-- Bullets are short. One line each. Mention the model `name`, then provider/family if the diff exposes it, then a one-clause "why it matters" only when the diff data supports it (e.g. `vision: true`, `reasoning: true`, paid_only flip, alias change). Otherwise just state what changed.
-- No marketing language ("blazing fast", "game-changing"). Dev-friendly, factual.
-- No emojis in `models_md_section`. Discord text may use 1-3 sparingly.
-- Do not reference PR numbers, authors, internal infra, or pricing changes.
+- Output ONLY `{"models_md_section": "...", "discord_text": "..."}`. No prose, no fences.
+- Use only facts from the diff. Never invent providers, prices, or capabilities.
+- Skip any section that has no entries — no empty headers.
+- A model must appear in `added`, `removed`, or `changed` to be mentioned. Never infer or assume.
+- Factual, dev-friendly tone. No marketing language ("blazing fast", "game-changing").
+- Max 3 emojis per section header in Discord. None in `models_md_section`.
+
+## Change-type detection (apply to each model in `diff.changed`)
+
+For each `{before, after}` pair, identify what actually changed:
+
+1. **Access change** — `paid_only` flipped `false→true` → 🔒 going paid-only. `true→false` → 🔓 going free.
+2. **Price cut** — any numeric pricing token value decreased. Compute the primary token % drop:
+   - Image/video: `completionImageTokens`
+   - Text: `completionTextTokens`
+   - Audio: `completionAudioTokens`
+   - Embeddings: `completionEmbeddingTokens`
+   Round to nearest 5%. Group these under ⬇️ by category.
+3. **Price increase** — any pricing token value increased. Same calculation. Group under ⬆️.
+4. **Modality change** — `input_modalities` or `output_modalities` changed → ✨ section.
+5. **Capability change** — `capabilities` array changed → ✨ section.
+6. If multiple change types apply to one model, list it only in the most prominent section
+   (access > price > capability).
+
+Category emojis: 🎨 image/video · 🧠 text · 🔊 audio · 🔢 embeddings
+
+## discord_text format
+
+```
+<@&MODEL_ROLE_ID> Model updates — {date}
+
+### 🆕 New
+- [category emoji] **Model Name** (provider) — one-clause note (e.g. "vision + tool calling")
+
+### 🗑️ Removed
+- `model-name` (category)
+
+### ⬇️ Price cuts (~X% off)
+- 🎨 Image: Model A · Model B · Model C
+- 🧠 Text: Model D · Model E
+- 🔢 Embeddings: Model F
+
+### ⬆️ Price increases (~X% more)
+- 🧠 Text: Model A · Model B
+
+### 🔒 Going paid-only
+- Model A
+- Model B
+
+### 🔓 Now free
+- Model A
+
+### ✨ Capability updates
+- `model-name` — what changed (e.g. "added vision input", "tools now supported")
+
+Explore at https://gen.pollinations.ai/docs
+```
+
+Rules:
+- Omit any section with no entries.
+- Within price-cut/increase sections, collapse models into one line per category, separated by `·`.
+- If all models in a price group have the same % change, state it once in the section header.
+  If changes vary, omit the % from the header and note per-model where it differs significantly.
+- Title line `<@&MODEL_ROLE_ID>` is mandatory and must be the first line.
+- Stay under 1900 characters total.
 
 ## models_md_section format
 
-A single dated section to be prepended to `models.md`. Newest stays at top.
+A single section to prepend to `models.md`. No emojis. Dev-readable.
 
 ```
 ## {date}
 
-### Text
-- `model-name` (provider) — short note when warranted.
+### Added
+- `model-name` (provider, category) — short capability note.
 
-### Image
-- `model-name` — short note.
-
-### Audio
-- ...
-
-### Embeddings
-- ...
+### Changed
+- `model-name` — specific delta (e.g. "price cut ~33%", "added vision input", "now paid-only", "price +20%").
 
 ### Removed
-- `old-model-name` (was: text/image/...)
+- `model-name` (was: category)
 ```
 
-Order categories: Text, Image, Audio, Embeddings, Removed. Skip categories with no entries. Within a category, list `added` then `changed`. Use a single `### Removed` block at the end aggregating removals across categories.
+Order within Changed: access changes first, then pricing, then capability. Skip any sub-group with no entries.
 
-For `changed`, describe the delta concisely: `` `model-name` — now paid-only `` or `` `model-name` — added vision support ``.
+## Inputs
 
-## discord_text format
+- `date` — report date (YYYY-MM-DD).
+- `previous_date` — prior snapshot date or `null`.
+- `diff` — `{added, removed, changed}` keyed by category (`text`, `image`, `audio`, `embeddings`).
+  - `added[cat]`: full model objects that are new.
+  - `removed[cat]`: full model objects that were removed.
+  - `changed[cat]`: `[{before: {...}, after: {...}}]` pairs — compare them to find what changed.
 
-A single Discord message, max 1900 characters, role-pinging the model-news role: prefix with `<@&MODEL_ROLE_ID>` literally — the workflow substitutes it.
-
-Structure:
-
-```
-<@&MODEL_ROLE_ID> New models live on Pollinations this week.
-
-**Text**
-- `model-name` (provider)
-...
-
-**Image**
-- ...
-```
-
-Skip empty sections. End with one short closing line referencing the docs: `Try them via /v1/models or read the docs at https://gen.pollinations.ai/docs`.
-
-## Inputs you receive
-
-- `date` — the report date (Wednesday, YYYY-MM-DD).
-- `previous_date` — the previous snapshot date (or `null` if first run).
-- `diff` — `{added, removed, changed}` keyed by category (`text`, `image`, `audio`, `embeddings`). Each entry carries the model object verbatim from the API.
-
-## Your task
-
-Produce the JSON output. Nothing else.
+Only models present in the diff may appear in your output. Produce the JSON. Nothing else.

--- a/social/scripts/generate_models_news.py
+++ b/social/scripts/generate_models_news.py
@@ -258,14 +258,29 @@ def load_models_md(github_token: str, owner: str, repo: str) -> str:
     return base64.b64decode(resp.json()["content"]).decode()
 
 
-# Fields ignored when comparing models. Pricing fluctuates frequently and is
-# not user-facing model news; description text gets edited for clarity without
-# any underlying capability change.
-_DIFF_IGNORED_FIELDS: frozenset[str] = frozenset({"pricing", "description"})
+# Fields ignored when comparing models.
+# description: prose edits with no capability change.
+# added_date: static timestamp, never changes for existing models.
+# name / id: identity key fields used for lookup — excluded from value comparison
+#   so that snapshots migrating from 'id' to 'name' don't flood the diff.
+_DIFF_IGNORED_FIELDS: frozenset[str] = frozenset({"description", "added_date", "name", "id"})
 
 
 def _normalize_for_diff(model: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in model.items() if k not in _DIFF_IGNORED_FIELDS}
+    result: dict[str, Any] = {}
+    for k, v in model.items():
+        if k in _DIFF_IGNORED_FIELDS:
+            continue
+        # Sort lists so reordering aliases/modalities/capabilities doesn't
+        # trigger false "changed" entries.
+        result[k] = sorted(str(x) for x in v) if isinstance(v, list) else v
+    return result
+
+
+def _model_key(m: dict[str, Any]) -> str | None:
+    """Return a stable identity key for a model, falling back to 'id' for
+    older snapshots that predate the 'name' field."""
+    return m.get("name") or m.get("id")
 
 
 def diff_models(
@@ -277,15 +292,25 @@ def diff_models(
     changed: dict[str, list[dict[str, Any]]] = {c: [] for c in CATEGORIES}
 
     if previous is None:
-        # First run: do not flood the diff with every existing model. Treat
-        # the very first snapshot as a baseline with no announced changes.
+        # First run: treat the snapshot as baseline with no announced changes.
         return Diff(added=added, removed=removed, changed=changed)
 
     for cat in CATEGORIES:
-        prev_by_name = {
-            m.get("name"): m for m in previous.get(cat, []) if m.get("name")
-        }
-        curr_by_name = {m.get("name"): m for m in current.get(cat, []) if m.get("name")}
+        prev_raw = previous.get(cat, [])
+        curr_raw = current.get(cat, [])
+
+        prev_by_name = {_model_key(m): m for m in prev_raw if _model_key(m)}
+        curr_by_name = {_model_key(m): m for m in curr_raw if _model_key(m)}
+
+        # If the previous snapshot has raw models but none resolved to a key,
+        # the snapshot used a different structure — treat as no baseline to
+        # avoid flooding the diff with every current model as "added".
+        if prev_raw and not prev_by_name:
+            print(
+                f"  Warning: previous snapshot for {cat} has {len(prev_raw)} models "
+                "but none have a resolvable key — skipping diff for this category."
+            )
+            continue
 
         for name, model in curr_by_name.items():
             if name not in prev_by_name:

--- a/social/scripts/generate_models_news.py
+++ b/social/scripts/generate_models_news.py
@@ -291,6 +291,42 @@ def _normalize_for_diff(model: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _migrate_old_snapshot(
+    snapshot: dict[str, list[dict[str, Any]]],
+) -> dict[str, list[dict[str, Any]]]:
+    """One-time migration: old snapshots stored image+video together under 'image'
+    (fetched from /image/models before the video split). If 'video' is absent but
+    'image' is present, re-bucket by each model's 'category' field so the diff
+    doesn't report all video models as removed from image."""
+    if "video" in snapshot or "image" not in snapshot:
+        return snapshot
+    migrated = {k: list(v) for k, v in snapshot.items()}
+    migrated["image"] = [m for m in snapshot["image"] if m.get("category") != "video"]
+    migrated["video"] = [m for m in snapshot["image"] if m.get("category") == "video"]
+    video_count = len(migrated["video"])
+    if video_count:
+        print(f"  Migrated {video_count} video model(s) out of old 'image' bucket.")
+    return migrated
+
+
+def _migrate_old_snapshot(
+    snapshot: dict[str, list[dict[str, Any]]],
+) -> dict[str, list[dict[str, Any]]]:
+    """One-time migration: old snapshots stored image+video together under 'image'
+    (fetched from /image/models before the video split). If 'video' is absent but
+    'image' is present, re-bucket by each model's 'category' field so the diff
+    doesn't report all video models as removed from image."""
+    if "video" in snapshot or "image" not in snapshot:
+        return snapshot
+    migrated = {k: list(v) for k, v in snapshot.items()}
+    migrated["image"] = [m for m in snapshot["image"] if m.get("category") != "video"]
+    migrated["video"] = [m for m in snapshot["image"] if m.get("category") == "video"]
+    video_count = len(migrated["video"])
+    if video_count:
+        print(f"  Migrated {video_count} video model(s) out of old 'image' bucket.")
+    return migrated
+
+
 def _model_key(m: dict[str, Any]) -> str | None:
     """Return a stable identity key for a model, falling back to 'id' for
     older snapshots that predate the 'name' field."""
@@ -468,7 +504,9 @@ def main() -> int:
             github_token, owner, repo, target_date
         )
         previous = (
-            load_snapshot_from_news(github_token, owner, repo, previous_date)
+            _migrate_old_snapshot(
+                load_snapshot_from_news(github_token, owner, repo, previous_date)
+            )
             if previous_date
             else None
         )

--- a/social/scripts/generate_models_news.py
+++ b/social/scripts/generate_models_news.py
@@ -51,7 +51,7 @@ from common import (
     parse_json_response,
 )
 
-CATEGORIES: tuple[str, ...] = ("text", "image", "audio", "embeddings")
+CATEGORIES: tuple[str, ...] = ("text", "image", "video", "audio", "embeddings")
 GEN_BASE = "https://gen.pollinations.ai"
 MODELS_DIR = MODELS_NEWS_DIR
 MODELS_MD_PATH = f"{MODELS_DIR}/models.md"
@@ -74,24 +74,41 @@ class Diff:
         return {"added": self.added, "removed": self.removed, "changed": self.changed}
 
 
-def fetch_models(category: str) -> list[dict[str, Any]]:
-    """GET /{category}/models without auth — auth filters models by key permissions,
-    which would create false 'removed' entries when keys differ. Unauth returns the
-    full public superset including paid_only entries."""
-    url = f"{GEN_BASE}/{category}/models"
+def fetch_all_snapshots() -> dict[str, list[dict[str, Any]]]:
+    """GET /models returns every model in one call with a 'category' field.
+    We bucket by that field into the known categories.
+
+    No auth — authenticated requests filter by key permissions, which would
+    create false 'removed' entries when keys differ between runs."""
+    url = f"{GEN_BASE}/models"
     resp = requests.get(url, headers={"Accept": "application/json"}, timeout=30)
     resp.raise_for_status()
     payload = resp.json()
-    # /v1/models wraps in {data:[...]}. The rich endpoints return a bare list.
-    if isinstance(payload, dict) and "data" in payload:
-        return list(payload["data"])
-    if isinstance(payload, list):
-        return payload
-    raise ValueError(f"Unexpected shape from {url}: {type(payload).__name__}")
+    # /v1/models wraps in {data:[...]}; /models returns a bare list.
+    all_models: list[dict[str, Any]] = (
+        list(payload["data"])
+        if isinstance(payload, dict) and "data" in payload
+        else list(payload)
+        if isinstance(payload, list)
+        else []
+    )
+    if not all_models:
+        raise ValueError(f"Unexpected or empty response from {url}: {payload!r:.200}")
 
-
-def fetch_all_snapshots() -> dict[str, list[dict[str, Any]]]:
-    return {cat: fetch_models(cat) for cat in CATEGORIES}
+    result: dict[str, list[dict[str, Any]]] = {cat: [] for cat in CATEGORIES}
+    unknown: list[str] = []
+    for model in all_models:
+        cat = model.get("category", "")
+        # API returns "embedding" (singular); we bucket under "embeddings"
+        if cat == "embedding":
+            cat = "embeddings"
+        if cat in result:
+            result[cat].append(model)
+        else:
+            unknown.append(f"{model.get('name', '?')}({cat})")
+    if unknown:
+        print(f"  Warning: unrecognised categories, skipped: {unknown[:10]}")
+    return result
 
 
 class GithubProbeError(RuntimeError):
@@ -116,9 +133,7 @@ def _news_branch_exists(github_token: str, owner: str, repo: str) -> bool:
     )
 
 
-def _path_exists_on_news(
-    github_token: str, owner: str, repo: str, path: str
-) -> bool:
+def _path_exists_on_news(github_token: str, owner: str, repo: str, path: str) -> bool:
     """True on confirmed 200, False on confirmed 404, raises on anything else."""
     headers = _github_headers(github_token)
     url = f"{GITHUB_API_BASE}/repos/{owner}/{repo}/contents/{path}?ref={GISTS_BRANCH}"
@@ -189,10 +204,7 @@ def find_previous_snapshot_date(
         return None
     entries = resp.json()
     if not isinstance(entries, list):
-        msg = (
-            f"Unexpected payload listing {SNAPSHOT_PREFIX}: "
-            f"{type(entries).__name__}"
-        )
+        msg = f"Unexpected payload listing {SNAPSHOT_PREFIX}: {type(entries).__name__}"
         if needs_guard:
             raise MissingPriorSnapshotError(msg)
         print(f"  {msg}")
@@ -263,7 +275,9 @@ def load_models_md(github_token: str, owner: str, repo: str) -> str:
 # added_date: static timestamp, never changes for existing models.
 # name / id: identity key fields used for lookup — excluded from value comparison
 #   so that snapshots migrating from 'id' to 'name' don't flood the diff.
-_DIFF_IGNORED_FIELDS: frozenset[str] = frozenset({"description", "added_date", "name", "id"})
+_DIFF_IGNORED_FIELDS: frozenset[str] = frozenset(
+    {"description", "added_date", "name", "id"}
+)
 
 
 def _normalize_for_diff(model: dict[str, Any]) -> dict[str, Any]:
@@ -296,18 +310,27 @@ def diff_models(
         return Diff(added=added, removed=removed, changed=changed)
 
     for cat in CATEGORIES:
-        prev_raw = previous.get(cat, [])
         curr_raw = current.get(cat, [])
-
-        prev_by_name = {_model_key(m): m for m in prev_raw if _model_key(m)}
         curr_by_name = {_model_key(m): m for m in curr_raw if _model_key(m)}
 
-        # If the previous snapshot has raw models but none resolved to a key,
-        # the snapshot used a different structure — treat as no baseline to
-        # avoid flooding the diff with every current model as "added".
+        # Category absent from previous snapshot = newly tracked (e.g. 'video'
+        # added after this code change). Treat as no baseline — don't flood the
+        # diff by announcing every existing model as "added".
+        if cat not in previous:
+            print(
+                f"  Info: '{cat}' not in previous snapshot — skipping (new category)."
+            )
+            continue
+
+        prev_raw = previous[cat]
+        prev_by_name = {_model_key(m): m for m in prev_raw if _model_key(m)}
+
+        # Old snapshot has raw models but none resolved to a key — structural
+        # mismatch (e.g. old format used a different field). Skip rather than
+        # reporting every current model as "added".
         if prev_raw and not prev_by_name:
             print(
-                f"  Warning: previous snapshot for {cat} has {len(prev_raw)} models "
+                f"  Warning: previous snapshot for '{cat}' has {len(prev_raw)} models "
                 "but none have a resolvable key — skipping diff for this category."
             )
             continue
@@ -528,7 +551,9 @@ def main() -> int:
     for filename, body in contents.items():
         with open(os.path.join(out_dir, filename), "w", encoding="utf-8") as fh:
             fh.write(body)
-    print(f"  Staged {len(contents)} artifacts in {out_dir} (commit deferred to publish)")
+    print(
+        f"  Staged {len(contents)} artifacts in {out_dir} (commit deferred to publish)"
+    )
     return 0
 
 


### PR DESCRIPTION
The weekly models report was announcing models that hadn't changed at all — calling them "added" — and ignoring pricing changes entirely. Both issues are fixed here.

**What was wrong:**
- `pricing` was in the ignored-fields set, so price changes were invisible to the diff
- Old snapshots keyed models by `id`; current snapshots use `name`. When comparing the two, `prev_by_name` resolved to an empty dict, making every live model appear as newly added
- List fields like `aliases` and `input_modalities` weren't sorted before comparison, so a reordering from the API would trigger a false "changed" entry

**What's fixed:**
- `pricing` is now compared — price cuts, hikes, and paid-only flips all show up in the diff
- `_model_key()` tries `name` first, then `id` as fallback, so old and new snapshots resolve to the same identity
- `name` and `id` are excluded from the *value* comparison (they're already the lookup key)
- `added_date` excluded — it's a static timestamp that never changes for existing models
- List fields sorted before compare — alias reordering is not news
- Guard added: if old snapshot has raw models but none resolve to a key, skip that category rather than flooding the diff
- `models_news.md` prompt rewritten: Discord output now groups by change type (new · removed · price cuts · price hikes · paid-only · newly free · capability updates) with category emojis, matching the intended announcement style