### PR TITLE
feat: swap Stable Audio 2.5 for Stable Audio 3 Medium (fal)

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1026,10 +1026,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "stable-audio-3-medium": {
     "cost": {
-      "completionAudioTokens": 0.0376,
+      "completionAudioTokens": 0.0001,
     },
     "price": {
-      "completionAudioTokens": 0.0376,
+      "completionAudioTokens": 0.0001,
     },
   },
   "step-3.5-flash": {

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1024,12 +1024,12 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.035,
     },
   },
-  "stable-audio-2.5": {
+  "stable-audio-3-medium": {
     "cost": {
-      "completionAudioTokens": 0.2,
+      "completionAudioTokens": 0.0376,
     },
     "price": {
-      "completionAudioTokens": 0.2,
+      "completionAudioTokens": 0.0376,
     },
   },
   "step-3.5-flash": {

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -63,13 +63,13 @@ const CreateSpeechRequestSchema = z
                 "Output duration in seconds (elevenmusic/acestep 3-300; eleven-sfx 0.5-30)",
             example: 30,
         }),
-        seconds: z.number().min(1).max(190).optional().meta({
+        seconds: z.number().min(1).max(380).optional().meta({
             description:
-                "Audio duration in seconds for stable-audio-2.5, 1-190.",
+                "Audio duration in seconds for stable-audio-3-medium, 1-380.",
             example: 30,
         }),
-        steps: z.number().int().min(4).max(8).optional().meta({
-            description: "Sampling steps for stable-audio-2.5, 4-8.",
+        steps: z.number().int().min(1).max(100).optional().meta({
+            description: "Sampling steps for stable-audio-3-medium, 1-100.",
             example: 8,
         }),
         loop: z.boolean().optional().meta({
@@ -1248,10 +1248,11 @@ export async function generateAceStepMusic(opts: {
  * Callers normalize their inputs first (GET maps seed=-1 -> undefined since
  * only its schema permits the sentinel).
  */
-// fal synchronous inference endpoint. Stable Audio 2.5 generates in ~2s, so the
-// blocking `fal.run` route returns inline without needing the queue/poll API.
-const STABLE_AUDIO_25_ENDPOINT =
-    "https://fal.run/fal-ai/stable-audio-25/text-to-audio";
+// fal synchronous inference endpoint. Stable Audio 3 Medium generates quickly,
+// so the blocking `fal.run` route returns inline without needing the queue/poll
+// API.
+const STABLE_AUDIO_3_MEDIUM_ENDPOINT =
+    "https://fal.run/fal-ai/stable-audio-3/medium/text-to-audio";
 
 // fal returns the generated file as a URL (or {url}) on a fal.media CDN, not
 // inline bytes — we fetch it and stream the bytes back to the caller.
@@ -1260,7 +1261,7 @@ type FalAudioOutput = {
     seed?: number;
 };
 
-export async function generateStableAudio25(opts: {
+export async function generateStableAudio3Medium(opts: {
     prompt: string;
     seconds?: number;
     steps?: number;
@@ -1272,7 +1273,8 @@ export async function generateStableAudio25(opts: {
 
     if (!falKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
-            message: "Stable Audio 2.5 is not configured (missing FAL_KEY)",
+            message:
+                "Stable Audio 3 Medium is not configured (missing FAL_KEY)",
         });
     }
 
@@ -1282,24 +1284,24 @@ export async function generateStableAudio25(opts: {
         });
     }
 
-    const secondsTotal = Math.min(190, Math.max(1, seconds ?? 190));
+    const duration = Math.min(380, Math.max(1, seconds ?? 30));
     const input: Record<string, unknown> = {
         prompt,
-        seconds_total: secondsTotal,
+        duration,
     };
     if (steps !== undefined) input.num_inference_steps = steps;
     if (seed !== undefined) input.seed = seed;
 
     log.info(
-        "Stable Audio 2.5 request: chars={chars}, seconds_total={seconds}, steps={steps}",
+        "Stable Audio 3 Medium request: chars={chars}, duration={duration}, steps={steps}",
         {
             chars: prompt.length,
-            seconds: secondsTotal,
+            duration,
             steps: steps ?? "(default)",
         },
     );
 
-    const rawResponse = await fetch(STABLE_AUDIO_25_ENDPOINT, {
+    const rawResponse = await fetch(STABLE_AUDIO_3_MEDIUM_ENDPOINT, {
         method: "POST",
         headers: {
             // fal uses `Authorization: Key <id:secret>`, NOT `Bearer`.
@@ -1310,14 +1312,14 @@ export async function generateStableAudio25(opts: {
     });
     const response = await ensureUpstreamOk(
         rawResponse,
-        STABLE_AUDIO_25_ENDPOINT,
+        STABLE_AUDIO_3_MEDIUM_ENDPOINT,
     );
     const result = (await response.json()) as FalAudioOutput;
     const audioUrl =
         typeof result.audio === "string" ? result.audio : result.audio?.url;
     if (!audioUrl) {
         throw new UpstreamError(502 as ContentfulStatusCode, {
-            message: "Stable Audio 2.5 returned no audio URL",
+            message: "Stable Audio 3 Medium returned no audio URL",
         });
     }
 
@@ -1326,19 +1328,19 @@ export async function generateStableAudio25(opts: {
         audioUrl,
     );
     const audioBuffer = await fileResponse.arrayBuffer();
-    // fal SA2.5 always outputs WAV, but its CDN serves the file as
+    // fal SA3 Medium defaults to MP3 output, but its CDN serves the file as
     // application/octet-stream — only trust the header when it's a real audio/*
-    // type, otherwise label it audio/wav so clients play it correctly.
+    // type, otherwise label it audio/mpeg so clients play it correctly.
     const headerContentType = fileResponse.headers.get("content-type");
     const contentType = headerContentType?.startsWith("audio/")
         ? headerContentType
-        : "audio/wav";
+        : "audio/mpeg";
 
-    const usageHeaders = buildUsageHeaders("stable-audio-2.5", {
+    const usageHeaders = buildUsageHeaders("stable-audio-3-medium", {
         completionAudioTokens: 1,
     });
 
-    log.info("Stable Audio 2.5 success: {bytes} bytes", {
+    log.info("Stable Audio 3 Medium success: {bytes} bytes", {
         bytes: audioBuffer.byteLength,
     });
 
@@ -1436,10 +1438,10 @@ async function dispatchAudioGeneration(
         );
     }
 
-    if (c.var.model.resolved === "stable-audio-2.5") {
+    if (c.var.model.resolved === "stable-audio-3-medium") {
         return withSafetyHeaders(
             c,
-            await generateStableAudio25({
+            await generateStableAudio3Medium({
                 prompt: text,
                 seconds: seconds ?? duration,
                 steps,
@@ -1653,7 +1655,7 @@ export const audioRoutes = new Hono<Env>()
             description: [
                 "Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.",
                 "",
-                "Set `model` to `elevenmusic`, `acestep`, or `stable-audio-2.5` to generate music. For reference-audio conditioning, send multipart/form-data with `reference_audio` plus `input`; for inpainting, pass an ElevenLabs `composition_plan`.",
+                "Set `model` to `elevenmusic`, `acestep`, or `stable-audio-3-medium` to generate music. For reference-audio conditioning, send multipart/form-data with `reference_audio` plus `input`; for inpainting, pass an ElevenLabs `composition_plan`.",
                 "",
                 `**Available voices:** ${ELEVENLABS_VOICES.join(", ")}`,
                 "",

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -30,6 +30,7 @@ import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
 import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
+import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
 import { buildTranscriptionResponse } from "./transcription-response.ts";
@@ -869,20 +870,34 @@ function requireElevenMusicOptions(
         extractCompositionPlan?: boolean;
     },
 ): void {
-    if (
-        model === "elevenmusic" ||
-        (!opts.referenceAudio &&
-            opts.compositionPlan === undefined &&
-            opts.conditioningRef === undefined &&
-            !opts.storeForInpainting &&
-            !opts.extractCompositionPlan)
-    ) {
+    // elevenmusic supports every conditioning option.
+    if (model === "elevenmusic") return;
+
+    // ElevenLabs-only options (everything except a plain reference clip).
+    const usesElevenOnlyOptions =
+        opts.compositionPlan !== undefined ||
+        opts.conditioningRef !== undefined ||
+        opts.storeForInpainting === true ||
+        opts.extractCompositionPlan === true;
+
+    // stable-audio-3-medium accepts reference_audio (fal audio-to-audio) but
+    // not the ElevenLabs composition/conditioning options.
+    if (model === "stable-audio-3-medium") {
+        if (usesElevenOnlyOptions) {
+            throw new UpstreamError(400 as ContentfulStatusCode, {
+                message:
+                    "conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic.",
+            });
+        }
         return;
     }
 
+    // Any other model: none of these options are supported.
+    if (!opts.referenceAudio && !usesElevenOnlyOptions) return;
+
     throw new UpstreamError(400 as ContentfulStatusCode, {
         message:
-            "Reference audio, conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic.",
+            "reference_audio, conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic (stable-audio-3-medium also accepts reference_audio).",
     });
 }
 
@@ -975,6 +990,10 @@ async function parseSpeechRequest(c: AudioContext): Promise<
                     | "aac"
                     | "pcm") || "mp3",
             duration: parseOptionalNumber(formData.get("duration"), "duration"),
+            // stable-audio-3-medium controls (also used on the audio-to-audio
+            // multipart path, which is the only way to send reference_audio).
+            seconds: parseOptionalNumber(formData.get("seconds"), "seconds"),
+            steps: parseOptionalNumber(formData.get("steps"), "steps"),
             instrumental: parseOptionalBoolean(
                 formData.get("instrumental"),
                 "instrumental",
@@ -1253,6 +1272,15 @@ export async function generateAceStepMusic(opts: {
 // API.
 const STABLE_AUDIO_3_MEDIUM_ENDPOINT =
     "https://fal.run/fal-ai/stable-audio-3/medium/text-to-audio";
+// A reference clip switches fal to audio-to-audio (style transfer) — a separate
+// endpoint with its own flat fee.
+const STABLE_AUDIO_3_MEDIUM_A2A_ENDPOINT =
+    "https://fal.run/fal-ai/stable-audio-3/medium/audio-to-audio";
+
+// Flat per-generation fees encoded at $0.0001/unit (see registry cost block) so
+// each path bills fal's exact rate: text-to-audio $0.0376, audio-to-audio $0.0417.
+const SA3M_TEXT_TO_AUDIO_UNITS = 376;
+const SA3M_AUDIO_TO_AUDIO_UNITS = 417;
 
 // fal returns the generated file as a URL (or {url}) on a fal.media CDN, not
 // inline bytes — we fetch it and stream the bytes back to the caller.
@@ -1266,10 +1294,11 @@ export async function generateStableAudio3Medium(opts: {
     seconds?: number;
     steps?: number;
     seed?: number;
+    referenceAudio?: File;
     falKey?: string;
     log: Logger;
 }): Promise<Response> {
-    const { prompt, seconds, steps, seed, falKey, log } = opts;
+    const { prompt, seconds, steps, seed, referenceAudio, falKey, log } = opts;
 
     if (!falKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
@@ -1284,6 +1313,9 @@ export async function generateStableAudio3Medium(opts: {
         });
     }
 
+    // A reference clip switches fal from text-to-audio to audio-to-audio
+    // (style transfer) — a different endpoint, body field, and flat fee.
+    const isAudioToAudio = referenceAudio !== undefined;
     const duration = Math.min(380, Math.max(1, seconds ?? 30));
     const input: Record<string, unknown> = {
         prompt,
@@ -1291,17 +1323,29 @@ export async function generateStableAudio3Medium(opts: {
     };
     if (steps !== undefined) input.num_inference_steps = steps;
     if (seed !== undefined) input.seed = seed;
+    if (isAudioToAudio) {
+        // fal a2a takes the reference clip as a data-URI `audio_url`.
+        const mime = referenceAudio.type || "audio/wav";
+        input.audio_url = `data:${mime};base64,${arrayBufferToBase64(
+            await referenceAudio.arrayBuffer(),
+        )}`;
+    }
+
+    const endpoint = isAudioToAudio
+        ? STABLE_AUDIO_3_MEDIUM_A2A_ENDPOINT
+        : STABLE_AUDIO_3_MEDIUM_ENDPOINT;
 
     log.info(
-        "Stable Audio 3 Medium request: chars={chars}, duration={duration}, steps={steps}",
+        "Stable Audio 3 Medium {mode} request: chars={chars}, duration={duration}, steps={steps}",
         {
+            mode: isAudioToAudio ? "audio-to-audio" : "text-to-audio",
             chars: prompt.length,
             duration,
             steps: steps ?? "(default)",
         },
     );
 
-    const rawResponse = await fetch(STABLE_AUDIO_3_MEDIUM_ENDPOINT, {
+    const rawResponse = await fetch(endpoint, {
         method: "POST",
         headers: {
             // fal uses `Authorization: Key <id:secret>`, NOT `Bearer`.
@@ -1310,10 +1354,7 @@ export async function generateStableAudio3Medium(opts: {
         },
         body: JSON.stringify(input),
     });
-    const response = await ensureUpstreamOk(
-        rawResponse,
-        STABLE_AUDIO_3_MEDIUM_ENDPOINT,
-    );
+    const response = await ensureUpstreamOk(rawResponse, endpoint);
     const result = (await response.json()) as FalAudioOutput;
     const audioUrl =
         typeof result.audio === "string" ? result.audio : result.audio?.url;
@@ -1336,8 +1377,12 @@ export async function generateStableAudio3Medium(opts: {
         ? headerContentType
         : "audio/mpeg";
 
+    // Flat per-generation fee; the unit count encodes fal's exact price for the
+    // chosen endpoint (see registry cost block, billed at $0.0001/unit).
     const usageHeaders = buildUsageHeaders("stable-audio-3-medium", {
-        completionAudioTokens: 1,
+        completionAudioTokens: isAudioToAudio
+            ? SA3M_AUDIO_TO_AUDIO_UNITS
+            : SA3M_TEXT_TO_AUDIO_UNITS,
     });
 
     log.info("Stable Audio 3 Medium success: {bytes} bytes", {
@@ -1446,6 +1491,7 @@ async function dispatchAudioGeneration(
                 seconds: seconds ?? duration,
                 steps,
                 seed,
+                referenceAudio,
                 falKey,
                 log,
             }),
@@ -1655,7 +1701,7 @@ export const audioRoutes = new Hono<Env>()
             description: [
                 "Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.",
                 "",
-                "Set `model` to `elevenmusic`, `acestep`, or `stable-audio-3-medium` to generate music. For reference-audio conditioning, send multipart/form-data with `reference_audio` plus `input`; for inpainting, pass an ElevenLabs `composition_plan`.",
+                "Set `model` to `elevenmusic`, `acestep`, or `stable-audio-3-medium` to generate music. Send multipart/form-data with `reference_audio` plus `input` to run fal audio-to-audio (style transfer) on `stable-audio-3-medium`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
                 "",
                 `**Available voices:** ${ELEVENLABS_VOICES.join(", ")}`,
                 "",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -771,7 +771,7 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
                 "",
-                "**Music generation:** Set `model=elevenmusic`, `acestep`, or `stable-audio-2.5` to generate music instead of speech. `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-2.5` supports `seconds` (1-190), `steps` (4-8), and `seed`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer, or `POST /v1/audio/music/upload` to register a source track for inpainting.",
+                "**Music generation:** Set `model=elevenmusic`, `acestep`, or `stable-audio-3-medium` to generate music instead of speech. `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium` supports `seconds` (1-380), `steps` (1-100), and `seed`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer, or `POST /v1/audio/music/upload` to register a source track for inpainting.",
             ].join("\n"),
             responses: {
                 200: {
@@ -829,13 +829,14 @@ export const proxyRoutes = new Hono<Env>()
                             "Music duration in seconds, 3-300 (elevenmusic only)",
                         example: "30",
                     }),
-                seconds: z.coerce.number().min(1).max(190).optional().meta({
+                seconds: z.coerce.number().min(1).max(380).optional().meta({
                     description:
-                        "Audio duration in seconds for stable-audio-2.5, 1-190",
+                        "Audio duration in seconds for stable-audio-3-medium, 1-380",
                     example: "30",
                 }),
-                steps: z.coerce.number().int().min(4).max(8).optional().meta({
-                    description: "Sampling steps for stable-audio-2.5, 4-8",
+                steps: z.coerce.number().int().min(1).max(100).optional().meta({
+                    description:
+                        "Sampling steps for stable-audio-3-medium, 1-100",
                     example: "8",
                 }),
                 instrumental: z

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -346,12 +346,12 @@ fixtureTest(
 );
 
 fixtureTest(
-    "routes stable-audio-2.5 requests through fal",
+    "routes stable-audio-3-medium requests through fal",
     async ({ paidApiKey }) => {
         const calls: string[] = [];
         const falEndpoint =
-            "https://fal.run/fal-ai/stable-audio-25/text-to-audio";
-        const falFileUrl = "https://v3.fal.media/files/test-stable-audio.wav";
+            "https://fal.run/fal-ai/stable-audio-3/medium/text-to-audio";
+        const falFileUrl = "https://v3.fal.media/files/test-stable-audio.mp3";
 
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
@@ -369,19 +369,19 @@ fixtureTest(
                         unknown
                     >;
                     expect(body.prompt).toBe("lofi rain loop");
-                    expect(body.seconds_total).toBe(12);
+                    expect(body.duration).toBe(12);
                     expect(body.num_inference_steps).toBe(6);
                     expect(body.seed).toBe(42);
 
                     return Response.json({
-                        audio: { url: falFileUrl, content_type: "audio/wav" },
+                        audio: { url: falFileUrl, content_type: "audio/mpeg" },
                         seed: 42,
                     });
                 }
 
                 if (request.url === falFileUrl) {
-                    return new Response(new Uint8Array([82, 73, 70, 70]), {
-                        headers: { "Content-Type": "audio/wav" },
+                    return new Response(new Uint8Array([73, 68, 51, 4]), {
+                        headers: { "Content-Type": "audio/mpeg" },
                     });
                 }
 
@@ -401,7 +401,7 @@ fixtureTest(
         const ctx = createExecutionContext();
         const response = await worker.fetch(
             new Request(
-                "https://staging.gen.pollinations.ai/audio/lofi%20rain%20loop?model=stable-audio-2.5&seconds=12&steps=6&seed=42",
+                "https://staging.gen.pollinations.ai/audio/lofi%20rain%20loop?model=stable-audio-3-medium&seconds=12&steps=6&seed=42",
                 {
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
@@ -414,8 +414,10 @@ fixtureTest(
         );
 
         expect(response.status).toBe(200);
-        expect(response.headers.get("content-type")).toBe("audio/wav");
-        expect(response.headers.get("x-model-used")).toBe("stable-audio-2.5");
+        expect(response.headers.get("content-type")).toBe("audio/mpeg");
+        expect(response.headers.get("x-model-used")).toBe(
+            "stable-audio-3-medium",
+        );
         expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
             "1",
         );
@@ -427,12 +429,12 @@ fixtureTest(
     },
 );
 
-it("lists stable-audio-2.5 in audio models", async () => {
+it("lists stable-audio-3-medium in audio models", async () => {
     const response = await fetchWorker("/audio/models");
 
     expect(response.status).toBe(200);
     const models = (await response.json()) as { name: string }[];
-    expect(models.some((model) => model.name === "stable-audio-2.5")).toBe(
+    expect(models.some((model) => model.name === "stable-audio-3-medium")).toBe(
         true,
     );
 });

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -418,13 +418,106 @@ fixtureTest(
         expect(response.headers.get("x-model-used")).toBe(
             "stable-audio-3-medium",
         );
+        // text-to-audio bills 376 units ($0.0376 at $0.0001/unit).
         expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
-            "1",
+            "376",
         );
 
         await waitOnExecutionContext(ctx);
 
         expect(calls).toContain(falEndpoint);
+        expect(calls).toContain(falFileUrl);
+    },
+);
+
+fixtureTest(
+    "routes stable-audio-3-medium reference_audio through fal audio-to-audio",
+    async ({ paidApiKey }) => {
+        const calls: string[] = [];
+        const a2aEndpoint =
+            "https://fal.run/fal-ai/stable-audio-3/medium/audio-to-audio";
+        const falFileUrl = "https://v3.fal.media/files/test-a2a.mp3";
+        let sentAudioUrl: unknown;
+
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+
+                if (request.url === a2aEndpoint) {
+                    expect(request.headers.get("authorization")).toBe(
+                        "Key test-fal-key",
+                    );
+                    const body = (await request.json()) as Record<
+                        string,
+                        unknown
+                    >;
+                    expect(body.prompt).toBe("warm pads");
+                    sentAudioUrl = body.audio_url;
+
+                    return Response.json({
+                        audio: { url: falFileUrl, content_type: "audio/mpeg" },
+                        seed: 1,
+                    });
+                }
+
+                if (request.url === falFileUrl) {
+                    return new Response(new Uint8Array([73, 68, 51, 4]), {
+                        headers: { "Content-Type": "audio/mpeg" },
+                    });
+                }
+
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const form = new FormData();
+        form.append("model", "stable-audio-3-medium");
+        form.append("input", "warm pads");
+        form.append(
+            "reference_audio",
+            new File([new Uint8Array([82, 73, 70, 70])], "ref.wav", {
+                type: "audio/wav",
+            }),
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
+                method: "POST",
+                headers: { Authorization: `Bearer ${paidApiKey}` },
+                body: form,
+            }),
+            {
+                ...env,
+                FAL_KEY: "test-fal-key",
+            } as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-model-used")).toBe(
+            "stable-audio-3-medium",
+        );
+        // audio-to-audio bills 417 units ($0.0417 at $0.0001/unit).
+        expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
+            "417",
+        );
+        // reference clip is forwarded as a base64 data-URI audio_url.
+        expect(String(sentAudioUrl)).toMatch(/^data:audio\/wav;base64,/);
+
+        await waitOnExecutionContext(ctx);
+
+        expect(calls).toContain(a2aEndpoint);
         expect(calls).toContain(falFileUrl);
     },
 );

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -261,7 +261,7 @@ export const AUDIO_SERVICES = {
         alpha: true,
     },
     "stable-audio-3-medium": {
-        aliases: ["stable-audio", "stability-audio"],
+        aliases: ["stable-audio", "stability-audio", "stable-audio-2.5"],
         modelId: "stable-audio-3-medium",
         provider: "fal",
         brand: "Stability AI",

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -270,9 +270,12 @@ export const AUDIO_SERVICES = {
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            // fal fal-ai/stable-audio-3/medium/text-to-audio: flat $0.0376 per
-            // output audio file (verified via fal model page 2026-06-23).
-            completionAudioTokens: 0.0376,
+            // Flat per-generation fee billed in $0.0001 units so each fal
+            // endpoint lands exactly (rates from fal model pages 2026-06-23):
+            //   text-to-audio  -> 376 units = $0.0376
+            //   audio-to-audio -> 417 units = $0.0417
+            // The handler picks the unit count from the request path (audio.ts).
+            completionAudioTokens: 0.0001,
         },
         title: "Stable Audio 3 Medium",
         description:

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -260,23 +260,23 @@ export const AUDIO_SERVICES = {
         outputModalities: ["audio"],
         alpha: true,
     },
-    "stable-audio-2.5": {
+    "stable-audio-3-medium": {
         aliases: ["stable-audio", "stability-audio"],
-        modelId: "stable-audio-2.5",
+        modelId: "stable-audio-3-medium",
         provider: "fal",
         brand: "Stability AI",
         category: "audio",
-        addedDate: new Date("2026-06-18").getTime(),
+        addedDate: new Date("2026-06-23").getTime(),
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            // fal fal-ai/stable-audio-25/text-to-audio: flat $0.20 per output
-            // audio file (verified via fal pricing/estimate API 2026-06-22).
-            completionAudioTokens: 0.2,
+            // fal fal-ai/stable-audio-3/medium/text-to-audio: flat $0.0376 per
+            // output audio file (verified via fal model page 2026-06-23).
+            completionAudioTokens: 0.0376,
         },
-        title: "Stable Audio 2.5",
+        title: "Stable Audio 3 Medium",
         description:
-            "Stable Audio 2.5 - Long-form 44.1 kHz stereo music and sound generation",
+            "Stable Audio 3 Medium - Long-form 44.1 kHz stereo music and sound generation",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         alpha: true,


### PR DESCRIPTION
Adds Stable Audio 3 Medium (fal) with text-to-audio and reference-audio (audio-to-audio) support.

- Replaces `stable-audio-2.5` with `stable-audio-3-medium` (fal `fal-ai/stable-audio-3/medium/text-to-audio`). `stable-audio-2.5` is kept as a backward-compat alias (alongside `stable-audio` / `stability-audio`), so existing calls keep resolving.
- `reference_audio` (multipart) routes to fal audio-to-audio (`.../medium/audio-to-audio`) for style transfer; plain prompts use text-to-audio.
- Exact per-path billing: cost rate is `$0.0001`/unit and the handler emits the unit count per endpoint — text-to-audio = 376 units (`$0.0376`), audio-to-audio = 417 units (`$0.0417`) — matching fal's posted per-request rates. Flat per generation (not per second).
- Params: `seconds` 1–380 (fal `duration`), `steps` (`num_inference_steps`), `seed`; output mp3 44.1 kHz stereo. Reuses existing `FAL_KEY` — no new secret, no GPU.
- The conditioning guard now allows `reference_audio` for `stable-audio-3-medium` (still rejects ElevenLabs-only options); the multipart parser forwards `seconds`/`steps` (a2a is multipart-only).

Tested: gen + enter suites green; real e2e through local gen for both paths (t2a 376u/`$0.0376`, a2a 417u/`$0.0417`, valid 192 kbps stereo MP3, cache MISS→HIT, billing rows match).
