### PR TITLE
feat: add ElevenLabs SFX + Multilingual v2; correct ElevenLabs TTS pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -114,10 +114,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "eleven-multilingual-v2": {
     "cost": {
-      "completionAudioTokens": 0.000166,
+      "completionAudioTokens": 0.0001,
     },
     "price": {
-      "completionAudioTokens": 0.000166,
+      "completionAudioTokens": 0.0001,
     },
   },
   "eleven-sfx": {
@@ -130,18 +130,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "elevenflash": {
     "cost": {
-      "completionAudioTokens": 0.000083,
+      "completionAudioTokens": 0.00005,
     },
     "price": {
-      "completionAudioTokens": 0.000083,
+      "completionAudioTokens": 0.00005,
     },
   },
   "elevenlabs": {
     "cost": {
-      "completionAudioTokens": 0.000166,
+      "completionAudioTokens": 0.0001,
     },
     "price": {
-      "completionAudioTokens": 0.000166,
+      "completionAudioTokens": 0.0001,
     },
   },
   "elevenmusic": {

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -112,6 +112,22 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000174,
     },
   },
+  "eleven-multilingual-v2": {
+    "cost": {
+      "completionAudioTokens": 0.000166,
+    },
+    "price": {
+      "completionAudioTokens": 0.000166,
+    },
+  },
+  "eleven-sfx": {
+    "cost": {
+      "completionAudioSeconds": 0.004,
+    },
+    "price": {
+      "completionAudioSeconds": 0.004,
+    },
+  },
   "elevenflash": {
     "cost": {
       "completionAudioTokens": 0.000083,
@@ -130,10 +146,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "elevenmusic": {
     "cost": {
-      "completionAudioSeconds": 0.005,
+      "completionAudioSeconds": 0.0025,
     },
     "price": {
-      "completionAudioSeconds": 0.005,
+      "completionAudioSeconds": 0.0025,
     },
   },
   "flux": {

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -60,7 +60,7 @@ const CreateSpeechRequestSchema = z
             }),
         duration: z.number().min(3).max(300).optional().meta({
             description:
-                "Music duration in seconds, 3-300 (elevenmusic/acestep)",
+                "Output duration in seconds (elevenmusic/acestep 3-300; eleven-sfx 3-30)",
             example: 30,
         }),
         instrumental: z.boolean().optional().meta({
@@ -705,6 +705,73 @@ export async function generateMusic(
     });
 }
 
+/**
+ * Calls ElevenLabs Sound Effects (text -> sound effect) via /v1/sound-generation.
+ * Billed per second of output audio (see registry `eleven-sfx` cost block).
+ */
+export async function generateSoundEffect(opts: {
+    prompt: string;
+    durationSeconds?: number;
+    apiKey: string;
+    log: Logger;
+}): Promise<Response> {
+    const { prompt, durationSeconds, apiKey, log } = opts;
+
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message:
+                "Sound effects service is not configured (missing API key)",
+        });
+    }
+    if (prompt.length > 1000) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Prompt too long: ${prompt.length} characters. Maximum is 1000.`,
+        });
+    }
+
+    const modelId = AUDIO_SERVICES["eleven-sfx"].modelId;
+    const elevenLabsUrl = "https://api.elevenlabs.io/v1/sound-generation";
+
+    const body: Record<string, unknown> = { text: prompt, model_id: modelId };
+    // ElevenLabs SFX supports 0.5-30s; omit to let the model decide the length.
+    if (durationSeconds !== undefined) {
+        body.duration_seconds = Math.min(Math.max(durationSeconds, 0.5), 30);
+    }
+
+    log.info("Sound effect request: chars={chars}, duration={duration}", {
+        chars: prompt.length,
+        duration: durationSeconds ?? "auto",
+    });
+
+    const rawResponse = await fetch(elevenLabsUrl, {
+        method: "POST",
+        headers: { "xi-api-key": apiKey, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+    const response = await ensureUpstreamOk(rawResponse, elevenLabsUrl);
+
+    const contentType = response.headers.get("content-type") || "audio/mpeg";
+    const audioBuffer = await response.arrayBuffer();
+    // ElevenLabs Sound Effects returns 128 kbps CBR MP3 (= 16 kB/s, ffprobe-verified).
+    const SFX_MP3_BYTES_PER_SECOND = 16000;
+    const estimatedDuration = audioBuffer.byteLength / SFX_MP3_BYTES_PER_SECOND;
+
+    const usageHeaders = buildUsageHeaders(
+        "eleven-sfx",
+        createCompletionAudioSecondsUsage(estimatedDuration),
+    );
+
+    log.info("Sound effect success: {bytes} bytes, ~{duration}s", {
+        bytes: audioBuffer.byteLength,
+        duration: Math.round(estimatedDuration),
+    });
+
+    return new Response(audioBuffer, {
+        status: 200,
+        headers: { "Content-Type": contentType, ...usageHeaders },
+    });
+}
+
 const QWEN_TTS_ENDPOINT =
     "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 
@@ -1203,6 +1270,18 @@ async function dispatchAudioGeneration(
                 conditioningRef,
                 compositionPlan,
                 referenceAudio,
+                apiKey,
+                log,
+            }),
+        );
+    }
+
+    if (c.var.model.resolved === "eleven-sfx") {
+        return withSafetyHeaders(
+            c,
+            await generateSoundEffect({
+                prompt: text,
+                durationSeconds: duration,
                 apiKey,
                 log,
             }),

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -37,9 +37,9 @@ import { buildTranscriptionResponse } from "./transcription-response.ts";
 const CreateSpeechRequestSchema = z
     .object({
         model: z.string().optional(),
-        input: z.string().min(1).max(4096).meta({
+        input: z.string().min(1).max(10000).meta({
             description:
-                "The text to generate audio for. Maximum 4096 characters.",
+                "The text to generate audio for. Maximum 10000 characters.",
             example: "Hello, welcome to Pollinations!",
         }),
         safe: SafeSchema,
@@ -58,10 +58,19 @@ const CreateSpeechRequestSchema = z
                     "The audio format for the output. Qwen TTS currently returns WAV regardless of this setting.",
                 example: "mp3",
             }),
-        duration: z.number().min(3).max(300).optional().meta({
+        duration: z.number().min(0.5).max(300).optional().meta({
             description:
-                "Output duration in seconds (elevenmusic/acestep 3-300; eleven-sfx 3-30)",
+                "Output duration in seconds (elevenmusic/acestep 3-300; eleven-sfx 0.5-30)",
             example: 30,
+        }),
+        loop: z.boolean().optional().meta({
+            description: "Loop the generated sound effect (eleven-sfx only)",
+            example: false,
+        }),
+        prompt_influence: z.number().min(0).max(1).optional().meta({
+            description:
+                "How strictly to follow the prompt, 0-1 (eleven-sfx only)",
+            example: 0.3,
         }),
         instrumental: z.boolean().optional().meta({
             description:
@@ -115,6 +124,8 @@ type SimpleAudioQuery = {
     voice: string;
     response_format: string;
     instruct?: string;
+    loop?: boolean;
+    prompt_influence?: number;
 };
 
 type AudioRefChunk = {
@@ -209,9 +220,9 @@ export async function generateSpeech(opts: {
         });
     }
 
-    if (text.length > 4096) {
+    if (text.length > 10000) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Input text too long: ${text.length} characters. Maximum is 4096.`,
+            message: `Input text too long: ${text.length} characters. Maximum is 10000.`,
         });
     }
 
@@ -273,7 +284,7 @@ export async function generateSpeech(opts: {
     log.info("TTS success: {chars} characters", { chars: text.length });
 
     // WAV needs its RIFF header repaired (ElevenLabs ships a placeholder length),
-    // which requires buffering the body. Audio is small (input capped at 4096
+    // which requires buffering the body. Audio is small (input capped at 10000
     // chars) so this is cheap; all other formats keep streaming.
     if (responseFormat === "wav") {
         const audioBuffer = fixWavHeader(await response.arrayBuffer());
@@ -712,10 +723,13 @@ export async function generateMusic(
 export async function generateSoundEffect(opts: {
     prompt: string;
     durationSeconds?: number;
+    loop?: boolean;
+    promptInfluence?: number;
     apiKey: string;
     log: Logger;
 }): Promise<Response> {
-    const { prompt, durationSeconds, apiKey, log } = opts;
+    const { prompt, durationSeconds, loop, promptInfluence, apiKey, log } =
+        opts;
 
     if (!apiKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
@@ -737,6 +751,8 @@ export async function generateSoundEffect(opts: {
     if (durationSeconds !== undefined) {
         body.duration_seconds = Math.min(Math.max(durationSeconds, 0.5), 30);
     }
+    if (loop !== undefined) body.loop = loop;
+    if (promptInfluence !== undefined) body.prompt_influence = promptInfluence;
 
     log.info("Sound effect request: chars={chars}, duration={duration}", {
         chars: prompt.length,
@@ -947,6 +963,11 @@ async function parseSpeechRequest(c: AudioContext): Promise<
             seed: parseOptionalNumber(formData.get("seed"), "seed"),
             style: (formData.get("style") as string | null) || undefined,
             instruct: (formData.get("instruct") as string | null) || undefined,
+            loop: parseOptionalBoolean(formData.get("loop"), "loop"),
+            prompt_influence: parseOptionalNumber(
+                formData.get("prompt_influence"),
+                "prompt_influence",
+            ),
             conditioning_ref:
                 typeof rawConditioningRef === "string"
                     ? parseJsonObject(rawConditioningRef, "conditioning_ref")
@@ -1217,6 +1238,8 @@ async function dispatchAudioGeneration(
         compositionPlan?: unknown;
         referenceAudio?: File;
         instruct?: string;
+        loop?: boolean;
+        promptInfluence?: number;
         apiKey: string;
         dashScopeApiKey: string;
         env: Env["Bindings"];
@@ -1237,6 +1260,8 @@ async function dispatchAudioGeneration(
         compositionPlan,
         referenceAudio,
         instruct,
+        loop,
+        promptInfluence,
         apiKey,
         dashScopeApiKey,
         env,
@@ -1282,6 +1307,8 @@ async function dispatchAudioGeneration(
             await generateSoundEffect({
                 prompt: text,
                 durationSeconds: duration,
+                loop,
+                promptInfluence,
                 apiKey,
                 log,
             }),
@@ -1348,6 +1375,8 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
         style: query.style,
         instrumental: query.instrumental,
         instruct: query.instruct,
+        loop: query.loop,
+        promptInfluence: query.prompt_influence,
         apiKey,
         dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
         env: c.env,
@@ -1522,6 +1551,8 @@ export const audioRoutes = new Hono<Env>()
                 seed,
                 style,
                 instruct,
+                loop,
+                prompt_influence,
             } = await parseSpeechRequest(c);
             requireTextToAudioModel(c.var.model.resolved);
             requireElevenMusicOptions(c.var.model.resolved, {
@@ -1551,6 +1582,8 @@ export const audioRoutes = new Hono<Env>()
                 compositionPlan: composition_plan,
                 referenceAudio: reference_audio,
                 instruct,
+                loop,
+                promptInfluence: prompt_influence,
                 apiKey,
                 dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
                 env: c.env,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -725,16 +725,32 @@ export async function generateSoundEffect(opts: {
     durationSeconds?: number;
     loop?: boolean;
     promptInfluence?: number;
+    responseFormat?: string;
     apiKey: string;
     log: Logger;
 }): Promise<Response> {
-    const { prompt, durationSeconds, loop, promptInfluence, apiKey, log } =
-        opts;
+    const {
+        prompt,
+        durationSeconds,
+        loop,
+        promptInfluence,
+        responseFormat,
+        apiKey,
+        log,
+    } = opts;
 
     if (!apiKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
             message:
                 "Sound effects service is not configured (missing API key)",
+        });
+    }
+    // SFX always returns 128 kbps MP3. The per-second price is derived from the
+    // MP3 byte rate, so honoring other formats would need per-format billing
+    // math — reject instead of silently downgrading (default "mp3" passes).
+    if (responseFormat && responseFormat !== "mp3") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `eleven-sfx only supports mp3 output; response_format=${responseFormat} is not available.`,
         });
     }
     if (prompt.length > 1000) {
@@ -1309,6 +1325,7 @@ async function dispatchAudioGeneration(
                 durationSeconds: duration,
                 loop,
                 promptInfluence,
+                responseFormat,
                 apiKey,
                 log,
             }),

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -55,7 +55,7 @@ const CreateSpeechRequestSchema = z
             .default("mp3")
             .meta({
                 description:
-                    "The audio format for the output. Qwen TTS currently returns WAV regardless of this setting.",
+                    "The audio format for the output. Qwen TTS currently returns WAV regardless of this setting; eleven-sfx supports mp3 only (other values are rejected).",
                 example: "mp3",
             }),
         duration: z.number().min(0.5).max(300).optional().meta({

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -847,6 +847,26 @@ export const proxyRoutes = new Hono<Env>()
                         "Emotion/style instruction (qwen-tts-instruct only)",
                     example: "speak softly and warmly",
                 }),
+                loop: z
+                    .enum(["true", "false"])
+                    .optional()
+                    .transform((v) =>
+                        v === undefined ? undefined : v === "true",
+                    )
+                    .meta({
+                        description:
+                            "Loop the generated sound effect (eleven-sfx only)",
+                        example: "false",
+                    }),
+                prompt_influence: z
+                    .string()
+                    .optional()
+                    .transform((v) => (v ? Number.parseFloat(v) : undefined))
+                    .meta({
+                        description:
+                            "How strictly to follow the prompt, 0-1 (eleven-sfx only)",
+                        example: "0.3",
+                    }),
                 seed: z.coerce
                     .number()
                     .int()

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -823,6 +823,7 @@ export const proxyRoutes = new Hono<Env>()
                     .string()
                     .optional()
                     .transform((v) => (v ? parseFloat(v) : undefined))
+                    .pipe(z.number().min(0.5).max(300).optional())
                     .meta({
                         description:
                             "Music duration in seconds, 3-300 (elevenmusic only)",
@@ -862,6 +863,7 @@ export const proxyRoutes = new Hono<Env>()
                     .string()
                     .optional()
                     .transform((v) => (v ? Number.parseFloat(v) : undefined))
+                    .pipe(z.number().min(0).max(1).optional())
                     .meta({
                         description:
                             "How strictly to follow the prompt, 0-1 (eleven-sfx only)",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -811,7 +811,7 @@ export const proxyRoutes = new Hono<Env>()
                     .default("mp3")
                     .meta({
                         description:
-                            "Audio output format (TTS only). Qwen TTS currently returns WAV regardless of this setting.",
+                            "Audio output format (TTS only). Qwen TTS currently returns WAV regardless of this setting; eleven-sfx supports mp3 only (other values are rejected).",
                         example: "mp3",
                     }),
                 model: z.string().optional().meta({

--- a/gen.pollinations.ai/test/elevenlabs-sfx.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-sfx.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateSoundEffect } from "../src/routes/audio.ts";
+
+const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+} as never;
+
+describe("ElevenLabs sound effects", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("posts prompt, duration, loop and prompt_influence to /v1/sound-generation", async () => {
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(new Uint8Array(16000), {
+                headers: { "content-type": "audio/mpeg" },
+            }),
+        );
+
+        const response = await generateSoundEffect({
+            prompt: "distant thunder rolling",
+            durationSeconds: 5,
+            loop: true,
+            promptInfluence: 0.7,
+            apiKey: "test-eleven-key",
+            log,
+        });
+
+        expect(response.status).toBe(200);
+        // 16000 bytes / 16000 B/s = ~1s of audio billed.
+        expect(response.headers.get("x-usage-completion-audio-seconds")).toBe(
+            "1",
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const request = new Request(
+            fetchMock.mock.calls[0][0],
+            fetchMock.mock.calls[0][1],
+        );
+        expect(request.url).toBe(
+            "https://api.elevenlabs.io/v1/sound-generation",
+        );
+        await expect(request.json()).resolves.toMatchObject({
+            model_id: "eleven_text_to_sound_v2",
+            text: "distant thunder rolling",
+            duration_seconds: 5,
+            loop: true,
+            prompt_influence: 0.7,
+        });
+    });
+
+    it("clamps duration into the 0.5-30s ElevenLabs range", async () => {
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(new Uint8Array(16000), {
+                headers: { "content-type": "audio/mpeg" },
+            }),
+        );
+
+        await generateSoundEffect({
+            prompt: "tick",
+            durationSeconds: 120,
+            apiKey: "test-eleven-key",
+            log,
+        });
+
+        const request = new Request(
+            fetchMock.mock.calls[0][0],
+            fetchMock.mock.calls[0][1],
+        );
+        await expect(request.json()).resolves.toMatchObject({
+            duration_seconds: 30,
+        });
+    });
+
+    it("rejects non-mp3 response_format instead of silently downgrading", async () => {
+        const fetchMock = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            generateSoundEffect({
+                prompt: "ocean waves",
+                responseFormat: "wav",
+                apiKey: "test-eleven-key",
+                log,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+
+        // Must reject before hitting ElevenLabs (no spurious billed generation).
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("allows the default mp3 response_format", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(new Uint8Array(16000), {
+                headers: { "content-type": "audio/mpeg" },
+            }),
+        );
+
+        const response = await generateSoundEffect({
+            prompt: "camera shutter",
+            responseFormat: "mp3",
+            apiKey: "test-eleven-key",
+            log,
+        });
+
+        expect(response.status).toBe(200);
+    });
+});

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -346,6 +346,39 @@ fixtureTest(
 );
 
 fixtureTest(
+    "rejects out-of-range prompt_influence on GET /audio before billing",
+    async ({ paidApiKey }) => {
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+                return Response.json({ data: [] });
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/audio/tick?model=eleven-sfx&prompt_influence=abc",
+                { headers: { Authorization: `Bearer ${paidApiKey}` } },
+            ),
+            {
+                ...env,
+                ELEVENLABS_API_KEY: "test-eleven-key",
+            } as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(400);
+        await waitOnExecutionContext(ctx);
+        expect(
+            calls.some((url) => new URL(url).hostname === "api.elevenlabs.io"),
+        ).toBe(false);
+    },
+);
+
+fixtureTest(
     "rejects transcription models on OpenAI speech endpoint",
     async ({ apiKey }) => {
         const calls: string[] = [];

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -96,6 +96,18 @@ Default voice is `sage`. To discover the full live voice list, use the model reg
 polli gen audio "lofi hip-hop beat" --model elevenmusic --duration 30 --instrumental --output track.mp3
 ```
 
+### Generate sound effects (eleven-sfx)
+```bash
+polli gen audio "thunderclap with heavy rain" --model eleven-sfx --duration 5 --output thunder.mp3
+```
+Text-to-sound-effect via ElevenLabs (aliases: `sfx`, `sound-effects`). `--duration` 0.5–30s (omit to let the model pick). Billed per second of output (~$0.004/s, capped at $0.12 for a full 30s).
+
+### Multilingual TTS (eleven-multilingual-v2)
+```bash
+polli gen audio "Bonjour, ceci est un test" --model multilingual-v2 --voice rachel --output fr.mp3
+```
+Stable, lifelike TTS across 29 languages (aliases: `multilingual-v2`, `eleven-v2`) — a non-alpha alternative to the default v3.
+
 ### Generate video
 ```bash
 polli gen video "a spacecraft landing on mars" --model wan-fast --duration 5 --output mars.mp4

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -60,8 +60,10 @@ export const AUDIO_SERVICES = {
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            // ElevenLabs Scale plan: 1 credit/char * $0.166/1k credits
-            completionAudioTokens: 0.166 / 1000,
+            // ElevenLabs v3 via API: measured 0.60 credits/char (API-discounted
+            // from the 1 cr/char UI rate) * $0.166/1k Scale credits = $0.10/1k chars
+            // (matches elevenlabs.io/pricing/api).
+            completionAudioTokens: 0.1 / 1000,
         },
         title: "ElevenLabs v3 TTS",
         description:
@@ -81,8 +83,10 @@ export const AUDIO_SERVICES = {
         addedDate: new Date("2026-05-14").getTime(),
         priceMultiplier: 1,
         cost: {
-            // ElevenLabs Scale plan: Flash v2.5 = 0.5 credit/char
-            completionAudioTokens: 0.083 / 1000,
+            // ElevenLabs Flash v2.5 via API: measured 0.30 credits/char
+            // (API-discounted from the 0.5 cr/char UI rate) * $0.166/1k Scale
+            // credits = $0.05/1k chars (matches elevenlabs.io/pricing/api).
+            completionAudioTokens: 0.05 / 1000,
         },
         title: "ElevenLabs Flash v2.5",
         description:
@@ -102,8 +106,10 @@ export const AUDIO_SERVICES = {
         addedDate: new Date("2026-06-22").getTime(),
         priceMultiplier: 1,
         cost: {
-            // ElevenLabs Scale plan: Multilingual v2 = 1 credit/char * $0.166/1k credits
-            completionAudioTokens: 0.166 / 1000,
+            // ElevenLabs Multilingual v2 via API: measured 0.60 credits/char
+            // (API-discounted from the 1 cr/char UI rate) * $0.166/1k Scale credits
+            // = $0.10/1k chars (matches elevenlabs.io/pricing/api).
+            completionAudioTokens: 0.1 / 1000,
         },
         title: "ElevenLabs Multilingual v2",
         description:
@@ -148,6 +154,9 @@ export const AUDIO_SERVICES = {
             // ElevenLabs Sound Effects v2: billed per second of output audio.
             // Measured empirically (5s=120cr, 10s=241cr => 24.0 credits/sec, linear).
             // Scale plan $0.166/1k credits => 24 * 0.166/1000 ≈ $0.004/sec.
+            // Duration caps at 30s, so max per generation = 30 * $0.004 = $0.12,
+            // matching ElevenLabs' "$0.12 per generation" public price; shorter
+            // effects cost proportionally less. One exact per-second rate.
             completionAudioSeconds: 0.004,
         },
         title: "ElevenLabs Sound Effects",

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -92,6 +92,27 @@ export const AUDIO_SERVICES = {
         voices: ELEVENLABS_VOICES as string[],
         alpha: true,
     },
+    "eleven-multilingual-v2": {
+        aliases: ["multilingual-v2", "eleven-v2", "tts-multilingual"],
+        modelId: "eleven_multilingual_v2",
+        provider: "elevenlabs",
+        brand: "ElevenLabs",
+        category: "audio",
+        paidOnly: true,
+        addedDate: new Date("2026-06-22").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            // ElevenLabs Scale plan: Multilingual v2 = 1 credit/char * $0.166/1k credits
+            completionAudioTokens: 0.166 / 1000,
+        },
+        title: "ElevenLabs Multilingual v2",
+        description:
+            "ElevenLabs Multilingual v2 - Lifelike, emotionally rich TTS (29 languages)",
+        inputModalities: ["text"],
+        outputModalities: ["audio"],
+        voices: ELEVENLABS_VOICES as string[],
+        alpha: true,
+    },
     elevenmusic: {
         aliases: ["music"],
         modelId: "music_v2",
@@ -111,6 +132,28 @@ export const AUDIO_SERVICES = {
         description:
             "ElevenLabs Music - Generate studio-grade music from text prompts and reference audio",
         inputModalities: ["text", "audio"],
+        outputModalities: ["audio"],
+        alpha: true,
+    },
+    "eleven-sfx": {
+        aliases: ["sfx", "sound-effects", "eleven-sound-effects"],
+        modelId: "eleven_text_to_sound_v2",
+        provider: "elevenlabs",
+        brand: "ElevenLabs",
+        category: "audio",
+        paidOnly: true,
+        addedDate: new Date("2026-06-22").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            // ElevenLabs Sound Effects v2: billed per second of output audio.
+            // Measured empirically (5s=120cr, 10s=241cr => 24.0 credits/sec, linear).
+            // Scale plan $0.166/1k credits => 24 * 0.166/1000 ≈ $0.004/sec.
+            completionAudioSeconds: 0.004,
+        },
+        title: "ElevenLabs Sound Effects",
+        description:
+            "ElevenLabs Sound Effects - Generate sound effects from text prompts",
+        inputModalities: ["text"],
         outputModalities: ["audio"],
         alpha: true,
     },


### PR DESCRIPTION
Adds two ElevenLabs audio models and corrects ElevenLabs TTS pricing across the board.

### New models
- **`eleven-sfx`** — text → sound effects (`eleven_text_to_sound_v2`). New `generateSoundEffect()` handler on the audio dispatch. `GET /audio/{text}?model=eleven-sfx` and `POST /v1/audio/speech`. Supports `duration` (0.5–30s), `loop`, `prompt_influence`. Aliases: `sfx`, `sound-effects`.
- **`eleven-multilingual-v2`** — stable, lifelike TTS (`eleven_multilingual_v2`, 29 languages); registry-only (flows through `generateSpeech`). Aliases: `multilingual-v2`, `eleven-v2`.

### Pricing — corrected to measured cost
Measured actual credit consumption on our Scale account (the API discounts TTS to ~0.6× the UI credit rate). Now matches elevenlabs.io/pricing/api:
- `eleven_v3`: $0.166 → **$0.10/1k** (0.602 cr/char measured) — *fixes a live ~66% overcharge*
- `eleven_flash_v2_5`: $0.083 → **$0.05/1k** (0.301 cr/char) — *live fix*
- `eleven-multilingual-v2`: $0.166 → **$0.10/1k** (0.601 cr/char)
- `eleven-sfx`: **$0.004/s** (24 cr/s measured), one exact per-second rate; caps at 30s = $0.12, matching ElevenLabs' "per generation" price
- All `priceMultiplier: 1` (at-cost). No `output_format` for SFX — it would make the byte-based duration billing vary by format (variable pricing).

### Other fixes (from review)
- TTS input cap 4096 → 10000 (schema + `generateSpeech` guard) for multilingual's 10k limit.
- SFX `duration` floor lowered (schema min 3 → 0.5).
- `polli-cli` SKILL.md: added SFX + multilingual examples.

### Verification
Empirical (live ElevenLabs): generation for both models, `loop`/`prompt_influence`/short-duration SFX, 5.6k-char multilingual, usage headers, Tinybird billing (multilingual 5625 chars → $0.5625 at the new rate), alias resolution, field-parity. Full suite green: gen 404/404, typecheck clean, price snapshot updated (exactly v3/flash/multilingual repriced).
