### PR TITLE
refactor: simplify dashboard hash routing

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-routing.ts
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-routing.ts
@@ -1,0 +1,52 @@
+import { type DashboardPage, isDashboardPage } from "./dashboard-theme.ts";
+
+type DashboardHashAliases = Readonly<Partial<Record<string, DashboardPage>>>;
+
+const COMMON_DASHBOARD_HASH_ALIASES = {
+    news: "news-faq",
+    faq: "news-faq",
+    updates: "news-faq",
+    pricing: "models",
+} as const satisfies DashboardHashAliases;
+
+export const AUTHENTICATED_DASHBOARD_HASH_ALIASES = {
+    ...COMMON_DASHBOARD_HASH_ALIASES,
+    "buy-pollen": "pollen",
+    earnings: "activity",
+    usage: "activity",
+    "activity-table": "activity",
+} as const satisfies DashboardHashAliases;
+
+const FAQ_ANCHOR_HASH_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)+$/;
+
+type DashboardPageFromHashOptions = {
+    allowedPages?: ReadonlySet<DashboardPage>;
+    aliases?: DashboardHashAliases;
+    fallbackPage: DashboardPage;
+    faqAnchorPage?: DashboardPage;
+};
+
+export function dashboardPageFromHash(
+    hash: string,
+    {
+        allowedPages,
+        aliases = COMMON_DASHBOARD_HASH_ALIASES,
+        fallbackPage,
+        faqAnchorPage,
+    }: DashboardPageFromHashOptions,
+): DashboardPage {
+    const slug = hash.replace(/^#/, "");
+    const page = isDashboardPage(slug) ? slug : aliases[slug];
+
+    if (page && (!allowedPages || allowedPages.has(page))) return page;
+    if (
+        faqAnchorPage &&
+        slug &&
+        FAQ_ANCHOR_HASH_PATTERN.test(slug) &&
+        (!allowedPages || allowedPages.has(faqAnchorPage))
+    ) {
+        return faqAnchorPage;
+    }
+
+    return fallbackPage;
+}

--- a/enter.pollinations.ai/frontend/src/routes/index.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/index.tsx
@@ -18,10 +18,13 @@ import {
     type CreateApiKeyResponse,
 } from "../components/keys";
 import {
+    AUTHENTICATED_DASHBOARD_HASH_ALIASES,
+    dashboardPageFromHash,
+} from "../components/layout/dashboard-routing.ts";
+import {
     type DashboardPage,
     DashboardShell,
 } from "../components/layout/dashboard-shell.tsx";
-import { isDashboardPage } from "../components/layout/dashboard-theme.ts";
 import { usePageFromHash } from "../components/layout/use-page-from-hash.ts";
 import { Models } from "../components/models";
 import { NewsFaq } from "../components/news-faq";
@@ -36,18 +39,11 @@ import { createKeyWithPermissions } from "../lib/create-api-key.ts";
 const ACTIVITY_MIN_DATE = new Date("2026-01-01T00:00:00.000Z");
 
 function pageFromHash(hash: string): DashboardPage {
-    const page = hash.replace(/^#/, "");
-    if (isDashboardPage(page)) return page;
-    if (page === "news" || page === "faq" || page === "updates")
-        return "news-faq";
-    if (page === "buy-pollen") return "pollen";
-    if (page === "pricing") return "models";
-    if (page === "earnings" || page === "usage" || page === "activity-table")
-        return "activity";
-    // Kebab-case slugs are FAQ anchors — route to news-faq and let the
-    // FAQ component scroll/expand the matching question.
-    if (page && /^[a-z0-9]+(-[a-z0-9]+)+$/.test(page)) return "news-faq";
-    return "pollen";
+    return dashboardPageFromHash(hash, {
+        aliases: AUTHENTICATED_DASHBOARD_HASH_ALIASES,
+        fallbackPage: "pollen",
+        faqAnchorPage: "news-faq",
+    });
 }
 
 export const Route = createFileRoute("/")({

--- a/enter.pollinations.ai/frontend/src/routes/sign-in.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/sign-in.tsx
@@ -2,14 +2,12 @@ import { Button, GitHubIcon } from "@pollinations/ui";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "../auth.ts";
+import { dashboardPageFromHash } from "../components/layout/dashboard-routing.ts";
 import {
     type DashboardPage,
     DashboardShell,
 } from "../components/layout/dashboard-shell.tsx";
-import {
-    DASHBOARD_NAV_ITEMS,
-    isDashboardPage,
-} from "../components/layout/dashboard-theme.ts";
+import { DASHBOARD_NAV_ITEMS } from "../components/layout/dashboard-theme.ts";
 import { usePageFromHash } from "../components/layout/use-page-from-hash.ts";
 import { Models } from "../components/models";
 import { NewsFaq } from "../components/news-faq";
@@ -26,12 +24,10 @@ const SIGNED_OUT_NAV_ITEMS = DASHBOARD_NAV_ITEMS.filter((item) =>
 );
 
 function pageFromHash(hash: string): DashboardPage {
-    const page = hash.replace(/^#/, "");
-    if (isDashboardPage(page) && SIGNED_OUT_PAGES.has(page)) return page;
-    if (page === "news" || page === "faq" || page === "updates")
-        return "news-faq";
-    if (page === "pricing") return "models";
-    return "news-faq";
+    return dashboardPageFromHash(hash, {
+        allowedPages: SIGNED_OUT_PAGES,
+        fallbackPage: "news-faq",
+    });
 }
 
 export const Route = createFileRoute("/sign-in")({


### PR DESCRIPTION
- Adds a shared dashboard hash parser for common aliases and authenticated-only dashboard hashes.
- Updates signed-in and signed-out routes to use the shared parser while preserving existing fallback behavior.
- Keeps OAuth callback hash forwarding untouched and preserves `#buy-pollen`, `#keys`, `#models`, activity aliases, and FAQ anchors.

Checks:
- `npx --prefix /Users/thomash/Documents/GitHub/pollinations biome check --write <changed files>`
- `npm run typecheck --workspace pollinations-enter --ignore-scripts`