### PR TITLE
Quest panel redesign: journey lanes + honest progress counts

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
+++ b/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
@@ -1,16 +1,26 @@
 import {
+    AppIcon,
+    CheckIcon,
     Chip,
     ClockIcon,
     GitHubIcon,
     InlineLink,
+    KeyIcon,
     SproutIcon,
-    StatCard,
     Surface,
     TabButton,
     Text,
+    TokensIcon,
+    WalletIcon,
 } from "@pollinations/ui";
 import { formatPollen, PaidChip, TierChip } from "@pollinations/ui/wallet";
-import { type FC, useEffect, useMemo, useState } from "react";
+import {
+    type ComponentType,
+    type FC,
+    useEffect,
+    useMemo,
+    useState,
+} from "react";
 import { apiClient } from "../../api.ts";
 import type {
     QuestCatalogItem,
@@ -48,6 +58,77 @@ const INITIAL_STATE: FetchState = {
     loading: true,
     error: null,
 };
+
+type IconComponent = ComponentType<{ className?: string }>;
+
+// Category metadata decoded from the quest id prefix (onboarding: / spend: /
+// grow: / github:). Drives section grouping, ordering, and the icon medallion.
+// Pure display logic — no new backend data.
+type CategoryKey = "plant" | "grow" | "community";
+
+type CategoryMeta = {
+    key: CategoryKey;
+    label: string;
+    blurb: string;
+    icon: IconComponent;
+    order: number;
+    tint: string;
+};
+
+const CATEGORY_PLANT: CategoryMeta = {
+    key: "plant",
+    label: "Plant",
+    blurb: "Get set up",
+    icon: SproutIcon,
+    order: 0,
+    tint: "text-intent-success-text",
+};
+const CATEGORY_GROW: CategoryMeta = {
+    key: "grow",
+    label: "Grow",
+    blurb: "Go deeper",
+    icon: WalletIcon,
+    order: 1,
+    tint: "text-intent-news-text",
+};
+const CATEGORY_COMMUNITY: CategoryMeta = {
+    key: "community",
+    label: "Community",
+    blurb: "Build for others",
+    icon: GitHubIcon,
+    order: 2,
+    tint: "text-theme-text-soft",
+};
+
+const CATEGORY_ORDER: CategoryMeta[] = [
+    CATEGORY_PLANT,
+    CATEGORY_GROW,
+    CATEGORY_COMMUNITY,
+];
+
+function categoryForQuest(quest: QuestCatalogItem): CategoryMeta {
+    const id = quest.id;
+    if (id.startsWith("github:") || quest.kind === "github_issue") {
+        return CATEGORY_COMMUNITY;
+    }
+    if (id.startsWith("onboarding:")) return CATEGORY_PLANT;
+    // spend: + grow: + anything else product-y maps to the middle "Grow" lane.
+    return CATEGORY_GROW;
+}
+
+// Per-quest icon medallion. More specific than the category icon where the id
+// makes the intent obvious.
+function iconForQuest(quest: QuestCatalogItem): IconComponent {
+    const id = quest.id;
+    if (id.startsWith("github:") || quest.kind === "github_issue") {
+        return GitHubIcon;
+    }
+    if (id.includes("api_key") || id.includes("first_api_key")) return KeyIcon;
+    if (id.startsWith("spend:") || id.includes("top_up")) return WalletIcon;
+    if (id.includes("github_account")) return GitHubIcon;
+    if (id.startsWith("grow:") || id.includes("list_app")) return AppIcon;
+    return SproutIcon;
+}
 
 function formatGrantAmount(value: number | null): string {
     if (value == null) return "TBD";
@@ -172,6 +253,54 @@ function BalanceBucketChip({ bucket }: { bucket: string }) {
     );
 }
 
+// Tinted circular icon holder left of each quest. The single biggest visual
+// delta from the old flat-row look.
+function IconMedallion({
+    icon: Icon,
+    tint,
+    completed = false,
+}: {
+    icon: IconComponent;
+    tint: string;
+    completed?: boolean;
+}) {
+    return (
+        <span
+            className={[
+                "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+                completed
+                    ? "bg-intent-success-bg-light text-intent-success-text"
+                    : `bg-theme-bg-active ${tint}`,
+            ].join(" ")}
+        >
+            {completed ? (
+                <CheckIcon className="h-5 w-5" />
+            ) : (
+                <Icon className="h-5 w-5" />
+            )}
+        </span>
+    );
+}
+
+// Reward "seed coin": a Pollen glyph + tabular amount. Weight scales gently
+// with size (outline feel at small amounts) without slot-machine emphasis.
+function RewardCoin({ amount }: { amount: number | null }) {
+    const big = (amount ?? 0) >= 5;
+    return (
+        <span
+            className={[
+                "inline-flex shrink-0 items-center gap-1 rounded-lg px-2.5 py-1 text-sm",
+                big
+                    ? "bg-intent-news-bg-light font-semibold text-intent-news-text"
+                    : "bg-theme-bg-active font-medium text-theme-text-soft",
+            ].join(" ")}
+        >
+            <TokensIcon className="h-3.5 w-3.5" />
+            <span className="tabular-nums">{formatRewardLabel(amount)}</span>
+        </span>
+    );
+}
+
 function CatalogQuestCard({
     quest,
     completed,
@@ -180,40 +309,47 @@ function CatalogQuestCard({
     completed: boolean;
 }) {
     const assignees = quest.assignees ?? [];
+    const category = categoryForQuest(quest);
 
     return (
-        <Surface className="space-y-3">
-            <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <Text as="span" weight="semibold" tone="strong">
-                            {quest.title}
-                        </Text>
-                        <StatusChip quest={quest} completed={completed} />
+        <Surface className="flex items-start gap-3">
+            <IconMedallion
+                icon={iconForQuest(quest)}
+                tint={category.tint}
+                completed={completed}
+            />
+            <div className="min-w-0 flex-1 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Text as="span" weight="semibold" tone="strong">
+                                {quest.title}
+                            </Text>
+                            <StatusChip quest={quest} completed={completed} />
+                        </div>
+                        {quest.description && (
+                            <Text size="sm" tone="soft" className="mt-2">
+                                {quest.description}
+                            </Text>
+                        )}
+                        {assignees.length > 0 && (
+                            <Text size="xs" tone="muted" className="mt-1">
+                                {assignees.length === 1
+                                    ? `Claimed by @${assignees[0]}`
+                                    : `${assignees.length} builders on this`}
+                            </Text>
+                        )}
                     </div>
-                    {quest.description && (
-                        <Text size="sm" tone="soft" className="mt-2">
-                            {quest.description}
-                        </Text>
-                    )}
-                    {assignees.length > 0 && (
-                        <Text size="xs" tone="muted" className="mt-1">
-                            Assigned to{" "}
-                            {assignees.map((name) => `@${name}`).join(", ")}
-                        </Text>
-                    )}
+                    <div className="shrink-0">
+                        <RewardCoin amount={quest.rewardAmount} />
+                    </div>
                 </div>
-                <div className="shrink-0">
-                    <PaidChip size="sm">
-                        {formatRewardLabel(quest.rewardAmount)}
-                    </PaidChip>
-                </div>
+                {quest.url && (
+                    <InlineLink href={quest.url} className="text-sm">
+                        View details
+                    </InlineLink>
+                )}
             </div>
-            {quest.url && (
-                <InlineLink href={quest.url} className="text-sm">
-                    View details
-                </InlineLink>
-            )}
         </Surface>
     );
 }
@@ -238,7 +374,7 @@ function StatusChip({
 }) {
     if (completed) {
         return (
-            <Chip size="sm" intent="neutral">
+            <Chip size="sm" intent="success">
                 Completed
             </Chip>
         );
@@ -265,46 +401,172 @@ function CompletedGrantCard({
     const showGitHubIcon = grantLinkIsGitHub(grant);
 
     return (
-        <Surface className="space-y-3">
-            <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <Text as="span" weight="semibold" tone="strong">
-                            {grantTitle(grant, catalogById)}
-                        </Text>
-                        <BalanceBucketChip bucket={grant.balanceBucket} />
-                    </div>
-                    <div className="mt-2 flex flex-wrap items-center gap-2">
-                        <Text as="span" size="xs" tone="muted">
-                            {formatTimestamp(grant.createdAt)}
-                        </Text>
-                        {context && (
-                            <Text as="span" size="xs" tone="muted">
-                                {context}
+        <Surface className="flex items-start gap-3 opacity-80">
+            <IconMedallion icon={CheckIcon} tint="" completed />
+            <div className="min-w-0 flex-1 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Text as="span" weight="semibold" tone="strong">
+                                {grantTitle(grant, catalogById)}
                             </Text>
-                        )}
+                            <BalanceBucketChip bucket={grant.balanceBucket} />
+                        </div>
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                            <Text as="span" size="xs" tone="muted">
+                                {formatTimestamp(grant.createdAt)}
+                            </Text>
+                            {context && (
+                                <Text as="span" size="xs" tone="muted">
+                                    {context}
+                                </Text>
+                            )}
+                        </div>
+                    </div>
+                    <div className="shrink-0">
+                        <Text
+                            as="span"
+                            weight="semibold"
+                            tone="strong"
+                            className="tabular-nums text-intent-success-text"
+                        >
+                            +{formatGrantAmount(grant.pollenCredited)}
+                        </Text>
                     </div>
                 </div>
-                <div className="shrink-0">
-                    <Text
-                        as="span"
-                        weight="semibold"
-                        tone="strong"
-                        className="tabular-nums"
-                    >
-                        +{formatGrantAmount(grant.pollenCredited)}
-                    </Text>
-                </div>
+                {url && (
+                    <InlineLink href={url} className="text-sm">
+                        {showGitHubIcon && (
+                            <GitHubIcon className="h-3.5 w-3.5 shrink-0" />
+                        )}
+                        {grantLinkLabel(grant)}
+                    </InlineLink>
+                )}
             </div>
-            {url && (
-                <InlineLink href={url} className="text-sm">
-                    {showGitHubIcon && (
-                        <GitHubIcon className="h-3.5 w-3.5 shrink-0" />
-                    )}
-                    {grantLinkLabel(grant)}
-                </InlineLink>
-            )}
         </Surface>
+    );
+}
+
+// On-brand "endowed progress" header: the sprout grows through discrete stages
+// (seed → sprout → leafy → bloom) as completion rises, wrapped in a thin SVG
+// progress ring. Replaces the three redundant stat cards. Pure derived data.
+function GardenProgress({
+    completed,
+    total,
+    totalPollen,
+}: {
+    completed: number;
+    total: number;
+    totalPollen: number;
+}) {
+    const safeTotal = Math.max(total, 1);
+    const ratio = Math.min(1, completed / safeTotal);
+    const radius = 34;
+    const circumference = 2 * Math.PI * radius;
+    const dash = circumference * ratio;
+    const stage = ratio >= 1 ? 4 : ratio >= 0.66 ? 3 : ratio >= 0.33 ? 2 : 1;
+    const allDone = total > 0 && completed >= total;
+
+    return (
+        <Surface
+            variant="card-themed"
+            className="flex items-center gap-5 sm:gap-6"
+        >
+            <div className="relative h-20 w-20 shrink-0">
+                <svg
+                    aria-hidden="true"
+                    viewBox="0 0 80 80"
+                    className="h-20 w-20 -rotate-90"
+                >
+                    <circle
+                        cx="40"
+                        cy="40"
+                        r={radius}
+                        fill="none"
+                        strokeWidth="5"
+                        className="stroke-theme-bg-active"
+                    />
+                    <circle
+                        cx="40"
+                        cy="40"
+                        r={radius}
+                        fill="none"
+                        strokeWidth="5"
+                        strokeLinecap="round"
+                        strokeDasharray={`${dash} ${circumference}`}
+                        className="stroke-intent-success-text transition-[stroke-dasharray] duration-700 ease-out"
+                    />
+                </svg>
+                <span className="absolute inset-0 flex items-center justify-center">
+                    <SproutIcon
+                        className={[
+                            "text-intent-success-text transition-all duration-500",
+                            stage === 1
+                                ? "h-5 w-5 opacity-70"
+                                : stage === 2
+                                  ? "h-7 w-7 opacity-85"
+                                  : "h-9 w-9 opacity-100",
+                        ].join(" ")}
+                    />
+                </span>
+            </div>
+            <div className="min-w-0 flex-1">
+                <Text
+                    as="div"
+                    size="micro"
+                    tone="soft"
+                    weight="bold"
+                    className="uppercase tracking-wide"
+                >
+                    Your garden
+                </Text>
+                <Text
+                    as="div"
+                    weight="semibold"
+                    tone="strong"
+                    className="mt-1 text-lg"
+                >
+                    {allDone
+                        ? "In full bloom 🌸"
+                        : `${completed} of ${total} quests`}
+                </Text>
+                <Text as="div" size="sm" tone="soft" className="mt-0.5">
+                    {formatGrantAmount(totalPollen)} Pollen earned
+                </Text>
+            </div>
+        </Surface>
+    );
+}
+
+function SectionHeader({
+    category,
+    done,
+    total,
+}: {
+    category: CategoryMeta;
+    done: number;
+    total: number;
+}) {
+    const Icon = category.icon;
+    return (
+        <div className="mt-1 flex items-center gap-2">
+            <Icon className={`h-4 w-4 shrink-0 ${category.tint}`} />
+            <Text
+                as="span"
+                size="micro"
+                tone="soft"
+                weight="bold"
+                className="uppercase tracking-wide"
+            >
+                {category.label}
+            </Text>
+            <Text as="span" size="xs" tone="muted">
+                — {category.blurb}
+            </Text>
+            <Chip size="sm" intent="neutral" className="ml-auto tabular-nums">
+                {done} / {total}
+            </Chip>
+        </div>
     );
 }
 
@@ -374,18 +636,19 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
             ),
         [state.grants],
     );
+
+    // Visible available quests, ordered so an easy win (cheapest reward) is
+    // always near the top, then grouped by category for the journey framing.
     const visibleCatalog = useMemo(
         () =>
             state.catalog.filter((quest) => {
                 if (completedCatalogIds.has(quest.id)) return false;
-                if (activeTab === "available") {
-                    return (
-                        quest.availability === "available" ||
-                        (quest.availability === "claimed" &&
-                            claimedByUser(quest, normalizedGithubUsername))
-                    );
-                }
-                return false;
+                if (activeTab !== "available") return false;
+                return (
+                    quest.availability === "available" ||
+                    (quest.availability === "claimed" &&
+                        claimedByUser(quest, normalizedGithubUsername))
+                );
             }),
         [
             activeTab,
@@ -395,38 +658,53 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
         ],
     );
 
-    const availableCount = state.catalog.filter(
-        (quest) =>
-            !completedCatalogIds.has(quest.id) &&
-            (quest.availability === "available" ||
-                (quest.availability === "claimed" &&
-                    claimedByUser(quest, normalizedGithubUsername))),
-    ).length;
+    // Group available quests into the journey sections.
+    const grouped = useMemo(() => {
+        const map = new Map<CategoryKey, QuestCatalogItem[]>();
+        for (const quest of visibleCatalog) {
+            const key = categoryForQuest(quest).key;
+            const list = map.get(key) ?? [];
+            list.push(quest);
+            map.set(key, list);
+        }
+        // Cheapest reward first within each lane (the always-visible easy win).
+        for (const list of map.values()) {
+            list.sort(
+                (a, b) =>
+                    (a.rewardAmount ?? Number.POSITIVE_INFINITY) -
+                    (b.rewardAmount ?? Number.POSITIVE_INFINITY),
+            );
+        }
+        return map;
+    }, [visibleCatalog]);
+
+    // Per-category totals (available + already-completed) for the section count
+    // chips — gives the "2 / 3" goal-gradient cue.
+    const categoryTotals = useMemo(() => {
+        const totals = new Map<CategoryKey, { done: number; total: number }>();
+        for (const quest of state.catalog) {
+            const key = categoryForQuest(quest).key;
+            const entry = totals.get(key) ?? { done: 0, total: 0 };
+            entry.total += 1;
+            if (completedCatalogIds.has(quest.id)) entry.done += 1;
+            totals.set(key, entry);
+        }
+        return totals;
+    }, [state.catalog, completedCatalogIds]);
+
+    const availableCount = visibleCatalog.length;
+    const completedCount = state.grants.length;
+    const totalQuests = state.catalog.length;
     const currentItems =
-        activeTab === "completed" ? state.grants.length : visibleCatalog.length;
+        activeTab === "completed" ? completedCount : availableCount;
 
     return (
-        <div className="flex flex-col gap-4">
-            <div className="grid gap-2 sm:grid-cols-3">
-                <Surface>
-                    <StatCard
-                        label="Available"
-                        value={availableCount.toLocaleString()}
-                    />
-                </Surface>
-                <Surface>
-                    <StatCard
-                        label="Completed"
-                        value={state.grants.length.toLocaleString()}
-                    />
-                </Surface>
-                <Surface>
-                    <StatCard
-                        label="Earned"
-                        value={formatGrantAmount(state.totalPollen)}
-                    />
-                </Surface>
-            </div>
+        <div className="flex flex-col gap-5">
+            <GardenProgress
+                completed={completedCount}
+                total={Math.max(totalQuests, completedCount)}
+                totalPollen={state.totalPollen}
+            />
 
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex flex-wrap gap-1.5">
@@ -438,7 +716,7 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
                         >
                             {tab === "available"
                                 ? `Available (${availableCount})`
-                                : `Completed (${state.grants.length})`}
+                                : `Completed (${completedCount})`}
                         </TabButton>
                     ))}
                 </div>
@@ -460,29 +738,62 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
                     <SproutIcon className="mt-0.5 h-5 w-5 shrink-0 text-theme-text-muted" />
                     <div className="min-w-0">
                         <p className="font-semibold text-ink-900">
-                            No {activeTab} quests
+                            {activeTab === "available"
+                                ? "Your garden is in full bloom"
+                                : "No completed quests yet"}
                         </p>
+                        <Text size="sm" tone="soft" className="mt-1">
+                            {activeTab === "available"
+                                ? "You've cleared every available quest. Nice work."
+                                : "Complete a quest to start your garden."}
+                        </Text>
                     </div>
                 </Surface>
             )}
 
-            <div className="flex flex-col gap-3">
-                {activeTab === "completed"
-                    ? state.grants.map((grant, index) => (
-                          <CompletedGrantCard
-                              key={`${grant.source}-${grant.questId ?? grant.sourceRef ?? "grant"}-${grant.createdAt}-${index}`}
-                              grant={grant}
-                              catalogById={catalogById}
-                          />
-                      ))
-                    : visibleCatalog.map((quest) => (
-                          <CatalogQuestCard
-                              key={quest.id}
-                              quest={quest}
-                              completed={completedCatalogIds.has(quest.id)}
-                          />
-                      ))}
-            </div>
+            {activeTab === "completed" ? (
+                <div className="flex flex-col gap-3">
+                    {state.grants.map((grant, index) => (
+                        <CompletedGrantCard
+                            key={`${grant.source}-${grant.questId ?? grant.sourceRef ?? "grant"}-${grant.createdAt}-${index}`}
+                            grant={grant}
+                            catalogById={catalogById}
+                        />
+                    ))}
+                </div>
+            ) : (
+                <div className="flex flex-col gap-5">
+                    {CATEGORY_ORDER.map((category) => {
+                        const quests = grouped.get(category.key) ?? [];
+                        if (quests.length === 0) return null;
+                        const totals = categoryTotals.get(category.key) ?? {
+                            done: 0,
+                            total: quests.length,
+                        };
+                        return (
+                            <div
+                                key={category.key}
+                                className="flex flex-col gap-3"
+                            >
+                                <SectionHeader
+                                    category={category}
+                                    done={totals.done}
+                                    total={totals.total}
+                                />
+                                {quests.map((quest) => (
+                                    <CatalogQuestCard
+                                        key={quest.id}
+                                        quest={quest}
+                                        completed={completedCatalogIds.has(
+                                            quest.id,
+                                        )}
+                                    />
+                                ))}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
         </div>
     );
 };

--- a/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
+++ b/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
@@ -445,68 +445,33 @@ function CompletedGrantCard({
 }
 
 // On-brand "endowed progress" header: the sprout grows through discrete stages
-// as completion rises, wrapped in a thin SVG progress ring. Replaces the three
-// redundant stat cards. Pure derived data.
-function QuestProgress({
-    completed,
-    total,
+// as completion rises. Pure derived data.
+//
+// Headline metric is cumulative Pollen earned — an additive number that only
+// ever goes up. We deliberately AVOID a completion ring / "X of N" here: the
+// catalog mixes a finite product set with an open, ever-growing pool of
+// community bounties (only one user wins each), so any shared denominator would
+// recede as bounties are added and could never reach 100%. Per-section counts
+// below carry the finite "set up" progress instead.
+function QuestSummary({
+    completedSetup,
+    totalSetup,
+    bountiesCompleted,
     totalPollen,
 }: {
-    completed: number;
-    total: number;
+    completedSetup: number;
+    totalSetup: number;
+    bountiesCompleted: number;
     totalPollen: number;
 }) {
-    const safeTotal = Math.max(total, 1);
-    const ratio = Math.min(1, completed / safeTotal);
-    const radius = 34;
-    const circumference = 2 * Math.PI * radius;
-    const dash = circumference * ratio;
-    const stage = ratio >= 1 ? 4 : ratio >= 0.66 ? 3 : ratio >= 0.33 ? 2 : 1;
-    const allDone = total > 0 && completed >= total;
-
     return (
         <Surface
             variant="card-themed"
             className="flex items-center gap-5 sm:gap-6"
         >
-            <div className="relative h-20 w-20 shrink-0">
-                <svg
-                    aria-hidden="true"
-                    viewBox="0 0 80 80"
-                    className="h-20 w-20 -rotate-90"
-                >
-                    <circle
-                        cx="40"
-                        cy="40"
-                        r={radius}
-                        fill="none"
-                        strokeWidth="5"
-                        className="stroke-theme-bg-active"
-                    />
-                    <circle
-                        cx="40"
-                        cy="40"
-                        r={radius}
-                        fill="none"
-                        strokeWidth="5"
-                        strokeLinecap="round"
-                        strokeDasharray={`${dash} ${circumference}`}
-                        className="stroke-intent-success-text transition-[stroke-dasharray] duration-700 ease-out"
-                    />
-                </svg>
-                <span className="absolute inset-0 flex items-center justify-center">
-                    <SproutIcon
-                        className={[
-                            "text-intent-success-text transition-all duration-500",
-                            stage === 1
-                                ? "h-5 w-5 opacity-70"
-                                : stage === 2
-                                  ? "h-7 w-7 opacity-85"
-                                  : "h-9 w-9 opacity-100",
-                        ].join(" ")}
-                    />
-                </span>
-            </div>
+            <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-theme-bg-active">
+                <SproutIcon className="h-7 w-7 text-intent-success-text" />
+            </span>
             <div className="min-w-0 flex-1">
                 <Text
                     as="div"
@@ -515,20 +480,24 @@ function QuestProgress({
                     weight="bold"
                     className="uppercase tracking-wide"
                 >
-                    Your progress
+                    Pollen earned from quests
                 </Text>
                 <Text
                     as="div"
                     weight="semibold"
                     tone="strong"
-                    className="mt-1 text-lg"
+                    className="mt-1 text-2xl tabular-nums"
                 >
-                    {allDone
-                        ? "All caught up"
-                        : `${completed} of ${total} quests`}
+                    {formatGrantAmount(totalPollen)}
                 </Text>
                 <Text as="div" size="sm" tone="soft" className="mt-0.5">
-                    {formatGrantAmount(totalPollen)} Pollen earned
+                    {totalSetup > 0 &&
+                        `${completedSetup} of ${totalSetup} set up`}
+                    {totalSetup > 0 && bountiesCompleted > 0 && " · "}
+                    {bountiesCompleted > 0 &&
+                        `${bountiesCompleted} ${
+                            bountiesCompleted === 1 ? "bounty" : "bounties"
+                        } completed`}
                 </Text>
             </div>
         </Surface>
@@ -539,10 +508,15 @@ function SectionHeader({
     category,
     done,
     total,
+    openCount,
 }: {
     category: CategoryMeta;
     done: number;
     total: number;
+    // When set, this lane is an open pool (community bounties): show a
+    // denominator-free "N open" count instead of a "done / total" ratio that
+    // would recede as the pool grows.
+    openCount?: number;
 }) {
     const Icon = category.icon;
     return (
@@ -561,7 +535,7 @@ function SectionHeader({
                 — {category.blurb}
             </Text>
             <Chip size="sm" intent="neutral" className="ml-auto tabular-nums">
-                {done} / {total}
+                {openCount != null ? `${openCount} open` : `${done} / ${total}`}
             </Chip>
         </div>
     );
@@ -691,15 +665,41 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
 
     const availableCount = visibleCatalog.length;
     const completedCount = state.grants.length;
-    const totalQuests = state.catalog.length;
     const currentItems =
         activeTab === "completed" ? completedCount : availableCount;
 
+    // Finite "set up" progress = product quests only (the Set up + Grow lanes).
+    // Community bounties are an open, ever-growing pool, so they are NOT part of
+    // any "X of N" denominator — they only contribute an additive completed count.
+    const setupTotals = useMemo(() => {
+        let done = 0;
+        let total = 0;
+        for (const quest of state.catalog) {
+            if (categoryForQuest(quest).key === "community") continue;
+            total += 1;
+            if (completedCatalogIds.has(quest.id)) done += 1;
+        }
+        return { done, total };
+    }, [state.catalog, completedCatalogIds]);
+
+    const bountiesCompleted = useMemo(
+        () =>
+            state.grants.filter((grant) => {
+                const key = catalogKeyForGrant(grant);
+                return (
+                    grant.questId === "github:community_issue_quest" ||
+                    (key?.startsWith("github:") ?? false)
+                );
+            }).length,
+        [state.grants],
+    );
+
     return (
         <div className="flex flex-col gap-5">
-            <QuestProgress
-                completed={completedCount}
-                total={Math.max(totalQuests, completedCount)}
+            <QuestSummary
+                completedSetup={setupTotals.done}
+                totalSetup={setupTotals.total}
+                bountiesCompleted={bountiesCompleted}
                 totalPollen={state.totalPollen}
             />
 
@@ -776,6 +776,11 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
                                     category={category}
                                     done={totals.done}
                                     total={totals.total}
+                                    openCount={
+                                        category.key === "community"
+                                            ? quests.length
+                                            : undefined
+                                    }
                                 />
                                 {quests.map((quest) => (
                                     <CatalogQuestCard

--- a/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
+++ b/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
@@ -10,10 +10,14 @@ import {
     Surface,
     TabButton,
     Text,
-    TokensIcon,
     WalletIcon,
 } from "@pollinations/ui";
-import { formatPollen, PaidChip, TierChip } from "@pollinations/ui/wallet";
+import {
+    formatPollen,
+    PaidChip,
+    TierChip,
+    WalletKindIcon,
+} from "@pollinations/ui/wallet";
 import {
     type ComponentType,
     type FC,
@@ -77,8 +81,8 @@ type CategoryMeta = {
 
 const CATEGORY_PLANT: CategoryMeta = {
     key: "plant",
-    label: "Plant",
-    blurb: "Get set up",
+    label: "Set up",
+    blurb: "Get started",
     icon: SproutIcon,
     order: 0,
     tint: "text-intent-success-text",
@@ -86,7 +90,7 @@ const CATEGORY_PLANT: CategoryMeta = {
 const CATEGORY_GROW: CategoryMeta = {
     key: "grow",
     label: "Grow",
-    blurb: "Go deeper",
+    blurb: "Use more, earn more",
     icon: WalletIcon,
     order: 1,
     tint: "text-intent-news-text",
@@ -94,7 +98,7 @@ const CATEGORY_GROW: CategoryMeta = {
 const CATEGORY_COMMUNITY: CategoryMeta = {
     key: "community",
     label: "Community",
-    blurb: "Build for others",
+    blurb: "Build for the community",
     icon: GitHubIcon,
     order: 2,
     tint: "text-theme-text-soft",
@@ -282,22 +286,15 @@ function IconMedallion({
     );
 }
 
-// Reward "seed coin": a Pollen glyph + tabular amount. Weight scales gently
-// with size (outline feel at small amounts) without slot-machine emphasis.
-function RewardCoin({ amount }: { amount: number | null }) {
-    const big = (amount ?? 0) >= 5;
+// Reward chip: the canonical wallet "paid" chip with its Pollen marker.
+// Uses @pollinations/ui's PaidChip + WalletKindIcon so the reward reads in the
+// same visual language as balances elsewhere in the dashboard.
+function RewardChip({ amount }: { amount: number | null }) {
     return (
-        <span
-            className={[
-                "inline-flex shrink-0 items-center gap-1 rounded-lg px-2.5 py-1 text-sm",
-                big
-                    ? "bg-intent-news-bg-light font-semibold text-intent-news-text"
-                    : "bg-theme-bg-active font-medium text-theme-text-soft",
-            ].join(" ")}
-        >
-            <TokensIcon className="h-3.5 w-3.5" />
-            <span className="tabular-nums">{formatRewardLabel(amount)}</span>
-        </span>
+        <PaidChip size="sm" className="tabular-nums">
+            <WalletKindIcon kind="paid" />
+            {formatRewardLabel(amount)}
+        </PaidChip>
     );
 }
 
@@ -341,7 +338,7 @@ function CatalogQuestCard({
                         )}
                     </div>
                     <div className="shrink-0">
-                        <RewardCoin amount={quest.rewardAmount} />
+                        <RewardChip amount={quest.rewardAmount} />
                     </div>
                 </div>
                 {quest.url && (
@@ -448,9 +445,9 @@ function CompletedGrantCard({
 }
 
 // On-brand "endowed progress" header: the sprout grows through discrete stages
-// (seed → sprout → leafy → bloom) as completion rises, wrapped in a thin SVG
-// progress ring. Replaces the three redundant stat cards. Pure derived data.
-function GardenProgress({
+// as completion rises, wrapped in a thin SVG progress ring. Replaces the three
+// redundant stat cards. Pure derived data.
+function QuestProgress({
     completed,
     total,
     totalPollen,
@@ -518,7 +515,7 @@ function GardenProgress({
                     weight="bold"
                     className="uppercase tracking-wide"
                 >
-                    Your garden
+                    Your progress
                 </Text>
                 <Text
                     as="div"
@@ -527,7 +524,7 @@ function GardenProgress({
                     className="mt-1 text-lg"
                 >
                     {allDone
-                        ? "In full bloom 🌸"
+                        ? "All caught up"
                         : `${completed} of ${total} quests`}
                 </Text>
                 <Text as="div" size="sm" tone="soft" className="mt-0.5">
@@ -700,7 +697,7 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
 
     return (
         <div className="flex flex-col gap-5">
-            <GardenProgress
+            <QuestProgress
                 completed={completedCount}
                 total={Math.max(totalQuests, completedCount)}
                 totalPollen={state.totalPollen}
@@ -739,13 +736,13 @@ export const QuestOverview: FC<QuestOverviewProps> = ({ githubUsername }) => {
                     <div className="min-w-0">
                         <p className="font-semibold text-ink-900">
                             {activeTab === "available"
-                                ? "Your garden is in full bloom"
+                                ? "You're all caught up"
                                 : "No completed quests yet"}
                         </p>
                         <Text size="sm" tone="soft" className="mt-1">
                             {activeTab === "available"
                                 ? "You've cleared every available quest. Nice work."
-                                : "Complete a quest to start your garden."}
+                                : "Complete a quest to get started."}
                         </Text>
                     </div>
                 </Surface>


### PR DESCRIPTION
Redesigns the quest dashboard from a flat checklist into a calmer, more legible layout — and fixes a conceptual flaw in the progress metric. All changes are display-only in \`enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx\` (no new backend fields).

### What changed
- **Journey lanes** — available quests grouped into **Set up** (onboarding), **Grow** (spend/usage), **Community** (GitHub bounties), each with a section header. Cheapest-reward quest sorts first within a lane.
- **Per-category icon medallions** + reward shown via the shared \`PaidChip\` + \`WalletKindIcon\` from \`@pollinations/ui\` (same visual language as wallet balances).
- **De-twee'd copy** — no "garden"/"bloom"; lanes read "Set up / Grow / Community".
- **Honest progress metric (the key fix).** The earlier draft used one "X of N" wheel over the whole catalog. That pooled the finite product quests with the **open, ever-growing community-bounty pool** (only one user wins each), so the goal receded as bounties were added and 100% was unreachable. Now:
  - Headline = **cumulative "Pollen earned"** (additive, only goes up)
  - **"<n> of <m> set up"** counts **product quests only** (finite, reachable)
  - **"<n> bounties completed"** — additive, no denominator
  - Community section header shows **"<n> open"**, never "done / total"

### Why
Backed by both the project's own quest history (prior UI always separated the two types; the single wheel was a new, uncommitted idea) and a survey of 14 platforms (GitHub, Steam, Stripe, Linear, Layer3, HackerOne, Upwork, …): a completion ring is valid only over a bounded set; open pools get an additive metric (count / earnings), never a shared denominator.

### Verification
- \`tsc --noEmit\` → 0 errors
- \`vite build --mode=staging\` → success
- biome → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)