### PR TITLE
fix: deploy gen worker before pushing secrets

### DIFF
--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -47,6 +47,18 @@ jobs:
       - name: Setup SOPS
         uses: nhedger/setup-sops@v2
 
+      # Deploy BEFORE pushing secrets: a fresh `wrangler deploy` makes the
+      # latest worker version the deployed one. `wrangler secret bulk` edits
+      # the latest version's settings and fails (Cloudflare 10214) if that
+      # version isn't deployed — which happens after a manual version upload or
+      # rollback. Deploying first guarantees latest == deployed so the secret
+      # push can never hit that state. A brand-new secret is briefly missing in
+      # the few seconds between deploy and push, which self-heals.
+      - name: Deploy to Cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+        run: npm run deploy:production --workspace pollinations-gen
+
       - name: Push generation secrets
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
@@ -57,8 +69,3 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
         run: npm run apply-lifecycle:production --workspace pollinations-gen
-
-      - name: Deploy to Cloudflare
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
-        run: npm run deploy:production --workspace pollinations-gen


### PR DESCRIPTION
- `wrangler secret bulk` edits the latest worker version's settings and fails with Cloudflare 10214 when the latest version isn't the deployed one
- That drift state is left behind by a manual `wrangler versions upload` + rollback (happened 2026-06-27), and silently breaks the next CI deploy
- Reordering so deploy runs first guarantees latest == deployed before the secret push, eliminating the 10214 class
- A brand-new secret is briefly absent in the seconds between deploy and push, which self-heals

🤖 Generated with [Claude Code](https://claude.com/claude-code)