### PR TITLE
feat: allowlist smplstuff for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -11,6 +11,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     204561696, // tomdacatto
     93234024, // skullcrushercmd
     201248601, // CloudCompile
+    206557620, // smplstuff
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
Adds GitHub ID `206557620` (`smplstuff`) to the community model owner allowlist.

- Verified: registered on enter.pollinations.ai (tier `flower`, github_id matches), active contributor with app submissions #11685, #8561, #2066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)