### PR TITLE
fix: pass through actual quality value to GPT Image API instead of clamping

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -335,7 +335,7 @@ const callGPTImageWithEndpoint = async (
     ]).size;
 
     // Use requested quality - access control runs in this worker's auth/balance middleware
-    const quality = safeParams.quality === "high" ? "high" : "medium";
+    const quality = safeParams.quality ?? "medium";
 
     // Set output format to png if model is gptimage, otherwise jpeg
     const outputFormat = "png";


### PR DESCRIPTION
## Description

Fixes #12089

The GPT Image handler currently clamps the quality parameter:

```typescript
const quality = safeParams.quality === "high" ? "high" : "medium";
```

This silently upgrades `low` to `medium`, overcharging users who intentionally selected lower quality. It also breaks `hd` by degrading it to `medium`.

## Change

```typescript
const quality = safeParams.quality ?? "medium";
```

This passes through the user's actual quality selection (`low`, `medium`, `high`, `hd`) and only defaults to `medium` when no value is provided. The OpenAI/Azure provider API accepts all four values natively.

## Testing

- `quality=low` → passes `low` to provider, billed at low rate
- `quality=medium` → passes `medium` to provider (same as before)
- `quality=high` → passes `high` to provider (same as before)
- `quality=hd` → passes `hd` to provider (was broken)
- `quality=undefined` → defaults to `medium` (same as before)

## Related

- Issue: #12089
- Labels: IMAGE, .BUG
