### PR TITLE
feat: add nanobanana-lite (Gemini 3.1 Flash-Lite Image)

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -682,6 +682,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000005,
     },
   },
+  "nanobanana-lite": {
+    "cost": {
+      "completionImageTokens": 0.00003,
+      "completionTextTokens": 0.0000015,
+      "promptImageTokens": 0.00000025,
+      "promptTextTokens": 0.00000025,
+    },
+    "price": {
+      "completionImageTokens": 0.00003,
+      "completionTextTokens": 0.0000015,
+      "promptImageTokens": 0.00000025,
+      "promptTextTokens": 0.00000025,
+    },
+  },
   "nanobanana-pro": {
     "cost": {
       "completionImageTokens": 0.00012,
@@ -1036,12 +1050,22 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.035,
     },
   },
-  "stable-audio-3-medium": {
+  "stable-audio-3-large": {
     "cost": {
-      "completionAudioTokens": 0.0001,
+      "completionAudioTokens": 0.26,
     },
     "price": {
-      "completionAudioTokens": 0.0001,
+      "completionAudioTokens": 0.26,
+    },
+  },
+  "stable-audio-3-medium": {
+    "cost": {
+      "completionAudioTokens": 0.0376,
+      "promptAudioTokens": 0.0041,
+    },
+    "price": {
+      "completionAudioTokens": 0.0376,
+      "promptAudioTokens": 0.0041,
     },
   },
   "step-3.5-flash": {

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -606,6 +606,7 @@ const generateImage = async (
 
         case "nanobanana":
         case "nanobanana-2":
+        case "nanobanana-lite":
         case "nanobanana-pro": {
             logError(
                 "Nano Banana authentication check:",

--- a/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
+++ b/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
@@ -24,6 +24,10 @@ const NANOBANANA_MODELS: Record<string, { vertex: string; name: string }> = {
         vertex: "gemini-3.1-flash-image-preview",
         name: "Vertex AI Gemini 3.1 Flash Image Preview",
     },
+    "nanobanana-lite": {
+        vertex: "gemini-3.1-flash-lite-image",
+        name: "Vertex AI Gemini 3.1 Flash-Lite Image",
+    },
     "nanobanana": {
         vertex: "gemini-2.5-flash-image",
         name: "Vertex AI Gemini 2.5 Flash Image",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -68,6 +68,30 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations cap for Gemini 3.1 Flash Image route.
     },
+    "nanobanana-lite": {
+        aliases: ["nanobanana2-lite", "nanobanana-2-lite"],
+        modelId: "nanobanana-lite",
+        provider: "google",
+        brand: "Google",
+        category: "image",
+        addedDate: new Date("2026-06-30").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // Gemini 3.1 Flash-Lite Image via Vertex AI — half of nanobanana-2.
+            // Always emits 1K images at 1120 tokens (no imageSize support).
+            promptTextTokens: perMillion(0.25), // per 1M tokens
+            promptImageTokens: perMillion(0.25), // per 1M tokens
+            completionTextTokens: perMillion(1.5), // text/reasoning output tokens
+            completionImageTokens: perMillion(30), // per 1M tokens, 1120 tokens/image
+        },
+        title: "NanoBanana 2 Lite",
+        description:
+            "NanoBanana 2 Lite - Fastest, lowest-cost Gemini image generation",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+        maxReferenceImages: 14, // Pollinations cap for Gemini 3.1 Flash image route.
+    },
     "nanobanana-pro": {
         aliases: [],
         modelId: "nanobanana-pro",


### PR DESCRIPTION
Adds `gemini-3.1-flash-lite-image` ("Nano Banana 2 Lite") via Vertex AI as model `nanobanana-lite`.

- New slug `nanobanana-lite` (aliases: `nanobanana2-lite`, `nanobanana-2-lite`)
- Routes through existing Vertex AI Gemini image path (mirrors `nanobanana-2`)
- Pricing = half of `nanobanana-2`: $0.25/1M input, $30/1M image out, $1.5/1M text out (confirmed on Vertex pricing page)
- `paidOnly`, `priceMultiplier: 1` (at-cost, same as nanobanana-2)

**Empirically verified** against our Vertex project (`stellar-verve-465920-b7`):
- HTTP 200, returns real image, `finishReason: STOP`, 1120 tokens/1K image
- `thinkingConfig` accepted (existing 3.1 logic applies)
- `aspectRatio` works; **`imageSize` returns 400** — flash-lite always emits 1K, so it is correctly omitted from the size gate

Tests: aliases (219), pricing-data, gen image suite (133), effective-prices snapshot updated.