### PR TITLE
feat: allowlist vendouple for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -22,6 +22,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     123343834, // LynxUnbanned
     244879637, // Catniti
     216855486, // Bakhshi7889
+    64634725, // vendouple
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds vendouple to COMMUNITY_MODEL_ALLOWED_GITHUB_IDS