### PR TITLE
fix(gen): surface Bedrock 400 instead of clamping Claude thinking budget

### DIFF
--- a/gen.pollinations.ai/src/text/transforms/createClaudeThinkingTransform.ts
+++ b/gen.pollinations.ai/src/text/transforms/createClaudeThinkingTransform.ts
@@ -19,8 +19,7 @@ export type ClaudeThinkingMode = "budget" | "adaptive";
 
 const MIN_THINKING_BUDGET = 1024;
 
-// reasoning_effort -> budget_tokens for budget-mode models. budget_tokens must
-// be < max_tokens, so caller-provided max_tokens can force a clamp below.
+// reasoning_effort -> budget_tokens for budget-mode models.
 const EFFORT_TO_BUDGET: Record<string, number> = {
     minimal: MIN_THINKING_BUDGET,
     low: MIN_THINKING_BUDGET,
@@ -42,31 +41,6 @@ const EFFORT_TO_OUTPUT_EFFORT: Record<string, string> = {
 
 function normalizeEffort(value: unknown): string | undefined {
     return typeof value === "string" ? value.toLowerCase() : undefined;
-}
-
-function numericOption(value: unknown): number | undefined {
-    return typeof value === "number" && Number.isFinite(value)
-        ? Math.floor(value)
-        : undefined;
-}
-
-function maxTokenLimit(options: TransformOptions): number | undefined {
-    return (
-        numericOption(options.max_completion_tokens) ??
-        numericOption(options.max_tokens)
-    );
-}
-
-function clampBudgetToMaxTokens(
-    budgetTokens: number,
-    options: TransformOptions,
-): number | undefined {
-    const maxTokens = maxTokenLimit(options);
-    if (maxTokens === undefined) return budgetTokens;
-
-    const maxBudget = maxTokens - 1;
-    if (maxBudget < MIN_THINKING_BUDGET) return undefined;
-    return Math.min(budgetTokens, maxBudget);
 }
 
 /**
@@ -107,21 +81,16 @@ export function createClaudeThinkingTransform(
             };
             log("Enabled adaptive thinking, effort=%s", updated.output_config);
         } else {
-            const requestedBudgetTokens =
+            // Anthropic requires budget_tokens < max_tokens (min 1024). We pass
+            // the requested budget through as-is — if it exceeds the caller's
+            // max_tokens, Bedrock returns its own clear 400 ("max_tokens must be
+            // greater than thinking budget"). Thin proxy: surface the upstream
+            // error rather than silently shrinking a budget the caller set.
+            const budgetTokens =
                 typeof budget === "number" && budget > 0
                     ? budget
                     : (effort && EFFORT_TO_BUDGET[effort]) ||
                       EFFORT_TO_BUDGET.medium;
-            const budgetTokens = clampBudgetToMaxTokens(
-                requestedBudgetTokens,
-                updated,
-            );
-            if (budgetTokens === undefined) {
-                log(
-                    "Skipping Claude budget thinking because max_tokens is too small",
-                );
-                return { messages, options: updated };
-            }
             updated.thinking = {
                 type: "enabled",
                 budget_tokens: budgetTokens,

--- a/gen.pollinations.ai/test/text/transforms/createClaudeThinkingTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createClaudeThinkingTransform.test.ts
@@ -46,23 +46,17 @@ describe("createClaudeThinkingTransform — budget mode (Haiku 4.5)", () => {
         });
     });
 
-    it("clamps budget below max_tokens", async () => {
+    it("passes the budget through unchanged regardless of max_tokens", async () => {
+        // Thin proxy: don't shrink the budget to fit max_tokens — if it
+        // exceeds max_tokens, Bedrock returns its own clear 400.
         const { options } = await budget([], {
             reasoning_effort: "high",
             max_tokens: 3000,
         });
         expect(options.thinking).toEqual({
             type: "enabled",
-            budget_tokens: 2999,
+            budget_tokens: 4096,
         });
-    });
-
-    it("skips thinking when max_tokens is too small for the minimum budget", async () => {
-        const { options } = await budget([], {
-            reasoning_effort: "high",
-            max_tokens: 512,
-        });
-        expect(options.thinking).toBeUndefined();
     });
 
     it("strips temperature/top_p/top_k when thinking is enabled", async () => {


### PR DESCRIPTION
Follow-up to the reasoning_effort normalization work.

- Removes the silent `budget_tokens → max_tokens` clamp for Claude budget-mode thinking (Haiku)
- Passes the requested budget through as-is; if it exceeds `max_tokens`, Bedrock returns its own clear 400 (`max_tokens must be greater than thinking budget`)
- Thin proxy: don't silently shrink — or worse, silently drop — a thinking budget the caller explicitly set

Scope deliberately limited to the budget clamp. Lenient normalization for mandatory-reasoning and non-reasoning (strip) models is kept — that matches OpenRouter's "map to nearest supported / ignore inapplicable" convention so one request shape works across models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)