### PR TITLE
fix: sandbox Websim opened previews

### DIFF
--- a/apps/websim/src/App.tsx
+++ b/apps/websim/src/App.tsx
@@ -57,12 +57,36 @@ function saveHtml(html: string) {
     URL.revokeObjectURL(blobUrl);
 }
 
+function escapeSrcDoc(html: string) {
+    return html
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+
 function openHtml(html: string) {
-    const blobUrl = URL.createObjectURL(
-        new Blob([html], { type: "text/html;charset=utf-8" }),
-    );
-    window.open(blobUrl, "_blank", "noopener,noreferrer");
-    window.setTimeout(() => URL.revokeObjectURL(blobUrl), 10_000);
+    const preview = window.open("", "_blank");
+    if (!preview) return;
+
+    preview.opener = null;
+    preview.document.open();
+    preview.document.write(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Websim Preview</title>
+<style>
+html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#fff}
+iframe{display:block;width:100%;height:100%;border:0;background:#fff}
+</style>
+</head>
+<body>
+<iframe title="Generated Websim page" sandbox="allow-forms allow-modals allow-popups allow-scripts" srcdoc="${escapeSrcDoc(html)}"></iframe>
+</body>
+</html>`);
+    preview.document.close();
 }
 
 function PreviewPanel({


### PR DESCRIPTION
## What

Changes Websim's **Open** action so generated HTML opens inside a sandboxed `srcdoc` iframe in a new preview wrapper, instead of opening the generated document as a same-origin Blob URL.

## Why

Generated Websim HTML is untrusted and can contain scripts. Blob URLs created by the app inherit the Websim origin, so opening generated HTML directly as a Blob gives that script same-origin access to Websim storage. Websim stores the delegated Pollinations key in localStorage via `@pollinations/sdk/react`.

The in-app preview already used a sandboxed iframe. This makes the separate Open action use the same trust boundary.

## Verification

- `npx biome check apps/websim/src/App.tsx`
- `npx tsc --noEmit -p apps/websim/tsconfig.json`
- Browser CDP check on `https://websim.pollinations.ai`: same-origin Blob page can read a fake `polli:pk_wYCqFfSdCXZL8UBW:token` value from localStorage before this pattern.
- Browser CDP check with the patched wrapper: generated sandboxed iframe receives `SecurityError` for both `localStorage` and `parent.localStorage` while the parent still has the fake token.

Note: `npm run build --prefix apps/websim` reached the UI package build but failed on Windows because `packages/ui` uses Unix `sed` in `build:css`; the failure is unrelated to this change.