### PR TITLE
[codex] restore claude fable 5

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -24,6 +24,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000003,
     },
   },
+  "claude-fable-5": {
+    "cost": {
+      "completionTextTokens": 0.00005,
+      "promptCacheWriteTokens": 0.0000125,
+      "promptCachedTokens": 0.000001,
+      "promptTextTokens": 0.00001,
+    },
+    "price": {
+      "completionTextTokens": 0.00005,
+      "promptCacheWriteTokens": 0.0000125,
+      "promptCachedTokens": 0.000001,
+      "promptTextTokens": 0.00001,
+    },
+  },
   "claude-fast": {
     "cost": {
       "completionTextTokens": 0.000005,
@@ -247,13 +261,19 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "gemini-large": {
     "cost": {
       "completionTextTokens": 0.000012,
+      "promptAudioTokens": 0.000002,
       "promptCachedTokens": 0.0000002,
+      "promptImageTokens": 0.000002,
       "promptTextTokens": 0.000002,
+      "promptVideoTokens": 0.000002,
     },
     "price": {
       "completionTextTokens": 0.000012,
+      "promptAudioTokens": 0.000002,
       "promptCachedTokens": 0.0000002,
+      "promptImageTokens": 0.000002,
       "promptTextTokens": 0.000002,
+      "promptVideoTokens": 0.000002,
     },
   },
   "gemini-search": {
@@ -315,9 +335,9 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000014,
     },
     "price": {
-      "completionTextTokens": 0.0000022,
-      "promptCachedTokens": 0.00000013,
-      "promptTextTokens": 0.0000007,
+      "completionTextTokens": 0.0000044,
+      "promptCachedTokens": 0.00000026,
+      "promptTextTokens": 0.0000014,
     },
   },
   "gpt-5.4": {
@@ -470,6 +490,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
     },
     "price": {
       "completionVideoSeconds": 0.05,
+    },
+  },
+  "hyper3d-rodin": {
+    "cost": {
+      "completionImageTokens": 0.4,
+    },
+    "price": {
+      "completionImageTokens": 0.4,
     },
   },
   "ideogram-v4-balanced": {
@@ -1104,6 +1132,30 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionTextTokens": 0.00000115,
       "promptCachedTokens": 0.00000004,
       "promptTextTokens": 0.0000002,
+    },
+  },
+  "trellis-2-high": {
+    "cost": {
+      "completionImageTokens": 0.35,
+    },
+    "price": {
+      "completionImageTokens": 0.35,
+    },
+  },
+  "trellis-2-low": {
+    "cost": {
+      "completionImageTokens": 0.24,
+    },
+    "price": {
+      "completionImageTokens": 0.24,
+    },
+  },
+  "trellis-2-medium": {
+    "cost": {
+      "completionImageTokens": 0.29,
+    },
+    "price": {
+      "completionImageTokens": 0.29,
     },
   },
   "universal-2": {

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -335,6 +335,22 @@ test("reasoning token usage bills through completion text rates", () => {
     }
 });
 
+test("Claude Fable 5 is paid-only and billed at current standard rates", () => {
+    const definition = getRegistryModelDefinition("claude-fable-5");
+
+    expect(definition.paidOnly).toBe(true);
+    expect(definition.priceMultiplier).toBe(1);
+    expect(getCostDefinition("claude-fable-5")).toEqual({
+        promptTextTokens: 0.00001,
+        promptCachedTokens: 0.000001,
+        promptCacheWriteTokens: 0.0000125,
+        completionTextTokens: 0.00005,
+    });
+    expect(getPriceDefinition("claude-fable-5")).toEqual(
+        getCostDefinition("claude-fable-5"),
+    );
+});
+
 test("Gemini grounding cost is added by family billing rules", () => {
     const usage = {
         promptTextTokens: 1_000_000,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -183,6 +183,11 @@ const models: ModelDefinition[] = [
         transform: claudeAdaptiveThinking,
     },
     {
+        name: "claude-fable-5",
+        config: portkeyConfig["claude-fable-5"],
+        transform: claudeAdaptiveThinking,
+    },
+    {
         name: "gemini-3-flash",
         config: portkeyConfig["gemini-3-flash-preview"],
         transform: pipe(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -190,6 +190,11 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "us.anthropic.claude-opus-4-8",
             defaultOptions: { max_tokens: 128000 },
         }),
+    "claude-fable-5": () =>
+        createBedrockNativeConfig({
+            model: "global.anthropic.claude-fable-5",
+            defaultOptions: { max_tokens: 128000 },
+        }),
     "claude-haiku-4-5": () =>
         createBedrockNativeConfig({
             model: "global.anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
+++ b/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
@@ -70,9 +70,9 @@ export function processParameters(
         updatedOptions.temperature = 1;
     }
 
-    // Claude Opus 4.7/4.8 deprecated temperature/top_p/top_k — non-default values
-    // return 400 from Anthropic. Strip them entirely.
-    if (/claude-opus-4-[78]/i.test(model)) {
+    // Claude Opus 4.7/4.8 and Fable 5 reject non-default sampling params.
+    // Strip them entirely.
+    if (/claude-(opus-4-[78]|fable-5)/i.test(model)) {
         for (const param of ["temperature", "top_p", "top_k"] as const) {
             if (updatedOptions[param] !== undefined) {
                 log(`Stripping ${param} for ${model}`);

--- a/gen.pollinations.ai/test/text/transforms/createClaudeThinkingTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createClaudeThinkingTransform.test.ts
@@ -114,6 +114,7 @@ describe("Claude thinking model wiring", () => {
         "claude-opus-4.6",
         "claude-large",
         "claude-opus-4.7",
+        "claude-fable-5",
     ])("wires adaptive thinking on %s", async (modelName) => {
         const transform = findModelByName(modelName)?.transform;
         if (!transform) throw new Error(`${modelName} transform missing`);

--- a/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
@@ -80,6 +80,7 @@ describe("processParameters", () => {
     it.each([
         "us.anthropic.claude-opus-4-7",
         "global.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-fable-5",
     ])("strips temperature/top_p/top_k for %s", (model) => {
         const result = processParameters(messages, {
             model,

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -17,6 +17,10 @@ describe("resolveModelConfig", () => {
             resolveModelConfig(messages, { model: "claude-large" }).options
                 .max_tokens,
         ).toBe(128000);
+        expect(
+            resolveModelConfig(messages, { model: "claude-fable-5" }).options
+                .max_tokens,
+        ).toBe(128000);
     });
 
     it("lets callers override Anthropic max_tokens", () => {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -860,6 +860,31 @@ export const TEXT_SERVICES = {
         contextLength: 1000000,
         isSpecialized: false,
     },
+    "claude-fable-5": {
+        aliases: [],
+        modelId: "claude-fable-5",
+        provider: "bedrock",
+        brand: "Anthropic",
+        category: "text",
+        addedDate: new Date("2026-06-11").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // Bedrock global.anthropic.claude-fable-5 global standard rates.
+            promptTextTokens: perMillion(10),
+            promptCachedTokens: perMillion(1),
+            promptCacheWriteTokens: perMillion(12.5),
+            completionTextTokens: perMillion(50),
+        },
+        title: "Claude Fable 5",
+        description: "Claude Fable 5 - Frontier reasoning & agentic work",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 20, // Bedrock Converse image limit.
+        tools: true,
+        contextLength: 1000000,
+        isSpecialized: false,
+    },
     "perplexity-fast": {
         aliases: ["sonar"],
         modelId: "sonar",


### PR DESCRIPTION
- Restores `claude-fable-5` as a paid-only Bedrock text model via `global.anthropic.claude-fable-5`.
- Keeps Fable pricing at provider cost: $10/MTok input, $1/MTok cache read, $12.50/MTok cache write, $50/MTok output.
- Wires Claude adaptive thinking and strips unsupported Fable sampling params.
- Adds focused paid-only/pricing, model resolution, transform, and snapshot coverage.

Validation:
- AWS CLI: model is `ACTIVE`; direct Bedrock Runtime converse returned `OK`.
- Local gen e2e: `/v1/chat/completions` returned 200 with `OK`; billing charged 0.00105 Pollen for 20 input + 17 output tokens.
- `biome`, focused gen/enter vitest suites, and `gen` typecheck pass.