### PR TITLE
Fix inability to scroll on auth screen on mobile

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -129,7 +129,10 @@ export function Authorize() {
         parsedRedirectUrl !== null &&
         (!app_key || redirectValidationState === "valid");
 
-    useScrollLock();
+    const isMobile = window.innerWidth < 768;
+    if (!isMobile) {
+        useScrollLock();
+    }
 
     useEffect(() => {
         let cancelled = false;


### PR DESCRIPTION
Remove `useScrollLock` call for non-mobile devices.
Maintains status quo for desktop and wider screens.

Fixes [#12000](https://github.com/pollinations/pollinations/issues/12000)