### PR TITLE
fix: lower app_listed quest reward to 10 pollen

### DIFF
--- a/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
@@ -59,7 +59,7 @@ const appListedQuest: QuestDefinition = {
         "Submit your app for review, get it approved, and have it listed in the [app directory](https://pollinations.ai/apps).",
     category: "grow",
     scope: "perUser",
-    rewardAmount: 15,
+    rewardAmount: 10,
     balanceBucket: "tier",
     url: "https://github.com/pollinations/pollinations/issues/new?template=tier-app-submission.yml",
 };

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -244,7 +244,7 @@ test("catalog returns quest definitions without ledger stats", async ({
     });
     expectStableCatalogFields("app_listed", {
         state: "available",
-        rewardAmount: 15,
+        rewardAmount: 10,
         balanceBucket: "tier",
     });
 });


### PR DESCRIPTION
- Lowers the **App listed on Pollinations** quest reward from 15 → 10 pollen
- Updates the catalog test assertion to match
- No catalog version bump needed — `quests:catalog` cache has a 60s TTL, so the new amount propagates within a minute
