### PR TITLE
fix: stop community model updates from silently reactivating disabled endpoints

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -533,9 +533,6 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const update: Partial<
                 typeof schema.communityEndpoint.$inferInsert
             > = {
-                disabledAt: null,
-                disabledReason: null,
-                disabledBy: null,
                 updatedAt: new Date(),
             };
             if (input.name !== undefined) update.name = input.name;


### PR DESCRIPTION
## Summary
- `POST /:id/update` unconditionally cleared `disabledAt`/`disabledReason`/`disabledBy` on every save, even edits unrelated to the broken config
- Confirmed in prod: MarcosFRG's deactivated models kept reactivating themselves (traced to their dashboard session resaving, clearing the flag as a side effect, not a deliberate reactivate action)
- Reactivation is now exclusively manual/out-of-band — owner pings to reactivate after fixing the issue; a dedicated reactivate flow is a follow-up

## Test plan
- [x] `enter.pollinations.ai` targeted tests pass (community-endpoint-openai, admin-auth)
- [x] typecheck + biome clean