### PR TITLE
fix: count exact 100 pollen top-ups

### DIFF
--- a/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
@@ -14,7 +14,7 @@ import {
  *   - use_app        -> apikey.byop_client_key_id (one BYOP login per user)
  *   - early_adopter  -> user.created_at           (registered 6+ months ago)
  *   - first_top_up   -> stripe_checkout_credits   (one paid checkout per user)
- *   - top_up_100     -> stripe_checkout_credits   (>100 total paid Pollen)
+ *   - top_up_100     -> stripe_checkout_credits   (>=100 total paid Pollen)
  *
  * The SQL decides whether the current user qualifies. The rewards table is the
  * single idempotency layer, so quest code does not filter already rewarded
@@ -129,7 +129,7 @@ export async function findRewardProposalsForUser(
         FROM stripe_checkout_credits
         WHERE stripe_checkout_credits.user_id = ${user.id}
         GROUP BY stripe_checkout_credits.user_id
-        HAVING SUM(stripe_checkout_credits.pollen_credited) > 100
+        HAVING SUM(stripe_checkout_credits.pollen_credited) >= 100
         LIMIT 1`)
             : [],
         rewardableQuestIds.has(byopLoginQuest.id)

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -403,6 +403,34 @@ test("quest check records product rewards and claim endpoint credits one", async
     );
 });
 
+test("top-up 100 quest records for exactly 100 paid checkout pollen", async ({
+    apiKey: _apiKey,
+    mocks,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await getOnlyUser();
+    await mocks.enable("github", "tinybird");
+
+    await db.insert(schema.stripeCheckoutCredits).values({
+        sessionId: `cs_test_${user.id}_exact_100`,
+        eventId: `evt_${user.id}_exact_100`,
+        eventType: "checkout.session.completed",
+        userId: user.id,
+        pollenCredited: 100,
+        createdAt: new Date(),
+    });
+
+    await checkQuestsForUser(env, user.id);
+
+    const rewards = await db
+        .select({ questId: schema.rewards.questId })
+        .from(schema.rewards)
+        .where(eq(schema.rewards.userId, user.id));
+    const questIds = new Set(rewards.map((reward) => reward.questId));
+    expect(questIds.has("first_top_up")).toBe(true);
+    expect(questIds.has("top_up_100")).toBe(true);
+});
+
 test("POST /quests/check throttles a user to once per minute", async ({
     apiKey: _apiKey,
     mocks,


### PR DESCRIPTION
- Changes the 100 Pollen top-up quest threshold from `> 100` to `>= 100`.
- Keeps eligibility sourced from the existing `stripe_checkout_credits` ledger.
- Adds a regression test for exactly 100 paid checkout Pollen.

Validation:
- `npx biome check --write enter.pollinations.ai/src/services/quests/groups/account-setup.ts enter.pollinations.ai/test/quests.test.ts`
- `npm run decrypt-vars && npx vitest run test/quests.test.ts`