### PR TITLE
Rate limit media uploads by API key and IP

### DIFF
--- a/media.pollinations.ai/README.md
+++ b/media.pollinations.ai/README.md
@@ -95,6 +95,7 @@ Upload a media file. **Requires API key** via `Authorization: Bearer <key>` head
 **Errors:**
 - `400` - No file provided, empty file, or invalid JSON/base64
 - `413` - File too large (max 50MB)
+- `429` - Too many upload attempts from the same API key and IP
 
 ### `GET /:hash`
 
@@ -167,6 +168,7 @@ npm run deploy:production
 ## 📊 Limits
 
 - **Max file size:** 50MB
+- **Upload rate limit:** 60 uploads per minute per API key and IP
 - **Storage:** Cloudflare R2
 - **Default retention:** 30 days (re-uploading the same file resets the timer)
 

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -1,5 +1,6 @@
+import { bytesToHex, getRealClientIp } from "@shared/client-ip.ts";
 import { refreshR2ObjectTtl } from "@shared/r2-storage.ts";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi";
 import { z } from "zod";
@@ -21,6 +22,7 @@ const DEFAULT_MAX_SIZE = 52428800; // 50 MB
 interface Env {
     MEDIA_BUCKET: R2Bucket;
     MAX_FILE_SIZE: string;
+    UPLOAD_RATE_LIMITER?: RateLimit;
 }
 
 interface AuthResult {
@@ -28,6 +30,8 @@ interface AuthResult {
     type: string;
     name: string | null;
 }
+
+type MediaContext = Context<{ Bindings: Env }>;
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
     try {
@@ -56,6 +60,37 @@ function fileTooLargeError(maxSize: number): { error: string } {
 
 function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
+}
+
+async function hashRateLimitKey(apiKey: string): Promise<string> {
+    const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(apiKey),
+    );
+    return bytesToHex(digest).substring(0, 16);
+}
+
+async function enforceUploadRateLimit(
+    c: MediaContext,
+    apiKey: string,
+): Promise<Response | null> {
+    if (!c.env.UPLOAD_RATE_LIMITER) return null;
+
+    const ip = getRealClientIp(c);
+    const keyHash = await hashRateLimitKey(apiKey);
+    const { success } = await c.env.UPLOAD_RATE_LIMITER.limit({
+        key: `key:${keyHash}:ip:${ip}`,
+    });
+
+    if (success) return null;
+
+    c.header("Retry-After", "60");
+    return c.json(
+        {
+            error: "Too many uploads from this API key and IP. Please slow down.",
+        },
+        429,
+    );
 }
 
 const UploadResponseSchema = z.object({
@@ -110,6 +145,12 @@ api.post(
                     "application/json": { schema: resolver(ErrorSchema) },
                 },
             },
+            429: {
+                description: "Upload rate limit exceeded",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
         },
     }),
     async (c) => {
@@ -126,6 +167,9 @@ api.post(
         if (!authResult) {
             return c.json({ error: "Invalid or expired API key" }, 401);
         }
+
+        const rateLimitResponse = await enforceUploadRateLimit(c, apiKey);
+        if (rateLimitResponse) return rateLimitResponse;
 
         const maxSize = parseInt(c.env.MAX_FILE_SIZE, 10) || DEFAULT_MAX_SIZE;
 

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, getRealClientIp } from "@shared/client-ip.ts";
+import { bytesToHex } from "@shared/client-ip.ts";
 import { refreshR2ObjectTtl } from "@shared/r2-storage.ts";
 import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
@@ -70,13 +70,17 @@ async function hashRateLimitKey(apiKey: string): Promise<string> {
     return bytesToHex(digest).substring(0, 16);
 }
 
+function getUploadRateLimitIp(c: MediaContext): string {
+    return c.req.header("cf-connecting-ip") || "unknown";
+}
+
 async function enforceUploadRateLimit(
     c: MediaContext,
     apiKey: string,
 ): Promise<Response | null> {
     if (!c.env.UPLOAD_RATE_LIMITER) return null;
 
-    const ip = getRealClientIp(c);
+    const ip = getUploadRateLimitIp(c);
     const keyHash = await hashRateLimitKey(apiKey);
     const { success } = await c.env.UPLOAD_RATE_LIMITER.limit({
         key: `key:${keyHash}:ip:${ip}`,

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -155,6 +155,8 @@ describe("media.pollinations.ai", () => {
                 headers: {
                     Authorization: `Bearer ${VALID_KEY}`,
                     "CF-Connecting-IP": "203.0.113.7",
+                    "X-Forwarded-Host": "media.pollinations.ai",
+                    "X-Original-Client-IP": "198.51.100.99",
                     "Content-Type": "image/png",
                 },
             }),

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -5,7 +5,7 @@ import {
     waitOnExecutionContext,
 } from "cloudflare:test";
 import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import app from "../src/index";
 
 // 1x1 red PNG (67 bytes)
@@ -138,6 +138,39 @@ describe("media.pollinations.ai", () => {
         const dup = (await dupRes.json()) as UploadResponse;
         expect(dup.id).toBe(upload.id);
         expect(dup.duplicate).toBe(true);
+    });
+
+    it("rate limits uploads by client IP before writing to R2", async () => {
+        const bucket = createTestR2Bucket();
+        const limit = vi.fn(async () => ({ success: false }));
+        const env = {
+            ...createMediaEnv(bucket),
+            UPLOAD_RATE_LIMITER: { limit } as unknown as RateLimit,
+        };
+
+        const res = await app.fetch(
+            new Request("https://media.pollinations.ai/upload", {
+                method: "POST",
+                body: TINY_PNG,
+                headers: {
+                    Authorization: `Bearer ${VALID_KEY}`,
+                    "CF-Connecting-IP": "203.0.113.7",
+                    "Content-Type": "image/png",
+                },
+            }),
+            env,
+            createExecutionContext(),
+        );
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get("retry-after")).toBe("60");
+        await expect(res.json()).resolves.toEqual({
+            error: "Too many uploads from this API key and IP. Please slow down.",
+        });
+        expect(limit).toHaveBeenCalledWith({
+            key: expect.stringMatching(/^key:[a-f0-9]{16}:ip:203\.0\.113\.7$/),
+        });
+        expect(bucket.putCount).toBe(0);
     });
 
     it("refreshes uploaded media TTL on aged GET", async () => {

--- a/media.pollinations.ai/wrangler.toml
+++ b/media.pollinations.ai/wrangler.toml
@@ -11,6 +11,11 @@ name = "pollinations-media-dev"
 [env.development.vars]
 MAX_FILE_SIZE = "52428800"  # 50MB in bytes
 
+[[env.development.ratelimits]]
+name = "UPLOAD_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 60, period = 60 }
+
 [[env.development.r2_buckets]]
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media-dev"
@@ -21,6 +26,11 @@ name = "pollinations-media-prod"
 
 [env.production.vars]
 MAX_FILE_SIZE = "52428800"  # 50MB in bytes
+
+[[env.production.ratelimits]]
+name = "UPLOAD_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 60, period = 60 }
 
 [[env.production.routes]]
 pattern = "media.myceli.ai"
@@ -33,6 +43,11 @@ bucket_name = "pollinations-media"
 
 [vars]
 MAX_FILE_SIZE = "52428800"  # 50MB in bytes
+
+[[ratelimits]]
+name = "UPLOAD_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 60, period = 60 }
 
 [[r2_buckets]]
 binding = "MEDIA_BUCKET"


### PR DESCRIPTION
## Summary
- add a Cloudflare native upload rate limit binding for media.pollinations.ai
- enforce the limit after API-key verification and before request body parsing/R2 writes
- key the limit by hashed API key + real client IP to avoid storing raw keys and reduce shared-IP collateral damage
- document the 60 uploads/minute limit and add a regression test for 429 behavior

## Notes
This does not change the intended public retrieval behavior or make media upload paid-only. It only adds bounded abuse-control for authenticated uploads.

## Test plan
- `npx @biomejs/biome@2.3.10 check media.pollinations.ai/src/index.ts media.pollinations.ai/test/integration.test.ts media.pollinations.ai/wrangler.toml`
- `npx tsc --noEmit` from `media.pollinations.ai`
- `npm run test` from `media.pollinations.ai`
- `npx wrangler deploy --dry-run --env production` from `media.pollinations.ai`