### PR TITLE
fix: add Stripe failed-card gate metadata

### DIFF
--- a/enter.pollinations.ai/drizzle/0033_stripe_card_fingerprint_attempt.sql
+++ b/enter.pollinations.ai/drizzle/0033_stripe_card_fingerprint_attempt.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `stripe_card_fingerprint_attempt` (
+	`event_id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`stripe_customer_id` text,
+	`customer_email` text,
+	`card_fingerprint` text NOT NULL,
+	`card_brand` text,
+	`card_country` text,
+	`payment_intent_id` text,
+	`charge_id` text,
+	`status` text NOT NULL,
+	`livemode` integer DEFAULT false NOT NULL,
+	`created_at` integer DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_stripe_card_fingerprint_attempt_user_created` ON `stripe_card_fingerprint_attempt` (`user_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_stripe_card_fingerprint_attempt_user_fingerprint` ON `stripe_card_fingerprint_attempt` (`user_id`,`card_fingerprint`);--> statement-breakpoint
+CREATE INDEX `idx_stripe_card_fingerprint_attempt_customer_created` ON `stripe_card_fingerprint_attempt` (`stripe_customer_id`,`created_at`);

--- a/enter.pollinations.ai/drizzle/0033_stripe_card_fingerprint_attempt.sql
+++ b/enter.pollinations.ai/drizzle/0033_stripe_card_fingerprint_attempt.sql
@@ -1,19 +1,10 @@
 CREATE TABLE `stripe_card_fingerprint_attempt` (
 	`event_id` text PRIMARY KEY NOT NULL,
 	`user_id` text NOT NULL,
-	`stripe_customer_id` text,
-	`customer_email` text,
 	`card_fingerprint` text NOT NULL,
-	`card_brand` text,
-	`card_country` text,
-	`payment_intent_id` text,
-	`charge_id` text,
-	`status` text NOT NULL,
-	`livemode` integer DEFAULT false NOT NULL,
 	`created_at` integer DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer)) NOT NULL,
 	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
 CREATE INDEX `idx_stripe_card_fingerprint_attempt_user_created` ON `stripe_card_fingerprint_attempt` (`user_id`,`created_at`);--> statement-breakpoint
-CREATE INDEX `idx_stripe_card_fingerprint_attempt_user_fingerprint` ON `stripe_card_fingerprint_attempt` (`user_id`,`card_fingerprint`);--> statement-breakpoint
-CREATE INDEX `idx_stripe_card_fingerprint_attempt_customer_created` ON `stripe_card_fingerprint_attempt` (`stripe_customer_id`,`created_at`);
+CREATE INDEX `idx_stripe_card_fingerprint_attempt_user_fingerprint` ON `stripe_card_fingerprint_attempt` (`user_id`,`card_fingerprint`);

--- a/enter.pollinations.ai/drizzle/meta/0033_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,1549 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "444712bc-1964-4942-987b-9d06466be85c",
+  "prevId": "563664d8-2b9f-4511-9a27-fdf292ac08f0",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_country": {
+          "name": "card_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_intent_id": {
+          "name": "payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "livemode": {
+          "name": "livemode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_customer_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_customer_created",
+          "columns": [
+            "stripe_customer_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/0033_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0033_snapshot.json
@@ -1417,69 +1417,12 @@
           "notNull": true,
           "autoincrement": false
         },
-        "stripe_customer_id": {
-          "name": "stripe_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "customer_email": {
-          "name": "customer_email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
         "card_fingerprint": {
           "name": "card_fingerprint",
           "type": "text",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
-        },
-        "card_brand": {
-          "name": "card_brand",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "card_country": {
-          "name": "card_country",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "payment_intent_id": {
-          "name": "payment_intent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "charge_id": {
-          "name": "charge_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "livemode": {
-          "name": "livemode",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": false
         },
         "created_at": {
           "name": "created_at",
@@ -1504,14 +1447,6 @@
           "columns": [
             "user_id",
             "card_fingerprint"
-          ],
-          "isUnique": false
-        },
-        "idx_stripe_card_fingerprint_attempt_customer_created": {
-          "name": "idx_stripe_card_fingerprint_attempt_customer_created",
-          "columns": [
-            "stripe_customer_id",
-            "created_at"
           ],
           "isUnique": false
         }

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1782557977942,
       "tag": "0032_parallel_albert_cleary",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1782823187000,
+      "tag": "0033_stripe_card_fingerprint_attempt",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -93,14 +93,6 @@ function snapshotFromCharge(
     };
 }
 
-function readStripeId(
-    value: string | { id?: string | null } | null | undefined,
-): string {
-    if (!value) return "";
-    if (typeof value === "string") return value;
-    return value.id ?? "";
-}
-
 function readUserIdFromMetadata(
     metadata: Stripe.Metadata | null | undefined,
 ): string {
@@ -112,13 +104,11 @@ async function recordCardFingerprintFromCharge({
     event,
     charge,
     snapshot,
-    status,
 }: {
     env: CloudflareBindings;
     event: Stripe.Event;
     charge: Stripe.Charge | null | undefined;
     snapshot: ChargeSnapshot;
-    status: string;
 }): Promise<void> {
     if (!charge || !snapshot.cardFingerprint) return;
 
@@ -126,16 +116,7 @@ async function recordCardFingerprintFromCharge({
         await recordStripeCardFingerprintAttempt(env.DB, {
             eventId: event.id,
             userId: readUserIdFromMetadata(charge.metadata),
-            stripeCustomerId: readStripeId(charge.customer),
-            customerEmail:
-                charge.billing_details?.email || charge.receipt_email || "",
             cardFingerprint: snapshot.cardFingerprint,
-            cardBrand: snapshot.cardBrand,
-            cardCountry: snapshot.cardCountry,
-            paymentIntentId: readStripeId(charge.payment_intent),
-            chargeId: charge.id,
-            status,
-            livemode: event.livemode,
             createdAt: event.created ? event.created * 1000 : Date.now(),
         });
     } catch (err) {
@@ -414,7 +395,6 @@ function emitPaymentIntentAnalytics(
                     event,
                     charge,
                     snapshot,
-                    status: paymentStatus,
                 });
             }
             await sendStripeEventToTinybird(c.env, {
@@ -602,7 +582,6 @@ export const stripeWebhooksRoutes = new Hono<Env>()
                     event,
                     charge,
                     snapshot,
-                    status: charge.status || "succeeded",
                 });
                 c.executionCtx.waitUntil(
                     sendStripeEventToTinybird(c.env, {

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -10,6 +10,7 @@ import {
     creditAutoTopUpInvoice,
     markAutoTopUpInvoiceFailed,
 } from "../utils/stripe-billing.ts";
+import { recordStripeCardFingerprintAttempt } from "../utils/stripe-card-gate.ts";
 
 interface StripeEventData {
     eventType: string;
@@ -42,6 +43,7 @@ type ChargeSnapshot = {
     cardCountry: string;
     cardBrand: string;
     cardNetwork: string;
+    cardFingerprint: string;
     riskLevel: string;
     riskScore: number;
 };
@@ -53,6 +55,7 @@ const EMPTY_CHARGE_SNAPSHOT: ChargeSnapshot = {
     cardCountry: "",
     cardBrand: "",
     cardNetwork: "",
+    cardFingerprint: "",
     riskLevel: "",
     riskScore: 0,
 };
@@ -84,9 +87,63 @@ function snapshotFromCharge(
         cardCountry: card?.country ?? "",
         cardBrand: card?.brand ?? "",
         cardNetwork: card?.network ?? "",
+        cardFingerprint: card?.fingerprint ?? "",
         riskLevel: outcome?.risk_level ?? "",
         riskScore: outcome?.risk_score ?? 0,
     };
+}
+
+function readStripeId(
+    value: string | { id?: string | null } | null | undefined,
+): string {
+    if (!value) return "";
+    if (typeof value === "string") return value;
+    return value.id ?? "";
+}
+
+function readUserIdFromMetadata(
+    metadata: Stripe.Metadata | null | undefined,
+): string {
+    return metadata?.userId || metadata?.pollinations_user_id || "";
+}
+
+async function recordCardFingerprintFromCharge({
+    env,
+    event,
+    charge,
+    snapshot,
+    status,
+}: {
+    env: CloudflareBindings;
+    event: Stripe.Event;
+    charge: Stripe.Charge | null | undefined;
+    snapshot: ChargeSnapshot;
+    status: string;
+}): Promise<void> {
+    if (!charge || !snapshot.cardFingerprint) return;
+
+    try {
+        await recordStripeCardFingerprintAttempt(env.DB, {
+            eventId: event.id,
+            userId: readUserIdFromMetadata(charge.metadata),
+            stripeCustomerId: readStripeId(charge.customer),
+            customerEmail:
+                charge.billing_details?.email || charge.receipt_email || "",
+            cardFingerprint: snapshot.cardFingerprint,
+            cardBrand: snapshot.cardBrand,
+            cardCountry: snapshot.cardCountry,
+            paymentIntentId: readStripeId(charge.payment_intent),
+            chargeId: charge.id,
+            status,
+            livemode: event.livemode,
+            createdAt: event.created ? event.created * 1000 : Date.now(),
+        });
+    } catch (err) {
+        console.error(
+            `Failed to record Stripe card fingerprint for event ${event.id}:`,
+            err,
+        );
+    }
 }
 
 /**
@@ -335,7 +392,12 @@ function emitPaymentIntentAnalytics(
     {
         paymentStatus,
         customerEmail,
-    }: { paymentStatus: string; customerEmail: string },
+        recordCardFingerprint = false,
+    }: {
+        paymentStatus: string;
+        customerEmail: string;
+        recordCardFingerprint?: boolean;
+    },
 ): void {
     const methodsOffered = (paymentIntent.payment_method_types ?? []).join(",");
 
@@ -346,6 +408,15 @@ function emitPaymentIntentAnalytics(
                 paymentIntent.id,
             );
             const snapshot = snapshotFromCharge(charge);
+            if (recordCardFingerprint) {
+                await recordCardFingerprintFromCharge({
+                    env: c.env,
+                    event,
+                    charge,
+                    snapshot,
+                    status: paymentStatus,
+                });
+            }
             await sendStripeEventToTinybird(c.env, {
                 eventType: event.type,
                 eventId: event.id,
@@ -521,11 +592,18 @@ export const stripeWebhooksRoutes = new Hono<Env>()
             case "charge.succeeded": {
                 // The Charge IS the event payload, so we can read
                 // payment_method_details + card.country + risk_score directly
-                // without an additional Stripe API call. Emitted to Tinybird
-                // for analytics; D1 credit insert happens via the parallel
-                // checkout.session.completed / async_payment_succeeded path.
+                // without an additional Stripe API call. Pack credit still
+                // happens via checkout.session.completed; this path records
+                // the card fingerprint gate ledger and emits analytics.
                 const charge = event.data.object as Stripe.Charge;
                 const snapshot = snapshotFromCharge(charge);
+                await recordCardFingerprintFromCharge({
+                    env: c.env,
+                    event,
+                    charge,
+                    snapshot,
+                    status: charge.status || "succeeded",
+                });
                 c.executionCtx.waitUntil(
                     sendStripeEventToTinybird(c.env, {
                         eventType: event.type,
@@ -727,6 +805,7 @@ export const stripeWebhooksRoutes = new Hono<Env>()
                 emitPaymentIntentAnalytics(c, stripe, event, paymentIntent, {
                     paymentStatus: "failed",
                     customerEmail: paymentIntent.receipt_email || "",
+                    recordCardFingerprint: true,
                 });
                 break;
             }

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -99,29 +99,32 @@ function readUserIdFromMetadata(
     return metadata?.userId || metadata?.pollinations_user_id || "";
 }
 
-async function recordCardFingerprintFromCharge({
+async function recordFailedCardFingerprintFromCharge({
     env,
     event,
     charge,
     snapshot,
+    fallbackUserId = "",
 }: {
     env: CloudflareBindings;
     event: Stripe.Event;
     charge: Stripe.Charge | null | undefined;
     snapshot: ChargeSnapshot;
+    fallbackUserId?: string;
 }): Promise<void> {
     if (!charge || !snapshot.cardFingerprint) return;
+    const userId = readUserIdFromMetadata(charge.metadata) || fallbackUserId;
 
     try {
         await recordStripeCardFingerprintAttempt(env.DB, {
             eventId: event.id,
-            userId: readUserIdFromMetadata(charge.metadata),
+            userId,
             cardFingerprint: snapshot.cardFingerprint,
             createdAt: event.created ? event.created * 1000 : Date.now(),
         });
     } catch (err) {
         console.error(
-            `Failed to record Stripe card fingerprint for event ${event.id}:`,
+            `Failed to record Stripe failed-card fingerprint for event ${event.id}:`,
             err,
         );
     }
@@ -373,11 +376,11 @@ function emitPaymentIntentAnalytics(
     {
         paymentStatus,
         customerEmail,
-        recordCardFingerprint = false,
+        recordFailedCardFingerprint = false,
     }: {
         paymentStatus: string;
         customerEmail: string;
-        recordCardFingerprint?: boolean;
+        recordFailedCardFingerprint?: boolean;
     },
 ): void {
     const methodsOffered = (paymentIntent.payment_method_types ?? []).join(",");
@@ -389,12 +392,13 @@ function emitPaymentIntentAnalytics(
                 paymentIntent.id,
             );
             const snapshot = snapshotFromCharge(charge);
-            if (recordCardFingerprint) {
-                await recordCardFingerprintFromCharge({
+            if (recordFailedCardFingerprint) {
+                await recordFailedCardFingerprintFromCharge({
                     env: c.env,
                     event,
                     charge,
                     snapshot,
+                    fallbackUserId: paymentIntent.metadata?.userId || "",
                 });
             }
             await sendStripeEventToTinybird(c.env, {
@@ -573,16 +577,10 @@ export const stripeWebhooksRoutes = new Hono<Env>()
                 // The Charge IS the event payload, so we can read
                 // payment_method_details + card.country + risk_score directly
                 // without an additional Stripe API call. Pack credit still
-                // happens via checkout.session.completed; this path records
-                // the card fingerprint gate ledger and emits analytics.
+                // happens via checkout.session.completed; successful cards
+                // don't feed the failed-card gate ledger.
                 const charge = event.data.object as Stripe.Charge;
                 const snapshot = snapshotFromCharge(charge);
-                await recordCardFingerprintFromCharge({
-                    env: c.env,
-                    event,
-                    charge,
-                    snapshot,
-                });
                 c.executionCtx.waitUntil(
                     sendStripeEventToTinybird(c.env, {
                         eventType: event.type,
@@ -784,7 +782,7 @@ export const stripeWebhooksRoutes = new Hono<Env>()
                 emitPaymentIntentAnalytics(c, stripe, event, paymentIntent, {
                     paymentStatus: "failed",
                     customerEmail: paymentIntent.receipt_email || "",
-                    recordCardFingerprint: true,
+                    recordFailedCardFingerprint: true,
                 });
                 break;
             }

--- a/enter.pollinations.ai/src/routes/stripe.ts
+++ b/enter.pollinations.ai/src/routes/stripe.ts
@@ -18,6 +18,10 @@ import {
     processAutoTopUpForUser,
     updateAutoTopUpSettings,
 } from "../utils/stripe-billing.ts";
+import {
+    getStripeNewCardGateStatus,
+    stripeNewCardGateMetadata,
+} from "../utils/stripe-card-gate.ts";
 
 /**
  * Stripe pack configuration
@@ -86,6 +90,10 @@ export const stripeRoutes = new Hono<Env>()
                 c.env,
                 userId,
             );
+            const newCardGate = await getStripeNewCardGateStatus(
+                c.env.DB,
+                userId,
+            );
 
             // packKey identifies the pack; the webhook looks up its fixed USD
             // amount to credit, independent of how Adaptive Pricing localized
@@ -94,6 +102,7 @@ export const stripeRoutes = new Hono<Env>()
                 userId,
                 packKey: pack.packKey,
                 cohort,
+                ...stripeNewCardGateMetadata(newCardGate),
             };
 
             const checkoutSession = await stripe.checkout.sessions.create({

--- a/enter.pollinations.ai/src/utils/stripe-card-gate.ts
+++ b/enter.pollinations.ai/src/utils/stripe-card-gate.ts
@@ -1,0 +1,118 @@
+export const STRIPE_NEW_CARD_LIMIT = 4;
+export const STRIPE_NEW_CARD_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export const STRIPE_NEW_CARD_GATE_METADATA = {
+    gate: "app_new_card_gate",
+    count24h: "app_new_card_count_24h",
+    limit24h: "app_new_card_limit_24h",
+} as const;
+
+export type StripeNewCardGateStatus = {
+    gate: "ok" | "locked";
+    distinctCardCount24h: number;
+    limit: number;
+};
+
+export type StripeCardFingerprintAttemptInput = {
+    eventId: string;
+    userId: string;
+    stripeCustomerId?: string;
+    customerEmail?: string;
+    cardFingerprint: string;
+    cardBrand?: string;
+    cardCountry?: string;
+    paymentIntentId?: string;
+    chargeId?: string;
+    status: string;
+    livemode: boolean;
+    createdAt?: number;
+};
+
+export async function getStripeNewCardGateStatus(
+    db: D1Database,
+    userId: string,
+    now = Date.now(),
+): Promise<StripeNewCardGateStatus> {
+    if (!userId) {
+        return {
+            gate: "ok",
+            distinctCardCount24h: 0,
+            limit: STRIPE_NEW_CARD_LIMIT,
+        };
+    }
+
+    const windowStart = now - STRIPE_NEW_CARD_WINDOW_MS;
+    const row = await db
+        .prepare(
+            `SELECT COUNT(DISTINCT card_fingerprint) AS count
+            FROM stripe_card_fingerprint_attempt
+            WHERE user_id = ?
+                AND created_at >= ?`,
+        )
+        .bind(userId, windowStart)
+        .first<{ count: number | null }>();
+
+    const distinctCardCount24h = Number(row?.count ?? 0);
+
+    return {
+        gate: distinctCardCount24h >= STRIPE_NEW_CARD_LIMIT ? "locked" : "ok",
+        distinctCardCount24h,
+        limit: STRIPE_NEW_CARD_LIMIT,
+    };
+}
+
+export function stripeNewCardGateMetadata(
+    status: StripeNewCardGateStatus,
+): Record<string, string> {
+    return {
+        [STRIPE_NEW_CARD_GATE_METADATA.gate]: status.gate,
+        [STRIPE_NEW_CARD_GATE_METADATA.count24h]: String(
+            status.distinctCardCount24h,
+        ),
+        [STRIPE_NEW_CARD_GATE_METADATA.limit24h]: String(status.limit),
+    };
+}
+
+export async function recordStripeCardFingerprintAttempt(
+    db: D1Database,
+    input: StripeCardFingerprintAttemptInput,
+): Promise<boolean> {
+    if (!input.eventId || !input.userId || !input.cardFingerprint) {
+        return false;
+    }
+
+    const result = await db
+        .prepare(
+            `INSERT OR IGNORE INTO stripe_card_fingerprint_attempt (
+                event_id,
+                user_id,
+                stripe_customer_id,
+                customer_email,
+                card_fingerprint,
+                card_brand,
+                card_country,
+                payment_intent_id,
+                charge_id,
+                status,
+                livemode,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+            input.eventId,
+            input.userId,
+            input.stripeCustomerId ?? null,
+            input.customerEmail ?? null,
+            input.cardFingerprint,
+            input.cardBrand ?? null,
+            input.cardCountry ?? null,
+            input.paymentIntentId ?? null,
+            input.chargeId ?? null,
+            input.status,
+            input.livemode ? 1 : 0,
+            input.createdAt ?? Date.now(),
+        )
+        .run();
+
+    return (result.meta.changes ?? 0) > 0;
+}

--- a/enter.pollinations.ai/src/utils/stripe-card-gate.ts
+++ b/enter.pollinations.ai/src/utils/stripe-card-gate.ts
@@ -9,7 +9,7 @@ export const STRIPE_NEW_CARD_GATE_METADATA = {
 
 export type StripeNewCardGateStatus = {
     gate: "ok" | "locked";
-    distinctCardCount24h: number;
+    distinctFailedCardCount24h: number;
     limit: number;
 };
 
@@ -28,7 +28,7 @@ export async function getStripeNewCardGateStatus(
     if (!userId) {
         return {
             gate: "ok",
-            distinctCardCount24h: 0,
+            distinctFailedCardCount24h: 0,
             limit: STRIPE_NEW_CARD_LIMIT,
         };
     }
@@ -44,11 +44,14 @@ export async function getStripeNewCardGateStatus(
         .bind(userId, windowStart)
         .first<{ count: number | null }>();
 
-    const distinctCardCount24h = Number(row?.count ?? 0);
+    const distinctFailedCardCount24h = Number(row?.count ?? 0);
 
     return {
-        gate: distinctCardCount24h >= STRIPE_NEW_CARD_LIMIT ? "locked" : "ok",
-        distinctCardCount24h,
+        gate:
+            distinctFailedCardCount24h >= STRIPE_NEW_CARD_LIMIT
+                ? "locked"
+                : "ok",
+        distinctFailedCardCount24h,
         limit: STRIPE_NEW_CARD_LIMIT,
     };
 }
@@ -59,7 +62,7 @@ export function stripeNewCardGateMetadata(
     return {
         [STRIPE_NEW_CARD_GATE_METADATA.gate]: status.gate,
         [STRIPE_NEW_CARD_GATE_METADATA.count24h]: String(
-            status.distinctCardCount24h,
+            status.distinctFailedCardCount24h,
         ),
         [STRIPE_NEW_CARD_GATE_METADATA.limit24h]: String(status.limit),
     };

--- a/enter.pollinations.ai/src/utils/stripe-card-gate.ts
+++ b/enter.pollinations.ai/src/utils/stripe-card-gate.ts
@@ -16,15 +16,7 @@ export type StripeNewCardGateStatus = {
 export type StripeCardFingerprintAttemptInput = {
     eventId: string;
     userId: string;
-    stripeCustomerId?: string;
-    customerEmail?: string;
     cardFingerprint: string;
-    cardBrand?: string;
-    cardCountry?: string;
-    paymentIntentId?: string;
-    chargeId?: string;
-    status: string;
-    livemode: boolean;
     createdAt?: number;
 };
 
@@ -86,30 +78,14 @@ export async function recordStripeCardFingerprintAttempt(
             `INSERT OR IGNORE INTO stripe_card_fingerprint_attempt (
                 event_id,
                 user_id,
-                stripe_customer_id,
-                customer_email,
                 card_fingerprint,
-                card_brand,
-                card_country,
-                payment_intent_id,
-                charge_id,
-                status,
-                livemode,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            ) VALUES (?, ?, ?, ?)`,
         )
         .bind(
             input.eventId,
             input.userId,
-            input.stripeCustomerId ?? null,
-            input.customerEmail ?? null,
             input.cardFingerprint,
-            input.cardBrand ?? null,
-            input.cardCountry ?? null,
-            input.paymentIntentId ?? null,
-            input.chargeId ?? null,
-            input.status,
-            input.livemode ? 1 : 0,
             input.createdAt ?? Date.now(),
         )
         .run();

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -165,44 +165,29 @@ async function getSeededUserId(): Promise<string> {
     return user.id;
 }
 
-function createCardChargeSucceededEvent({
+function createCardPaymentFailedEvent({
     eventId,
-    chargeId,
+    paymentIntentId,
     userId,
-    fingerprint,
-    customer = "cus_test_card_gate",
 }: {
     eventId: string;
-    chargeId: string;
+    paymentIntentId: string;
     userId: string;
-    fingerprint: string;
-    customer?: string;
 }): Record<string, unknown> {
     return {
         id: eventId,
-        type: "charge.succeeded",
+        type: "payment_intent.payment_failed",
         livemode: false,
         data: {
             object: {
-                id: chargeId,
-                object: "charge",
+                id: paymentIntentId,
+                object: "payment_intent",
                 amount: 1000,
                 currency: "usd",
-                status: "succeeded",
-                customer,
-                payment_intent: `pi_${chargeId}`,
+                status: "requires_payment_method",
                 metadata: { userId },
-                billing_details: { email: "buyer@example.com" },
-                payment_method_details: {
-                    type: "card",
-                    card: {
-                        fingerprint,
-                        brand: "visa",
-                        country: "US",
-                        network: "visa",
-                    },
-                },
-                outcome: { risk_level: "normal", risk_score: 12 },
+                payment_method_types: ["card"],
+                receipt_email: "buyer@example.com",
             },
         },
     };
@@ -360,7 +345,7 @@ test("GET /api/stripe/checkout/p10 sets pack identity in session metadata", asyn
     );
 });
 
-test("GET /api/stripe/checkout marks new-card gate locked after four distinct cards in 24h", async ({
+test("GET /api/stripe/checkout marks new-card gate locked after four distinct failed cards in 24h", async ({
     sessionToken,
     mocks,
 }) => {
@@ -373,12 +358,44 @@ test("GET /api/stripe/checkout marks new-card gate locked after four distinct ca
         "fp_gate_3",
         "fp_gate_4",
     ]) {
+        const paymentIntentId = `pi_${fingerprint}`;
+        mocks.stripe.state.paymentIntents.push({
+            id: paymentIntentId,
+            object: "payment_intent",
+            status: "requires_payment_method",
+            amount: 1000,
+            currency: "usd",
+            metadata: { userId },
+            payment_method_types: ["card"],
+            receipt_email: "buyer@example.com",
+            latest_charge: {
+                id: `ch_${fingerprint}`,
+                object: "charge",
+                amount: 1000,
+                currency: "usd",
+                status: "failed",
+                customer: "cus_test_card_gate",
+                payment_intent: paymentIntentId,
+                metadata: { userId },
+                billing_details: { email: "buyer@example.com" },
+                payment_method_details: {
+                    type: "card",
+                    card: {
+                        fingerprint,
+                        brand: "visa",
+                        country: "US",
+                        network: "visa",
+                    },
+                },
+                outcome: { risk_level: "elevated", risk_score: 61 },
+            },
+        });
+
         const response = await postSignedStripeWebhook(
-            createCardChargeSucceededEvent({
+            createCardPaymentFailedEvent({
                 eventId: `evt_${fingerprint}`,
-                chargeId: `ch_${fingerprint}`,
+                paymentIntentId,
                 userId,
-                fingerprint,
             }),
         );
         expect(response.status).toBe(200);
@@ -2913,7 +2930,7 @@ test("POST /api/webhooks/stripe charge.succeeded enriches Tinybird with card iss
     });
 });
 
-test("POST /api/webhooks/stripe charge.succeeded records card fingerprint without crediting checkout", async ({
+test("POST /api/webhooks/stripe charge.succeeded does not record failed-card gate fingerprint or credit checkout", async ({
     sessionToken,
     mocks,
 }) => {
@@ -2966,59 +2983,7 @@ test("POST /api/webhooks/stripe charge.succeeded records card fingerprint withou
     const attemptsAfter = await env.DB.prepare(
         "SELECT COUNT(*) AS count FROM stripe_card_fingerprint_attempt",
     ).first<{ count: number }>();
-    expect(attemptsAfter?.count).toBe((attemptsBefore?.count ?? 0) + 1);
-
-    const [attempt] = await drizzle(env.DB)
-        .select({
-            userId: stripeCardFingerprintAttemptTable.userId,
-            cardFingerprint: stripeCardFingerprintAttemptTable.cardFingerprint,
-            createdAt: stripeCardFingerprintAttemptTable.createdAt,
-        })
-        .from(stripeCardFingerprintAttemptTable)
-        .where(
-            eq(
-                stripeCardFingerprintAttemptTable.eventId,
-                "evt_test_charge_no_d1",
-            ),
-        )
-        .limit(1);
-
-    expect(attempt).toMatchObject({
-        userId,
-        cardFingerprint: "fp_test_charge_no_d1",
-    });
-    expect(attempt?.createdAt).toBeInstanceOf(Date);
-
-    const duplicateResponse = await postSignedStripeWebhook({
-        id: "evt_test_charge_no_d1",
-        type: "charge.succeeded",
-        livemode: false,
-        data: {
-            object: {
-                id: "ch_test_charge_no_d1",
-                object: "charge",
-                amount: 500,
-                currency: "usd",
-                status: "succeeded",
-                metadata: { userId },
-                payment_method_details: {
-                    type: "card",
-                    card: {
-                        fingerprint: "fp_test_charge_no_d1",
-                        brand: "visa",
-                        country: "US",
-                        network: "visa",
-                    },
-                },
-            },
-        },
-    });
-    expect(duplicateResponse.status).toBe(200);
-
-    const attemptsAfterDuplicate = await env.DB.prepare(
-        "SELECT COUNT(*) AS count FROM stripe_card_fingerprint_attempt",
-    ).first<{ count: number }>();
-    expect(attemptsAfterDuplicate?.count).toBe(attemptsAfter?.count);
+    expect(attemptsAfter?.count).toBe(attemptsBefore?.count);
 });
 
 test("POST /api/webhooks/stripe payment_intent.payment_failed records latest charge fingerprint", async ({

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -1,6 +1,9 @@
 import { env, SELF } from "cloudflare:test";
 import { createHmac } from "node:crypto";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    stripeCardFingerprintAttempt as stripeCardFingerprintAttemptTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import {
     describePollenPack,
     getPollenPackByAmount,
@@ -10,6 +13,7 @@ import {
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
+import { STRIPE_NEW_CARD_GATE_METADATA } from "../../src/utils/stripe-card-gate.ts";
 import { test } from "../fixtures.ts";
 import { mockCardPaymentMethod, mockCustomer } from "../mocks/stripe.ts";
 
@@ -149,6 +153,61 @@ async function postSignedStripeWebhook(
     });
 }
 
+async function getSeededUserId(): Promise<string> {
+    const db = drizzle(env.DB);
+    const [user] = await db
+        .select({ id: userTable.id })
+        .from(userTable)
+        .limit(1);
+
+    expect(user).toBeTruthy();
+    if (!user) throw new Error("Expected seeded test user");
+    return user.id;
+}
+
+function createCardChargeSucceededEvent({
+    eventId,
+    chargeId,
+    userId,
+    fingerprint,
+    customer = "cus_test_card_gate",
+}: {
+    eventId: string;
+    chargeId: string;
+    userId: string;
+    fingerprint: string;
+    customer?: string;
+}): Record<string, unknown> {
+    return {
+        id: eventId,
+        type: "charge.succeeded",
+        livemode: false,
+        data: {
+            object: {
+                id: chargeId,
+                object: "charge",
+                amount: 1000,
+                currency: "usd",
+                status: "succeeded",
+                customer,
+                payment_intent: `pi_${chargeId}`,
+                metadata: { userId },
+                billing_details: { email: "buyer@example.com" },
+                payment_method_details: {
+                    type: "card",
+                    card: {
+                        fingerprint,
+                        brand: "visa",
+                        country: "US",
+                        network: "visa",
+                    },
+                },
+                outcome: { risk_level: "normal", risk_score: 12 },
+            },
+        },
+    };
+}
+
 test.for(
     checkoutAmounts,
 )("%s should only be accessible when authenticated via session cookie", async (route, {
@@ -276,11 +335,88 @@ test("GET /api/stripe/checkout/p10 sets pack identity in session metadata", asyn
     // branch was taken.
     expect(body?.["metadata[packKey]"]).toBe(pack?.packKey);
     expect(body?.["metadata[cohort]"]).toBe("USD");
+    expect(body?.[`metadata[${STRIPE_NEW_CARD_GATE_METADATA.gate}]`]).toBe(
+        "ok",
+    );
+    expect(body?.[`metadata[${STRIPE_NEW_CARD_GATE_METADATA.count24h}]`]).toBe(
+        "0",
+    );
+    expect(body?.[`metadata[${STRIPE_NEW_CARD_GATE_METADATA.limit24h}]`]).toBe(
+        "4",
+    );
 
     // payment_intent metadata mirrors session metadata for Stripe dashboard
     // inspection and reconciliation.
     expect(body?.["payment_intent_data[metadata][packKey]"]).toBe(
         pack?.packKey,
+    );
+    expect(
+        body?.[
+            `payment_intent_data[metadata][${STRIPE_NEW_CARD_GATE_METADATA.gate}]`
+        ],
+    ).toBe("ok");
+    expect(body?.["payment_method_options[card][request_three_d_secure]"]).toBe(
+        undefined,
+    );
+});
+
+test("GET /api/stripe/checkout marks new-card gate locked after four distinct cards in 24h", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const userId = await getSeededUserId();
+
+    for (const fingerprint of [
+        "fp_gate_1",
+        "fp_gate_2",
+        "fp_gate_3",
+        "fp_gate_4",
+    ]) {
+        const response = await postSignedStripeWebhook(
+            createCardChargeSucceededEvent({
+                eventId: `evt_${fingerprint}`,
+                chargeId: `ch_${fingerprint}`,
+                userId,
+                fingerprint,
+            }),
+        );
+        expect(response.status).toBe(200);
+    }
+
+    const response = await SELF.fetch(`${base}/checkout/p10`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+        redirect: "manual",
+    });
+    expect(response.status).toBe(302);
+
+    const body = mocks.stripe.state.requests.find(
+        (request) => request.path === "/v1/checkout/sessions",
+    )?.body;
+    expect(body).toBeTruthy();
+
+    expect(body?.[`metadata[${STRIPE_NEW_CARD_GATE_METADATA.gate}]`]).toBe(
+        "locked",
+    );
+    expect(body?.[`metadata[${STRIPE_NEW_CARD_GATE_METADATA.count24h}]`]).toBe(
+        "4",
+    );
+    expect(body?.[`metadata[${STRIPE_NEW_CARD_GATE_METADATA.limit24h}]`]).toBe(
+        "4",
+    );
+    expect(
+        body?.[
+            `payment_intent_data[metadata][${STRIPE_NEW_CARD_GATE_METADATA.gate}]`
+        ],
+    ).toBe("locked");
+    expect(
+        body?.[
+            `payment_intent_data[metadata][${STRIPE_NEW_CARD_GATE_METADATA.count24h}]`
+        ],
+    ).toBe("4");
+    expect(body?.["payment_method_options[card][request_three_d_secure]"]).toBe(
+        undefined,
     );
 });
 
@@ -2745,7 +2881,12 @@ test("POST /api/webhooks/stripe charge.succeeded enriches Tinybird with card iss
                 billing_details: { email: "buyer@example.com" },
                 payment_method_details: {
                     type: "card",
-                    card: { brand: "visa", country: "CZ", network: "visa" },
+                    card: {
+                        fingerprint: "fp_test_charge_succeeded",
+                        brand: "visa",
+                        country: "CZ",
+                        network: "visa",
+                    },
                 },
                 outcome: { risk_level: "normal", risk_score: 21 },
             },
@@ -2772,13 +2913,19 @@ test("POST /api/webhooks/stripe charge.succeeded enriches Tinybird with card iss
     });
 });
 
-test("POST /api/webhooks/stripe charge.succeeded does not write to D1 (Tinybird-only analytics)", async ({
+test("POST /api/webhooks/stripe charge.succeeded records card fingerprint without crediting checkout", async ({
+    sessionToken,
     mocks,
 }) => {
     await mocks.enable("tinybird");
+    expect(sessionToken).toBeTruthy();
+    const userId = await getSeededUserId();
 
-    const before = await env.DB.prepare(
+    const creditsBefore = await env.DB.prepare(
         "SELECT COUNT(*) AS count FROM stripe_checkout_credits",
+    ).first<{ count: number }>();
+    const attemptsBefore = await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM stripe_card_fingerprint_attempt",
     ).first<{ count: number }>();
 
     const response = await postSignedStripeWebhook({
@@ -2792,9 +2939,18 @@ test("POST /api/webhooks/stripe charge.succeeded does not write to D1 (Tinybird-
                 amount: 500,
                 currency: "usd",
                 status: "succeeded",
+                customer: "cus_test_charge_no_d1",
+                payment_intent: "pi_test_charge_no_d1",
+                metadata: { userId },
+                billing_details: { email: "buyer@example.com" },
                 payment_method_details: {
                     type: "card",
-                    card: { brand: "visa", country: "US", network: "visa" },
+                    card: {
+                        fingerprint: "fp_test_charge_no_d1",
+                        brand: "visa",
+                        country: "US",
+                        network: "visa",
+                    },
                 },
                 outcome: { risk_level: "normal", risk_score: 5 },
             },
@@ -2805,7 +2961,149 @@ test("POST /api/webhooks/stripe charge.succeeded does not write to D1 (Tinybird-
     const after = await env.DB.prepare(
         "SELECT COUNT(*) AS count FROM stripe_checkout_credits",
     ).first<{ count: number }>();
-    expect(after?.count).toBe(before?.count);
+    expect(after?.count).toBe(creditsBefore?.count);
+
+    const attemptsAfter = await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM stripe_card_fingerprint_attempt",
+    ).first<{ count: number }>();
+    expect(attemptsAfter?.count).toBe((attemptsBefore?.count ?? 0) + 1);
+
+    const [attempt] = await drizzle(env.DB)
+        .select({
+            userId: stripeCardFingerprintAttemptTable.userId,
+            cardFingerprint: stripeCardFingerprintAttemptTable.cardFingerprint,
+            status: stripeCardFingerprintAttemptTable.status,
+            chargeId: stripeCardFingerprintAttemptTable.chargeId,
+        })
+        .from(stripeCardFingerprintAttemptTable)
+        .where(
+            eq(
+                stripeCardFingerprintAttemptTable.eventId,
+                "evt_test_charge_no_d1",
+            ),
+        )
+        .limit(1);
+
+    expect(attempt).toMatchObject({
+        userId,
+        cardFingerprint: "fp_test_charge_no_d1",
+        status: "succeeded",
+        chargeId: "ch_test_charge_no_d1",
+    });
+
+    const duplicateResponse = await postSignedStripeWebhook({
+        id: "evt_test_charge_no_d1",
+        type: "charge.succeeded",
+        livemode: false,
+        data: {
+            object: {
+                id: "ch_test_charge_no_d1",
+                object: "charge",
+                amount: 500,
+                currency: "usd",
+                status: "succeeded",
+                metadata: { userId },
+                payment_method_details: {
+                    type: "card",
+                    card: {
+                        fingerprint: "fp_test_charge_no_d1",
+                        brand: "visa",
+                        country: "US",
+                        network: "visa",
+                    },
+                },
+            },
+        },
+    });
+    expect(duplicateResponse.status).toBe(200);
+
+    const attemptsAfterDuplicate = await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM stripe_card_fingerprint_attempt",
+    ).first<{ count: number }>();
+    expect(attemptsAfterDuplicate?.count).toBe(attemptsAfter?.count);
+});
+
+test("POST /api/webhooks/stripe payment_intent.payment_failed records latest charge fingerprint", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    expect(sessionToken).toBeTruthy();
+    const userId = await getSeededUserId();
+
+    mocks.stripe.state.paymentIntents.push({
+        id: "pi_test_failed_card_gate",
+        object: "payment_intent",
+        status: "requires_payment_method",
+        amount: 500,
+        currency: "usd",
+        metadata: { userId },
+        payment_method_types: ["card"],
+        receipt_email: "buyer@example.com",
+        latest_charge: {
+            id: "ch_test_failed_card_gate",
+            object: "charge",
+            amount: 500,
+            currency: "usd",
+            status: "failed",
+            customer: "cus_test_failed_card_gate",
+            payment_intent: "pi_test_failed_card_gate",
+            metadata: { userId },
+            billing_details: { email: "buyer@example.com" },
+            payment_method_details: {
+                type: "card",
+                card: {
+                    fingerprint: "fp_test_failed_card_gate",
+                    brand: "visa",
+                    country: "US",
+                    network: "visa",
+                },
+            },
+            outcome: { risk_level: "elevated", risk_score: 61 },
+        },
+    });
+
+    const response = await postSignedStripeWebhook({
+        id: "evt_test_failed_card_gate",
+        type: "payment_intent.payment_failed",
+        livemode: false,
+        data: {
+            object: {
+                id: "pi_test_failed_card_gate",
+                object: "payment_intent",
+                status: "requires_payment_method",
+                amount: 500,
+                currency: "usd",
+                metadata: { userId },
+                payment_method_types: ["card"],
+                receipt_email: "buyer@example.com",
+            },
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const [attempt] = await drizzle(env.DB)
+        .select({
+            userId: stripeCardFingerprintAttemptTable.userId,
+            cardFingerprint: stripeCardFingerprintAttemptTable.cardFingerprint,
+            status: stripeCardFingerprintAttemptTable.status,
+            chargeId: stripeCardFingerprintAttemptTable.chargeId,
+        })
+        .from(stripeCardFingerprintAttemptTable)
+        .where(
+            eq(
+                stripeCardFingerprintAttemptTable.eventId,
+                "evt_test_failed_card_gate",
+            ),
+        )
+        .limit(1);
+
+    expect(attempt).toMatchObject({
+        userId,
+        cardFingerprint: "fp_test_failed_card_gate",
+        status: "failed",
+        chargeId: "ch_test_failed_card_gate",
+    });
 });
 
 test("POST /api/webhooks/stripe emits checkout.session.async_payment_failed to Tinybird", async ({

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -2972,8 +2972,7 @@ test("POST /api/webhooks/stripe charge.succeeded records card fingerprint withou
         .select({
             userId: stripeCardFingerprintAttemptTable.userId,
             cardFingerprint: stripeCardFingerprintAttemptTable.cardFingerprint,
-            status: stripeCardFingerprintAttemptTable.status,
-            chargeId: stripeCardFingerprintAttemptTable.chargeId,
+            createdAt: stripeCardFingerprintAttemptTable.createdAt,
         })
         .from(stripeCardFingerprintAttemptTable)
         .where(
@@ -2987,9 +2986,8 @@ test("POST /api/webhooks/stripe charge.succeeded records card fingerprint withou
     expect(attempt).toMatchObject({
         userId,
         cardFingerprint: "fp_test_charge_no_d1",
-        status: "succeeded",
-        chargeId: "ch_test_charge_no_d1",
     });
+    expect(attempt?.createdAt).toBeInstanceOf(Date);
 
     const duplicateResponse = await postSignedStripeWebhook({
         id: "evt_test_charge_no_d1",
@@ -3086,8 +3084,7 @@ test("POST /api/webhooks/stripe payment_intent.payment_failed records latest cha
         .select({
             userId: stripeCardFingerprintAttemptTable.userId,
             cardFingerprint: stripeCardFingerprintAttemptTable.cardFingerprint,
-            status: stripeCardFingerprintAttemptTable.status,
-            chargeId: stripeCardFingerprintAttemptTable.chargeId,
+            createdAt: stripeCardFingerprintAttemptTable.createdAt,
         })
         .from(stripeCardFingerprintAttemptTable)
         .where(
@@ -3101,9 +3098,8 @@ test("POST /api/webhooks/stripe payment_intent.payment_failed records latest cha
     expect(attempt).toMatchObject({
         userId,
         cardFingerprint: "fp_test_failed_card_gate",
-        status: "failed",
-        chargeId: "ch_test_failed_card_gate",
     });
+    expect(attempt?.createdAt).toBeInstanceOf(Date);
 });
 
 test("POST /api/webhooks/stripe emits checkout.session.async_payment_failed to Tinybird", async ({

--- a/enter.pollinations.ai/test/mocks/stripe.ts
+++ b/enter.pollinations.ai/test/mocks/stripe.ts
@@ -124,6 +124,12 @@ type StripePaymentIntent = {
     id: string;
     object: "payment_intent";
     status: string;
+    amount?: number;
+    currency?: string;
+    metadata?: Record<string, string>;
+    payment_method_types?: string[];
+    receipt_email?: string | null;
+    latest_charge?: unknown;
 };
 
 type StripeRequest = {

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -178,17 +178,7 @@ export const stripeCardFingerprintAttempt = sqliteTable("stripe_card_fingerprint
   userId: text("user_id")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
-  stripeCustomerId: text("stripe_customer_id"),
-  customerEmail: text("customer_email"),
   cardFingerprint: text("card_fingerprint").notNull(),
-  cardBrand: text("card_brand"),
-  cardCountry: text("card_country"),
-  paymentIntentId: text("payment_intent_id"),
-  chargeId: text("charge_id"),
-  status: text("status").notNull(),
-  livemode: integer("livemode", { mode: "boolean" })
-    .default(false)
-    .notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .defaultNow()
     .notNull(),
@@ -200,10 +190,6 @@ export const stripeCardFingerprintAttempt = sqliteTable("stripe_card_fingerprint
   index("idx_stripe_card_fingerprint_attempt_user_fingerprint").on(
     table.userId,
     table.cardFingerprint,
-  ),
-  index("idx_stripe_card_fingerprint_attempt_customer_created").on(
-    table.stripeCustomerId,
-    table.createdAt,
   ),
 ]);
 

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -173,6 +173,40 @@ export const stripeAutoTopUpAttempt = sqliteTable("stripe_auto_top_up_attempt", 
   index("idx_stripe_auto_top_up_attempt_status").on(table.status),
 ]);
 
+export const stripeCardFingerprintAttempt = sqliteTable("stripe_card_fingerprint_attempt", {
+  eventId: text("event_id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  stripeCustomerId: text("stripe_customer_id"),
+  customerEmail: text("customer_email"),
+  cardFingerprint: text("card_fingerprint").notNull(),
+  cardBrand: text("card_brand"),
+  cardCountry: text("card_country"),
+  paymentIntentId: text("payment_intent_id"),
+  chargeId: text("charge_id"),
+  status: text("status").notNull(),
+  livemode: integer("livemode", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .defaultNow()
+    .notNull(),
+}, (table) => [
+  index("idx_stripe_card_fingerprint_attempt_user_created").on(
+    table.userId,
+    table.createdAt,
+  ),
+  index("idx_stripe_card_fingerprint_attempt_user_fingerprint").on(
+    table.userId,
+    table.cardFingerprint,
+  ),
+  index("idx_stripe_card_fingerprint_attempt_customer_created").on(
+    table.stripeCustomerId,
+    table.createdAt,
+  ),
+]);
+
 export const communityEndpoint = sqliteTable("community_endpoint", {
   id: text("id").primaryKey(),
   ownerUserId: text("owner_user_id")
@@ -212,6 +246,7 @@ export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),
   stripeAutoTopUpAttempts: many(stripeAutoTopUpAttempt),
+  stripeCardFingerprintAttempts: many(stripeCardFingerprintAttempt),
   communityEndpoints: many(communityEndpoint),
 }));
 
@@ -241,6 +276,16 @@ export const stripeAutoTopUpAttemptRelations = relations(
   ({ one }) => ({
     user: one(user, {
       fields: [stripeAutoTopUpAttempt.userId],
+      references: [user.id],
+    }),
+  }),
+);
+
+export const stripeCardFingerprintAttemptRelations = relations(
+  stripeCardFingerprintAttempt,
+  ({ one }) => ({
+    user: one(user, {
+      fields: [stripeCardFingerprintAttempt.userId],
       references: [user.id],
     }),
   }),


### PR DESCRIPTION
- Adds a minimal D1 ledger for failed Stripe card fingerprints: `event_id`, `user_id`, `card_fingerprint`, `created_at`.
- Records fingerprints only from `payment_intent.payment_failed`; successful `charge.succeeded` events remain analytics-only and do not feed the gate.
- Adds Checkout and PaymentIntent metadata for the 4-distinct-failed-cards/24h gate so Radar can block only new cards when locked.
- Keeps Checkout open and leaves 3DS to Stripe/Radar; no app-side forced 3DS.
- Adds migration/schema updates and Stripe integration coverage.

Validation:
- `npx biome check --write ...`
- `npx vitest run test/integration/stripe.test.ts` (65 passed)
- `npx tsc --noEmit` fails on existing `FieldStackProps.helper` errors in `frontend/src/components/community-endpoints/community-endpoint-dialog.tsx`.