### PR TITLE
feat: allowlist cemalgnlts for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -18,6 +18,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     178960782, // morriszdweck
     219871313, // mikl-shortcuts
     229514703, // sixfingerdev
+    45357531, // cemalgnlts
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds cemalgnlts (GitHub ID 45357531) to COMMUNITY_MODEL_ALLOWED_GITHUB_IDS