### PR TITLE
fix: render 3D model prices in dashboard

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -258,7 +258,10 @@ function modelPriceFromCatalog(model: ApiModelInfo): ModelPrice | null {
         };
     }
 
-    if (price.type === "image") {
+    // 3D generations are flat per-generation charges stored in
+    // completionImageTokens (same convention as image models), so they render
+    // through the image branch: no prompt-token prices → flat "/gen" line.
+    if (price.type === "image" || price.type === "3d") {
         if (promptTextTokens || promptImageTokens) {
             return {
                 ...price,
@@ -293,14 +296,6 @@ function modelPriceFromCatalog(model: ApiModelInfo): ModelPrice | null {
                 "request",
             ]),
         };
-    }
-
-    if ((price.type as string) === "3d") {
-        return {
-            ...price,
-            perRequest: true,
-            perImagePrice: formatPrice(completionImageTokens, formatPriceFlat),
-        } as ModelPrice;
     }
 
     if (price.type === "audio") {

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -5,6 +5,7 @@ import {
     getAudioModelsInfo,
     getEmbeddingModelsInfo,
     getImageModelsInfo,
+    getModel3dModelsInfo,
     getRealtimeModelsInfo,
     getTextModelsInfo,
 } from "@shared/registry/model-info.ts";
@@ -19,13 +20,17 @@ import {
 } from "@shared/registry/registry.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import { expect, test } from "vitest";
-import { formatPricePer1M } from "../frontend/src/components/models/formatters.ts";
+import {
+    formatPriceFlat,
+    formatPricePer1M,
+} from "../frontend/src/components/models/formatters.ts";
 import { getModelPricesFromCatalog } from "../frontend/src/components/models/model-catalog.ts";
 
 const getCatalogModelPrices = () =>
     getModelPricesFromCatalog([
         ...getTextModelsInfo(),
         ...getImageModelsInfo(),
+        ...getModel3dModelsInfo(),
         ...getRealtimeModelsInfo(),
         ...getAudioModelsInfo(),
         ...getEmbeddingModelsInfo(),
@@ -34,6 +39,7 @@ const getCatalogModelPrices = () =>
 const getCatalogModels = () => [
     ...getTextModelsInfo(),
     ...getImageModelsInfo(),
+    ...getModel3dModelsInfo(),
     ...getRealtimeModelsInfo(),
     ...getAudioModelsInfo(),
     ...getEmbeddingModelsInfo(),
@@ -116,8 +122,9 @@ test("catalog prices format token rates through formatPricePer1M", () => {
         const imageUsesTokenRows =
             Number(pricing?.promptTextTokens) > 0 ||
             Number(pricing?.promptImageTokens) > 0;
+        // 3D reuses the flat image branch (no token rows), same as flat images.
         const rows =
-            sourceModel?.category === "image"
+            sourceModel?.category === "image" || sourceModel?.category === "3d"
                 ? imageUsesTokenRows
                     ? imageTokenPriceRows
                     : []
@@ -138,6 +145,34 @@ test("catalog prices format token rates through formatPricePer1M", () => {
     }
 
     expect(checkedFields).toBeGreaterThan(0);
+});
+
+test("catalog prices render 3D models as a flat per-generation rate", () => {
+    const model3d = getModel3dModelsInfo();
+    expect(model3d.length).toBeGreaterThan(0);
+
+    const pricesByName = new Map(
+        getCatalogModelPrices().map((price) => [price.name, price]),
+    );
+
+    for (const source of model3d) {
+        expect(source.category).toBe("3d");
+        const rawRate = Number(source.pricing?.completionImageTokens);
+        expect(Number.isFinite(rawRate) && rawRate > 0).toBe(true);
+
+        const modelPrice = pricesByName.get(source.name);
+        expect(modelPrice?.type).toBe("3d");
+        // Flat charge → single output/image line billed per request ("/gen"),
+        // no token lines.
+        expect(modelPrice?.prices).toEqual([
+            {
+                direction: "output",
+                kind: "image",
+                price: formatPriceFlat(rawRate),
+                unit: "request",
+            },
+        ]);
+    }
 });
 
 test("catalog prices keep community text models flagged for display", () => {


### PR DESCRIPTION
3D models showed up in the dashboard's new 3D tab but with an **empty price cell**.

### Cause
`modelPriceFromCatalog` has no `type === "3d"` branch, so 3D models fell through to the final `return` (the text-model formatter), which reads `promptTextTokens`/`completionTextTokens` — fields a 3D model doesn't have. `priceLines` drops empty lines → `prices: []` → blank cell. (The `perRequest`/`perImagePrice` 3d block from #12048's history was dropped on rebase, and returned fields that don't exist on `ModelPrice` anyway.)

### Fix
- Reuse the **existing image flat-rate branch** — 3D stores its flat per-generation fee in `completionImageTokens` exactly like flat image models, so it renders the correct `/gen` line with **no new price type, unit, or config**.
- Remove the dead/unreachable `"3d"` block.
- Add a pricing-data test asserting each 3D model yields one flat per-request line.

Sort price + per-Pollen already worked (`completionImageTokens` is in `OUTPUT_PRICE_FIELDS`).

Follow-up to #12048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)