### PR TITLE
feat: auto-fetch USD→EUR from ECB in runway rebuild

### DIFF
--- a/apps/operation/finance/bin/rebuild-sheet.mjs
+++ b/apps/operation/finance/bin/rebuild-sheet.mjs
@@ -2,6 +2,7 @@
 import { aggregate } from "../lib/aggregate.mjs";
 import { buildFleetLayout } from "../lib/fleet-layout.mjs";
 import { forecast } from "../lib/forecast.mjs";
+import { fetchUsdToEur } from "../lib/fx.mjs";
 import {
     applyFormat,
     applyNumberFormat,
@@ -124,6 +125,20 @@ async function main() {
     if (!spreadsheetId || !account) {
         throw new Error(
             "config.local.json must set spreadsheetId and gogAccount",
+        );
+    }
+
+    // Refresh USD→EUR from the ECB at rebuild time so the rate never silently
+    // goes stale. Falls back to the static config value if the fetch fails
+    // (e.g. the daily cron runs while offline).
+    const liveFx = await fetchUsdToEur();
+    if (liveFx) {
+        config.usd_to_eur = liveFx.rate;
+        config.usd_to_eur_as_of = liveFx.asOf;
+        console.log(`FX (ECB live): 1 USD = €${liveFx.rate} (${liveFx.asOf})`);
+    } else {
+        console.log(
+            `FX (config fallback): 1 USD = €${config.usd_to_eur} (${config.usd_to_eur_as_of})`,
         );
     }
 

--- a/apps/operation/finance/lib/fx.mjs
+++ b/apps/operation/finance/lib/fx.mjs
@@ -1,0 +1,47 @@
+/**
+ * Live USD→EUR FX rate from the ECB reference rates (via frankfurter.dev).
+ *
+ * The runway sheet stores a static `usd_to_eur` in config.local.json as a
+ * fallback. Rebuild refreshes it from the ECB at run time so the rate never
+ * silently goes stale (it once sat at an April rate for months). Any
+ * network/parse failure returns null and the caller keeps the config value.
+ */
+
+const FRANKFURTER_URL =
+    "https://api.frankfurter.dev/v1/latest?base=USD&symbols=EUR";
+
+/**
+ * Parse a frankfurter.dev /latest response into { rate, asOf }.
+ * Pure + exported for unit testing. Throws on an unexpected shape.
+ *
+ * @param {object} json  parsed JSON body
+ * @returns {{ rate: number, asOf: string }}
+ */
+export function parseFrankfurter(json) {
+    const rate = json?.rates?.EUR;
+    if (json?.base !== "USD" || typeof rate !== "number" || !json?.date) {
+        throw new Error("unexpected frankfurter response shape");
+    }
+    return { rate, asOf: json.date };
+}
+
+/**
+ * Fetch the live USD→EUR rate. Returns { rate, asOf } or null on any failure
+ * (offline, non-200, malformed body) so callers can fall back to config.
+ *
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<{ rate: number, asOf: string } | null>}
+ */
+export async function fetchUsdToEur({ timeoutMs = 8000 } = {}) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(FRANKFURTER_URL, { signal: controller.signal });
+        if (!res.ok) return null;
+        return parseFrankfurter(await res.json());
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}

--- a/apps/operation/finance/test/fx.test.mjs
+++ b/apps/operation/finance/test/fx.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fetchUsdToEur, parseFrankfurter } from "../lib/fx.mjs";
+
+test("parseFrankfurter extracts rate and date", () => {
+    const out = parseFrankfurter({
+        amount: 1,
+        base: "USD",
+        date: "2026-06-22",
+        rates: { EUR: 0.87291 },
+    });
+    assert.deepEqual(out, { rate: 0.87291, asOf: "2026-06-22" });
+});
+
+test("parseFrankfurter throws on unexpected shape", () => {
+    assert.throws(() => parseFrankfurter({ base: "EUR", rates: {} }));
+    assert.throws(() =>
+        parseFrankfurter({
+            base: "USD",
+            rates: { EUR: "x" },
+            date: "2026-06-22",
+        }),
+    );
+    assert.throws(() => parseFrankfurter(null));
+});
+
+test("fetchUsdToEur returns parsed rate on success", async (t) => {
+    const oldFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+        assert.match(url, /frankfurter\.dev/);
+        return Response.json({
+            base: "USD",
+            date: "2026-06-22",
+            rates: { EUR: 0.873 },
+        });
+    };
+    t.after(() => {
+        globalThis.fetch = oldFetch;
+    });
+
+    assert.deepEqual(await fetchUsdToEur(), {
+        rate: 0.873,
+        asOf: "2026-06-22",
+    });
+});
+
+test("fetchUsdToEur returns null on non-200", async (t) => {
+    const oldFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response("nope", { status: 503 });
+    t.after(() => {
+        globalThis.fetch = oldFetch;
+    });
+
+    assert.equal(await fetchUsdToEur(), null);
+});
+
+test("fetchUsdToEur returns null when fetch throws (offline)", async (t) => {
+    const oldFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+        throw new Error("getaddrinfo ENOTFOUND");
+    };
+    t.after(() => {
+        globalThis.fetch = oldFetch;
+    });
+
+    assert.equal(await fetchUsdToEur(), null);
+});


### PR DESCRIPTION
- `rebuild-sheet.mjs` now refreshes `usd_to_eur` from the ECB (frankfurter.dev) at run time instead of relying on the static `config.local.json` value
- Falls back to the config value when the fetch fails (e.g. the daily cron runs offline)
- New `lib/fx.mjs` (pure parser + fetch wrapper) with unit tests
- Fixes the FX rate silently going stale — it had been sitting at an April rate for months, overstating USD costs in EUR by ~5%