### PR TITLE
docs: document publishable keys replaced by BYOP in authentication.md

### DIFF
--- a/gen.pollinations.ai/src/docs/authentication.md
+++ b/gen.pollinations.ai/src/docs/authentication.md
@@ -2,14 +2,16 @@
 
 All generation requests require an API key from [enter.pollinations.ai](https://enter.pollinations.ai). Model listing endpoints work without authentication.
 
-| Type | Prefix | Use case | Rate limits |
-|------|--------|----------|-------------|
-| Secret | `sk_` | Server-side apps | None |
-| Publishable | `pk_` | Client-side apps (beta) | 1 pollen/IP/hour |
+| Type | Prefix | Use case | Rate limits | Description |
+|------|--------|----------|-------------|-------------|
+| Secret | `sk_` | Server-side apps | None | Personal developer key. Never expose in client-side code. |
+| App Key (BYOP) | `pk_` | Client-side & Frontend apps | None | Publishable key used in the **BYOP (Bring Your Own Pollen)** flow to authorize users' balances. |
 
-Two ways to authenticate:
+> **Note:** Publishable Keys (`pk_`) for direct client-side requests have been replaced by the **BYOP (Bring Your Own Pollen)** auth flow. Frontend applications must obtain a temporary user-authorized secret key (`sk_`) via the authorize redirect or device flow.
+
+Two ways to authenticate generation requests:
 
 - Header: `Authorization: Bearer YOUR_API_KEY`
 - Query param: `?key=YOUR_API_KEY`
 
-> **Warning:** Never expose secret keys (`sk_`) in client-side code. Use publishable keys (`pk_`) for frontend apps.
+For detailed integration guides on user-pays authorization, refer to the [Bring Your Own Pollen (BYOP) guide](https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md).


### PR DESCRIPTION
Closes #12001. Documented that Publishable Keys have been replaced by the BYOP (Bring Your Own Pollen) flow in authentication.md.