### PR TITLE
feat: allowlist CloudCompile for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -10,6 +10,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     84981998, // Spit-fires
     204561696, // tomdacatto
     93234024, // skullcrushercmd
+    201248601, // CloudCompile
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
Adds GitHub ID `201248601` (`CloudCompile` / CJ Hauser) to the community model owner allowlist.

- Verified `CloudCompile` is the correct login — it owns the repo fork and has an extensive contribution history (PRs #10927, #10787, #10753, #10538, #9942). The similarly-named `cjhauser` account is unrelated (zero pollinations activity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)