### PR TITLE
fix: correct stale reactivate instructions on disabled model card

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -81,7 +81,9 @@ export function CommunityEndpointCard({
                                 "Deactivated due to repeated failures."}
                         </span>
                         <span className="text-sm">
-                            Edit, test, then save the model to reactivate it.
+                            Fix the issue, then ping a maintainer on Discord to
+                            reactivate it — there's no self-serve reactivate
+                            yet.
                         </span>
                     </div>
                 </Alert>


### PR DESCRIPTION
- The dashboard's "edit, test, then save to reactivate" message is stale — that flow was intentionally removed in #12154 to stop silent reactivation on unrelated saves
- There's currently no self-serve reactivate path at all; owners need a maintainer to flip it back on
- Points owners at that instead of a broken instruction