### PR TITLE
feat: make hyper3d-rodin (fal.ai) paid-only

### DIFF
--- a/shared/registry/model3d.ts
+++ b/shared/registry/model3d.ts
@@ -75,6 +75,7 @@ export const MODEL3D_SERVICES = {
         category: "3d",
         addedDate: new Date("2026-06-24").getTime(),
         priceMultiplier: 1,
+        paidOnly: true, // fal.ai-served — restrict to paid balance
         flatRate: true,
 
         cost: {


### PR DESCRIPTION
- Sets `paidOnly: true` on `hyper3d-rodin` (the fal.ai-served 3D model).
- Effect: free/quest-tier users (tierBalance) get a 402; only paid pack balance covers it — enforced in `generation-access.ts` (`canCoverEstimatedCharge`), same gating as ElevenLabs/Azure-image paid-only models.
- Trellis 2 (inferenceport) stays free.

Follow-up to #12048 / #12188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)