### PR TITLE
docs: align legal terms with service fee + exclusive-tax pricing

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
@@ -3,6 +3,7 @@ import {
     ClockIcon,
     CopyButton,
     ExternalLinkButton,
+    GlobeIcon,
     InfoTip,
     InlineLink,
     MailIcon,
@@ -352,7 +353,7 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
                                         {chargeLabel}
                                     </span>
                                     <span className="mt-1 block text-theme-text-muted">
-                                        Tax calculated at checkout.
+                                        Tax calculated at checkout
                                     </span>
                                 </span>
                             }
@@ -376,6 +377,13 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
                 <AutoTopUpPanel initialBillingState={initialBillingState} />
             </Surface>
             <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                <p className="flex items-start gap-1.5">
+                    <GlobeIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>
+                        Prices exclude tax — VAT or sales tax is added at
+                        checkout.
+                    </span>
+                </p>
                 <p className="flex items-start gap-1.5">
                     <ClockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                     <span>

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
@@ -377,13 +377,7 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
                 <AutoTopUpPanel initialBillingState={initialBillingState} />
             </Surface>
             <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                <p className="flex items-start gap-1.5">
-                    <GlobeIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>
-                        Prices exclude tax — VAT or sales tax is added at
-                        checkout.
-                    </span>
-                </p>
+                <PaymentTrustBadge className="mt-0 pt-0" />
                 <p className="flex items-start gap-1.5">
                     <ClockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                     <span>
@@ -392,6 +386,13 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
                             Refund Policy
                         </InlineLink>
                         .
+                    </span>
+                </p>
+                <p className="flex items-start gap-1.5">
+                    <GlobeIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>
+                        Prices exclude tax — VAT or sales tax is added at
+                        checkout.
                     </span>
                 </p>
                 <p className="flex items-start gap-1.5">
@@ -409,7 +410,6 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
                         — we reply same day.
                     </span>
                 </p>
-                <PaymentTrustBadge className="mt-0 pt-0" />
             </div>
         </>
     );

--- a/pollinations.ai/public/legal/PRIVACY_POLICY.md
+++ b/pollinations.ai/public/legal/PRIVACY_POLICY.md
@@ -78,7 +78,7 @@ Where data leaves the EEA, we use approved safeguards (e.g., EU Standard Contrac
 
 Access, correction, deletion, restriction, portability, objection to legitimate-interest processing, and withdrawal of consent where applicable.
 
-You can complain to your local authority or the Estonian Data Protection Inspectorate (AKI). **Contact:** hi@myceli.ai.
+You can complain to your local authority or the Estonian Data Protection Inspectorate (AKI). **Contact:** hello@myceli.ai.
 
 ## 11) Security
 
@@ -103,4 +103,4 @@ Myceli.AI OÜ
 Registry code: 17186693  
 VAT number: EE102877908  
 Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia  
-Email: hi@myceli.ai
+Email: hello@myceli.ai

--- a/pollinations.ai/public/legal/REFUNDS_AND_CANCELLATIONS.md
+++ b/pollinations.ai/public/legal/REFUNDS_AND_CANCELLATIONS.md
@@ -59,4 +59,4 @@ If you provide a valid VAT ID or purchase for business use, consumer withdrawal 
 
 ## 8) How to Request Review
 
-Email billing@myceli.ai with your order ID, account email, and a short description of the issue. We aim to review within 5-10 business days. Approved refunds return to the original payment method subject to payment-network timelines. A refund of a full purchase includes that purchase's service fee and tax; partial refunds are prorated on the amount paid. Business days are calculated in EET/EEST (Tallinn).
+Email billing@pollinations.ai with your order ID, account email, and a short description of the issue. We aim to review within 5-10 business days. Approved refunds return to the original payment method subject to payment-network timelines. A refund of a full purchase includes that purchase's service fee and tax; partial refunds are prorated on the amount paid. Business days are calculated in EET/EEST (Tallinn).

--- a/pollinations.ai/public/legal/REFUNDS_AND_CANCELLATIONS.md
+++ b/pollinations.ai/public/legal/REFUNDS_AND_CANCELLATIONS.md
@@ -1,6 +1,6 @@
 # Refunds & Cancellations
 
-**Updated: 2026-06-24**
+**Updated: 2026-07-02**
 
 ## Refunds & Cancellations (digital API services & Pollen)
 
@@ -59,4 +59,4 @@ If you provide a valid VAT ID or purchase for business use, consumer withdrawal 
 
 ## 8) How to Request Review
 
-Email billing@myceli.ai with your order ID, account email, and a short description of the issue. We aim to review within 5-10 business days. Approved refunds return to the original payment method subject to payment-network timelines. Business days are calculated in EET/EEST (Tallinn).
+Email billing@myceli.ai with your order ID, account email, and a short description of the issue. We aim to review within 5-10 business days. Approved refunds return to the original payment method subject to payment-network timelines. A refund of a full purchase includes that purchase's service fee and tax; partial refunds are prorated on the amount paid. Business days are calculated in EET/EEST (Tallinn).

--- a/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
+++ b/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
@@ -1,6 +1,8 @@
 # Terms of Service
 
-**Updated: 2026-06-24**
+**Updated: 2026-07-02**
+
+_2026-07-02 — Pollen purchases now include a service fee shown before payment, and prices are shown exclusive of tax; applicable VAT or similar taxes are added at checkout._
 
 _2026-05-11 — Wallet now expires after 12 months of account inactivity. Effective 2026-06-01; the inactivity clock starts on that date for all existing balances._
 
@@ -54,7 +56,7 @@ Do not violate law; infringe IP/likeness/privacy; attack the Service; evade rate
 
 ## 6) Pollen, Fees, Taxes & Billing
 
-Fees are per plan/order/invoice; currency is by default USD.
+Fees are per plan/order/invoice; currency is by default USD. Pollen purchases, including auto top-up charges, include a service fee shown before payment.
 
 **Pollen.** "Pollen" is an in-service credit used only to pay for Pollinations API usage. Pollen is not legal tender, e-money, cryptocurrency, a deposit, a bank account balance, or stored value outside the Service. Pollen is not transferable, withdrawable, or redeemable for cash except where required by law or expressly approved by us as a refund under these Terms.
 
@@ -73,7 +75,7 @@ Fees are per plan/order/invoice; currency is by default USD.
 
 Developer earnings are credited as Pollen to the developer wallet in the same balance type the user paid from. They are not cash payouts and are not transferable, withdrawable, or redeemable outside the Service. We may review and adjust developer earnings for refunds, chargebacks, fraud, abuse, pricing errors, self-crediting (using your own app to inflate your earnings), or other billing corrections.
 
-**Taxes.** Prices include applicable VAT or similar transaction taxes where required. Estonian standard VAT is 24% where applicable. For eligible EU B2B customers with a valid VAT ID, reverse-charge rules may apply.
+**Taxes.** Prices for Pollen purchases are shown exclusive of tax. Applicable VAT or similar transaction taxes are calculated and added at checkout based on your billing details. Estonian standard VAT is 24% where applicable. For eligible EU B2B customers with a valid VAT ID, reverse-charge rules may apply.
 
 **Payments.** Payments are processed by Stripe Payments Europe, Limited. Stripe sends purchase invoices by email.
 

--- a/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
+++ b/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
@@ -15,7 +15,7 @@ Myceli.AI OÜ
 Registry code: 17186693  
 VAT number: EE102877908  
 Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia  
-Email: hi@myceli.ai
+Email: hello@myceli.ai
 
 ---
 


### PR DESCRIPTION
- Fixes ToS §6 Taxes: prices were stated as VAT-inclusive; checkout now adds tax on top (shipped in #12129).
- Discloses the service fee on Pollen purchases and auto top-up in ToS §6.
- Refunds policy: full-purchase refunds include the service fee and tax; partial refunds prorated.
- Adds an always-visible wallet footer line: prices exclude tax, VAT/sales tax added at checkout.
- Drops the trailing period in the Buy tooltip tax note.
- Bumps Updated dates + ToS changelog line.