### PR TITLE
fix(polly): kimi-code model, glm fallback, 402 bail, crawl4ai fixes, rnet→scrapling→crawl4ai cascade

### DIFF
--- a/apps/polly/config.json
+++ b/apps/polly/config.json
@@ -22,7 +22,7 @@
     "port": 55288
   },
   "ai": {
-    "model": "kimi",
+    "model": "kimi-code",
     "fallback_model": "glm"
   },
   "features": {

--- a/apps/polly/requirements.txt
+++ b/apps/polly/requirements.txt
@@ -19,6 +19,7 @@ charset-normalizer==3.4.4
 chromadb==1.4.1
 click==8.3.1
 coloredlogs==15.0.1
+crawl4ai==0.8.0
 cryptography==46.0.4
 discord.py==2.6.4
 distro==1.9.0

--- a/apps/polly/requirements.txt
+++ b/apps/polly/requirements.txt
@@ -19,7 +19,7 @@ charset-normalizer==3.4.4
 chromadb==1.4.1
 click==8.3.1
 coloredlogs==15.0.1
-crawl4ai==0.8.0
+crawl4ai==0.9.0
 cryptography==46.0.4
 discord.py==2.6.4
 distro==1.9.0
@@ -32,6 +32,7 @@ fsspec==2026.1.0
 granian>=1.7.0
 greenlet==3.3.1
 h11==0.16.0
+html2text>=2024.2.26
 httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
@@ -70,7 +71,9 @@ referencing==0.37.0
 regex==2026.1.15
 requests==2.32.5
 rich==14.3.1
+rnet==2.4.2
 rpds-py==0.30.0
+scrapling==0.4.9
 seaborn>=0.13.0
 sniffio==1.3.1
 soupsieve==2.8.3

--- a/apps/polly/src/bot.py
+++ b/apps/polly/src/bot.py
@@ -517,14 +517,10 @@ class PollyBot(commands.Bot):
             logger.info("Registered doc_search tool handler (doc embeddings enabled)")
 
         # Register web_search handler (always available)
-        from .services.pollinations import web_handler, web_search_handler
+        from .services.pollinations import web_search_handler
 
         pollinations_client.register_tool_handler("web_search", web_search_handler)
         logger.info("Registered web_search tool handler")
-
-        # Register web handler (nomnom - deep research)
-        pollinations_client.register_tool_handler("web", web_handler)
-        logger.info("Registered web tool handler (nomnom)")
 
         # Register web_scrape handler (always available - Crawl4AI powered)
         from .services.web_scraper import web_scrape_handler

--- a/apps/polly/src/config.py
+++ b/apps/polly/src/config.py
@@ -86,6 +86,7 @@ class Config:
         # =================================================================
         ai_cfg = cfg.get("ai", {})
         self.pollinations_model = ai_cfg.get("model", "gemini-large")
+        self.pollinations_fallback_model = ai_cfg.get("fallback_model", None)
 
         # Secret from .env
         self.pollinations_token = os.getenv("POLLINATIONS_TOKEN", "")

--- a/apps/polly/src/constants.py
+++ b/apps/polly/src/constants.py
@@ -826,42 +826,6 @@ Security: Results filtered to channels the user can access.""",
     },
 }
 
-# =============================================================================
-# WEB TOOL - Deep web research using nomnom model (search + scrape + crawl + code)
-# Use for complex research, multi-step analysis, data extraction with code
-# =============================================================================
-
-WEB_TOOL = {
-    "type": "function",
-    "function": {
-        "name": "web",
-        "description": """Deep web research tool powered by nomnom model.
-Use this for COMPLEX tasks that need multiple capabilities combined:
-- Multi-source research with analysis
-- Scraping sites that need JavaScript/anti-bot bypass
-- Data extraction + Python analysis/visualization
-- Crawling multiple pages and synthesizing results
-
-For SIMPLE tasks, prefer faster tools:
-- Quick searches → web_search with model=gemini-search (fast, Google Search grounding)
-- Balanced searches → web_search with model=perplexity-fast (default, citations)
-- Deep analysis → web_search with model=perplexity-reasoning (multi-step reasoning)
-- URL scraping → web_scrape (fast)
-
-This tool is SLOW but POWERFUL - combines search, scrape, crawl, and code execution.""",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Natural language request. Examples: 'Find top 10 laptops on Amazon and compare specs', 'Research latest AI news and summarize', 'Scrape this Discord CDN URL and parse the JSON'",
-                },
-            },
-            "required": ["query"],
-        },
-    },
-}
-
 
 # =============================================================================
 # DATA VISUALIZATION TOOL - Gemini native code_execution
@@ -957,7 +921,6 @@ def get_tools_with_embeddings(base_tools: list, embeddings_enabled: bool, doc_em
     tools.append(WEB_SEARCH_TOOL)
     tools.append(WEB_SCRAPE_TOOL)
     tools.append(DISCORD_SEARCH_TOOL)
-    tools.append(WEB_TOOL)  # nomnom - deep research (use sparingly, slow but powerful)
     tools.append(DATA_VIZ_TOOL)
 
     # Conditionally include code_search if embeddings enabled
@@ -1268,9 +1231,7 @@ Use tools for everything else:
 - GitHub issues/PRs → `github_issue`, `github_pr`
 - Live model pricing → `web_scrape` on `/text/models` or `/image/models`
 - Discord history → `discord_search`
-- Complex multi-source research → `web` (nomnom, slow but powerful)
-
-**Priority:** `doc_search` > `code_search` > `web_search(gemini-search)` > `web_search(perplexity-fast)` > `web_scrape` > `web`
+**Priority:** `doc_search` > `code_search` > `web_search(gemini-search)` > `web_search(perplexity-fast)` > `web_scrape`
 
 ## Tools
 {tools_section}
@@ -1309,7 +1270,8 @@ You are a sharp, knowledgeable teammate on the Pollinations Discord. You sound l
 **Use:** bold, italic, underline, code, blockquotes, bullet lists, headers (#/##/###), subtext (-#), spoiler tags (||)
 **Tables:** Markdown tables are fully supported and will be automatically rendered as high-quality, beautiful images for the user. Use markdown tables when presenting structured data, comparison tables, or model details. Ensure you use standard markdown table syntax (with or without outer pipes).
 **Spans:** Ensure inline formatting tags (like bold `**`, italic `*`, strikethrough `~~`, and spoiler `||`) are closed within the same paragraph so that they do not get broken across message boundaries if a message is split.
-**Links:** `[text](url)` for named links. `<url>` to suppress preview. Raw URL for preview.
+**Links:** Always suppress Discord preview bloat -- wrap every bare URL in `<url>`. For anything with a natural name (issues, PRs, docs, repos, models, etc.) use `[name](<url>)` -- angle brackets inside the parens suppress preview AND keep the link clickable. Exception: if the display text IS the URL itself, use `<url>` only -- never `[https://...](<https://...>)`. Never post a raw URL.
+**Named refs rule:** Whenever you mention something linkable -- `#123` issues, `#456` PRs, a model, a repo, a doc page, a workflow -- always embed it: `[#123](<https://github.com/pollinations/pollinations/issues/123>)`, `[name](<url>)`. Never leave a linkable reference as plain unlinked text when you have the URL.
 **Usernames:** backticks `username` — no @ mentions, no guessed IDs.
 **Avoid:** horizontal rules, HTML, nested blockquotes, long unbroken paragraphs.
 

--- a/apps/polly/src/services/embeddings.py
+++ b/apps/polly/src/services/embeddings.py
@@ -561,6 +561,37 @@ async def search_code(query: str, top_k: int = 5) -> list[dict]:
     return formatted
 
 
+_LAST_HEAD_FILE = EMBEDDINGS_DIR / "last_embedded_head.txt"
+
+
+def _read_last_embedded_head() -> str | None:
+    try:
+        return _LAST_HEAD_FILE.read_text().strip() if _LAST_HEAD_FILE.exists() else None
+    except Exception:
+        return None
+
+
+def _save_last_embedded_head(head: str) -> None:
+    try:
+        _LAST_HEAD_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _LAST_HEAD_FILE.write_text(head)
+    except Exception as e:
+        logger.warning(f"Failed to save last embedded HEAD: {e}")
+
+
+async def _get_repo_head(repo: str) -> str | None:
+    repo_path = REPO_DIR / repo.replace("/", "_")
+    try:
+        result = await asyncio.to_thread(
+            subprocess.run,
+            ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+            capture_output=True, text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except Exception:
+        return None
+
+
 async def pull_and_update():
     from ..config import config
 
@@ -573,6 +604,9 @@ async def pull_and_update():
             logger.info("Repository changes detected, running incremental embedding update...")
             count = await embed_repository(config.embeddings_repo, force_full=False)
             logger.info(f"Update complete. Embedded {count} new/changed chunks.")
+            head = await _get_repo_head(config.embeddings_repo)
+            if head:
+                _save_last_embedded_head(head)
 
         else:
             logger.info("No repository changes detected, skipping embedding update")
@@ -617,13 +651,31 @@ async def initialize():
         await clone_or_pull_repo(config.embeddings_repo)
 
         collection = _get_collection()
-        force_full = collection.count() == 0
+        current_head = await _get_repo_head(config.embeddings_repo)
+        last_head = _read_last_embedded_head()
+        has_existing = collection.count() > 0
+
+        if has_existing and current_head and current_head == last_head:
+            logger.info(
+                f"✅ Embeddings up to date (HEAD {current_head[:8]}, "
+                f"{collection.count()} chunks) — skipping re-embed"
+            )
+            _initialized.set()
+            return
+
+        force_full = not has_existing
         if force_full:
             logger.info("No existing embeddings found, running full embed (first initialization)...")
         else:
-            logger.info(f"Found {collection.count()} existing embeddings, checking for updates...")
+            logger.info(
+                f"Found {collection.count()} existing embeddings, HEAD changed "
+                f"({last_head[:8] if last_head else 'none'} -> {current_head[:8] if current_head else '?'}), updating..."
+            )
 
         await embed_repository(config.embeddings_repo, force_full=force_full)
+
+        if current_head:
+            _save_last_embedded_head(current_head)
 
         _initialized.set()
         logger.info("✅ Code embeddings initialization complete — %d chunks ready", collection.count())

--- a/apps/polly/src/services/embeddings.py
+++ b/apps/polly/src/services/embeddings.py
@@ -93,7 +93,23 @@ SKIP_DIRS = {
     ".mypy_cache",
 }
 
-MAX_FILE_SIZE = 500 * 1024
+# Lock files and generated files — large, noisy, zero search value
+SKIP_FILES = {
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "pnpm-lock.yml",
+    "Gemfile.lock",
+    "Pipfile.lock",
+    "poetry.lock",
+    "Cargo.lock",
+    "composer.lock",
+    "go.sum",
+    "flake.lock",
+    "packages.lock.json",
+}
+
+MAX_FILE_SIZE = 200 * 1024  # 200KB — lock files are large; most useful code is small
 
 UPDATE_DEBOUNCE_SECONDS = 30
 _pending_update_task: asyncio.Task | None = None
@@ -288,6 +304,7 @@ async def clone_or_pull_repo(repo: str) -> bool:
                     "git",
                     "clone",
                     "--depth=1",
+                    "--filter=blob:limit=100k",
                     f"https://github.com/{repo}.git",
                     str(repo_path),
                 ],
@@ -328,13 +345,16 @@ def _collect_code_files(repo_path: Path) -> list[Path]:
             list(SKIP_DIRS),
             MAX_FILE_SIZE,
         )
-        return [Path(p) for p in paths]
+        return [Path(p) for p in paths if Path(p).name not in SKIP_FILES]
 
     files = []
     for root, dirs, filenames in os.walk(repo_path):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
 
         for filename in filenames:
+            if filename in SKIP_FILES:
+                continue
+
             file_path = Path(root) / filename
 
             if file_path.suffix.lower() not in CODE_EXTENSIONS:

--- a/apps/polly/src/services/pollinations.py
+++ b/apps/polly/src/services/pollinations.py
@@ -117,6 +117,9 @@ class PollinationsClient:
                     return data["choices"][0]["message"].get("content", "")
                 else:
                     error_text = await response.text()
+                    if response.status == 402:
+                        logger.warning(f"generate_text: insufficient balance (402), bailing")
+                        return None
                     logger.error(f"generate_text error: HTTP {response.status}: {error_text[:200]}")
                     return None
         except Exception as e:
@@ -349,18 +352,34 @@ class PollinationsClient:
             ]
             logger.info(f"Executing {len(tool_calls)} tool(s): {', '.join(tool_names)}")
 
-            # Soft guidance: nudge AI if it keeps calling the same tool
+            # Escalating guidance: inject system messages when the AI loops on the same tool
             current_signature = tuple(sorted(tool_names))
             if current_signature == last_tool_signature:
                 consecutive_same_tool += 1
-                if consecutive_same_tool >= 3:
-                    logger.info(f"Soft nudge: {current_signature} called {consecutive_same_tool + 1}x consecutively")
-                    messages.append(
-                        {
-                            "role": "system",
-                            "content": f"[Hint: You've called {', '.join(tool_names)} {consecutive_same_tool + 1} times in a row. Consider if you already have enough info to respond, or try a different tool/approach.]",
-                        }
-                    )
+                count = consecutive_same_tool + 1
+                if count >= 3:
+                    logger.info(f"Soft nudge: {current_signature} called {count}x consecutively")
+                    tool_str = ", ".join(tool_names)
+                    if count >= 12:
+                        guidance = (
+                            f"[IMPORTANT: You have called {tool_str} {count} times in a row and are clearly stuck in a loop. "
+                            f"You now have enough context to give a useful answer. "
+                            f"Stop searching and respond directly with what you know — it is better to give a partial answer than to keep looping. "
+                            f"Do not call {tool_str} again.]"
+                        )
+                    elif count >= 7:
+                        guidance = (
+                            f"[You have called {tool_str} {count} times consecutively. "
+                            f"You are likely not finding new information. "
+                            f"Synthesize what you have gathered so far and give your best answer. "
+                            f"If you truly need one more lookup, use a different tool or a more specific query — do not repeat the same search.]"
+                        )
+                    else:
+                        guidance = (
+                            f"[Hint: {tool_str} called {count} times in a row. "
+                            f"Consider whether you already have enough to respond, or try a different tool or query angle.]"
+                        )
+                    messages.append({"role": "system", "content": guidance})
             else:
                 consecutive_same_tool = 0
             last_tool_signature = current_signature
@@ -558,13 +577,14 @@ class PollinationsClient:
         url = f"{POLLINATIONS_API_BASE}/v1/chat/completions"
         last_error = None
 
+        current_model = config.pollinations_model
         for attempt in range(MAX_RETRIES):
             # Use caller's seed if provided (default 42), otherwise random per attempt
             caller_seed = (api_params or {}).get("seed") if api_params else None
             seed = caller_seed if caller_seed is not None else 42
 
             payload = {
-                "model": config.pollinations_model,
+                "model": current_model,
                 "messages": messages,
                 "seed": seed,
             }
@@ -610,6 +630,13 @@ class PollinationsClient:
                         error_text = await response.text()
                         last_error = f"HTTP {response.status}: {error_text[:100]}"
                         logger.warning(f"Pollinations API error (attempt {attempt + 1}): {last_error}")
+                        # 402 = global balance exhausted -- bail immediately, no retry
+                        if response.status == 402:
+                            break
+                        # Other errors: switch to fallback model on next attempt
+                        if config.pollinations_fallback_model and current_model != config.pollinations_fallback_model:
+                            logger.info(f"Switching to fallback model {config.pollinations_fallback_model!r} after error")
+                            current_model = config.pollinations_fallback_model
                         # In API mode, propagate auth errors immediately — don't retry
                         if mode == "api" and response.status in (401, 403):
                             raise UpstreamAuthError(response.status, error_text)
@@ -879,71 +906,3 @@ async def web_search_handler(query: str, model: str = "perplexity-fast", **kwarg
         logger.error(f"Web search error: {e}")
         return {"error": f"Search failed: {str(e)}"}
 
-
-async def web_handler(query: str, **kwargs) -> dict:
-    """
-    Handle web tool calls using nomnom model for deep research.
-
-    nomnom combines search, scrape, crawl, and code execution for complex tasks.
-    Use sparingly - it's powerful but slower and more expensive than simple tools.
-
-    Args:
-        query: Natural language request describing what to research/analyze
-
-    Returns:
-        Dict with research results, including any generated images
-    """
-    messages = [
-        {
-            "role": "system",
-            "content": "You are a deep research assistant with web search, scraping, crawling, and Python code execution capabilities. Provide thorough, accurate, well-sourced answers. Use code for data analysis when helpful.",
-        },
-        {"role": "user", "content": query},
-    ]
-
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {config.pollinations_token}",
-    }
-
-    payload = {
-        "model": "perplexity-reasoning",
-        "messages": messages,
-    }
-
-    try:
-        session = await pollinations_client.get_session()
-        url = f"{POLLINATIONS_API_BASE}/v1/chat/completions"
-
-        # nomnom handles complex research - no timeout limit
-        async with session.post(url, json=payload, headers=headers) as response:
-            if response.status == 200:
-                data = await response.json()
-                message = data["choices"][0]["message"]
-                content = message.get("content", "")
-
-                # Extract image URLs from content_blocks (nomnom can generate images)
-                content_blocks = message.get("content_blocks", [])
-                image_urls = []
-                for block in content_blocks:
-                    if block.get("type") == "image_url":
-                        img_url = block.get("image_url", {}).get("url", "")
-                        if img_url and img_url.startswith("http"):
-                            image_urls.append(img_url)
-
-                result = {"result": content, "model": "nomnom", "query": query}
-                if image_urls:
-                    result["image_urls"] = image_urls
-                    logger.info(f"nomnom returned {len(image_urls)} image(s)")
-                return result
-            else:
-                error_text = await response.text()
-                logger.error(f"Web (nomnom) API error: {response.status} - {error_text[:200]}")
-                return {"error": f"Research failed: HTTP {response.status}"}
-
-    except TimeoutError:
-        logger.error("Web (nomnom) timeout")
-        return {"error": "Research timed out. Try a simpler query or use web_search instead."}
-    except Exception as e:
-        logger.error(f"Web (nomnom) error: {e}")
-        return {"error": f"Research failed: {str(e)}"}

--- a/apps/polly/src/services/web_scraper.py
+++ b/apps/polly/src/services/web_scraper.py
@@ -7,6 +7,125 @@ from .._url import parse_url
 
 logger = logging.getLogger(__name__)
 
+_BOT_MARKERS = [
+    "cloudflare",
+    "captcha",
+    "just a moment",
+    "checking your browser",
+    "access denied",
+    "please enable javascript",
+    "are you a robot",
+    "security check",
+    "ddos protection",
+    "cf-browser-verification",
+    "recaptcha",
+]
+
+
+def _is_bot_blocked(html: str, status: int) -> bool:
+    if status in (403, 429, 503):
+        return True
+    if len(html) < 1500:
+        lower = html.lower()
+        return any(m in lower for m in _BOT_MARKERS)
+    return False
+
+
+def _html_to_markdown(html: str) -> str:
+    try:
+        import html2text
+
+        h = html2text.HTML2Text()
+        h.ignore_links = False
+        h.ignore_images = True
+        h.body_width = 0
+        h.unicode_snob = True
+        return h.handle(html).strip()
+    except ImportError:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["script", "style", "noscript", "nav", "footer", "aside"]):
+            tag.decompose()
+        return soup.get_text(separator="\n", strip=True)
+
+
+def _needs_browser(
+    output_format: str,
+    extraction_strategy: str | None,
+    content_filter: str | None,
+    js_code: str | None,
+    wait_for: str | None,
+    screenshot: bool,
+    pdf: bool,
+    stealth_mode: bool,
+    simulate_user: bool,
+    magic_mode: bool,
+    process_iframes: bool,
+    include_links: bool,
+    include_images: bool,
+    include_tables: bool,
+) -> bool:
+    return bool(
+        output_format in ("fit_markdown", "html")
+        or extraction_strategy
+        or content_filter
+        or js_code
+        or wait_for
+        or screenshot
+        or pdf
+        or stealth_mode
+        or simulate_user
+        or magic_mode
+        or process_iframes
+        or include_links
+        or include_images
+        or include_tables
+    )
+
+
+async def _try_rnet(url: str, timeout: int) -> str | None:
+    try:
+        from rnet import Client, Impersonate
+
+        client = Client(
+            timeout=timeout,
+            impersonate=Impersonate.Chrome136,
+            redirect=10,
+        )
+        resp = await client.get(url)
+        status = resp.status
+        if status in (403, 429, 503):
+            return None
+        html = await resp.text()
+        if not html or _is_bot_blocked(html, status):
+            return None
+        md = _html_to_markdown(html)
+        return md if md and len(md) > 50 else None
+    except Exception as e:
+        logger.debug(f"rnet failed for {url}: {e}")
+        return None
+
+
+async def _try_scrapling(url: str, timeout: int) -> str | None:
+    try:
+        from scrapling.fetchers import AsyncFetcher
+
+        page = await asyncio.wait_for(
+            AsyncFetcher().get(url, follow_redirects=True),
+            timeout=timeout,
+        )
+        html = page.html_content if hasattr(page, "html_content") else ""
+        if not html:
+            html = page.body.decode(page.encoding or "utf-8", errors="replace") if hasattr(page, "body") else ""
+        if not html or _is_bot_blocked(html, 200):
+            return None
+        md = _html_to_markdown(html)
+        return md if md and len(md) > 50 else None
+    except Exception as e:
+        logger.debug(f"scrapling failed for {url}: {e}")
+        return None
+
 
 async def scrape_url(
     url: str,
@@ -47,6 +166,99 @@ async def scrape_url(
     except Exception:
         return {"success": False, "url": url, "error": "Invalid URL format"}
 
+    # ── Layer 1: rnet (Rust HTTP + Chrome TLS) ────────────────────────────────
+    # ── Layer 2: scrapling AsyncFetcher (curl_cffi stealth) ──────────────────
+    # Fast path for basic markdown — skip browser entirely when not needed.
+    if not _needs_browser(
+        output_format=output_format,
+        extraction_strategy=extraction_strategy,
+        content_filter=content_filter,
+        js_code=js_code,
+        wait_for=wait_for,
+        screenshot=screenshot,
+        pdf=pdf,
+        stealth_mode=stealth_mode,
+        simulate_user=simulate_user,
+        magic_mode=magic_mode,
+        process_iframes=process_iframes,
+        include_links=include_links,
+        include_images=include_images,
+        include_tables=include_tables,
+    ):
+        rnet_timeout = min(timeout, 12)
+        md = await _try_rnet(url, rnet_timeout)
+        if md:
+            logger.debug(f"rnet succeeded for {url}")
+            return {"success": True, "url": url, "title": "", "markdown": md, "_fetcher": "rnet"}
+
+        scrapling_timeout = min(timeout, 18)
+        md = await _try_scrapling(url, scrapling_timeout)
+        if md:
+            logger.debug(f"scrapling succeeded for {url}")
+            return {"success": True, "url": url, "title": "", "markdown": md, "_fetcher": "scrapling"}
+
+        logger.debug(f"rnet+scrapling both failed for {url}, falling back to crawl4ai")
+
+    # ── Layer 3: crawl4ai (Playwright browser) ────────────────────────────────
+    # Used when: browser features needed, or rnet/scrapling returned empty.
+    return await _scrape_with_crawl4ai(
+        url=url,
+        extraction_strategy=extraction_strategy,
+        schema=schema,
+        instruction=instruction,
+        semantic_filter=semantic_filter,
+        regex_patterns=regex_patterns,
+        content_filter=content_filter,
+        filter_query=filter_query,
+        include_links=include_links,
+        include_images=include_images,
+        include_raw_html=include_raw_html,
+        include_tables=include_tables,
+        output_format=output_format,
+        js_code=js_code,
+        wait_for=wait_for,
+        screenshot=screenshot,
+        pdf=pdf,
+        stealth_mode=stealth_mode,
+        simulate_user=simulate_user,
+        magic_mode=magic_mode,
+        scan_full_page=scan_full_page,
+        process_iframes=process_iframes,
+        remove_overlays=remove_overlays,
+        timeout=timeout,
+        headless=headless,
+        session_id=session_id,
+    )
+
+
+async def _scrape_with_crawl4ai(
+    url: str,
+    extraction_strategy: str | None = None,
+    schema: dict[str, Any] | None = None,
+    instruction: str | None = None,
+    semantic_filter: str | None = None,
+    regex_patterns: list[str] | None = None,
+    content_filter: str | None = None,
+    filter_query: str | None = None,
+    include_links: bool = False,
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    include_tables: bool = False,
+    output_format: str = "markdown",
+    js_code: str | None = None,
+    wait_for: str | None = None,
+    screenshot: bool = False,
+    pdf: bool = False,
+    stealth_mode: bool = False,
+    simulate_user: bool = False,
+    magic_mode: bool = False,
+    scan_full_page: bool = False,
+    process_iframes: bool = False,
+    remove_overlays: bool = True,
+    timeout: int = 30,
+    headless: bool = True,
+    session_id: str | None = None,
+) -> dict:
     try:
         from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
 
@@ -105,6 +317,7 @@ async def scrape_url(
                 "success": True,
                 "url": url,
                 "title": result.metadata.get("title", "") if result.metadata else "",
+                "_fetcher": "crawl4ai",
             }
 
             if output_format == "fit_markdown" and result.markdown and result.markdown.fit_markdown:
@@ -628,7 +841,7 @@ async def web_scrape_handler(
         return {
             "error": f"Unknown action: {action}",
             "available_actions": [
-                "scrape - Single URL to markdown",
+                "scrape - Single URL to markdown (rnet → scrapling → crawl4ai)",
                 "extract - URL + LLM extraction",
                 "css_extract - URL + CSS schema (fast)",
                 "semantic - URL + cosine clustering",

--- a/apps/polly/src/services/web_scraper.py
+++ b/apps/polly/src/services/web_scraper.py
@@ -107,12 +107,12 @@ async def scrape_url(
                 "title": result.metadata.get("title", "") if result.metadata else "",
             }
 
-            if output_format == "fit_markdown" and result.fit_markdown:
-                response["markdown"] = result.fit_markdown
+            if output_format == "fit_markdown" and result.markdown and result.markdown.fit_markdown:
+                response["markdown"] = result.markdown.fit_markdown
             elif output_format == "html" and result.html:
                 response["html"] = result.html
             else:
-                response["markdown"] = result.markdown or ""
+                response["markdown"] = result.markdown.raw_markdown if result.markdown else ""
 
             if include_raw_html and result.html:
                 response["raw_html"] = result.html


### PR DESCRIPTION
Small set of fixes for Polly:

- Switch main model to `kimi-code`, `glm` as fallback for non-balance errors
- HTTP 402 now bails immediately (balance is global, no point retrying)
- Tool loop: inject escalating guidance into context so the AI can self-correct instead of looping forever
- Embeddings skip re-indexing on restart if the repo HEAD hasn't changed
- Discord link formatting rules in system prompt (suppress preview bloat, embed named refs)
- Fixed a couple crawl4ai API deprecations
- Removed the broken web tool (model no longer exists upstream)