### PR TITLE
fix: accept chat responses without model

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -332,7 +332,6 @@ fixtureTest(
                 return Response.json({
                     id: "chatcmpl_test",
                     object: "chat.completion",
-                    model: "gpt-4.1-mini",
                     choices: [
                         {
                             index: 0,
@@ -372,18 +371,12 @@ fixtureTest(
         );
 
         expect(response.status).toBe(200);
-        await expect(response.json()).resolves.toMatchObject({
-            model: "gpt-4.1-mini",
-            choices: [
-                {
-                    message: { content: "ok" },
-                },
-            ],
-            usage: {
-                prompt_tokens: 2,
-                completion_tokens: 3,
-                total_tokens: 5,
-            },
+        expect(response.headers.get("x-model-used")).toBe(modelId);
+        const body = await response.json();
+        expect(body).not.toHaveProperty("model");
+        expect(body).toMatchObject({
+            choices: [{ message: { content: "ok" } }],
+            usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
         });
 
         const legacyResponse = await SELF.fetch(
@@ -404,13 +397,10 @@ fixtureTest(
             }),
         );
         expect(legacyResponse.status).toBe(200);
-        await expect(legacyResponse.json()).resolves.toMatchObject({
-            model: "gpt-4.1-mini",
-            choices: [
-                {
-                    message: { content: "ok" },
-                },
-            ],
+        const legacyBody = await legacyResponse.json();
+        expect(legacyBody).not.toHaveProperty("model");
+        expect(legacyBody).toMatchObject({
+            choices: [{ message: { content: "ok" } }],
         });
 
         const upstreamCalls = fetchMock.mock.calls.filter(([input, init]) =>

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -101,16 +101,20 @@ function withGatewayContext(c: TextContext, requestData: RequestData) {
     };
 }
 
-function usageHeaders(completion: ChatCompletion): Headers {
+function usageHeaders(
+    completion: ChatCompletion,
+    fallbackModel?: string,
+): Headers {
     const headers = new Headers();
-    if (completion?.usage && completion?.model) {
+    const modelUsed = completion?.model || fallbackModel;
+    if (completion?.usage && modelUsed) {
         const usage = openaiUsageToUsage(
             completion.usage as unknown as Parameters<
                 typeof openaiUsageToUsage
             >[0],
         );
         for (const [key, value] of Object.entries(
-            buildUsageHeaders(completion.model, usage),
+            buildUsageHeaders(modelUsed, usage),
         )) {
             headers.set(key, String(value));
         }
@@ -121,8 +125,11 @@ function usageHeaders(completion: ChatCompletion): Headers {
     return headers;
 }
 
-function sendOpenAIResponse(completion: ChatCompletion): Response {
-    const headers = usageHeaders(completion);
+function sendOpenAIResponse(
+    completion: ChatCompletion,
+    fallbackModel?: string,
+): Response {
+    const headers = usageHeaders(completion, fallbackModel);
     headers.set("Content-Type", "application/json; charset=utf-8");
 
     return new Response(
@@ -136,8 +143,11 @@ function sendOpenAIResponse(completion: ChatCompletion): Response {
     );
 }
 
-function sendTextContentResponse(completion: ChatCompletion): Response {
-    const headers = usageHeaders(completion);
+function sendTextContentResponse(
+    completion: ChatCompletion,
+    fallbackModel?: string,
+): Response {
+    const headers = usageHeaders(completion, fallbackModel);
     headers.set("Cache-Control", IMMUTABLE_CACHE_CONTROL);
 
     if (!completion.choices?.[0]) {
@@ -291,8 +301,10 @@ async function generateTextResponse(
         }
 
         if (requestData.stream) return sendTextStreamResponse(completion);
-        if (contentResponse) return sendTextContentResponse(completion);
-        return sendOpenAIResponse(completion);
+        const fallbackModel = c.var.model?.resolved;
+        if (contentResponse)
+            return sendTextContentResponse(completion, fallbackModel);
+        return sendOpenAIResponse(completion, fallbackModel);
     } catch (thrown: unknown) {
         throwTextError(thrown as ServiceError, c);
     }

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -498,7 +498,7 @@ export const CreateChatCompletionResponseSchema = z.object({
     choices: z.array(CompletionChoiceSchema),
     prompt_filter_results: PromptFilterResultSchema.nullish(),
     created: z.number().int(),
-    model: z.string(),
+    model: z.string().optional(),
     system_fingerprint: z.string().nullish(),
     object: z.literal("chat.completion"),
     usage: CompletionUsageSchema.optional(),


### PR DESCRIPTION
- Allows non-streaming chat completion responses without a `model` field.
- Falls back to the resolved request model only for usage headers when upstream omits `model`.
- Adds community endpoint regression coverage.
- Tests: `npx biome check --write shared/schemas/openai.ts gen.pollinations.ai/src/community-endpoints.test.ts gen.pollinations.ai/src/text/handler.ts`; `npm run test -- src/community-endpoints.test.ts --testNamePattern "routes chat completions through a registered community endpoint with its saved token"`; `npm run typecheck`.
- Fixes #12142