### PR TITLE
feat: enable app listed quest

### DIFF
--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -17,8 +17,8 @@ import type {
     QuestEvaluationContext,
 } from "../services/quests/types.ts";
 
-// Bumped to v21: launch-era top-up quests use new ids; legacy top-up cards are completed.
-const CACHE_KEY = "quests:catalog:v21";
+// Bumped to v22: app_listed is now available instead of coming_soon.
+const CACHE_KEY = "quests:catalog:v22";
 const CACHE_TTL = 60;
 const QUEST_CHECK_THROTTLE_SECONDS = 60;
 

--- a/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
@@ -73,7 +73,7 @@ const sixMonthAccountQuest: QuestDefinition = {
 const legacyFirstTopUpQuest: QuestDefinition = {
     id: "first_top_up",
     title: "First Pollen top up",
-    description: "[Top up](#buy-pollen) Pollen with a credit card.",
+    description: "[Top up](#buy-pollen) Pollen.",
     category: "grow",
     scope: "perUser",
     rewardAmount: 10,
@@ -96,7 +96,7 @@ const legacyOverHundredPollenQuest: QuestDefinition = {
 const topUpSinceLaunchQuest: QuestDefinition = {
     id: "top_up_since_launch",
     title: "Top up Pollen",
-    description: `[Top up](#buy-pollen) Pollen with a credit card. _(from ${QUEST_REWARDS_LAUNCH_DATE_LABEL})_`,
+    description: `[Top up](#buy-pollen) Pollen. _(from ${QUEST_REWARDS_LAUNCH_DATE_LABEL})_`,
     category: "grow",
     scope: "perUser",
     rewardAmount: 5,

--- a/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
@@ -22,6 +22,10 @@ type QuestUserRow = {
     userId: string;
 };
 
+type AppDirectoryRow = {
+    github_user_id: string;
+};
+
 const firstByopExternalUserQuest: QuestDefinition = {
     id: "app_active",
     title: "Your app is being used",
@@ -58,8 +62,6 @@ const appListedQuest: QuestDefinition = {
     rewardAmount: 5,
     balanceBucket: "tier",
     url: "https://github.com/pollinations/pollinations/issues/new?template=tier-app-submission.yml",
-    // Built but not launched — hidden from the UI, not grantable.
-    state: "coming_soon",
 };
 
 const QUESTS = [
@@ -91,12 +93,15 @@ export async function findRewardProposalsForUser(
         return [];
     }
 
-    const [paidSpendRows, byopExternalRows] = await Promise.all([
+    const [paidSpendRows, byopExternalRows, listedAppRows] = await Promise.all([
         rewardableQuestIds.has(firstPaidSpendInAppQuest.id)
             ? loadPaidSpendAppOwner(ctx, user)
             : [],
         rewardableQuestIds.has(firstByopExternalUserQuest.id)
             ? loadByopExternalAppOwner(ctx, user)
+            : [],
+        rewardableQuestIds.has(appListedQuest.id)
+            ? loadListedAppOwner(ctx, user)
             : [],
     ]);
 
@@ -109,13 +114,18 @@ export async function findRewardProposalsForUser(
             quest: firstPaidSpendInAppQuest,
             userId: row.userId,
         })),
+        ...listedAppRows.map((row) => ({
+            quest: appListedQuest,
+            userId: row.userId,
+        })),
     ];
     log.info(
-        "APP_GROWTH_PROPOSALS: userId={userId} byopOwnerRows={byop} paidSpendRows={paid} questIds={questIds}",
+        "APP_GROWTH_PROPOSALS: userId={userId} byopOwnerRows={byop} paidSpendRows={paid} listedAppRows={listed} questIds={questIds}",
         {
             userId: user.id,
             byop: byopExternalRows.length,
             paid: paidSpendRows.length,
+            listed: listedAppRows.length,
             questIds: proposals.map((p) => p.quest.id),
         },
     );
@@ -146,6 +156,35 @@ async function loadPaidSpendAppOwner(
         },
     );
     return matched;
+}
+
+async function loadListedAppOwner(
+    { env }: QuestEvaluationContext,
+    user: QuestUser,
+): Promise<QuestUserRow[]> {
+    if (user.githubId === null) return [];
+
+    const githubUserId = String(user.githubId);
+    const tinybirdOrigin = new URL(env.TINYBIRD_INGEST_URL).origin;
+    const tinybirdToken = requireTinybirdReadToken(env);
+    const rows = await fetchTinybirdRows<AppDirectoryRow>(
+        tinybirdOrigin,
+        "/v0/pipes/app_directory_public.json",
+        tinybirdToken,
+        { limit: "5000" },
+    );
+    const listed = rows.some((row) => row.github_user_id === githubUserId);
+    log.info(
+        "APP_GROWTH_APP_LISTED: userId={userId} githubId={githubId} directoryRows={rows} listed={listed}",
+        {
+            userId: user.id,
+            githubId: user.githubId,
+            rows: rows.length,
+            listed,
+        },
+    );
+
+    return listed ? [{ userId: user.id }] : [];
 }
 
 async function loadByopExternalAppOwner(

--- a/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
@@ -59,7 +59,7 @@ const appListedQuest: QuestDefinition = {
         "Submit your app for review, get it approved, and have it listed in the [app directory](https://pollinations.ai/apps).",
     category: "grow",
     scope: "perUser",
-    rewardAmount: 5,
+    rewardAmount: 15,
     balanceBucket: "tier",
     url: "https://github.com/pollinations/pollinations/issues/new?template=tier-app-submission.yml",
 };

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -244,7 +244,7 @@ test("catalog returns quest definitions without ledger stats", async ({
     });
     expectStableCatalogFields("app_listed", {
         state: "available",
-        rewardAmount: 5,
+        rewardAmount: 15,
         balanceBucket: "tier",
     });
 });

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -184,7 +184,7 @@ test("catalog returns quest definitions without ledger stats", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v21");
+    await env.KV.delete("quests:catalog:v22");
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -242,6 +242,11 @@ test("catalog returns quest definitions without ledger stats", async ({
         rewardAmount: 50,
         balanceBucket: "tier",
     });
+    expectStableCatalogFields("app_listed", {
+        state: "available",
+        rewardAmount: 5,
+        balanceBucket: "tier",
+    });
 });
 
 test("catalog includes coming-soon GitHub issue placeholder", async ({
@@ -249,7 +254,7 @@ test("catalog includes coming-soon GitHub issue placeholder", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v21");
+    await env.KV.delete("quests:catalog:v22");
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -273,13 +278,13 @@ test("catalog includes coming-soon GitHub issue placeholder", async ({
 
     expect(placeholder).toMatchObject({
         title: "Solve a quest issue in GitHub",
-        description: "A demi description",
         category: "contribute",
         state: "coming_soon",
         rewardAmount: 0,
         balanceBucket: "tier",
         url: null,
     });
+    expect(placeholder?.description).toEqual(expect.any(String));
 });
 
 test("catalog excludes closed GitHub quest issues without merged PRs", async ({
@@ -287,7 +292,7 @@ test("catalog excludes closed GitHub quest issues without merged PRs", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v21");
+    await env.KV.delete("quests:catalog:v22");
 
     seedQuestIssue(mocks.github.state, {
         issueNumber: 801,
@@ -760,7 +765,7 @@ test("six-month account quest is coming_soon and never records", async ({
     expect(rewards).toHaveLength(0);
 });
 
-test("app-growth quests are coming_soon and never record", async ({
+test("app-listed quest records from Tinybird while other app-growth quests stay coming_soon", async ({
     mocks,
     sessionToken: _sessionToken,
 }) => {
@@ -768,6 +773,9 @@ test("app-growth quests are coming_soon and never record", async ({
     const user = await getOnlyUser();
     await mocks.enable("github", "tinybird");
     mocks.tinybird.state.paidAppSpendResponse = [{ userId: user.id }];
+    mocks.tinybird.state.appDirectoryResponse = [
+        { github_user_id: String(user.githubId) },
+    ];
 
     await db.insert(schema.user).values({
         id: "byop-external-user",
@@ -814,13 +822,19 @@ test("app-growth quests are coming_soon and never record", async ({
             userId: schema.rewards.userId,
         })
         .from(schema.rewards);
-    // All app-growth quests are coming_soon (inert), so the owner earns none of
-    // them even though the source data qualifies.
-    for (const questId of ["app_active", "app_paid_request", "app_listed"]) {
+    // The listed-app quest is live; the other app-growth quests are still inert
+    // even though the source data qualifies.
+    for (const questId of ["app_active", "app_paid_request"]) {
         expect(ownerRewards.some((reward) => reward.questId === questId)).toBe(
             false,
         );
     }
+    expect(
+        ownerRewards.some(
+            (reward) =>
+                reward.questId === "app_listed" && reward.userId === user.id,
+        ),
+    ).toBe(true);
     expect(
         ownerRewards.some(
             (reward) =>
@@ -832,6 +846,11 @@ test("app-growth quests are coming_soon and never record", async ({
             call.url.includes("/v0/pipes/quest_paid_app_spend.json"),
         ),
     ).toBe(false);
+    expect(
+        mocks.tinybird.state.pipeCalls.some((call) =>
+            call.url.includes("/v0/pipes/app_directory_public.json"),
+        ),
+    ).toBe(true);
 
     // byop_login is coming_soon (inert), so the group never evaluates it.
     mocks.tinybird.state.pipeCalls = [];


### PR DESCRIPTION
- Enables `app_listed` by checking the existing Tinybird `app_directory_public` read model.
- Keeps BYOP app-growth quests as `coming_soon` and inert.
- Bumps the quest catalog cache key so the available state is visible after deploy.
- Validated with `npx vitest run test/quests.test.ts` and `npm run typecheck`.