### PR TITLE
feat: add generation privacy settings

### DIFF
--- a/enter.pollinations.ai/drizzle/0032_generation_preferences.sql
+++ b/enter.pollinations.ai/drizzle/0032_generation_preferences.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `user` ADD `cache_writes_disabled` integer DEFAULT 0 NOT NULL;
+ALTER TABLE `user` ADD `privacy_mode_enabled` integer DEFAULT 0 NOT NULL;

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1782467647638,
       "tag": "0031_lucky_alex_power",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1782555975697,
+      "tag": "0032_generation_preferences",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/routes/index.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Section } from "@pollinations/ui";
+import { Section, Switch } from "@pollinations/ui";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { apiClient } from "../api.ts";
@@ -34,6 +34,108 @@ import { QuestOverview } from "../components/quests";
 import { createKeyWithPermissions } from "../lib/create-api-key.ts";
 
 const ACTIVITY_MIN_DATE = new Date("2026-01-01T00:00:00.000Z");
+
+type GenerationSettingsState = {
+    cacheWritesDisabled: boolean;
+    privacyModeEnabled: boolean;
+};
+
+type GenerationSettingsProps = {
+    initialCacheWritesDisabled: boolean;
+    initialPrivacyModeEnabled: boolean;
+};
+
+function GenerationSettings({
+    initialCacheWritesDisabled,
+    initialPrivacyModeEnabled,
+}: GenerationSettingsProps) {
+    const [settings, setSettings] = useState<GenerationSettingsState>({
+        cacheWritesDisabled: initialCacheWritesDisabled,
+        privacyModeEnabled: initialPrivacyModeEnabled,
+    });
+    const [saving, setSaving] = useState<keyof GenerationSettingsState | null>(
+        null,
+    );
+
+    async function updateSetting(
+        key: keyof GenerationSettingsState,
+        value: boolean,
+    ): Promise<void> {
+        const previous = settings;
+        const next = { ...settings, [key]: value };
+        setSettings(next);
+        setSaving(key);
+
+        try {
+            const response = await apiClient.account.settings.$patch({
+                json: { [key]: value } as Partial<GenerationSettingsState>,
+            });
+            if (!response.ok) {
+                throw new Error(await response.text());
+            }
+            const saved = (await response.json()) as GenerationSettingsState;
+            setSettings(saved);
+        } catch (error) {
+            console.error("Failed to update generation settings", error);
+            setSettings(previous);
+        } finally {
+            setSaving(null);
+        }
+    }
+
+    return (
+        <Section title="Generation settings" framed>
+            <div className="flex flex-col gap-5">
+                <div className="flex min-w-0 items-start justify-between gap-4">
+                    <div className="min-w-0">
+                        <div className="text-sm font-semibold">
+                            Disable cache writes
+                        </div>
+                        <p className="mt-0.5 text-xs text-theme-text-soft">
+                            New generated results are not written to caches.
+                            Cached reads can still be used.
+                        </p>
+                    </div>
+                    <Switch
+                        checked={settings.cacheWritesDisabled}
+                        onChange={(checked) =>
+                            updateSetting("cacheWritesDisabled", checked)
+                        }
+                        disabled={saving !== null}
+                        ariaLabel={
+                            settings.cacheWritesDisabled
+                                ? "Enable cache writes"
+                                : "Disable cache writes"
+                        }
+                    />
+                </div>
+                <div className="flex min-w-0 items-start justify-between gap-4">
+                    <div className="min-w-0">
+                        <div className="text-sm font-semibold">
+                            Privacy mode
+                        </div>
+                        <p className="mt-0.5 text-xs text-theme-text-soft">
+                            Redacts sensitive text with existing safety
+                            guardrails before provider calls.
+                        </p>
+                    </div>
+                    <Switch
+                        checked={settings.privacyModeEnabled}
+                        onChange={(checked) =>
+                            updateSetting("privacyModeEnabled", checked)
+                        }
+                        disabled={saving !== null}
+                        ariaLabel={
+                            settings.privacyModeEnabled
+                                ? "Disable privacy mode"
+                                : "Enable privacy mode"
+                        }
+                    />
+                </div>
+            </div>
+        </Section>
+    );
+}
 
 function pageFromHash(hash: string): DashboardPage {
     const page = hash.replace(/^#/, "");
@@ -91,10 +193,14 @@ export const Route = createFileRoute("/")({
             | undefined;
         const githubUsername =
             profileResult?.githubUsername ?? sessionUser?.githubUsername ?? "";
+        const cacheWritesDisabled = profileResult?.cacheWritesDisabled === true;
+        const privacyModeEnabled = profileResult?.privacyModeEnabled === true;
 
         return {
             user: context.user,
             githubUsername,
+            cacheWritesDisabled,
+            privacyModeEnabled,
             apiKeys,
             tierData,
             tierBalance,
@@ -111,6 +217,8 @@ function RouteComponent() {
     const {
         user,
         githubUsername,
+        cacheWritesDisabled,
+        privacyModeEnabled,
         apiKeys,
         tierData,
         tierBalance,
@@ -298,12 +406,18 @@ function RouteComponent() {
             )}
             {activePage === "quests" && <QuestOverview />}
             {activePage === "keys" && (
-                <ApiKeyList
-                    apiKeys={apiKeys}
-                    onCreate={handleCreateApiKey}
-                    onUpdate={handleUpdateApiKey}
-                    onDelete={handleDeleteApiKey}
-                />
+                <div className="flex flex-col gap-6">
+                    <GenerationSettings
+                        initialCacheWritesDisabled={cacheWritesDisabled}
+                        initialPrivacyModeEnabled={privacyModeEnabled}
+                    />
+                    <ApiKeyList
+                        apiKeys={apiKeys}
+                        onCreate={handleCreateApiKey}
+                        onUpdate={handleUpdateApiKey}
+                        onDelete={handleDeleteApiKey}
+                    />
+                </div>
             )}
             {activePage === "models" && <Models />}
         </DashboardShell>

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -666,6 +666,12 @@ async function respondDetailedUsage(
 // Response schemas for OpenAPI documentation
 const profileResponseSchema = z.object({
     githubUsername: z.string().nullable().describe("GitHub username if linked"),
+    cacheWritesDisabled: z
+        .boolean()
+        .describe("Whether generation cache writes are disabled"),
+    privacyModeEnabled: z
+        .boolean()
+        .describe("Whether generation privacy mode is enabled"),
     image: z
         .string()
         .nullable()
@@ -693,6 +699,23 @@ const profileResponseSchema = z.object({
         .describe(
             "User's email address (only returned when the key has `account:profile`)",
         ),
+});
+
+const accountSettingsRequestSchema = z
+    .object({
+        cacheWritesDisabled: z.boolean().optional(),
+        privacyModeEnabled: z.boolean().optional(),
+    })
+    .refine(
+        (settings) =>
+            settings.cacheWritesDisabled !== undefined ||
+            settings.privacyModeEnabled !== undefined,
+        { message: "At least one setting is required" },
+    );
+
+const accountSettingsResponseSchema = z.object({
+    cacheWritesDisabled: z.boolean(),
+    privacyModeEnabled: z.boolean(),
 });
 
 const balanceResponseSchema = z.object({
@@ -804,6 +827,8 @@ export const accountRoutes = new Hono<Env>()
                     githubUsername: userTable.githubUsername,
                     image: userTable.image,
                     tier: userTable.tier,
+                    cacheWritesDisabled: userTable.cacheWritesDisabled,
+                    privacyModeEnabled: userTable.privacyModeEnabled,
                     name: userTable.name,
                     email: userTable.email,
                 })
@@ -820,12 +845,82 @@ export const accountRoutes = new Hono<Env>()
                 githubUsername: profile.githubUsername ?? null,
                 image: profile.image ?? null,
                 tier: profile.tier,
+                cacheWritesDisabled: profile.cacheWritesDisabled,
+                privacyModeEnabled: profile.privacyModeEnabled,
                 nextResetAt: getNextRefillAt(profile.tier),
                 ...(includeProfilePII && {
                     name: profile.name ?? null,
                     email: profile.email ?? null,
                 }),
             });
+        },
+    )
+    .patch(
+        "/settings",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "Update Generation Settings",
+            description:
+                "Updates account-wide generation settings. Requires session authentication.",
+            responses: {
+                200: {
+                    description: "Updated generation settings",
+                    content: {
+                        "application/json": {
+                            schema: resolver(accountSettingsResponseSchema),
+                        },
+                    },
+                },
+                401: { description: "Unauthorized" },
+                403: {
+                    description:
+                        "Session authentication required to update account settings",
+                },
+            },
+        }),
+        validator("json", accountSettingsRequestSchema),
+        async (c) => {
+            await c.var.auth.requireAuthorization();
+            if (c.var.auth.apiKey) {
+                throw new HTTPException(403, {
+                    message: "Session authentication required",
+                });
+            }
+
+            const user = c.var.auth.requireUser();
+            const body = c.req.valid("json");
+            const updates: {
+                cacheWritesDisabled?: boolean;
+                privacyModeEnabled?: boolean;
+            } = {};
+
+            if (body.cacheWritesDisabled !== undefined) {
+                updates.cacheWritesDisabled = body.cacheWritesDisabled;
+            }
+            if (body.privacyModeEnabled !== undefined) {
+                updates.privacyModeEnabled = body.privacyModeEnabled;
+            }
+
+            const db = drizzle(c.env.DB);
+            await db
+                .update(userTable)
+                .set(updates)
+                .where(eq(userTable.id, user.id));
+
+            const [settings] = await db
+                .select({
+                    cacheWritesDisabled: userTable.cacheWritesDisabled,
+                    privacyModeEnabled: userTable.privacyModeEnabled,
+                })
+                .from(userTable)
+                .where(eq(userTable.id, user.id))
+                .limit(1);
+
+            if (!settings) {
+                throw new HTTPException(404, { message: "User not found" });
+            }
+
+            return c.json(settings);
         },
     )
     .get(

--- a/enter.pollinations.ai/test/integration/account-profile.test.ts
+++ b/enter.pollinations.ai/test/integration/account-profile.test.ts
@@ -20,6 +20,8 @@ describe("GET /api/account/profile", () => {
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
         expect(data).toHaveProperty("tier");
+        expect(data).toHaveProperty("cacheWritesDisabled", false);
+        expect(data).toHaveProperty("privacyModeEnabled", false);
         expect(data).toHaveProperty("nextResetAt");
         expect(data).toHaveProperty("name");
         expect(data).toHaveProperty("email");
@@ -38,6 +40,8 @@ describe("GET /api/account/profile", () => {
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
         expect(data).toHaveProperty("tier");
+        expect(data).toHaveProperty("cacheWritesDisabled", false);
+        expect(data).toHaveProperty("privacyModeEnabled", false);
         expect(data).toHaveProperty("nextResetAt");
         expect(data).not.toHaveProperty("name");
         expect(data).not.toHaveProperty("email");
@@ -90,8 +94,52 @@ describe("GET /api/account/profile", () => {
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
         expect(data).toHaveProperty("tier");
+        expect(data).toHaveProperty("cacheWritesDisabled", false);
+        expect(data).toHaveProperty("privacyModeEnabled", false);
         expect(data).toHaveProperty("nextResetAt");
         expect(data).toHaveProperty("name");
         expect(data).toHaveProperty("email");
+    });
+});
+
+describe("PATCH /api/account/settings", () => {
+    test("session auth updates global generation preferences", async ({
+        sessionToken,
+    }) => {
+        const update = await SELF.fetch(
+            "http://localhost:3000/api/account/settings",
+            {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+                body: JSON.stringify({
+                    cacheWritesDisabled: true,
+                    privacyModeEnabled: true,
+                }),
+            },
+        );
+
+        expect(update.status).toBe(200);
+        await expect(update.json()).resolves.toMatchObject({
+            cacheWritesDisabled: true,
+            privacyModeEnabled: true,
+        });
+
+        const profile = await SELF.fetch(
+            "http://localhost:3000/api/account/profile",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(profile.status).toBe(200);
+        await expect(profile.json()).resolves.toMatchObject({
+            cacheWritesDisabled: true,
+            privacyModeEnabled: true,
+        });
     });
 });

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -10,9 +10,11 @@
 
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { refreshR2ObjectTtl } from "@shared/r2-storage.ts";
+import type { SafetyFeature } from "@shared/schemas/safety.ts";
 import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
 import { createMiddleware } from "hono/factory";
 import type { RequestIdVariables } from "hono/request-id";
+import type { AuthVariables } from "@/middleware/auth.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import {
     cacheMediaResponse,
@@ -22,8 +24,18 @@ import {
 
 type MediaCacheEnv = {
     Bindings: CloudflareBindings;
-    Variables: LoggerVariables & RequestIdVariables;
+    Variables: LoggerVariables & RequestIdVariables & Partial<AuthVariables>;
 };
+
+function cacheWritesDisabled(c: { var: Partial<AuthVariables> }): boolean {
+    return c.var.auth?.user?.cacheWritesDisabled === true;
+}
+
+function defaultSafetyFeatures(c: {
+    var: Partial<AuthVariables>;
+}): SafetyFeature[] {
+    return c.var.auth?.user?.privacyModeEnabled === true ? ["privacy"] : [];
+}
 
 type MediaCacheConfig = {
     /** Content types to cache, e.g. ["image/", "video/"] or ["audio/"] */
@@ -44,11 +56,17 @@ export function createMediaCache(config: MediaCacheConfig) {
             return next();
         }
 
+        const accountSafetyFeatures = defaultSafetyFeatures(c);
         const cacheKey = generateCacheKey(
             new URL(c.req.url),
             c.req.header(SAFETY_HEADER_NAME),
+            {
+                defaultSafetyFeatures: accountSafetyFeatures,
+                opaque: accountSafetyFeatures.length > 0,
+            },
         );
         log.debug("Cache key: {key}", { key: cacheKey });
+        const skipCacheWrites = cacheWritesDisabled(c);
 
         try {
             const cached = await c.env.IMAGE_BUCKET.get(cacheKey);
@@ -64,18 +82,20 @@ export function createMediaCache(config: MediaCacheConfig) {
                 c.header("X-Cache", "HIT");
                 c.header("X-Cache-Type", "EXACT");
                 return c.body(
-                    refreshR2ObjectTtl(
-                        c.env.IMAGE_BUCKET,
-                        cacheKey,
-                        cached,
-                        (promise) => c.executionCtx.waitUntil(promise),
-                        (error) => {
-                            log.error(
-                                "Error refreshing media cache TTL: {error}",
-                                { error },
-                            );
-                        },
-                    ),
+                    skipCacheWrites
+                        ? cached.body
+                        : refreshR2ObjectTtl(
+                              c.env.IMAGE_BUCKET,
+                              cacheKey,
+                              cached,
+                              (promise) => c.executionCtx.waitUntil(promise),
+                              (error) => {
+                                  log.error(
+                                      "Error refreshing media cache TTL: {error}",
+                                      { error },
+                                  );
+                              },
+                          ),
                 );
             }
 
@@ -93,6 +113,12 @@ export function createMediaCache(config: MediaCacheConfig) {
         const isMatchingContent = config.mediaTypes.some((type) =>
             contentType?.includes(type),
         );
+        if (c.res?.ok && isMatchingContent && skipCacheWrites) {
+            log.debug("Cache writes disabled for user");
+            c.res.headers.set("X-Cache-Write", "SKIP");
+            return;
+        }
+
         if (c.res?.ok && isMatchingContent && xCache !== "HIT") {
             log.debug("Caching response");
             cacheMediaResponse(

--- a/gen.pollinations.ai/src/middleware/safety.ts
+++ b/gen.pollinations.ai/src/middleware/safety.ts
@@ -2,11 +2,12 @@ import type {
     CreateChatCompletionRequest,
     MessageContentPart,
 } from "@shared/schemas/openai.ts";
-import type { SafeValue } from "@shared/schemas/safety.ts";
+import type { SafetyFeature, SafeValue } from "@shared/schemas/safety.ts";
 import {
     invalidSafeTokens,
     normalizeSafeValue,
     parseSafeFeatures,
+    SAFETY_FEATURES,
     SAFETY_HEADER_NAME,
     VALID_SAFE_TOKENS,
 } from "@shared/schemas/safety.ts";
@@ -46,13 +47,13 @@ export async function applySafetyToTexts(
     bodySafe?: SafeValue,
 ): Promise<string[]> {
     const safeValue = resolveSafeValue(c, bodySafe);
-    const features = getRequestFeatures(safeValue);
+    const features = getRequestFeatures(c, safeValue);
     if (features.size === 0) return texts;
 
     const guardrailInputs = selectGuardrailInputs(texts);
     if (guardrailInputs.length === 0) return texts;
 
-    setSafetyHeader(c, "X-Safety-Applied", [...features].join(","));
+    setSafetyHeader(c, "X-Safety-Applied", formatSafetyFeatures(features));
 
     let response: BedrockResponse;
     try {
@@ -155,6 +156,10 @@ function resolveSafeValue(
         return providedSafe;
     }
     return c.req.query("safe") ?? c.req.header(SAFETY_HEADER_NAME);
+}
+
+function isAccountPrivacyModeEnabled(c: SafetyContext): boolean {
+    return c.var.auth?.user?.privacyModeEnabled === true;
 }
 
 export function withSafetyHeaders(
@@ -282,7 +287,7 @@ function isTextPart(part: MessageContentPart): part is MessageContentPart & {
     return part.type === "text" && typeof part.text === "string";
 }
 
-function getRequestFeatures(safeValue: SafeValue) {
+function getRequestFeatures(c: SafetyContext, safeValue: SafeValue) {
     const normalized = normalizeSafeValue(safeValue);
     const invalid = invalidSafeTokens(normalized);
     if (invalid.length > 0) {
@@ -294,7 +299,16 @@ function getRequestFeatures(safeValue: SafeValue) {
         });
     }
 
-    return parseSafeFeatures(normalized);
+    const features = parseSafeFeatures(normalized);
+    if (isAccountPrivacyModeEnabled(c)) {
+        features.add("privacy");
+    }
+
+    return features;
+}
+
+function formatSafetyFeatures(features: Set<SafetyFeature>): string {
+    return SAFETY_FEATURES.filter((feature) => features.has(feature)).join(",");
 }
 
 function safetyError(

--- a/gen.pollinations.ai/src/middleware/text-cache.ts
+++ b/gen.pollinations.ai/src/middleware/text-cache.ts
@@ -5,8 +5,10 @@
  */
 
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
+import type { SafetyFeature } from "@shared/schemas/safety.ts";
 import { createMiddleware } from "hono/factory";
 import type { RequestIdVariables } from "hono/request-id";
+import type { AuthVariables } from "@/middleware/auth.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import {
     createCaptureStream,
@@ -16,8 +18,18 @@ import {
 
 type TextCacheEnv = {
     Bindings: CloudflareBindings;
-    Variables: LoggerVariables & RequestIdVariables;
+    Variables: LoggerVariables & RequestIdVariables & Partial<AuthVariables>;
 };
+
+function cacheWritesDisabled(c: { var: Partial<AuthVariables> }): boolean {
+    return c.var.auth?.user?.cacheWritesDisabled === true;
+}
+
+function defaultSafetyFeatures(c: {
+    var: Partial<AuthVariables>;
+}): SafetyFeature[] {
+    return c.var.auth?.user?.privacyModeEnabled === true ? ["privacy"] : [];
+}
 
 /**
  * Text cache middleware
@@ -79,14 +91,20 @@ export const textCache = createMiddleware<TextCacheEnv>(async (c, next) => {
     }
 
     // Generate cache key
-    const cacheKey = await generateCacheKey(c.req.raw, bodyText);
+    const accountSafetyFeatures = defaultSafetyFeatures(c);
+    const cacheKey = await generateCacheKey(c.req.raw, bodyText, {
+        defaultSafetyFeatures: accountSafetyFeatures,
+    });
     log.debug("[TEXT-CACHE] Cache key: {key}", {
         key: `${cacheKey.substring(0, 16)}...`,
     });
+    const skipCacheWrites = cacheWritesDisabled(c);
 
     // Try to get from cache
     try {
-        const cachedResponse = await getCachedResponse(c, cacheKey);
+        const cachedResponse = await getCachedResponse(c, cacheKey, {
+            refreshTtl: !skipCacheWrites,
+        });
         if (cachedResponse) {
             log.info("[TEXT-CACHE] Cache HIT");
             return cachedResponse;
@@ -107,6 +125,13 @@ export const textCache = createMiddleware<TextCacheEnv>(async (c, next) => {
         log.debug("[TEXT-CACHE] Not caching non-OK response: {status}", {
             status: c.res?.status,
         });
+        return;
+    }
+
+    if (skipCacheWrites) {
+        log.debug("[TEXT-CACHE] Cache writes disabled for user");
+        c.res.headers.set("X-Cache", "MISS");
+        c.res.headers.set("X-Cache-Write", "SKIP");
         return;
     }
 

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Logger } from "@logtape/logtape";
+import type { SafetyFeature } from "@shared/schemas/safety.ts";
 import { parseSafeFeatures } from "@shared/schemas/safety.ts";
 import { removeUnset } from "@shared/util.ts";
 import type { Context } from "hono";
@@ -21,11 +22,29 @@ function hasActiveSafety(value: string | null | undefined): boolean {
     return parseSafeFeatures(value).size > 0;
 }
 
-export function generateCacheKey(url: URL, safeHeader?: string | null): string {
+function normalizeSafetyFeatures(
+    features: readonly SafetyFeature[] | undefined,
+): string {
+    return [...new Set(features ?? [])].sort().join(",");
+}
+
+type GenerateCacheKeyOptions = {
+    defaultSafetyFeatures?: readonly SafetyFeature[];
+    opaque?: boolean;
+};
+
+export function generateCacheKey(
+    url: URL,
+    safeHeader?: string | null,
+    options: GenerateCacheKeyOptions = {},
+): string {
     const normalizedUrl = new URL(url);
     const hasQuerySafe = normalizedUrl.searchParams.has("safe");
     const usesSafety = hasActiveSafety(normalizedUrl.searchParams.get("safe"));
     const usesHeaderSafety = !hasQuerySafe && hasActiveSafety(safeHeader);
+    const defaultSafetyFeatures = normalizeSafetyFeatures(
+        options.defaultSafetyFeatures,
+    );
     const params = Array.from(normalizedUrl.searchParams.entries()).sort(
         ([keyA], [keyB]) => keyA.localeCompare(keyB),
     );
@@ -39,12 +58,21 @@ export function generateCacheKey(url: URL, safeHeader?: string | null): string {
     if (safeHeader !== undefined && safeHeader !== null && !hasQuerySafe) {
         normalizedUrl.searchParams.append("__safe_header", safeHeader);
     }
-    if (usesSafety || usesHeaderSafety) {
+    if (defaultSafetyFeatures) {
+        normalizedUrl.searchParams.append(
+            "__default_safe",
+            defaultSafetyFeatures,
+        );
+    }
+    if (usesSafety || usesHeaderSafety || defaultSafetyFeatures) {
         normalizedUrl.searchParams.append("__safety", SAFETY_CACHE_VERSION);
     }
 
     const fullPath = normalizedUrl.pathname + normalizedUrl.search;
     const hash = createHash(fullPath);
+    if (options.opaque) {
+        return `private-${hash}`;
+    }
     const safePath = fullPath.replace(/[/\s?=&]/g, "_");
     const trimmedPath = safePath.substring(0, 990);
 

--- a/gen.pollinations.ai/src/utils/text-cache.ts
+++ b/gen.pollinations.ai/src/utils/text-cache.ts
@@ -7,6 +7,7 @@
 import type { Logger } from "@logtape/logtape";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { refreshR2ObjectTtl } from "@shared/r2-storage.ts";
+import type { SafetyFeature } from "@shared/schemas/safety.ts";
 import {
     parseSafeFeatures,
     SAFETY_HEADER_NAME,
@@ -26,6 +27,16 @@ function hasActiveSafety(value: unknown): boolean {
     );
 }
 
+function normalizeSafetyFeatures(
+    features: readonly SafetyFeature[] | undefined,
+): string {
+    return [...new Set(features ?? [])].sort().join(",");
+}
+
+type GenerateCacheKeyOptions = {
+    defaultSafetyFeatures?: readonly SafetyFeature[];
+};
+
 /**
  * Generate a cache key for the request using SHA-256 hash
  * Handles both GET and POST requests
@@ -36,6 +47,7 @@ function hasActiveSafety(value: unknown): boolean {
 export async function generateCacheKey(
     request: Request,
     bodyText?: string,
+    options: GenerateCacheKeyOptions = {},
 ): Promise<string> {
     const url = new URL(request.url);
 
@@ -61,6 +73,13 @@ export async function generateCacheKey(
     const hasQuerySafe = url.searchParams.has("safe");
     let hasBodySafe = false;
     let usesSafety = hasActiveSafety(url.searchParams.get("safe"));
+    const defaultSafetyFeatures = normalizeSafetyFeatures(
+        options.defaultSafetyFeatures,
+    );
+    if (defaultSafetyFeatures) {
+        parts.push(`default-safe:${defaultSafetyFeatures}`);
+        usesSafety = true;
+    }
 
     // Add filtered body for POST/PUT requests
     if (bodyText && (request.method === "POST" || request.method === "PUT")) {
@@ -144,6 +163,7 @@ type TextCacheEnv = {
 export async function getCachedResponse<TEnv extends TextCacheEnv>(
     c: Context<TEnv>,
     key: string,
+    options: { refreshTtl?: boolean } = {},
 ): Promise<Response | null> {
     try {
         const cachedObject = await c.env.TEXT_BUCKET.get(key);
@@ -175,18 +195,21 @@ export async function getCachedResponse<TEnv extends TextCacheEnv>(
         // Browser cache: immutable since same request = same response
         headers.set("Cache-Control", IMMUTABLE_CACHE_CONTROL);
 
-        const responseBody = refreshR2ObjectTtl(
-            c.env.TEXT_BUCKET,
-            key,
-            cachedObject,
-            (promise) => c.executionCtx.waitUntil(promise),
-            (error) => {
-                c.get("log")?.error(
-                    "[TEXT-CACHE] Error refreshing cached response TTL: {error}",
-                    { error },
-                );
-            },
-        );
+        const responseBody =
+            options.refreshTtl === false
+                ? cachedObject.body
+                : refreshR2ObjectTtl(
+                      c.env.TEXT_BUCKET,
+                      key,
+                      cachedObject,
+                      (promise) => c.executionCtx.waitUntil(promise),
+                      (error) => {
+                          c.get("log")?.error(
+                              "[TEXT-CACHE] Error refreshing cached response TTL: {error}",
+                              { error },
+                          );
+                      },
+                  );
 
         // Create response from cached object
         return new Response(responseBody, {

--- a/gen.pollinations.ai/test/error-observability.test.ts
+++ b/gen.pollinations.ai/test/error-observability.test.ts
@@ -186,6 +186,77 @@ describe("error observability", () => {
         });
     });
 
+    it("redacts request inputs in error events when account privacy mode is enabled", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+
+        const app = new Hono<Env>();
+        app.use("*", requestId());
+        app.use("*", logger);
+        app.post("/v1/chat/completions", async (c) => {
+            const user = {
+                id: "user-privacy-mode",
+                privacyModeEnabled: true,
+            } as NonNullable<Env["Variables"]["auth"]["user"]>;
+            c.set("auth", {
+                user,
+                requireAuthorization: async () => {},
+                requireUser: () => user,
+                requireModelAccess: () => {},
+            });
+            await c.req.json();
+            throw new Error("privacy-mode failure");
+        });
+        app.onError(handleError);
+
+        const ctx = createExecutionContext();
+        const response = await app.fetch(
+            new Request(
+                "https://gen.pollinations.ai/v1/chat/completions?system=secret",
+                {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify({
+                        model: "openai",
+                        messages: [
+                            {
+                                role: "user",
+                                content: "email a@example.com",
+                            },
+                        ],
+                    }),
+                },
+            ),
+            {
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(500);
+        expect(tinybirdRequests).toHaveLength(1);
+        const tinybirdPayload = (await tinybirdRequests[0].json()) as Record<
+            string,
+            unknown
+        >;
+        expect(tinybirdPayload).toMatchObject({
+            kind: "server_error",
+            request_inputs: JSON.stringify({ privacy: "redacted" }),
+        });
+    });
+
     it("does not mask 5xx errors when no route matched", async () => {
         const tinybirdRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -8,6 +8,7 @@ import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { Hono } from "hono";
 import type { RequestIdVariables } from "hono/request-id";
 import { describe, expect, it } from "vitest";
+import type { AuthVariables } from "@/middleware/auth.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { audioCache, imageCache } from "@/middleware/media-cache.ts";
 
@@ -21,17 +22,44 @@ const testLog = {
 
 type TestEnv = {
     Bindings: CloudflareBindings;
-    Variables: LoggerVariables & RequestIdVariables;
+    Variables: LoggerVariables & RequestIdVariables & Partial<AuthVariables>;
 };
 
 type MediaCache = typeof imageCache;
 
-function createMediaCacheApp(cache: MediaCache, contentType: string) {
+function createAuthState(opts: {
+    cacheWritesDisabled?: boolean;
+    privacyModeEnabled?: boolean;
+}): AuthVariables["auth"] {
+    const user = {
+        id: "user-cache-pref",
+        cacheWritesDisabled: opts.cacheWritesDisabled === true,
+        privacyModeEnabled: opts.privacyModeEnabled === true,
+    } as NonNullable<AuthVariables["auth"]["user"]>;
+    return {
+        user,
+        requireAuthorization: async () => {},
+        requireUser: () => user,
+        requireModelAccess: () => {},
+    };
+}
+
+function createMediaCacheApp(
+    cache: MediaCache,
+    contentType: string,
+    opts: { cacheWritesDisabled?: boolean; privacyModeEnabled?: boolean } = {},
+) {
     let originHits = 0;
     const app = new Hono<TestEnv>()
         .use("*", async (c, next) => {
             c.set("log", testLog);
             c.set("requestId", "test-request");
+            if (
+                typeof opts.cacheWritesDisabled === "boolean" ||
+                typeof opts.privacyModeEnabled === "boolean"
+            ) {
+                c.set("auth", createAuthState(opts));
+            }
             await next();
         })
         .get(
@@ -163,6 +191,100 @@ describe("media cache", () => {
         expect(await consumeAndWait(cached)).toBe("origin:1");
         expect(cached.response.headers.get("X-Cache")).toBe("HIT");
         expect(media.originHits).toBe(1);
+        expect(bucket.putCount).toBe(2);
+    });
+
+    it("skips media cache writes for users with cache writes disabled", async () => {
+        const media = createMediaCacheApp(imageCache, "image/png", {
+            cacheWritesDisabled: true,
+        });
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/no-write";
+
+        const first = await dispatch(
+            media.app,
+            path,
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+        expect(await consumeAndWait(first)).toBe("origin:1");
+        expect(first.response.headers.get("X-Cache-Write")).toBe("SKIP");
+        expect(bucket.putCount).toBe(0);
+
+        const second = await dispatch(
+            media.app,
+            path,
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+        expect(await consumeAndWait(second)).toBe("origin:2");
+        expect(second.response.headers.get("X-Cache-Write")).toBe("SKIP");
+        expect(media.originHits).toBe(2);
+        expect(bucket.putCount).toBe(0);
+    });
+
+    it("serves media cache hits without TTL refresh when cache writes are disabled", async () => {
+        const writer = createMediaCacheApp(imageCache, "image/png");
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/read-existing";
+
+        const warm = await dispatch(
+            writer.app,
+            path,
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+        expect(await consumeAndWait(warm)).toBe("origin:1");
+        expect(bucket.putCount).toBe(1);
+
+        const reader = createMediaCacheApp(imageCache, "image/png", {
+            cacheWritesDisabled: true,
+        });
+        const cached = await dispatch(reader.app, path, undefined, env);
+        expect(await consumeAndWait(cached)).toBe("origin:1");
+        expect(cached.response.headers.get("X-Cache")).toBe("HIT");
+        expect(reader.originHits).toBe(0);
+        expect(bucket.putCount).toBe(1);
+    });
+
+    it("does not serve non-privacy media cache entries to privacy-mode users", async () => {
+        const writer = createMediaCacheApp(imageCache, "image/png");
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/privacy-namespace";
+
+        const warm = await dispatch(
+            writer.app,
+            path,
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+        expect(await consumeAndWait(warm)).toBe("origin:1");
+        expect(bucket.putCount).toBe(1);
+
+        const reader = createMediaCacheApp(imageCache, "image/png", {
+            privacyModeEnabled: true,
+        });
+        const privacyModeResponse = await dispatch(
+            reader.app,
+            path,
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+        expect(await consumeAndWait(privacyModeResponse)).toBe("origin:1");
+        expect(reader.originHits).toBe(1);
         expect(bucket.putCount).toBe(2);
     });
 });

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -43,6 +43,18 @@ function safetyApp() {
         .use("*", async (c, next) => {
             c.set("log", testLog);
             c.set("requestId", "test-request");
+            if (c.req.header("x-test-privacy-mode") === "true") {
+                const user = {
+                    id: "user-privacy-mode",
+                    privacyModeEnabled: true,
+                } as NonNullable<Env["Variables"]["auth"]["user"]>;
+                c.set("auth", {
+                    user,
+                    requireAuthorization: async () => {},
+                    requireUser: () => user,
+                    requireModelAccess: () => {},
+                });
+            }
             await next();
         })
         .get("/scan/:text", async (c) => {
@@ -163,6 +175,62 @@ describe("applySafety", { timeout: 30000 }, () => {
         expect(await response.text()).toBe("email {EMAIL}");
         expect(response.headers.get("X-Safety-Applied")).toBe("privacy");
         expect(response.headers.get("X-Safety-Redacted")).toBe("EMAIL");
+    });
+
+    it("applies account privacy mode when safe is omitted", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "a@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
+            },
+            [{ text: "email {EMAIL}" }],
+        );
+
+        const response = await safetyApp().request(
+            "/scan/email%20a%40example.com",
+            { headers: { "x-test-privacy-mode": "true" } },
+            configuredEnv,
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("email {EMAIL}");
+        expect(response.headers.get("X-Safety-Applied")).toBe("privacy");
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it("does not let safe=false disable account privacy mode", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "a@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
+            },
+            [{ text: "email {EMAIL}" }],
+        );
+
+        const response = await safetyApp().request(
+            "/scan/email%20a%40example.com?safe=false",
+            { headers: { "x-test-privacy-mode": "true" } },
+            configuredEnv,
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("email {EMAIL}");
+        expect(response.headers.get("X-Safety-Applied")).toBe("privacy");
+        expect(fetchMock).toHaveBeenCalledOnce();
     });
 
     it("accepts safety from the request header", async () => {
@@ -514,6 +582,21 @@ describe("safety cache keys", () => {
         expect(withQueryOverride).not.toBe(withHeaderSafety);
     });
 
+    it("separates text cache keys when account privacy mode is active", async () => {
+        const noSafety = await generateTextCacheKey(
+            new Request("https://gen.pollinations.ai/text/hello?model=openai"),
+        );
+        const withAccountPrivacy = await generateTextCacheKey(
+            new Request(
+                "https://gen.pollinations.ai/text/hello?model=openai&safe=false",
+            ),
+            undefined,
+            { defaultSafetyFeatures: ["privacy"] },
+        );
+
+        expect(withAccountPrivacy).not.toBe(noSafety);
+    });
+
     it("adds a visible safety namespace to media cache keys when safe is active", () => {
         const withSafety = generateMediaCacheKey(
             new URL("https://gen.pollinations.ai/image/hello?safe=true"),
@@ -524,6 +607,19 @@ describe("safety cache keys", () => {
 
         expect(withSafety).toContain("safety_bedrock-input-v1");
         expect(withoutSafety).not.toContain("safety_bedrock-input-v1");
+    });
+
+    it("uses opaque media cache keys when account privacy mode is active", () => {
+        const withAccountPrivacy = generateMediaCacheKey(
+            new URL(
+                "https://gen.pollinations.ai/image/email%20a%40example.com",
+            ),
+            null,
+            { defaultSafetyFeatures: ["privacy"], opaque: true },
+        );
+
+        expect(withAccountPrivacy).toMatch(/^private-[a-f0-9]+$/);
+        expect(withAccountPrivacy).not.toContain("email");
     });
 
     it("adds header safety to media cache keys", () => {

--- a/gen.pollinations.ai/test/text-cache.test.ts
+++ b/gen.pollinations.ai/test/text-cache.test.ts
@@ -10,6 +10,7 @@ import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { Hono } from "hono";
 import type { RequestIdVariables } from "hono/request-id";
 import { describe, expect, it } from "vitest";
+import type { AuthVariables } from "@/middleware/auth.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { textCache } from "@/middleware/text-cache.ts";
 
@@ -23,15 +24,40 @@ const testLog = {
 
 type TestEnv = {
     Bindings: CloudflareBindings;
-    Variables: LoggerVariables & RequestIdVariables;
+    Variables: LoggerVariables & RequestIdVariables & Partial<AuthVariables>;
 };
 
-function createTextCacheApp() {
+function createAuthState(opts: {
+    cacheWritesDisabled?: boolean;
+    privacyModeEnabled?: boolean;
+}): AuthVariables["auth"] {
+    const user = {
+        id: "user-cache-pref",
+        cacheWritesDisabled: opts.cacheWritesDisabled === true,
+        privacyModeEnabled: opts.privacyModeEnabled === true,
+    } as NonNullable<AuthVariables["auth"]["user"]>;
+    return {
+        user,
+        requireAuthorization: async () => {},
+        requireUser: () => user,
+        requireModelAccess: () => {},
+    };
+}
+
+function createTextCacheApp(
+    opts: { cacheWritesDisabled?: boolean; privacyModeEnabled?: boolean } = {},
+) {
     let originHits = 0;
     const app = new Hono<TestEnv>()
         .use("*", async (c, next) => {
             c.set("log", testLog);
             c.set("requestId", "test-request");
+            if (
+                typeof opts.cacheWritesDisabled === "boolean" ||
+                typeof opts.privacyModeEnabled === "boolean"
+            ) {
+                c.set("auth", createAuthState(opts));
+            }
             await next();
         })
         .post(
@@ -309,6 +335,72 @@ describe("text cache", () => {
         expect(second.response.headers.get("X-Cache")).toBe("HIT");
         expect(body).toBe("hit:1:ttl-refresh");
         expect(cache.originHits).toBe(1);
+        expect(bucket.putCount).toBe(2);
+    });
+
+    it("skips text cache writes for users with cache writes disabled", async () => {
+        const cache = createTextCacheApp({ cacheWritesDisabled: true });
+        const { app } = cache;
+        const bucket = createTestR2Bucket();
+        const env = createTextCacheEnv(bucket);
+        const path = "/text/no-write?model=openai-fast";
+
+        const first = await dispatch(app, path, undefined, env);
+        expect(await consumeAndWait(first)).toBe("hit:1:no-write");
+        expect(first.response.headers.get("X-Cache")).toBe("MISS");
+        expect(first.response.headers.get("X-Cache-Write")).toBe("SKIP");
+        expect(bucket.putCount).toBe(0);
+
+        const second = await dispatch(app, path, undefined, env);
+        expect(await consumeAndWait(second)).toBe("hit:2:no-write");
+        expect(second.response.headers.get("X-Cache")).toBe("MISS");
+        expect(second.response.headers.get("X-Cache-Write")).toBe("SKIP");
+        expect(cache.originHits).toBe(2);
+        expect(bucket.putCount).toBe(0);
+    });
+
+    it("serves text cache hits without TTL refresh when cache writes are disabled", async () => {
+        const writer = createTextCacheApp();
+        const bucket = createTestR2Bucket();
+        const env = createTextCacheEnv(bucket);
+        const path = "/text/read-existing?model=openai-fast";
+
+        const warm = await dispatch(writer.app, path, undefined, env);
+        expect(await consumeAndWait(warm)).toBe("hit:1:read-existing");
+        expect(bucket.putCount).toBe(1);
+
+        const reader = createTextCacheApp({ cacheWritesDisabled: true });
+        const cached = await dispatch(reader.app, path, undefined, env);
+        expect(await consumeAndWait(cached)).toBe("hit:1:read-existing");
+        expect(cached.response.headers.get("X-Cache")).toBe("HIT");
+        expect(reader.originHits).toBe(0);
+        expect(bucket.putCount).toBe(1);
+    });
+
+    it("does not serve non-privacy text cache entries to privacy-mode users", async () => {
+        const writer = createTextCacheApp();
+        const bucket = createTestR2Bucket();
+        const env = createTextCacheEnv(bucket);
+        const path = "/text/privacy-namespace?model=openai-fast";
+
+        const warm = await dispatch(writer.app, path, undefined, env);
+        expect(await consumeAndWait(warm)).toBe("hit:1:privacy-namespace");
+        expect(bucket.putCount).toBe(1);
+
+        const reader = createTextCacheApp({ privacyModeEnabled: true });
+        const privacyModeResponse = await dispatch(
+            reader.app,
+            path,
+            undefined,
+            env,
+        );
+        expect(await consumeAndWait(privacyModeResponse)).toBe(
+            "hit:1:privacy-namespace",
+        );
+        expect(privacyModeResponse.response.headers.get("X-Cache")).toBe(
+            "MISS",
+        );
+        expect(reader.originHits).toBe(1);
         expect(bucket.putCount).toBe(2);
     });
 

--- a/shared/auth/additional-fields.ts
+++ b/shared/auth/additional-fields.ts
@@ -13,5 +13,15 @@ export const authAdditionalFields = {
             defaultValue: "spore",
             input: false,
         },
+        cacheWritesDisabled: {
+            type: "boolean",
+            defaultValue: false,
+            input: false,
+        },
+        privacyModeEnabled: {
+            type: "boolean",
+            defaultValue: false,
+            input: false,
+        },
     },
 } as const;

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -38,6 +38,12 @@ export const user = sqliteTable("user", {
     .default(sql`0`)
     .notNull(),
   autoTopUpAmountUsd: integer("auto_top_up_amount_usd"),
+  cacheWritesDisabled: integer("cache_writes_disabled", { mode: "boolean" })
+    .default(sql`0`)
+    .notNull(),
+  privacyModeEnabled: integer("privacy_mode_enabled", { mode: "boolean" })
+    .default(sql`0`)
+    .notNull(),
 }, (table) => [
   index("idx_user_email").on(table.email),
   index("idx_user_auto_top_up_enabled").on(table.autoTopUpEnabled),

--- a/shared/observability/request-inputs.ts
+++ b/shared/observability/request-inputs.ts
@@ -4,6 +4,7 @@ export type RequestInputs = {
     params?: Record<string, string>;
     query?: Record<string, string | string[]>;
     body?: unknown;
+    privacy?: "redacted";
 };
 
 const BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -16,6 +17,10 @@ const CREDENTIAL_QUERY_PARAMS = new Set([
 const REDACTED = "[redacted]";
 
 export async function collectRequestInputs(c: Context): Promise<RequestInputs> {
+    if (privacyModeEnabled(c)) {
+        return { privacy: "redacted" };
+    }
+
     const inputs: RequestInputs = {
         params: removeEmptyRecord(safeParams(c)),
         query: removeEmptyRecord(queryParams(c)),
@@ -27,6 +32,16 @@ export async function collectRequestInputs(c: Context): Promise<RequestInputs> {
     }
 
     return removeUndefined(inputs);
+}
+
+function privacyModeEnabled(c: Context): boolean {
+    return (
+        (
+            c.var as {
+                auth?: { user?: { privacyModeEnabled?: boolean } };
+            }
+        ).auth?.user?.privacyModeEnabled === true
+    );
 }
 
 // Hono's c.req.param() throws TypeError when called on a request that didn't


### PR DESCRIPTION
- Adds account-level generation settings for cache-write opt-out and privacy mode.
- Skips gen cache writes/TTL refreshes when disabled while preserving cache reads.
- Enables existing privacy guardrails for text/image/audio prompts when privacy mode is on.
- Leaves embeddings routes untouched.

Checks:
- npx biome check --write targeted files
- npm run test -- safety.test.ts text-cache.test.ts media-cache.test.ts error-observability.test.ts
- npm exec -- vitest run integration/account-profile.test.ts -t "session auth|global generation preferences"
- npm run typecheck --prefix gen.pollinations.ai
- Enter/frontend typecheck currently fail on existing main: github-contributions.ts CloudflareBindings credential typing.
