### PR TITLE
feat: allowlist sixfingerdev for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -17,6 +17,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     45744798, // Minor-fun
     178960782, // morriszdweck
     219871313, // mikl-shortcuts
+    229514703, // sixfingerdev
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds sixfingerdev (GitHub ID 229514703) to COMMUNITY_MODEL_ALLOWED_GITHUB_IDS