### PR TITLE
fix: convert progressive JPEG to baseline for Fireworks Flux

### DIFF
--- a/gen.pollinations.ai/src/image/models/fireworksFluxModel.ts
+++ b/gen.pollinations.ai/src/image/models/fireworksFluxModel.ts
@@ -6,7 +6,7 @@ import type { ImageParams } from "../params.ts";
 import { sanitizeString } from "../util.ts";
 import { closestByRatio } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
-import { transformImage } from "../utils/imageTransform.ts";
+import { transformImage, ensureBaselineJpeg } from "../utils/imageTransform.ts";
 
 const logOps = debug("pollinations:fireworks-flux:ops");
 
@@ -41,6 +41,7 @@ export async function callFireworksFluxSchnellAPI(
         safeParams.height || 1024,
         FIREWORKS_ASPECT_RATIOS,
     ).label;
+    
     const body = {
         prompt: sanitizeString(prompt),
         aspect_ratio: aspectRatio,
@@ -74,7 +75,10 @@ export async function callFireworksFluxSchnellAPI(
         );
     }
 
+    // Получаем буфер от Fireworks API
     let buffer: Buffer = Buffer.from(await response.arrayBuffer());
+
+    // ✅ Если нужен ресайз - делаем его с принудительным baseline
     if (safeParams.dimensionsExplicit) {
         buffer = await transformImage(buffer, {
             width: safeParams.width,
@@ -82,7 +86,20 @@ export async function callFireworksFluxSchnellAPI(
             fit: "cover",
             format: "image/jpeg",
             quality: 90,
+            forceBaseline: true, // ✅ Принудительно baseline
         });
+        logOps("Image resized and converted to baseline JPEG");
+    } else {
+        // ✅ Если ресайз не нужен - проверяем и конвертируем только при необходимости
+        const beforeIsProgressive = isProgressiveJpeg(buffer);
+        buffer = await ensureBaselineJpeg(buffer, 90);
+        const afterIsProgressive = isProgressiveJpeg(buffer);
+        
+        if (beforeIsProgressive && !afterIsProgressive) {
+            logOps("Converted progressive JPEG to baseline JPEG");
+        } else if (!beforeIsProgressive) {
+            logOps("Image already baseline JPEG, no conversion needed");
+        }
     }
 
     return {

--- a/gen.pollinations.ai/src/image/utils/imageTransform.ts
+++ b/gen.pollinations.ai/src/image/utils/imageTransform.ts
@@ -6,6 +6,7 @@ type TransformOptions = {
     fit?: ImageTransform["fit"];
     maxWidth?: number;
     maxHeight?: number;
+    forceBaseline?: boolean; // ✅ НОВЫЙ ПАРАМЕТР
 };
 
 let imagesBinding: ImagesBinding | null = null;
@@ -16,6 +17,49 @@ export function setImagesBinding(binding: ImagesBinding | undefined): void {
 
 export function getImagesBinding(): ImagesBinding | null {
     return imagesBinding;
+}
+
+/**
+ * Проверяет, является ли JPEG прогрессивным
+ * По маркеру SOF2 (FF C2) в заголовке JPEG
+ */
+export function isProgressiveJpeg(buffer: Buffer): boolean {
+    // JPEG начинается с FF D8
+    if (buffer.length < 10 || buffer[0] !== 0xFF || buffer[1] !== 0xD8) {
+        return false;
+    }
+    
+    // Ищем маркер SOF (Start of Frame)
+    let offset = 2; // Пропускаем SOI (Start of Image)
+    
+    while (offset + 9 < buffer.length) {
+        // Ищем маркер FF
+        if (buffer[offset] !== 0xFF) {
+            offset++;
+            continue;
+        }
+        
+        const marker = buffer[offset + 1];
+        
+        // SOF0 = Baseline (FF C0)
+        // SOF2 = Progressive (FF C2)
+        if (marker === 0xC0 || marker === 0xC2) {
+            return marker === 0xC2;
+        }
+        
+        // Пропускаем остальные маркеры
+        const segmentLength = buffer.readUInt16BE(offset + 2);
+        offset += 2 + segmentLength;
+    }
+    
+    return false; // По умолчанию считаем baseline
+}
+
+/**
+ * Проверяет, является ли изображение JPEG (по сигнатуре)
+ */
+export function isJpeg(buffer: Buffer): boolean {
+    return buffer.length >= 2 && buffer[0] === 0xFF && buffer[1] === 0xD8;
 }
 
 export async function transformImage(
@@ -36,7 +80,9 @@ export async function transformImage(
         fit = "scale-down",
         maxWidth,
         maxHeight,
+        forceBaseline = false, // ✅ НОВЫЙ ПАРАМЕТР
     } = options;
+    
     const bytes =
         inputBuffer instanceof Buffer
             ? new Uint8Array(
@@ -63,13 +109,42 @@ export async function transformImage(
         });
     }
 
+    // ✅ Добавляем progressive: false для принудительного baseline
+    const outputOptions: any = {
+        format,
+        quality,
+    };
+    
+    // Cloudflare Images Binding: progressive: false = baseline
+    if (format === "image/jpeg" && forceBaseline) {
+        outputOptions.progressive = false;
+    }
+
     const response = (
-        await pipeline.output({
-            format,
-            quality,
-        })
+        await pipeline.output(outputOptions)
     ).response();
     return Buffer.from(await response.arrayBuffer());
+}
+
+/**
+ * Конвертирует изображение в базовый JPEG (baseline)
+ * Если изображение уже baseline - возвращает как есть (экономия ресурсов)
+ */
+export async function ensureBaselineJpeg(
+    inputBuffer: Buffer,
+    quality = 90,
+): Promise<Buffer> {
+    // Если не JPEG или уже baseline - возвращаем как есть
+    if (!isJpeg(inputBuffer) || !isProgressiveJpeg(inputBuffer)) {
+        return inputBuffer;
+    }
+    
+    // Конвертируем прогрессивный JPEG в baseline
+    return transformImage(inputBuffer, {
+        format: "image/jpeg",
+        quality,
+        forceBaseline: true,
+    });
 }
 
 export async function convertToJpeg(
@@ -79,6 +154,7 @@ export async function convertToJpeg(
     return transformImage(inputBuffer, {
         format: "image/jpeg",
         quality,
+        forceBaseline: true, // ✅ Всегда baseline
     });
 }
 
@@ -88,5 +164,6 @@ export async function resizeForGptImage(inputBuffer: Buffer): Promise<Buffer> {
         quality: 90,
         maxWidth: 1536,
         maxHeight: 1536,
+        forceBaseline: true, // ✅ Всегда baseline
     });
 }


### PR DESCRIPTION
## 🐛 Проблема
При генерации изображений через Fireworks Flux API, ответ приходит в формате 
прогрессивного (progressive) JPEG. Это создает проблемы с совместимостью 
и увеличивает время загрузки для некоторых клиентов.

## ✅ Решение
Добавлена принудительная конвертация в baseline JPEG через Cloudflare Images Binding 
с проверкой типа изображения.

## 📝 Изменения
- Добавлена функция `isProgressiveJpeg()` для определения типа JPEG по маркерам (SOF0/SOF2)
- Добавлена функция `ensureBaselineJpeg()` для умной конвертации
- Добавлен параметр `forceBaseline` в `TransformOptions`
- Обновлена логика в `callFireworksFluxSchnellAPI` для использования новой конвертации
- Добавлено логирование для отслеживания процесса

## 🔍 Детали реализации

### Проверка типа JPEG
```typescript
export function isProgressiveJpeg(buffer: Buffer): boolean {
    // Ищем маркеры JPEG
    // SOF0 (FF C0) = Baseline
    // SOF2 (FF C2) = Progressive
    // ...
}

Умная конвертация
export async function ensureBaselineJpeg(buffer: Buffer): Promise<Buffer> {
    // Если не JPEG или уже baseline - возвращаем как есть
    if (!isJpeg(buffer) || !isProgressiveJpeg(buffer)) {
        return buffer;
    }
    // Конвертируем только если нужно
    return transformImage(buffer, {
        format: "image/jpeg",
        quality: 90,
        forceBaseline: true,
    });
}

Использование в Fireworks
// Получаем буфер от Fireworks API
let buffer: Buffer = Buffer.from(await response.arrayBuffer());

// Если нужен ресайз - делаем его с принудительным baseline
if (safeParams.dimensionsExplicit) {
    buffer = await transformImage(buffer, {
        // ... ресайз ...
        forceBaseline: true,
    });
} else {
    // Иначе проверяем и конвертируем только при необходимости
    buffer = await ensureBaselineJpeg(buffer);
}