### PR TITLE
feat: allowlist MarcosFRG + ytpk for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -12,6 +12,8 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     93234024, // skullcrushercmd
     201248601, // CloudCompile
     206557620, // smplstuff
+    201380514, // MarcosFRG
+    88273873, // ytpk
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds GitHub ID 201380514 (MarcosFRG) to community model allowlist
- Adds GitHub ID 88273873 (ytpk) to community model allowlist

Both can now register community models via the gen worker.

Note: a third requested user (Discord 'morrisdweck'/'Mincoffical') has no resolvable GitHub account yet — pending their GitHub username.