### PR TITLE
chore: small cleanup fixes

### DIFF
--- a/apps/operation/kpi/src/api/github.js
+++ b/apps/operation/kpi/src/api/github.js
@@ -7,11 +7,9 @@ export async function getGitHubStats() {
 }
 
 export async function getStarHistory(_days = 30) {
-    // GitHub doesn't provide star history directly
-    // For now, return current count - would need a service like star-history.com or track in DB
     const stats = await getGitHubStats();
     return {
         current: stats.stars,
-        history: [], // TODO: implement star history tracking
+        history: [], // TODO: implement star history tracking when needed
     };
 }

--- a/gen.pollinations.ai/src/image/util.ts
+++ b/gen.pollinations.ai/src/image/util.ts
@@ -1,5 +1,5 @@
 export async function sleep(ms: number) {
-    await new Promise<void>((resolve, _) => setTimeout(resolve, ms));
+    await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 // Strip control characters while preserving valid Unicode characters.

--- a/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
+++ b/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
@@ -723,7 +723,8 @@ export function PlayGenerator({
                             setUrlCopied(true);
                             setTimeout(() => setUrlCopied(false), 2000);
                         }}
-                        title={copy.copyButton} aria-label={copy.copyButton}
+                        title={copy.copyButton}
+                        aria-label={copy.copyButton}
                     >
                         {urlCopied ? (
                             <span className="font-body text-xs font-bold text-dark uppercase tracking-wider px-1">

--- a/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
+++ b/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
@@ -648,6 +648,7 @@ export function PlayGenerator({
                             className="w-full h-auto"
                             onLoadedData={() => setIsLoading(false)}
                         >
+                            <track kind="captions" />
                         </video>
                     )}
                     {resultType === "audio" && (
@@ -658,6 +659,7 @@ export function PlayGenerator({
                             className="w-full"
                             onLoadedData={() => setIsLoading(false)}
                         >
+                            <track kind="captions" />
                         </audio>
                     )}
                     {resultType === "text" && (

--- a/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
+++ b/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
@@ -648,7 +648,6 @@ export function PlayGenerator({
                             className="w-full h-auto"
                             onLoadedData={() => setIsLoading(false)}
                         >
-                            <track kind="captions" />
                         </video>
                     )}
                     {resultType === "audio" && (
@@ -659,7 +658,6 @@ export function PlayGenerator({
                             className="w-full"
                             onLoadedData={() => setIsLoading(false)}
                         >
-                            <track kind="captions" />
                         </audio>
                     )}
                     {resultType === "text" && (
@@ -725,7 +723,7 @@ export function PlayGenerator({
                             setUrlCopied(true);
                             setTimeout(() => setUrlCopied(false), 2000);
                         }}
-                        title={copy.copyButton}
+                        title={copy.copyButton} aria-label={copy.copyButton}
                     >
                         {urlCopied ? (
                             <span className="font-body text-xs font-bold text-dark uppercase tracking-wider px-1">


### PR DESCRIPTION
- Remove unused parameter in sleep() utility
- Remove empty <track> elements causing browser warnings
- Add missing aria-label to copy button for accessibility
- Clean up stale TODO comment in star history function