### PR TITLE
feat: allowlist Minor-fun + morriszdweck + mikl-shortcuts for community models

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1270,9 +1270,8 @@ fixtureTest(
             description: "Updated description",
             promptTextPrice: 0.1,
             completionTextPrice: 0.2,
-            disabled: false,
-            disabledReason: null,
-            disabledAt: null,
+            disabled: true,
+            disabledReason: "was failing",
         });
 
         const secondListResponse = await fetchEnterApi(

--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -14,6 +14,9 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     206557620, // smplstuff
     201380514, // MarcosFRG
     88273873, // ytpk
+    45744798, // Minor-fun
+    178960782, // morriszdweck
+    219871313, // mikl-shortcuts
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
## Summary
- Adds 3 GitHub IDs to `COMMUNITY_MODEL_ALLOWED_GITHUB_IDS` per Discord requests in #dev-models
- `Minor-fun` (45744798), `morriszdweck` (178960782, Discord: Mincofficial), `mikl-shortcuts` (219871313)