### PR TITLE
fix: deactivated community models return generic 400, not a special 500

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -811,12 +811,12 @@ fixtureTest(
                 },
             );
 
-            expect(response.status).toBe(500);
+            expect(response.status).toBe(400);
             const body = (await response.json()) as {
                 error?: { message?: string };
             };
-            expect(body.error?.message).toContain("deactivated");
-            expect(body.error?.message).toContain("repeated upstream 500s");
+            expect(body.error?.message).toContain("Invalid model or alias");
+            expect(body.error?.message).not.toContain("repeated upstream 500s");
         }
     },
 );

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -57,18 +57,6 @@ export async function resolveModelDefinition(
     const registry = await getGenerationModelRegistry(env);
     const entry = registry.resolve(model);
     if (!entry) {
-        const disabledEntry = registry.resolveIncludingDisabled(model);
-        if (disabledEntry?.communityEndpoint?.disabledAt) {
-            // Not a client mistake (unlike the 400s below) — the model name
-            // is valid, its backing endpoint is just down. 500 reflects that
-            // this is the server/operator's problem, not the caller's.
-            throw new HTTPException(500, {
-                message: `Community model "${model}" has been deactivated: ${
-                    disabledEntry.communityEndpoint.disabledReason ??
-                    "repeated upstream failures"
-                }. Contact the model owner or see your dashboard to reactivate.`,
-            });
-        }
         throw new HTTPException(400, {
             message: `Invalid model or alias: "${model}". Must be a valid model name or alias.`,
         });

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -41,9 +41,6 @@ export type GenerationModelEntry = {
 
 export type GenerationModelRegistry = {
     resolve: (model: string) => GenerationModelEntry | null;
-    /** Like `resolve`, but also returns deactivated community entries — used
-     * only to produce a specific "deactivated: <reason>" error message. */
-    resolveIncludingDisabled: (model: string) => GenerationModelEntry | null;
     visibleEntries: () => GenerationModelEntry[];
 };
 
@@ -123,12 +120,9 @@ function buildRegistry(
         }
     }
 
-    const resolveIncludingDisabled = (model: string) =>
-        byIdOrAlias.get(model) ?? null;
-
     return {
         resolve: (model) => {
-            const entry = resolveIncludingDisabled(model);
+            const entry = byIdOrAlias.get(model) ?? null;
             // Deactivated community models don't exist as far as callers are
             // concerned — unlike static `hidden` models (intentionally
             // unlisted but still callable), a disabled community endpoint is
@@ -136,7 +130,6 @@ function buildRegistry(
             if (entry?.communityEndpoint?.disabledAt) return null;
             return entry;
         },
-        resolveIncludingDisabled,
         visibleEntries: () => entries.filter((entry) => entry.visible),
     };
 }


### PR DESCRIPTION
## Summary
- Deactivated community models now behave like any unknown model — plain `400 Invalid model or alias`, no reason exposed to API callers
- Removes `resolveIncludingDisabled` and the special 500 error path added in #12150
- Owner-facing reason display (My Models dashboard) is unaffected — untouched in `enter.pollinations.ai`

## Test plan
- [x] `gen.pollinations.ai` full suite: 438/438 passing
- [x] `community-endpoints.test.ts` updated: deactivated model call → 400, message does not contain the disabled reason
- [x] typecheck + biome clean