### PR TITLE
feat: allowlist Catniti + Bakhshi7889 for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -20,6 +20,8 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     229514703, // sixfingerdev
     45357531, // cemalgnlts
     123343834, // LynxUnbanned
+    244879637, // Catniti
+    216855486, // Bakhshi7889
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds Catniti and Bakhshi7889 to COMMUNITY_MODEL_ALLOWED_GITHUB_IDS
- Both requested access in the community-models Discord thread