### PR TITLE
feat: add nanobanana-2-lite image model

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -682,6 +682,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000005,
     },
   },
+  "nanobanana-2-lite": {
+    "cost": {
+      "completionImageTokens": 0.00003,
+      "completionTextTokens": 0.0000015,
+      "promptImageTokens": 0.00000025,
+      "promptTextTokens": 0.00000025,
+    },
+    "price": {
+      "completionImageTokens": 0.00003,
+      "completionTextTokens": 0.0000015,
+      "promptImageTokens": 0.00000025,
+      "promptTextTokens": 0.00000025,
+    },
+  },
   "nanobanana-pro": {
     "cost": {
       "completionImageTokens": 0.00012,
@@ -1036,12 +1050,22 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.035,
     },
   },
-  "stable-audio-3-medium": {
+  "stable-audio-3-large": {
     "cost": {
-      "completionAudioTokens": 0.0001,
+      "completionAudioTokens": 0.26,
     },
     "price": {
-      "completionAudioTokens": 0.0001,
+      "completionAudioTokens": 0.26,
+    },
+  },
+  "stable-audio-3-medium": {
+    "cost": {
+      "completionAudioTokens": 0.0376,
+      "promptAudioTokens": 0.0041,
+    },
+    "price": {
+      "completionAudioTokens": 0.0376,
+      "promptAudioTokens": 0.0041,
     },
   },
   "step-3.5-flash": {

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -606,6 +606,7 @@ const generateImage = async (
 
         case "nanobanana":
         case "nanobanana-2":
+        case "nanobanana-2-lite":
         case "nanobanana-pro": {
             logError(
                 "Nano Banana authentication check:",

--- a/gen.pollinations.ai/src/image/vertexAIClient.ts
+++ b/gen.pollinations.ai/src/image/vertexAIClient.ts
@@ -117,7 +117,9 @@ export async function generateImageWithVertexAI(
         }
 
         // Determine image size based on pixel count
-        // Both gemini-3-pro-image-preview and gemini-3.1-flash-image-preview support imageSize
+        // Both gemini-3-pro-image-preview and gemini-3.1-flash-image-preview support imageSize.
+        // gemini-3.1-flash-lite-image only outputs 1K (Vertex 400s on imageSize 2K/4K),
+        // so it is intentionally omitted — it defaults to 1K.
         let imageSize: string | undefined;
         if (
             (modelId === "gemini-3-pro-image-preview" ||

--- a/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
+++ b/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
@@ -24,6 +24,10 @@ const NANOBANANA_MODELS: Record<string, { vertex: string; name: string }> = {
         vertex: "gemini-3.1-flash-image-preview",
         name: "Vertex AI Gemini 3.1 Flash Image Preview",
     },
+    "nanobanana-2-lite": {
+        vertex: "gemini-3.1-flash-lite-image",
+        name: "Vertex AI Gemini 3.1 Flash-Lite Image",
+    },
     "nanobanana": {
         vertex: "gemini-2.5-flash-image",
         name: "Vertex AI Gemini 2.5 Flash Image",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -68,6 +68,29 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations cap for Gemini 3.1 Flash Image route.
     },
+    "nanobanana-2-lite": {
+        aliases: ["nanobanana2lite", "nanobanana-lite"],
+        modelId: "nanobanana-2-lite",
+        provider: "google",
+        brand: "Google",
+        category: "image",
+        addedDate: new Date("2026-06-30").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // Gemini 3.1 Flash-Lite Image (GA) via Vertex AI — half of nanobanana-2
+            promptTextTokens: perMillion(0.25), // per 1M tokens
+            promptImageTokens: perMillion(0.25), // per 1M tokens
+            completionTextTokens: perMillion(1.5), // text/reasoning output tokens
+            completionImageTokens: perMillion(30), // per 1M tokens, 1120 tokens/1K image = $0.0336
+        },
+        title: "NanoBanana 2 Lite",
+        description:
+            "NanoBanana 2 Lite - Fast, low-cost image generation & editing",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+        maxReferenceImages: 14, // Pollinations cap for Gemini 3.1 Flash-Lite Image route.
+    },
     "nanobanana-pro": {
         aliases: [],
         modelId: "nanobanana-pro",


### PR DESCRIPTION
Adds Nano Banana 2 Lite (Gemini 3.1 Flash-Lite Image, GA on Vertex) as a new paid image model.

- Registry entry `nanobanana-2-lite` (aliases `nanobanana2lite`, `nanobanana-lite`), paid-only, routing to Vertex `gemini-3.1-flash-lite-image`
- Cost is exactly half of `nanobanana-2`: prompt text/image $0.25/1M, completion text $1.5/1M, completion image $30/1M (1120 tokens/1K image = $0.0336)
- Wired into the Vertex model map and image dispatch switch

Note: Google's docs list 512/1K/2K/4K output, but Vertex returns `400 INVALID_ARGUMENT` on imageSize 2K/4K for this model — it only outputs 1K. Left it out of the `imageSize` allow-list so large requests default to 1K instead of erroring.

Verified end-to-end on local gen against live Vertex: T2I across sizes/aspect ratios, image editing, output cache MISS→HIT, error paths (400 not 5xx), and billing (0.0336 pollen/image, matching Tinybird rows, no missing-rate warnings). Full automated suites pass (enter aliases/pricing/snapshot, gen usage/permissions/image/billing/cache).