### PR TITLE
fix: model pricing card — flat-rate /gen for Stable Audio + mobile cleanup

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/formatters.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/formatters.ts
@@ -26,14 +26,15 @@ export const formatPrice = (
     return formatter(price);
 };
 
-export const formatPricePerImage = (price: number): string => {
+// Flat per-request price — one fee per image or audio generation, shown with
+// the "/gen" badge. Keeps 4 decimals below $1 so odd rates like $0.0376 render
+// exactly instead of rounding to $0.038.
+export const formatPriceFlat = (price: number): string => {
     let formatted: string;
     if (price < 0.001) {
         formatted = price.toFixed(6);
-    } else if (price < 0.01) {
-        formatted = price.toFixed(4);
     } else if (price < 1) {
-        formatted = price.toFixed(3);
+        formatted = price.toFixed(4);
     } else {
         formatted = price.toFixed(2);
     }

--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -1,7 +1,7 @@
 import {
     formatPrice,
+    formatPriceFlat,
     formatPricePer1M,
-    formatPricePerImage,
 } from "./formatters.ts";
 import type { ModelCapability, ModelCategory, ModelPrice } from "./types.ts";
 import type { ModelStats } from "./use-model-stats.ts";
@@ -28,6 +28,7 @@ export type ApiModelInfo = {
     is_specialized?: boolean;
     paid_only?: boolean;
     alpha?: boolean;
+    flat_rate?: boolean;
     added_date?: number;
 };
 
@@ -233,14 +234,31 @@ function modelPriceFromCatalog(model: ApiModelInfo): ModelPrice | null {
         return {
             ...price,
             perToken: false,
-            perImagePrice: formatPrice(
-                completionImageTokens,
-                formatPricePerImage,
-            ),
+            perImagePrice: formatPrice(completionImageTokens, formatPriceFlat),
         };
     }
 
     if (price.type === "audio") {
+        // Flat per-generation models (e.g. Stable Audio): one fee per request,
+        // independent of length. Show flat "/gen" In/Out audio prices instead of
+        // estimating a per-second rate. Both flat-fee music and per-character TTS
+        // store their price in completionAudioTokens, so the registry flat_rate
+        // flag is what tells them apart.
+        if (model.flat_rate) {
+            return {
+                ...price,
+                perToken: false,
+                perRequest: true,
+                promptAudioPrice: formatPrice(
+                    promptAudioTokens,
+                    formatPriceFlat,
+                ),
+                completionAudioPrice: formatPrice(
+                    completionAudioTokens,
+                    formatPriceFlat,
+                ),
+            };
+        }
         if (promptAudioSeconds) {
             return {
                 ...price,

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -70,6 +70,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
             kind: "audioIn",
             subKinds: ["audioIn"],
             perToken: model.perToken,
+            perRequest: model.perRequest,
         },
         {
             prices: [model.promptImagePrice],
@@ -96,6 +97,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
             kind: "audioOut",
             subKinds: ["audioOut"],
             perToken: model.perToken,
+            perRequest: model.perRequest,
         },
         {
             prices: [model.perSecondPrice],
@@ -119,7 +121,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
             prices: [model.perImagePrice],
             kind: "image",
             subKinds: ["image"],
-            perImage: true,
+            perRequest: true,
         },
         {
             prices: [model.completionImagePrice],
@@ -277,7 +279,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                 <div className="flex flex-col gap-1 items-end">
                     {inputPriceBadges.map((badge) => (
                         <PriceBadge
-                            key={`${badge.subKinds.join("")}-${badge.prices[0]}-${badge.perToken ? "token" : ""}-${badge.perImage ? "img" : ""}-${badge.perSecond ? "sec" : ""}`}
+                            key={`${badge.subKinds.join("")}-${badge.prices[0]}-${badge.perToken ? "token" : ""}-${badge.perRequest ? "gen" : ""}-${badge.perSecond ? "sec" : ""}`}
                             {...badge}
                         />
                     ))}
@@ -289,7 +291,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                 <div className="flex flex-col gap-1 items-end">
                     {outputPriceBadges.map((badge) => (
                         <PriceBadge
-                            key={`${badge.subKinds.join("")}-${badge.prices[0]}-${badge.perToken ? "token" : ""}-${badge.perImage ? "img" : ""}-${badge.perSecond ? "sec" : ""}`}
+                            key={`${badge.subKinds.join("")}-${badge.prices[0]}-${badge.perToken ? "token" : ""}-${badge.perRequest ? "gen" : ""}-${badge.perSecond ? "sec" : ""}`}
                             {...badge}
                         />
                     ))}

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -3,7 +3,6 @@ import {
     ChevronIcon,
     CopyButton,
     cn,
-    InfoTip,
     SproutIcon,
     Tooltip,
 } from "@pollinations/ui";
@@ -223,19 +222,6 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                     </>
                                 )}
                             </CopyButton>
-                            {modelDescription && (
-                                <span className="pointer-events-auto inline-flex">
-                                    <InfoTip
-                                        content={modelDescription}
-                                        label={`About ${publicModelName}`}
-                                    />
-                                </span>
-                            )}
-                            <ModelStatusChips
-                                showNew={showNew}
-                                showAlpha={showAlpha}
-                                alphaTooltip={false}
-                            />
                         </div>
                         {(inputModalities.length > 0 ||
                             capabilities.length > 0) && (
@@ -243,6 +229,15 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 <MobileMetadataBadges
                                     inputModalities={inputModalities}
                                     capabilities={capabilities}
+                                />
+                            </div>
+                        )}
+                        {(showNew || showAlpha) && (
+                            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                                <ModelStatusChips
+                                    showNew={showNew}
+                                    showAlpha={showAlpha}
+                                    alphaTooltip={false}
                                 />
                             </div>
                         )}
@@ -261,10 +256,15 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                 </div>
             </div>
 
-            {/* Expanded: capabilities + full pricing */}
+            {/* Expanded: description + full pricing */}
             {expanded && (
                 <div className="px-4 pb-4 pt-0">
                     <div className="flex min-w-0 flex-col gap-2 pl-6">
+                        {modelDescription && (
+                            <p className="mb-2 text-sm leading-relaxed text-theme-text-muted">
+                                {modelDescription}
+                            </p>
+                        )}
                         <MobilePriceGroup
                             label="In"
                             model={model}
@@ -316,6 +316,7 @@ const MobilePriceGroup: FC<MobilePriceGroupProps> = ({
                       kind: "audioIn",
                       subKinds: ["audioIn"],
                       perToken: model.perToken,
+                      perRequest: model.perRequest,
                   },
                   {
                       prices: [model.promptImagePrice],
@@ -342,6 +343,7 @@ const MobilePriceGroup: FC<MobilePriceGroupProps> = ({
                       kind: "audioOut",
                       subKinds: ["audioOut"],
                       perToken: model.perToken,
+                      perRequest: model.perRequest,
                   },
                   {
                       prices: [model.perSecondPrice],
@@ -365,7 +367,7 @@ const MobilePriceGroup: FC<MobilePriceGroupProps> = ({
                       prices: [model.perImagePrice],
                       kind: "image",
                       subKinds: ["image"],
-                      perImage: true,
+                      perRequest: true,
                   },
                   {
                       prices: [model.completionImagePrice],
@@ -386,7 +388,7 @@ const MobilePriceGroup: FC<MobilePriceGroupProps> = ({
             <div className="flex min-w-0 flex-wrap justify-end gap-1">
                 {badges.map((badge) => (
                     <PriceBadge
-                        key={`${badge.subKinds.join("")}-${badge.prices[0]}-${badge.perToken ? "token" : ""}-${badge.perImage ? "img" : ""}-${badge.perSecond ? "sec" : ""}`}
+                        key={`${badge.subKinds.join("")}-${badge.prices[0]}-${badge.perToken ? "token" : ""}-${badge.perRequest ? "gen" : ""}-${badge.perSecond ? "sec" : ""}`}
                         {...badge}
                     />
                 ))}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -2,8 +2,8 @@ import {
     ClockIcon,
     ExternalLinkButton,
     GitHubIcon,
-    ImageIcon,
     Section,
+    SparklesIcon,
     TabButton,
     TokensIcon,
     TrendUpIcon,
@@ -124,9 +124,10 @@ export const Models: FC = () => {
                 </div>
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
                     <p className="flex items-start gap-1.5">
-                        <ImageIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>
-                            <strong>/img</strong> — flat rate per image.
+                            <strong>/gen</strong> — flat rate per image or audio
+                            generation.
                         </span>
                     </p>
                     <p className="flex items-start gap-1.5">

--- a/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
@@ -15,7 +15,7 @@ export type PriceBadgeConfig = {
     prices: (string | undefined)[];
     kind: PriceKind;
     subKinds: PriceKind[];
-    perImage?: boolean;
+    perRequest?: boolean;
     perToken?: boolean;
     perSecond?: boolean;
     className?: string;
@@ -34,7 +34,7 @@ export const groupPriceBadges = (
 
         const key = [
             validPrices[0],
-            badge.perImage ? "img" : "",
+            badge.perRequest ? "gen" : "",
             badge.perToken ? "token" : "",
             badge.perSecond ? "sec" : "",
             badge.className ?? "",
@@ -65,7 +65,7 @@ export const PriceBadge: FC<PriceBadgeConfig> = ({
     prices,
     kind,
     subKinds,
-    perImage,
+    perRequest,
     perToken,
     perSecond,
     className,
@@ -87,8 +87,8 @@ export const PriceBadge: FC<PriceBadgeConfig> = ({
     // Compact suffix based on pricing type
     const suffix = perSecond
         ? "/sec"
-        : perImage
-          ? "/img"
+        : perRequest
+          ? "/gen"
           : perToken
             ? "/M"
             : "";

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -27,6 +27,9 @@ export type ModelPrice = {
     inputSortPrice?: number;
     outputSortPrice?: number;
     perToken?: boolean;
+    // Flat per-generation pricing (one fee per request) — renders the "/gen"
+    // badge. Set for flat-fee audio (Stable Audio); images render flat directly.
+    perRequest?: boolean;
     // Text pricing
     promptTextPrice?: string;
     promptCachedPrice?: string;

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1298,11 +1298,6 @@ const STABLE_AUDIO_3_LARGE_A2A_ENDPOINT =
     "https://api.stability.ai/v2beta/audio/stable-audio/audio-to-audio";
 const STABILITY_RESULTS_ENDPOINT = "https://api.stability.ai/v2beta/results";
 
-// Flat per-generation fees encoded at $0.0001/unit (see registry cost block) so
-// each path bills fal's exact rate: text-to-audio $0.0376, audio-to-audio $0.0417.
-const SA3M_TEXT_TO_AUDIO_UNITS = 376;
-const SA3M_AUDIO_TO_AUDIO_UNITS = 417;
-
 // fal returns the generated file as a URL (or {url}) on a fal.media CDN, not
 // inline bytes — we fetch it and stream the bytes back to the caller.
 type FalAudioOutput = {
@@ -1398,12 +1393,12 @@ export async function generateStableAudio3Medium(opts: {
         ? headerContentType
         : "audio/mpeg";
 
-    // Flat per-generation fee; the unit count encodes fal's exact price for the
-    // chosen endpoint (see registry cost block, billed at $0.0001/unit).
+    // Flat per-generation fee: always one output audio unit, plus one input
+    // audio unit when a reference clip switches fal to audio-to-audio. The
+    // registry prices the base + audio-input surcharge (see its cost block).
     const usageHeaders = buildUsageHeaders("stable-audio-3-medium", {
-        completionAudioTokens: isAudioToAudio
-            ? SA3M_AUDIO_TO_AUDIO_UNITS
-            : SA3M_TEXT_TO_AUDIO_UNITS,
+        completionAudioTokens: 1,
+        promptAudioTokens: isAudioToAudio ? 1 : 0,
     });
 
     log.info("Stable Audio 3 Medium success: {bytes} bytes", {

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -418,10 +418,12 @@ fixtureTest(
         expect(response.headers.get("x-model-used")).toBe(
             "stable-audio-3-medium",
         );
-        // text-to-audio bills 376 units ($0.0376 at $0.0001/unit).
+        // text-to-audio bills 1 output audio unit ($0.0376 per generation).
         expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
-            "376",
+            "1",
         );
+        // no reference clip → no input audio unit billed.
+        expect(response.headers.get("x-usage-prompt-audio-tokens")).toBeNull();
 
         await waitOnExecutionContext(ctx);
 
@@ -508,10 +510,12 @@ fixtureTest(
         expect(response.headers.get("x-model-used")).toBe(
             "stable-audio-3-medium",
         );
-        // audio-to-audio bills 417 units ($0.0417 at $0.0001/unit).
+        // audio-to-audio bills 1 output unit + 1 input unit
+        // ($0.0376 + $0.0041 = $0.0417 per generation).
         expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
-            "417",
+            "1",
         );
+        expect(response.headers.get("x-usage-prompt-audio-tokens")).toBe("1");
         // reference clip is forwarded as a base64 data-URI audio_url.
         expect(String(sentAudioUrl)).toMatch(/^data:audio\/wav;base64,/);
 

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -106,6 +106,14 @@ export function GenApiIcon(props: IconProps) {
     );
 }
 
+export function SparklesIcon(props: IconProps) {
+    return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>
+            <path d="M12 3l1.9 5.8a2 2 0 0 0 1.3 1.3L21 12l-5.8 1.9a2 2 0 0 0-1.3 1.3L12 21l-1.9-5.8a2 2 0 0 0-1.3-1.3L3 12l5.8-1.9a2 2 0 0 0 1.3-1.3z" />
+        </svg>
+    );
+}
+
 export function GitHubIcon(props: IconProps) {
     return (
         <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -71,7 +71,6 @@ export const AUDIO_SERVICES = {
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
-        alpha: true,
     },
     elevenflash: {
         aliases: ["tts-flash", "eleven-flash", "flash"],
@@ -94,7 +93,6 @@ export const AUDIO_SERVICES = {
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
-        alpha: true,
     },
     "eleven-multilingual-v2": {
         aliases: ["multilingual-v2", "eleven-v2", "tts-multilingual"],
@@ -117,7 +115,6 @@ export const AUDIO_SERVICES = {
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
-        alpha: true,
     },
     elevenmusic: {
         aliases: ["music"],
@@ -139,7 +136,6 @@ export const AUDIO_SERVICES = {
             "ElevenLabs Music - Generate studio-grade music from text prompts and reference audio",
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
-        alpha: true,
     },
     "eleven-sfx": {
         aliases: ["sfx", "sound-effects", "eleven-sound-effects"],
@@ -164,7 +160,6 @@ export const AUDIO_SERVICES = {
             "ElevenLabs Sound Effects - Generate sound effects from text prompts",
         inputModalities: ["text"],
         outputModalities: ["audio"],
-        alpha: true,
     },
     whisper: {
         aliases: ["whisper-1", "whisper-large-v3"],
@@ -182,7 +177,6 @@ export const AUDIO_SERVICES = {
         description: "Whisper Large V3 - Speech to text transcription",
         inputModalities: ["audio"],
         outputModalities: ["text"],
-        alpha: true,
     },
     scribe: {
         aliases: ["scribe_v2", "scribe-v2"],
@@ -258,7 +252,6 @@ export const AUDIO_SERVICES = {
             "ACE-Step 1.5 Turbo - Fast open-source music generation with lyrics support",
         inputModalities: ["text"],
         outputModalities: ["audio"],
-        alpha: true,
     },
     "stable-audio-3-medium": {
         aliases: ["stable-audio", "stability-audio", "stable-audio-2.5"],
@@ -269,20 +262,21 @@ export const AUDIO_SERVICES = {
         addedDate: new Date("2026-06-23").getTime(),
         priceMultiplier: 1,
         paidOnly: true,
+        flatRate: true,
         cost: {
-            // Flat per-generation fee billed in $0.0001 units so each fal
-            // endpoint lands exactly (rates from fal model pages 2026-06-23):
-            //   text-to-audio  -> 376 units = $0.0376
-            //   audio-to-audio -> 417 units = $0.0417
-            // The handler picks the unit count from the request path (audio.ts).
-            completionAudioTokens: 0.0001,
+            // Flat per-generation fee (fal model pages 2026-06-23):
+            //   text-to-audio  $0.0376  (output audio)
+            //   audio-to-audio $0.0417  (+$0.0041 for the reference-clip input)
+            // The handler bills whole units: 1 completion audio unit always, plus
+            // 1 prompt audio unit for audio-to-audio (see gen audio.ts).
+            promptAudioTokens: 0.0417 - 0.0376,
+            completionAudioTokens: 0.0376,
         },
         title: "Stable Audio 3 Medium",
         description:
             "Stable Audio 3 Medium - Long-form 44.1 kHz stereo music and sound generation",
         inputModalities: ["text"],
         outputModalities: ["audio"],
-        alpha: true,
     },
     "stable-audio-3-large": {
         // Distinct from stable-audio-3-medium (fal): this is the larger
@@ -296,10 +290,12 @@ export const AUDIO_SERVICES = {
         addedDate: new Date("2026-06-23").getTime(),
         priceMultiplier: 1,
         paidOnly: true,
+        flatRate: true,
         cost: {
-            // Stability Stable Audio 3 (Large) via the direct API: flat 26
-            // credits/generation. Stability credits are $0.01 each, so bill one
-            // flat audio unit at $0.26.
+            // Stability Stable Audio 3.0 via the direct API: flat 26 credits/
+            // generation (Stable Audio 2.5 was 20); credits are $0.01 each → $0.26.
+            // Same fee for text-to-audio and audio-to-audio, so no audio-input
+            // surcharge — the handler bills one flat completion audio unit.
             completionAudioTokens: 0.26,
         },
         title: "Stable Audio 3 Large",
@@ -307,7 +303,6 @@ export const AUDIO_SERVICES = {
             "Stable Audio 3 Large - Long-form 44.1 kHz stereo music via Stability's direct API",
         inputModalities: ["text"],
         outputModalities: ["audio"],
-        alpha: true,
     },
     "qwen-tts": {
         aliases: ["qwen3-tts", "qwen3-tts-flash"],

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -588,7 +588,6 @@ export const IMAGE_SERVICES = {
         category: "image",
         addedDate: new Date("2026-01-17").getTime(),
         priceMultiplier: 1,
-        alpha: true,
         cost: {
             completionImageTokens: 0.01,
         },

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -54,6 +54,7 @@ export const ModelInfoSchema = z.object({
     is_specialized: z.boolean().optional(),
     paid_only: z.boolean().optional(),
     alpha: z.boolean().optional(),
+    flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
 });
 
@@ -119,6 +120,7 @@ function getModelInfo(modelName: ModelName): ModelInfo {
         is_specialized: service.isSpecialized,
         paid_only: service.paidOnly,
         alpha: service.alpha,
+        flat_rate: service.flatRate,
         added_date: service.addedDate,
     };
 }

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -111,6 +111,11 @@ export type ModelDefinition<TModelId extends string = ModelId> = {
     isSpecialized?: boolean;
     paidOnly?: boolean; // Models that require paid balance only
     alpha?: boolean; // Experimental models with potential instability
+    // Flat per-generation pricing (one fee per request, independent of output
+    // size/length). Lets the pricing UI show a "/gen" badge instead of guessing
+    // a per-second rate from a per-token cost. Used to disambiguate flat-fee
+    // audio (e.g. Stable Audio) from per-character TTS, which share cost fields.
+    flatRate?: boolean;
     hidden?: boolean; // Hidden from /models endpoints and dashboard, but still usable via API
     videoCapabilities?: VideoCapability[]; // Video-only: which frame controls the provider supports
     maxReferenceImages?: number; // Models with image input: effective accepted reference images

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1228,7 +1228,6 @@ export const TEXT_SERVICES = {
         codeExecution: true,
         search: true,
         isSpecialized: false,
-        alpha: true,
     },
     "qwen-coder-large": {
         aliases: ["qwen3-coder-next"],


### PR DESCRIPTION
Fixes the model pricing card and corrects how Stable Audio is priced/displayed.

**Stable Audio pricing**
- The pricing page showed `3.9/sec` for Stable Audio 3 Large — it's a flat per-generation fee, not per-second. The audio display was multiplying a flat per-token cost by a TTS chars/sec estimate.
- New modality-agnostic flat-rate `/gen` badge (replaces `/img`); the icon shows image vs audio. Added a `SparklesIcon` for the legend.
- Registry: Medium now prices base + audio-input surcharge (text `$0.0376` / audio-to-audio `$0.0417`); Large flat `$0.26` (26 credits — Stable Audio 3.0; 2.5 was 20). New `flatRate` flag distinguishes flat-fee music from per-character TTS (they share `completionAudioTokens`).
- Handler bills whole units: 1 output, +1 input for audio-to-audio. **Billing amounts unchanged.**

**Mobile pricing card**
- Info tooltip moved into the expanded panel (was hard to tap); description shows there.
- `NEW`/`ALPHA` chips moved to their own row below the modalities (fixes 3-line wrap).
- Dropped the `ALPHA` badge from models that aren't alpha anymore (kept only on LTX-2).

**Verified**
- gen worker tests (both models, both modes) + live Medium generation; ledger decrements `0.0376` / `0.0417` / `0.26`.
- `/models` exposes `flat_rate` + flat prices; typecheck + biome clean.