### PR TITLE
refactor: share transcription response formatting

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -2266,11 +2266,18 @@ export const audioRoutes = new Hono<Env>()
                 createAudioSecondsUsage(duration),
             );
 
-            const result = formatWhisperResponse(
-                whisper,
+            const result = buildTranscriptionResponse({
+                normalized: {
+                    text: whisper.text,
+                    duration,
+                    words: [],
+                    diarizedSegments: [],
+                    subtitleSegments: whisper.segments ?? [],
+                    verboseJson: { ...whisper },
+                },
                 responseFormat,
                 usageHeaders,
-            );
+            });
             c.var.track.overrideResponseTracking(result.clone());
 
             return result;
@@ -2314,7 +2321,9 @@ const WHISPER_RESPONSE_FORMATS = [
 
 type WhisperResponseFormat = (typeof WHISPER_RESPONSE_FORMATS)[number];
 
-function validateWhisperResponseFormat(responseFormat: string | null): void {
+export function validateWhisperResponseFormat(
+    responseFormat: string | null,
+): void {
     if (
         responseFormat &&
         !WHISPER_RESPONSE_FORMATS.includes(
@@ -2336,64 +2345,4 @@ function extractWhisperUsage(json: WhisperVerboseJson, log: Logger): number {
     }
     log.debug("Whisper usage: {seconds}s", { seconds });
     return seconds;
-}
-
-/** Format SRT/VTT timestamps from seconds. SRT uses a comma, VTT a dot. */
-function formatTimestamp(seconds: number, sep: "," | "."): string {
-    const ms = Math.round(seconds * 1000);
-    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
-    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
-    const s = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
-    const msPart = String(ms % 1000).padStart(3, "0");
-    return `${h}:${m}:${s}${sep}${msPart}`;
-}
-
-function toSubtitles(segments: WhisperSegment[], kind: "srt" | "vtt"): string {
-    const sep = kind === "srt" ? "," : ".";
-    const cues = segments.map((seg, i) => {
-        const time = `${formatTimestamp(seg.start, sep)} --> ${formatTimestamp(seg.end, sep)}`;
-        const head = kind === "srt" ? `${i + 1}\n` : "";
-        return `${head}${time}\n${seg.text.trim()}`;
-    });
-    return kind === "vtt"
-        ? `WEBVTT\n\n${cues.join("\n\n")}\n`
-        : `${cues.join("\n\n")}\n`;
-}
-
-/**
- * Reformat OVH's verbose_json into the caller's requested response_format.
- * Mirrors the ElevenLabs scribe path so behaviour is consistent across backends.
- */
-export function formatWhisperResponse(
-    json: WhisperVerboseJson,
-    responseFormat: string | null,
-    usageHeaders: Record<string, string>,
-): Response {
-    validateWhisperResponseFormat(responseFormat);
-
-    if (responseFormat === "text") {
-        return new Response(json.text, {
-            headers: {
-                "Content-Type": "text/plain; charset=utf-8",
-                ...usageHeaders,
-            },
-        });
-    }
-
-    if (responseFormat === "srt" || responseFormat === "vtt") {
-        return new Response(toSubtitles(json.segments ?? [], responseFormat), {
-            headers: {
-                "Content-Type": "text/plain; charset=utf-8",
-                ...usageHeaders,
-            },
-        });
-    }
-
-    if (responseFormat === "verbose_json") {
-        const { usage: _usage, ...rest } = json;
-        return Response.json(rest, { headers: usageHeaders });
-    }
-
-    // Default: json
-    return Response.json({ text: json.text }, { headers: usageHeaders });
 }

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -4,8 +4,7 @@
  * Providers (ElevenLabs Scribe, AssemblyAI) each normalize their upstream
  * payload into the seconds-based `NormalizedTranscript` intermediate below
  * — keeping their own grouping and unit conversion — then call
- * `buildTranscriptionResponse` to emit the four response branches
- * (text / verbose_json / diarized_json / json) identically.
+ * `buildTranscriptionResponse` to emit the response branches identically.
  */
 
 export interface NormalizedWord {
@@ -21,6 +20,12 @@ export interface NormalizedDiarizedSegment {
     speaker: string | null;
 }
 
+export interface NormalizedSubtitleSegment {
+    start: number;
+    end: number;
+    text: string;
+}
+
 export interface NormalizedTranscript {
     text: string;
     /** ISO-639-1 language code, or undefined if unknown. */
@@ -29,6 +34,9 @@ export interface NormalizedTranscript {
     duration: number;
     words: NormalizedWord[];
     diarizedSegments: NormalizedDiarizedSegment[];
+    subtitleSegments?: NormalizedSubtitleSegment[];
+    /** Provider verbose_json body to preserve when the provider already returned one. */
+    verboseJson?: Record<string, unknown>;
 }
 
 function toOpenAiDiarizedSegments(segments: NormalizedDiarizedSegment[]): {
@@ -49,9 +57,59 @@ function toOpenAiDiarizedSegments(segments: NormalizedDiarizedSegment[]): {
     }));
 }
 
+/** Format SRT/VTT timestamps from seconds. SRT uses a comma, VTT a dot. */
+function formatTimestamp(seconds: number, sep: "," | "."): string {
+    const ms = Math.round(seconds * 1000);
+    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
+    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
+    const s = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
+    const msPart = String(ms % 1000).padStart(3, "0");
+    return `${h}:${m}:${s}${sep}${msPart}`;
+}
+
+function toSubtitles(
+    segments: NormalizedSubtitleSegment[],
+    kind: "srt" | "vtt",
+): string {
+    const sep = kind === "srt" ? "," : ".";
+    const cues = segments.map((seg, i) => {
+        const time = `${formatTimestamp(seg.start, sep)} --> ${formatTimestamp(seg.end, sep)}`;
+        const head = kind === "srt" ? `${i + 1}\n` : "";
+        return `${head}${time}\n${seg.text.trim()}`;
+    });
+    return kind === "vtt"
+        ? `WEBVTT\n\n${cues.join("\n\n")}\n`
+        : `${cues.join("\n\n")}\n`;
+}
+
+function buildVerboseJsonBody(
+    normalized: NormalizedTranscript,
+): Record<string, unknown> {
+    if (normalized.verboseJson) {
+        const { usage: _usage, ...body } = normalized.verboseJson;
+        return body;
+    }
+
+    return {
+        text: normalized.text,
+        task: "transcribe",
+        language: normalized.language || "unknown",
+        duration: normalized.duration,
+        words: normalized.words,
+        segments: [
+            {
+                id: 0,
+                start: 0,
+                end: normalized.duration,
+                text: normalized.text,
+            },
+        ],
+    };
+}
+
 export function buildTranscriptionResponse(opts: {
     normalized: NormalizedTranscript;
-    responseFormat: string;
+    responseFormat?: string | null;
     usageHeaders: Record<string, string>;
 }): Response {
     const { normalized, responseFormat, usageHeaders } = opts;
@@ -67,22 +125,21 @@ export function buildTranscriptionResponse(opts: {
     }
 
     if (responseFormat === "verbose_json") {
-        const body: Record<string, unknown> = {
-            text,
-            task: "transcribe",
-            language: normalized.language || "unknown",
-            duration,
-            words: normalized.words,
-            segments: [
-                {
-                    id: 0,
-                    start: 0,
-                    end: duration,
-                    text,
+        return Response.json(buildVerboseJsonBody(normalized), {
+            headers: usageHeaders,
+        });
+    }
+
+    if (responseFormat === "srt" || responseFormat === "vtt") {
+        return new Response(
+            toSubtitles(normalized.subtitleSegments ?? [], responseFormat),
+            {
+                headers: {
+                    "Content-Type": "text/plain; charset=utf-8",
+                    ...usageHeaders,
                 },
-            ],
-        };
-        return Response.json(body, { headers: usageHeaders });
+            },
+        );
     }
 
     if (responseFormat === "diarized_json") {

--- a/gen.pollinations.ai/test/whisper-format.test.ts
+++ b/gen.pollinations.ai/test/whisper-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatWhisperResponse } from "../src/routes/audio.ts";
+import { validateWhisperResponseFormat } from "../src/routes/audio.ts";
+import { buildTranscriptionResponse } from "../src/routes/transcription-response.ts";
 
 const VERBOSE = {
     text: "El ciclo del agua",
@@ -11,9 +12,24 @@ const VERBOSE = {
 };
 const usageHeaders = { "x-usage-seconds": "3.5" };
 
-describe("formatWhisperResponse", () => {
+function buildWhisperResponse(responseFormat: string | null): Response {
+    return buildTranscriptionResponse({
+        normalized: {
+            text: VERBOSE.text,
+            duration: VERBOSE.usage.seconds,
+            words: [],
+            diarizedSegments: [],
+            subtitleSegments: VERBOSE.segments,
+            verboseJson: { ...VERBOSE },
+        },
+        responseFormat,
+        usageHeaders,
+    });
+}
+
+describe("buildTranscriptionResponse for Whisper", () => {
     it("returns plain text for response_format=text (the #9028 bug)", async () => {
-        const res = formatWhisperResponse(VERBOSE, "text", usageHeaders);
+        const res = buildWhisperResponse("text");
         expect(res.headers.get("content-type")).toBe(
             "text/plain; charset=utf-8",
         );
@@ -22,17 +38,13 @@ describe("formatWhisperResponse", () => {
     });
 
     it("defaults to OpenAI-style { text } json", async () => {
-        const res = formatWhisperResponse(VERBOSE, null, usageHeaders);
+        const res = buildWhisperResponse(null);
         expect(res.headers.get("content-type")).toContain("application/json");
         expect(await res.json()).toEqual({ text: "El ciclo del agua" });
     });
 
     it("strips internal usage from verbose_json", async () => {
-        const res = formatWhisperResponse(
-            VERBOSE,
-            "verbose_json",
-            usageHeaders,
-        );
+        const res = buildWhisperResponse("verbose_json");
         const body = (await res.json()) as Record<string, unknown>;
         expect(body.usage).toBeUndefined();
         expect(body.text).toBe("El ciclo del agua");
@@ -40,7 +52,7 @@ describe("formatWhisperResponse", () => {
     });
 
     it("builds SRT cues from segments", async () => {
-        const res = formatWhisperResponse(VERBOSE, "srt", usageHeaders);
+        const res = buildWhisperResponse("srt");
         const srt = await res.text();
         expect(res.headers.get("content-type")).toBe(
             "text/plain; charset=utf-8",
@@ -50,16 +62,14 @@ describe("formatWhisperResponse", () => {
     });
 
     it("builds VTT with a WEBVTT header and dot separators", async () => {
-        const res = formatWhisperResponse(VERBOSE, "vtt", usageHeaders);
+        const res = buildWhisperResponse("vtt");
         const vtt = await res.text();
         expect(vtt.startsWith("WEBVTT\n\n")).toBe(true);
         expect(vtt).toContain("00:00:00.000 --> 00:00:01.500");
     });
 
     it("rejects unsupported Whisper response formats", () => {
-        expect(() =>
-            formatWhisperResponse(VERBOSE, "diarized_json", usageHeaders),
-        ).toThrow(
+        expect(() => validateWhisperResponseFormat("diarized_json")).toThrow(
             "Unsupported response_format for whisper model: diarized_json",
         );
     });


### PR DESCRIPTION
- Moves Whisper subtitle/text/json response shaping into the shared transcription response builder.
- Preserves OVH verbose_json passthrough behavior while stripping internal usage from client responses.
- Keeps Scribe and AssemblyAI normalized response paths on the same builder.

Checks:
- `npx biome check --write gen.pollinations.ai/src/routes/audio.ts gen.pollinations.ai/src/routes/transcription-response.ts gen.pollinations.ai/test/whisper-format.test.ts`
- `npx vitest run test/whisper-format.test.ts test/assemblyai-transcription.test.ts test/scribe-transcription.test.ts test/transcription-param-parsing.test.ts`
- `npm run typecheck --workspace pollinations-gen`