### PR TITLE
fix: /video/models returns video-only list

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -222,6 +222,14 @@ async function getVisibleModelEntriesForEventType(
         .filter((entry) => entry.eventType === eventType);
 }
 
+// Video models share the "generate.image" event type with image models, so
+// filter by category to return a video-only list for /video/models.
+async function getVisibleVideoModelEntries(c: Context<Env>) {
+    return (
+        await getVisibleModelEntriesForEventType(c, "generate.image")
+    ).filter((entry) => entry.definition.category === "video");
+}
+
 async function getOrderedVisibleModelEntries(c: Context<Env>) {
     const entries = await getVisibleModelEntries(c);
     return [
@@ -325,9 +333,8 @@ export const proxyRoutes = new Hono<Env>()
         }),
         modelsListHandler(getOrderedVisibleModelEntries),
     )
-    .on(
-        "GET",
-        ["/image/models", "/video/models"],
+    .get(
+        "/image/models",
         describeRoute({
             tags: ["🤖 Models"],
             summary: "List Image & Video Models",
@@ -353,6 +360,32 @@ export const proxyRoutes = new Hono<Env>()
         modelsListHandler((c) =>
             getVisibleModelEntriesForEventType(c, "generate.image"),
         ),
+    )
+    .get(
+        "/video/models",
+        describeRoute({
+            tags: ["🤖 Models"],
+            summary: "List Video Models",
+            description:
+                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+            responses: {
+                200: {
+                    description: "Success",
+                    content: {
+                        "application/json": {
+                            schema: resolver(
+                                z.array(z.any()).meta({
+                                    description:
+                                        "List of models with pricing and metadata",
+                                }),
+                            ),
+                        },
+                    },
+                },
+                ...errorResponseDescriptions(500),
+            },
+        }),
+        modelsListHandler(getVisibleVideoModelEntries),
     )
     .get(
         "/text/models",

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -262,6 +262,15 @@ describe("gen worker routing", () => {
         );
     });
 
+    it("returns only video models on /video/models", async () => {
+        const response = await fetchWorker("/video/models", envWithEnter());
+
+        expect(response.status).toBe(200);
+        const models = (await response.json()) as { category?: string }[];
+        expect(models.length).toBeGreaterThan(0);
+        expect(models.every((m) => m.category === "video")).toBe(true);
+    });
+
     it("serves OpenAI-compatible models without auth", async () => {
         const response = await fetchWorker("/v1/models", envWithEnter());
 


### PR DESCRIPTION
`/video/models` was aliased to `/image/models` (#12164), returning the full 37-model image+video list. Now it returns only the 12 `category: "video"` models.

- `/video/models` → filters to `category === "video"` (mirrors the `/3d/models` pattern)
- `/image/models` → unchanged (still the full image+video list)
- Keeps #8995 fixed (still a real route, no fall-through to generation/401)
- Adds a test asserting the list is video-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)