### PR TITLE
[codex] cleanup dashboard news runtime fetch

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -1,12 +1,8 @@
-import { cn, Surface } from "@pollinations/ui";
-import { type FC, type ReactNode, useEffect, useState } from "react";
+import { Surface } from "@pollinations/ui";
+import type { FC, ReactNode } from "react";
 
-const HIGHLIGHTS_RAW_URL =
-    "https://raw.githubusercontent.com/pollinations/pollinations/news/social/news/highlights.md";
 export const HIGHLIGHTS_GITHUB_URL =
     "https://github.com/pollinations/pollinations/blob/news/social/news/highlights.md";
-
-const DYNAMIC_NEWS_COUNT = 6;
 
 interface Highlight {
     date?: string;
@@ -19,10 +15,6 @@ interface Highlight {
     details?: string[];
 }
 
-/**
- * Pinned news items that stay visible regardless of daily updates.
- * Edit this array to add/remove pinned announcements.
- */
 const PINNED_NEWS: Highlight[] = [
     {
         date: "2026-06-02",
@@ -50,7 +42,6 @@ const PINNED_NEWS: Highlight[] = [
     },
 ];
 
-/** Render markdown links [text](url) as clickable <a> tags, preserving surrounding text. */
 function renderWithLinks(text: string): ReactNode[] {
     const parts: ReactNode[] = [];
     const matches = [...text.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g)];
@@ -79,25 +70,6 @@ function renderWithLinks(text: string): ReactNode[] {
     return parts;
 }
 
-function parseHighlights(md: string): Highlight[] {
-    return md
-        .split("\n")
-        .filter((line) => line.startsWith("- **"))
-        .filter((line) => !line.includes("<!-- app -->"))
-        .map((line) => {
-            const dateMatch = line.match(/^- \*\*(\d{4}-\d{2}-\d{2})\*\*/);
-            const emojiTitleMatch = line.match(/– \*\*(\S+)\s+([^*]+)\*\*/);
-            const descStart = line.lastIndexOf("**") + 2;
-            const description = line.slice(descStart).trim();
-            return {
-                date: dateMatch?.[1] ?? "",
-                emoji: emojiTitleMatch?.[1] ?? "",
-                title: emojiTitleMatch?.[2]?.trim() ?? "",
-                description,
-            };
-        });
-}
-
 function formatNewsDate(date: string): string {
     if (!date) return "";
     const parsed = new Date(`${date}T00:00:00.000Z`);
@@ -110,36 +82,12 @@ function formatNewsDate(date: string): string {
     });
 }
 
-/** Hand-curated, pinned announcements — stacked white cards. */
 export const Announcements: FC = () => {
     if (PINNED_NEWS.length === 0) return null;
     return (
         <div className="flex flex-col gap-3">
             {PINNED_NEWS.map((item) => (
                 <PinnedNews key={item.title} item={item} />
-            ))}
-        </div>
-    );
-};
-
-export const NewsBanner: FC = () => {
-    const [highlights, setHighlights] = useState<Highlight[]>([]);
-
-    useEffect(() => {
-        fetch(HIGHLIGHTS_RAW_URL)
-            .then((res) => res.text())
-            .then((md) =>
-                setHighlights(parseHighlights(md).slice(0, DYNAMIC_NEWS_COUNT)),
-            )
-            .catch((err) => console.error("Failed to fetch highlights:", err));
-    }, []);
-
-    if (highlights.length === 0) return null;
-
-    return (
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {highlights.map((item) => (
-                <DynamicNews key={`${item.date}-${item.title}`} item={item} />
             ))}
         </div>
     );
@@ -173,27 +121,5 @@ const PinnedNews: FC<{ item: Highlight }> = ({ item }) => (
                 ))}
             </ul>
         )}
-    </Surface>
-);
-
-const DynamicNews: FC<{ item: Highlight }> = ({ item }) => (
-    <Surface
-        variant="card"
-        className={cn("flex min-h-48 text-sm leading-relaxed")}
-    >
-        <div className="flex min-h-0 flex-1 flex-col items-start gap-3">
-            <span className="shrink-0 text-2xl leading-none">{item.emoji}</span>
-            <div className="min-w-0">
-                <div className="font-semibold text-ink-900">{item.title}</div>
-                {item.date && (
-                    <div className="mt-1 text-xs font-medium text-theme-text-muted">
-                        {formatNewsDate(item.date)}
-                    </div>
-                )}
-                <p className="mt-1 text-ink-700">
-                    {renderWithLinks(item.description)}
-                </p>
-            </div>
-        </div>
     </Surface>
 );

--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-faq.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-faq.tsx
@@ -1,19 +1,12 @@
 import { ExternalLinkButton, GitHubIcon, Section } from "@pollinations/ui";
 import type { FC } from "react";
 import { FAQ } from "./faq.tsx";
-import {
-    Announcements,
-    HIGHLIGHTS_GITHUB_URL,
-    NewsBanner,
-} from "./news-banner.tsx";
+import { Announcements, HIGHLIGHTS_GITHUB_URL } from "./news-banner.tsx";
 
 export const NewsFaq: FC = () => (
     <div className="flex flex-col gap-6">
-        <Section title="Announcements" framed>
-            <Announcements />
-        </Section>
         <Section
-            title="News"
+            title="Announcements"
             framed
             action={
                 <ExternalLinkButton href={HIGHLIGHTS_GITHUB_URL}>
@@ -24,7 +17,7 @@ export const NewsFaq: FC = () => (
                 </ExternalLinkButton>
             }
         >
-            <NewsBanner />
+            <Announcements />
         </Section>
         <Section title="FAQ" framed>
             <FAQ showTitle={false} />


### PR DESCRIPTION
- Removes the dashboard-side GitHub highlights fetch, markdown parser, and dynamic news card renderer.
- Keeps the pinned announcements and FAQ in place.
- Keeps the GitHub link available from the announcements section for full news history.

Validation:
- `npx biome check --write enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx enter.pollinations.ai/frontend/src/components/news-faq/news-faq.tsx`
- `npm run typecheck --workspace pollinations-enter`
- `git diff --check`

Note: local worktree dependency install hit disk-space limits earlier, so validation used symlinks to the existing installed dependency tree and removed them before commit.