### PR TITLE
fix: reduce top-up quest reward

### DIFF
--- a/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
@@ -99,7 +99,7 @@ const topUpSinceLaunchQuest: QuestDefinition = {
     description: `[Top up](#buy-pollen) Pollen with a credit card. _(from ${QUEST_REWARDS_LAUNCH_DATE_LABEL})_`,
     category: "grow",
     scope: "perUser",
-    rewardAmount: 10,
+    rewardAmount: 5,
     balanceBucket: "tier",
 };
 

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -234,7 +234,7 @@ test("catalog returns quest definitions without ledger stats", async ({
     });
     expectStableCatalogFields(TOP_UP_SINCE_LAUNCH_QUEST_ID, {
         state: "available",
-        rewardAmount: 10,
+        rewardAmount: 5,
         balanceBucket: "tier",
     });
     expectStableCatalogFields(TOP_UP_100_SINCE_LAUNCH_QUEST_ID, {


### PR DESCRIPTION
- Reduces the active Top up Pollen quest reward from 10 to 5 tier pollen.
- Updates the catalog test expectation.
- Leaves existing reward rows untouched.