### PR TITLE
fix: ignore Polar for launch top-up quests

### DIFF
--- a/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
@@ -180,12 +180,12 @@ export async function findRewardProposalsForUser(
           WHERE polar_checkout_credits.user_id = ${user.id}
             AND (
               (
-                polar_checkout_credits.created_at > ${TIMESTAMP_MILLIS_THRESHOLD}
-                AND polar_checkout_credits.created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS}
+                polar_checkout_credits.polar_created_at > ${TIMESTAMP_MILLIS_THRESHOLD}
+                AND polar_checkout_credits.polar_created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS}
               )
               OR (
-                polar_checkout_credits.created_at <= ${TIMESTAMP_MILLIS_THRESHOLD}
-                AND polar_checkout_credits.created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_SECONDS}
+                polar_checkout_credits.polar_created_at <= ${TIMESTAMP_MILLIS_THRESHOLD}
+                AND polar_checkout_credits.polar_created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_SECONDS}
               )
             )
         )

--- a/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
@@ -13,8 +13,8 @@ import {
  *   - first_api_key  -> apikey                    (one key per user)
  *   - use_app        -> apikey.byop_client_key_id (one BYOP login per user)
  *   - early_adopter  -> user.created_at           (registered 6+ months ago)
- *   - top_up_since_launch -> checkout credit ledgers (one launch-era checkout)
- *   - top_up_100_since_launch -> checkout credit ledgers (>=100 launch-era Pollen)
+ *   - top_up_since_launch -> stripe_checkout_credits (one launch-era checkout)
+ *   - top_up_100_since_launch -> stripe_checkout_credits (>=100 launch-era Pollen)
  *
  * The SQL decides whether the current user qualifies. The rewards table is the
  * single idempotency layer, so quest code does not filter already rewarded
@@ -156,40 +156,21 @@ export async function findRewardProposalsForUser(
             rewardableQuestIds.has(topUpSinceLaunchQuest.id) ||
             rewardableQuestIds.has(overHundredPollenSinceLaunchQuest.id)
                 ? db.all<TopUpSummaryRow>(sql`
-        SELECT userId
-             , SUM(pollenCredited) AS totalPollen
-        FROM (
-          SELECT stripe_checkout_credits.user_id AS userId,
-                 stripe_checkout_credits.pollen_credited AS pollenCredited
-          FROM stripe_checkout_credits
-          WHERE stripe_checkout_credits.user_id = ${user.id}
-            AND (
-              (
-                stripe_checkout_credits.created_at > ${TIMESTAMP_MILLIS_THRESHOLD}
-                AND stripe_checkout_credits.created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS}
-              )
-              OR (
-                stripe_checkout_credits.created_at <= ${TIMESTAMP_MILLIS_THRESHOLD}
-                AND stripe_checkout_credits.created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_SECONDS}
-              )
+        SELECT stripe_checkout_credits.user_id AS userId,
+               SUM(stripe_checkout_credits.pollen_credited) AS totalPollen
+        FROM stripe_checkout_credits
+        WHERE stripe_checkout_credits.user_id = ${user.id}
+          AND (
+            (
+              stripe_checkout_credits.created_at > ${TIMESTAMP_MILLIS_THRESHOLD}
+              AND stripe_checkout_credits.created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS}
             )
-          UNION ALL
-          SELECT polar_checkout_credits.user_id AS userId,
-                 polar_checkout_credits.pollen_credited AS pollenCredited
-          FROM polar_checkout_credits
-          WHERE polar_checkout_credits.user_id = ${user.id}
-            AND (
-              (
-                polar_checkout_credits.polar_created_at > ${TIMESTAMP_MILLIS_THRESHOLD}
-                AND polar_checkout_credits.polar_created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS}
-              )
-              OR (
-                polar_checkout_credits.polar_created_at <= ${TIMESTAMP_MILLIS_THRESHOLD}
-                AND polar_checkout_credits.polar_created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_SECONDS}
-              )
+            OR (
+              stripe_checkout_credits.created_at <= ${TIMESTAMP_MILLIS_THRESHOLD}
+              AND stripe_checkout_credits.created_at >= ${QUEST_REWARDS_LAUNCH_CUTOFF_SECONDS}
             )
-        )
-        GROUP BY userId
+          )
+        GROUP BY stripe_checkout_credits.user_id
         LIMIT 1`)
                 : [],
             rewardableQuestIds.has(byopLoginQuest.id)

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -21,8 +21,6 @@ const QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS = Date.parse(
 const BEFORE_QUEST_REWARDS_LAUNCH_MILLIS =
     QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS - 1;
 const AFTER_QUEST_REWARDS_LAUNCH_DATE = new Date("2026-06-22T00:00:00.000Z");
-const AFTER_QUEST_REWARDS_LAUNCH_MILLIS =
-    AFTER_QUEST_REWARDS_LAUNCH_DATE.getTime();
 
 // Build an issue body the deriver can parse: a "### Reward" heading (when a
 // reward is given) plus a short Goal section for the description.
@@ -523,7 +521,7 @@ test("top-up quests ignore paid checkout pollen before quest launch", async ({
     expect(questIds.has(LEGACY_TOP_UP_100_QUEST_ID)).toBe(false);
 });
 
-test("first top-up quest records paid Polar checkout pollen", async ({
+test("top-up quests ignore Polar checkout pollen", async ({
     apiKey: _apiKey,
     mocks,
 }) => {
@@ -537,46 +535,7 @@ test("first top-up quest records paid Polar checkout pollen", async ({
         eventType: "polar.order.paid",
         userId: user.id,
         pollenCredited: 40,
-        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_MILLIS,
-        amount: 2000,
-        totalAmount: 2400,
-        currency: "usd",
-        customerId: `polar_customer_${user.id}`,
-        productId: "polar_product_20x2",
-        productName: "20 pollen + 20 FREE",
-        productSlug: "v1:product:pack:20x2",
-        metadataJson: JSON.stringify({ source: "test" }),
-        createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
-    });
-
-    await checkQuestsForUser(env, user.id);
-
-    const rewards = await db
-        .select({ questId: schema.rewards.questId })
-        .from(schema.rewards)
-        .where(eq(schema.rewards.userId, user.id));
-    const questIds = new Set(rewards.map((reward) => reward.questId));
-    expect(questIds.has(TOP_UP_SINCE_LAUNCH_QUEST_ID)).toBe(true);
-    expect(questIds.has(TOP_UP_100_SINCE_LAUNCH_QUEST_ID)).toBe(false);
-    expect(questIds.has(LEGACY_FIRST_TOP_UP_QUEST_ID)).toBe(false);
-    expect(questIds.has(LEGACY_TOP_UP_100_QUEST_ID)).toBe(false);
-});
-
-test("top-up quests ignore old Polar orders synced after quest launch", async ({
-    apiKey: _apiKey,
-    mocks,
-}) => {
-    const db = drizzle(env.DB, { schema });
-    const user = await getOnlyUser();
-    await mocks.enable("github", "tinybird");
-
-    await db.insert(schema.polarCheckoutCredits).values({
-        orderId: `polar_order_${user.id}_old_synced_late`,
-        eventId: `polar:${user.id}:old_synced_late`,
-        eventType: "polar.order.paid",
-        userId: user.id,
-        pollenCredited: 40,
-        polarCreatedAt: BEFORE_QUEST_REWARDS_LAUNCH_MILLIS,
+        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_DATE.getTime(),
         amount: 2000,
         totalAmount: 2400,
         currency: "usd",
@@ -628,21 +587,12 @@ test("top-up 100 quest only sums checkout pollen since quest launch", async ({
             BEFORE_QUEST_REWARDS_LAUNCH_MILLIS,
         )
         .run();
-    await db.insert(schema.polarCheckoutCredits).values({
-        orderId: `polar_order_${user.id}_recent_40`,
-        eventId: `polar:${user.id}:recent_40`,
-        eventType: "polar.order.paid",
+    await db.insert(schema.stripeCheckoutCredits).values({
+        sessionId: `cs_test_${user.id}_recent_40`,
+        eventId: `evt_${user.id}_recent_40`,
+        eventType: "checkout.session.completed",
         userId: user.id,
         pollenCredited: 40,
-        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_MILLIS,
-        amount: 2000,
-        totalAmount: 2400,
-        currency: "usd",
-        customerId: `polar_customer_${user.id}`,
-        productId: "polar_product_20x2",
-        productName: "20 pollen + 20 FREE",
-        productSlug: "v1:product:pack:20x2",
-        metadataJson: JSON.stringify({ source: "test" }),
         createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
     });
 
@@ -659,7 +609,7 @@ test("top-up 100 quest only sums checkout pollen since quest launch", async ({
     expect(questIds.has(LEGACY_TOP_UP_100_QUEST_ID)).toBe(false);
 });
 
-test("top-up 100 quest sums Stripe and Polar checkout pollen", async ({
+test("top-up 100 quest sums multiple Stripe checkout rows", async ({
     apiKey: _apiKey,
     mocks,
 }) => {
@@ -675,21 +625,12 @@ test("top-up 100 quest sums Stripe and Polar checkout pollen", async ({
         pollenCredited: 60,
         createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
     });
-    await db.insert(schema.polarCheckoutCredits).values({
-        orderId: `polar_order_${user.id}_partial_40`,
-        eventId: `polar:${user.id}:partial_40`,
-        eventType: "polar.order.paid",
+    await db.insert(schema.stripeCheckoutCredits).values({
+        sessionId: `cs_test_${user.id}_partial_40`,
+        eventId: `evt_${user.id}_partial_40`,
+        eventType: "checkout.session.completed",
         userId: user.id,
         pollenCredited: 40,
-        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_MILLIS,
-        amount: 2000,
-        totalAmount: 2400,
-        currency: "usd",
-        customerId: `polar_customer_${user.id}`,
-        productId: "polar_product_20x2",
-        productName: "20 pollen + 20 FREE",
-        productSlug: "v1:product:pack:20x2",
-        metadataJson: JSON.stringify({ source: "test" }),
         createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
     });
 

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -21,6 +21,8 @@ const QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS = Date.parse(
 const BEFORE_QUEST_REWARDS_LAUNCH_MILLIS =
     QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS - 1;
 const AFTER_QUEST_REWARDS_LAUNCH_DATE = new Date("2026-06-22T00:00:00.000Z");
+const AFTER_QUEST_REWARDS_LAUNCH_MILLIS =
+    AFTER_QUEST_REWARDS_LAUNCH_DATE.getTime();
 
 // Build an issue body the deriver can parse: a "### Reward" heading (when a
 // reward is given) plus a short Goal section for the description.
@@ -535,7 +537,7 @@ test("first top-up quest records paid Polar checkout pollen", async ({
         eventType: "polar.order.paid",
         userId: user.id,
         pollenCredited: 40,
-        polarCreatedAt: Date.parse("2025-11-14T21:11:20.339Z"),
+        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_MILLIS,
         amount: 2000,
         totalAmount: 2400,
         currency: "usd",
@@ -555,6 +557,45 @@ test("first top-up quest records paid Polar checkout pollen", async ({
         .where(eq(schema.rewards.userId, user.id));
     const questIds = new Set(rewards.map((reward) => reward.questId));
     expect(questIds.has(TOP_UP_SINCE_LAUNCH_QUEST_ID)).toBe(true);
+    expect(questIds.has(TOP_UP_100_SINCE_LAUNCH_QUEST_ID)).toBe(false);
+    expect(questIds.has(LEGACY_FIRST_TOP_UP_QUEST_ID)).toBe(false);
+    expect(questIds.has(LEGACY_TOP_UP_100_QUEST_ID)).toBe(false);
+});
+
+test("top-up quests ignore old Polar orders synced after quest launch", async ({
+    apiKey: _apiKey,
+    mocks,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await getOnlyUser();
+    await mocks.enable("github", "tinybird");
+
+    await db.insert(schema.polarCheckoutCredits).values({
+        orderId: `polar_order_${user.id}_old_synced_late`,
+        eventId: `polar:${user.id}:old_synced_late`,
+        eventType: "polar.order.paid",
+        userId: user.id,
+        pollenCredited: 40,
+        polarCreatedAt: BEFORE_QUEST_REWARDS_LAUNCH_MILLIS,
+        amount: 2000,
+        totalAmount: 2400,
+        currency: "usd",
+        customerId: `polar_customer_${user.id}`,
+        productId: "polar_product_20x2",
+        productName: "20 pollen + 20 FREE",
+        productSlug: "v1:product:pack:20x2",
+        metadataJson: JSON.stringify({ source: "test" }),
+        createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
+    });
+
+    await checkQuestsForUser(env, user.id);
+
+    const rewards = await db
+        .select({ questId: schema.rewards.questId })
+        .from(schema.rewards)
+        .where(eq(schema.rewards.userId, user.id));
+    const questIds = new Set(rewards.map((reward) => reward.questId));
+    expect(questIds.has(TOP_UP_SINCE_LAUNCH_QUEST_ID)).toBe(false);
     expect(questIds.has(TOP_UP_100_SINCE_LAUNCH_QUEST_ID)).toBe(false);
     expect(questIds.has(LEGACY_FIRST_TOP_UP_QUEST_ID)).toBe(false);
     expect(questIds.has(LEGACY_TOP_UP_100_QUEST_ID)).toBe(false);
@@ -593,7 +634,7 @@ test("top-up 100 quest only sums checkout pollen since quest launch", async ({
         eventType: "polar.order.paid",
         userId: user.id,
         pollenCredited: 40,
-        polarCreatedAt: Date.now(),
+        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_MILLIS,
         amount: 2000,
         totalAmount: 2400,
         currency: "usd",
@@ -640,7 +681,7 @@ test("top-up 100 quest sums Stripe and Polar checkout pollen", async ({
         eventType: "polar.order.paid",
         userId: user.id,
         pollenCredited: 40,
-        polarCreatedAt: Date.parse("2025-11-14T21:11:20.339Z"),
+        polarCreatedAt: AFTER_QUEST_REWARDS_LAUNCH_MILLIS,
         amount: 2000,
         totalAmount: 2400,
         currency: "usd",


### PR DESCRIPTION
- Removes Polar checkout credits from the launch-era top-up quest evaluator.
- Keeps top_up_since_launch and top_up_100_since_launch based on Stripe checkout credits from 21/06/26 onward.
- Updates quest tests to assert Polar rows do not create launch top-up rewards and Stripe rows still do.