### PR TITLE
fix: restore inline link styling

### DIFF
--- a/packages/ui/src/primitives/InlineLink.tsx
+++ b/packages/ui/src/primitives/InlineLink.tsx
@@ -38,9 +38,9 @@ export function InlineLink<T extends React.ElementType = "a">({
             target={isExternal ? "_blank" : undefined}
             rel={isExternal ? "noopener noreferrer" : undefined}
             className={cn(
-                "polli-control polli:inline-flex polli:items-center polli:gap-1 polli:rounded-sm polli:font-semibold polli:text-theme-text-strong",
-                "polli:underline polli:decoration-theme-border polli:decoration-2 polli:underline-offset-3",
-                "polli:transition-colors polli:hover:text-theme-text-soft polli:hover:decoration-theme-text-soft",
+                "polli-control polli:inline-flex polli:items-center polli:gap-1 polli:rounded-sm polli:font-medium polli:text-theme-text-soft",
+                "polli:underline polli:underline-offset-2",
+                "polli:transition-colors polli:hover:text-theme-text-strong",
                 className,
             )}
             {...linkProps}


### PR DESCRIPTION
- Restores `InlineLink` to the amber, non-strong inline treatment.
- Removes the accidental bold/white shared link styling from PR #11943.
- Leaves the existing Enter consumers on the shared primitive.

Validation:
- `biome check --write packages/ui/src/primitives/InlineLink.tsx`
- `tsc --noEmit -p packages/ui/tsconfig.json`