### PR TITLE
feat: add INFERENCEPORT_API_KEY to gen secrets

### DIFF
--- a/gen.pollinations.ai/secrets/dev.vars.json
+++ b/gen.pollinations.ai/secrets/dev.vars.json
@@ -36,6 +36,7 @@
 	"INCEPTION_API_KEY": "ENC[AES256_GCM,data:zC+bmCWUwAy3sLTOix31FhVA8qYUnzoI1mzKO/6BgocZJZg=,iv:TIR/IbJ0X7NMb/472h2wlG8bK7ruPzGMVThNxvBPHNk=,tag:VfYZ2ykEWQXKzTQF9WB1jw==,type:str]",
 	"STABILITY_API_KEY": "ENC[AES256_GCM,data:DT4YDkZYtnJG0kQhBIpWUxsC+SR7CombY/vKzZrsSYTHFmjXfvWB+FyAF6mVcze/jTlm,iv:T18sv0vhAz7pd3jAW3twyFFm4T5CtIx6iXpWHp36gWU=,tag:qtT4DIbqNJzuFtbWo9G8IQ==,type:str]",
 	"AZURE_MYCELI_PROD_IMG_WESTUS3_API_KEY": "ENC[AES256_GCM,data:5GvPyrRx6VbYAJfWYsl2c6h20nZtlyT3GAmlaLAEnEcHtvNpkeyVGAw6vHE6lYWAeZXjYCI5xHpOiwaUG90MkXZ2Nx1jh++GiW22VdaFJQbrfWBf,iv:b3vvqIQGTk2xAPnjf3hxVkfmjYPi255wdcrSobJ5qwE=,tag:YJemXI3DDxhXzSkYXfh7GA==,type:str]",
+	"INFERENCEPORT_API_KEY": "ENC[AES256_GCM,data:TpZFCmhxPIe63VOZizrnsfcs++TbRj4mVrB0k9EUOAfU9IgHvVxLxaI=,iv:JWBbniqaa2vdUvuqt2M/urUr7IONr79Ex5M2MI016Vg=,tag:0mL/HAt2XFzMxXOJYMvl4g==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -51,8 +52,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4bElkUVQ5Z2lBK3VTbVJy\ncGF0V0s5a3RqRVY5VGhHQzM3bEtKU1liVGxVCmIyUFNST3hkVlREM21zc0xEWkJX\ncG0wSjBYNktaNHdHQWpReFc1QmowL2MKLS0tIG1oYjVIZElSTWdGcDlPa2pDS1Zk\nRGdmUEZPeXNWc0FGT25YTllRbjFPMHMKW+bejeiX+QdG7Og9MSel1mupyc3GDMfd\niHM1cS2O1nluMVS0gtAf+6j4SNH/1fX85EJQqd6q+zTn7UyXHP+KIw==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-06-28T13:04:41Z",
-		"mac": "ENC[AES256_GCM,data:8j/bNhA4SqSc0DvwcQOXzmTAEAJRTOS9wsP/7CFL9fEzz8LdFez3+9Od1ieqieJpLNAOttzqqlZqSlKixVhqXCjPS91x84ZZtfr66i1spO0hK6PA84l9ajmCNqmr3uMl7MZhy6/LrPTngRw3cKxl7kfNTR1oKh857fxB0d/5z+U=,iv:JnRdJIux13LdUBOT593ocQIwNbHa1D9pcqdFwiYMowM=,tag:RakmzzTCHbBxpJ8EA0zs+Q==,type:str]",
+		"lastmodified": "2026-07-02T15:04:10Z",
+		"mac": "ENC[AES256_GCM,data:XFfSPxY9MLPG78zv342sChxgAO3hZ/J5VuxktZBrWdNvxFUE9D6pxOxcKqMkjIurayg/HNfsWhurlWjJXa3IjORnBDwnnQv4Hd7L1qeJchMKWdZ+lM53TVOXsMnCdh7UCw0rCZRInDQ2VVpVJmJRNagxu5VE+P5lj7hoLT07PZ4=,iv:rD2ukUJTXw9XslvHJuTP+Q7YDngGtA7xiiXptUll3zo=,tag:i9XvtMQ9pX8lHFjUL2867A==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/gen.pollinations.ai/secrets/prod.vars.json
+++ b/gen.pollinations.ai/secrets/prod.vars.json
@@ -36,6 +36,7 @@
 	"INCEPTION_API_KEY": "ENC[AES256_GCM,data:3YstWjYY3frQ1v4BCjdQjP2GHOK6dnu09RZgUMZgZDsYLrI=,iv:WveoV5JvL7PQ4fFImszN6eDpo1a7Zt2wXqErjz141Qk=,tag:MceQNOJ7sLIQZ96vg2GGDA==,type:str]",
 	"STABILITY_API_KEY": "ENC[AES256_GCM,data:1qIrIb1jXqeFCoIToIbs++WuR+3h8Fn6BXmPjIdRsZV+0Yc36CpXPj9d1cLLn/Boom/G,iv:FO7ScIaWLv+cfpew5ifq4AkNc6TcROOSuwho9ifWLRE=,tag:p7zl4SMpbKlHYiydrc97Dg==,type:str]",
 	"AZURE_MYCELI_PROD_IMG_WESTUS3_API_KEY": "ENC[AES256_GCM,data:kfjoKn/3DfJs06vFhNikjlwph2tfcLWZZwekBaBwy5B7Gh668oHjvwIJoQJMfjvDZQ4AB+w5TaECsIXLoyUETULc8AbBRwShJ8/7VqXK5LB0h9rj,iv:rcvRRuwYExJweMU+ZsdBq3y4r5Bl8QfOFfO1maLY0Mc=,tag:uFLo5NC2Lz0LMY0spG1zPA==,type:str]",
+	"INFERENCEPORT_API_KEY": "ENC[AES256_GCM,data:qC8b7OdVoy3rK02Jkrk0Crqh2xBi/reflwZCwKpPBcRTgXjtcZK1Djo=,iv:I221xAesEUnFoaAZXq8KQNSwzSxS1f5war/0LUVV5iI=,tag:1YHZ+3X/KzDcYrObXORZ0w==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -51,8 +52,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArSHN0NXZacWF3UjhDK0Vj\nakFsYzk3Z2xuUXZXaXZTMEJ4cVFpN0psWjBzCngvNTY5RmdLaEtvenhrUmVCNFVy\nNzJEZXJNTjdKbVhqRWp3cVh2SzNaUkUKLS0tIE1kd1FVWTBJWENvSEs4NlE4aGkw\nNnBYb3dMT2w1ZkNQOFFMa2FHYjlKUGMKGqZcC/k7TWecUTKbWn4E2MKkl0mh3WWB\nzw0h7ZAenHv49azM2L5H+vTg8p0Ss7qGdk/gZHkCFRQktoepmNR3xA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-06-28T13:04:41Z",
-		"mac": "ENC[AES256_GCM,data:N9IMOY9q7R7YUfAbSr3zqgiRkv9dgd+TFwatRbkc6gg18m4z9JNQRQp0d+wWO7WSs1NyK0rieBwwkGZmwEGQwd7TA0Tzs87Xl7Kip/21kc7MjW3CYbl160HNReKy19gBNuhlP5sse5yCrHNPXqgW3l2Kvd3qM/7AodX3BbfqYjc=,iv:8sFBzEpSP391C7QoHPOZDHyqyIKmaKUeEQkg9b9ZL9U=,tag:5mDyjy121SbQd5Vr7pxHNQ==,type:str]",
+		"lastmodified": "2026-07-02T15:04:11Z",
+		"mac": "ENC[AES256_GCM,data:ZMyIgQZNEXHU6bpss7keyGhexqc4Gu/WVt0tQGMLkdPi9fL5acwi2QrY7d5LJQ3yK5YIOaF2g4/18jgj65n5YDp88qxHsBOMnflPyjITuHv1z9ywzNpYWeN40+s8b3HCciIQw+72vrEXLO4sfEBWq65mlG0dARiJDkTXRkKq3zc=,iv:BM1rwTTU3wuhYaLcgOhkK+b1sQT7hxN/pOpB9itpWEY=,tag:8ZALrsRBhJUXQDfmqX8eQg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/gen.pollinations.ai/secrets/staging.vars.json
+++ b/gen.pollinations.ai/secrets/staging.vars.json
@@ -36,6 +36,7 @@
 	"INCEPTION_API_KEY": "ENC[AES256_GCM,data:U4Xl7XOYszLrFMHOjnfudqcFdlGmuEiM9cjhfsRbs7HkuvM=,iv:p69P/vfebZgj+chernig+Va2Jeq/mIuC6r6MTBT4xfY=,tag:/Kp6qjXRXfQPfshZy8LtBA==,type:str]",
 	"STABILITY_API_KEY": "ENC[AES256_GCM,data:agYD899jZDB6sP6CkwXcT28mhkLIvDwILbC+09b/aFPzE7euJ1Fg5UcFs1BxoroiVJTB,iv:MJEBlFcHGhHLjQTb0cmtY4P5ZtRxltCfxi9mYaegPWg=,tag:zKPdrbqlh3JY5jsAW+8vDA==,type:str]",
 	"AZURE_MYCELI_PROD_IMG_WESTUS3_API_KEY": "ENC[AES256_GCM,data:woUM/MW0gkdcZDN7Xb3s+shQdOwCFU0DFuCvzx0zP0tZKmsZAZvCLQRcEcfYuW5EGM7vRhExBBKzYdwuAvlXgV6tcNIFP7V3Q+6vOZ+exdukN7E0,iv:3TfpUfdAPYEoX+4NwQZM5xRQJ7xWL0Jw0duHGC9tfj4=,tag:ao/rQrX+VQwAGRywx5Jm7A==,type:str]",
+	"INFERENCEPORT_API_KEY": "ENC[AES256_GCM,data:jO7j4yizSGKWZKnwcNa4VPhUFxempR7hNQVvrfYlLmzkqg3uyKIBaEg=,iv:aO4BwuDXt83rjeieEc8m3fk2RYjZbhkR3l6kw/RVQGA=,tag:sLaLeBq22PuX0h1zxtTD/w==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -51,8 +52,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEeTkwT2UzMUZEWWYxbkN5\nQjNyYnJEOTEremdlL3VNNGtwM3dyNTNrS2s4CmYrWU9kaUVoUG9uUEdvVWxTV25Q\ndXU1TVNkKzF4bFZ1STEwdER2eUdWd2sKLS0tIHBKSXIzV0ZIZ2Z1M1NmZ05wNkEy\nRFlvdmt3cm5qU3RmbzBRbXpoTzNXeGMKi8fVxVQ/2mStALlFxD9IgCJzEqvxXT4t\nAHRQ2bzL74hc7GeIsf7CZ7no6PvF0AzFFWplkN+XQ+fBfS6v1xaCDg==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-06-28T13:04:41Z",
-		"mac": "ENC[AES256_GCM,data:zRalq3Yyi/E+aCKceeJGOmt2eJmZ0CaRVk8hrZH9DOxF9eVp/IIPhpUDlqaf4rPdaKNSmDEe3XVXgXlO6mT/dqfnNcLQvUvwQi5qUG/30eWsAbOzxGfsrshXDSm+6SP9QXmas5oSeEqiS49IEAFi7Yo11x2EkbasF8KTnFyqkQA=,iv:+yhXh+YCVKZqNBzigXFlHKiyuAphPEhjKGq8dOSYlVc=,tag:LAFBbWG5iKz0e0F81iIibg==,type:str]",
+		"lastmodified": "2026-07-02T15:04:10Z",
+		"mac": "ENC[AES256_GCM,data:ewVktW4Jz8Zheta20LHtTLSU6A/4PCaVDoKofEH2hwKofae+BbfMutVvYddiBht4zsM0U7yyROiRtpW54z9PTZWse2KIkLHJZaqpt8XKdfvAr3/lhwR4cevbVmRBVY9RDHpghImukceQvy8DbFkgqSMsccL33m+UoUitXP3H6DE=,iv:c3fusiTv1LKLx0gXlJnxXahZwjwFJneMWkRNZEJNAPw=,tag:FYVteYMYK9czXWOkmaJBMQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
Provisions the `INFERENCEPORT_API_KEY` that #12048 (3D model generation) marks required in `push-generation-secrets.mjs`.

- Adds the key to `gen.pollinations.ai/secrets/{dev,staging,prod}.vars.json` via `sops set` (minimal diff)
- Without it, `decrypt-vars` hard-fails "Missing required generation secrets" → blocks `npm run dev` on that branch and staging/prod deploys
- Verified locally: `trellis-2-low` (inferenceport, sync API) returns a valid 4.2 MB glTF binary; direct backend probe 200 in ~54s cold / ~24s warm

Unblocks the Trellis 2 provider for #12048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)