### PR TITLE
refactor: align shared inline links in enter

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
@@ -272,25 +272,17 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                         <p className="text-xs text-theme-text-muted">
                             Publishable keys (<code>pk_</code>) deprecated –
                             create via{" "}
-                            <a
+                            <InlineLink
                                 href={genDocsUrl(
                                     "#tag/-account/POST/account/keys",
                                 )}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-theme-text-soft underline hover:text-theme-text-strong"
                             >
                                 API
-                            </a>{" "}
+                            </InlineLink>{" "}
                             or{" "}
-                            <a
-                                href="https://github.com/pollinations/pollinations/tree/main/packages/polli-cli"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-theme-text-soft underline hover:text-theme-text-strong"
-                            >
+                            <InlineLink href="https://github.com/pollinations/pollinations/tree/main/packages/polli-cli">
                                 polli CLI
-                            </a>
+                            </InlineLink>
                             .
                         </p>
                     )}

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
@@ -4,6 +4,7 @@ import {
     CopyButton,
     ExternalLinkButton,
     InfoTip,
+    InlineLink,
     MailIcon,
     SproutIcon,
     Surface,
@@ -339,14 +340,9 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
                     <ClockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                     <span>
                         Credits are instant, never expire, and follow our{" "}
-                        <a
-                            href={REFUND_POLICY_URL}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline decoration-theme-text-soft/30 underline-offset-2 transition-colors hover:text-theme-text-soft"
-                        >
+                        <InlineLink href={REFUND_POLICY_URL}>
                             Refund Policy
-                        </a>
+                        </InlineLink>
                         .
                     </span>
                 </p>

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
@@ -188,24 +188,29 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
             </div>
 
             {/* Learn more */}
-            <div className="mt-4 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                <button
-                    type="button"
-                    onClick={() => {
-                        const slug = "how-does-my-pollen-wallet-work";
-                        if (window.location.hash === `#${slug}`) {
-                            window.dispatchEvent(
-                                new HashChangeEvent("hashchange"),
-                            );
-                        } else {
-                            window.location.hash = slug;
-                        }
-                    }}
-                    className="flex items-start gap-1.5 underline decoration-theme-text-soft/30 underline-offset-2 transition-colors hover:text-theme-text-soft"
-                >
-                    <WalletIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>Learn more</span>
-                </button>
+            <div className="mt-4 flex items-start gap-1.5 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                <WalletIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>
+                    Your wallet holds Pollen you've purchased plus Pollen you've
+                    earned.{" "}
+                    <InlineLink
+                        as="button"
+                        type="button"
+                        external={false}
+                        onClick={() => {
+                            const slug = "how-does-my-pollen-wallet-work";
+                            if (window.location.hash === `#${slug}`) {
+                                window.dispatchEvent(
+                                    new HashChangeEvent("hashchange"),
+                                );
+                            } else {
+                                window.location.hash = slug;
+                            }
+                        }}
+                    >
+                        How it works
+                    </InlineLink>
+                </span>
             </div>
         </div>
     );

--- a/packages/ui/src/primitives/InlineLink.tsx
+++ b/packages/ui/src/primitives/InlineLink.tsx
@@ -38,9 +38,9 @@ export function InlineLink<T extends React.ElementType = "a">({
             target={isExternal ? "_blank" : undefined}
             rel={isExternal ? "noopener noreferrer" : undefined}
             className={cn(
-                "polli-control polli:inline-flex polli:items-center polli:gap-1 polli:rounded-sm polli:font-medium polli:text-theme-text-soft",
-                "polli:underline polli:underline-offset-2",
-                "polli:transition-colors polli:hover:text-theme-text-strong",
+                "polli-control polli:inline-flex polli:items-center polli:gap-1 polli:rounded-sm polli:font-semibold polli:text-theme-text-strong",
+                "polli:underline polli:decoration-theme-border polli:decoration-2 polli:underline-offset-3",
+                "polli:transition-colors polli:hover:text-theme-text-soft polli:hover:decoration-theme-text-soft",
                 className,
             )}
             {...linkProps}


### PR DESCRIPTION
- Updates `InlineLink` in `packages/ui` to the stronger vanilla inline-link treatment.
- Replaces hand-styled inline URL links in the Enter key dialog with `InlineLink`.
- Reuses `InlineLink` in the wallet footer, including the explanatory wallet text and Refund Policy link.

Validation:
- `biome check --write packages/ui/src/primitives/InlineLink.tsx enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx`
- `tsc --noEmit -p enter.pollinations.ai/tsconfig.json`