### PR TITLE
style: replace dashboard shadows with borders

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -295,7 +295,7 @@ export const DashboardShell: FC<DashboardShellProps> = ({
                 />
                 <div
                     className={cn(
-                        "absolute inset-y-0 left-0 flex w-[min(20rem,86vw)] transform-gpu flex-col overflow-hidden border-r border-theme-text-strong/10 bg-app-bg shadow-xl transition-transform ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform",
+                        "absolute inset-y-0 left-0 flex w-[min(20rem,86vw)] transform-gpu flex-col overflow-hidden border-r border-theme-text-strong/10 bg-app-bg transition-transform ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform",
                         "duration-[420ms]",
                         isDrawerOpen ? "translate-x-0" : "-translate-x-full",
                     )}

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -160,7 +160,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
     const perPollen = calculatePerPollen(model);
 
     return (
-        <div className="rounded-xl mb-1 bg-surface-opaque shadow-well transition-colors hover:bg-surface-opaque/90">
+        <div className="polli-surface-border rounded-xl mb-1 bg-surface-opaque transition-colors hover:bg-surface-opaque/90">
             {/* Clickable header */}
             <div className="relative">
                 <button

--- a/enter.pollinations.ai/frontend/src/routes/error.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/error.tsx
@@ -28,7 +28,7 @@ function ErrorPage() {
         <div className="flex min-h-screen items-center justify-center px-4">
             <Surface
                 variant="card"
-                className="w-full max-w-md p-8 text-center shadow-lg"
+                className="w-full max-w-md p-8 text-center"
             >
                 <h1 className="font-heading text-3xl mb-3">{title}</h1>
 

--- a/packages/ui/src/modules/auth/AuthModal.tsx
+++ b/packages/ui/src/modules/auth/AuthModal.tsx
@@ -40,7 +40,7 @@ export function AuthModal({
             ariaLabel={dialog?.label}
             labelledBy={dialog?.labelledBy}
             positionerClassName="polli:items-start polli:overflow-y-auto polli:bg-app-bg"
-            contentClassName={`polli:bg-surface-white polli:border-2 ${borderClass} polli:rounded-lg polli:shadow-lg polli:max-w-xl polli:w-full polli:my-auto`}
+            contentClassName={`polli:bg-surface-white polli:border-2 ${borderClass} polli:rounded-lg polli:max-w-xl polli:w-full polli:my-auto`}
         >
             {children}
         </Dialog>

--- a/packages/ui/src/modules/wallet/styles.css
+++ b/packages/ui/src/modules/wallet/styles.css
@@ -45,13 +45,11 @@
 .polli-wallet-panel-paid {
     background-color: var(--polli-color-paid-pale);
     color: var(--polli-color-paid-deep);
-    box-shadow: var(--polli-shadow-well);
 }
 
 .polli-wallet-panel-tier {
     background-color: var(--polli-color-tier-pale);
     color: var(--polli-color-tier-deep);
-    box-shadow: var(--polli-shadow-well);
 }
 
 .polli-wallet-text-paid {

--- a/packages/ui/src/modules/wallet/wallet-display.tsx
+++ b/packages/ui/src/modules/wallet/wallet-display.tsx
@@ -61,7 +61,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
 }) => (
     <div
         className={cn(
-            "polli:rounded-xl polli:p-4",
+            "polli:rounded-xl polli:p-4 polli-surface-border",
             walletPanelClasses[kind],
             className,
         )}

--- a/packages/ui/src/primitives/Dialog.tsx
+++ b/packages/ui/src/primitives/Dialog.tsx
@@ -77,7 +77,7 @@ export const Dialog: FC<DialogProps> = ({
                         aria-label={ariaLabel}
                         aria-labelledby={labelledBy}
                         className={cn(
-                            "polli:my-auto polli:w-full polli:overflow-hidden polli:rounded-lg polli:border-2 polli:border-theme-border polli:bg-surface-opaque polli:shadow-lg polli:outline-none polli:focus:outline-none polli:focus-visible:outline-none",
+                            "polli:my-auto polli:w-full polli:overflow-hidden polli:rounded-lg polli:border-2 polli:border-theme-border polli:bg-surface-opaque polli:outline-none polli:focus:outline-none polli:focus-visible:outline-none",
                             sizeClasses[size],
                             contentClassName,
                         )}

--- a/packages/ui/src/primitives/Dropdown.tsx
+++ b/packages/ui/src/primitives/Dropdown.tsx
@@ -4,7 +4,8 @@ import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import { cn } from "../lib/cn.ts";
 
-const DEFAULT_PANEL = "polli:rounded-lg polli:bg-theme-bg-pale polli:shadow-lg";
+const DEFAULT_PANEL =
+    "polli:rounded-lg polli:border polli:border-theme-border polli:bg-theme-bg-pale";
 
 export type DropdownProps = {
     /** Trigger element; receives the current open state (e.g. to rotate a chevron). */

--- a/packages/ui/src/primitives/Surface.tsx
+++ b/packages/ui/src/primitives/Surface.tsx
@@ -4,10 +4,10 @@ import { cn } from "../lib/cn.ts";
 type SurfaceVariant = "panel" | "card" | "card-themed";
 
 const variantClasses: Record<SurfaceVariant, string> = {
-    panel: "polli:rounded-2xl polli:bg-theme-bg-pale polli:p-6 polli:shadow-container",
-    card: "polli:rounded-xl polli:bg-surface-opaque polli:p-4 polli:shadow-well",
+    panel: "polli:rounded-2xl polli:bg-theme-bg-pale polli:p-6 polli-surface-border",
+    card: "polli:rounded-xl polli:bg-surface-opaque polli:p-4 polli-surface-border",
     "card-themed":
-        "polli:rounded-xl polli:bg-theme-bg-pale polli:p-4 polli:shadow-well",
+        "polli:rounded-xl polli:bg-theme-bg-pale polli:p-4 polli-surface-border",
 };
 
 type SurfaceOwnProps = {

--- a/packages/ui/src/primitives/Tooltip.tsx
+++ b/packages/ui/src/primitives/Tooltip.tsx
@@ -99,7 +99,7 @@ export const Tooltip: FC<TooltipProps> = ({
     // theme, while typography opts out of trigger inheritance so bold labels
     // do not make the whole tooltip shout.
     const popupClasses =
-        "polli:fixed polli:w-max polli:px-2 polli:py-1 polli:bg-theme-bg-pale polli:text-theme-text-base polli:font-normal polli:leading-snug polli:tracking-normal polli:normal-case polli:not-italic polli:border polli:border-theme-border polli:text-xs polli:rounded-md polli:shadow-sm polli:z-50 polli:pointer-events-none polli:transition-opacity polli:whitespace-pre-line polli:break-words";
+        "polli:fixed polli:w-max polli:px-2 polli:py-1 polli:bg-theme-bg-pale polli:text-theme-text-base polli:font-normal polli:leading-snug polli:tracking-normal polli:normal-case polli:not-italic polli:border polli:border-theme-border polli:text-xs polli:rounded-md polli:z-50 polli:pointer-events-none polli:transition-opacity polli:whitespace-pre-line polli:break-words";
 
     const contentNode = (
         <>

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -13,6 +13,21 @@
 @import "./tokens.css";
 @import "../modules/wallet/styles.css";
 
+.polli-surface-border {
+    outline: 1px solid rgba(50, 38, 24, 0.12);
+    outline-offset: -1px;
+}
+
+.dark .polli-surface-border {
+    outline-color: rgba(255, 255, 255, 0.1);
+}
+
+@supports (color: color-mix(in oklab, currentColor 12%, transparent)) {
+    .polli-surface-border {
+        outline-color: color-mix(in oklab, currentColor 12%, transparent);
+    }
+}
+
 .polli-scrollbar-subtle {
     scrollbar-width: thin;
     scrollbar-color: transparent transparent;


### PR DESCRIPTION
- Replaces shared dashboard `Surface` shadows with a faint inset outline.
- Applies the same border treatment to wallet balance panels and mobile model rows.
- Removes direct div shadows from dashboard shell, dialog, dropdown, tooltip, auth modal, and error surfaces.
- Validated with `npx biome check --write ...` and `npm run typecheck`.