### PR TITLE
feat: add claude-sonnet-5 (bedrock)

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -80,6 +80,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000005,
     },
   },
+  "claude-sonnet-5": {
+    "cost": {
+      "completionTextTokens": 0.000015,
+      "promptCacheWriteTokens": 0.00000375,
+      "promptCachedTokens": 0.0000003,
+      "promptTextTokens": 0.000003,
+    },
+    "price": {
+      "completionTextTokens": 0.000015,
+      "promptCacheWriteTokens": 0.00000375,
+      "promptCachedTokens": 0.0000003,
+      "promptTextTokens": 0.000003,
+    },
+  },
   "cohere-embed-v4": {
     "cost": {
       "promptTextTokens": 0.00000012,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -162,6 +162,11 @@ const models: ModelDefinition[] = [
         transform: claudeAdaptiveThinking,
     },
     {
+        name: "claude-sonnet-5",
+        config: portkeyConfig["claude-sonnet-5"],
+        transform: claudeAdaptiveThinking,
+    },
+    {
         name: "claude-opus-4.6",
         config: portkeyConfig["claude-opus-4-6"],
         transform: claudeAdaptiveThinking,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -168,6 +168,11 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "global.anthropic.claude-sonnet-4-6",
             defaultOptions: { max_tokens: 64000 },
         }),
+    "claude-sonnet-5": () =>
+        createBedrockNativeConfig({
+            model: "global.anthropic.claude-sonnet-5",
+            defaultOptions: { max_tokens: 64000 },
+        }),
     "claude-opus-4-6": () =>
         createBedrockNativeConfig({
             model: "global.anthropic.claude-opus-4-6-v1",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -741,6 +741,33 @@ export const TEXT_SERVICES = {
         contextLength: 1000000, // Bedrock global Claude Sonnet 4.6 context window.
         isSpecialized: false,
     },
+    "claude-sonnet-5": {
+        aliases: ["sonnet-5"],
+        modelId: "claude-sonnet-5",
+        provider: "bedrock",
+        brand: "Anthropic",
+        category: "text",
+        addedDate: new Date("2026-06-30").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // Bedrock anthropic.claude-sonnet-5 standard rates.
+            // Intro $2/$10 through 2026-08-31; use standard $3/$15 to match
+            // siblings and avoid a price bump when the intro period ends.
+            promptTextTokens: perMillion(3),
+            promptCachedTokens: perMillion(0.3),
+            promptCacheWriteTokens: perMillion(3.75),
+            completionTextTokens: perMillion(15),
+        },
+        title: "Claude Sonnet 5",
+        description: "Claude Sonnet 5 - Best balance of speed & intelligence",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 20, // Bedrock Converse image limit.
+        tools: true,
+        contextLength: 1000000, // Bedrock Claude Sonnet 5 context window.
+        isSpecialized: false,
+    },
     "claude-opus-4.6": {
         aliases: ["claude-opus-4.5"],
         modelId: "claude-opus-4-6",


### PR DESCRIPTION
Adds Claude Sonnet 5 as a paid text model via AWS Bedrock (launched today).

- Registry entry `claude-sonnet-5` (alias `sonnet-5`), routing to Bedrock `global.anthropic.claude-sonnet-5`
- 1M context, tools + vision, adaptive thinking (same transform as Sonnet 4.6)
- Priced at standard $3/$15 per MTok with cache rates ($0.30 read / $3.75 write). Intro $2/$10 runs through 2026-08-31, but using standard to match siblings and avoid a price bump when it ends
- The `global.*` inference profile works on our Bedrock account (no `us.*` needed, unlike Opus 4.7/4.8)

Verified end-to-end on local gen against live Bedrock: basic + streaming generation, max_tokens edge, tool calls, image input, and billing (Tinybird rows exact, no missing-rate warnings, multiplier 1). Automated suites pass (enter aliases/pricing/snapshot, gen permissions/usage/cache/billing).