### PR TITLE
feat: D1-backed media catalog (tags, galleries) on media.pollinations.ai

### DIFF
--- a/.github/workflows/deploy-media-cloudflare.yml
+++ b/.github/workflows/deploy-media-cloudflare.yml
@@ -43,6 +43,18 @@ jobs:
         run: npm run apply-lifecycle:production
         working-directory: ./media.pollinations.ai
 
+      # The worker queries media catalog tables in enter's D1 — enter/gen
+      # workflows also apply these migrations, but the three deploy workflows
+      # have no ordering guarantee between them, so apply before deploying
+      # rather than assuming enter ran first. `d1 migrations apply` is
+      # idempotent (already-applied files are skipped).
+      - name: Apply D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
+        run: npm run migrate:production
+        working-directory: ./media.pollinations.ai
+
       - name: Deploy to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}

--- a/enter.pollinations.ai/drizzle.config.ts
+++ b/enter.pollinations.ai/drizzle.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
     out: "./drizzle",
-    schema: "../shared/db/better-auth.ts",
+    schema: ["../shared/db/better-auth.ts", "../shared/db/media-catalog.ts"],
     dialect: "sqlite",
     driver: "d1-http",
     dbCredentials: {

--- a/enter.pollinations.ai/drizzle/0035_media_catalog.sql
+++ b/enter.pollinations.ai/drizzle/0035_media_catalog.sql
@@ -2,7 +2,6 @@ CREATE TABLE `media_item` (
 	`id` text PRIMARY KEY NOT NULL,
 	`kind` text NOT NULL,
 	`locator` text NOT NULL,
-	`content_hash` text,
 	`owner_user_id` text,
 	`app_key_id` text,
 	`content_type` text NOT NULL,

--- a/enter.pollinations.ai/drizzle/0035_media_catalog.sql
+++ b/enter.pollinations.ai/drizzle/0035_media_catalog.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `media_item` (
+	`id` text PRIMARY KEY NOT NULL,
+	`kind` text NOT NULL,
+	`locator` text NOT NULL,
+	`content_hash` text,
+	`owner_user_id` text,
+	`app_key_id` text,
+	`content_type` text NOT NULL,
+	`size` integer,
+	`model` text,
+	`prompt` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`owner_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_media_item_owner_locator` ON `media_item` (`owner_user_id`,`locator`);--> statement-breakpoint
+CREATE INDEX `idx_media_item_owner_created` ON `media_item` (`owner_user_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `media_tag` (
+	`item_id` text NOT NULL,
+	`tag` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `media_item`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_media_tag_item_tag` ON `media_tag` (`item_id`,`tag`);--> statement-breakpoint
+CREATE INDEX `idx_media_tag_tag_created` ON `media_tag` (`tag`,`created_at`);

--- a/enter.pollinations.ai/drizzle/meta/0035_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,1685 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "988e38a5-9d8e-4b78-882c-d4cac21b52f2",
+  "prevId": "b06b2fc4-e749-4253-90ba-e8da6ee5f553",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator": {
+          "name": "locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_locator": {
+          "name": "idx_media_item_owner_locator",
+          "columns": [
+            "owner_user_id",
+            "locator"
+          ],
+          "isUnique": true
+        },
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_created": {
+          "name": "idx_media_tag_tag_created",
+          "columns": [
+            "tag",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/0035_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0035_snapshot.json
@@ -1515,13 +1515,6 @@
           "notNull": true,
           "autoincrement": false
         },
-        "content_hash": {
-          "name": "content_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "autoincrement": false
-        },
         "owner_user_id": {
           "name": "owner_user_id",
           "type": "text",

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1782911825724,
       "tag": "0034_opposite_ultron",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1783347338031,
+      "tag": "0035_media_catalog",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1728,11 +1728,6 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Stable id of the user that owns this key — server-attested.",
                                         ),
-                                    keyId: z
-                                        .string()
-                                        .describe(
-                                            "Stable id of this API key — server-attested.",
-                                        ),
                                     byopClientKeyId: z
                                         .string()
                                         .nullable()
@@ -1820,7 +1815,6 @@ export const accountRoutes = new Hono<Env>()
                 // stamp ownership from these values — never from request
                 // params — so user and BYOP app ids cannot be spoofed.
                 userId: c.var.auth.user?.id ?? null,
-                keyId: apiKey.id,
                 byopClientKeyId: apiKey.byopClientKeyId ?? null,
             });
         },

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1722,6 +1722,23 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Whether rate limiting is enabled for this key",
                                         ),
+                                    userId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Stable id of the user that owns this key — server-attested.",
+                                        ),
+                                    keyId: z
+                                        .string()
+                                        .describe(
+                                            "Stable id of this API key — server-attested.",
+                                        ),
+                                    byopClientKeyId: z
+                                        .string()
+                                        .nullable()
+                                        .describe(
+                                            "Publishable app key that minted this key via the BYOP authorize flow. Server-attested; clients cannot forge.",
+                                        ),
                                 }),
                             ),
                         },
@@ -1799,6 +1816,12 @@ export const accountRoutes = new Hono<Env>()
                 pollenBudget: apiKey.pollenBalance ?? null,
                 // Generation rate limiting applies to publishable keys only.
                 rateLimitEnabled: keyType === "publishable",
+                // Server-attested identity. Downstream services (media catalog)
+                // stamp ownership from these values — never from request
+                // params — so user and BYOP app ids cannot be spoofed.
+                userId: c.var.auth.user?.id ?? null,
+                keyId: apiKey.id,
+                byopClientKeyId: apiKey.byopClientKeyId ?? null,
             });
         },
     )

--- a/media.pollinations.ai/package-lock.json
+++ b/media.pollinations.ai/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hono/standard-validator": "^0.2.2",
+        "drizzle-orm": "^0.44.7",
         "hono": "^4.6.0",
         "hono-openapi": "^1.2.0",
         "zod": "^3.25.76",
@@ -355,7 +356,7 @@
       "version": "4.20260111.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260111.0.tgz",
       "integrity": "sha512-NFA2U+AqEWHkAmw6oRzNWJyc14rIvBlF/OlK3lixokunRKwyziuON07nWUZ0w0kKWlW4fJ/muA09tEUaQY07tA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2063,6 +2064,131 @@
       "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.44.7",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
+      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",

--- a/media.pollinations.ai/package.json
+++ b/media.pollinations.ai/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hono/standard-validator": "^0.2.2",
+    "drizzle-orm": "^0.44.7",
     "hono": "^4.6.0",
     "hono-openapi": "^1.2.0",
     "zod": "^3.25.76",

--- a/media.pollinations.ai/package.json
+++ b/media.pollinations.ai/package.json
@@ -7,6 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "deploy:production": "wrangler deploy --env production",
+    "migrate:production": "wrangler d1 migrations apply DB --remote --env production",
     "apply-lifecycle:production": "wrangler r2 bucket lifecycle set pollinations-media --file r2-lifecycle.json --force",
     "tail": "wrangler tail",
     "test": "vitest run",

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -17,19 +17,16 @@ export function getDb(d1: D1Database): CatalogDb {
 // Lowercase, trimmed slug: letters/digits, then `_.:+-` allowed after the
 // first char. Keeps tags URL-safe and consistent for gallery lookups.
 export const TAG_PATTERN = /^[a-z0-9][a-z0-9_.:+-]{0,127}$/;
+// Prose twin of TAG_PATTERN for error messages — keep in sync with the regex.
+export const TAG_PATTERN_DESCRIPTION =
+    "lowercase letters, digits, and _.:+- (not leading), max 128 chars";
 export const MAX_TAGS = 8;
 
-export class InvalidTagError extends Error {
-    constructor(public readonly tag: string) {
-        super(`Invalid tag: "${tag}"`);
-        this.name = "InvalidTagError";
-    }
-}
-
-export class TooManyTagsError extends Error {
-    constructor(public readonly count: number) {
-        super(`Too many tags: ${count} (max ${MAX_TAGS})`);
-        this.name = "TooManyTagsError";
+/** Thrown by normalizeTags; message is complete and user-facing. */
+export class TagError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TagError";
     }
 }
 
@@ -47,13 +44,15 @@ export function normalizeTags(rawTags: string[]): string[] {
         if (!TAG_PATTERN.test(tag)) {
             // Name the tag as submitted (pre-lowercase) so the error is
             // unambiguous about which input was rejected.
-            throw new InvalidTagError(trimmed);
+            throw new TagError(
+                `Invalid tag: "${trimmed}". Tags must match ${TAG_PATTERN_DESCRIPTION}.`,
+            );
         }
         seen.add(tag);
     }
     const tags = [...seen];
     if (tags.length > MAX_TAGS) {
-        throw new TooManyTagsError(tags.length);
+        throw new TagError(`Too many tags: ${tags.length} (max ${MAX_TAGS}).`);
     }
     return tags;
 }
@@ -62,7 +61,6 @@ export interface UpsertUploadParams {
     ownerUserId: string;
     appKeyId: string | null;
     locator: string;
-    contentHash: string;
     contentType: string;
     size: number;
     model: string | null;
@@ -85,7 +83,6 @@ export async function upsertUploadCatalogItem(
             id: crypto.randomUUID(),
             kind: "upload",
             locator: params.locator,
-            contentHash: params.contentHash,
             ownerUserId: params.ownerUserId,
             appKeyId: params.appKeyId,
             contentType: params.contentType,
@@ -96,8 +93,10 @@ export async function upsertUploadCatalogItem(
         })
         .onConflictDoUpdate({
             target: [mediaItem.ownerUserId, mediaItem.locator],
+            // createdAt is deliberately NOT updated: it marks first catalog
+            // time, so re-uploading (which refreshes the R2 TTL and metadata)
+            // can't bump an item back to the top of newest-first feeds.
             set: {
-                createdAt: now,
                 contentType: params.contentType,
                 size: params.size,
                 model: params.model,
@@ -243,7 +242,13 @@ export async function listUserMedia(
     return paginate(rows, params.limit);
 }
 
-/** Public gallery: list catalog items for a tag, newest first. */
+/**
+ * Public gallery: list catalog items for a tag, newest first by when each
+ * item was tagged (media_tag.created_at is insert-only), not by the item's
+ * own createdAt. Late-tagged items surface as freshly published, and
+ * re-uploads can't bump themselves back to the top. The cursor rides on
+ * (taggedAt, itemId).
+ */
 export async function listByTag(
     db: CatalogDb,
     params: {
@@ -254,7 +259,15 @@ export async function listByTag(
 ): Promise<CatalogPage> {
     const conditions = [eq(mediaTag.tag, params.tag)];
     if (params.cursor) {
-        conditions.push(beforeCursor(params.cursor));
+        conditions.push(
+            sql`${or(
+                lt(mediaTag.createdAt, params.cursor.createdAt),
+                and(
+                    eq(mediaTag.createdAt, params.cursor.createdAt),
+                    lt(mediaItem.id, params.cursor.id),
+                ),
+            )}`,
+        );
     }
 
     const rows = await db
@@ -267,13 +280,22 @@ export async function listByTag(
             model: mediaItem.model,
             prompt: mediaItem.prompt,
             createdAt: mediaItem.createdAt,
+            taggedAt: mediaTag.createdAt,
         })
         .from(mediaTag)
         .innerJoin(mediaItem, eq(mediaItem.id, mediaTag.itemId))
         .where(and(...conditions))
-        .orderBy(desc(mediaItem.createdAt), desc(mediaItem.id))
+        .orderBy(desc(mediaTag.createdAt), desc(mediaItem.id))
         .limit(params.limit + 1);
-    return paginate(rows, params.limit);
+
+    const hasMore = rows.length > params.limit;
+    const page = hasMore ? rows.slice(0, params.limit) : rows;
+    const last = page[page.length - 1];
+    return {
+        items: page.map(({ taggedAt: _taggedAt, ...item }) => item),
+        nextCursor:
+            hasMore && last ? encodeCursor(last.taggedAt, last.id) : null,
+    };
 }
 
 /** Fetch tags for a page of item ids in one query, grouped by item id. */

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -1,0 +1,325 @@
+// Media catalog: D1-backed metadata for stored media (tags, prompt, model,
+// galleries). Blobs stay in R2 — this module only indexes them. Writes are
+// awaited inline on the upload path (no waitUntil): a D1 failure surfaces as
+// a 500 rather than silently dropping catalog data.
+
+import { mediaItem, mediaTag } from "@shared/db/media-catalog.ts";
+import type { SQL } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+
+export type CatalogDb = ReturnType<typeof drizzle>;
+
+export function getDb(d1: D1Database): CatalogDb {
+    return drizzle(d1);
+}
+
+// Lowercase, trimmed slug: letters/digits, then `_.:+-` allowed after the
+// first char. Keeps tags URL-safe and consistent for gallery lookups.
+export const TAG_PATTERN = /^[a-z0-9][a-z0-9_.:+-]{0,127}$/;
+export const MAX_TAGS = 8;
+
+export class InvalidTagError extends Error {
+    constructor(public readonly tag: string) {
+        super(`Invalid tag: "${tag}"`);
+        this.name = "InvalidTagError";
+    }
+}
+
+export class TooManyTagsError extends Error {
+    constructor(public readonly count: number) {
+        super(`Too many tags: ${count} (max ${MAX_TAGS})`);
+        this.name = "TooManyTagsError";
+    }
+}
+
+/**
+ * Normalize and validate a set of raw tag strings. Throws on the first
+ * invalid tag (naming it) or if the deduplicated count exceeds MAX_TAGS —
+ * no silent drops.
+ */
+export function normalizeTags(rawTags: string[]): string[] {
+    const seen = new Set<string>();
+    for (const raw of rawTags) {
+        const trimmed = raw.trim();
+        if (trimmed === "") continue;
+        const tag = trimmed.toLowerCase();
+        if (!TAG_PATTERN.test(tag)) {
+            // Name the tag as submitted (pre-lowercase) so the error is
+            // unambiguous about which input was rejected.
+            throw new InvalidTagError(trimmed);
+        }
+        seen.add(tag);
+    }
+    const tags = [...seen];
+    if (tags.length > MAX_TAGS) {
+        throw new TooManyTagsError(tags.length);
+    }
+    return tags;
+}
+
+export interface UpsertUploadParams {
+    ownerUserId: string;
+    appKeyId: string | null;
+    locator: string;
+    contentHash: string;
+    contentType: string;
+    size: number;
+    model: string | null;
+    prompt: string | null;
+    tags: string[];
+}
+
+/**
+ * Upsert a catalog row for an upload (keyed on ownerUserId+locator), then
+ * merge in any tags. Returns the catalog item id.
+ */
+export async function upsertUploadCatalogItem(
+    db: CatalogDb,
+    params: UpsertUploadParams,
+): Promise<string> {
+    const now = new Date();
+    const [row] = await db
+        .insert(mediaItem)
+        .values({
+            id: crypto.randomUUID(),
+            kind: "upload",
+            locator: params.locator,
+            contentHash: params.contentHash,
+            ownerUserId: params.ownerUserId,
+            appKeyId: params.appKeyId,
+            contentType: params.contentType,
+            size: params.size,
+            model: params.model,
+            prompt: params.prompt,
+            createdAt: now,
+        })
+        .onConflictDoUpdate({
+            target: [mediaItem.ownerUserId, mediaItem.locator],
+            set: {
+                createdAt: now,
+                contentType: params.contentType,
+                size: params.size,
+                model: params.model,
+                prompt: params.prompt,
+            },
+        })
+        .returning({ id: mediaItem.id });
+
+    if (params.tags.length > 0) {
+        await db
+            .insert(mediaTag)
+            .values(
+                params.tags.map((tag) => ({
+                    itemId: row.id,
+                    tag,
+                    createdAt: now,
+                })),
+            )
+            .onConflictDoNothing({
+                target: [mediaTag.itemId, mediaTag.tag],
+            });
+    }
+
+    return row.id;
+}
+
+export interface CatalogItem {
+    id: string;
+    kind: "upload" | "generation";
+    locator: string;
+    contentType: string;
+    size: number | null;
+    model: string | null;
+    prompt: string | null;
+    createdAt: Date;
+}
+
+export interface CatalogPage {
+    items: CatalogItem[];
+    nextCursor: string | null;
+}
+
+/** base64url(JSON [createdAtEpochSeconds, id]) keyset cursor. */
+export function encodeCursor(createdAt: Date, id: string): string {
+    const json = JSON.stringify([Math.floor(createdAt.getTime() / 1000), id]);
+    return btoa(json)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+}
+
+export class InvalidCursorError extends Error {
+    constructor() {
+        super("Invalid cursor");
+        this.name = "InvalidCursorError";
+    }
+}
+
+export function decodeCursor(cursor: string): {
+    createdAt: Date;
+    id: string;
+} {
+    try {
+        const padded = cursor
+            .replace(/-/g, "+")
+            .replace(/_/g, "/")
+            .padEnd(Math.ceil(cursor.length / 4) * 4, "=");
+        const [epochSeconds, id] = JSON.parse(atob(padded)) as [number, string];
+        if (
+            typeof epochSeconds !== "number" ||
+            !Number.isFinite(epochSeconds) ||
+            typeof id !== "string" ||
+            id === ""
+        ) {
+            throw new Error("malformed cursor payload");
+        }
+        return { createdAt: new Date(epochSeconds * 1000), id };
+    } catch {
+        throw new InvalidCursorError();
+    }
+}
+
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+/** Clamp a user-supplied limit into [1, MAX_LIMIT], NaN-safe. */
+export function clampLimit(raw: string | null | undefined): number {
+    const parsed = Number.parseInt(raw ?? "", 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+    return Math.min(parsed, MAX_LIMIT);
+}
+
+/** List catalog items owned by a user, newest first, optionally by tag. */
+export async function listUserMedia(
+    db: CatalogDb,
+    params: {
+        ownerUserId: string;
+        tag?: string;
+        limit: number;
+        cursor?: { createdAt: Date; id: string };
+    },
+): Promise<CatalogPage> {
+    const conditions = [eq(mediaItem.ownerUserId, params.ownerUserId)];
+    if (params.cursor) {
+        conditions.push(beforeCursor(params.cursor));
+    }
+
+    if (params.tag) {
+        const rows = await db
+            .select({
+                id: mediaItem.id,
+                kind: mediaItem.kind,
+                locator: mediaItem.locator,
+                contentType: mediaItem.contentType,
+                size: mediaItem.size,
+                model: mediaItem.model,
+                prompt: mediaItem.prompt,
+                createdAt: mediaItem.createdAt,
+            })
+            .from(mediaItem)
+            .innerJoin(mediaTag, eq(mediaTag.itemId, mediaItem.id))
+            .where(and(eq(mediaTag.tag, params.tag), ...conditions))
+            .orderBy(desc(mediaItem.createdAt), desc(mediaItem.id))
+            .limit(params.limit + 1);
+        return paginate(rows, params.limit);
+    }
+
+    const rows = await db
+        .select({
+            id: mediaItem.id,
+            kind: mediaItem.kind,
+            locator: mediaItem.locator,
+            contentType: mediaItem.contentType,
+            size: mediaItem.size,
+            model: mediaItem.model,
+            prompt: mediaItem.prompt,
+            createdAt: mediaItem.createdAt,
+        })
+        .from(mediaItem)
+        .where(and(...conditions))
+        .orderBy(desc(mediaItem.createdAt), desc(mediaItem.id))
+        .limit(params.limit + 1);
+    return paginate(rows, params.limit);
+}
+
+/** Public gallery: list catalog items for a tag, newest first. */
+export async function listByTag(
+    db: CatalogDb,
+    params: {
+        tag: string;
+        limit: number;
+        cursor?: { createdAt: Date; id: string };
+    },
+): Promise<CatalogPage> {
+    const conditions = [eq(mediaTag.tag, params.tag)];
+    if (params.cursor) {
+        conditions.push(beforeCursor(params.cursor));
+    }
+
+    const rows = await db
+        .select({
+            id: mediaItem.id,
+            kind: mediaItem.kind,
+            locator: mediaItem.locator,
+            contentType: mediaItem.contentType,
+            size: mediaItem.size,
+            model: mediaItem.model,
+            prompt: mediaItem.prompt,
+            createdAt: mediaItem.createdAt,
+        })
+        .from(mediaTag)
+        .innerJoin(mediaItem, eq(mediaItem.id, mediaTag.itemId))
+        .where(and(...conditions))
+        .orderBy(desc(mediaItem.createdAt), desc(mediaItem.id))
+        .limit(params.limit + 1);
+    return paginate(rows, params.limit);
+}
+
+/** Fetch tags for a page of item ids in one query, grouped by item id. */
+export async function tagsForItems(
+    db: CatalogDb,
+    itemIds: string[],
+): Promise<Map<string, string[]>> {
+    const byItem = new Map<string, string[]>();
+    if (itemIds.length === 0) return byItem;
+
+    const rows = await db
+        .select({ itemId: mediaTag.itemId, tag: mediaTag.tag })
+        .from(mediaTag)
+        .where(inArray(mediaTag.itemId, itemIds));
+
+    for (const row of rows) {
+        const existing = byItem.get(row.itemId);
+        if (existing) {
+            existing.push(row.tag);
+        } else {
+            byItem.set(row.itemId, [row.tag]);
+        }
+    }
+    return byItem;
+}
+
+function beforeCursor(cursor: { createdAt: Date; id: string }): SQL {
+    // Keyset pagination on (createdAt, id) both descending: strictly older
+    // rows, or same-instant rows with a strictly smaller id. Both branches
+    // passed to `or`/`and` are always defined, so the result is never
+    // undefined — assert that to keep the caller's condition arrays typed
+    // as SQL (not SQL | undefined).
+    return sql`${or(
+        lt(mediaItem.createdAt, cursor.createdAt),
+        and(
+            eq(mediaItem.createdAt, cursor.createdAt),
+            lt(mediaItem.id, cursor.id),
+        ),
+    )}`;
+}
+
+function paginate(rows: CatalogItem[], limit: number): CatalogPage {
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+    const last = items[items.length - 1];
+    const nextCursor =
+        hasMore && last ? encodeCursor(last.createdAt, last.id) : null;
+    return { items, nextCursor };
+}

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -3,6 +3,19 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi";
 import { z } from "zod";
+import type { CatalogItem, CatalogPage } from "./catalog.ts";
+import {
+    clampLimit,
+    decodeCursor,
+    getDb,
+    InvalidTagError,
+    listByTag,
+    listUserMedia,
+    normalizeTags,
+    TooManyTagsError,
+    tagsForItems,
+    upsertUploadCatalogItem,
+} from "./catalog.ts";
 
 const DOMAIN = "media.pollinations.ai";
 // gen.pollinations.ai proxies /account/* to enter — using the public path
@@ -21,12 +34,16 @@ const DEFAULT_MAX_SIZE = 52428800; // 50 MB
 interface Env {
     MEDIA_BUCKET: R2Bucket;
     MAX_FILE_SIZE: string;
+    DB: D1Database;
 }
 
 interface AuthResult {
     valid: boolean;
     type: string;
     name: string | null;
+    userId: string | null;
+    keyId: string;
+    byopClientKeyId: string | null;
 }
 
 async function verifyApiKey(apiKey: string): Promise<AuthResult | null> {
@@ -58,12 +75,137 @@ function mediaUrl(hash: string): string {
     return `https://${DOMAIN}/${hash}`;
 }
 
+const MAX_PROMPT_LENGTH = 2000;
+const MAX_MODEL_LENGTH = 128;
+
+// Splits a comma-separated `tags` value and merges it with repeated `tag`
+// params. Accepts the same shape whether it came from a query string,
+// multipart form field, or JSON body field.
+function collectTags(
+    getAll: (key: string) => string[],
+    get: (key: string) => string | null | undefined,
+): string[] {
+    const tags = [...getAll("tag")];
+    const tagsParam = get("tags");
+    if (tagsParam) {
+        tags.push(...tagsParam.split(","));
+    }
+    return tags;
+}
+
+interface UploadMetadata {
+    tags: string[];
+    prompt: string | null;
+    model: string | null;
+}
+
+class MetadataValidationError extends Error {}
+
+function validateMetadata(
+    rawTags: string[],
+    rawPrompt: string | null | undefined,
+    rawModel: string | null | undefined,
+): UploadMetadata {
+    let tags: string[];
+    try {
+        tags = normalizeTags(rawTags);
+    } catch (error) {
+        if (error instanceof InvalidTagError) {
+            throw new MetadataValidationError(
+                `Invalid tag: "${error.tag}". Tags must match ${TAG_PATTERN_DESCRIPTION}.`,
+            );
+        }
+        if (error instanceof TooManyTagsError) {
+            throw new MetadataValidationError(
+                `Too many tags: ${error.count} (max 8).`,
+            );
+        }
+        throw error;
+    }
+
+    const prompt = rawPrompt?.trim() || null;
+    if (prompt && prompt.length > MAX_PROMPT_LENGTH) {
+        throw new MetadataValidationError(
+            `Prompt too long: ${prompt.length} chars (max ${MAX_PROMPT_LENGTH}).`,
+        );
+    }
+
+    const model = rawModel?.trim() || null;
+    if (model && model.length > MAX_MODEL_LENGTH) {
+        throw new MetadataValidationError(
+            `Model name too long: ${model.length} chars (max ${MAX_MODEL_LENGTH}).`,
+        );
+    }
+
+    return { tags, prompt, model };
+}
+
+const TAG_PATTERN_DESCRIPTION =
+    "lowercase letters, digits, and _.:+- (not leading), max 128 chars";
+
+function hasMetadata(metadata: UploadMetadata): boolean {
+    return (
+        metadata.tags.length > 0 ||
+        metadata.prompt !== null ||
+        metadata.model !== null
+    );
+}
+
+// Item shape shared by /me/media and /tags/:tag — never exposes
+// ownerUserId/appKeyId.
+interface MediaItemResponse {
+    id: string;
+    url: string;
+    kind: "upload" | "generation";
+    contentType: string;
+    size: number | null;
+    tags: string[];
+    prompt: string | null;
+    model: string | null;
+    createdAt: string;
+}
+
+function toItemResponse(
+    item: CatalogItem,
+    tagsByItem: Map<string, string[]>,
+): MediaItemResponse {
+    return {
+        id: item.id,
+        url: item.kind === "upload" ? mediaUrl(item.locator) : item.locator,
+        kind: item.kind,
+        contentType: item.contentType,
+        size: item.size,
+        tags: tagsByItem.get(item.id) ?? [],
+        prompt: item.prompt,
+        model: item.model,
+        createdAt: item.createdAt.toISOString(),
+    };
+}
+
+async function toPageResponse(
+    db: ReturnType<typeof getDb>,
+    page: CatalogPage,
+): Promise<{ items: MediaItemResponse[]; nextCursor: string | null }> {
+    const tagsByItem = await tagsForItems(
+        db,
+        page.items.map((item) => item.id),
+    );
+    return {
+        items: page.items.map((item) => toItemResponse(item, tagsByItem)),
+        nextCursor: page.nextCursor,
+    };
+}
+
 const UploadResponseSchema = z.object({
     id: z.string().describe("16-char hex content hash"),
     url: z.string().describe("Public retrieval URL"),
     contentType: z.string(),
     size: z.number().int().describe("File size in bytes"),
     duplicate: z.boolean().describe("true if file already existed"),
+    tags: z
+        .array(z.string())
+        .optional()
+        .describe("Tags stored for this upload, present only when tagged"),
 });
 
 const ErrorSchema = z.object({
@@ -78,6 +220,26 @@ const MetadataResponseSchema = z.object({
         .string()
         .optional()
         .describe("ISO-8601 upload timestamp, when recorded"),
+});
+
+const MediaItemResponseSchema = z.object({
+    id: z.string().describe("Catalog item id"),
+    url: z.string().describe("Public URL, or generation locator"),
+    kind: z.enum(["upload", "generation"]),
+    contentType: z.string(),
+    size: z.number().int().nullable().describe("File size in bytes"),
+    tags: z.array(z.string()),
+    prompt: z.string().nullable(),
+    model: z.string().nullable(),
+    createdAt: z.string().describe("ISO-8601 timestamp"),
+});
+
+const MediaPageResponseSchema = z.object({
+    items: z.array(MediaItemResponseSchema),
+    nextCursor: z
+        .string()
+        .nullable()
+        .describe("Opaque cursor for the next page, null when exhausted"),
 });
 
 const api = new Hono<{ Bindings: Env }>();
@@ -143,6 +305,13 @@ api.post(
         let fileName: string | undefined;
 
         const requestContentType = c.req.header("content-type") || "";
+        const queryUrl = new URL(c.req.url);
+        const rawTags = collectTags(
+            (key) => queryUrl.searchParams.getAll(key),
+            (key) => queryUrl.searchParams.get(key),
+        );
+        let rawPrompt = queryUrl.searchParams.get("prompt");
+        let rawModel = queryUrl.searchParams.get("model");
 
         try {
             if (requestContentType.includes("multipart/form-data")) {
@@ -165,11 +334,41 @@ api.post(
                 fileBuffer = await file.arrayBuffer();
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
+
+                rawTags.push(
+                    ...collectTags(
+                        (key) =>
+                            formData
+                                .getAll(key)
+                                .filter(
+                                    (value): value is string =>
+                                        typeof value === "string",
+                                ),
+                        (key) => {
+                            const value = formData.get(key);
+                            return typeof value === "string" ? value : null;
+                        },
+                    ),
+                );
+                rawPrompt =
+                    rawPrompt ??
+                    (typeof formData.get("prompt") === "string"
+                        ? (formData.get("prompt") as string)
+                        : null);
+                rawModel =
+                    rawModel ??
+                    (typeof formData.get("model") === "string"
+                        ? (formData.get("model") as string)
+                        : null);
             } else if (requestContentType.includes("application/json")) {
                 const body = await c.req.json<{
                     data: string;
                     contentType?: string;
                     name?: string;
+                    tag?: string | string[];
+                    tags?: string;
+                    prompt?: string;
+                    model?: string;
                 }>();
 
                 if (!body.data) {
@@ -198,6 +397,22 @@ api.post(
 
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
+
+                rawTags.push(
+                    ...collectTags(
+                        (key) => {
+                            if (key !== "tag") return [];
+                            if (Array.isArray(body.tag)) return body.tag;
+                            return body.tag ? [body.tag] : [];
+                        },
+                        (key) => {
+                            if (key === "tags") return body.tags ?? null;
+                            return null;
+                        },
+                    ),
+                );
+                rawPrompt = rawPrompt ?? body.prompt ?? null;
+                rawModel = rawModel ?? body.model ?? null;
             } else {
                 fileBuffer = await c.req.arrayBuffer();
 
@@ -209,6 +424,23 @@ api.post(
                 }
 
                 contentType = requestContentType || "application/octet-stream";
+            }
+
+            let metadata: UploadMetadata;
+            try {
+                metadata = validateMetadata(rawTags, rawPrompt, rawModel);
+            } catch (error) {
+                if (error instanceof MetadataValidationError) {
+                    return c.json({ error: error.message }, 400);
+                }
+                throw error;
+            }
+
+            if (authResult.userId === null && hasMetadata(metadata)) {
+                return c.json(
+                    { error: "cataloging requires a user-owned API key" },
+                    400,
+                );
             }
 
             const hash = await generateHash(fileBuffer, fileName);
@@ -229,6 +461,29 @@ api.post(
                 },
             });
 
+            // Catalog write is awaited inline (not waitUntil): a D1 failure
+            // must surface as a 500, not be silently swallowed. Every upload
+            // by a user-owned key is cataloged (personal media library);
+            // keys with no user never catalog — metadata on them was
+            // rejected above, and without one there's no owner to attribute
+            // a row to.
+            let storedTags: string[] | undefined;
+            if (authResult.userId !== null) {
+                const db = getDb(c.env.DB);
+                await upsertUploadCatalogItem(db, {
+                    ownerUserId: authResult.userId,
+                    appKeyId: authResult.byopClientKeyId,
+                    locator: hash,
+                    contentHash: hash,
+                    contentType,
+                    size: fileBuffer.byteLength,
+                    model: metadata.model,
+                    prompt: metadata.prompt,
+                    tags: metadata.tags,
+                });
+                storedTags = metadata.tags;
+            }
+
             console.log(
                 JSON.stringify({
                     event: "upload",
@@ -247,11 +502,141 @@ api.post(
                 contentType,
                 size: fileBuffer.byteLength,
                 duplicate: !!existing,
+                ...(storedTags && storedTags.length > 0
+                    ? { tags: storedTags }
+                    : {}),
             });
         } catch (error) {
             console.error("Upload error:", error);
             return c.json({ error: "Upload failed" }, 500);
         }
+    },
+);
+
+api.get(
+    "/me/media",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "List your cataloged media",
+        description:
+            "List media items owned by the authenticated user, newest first. Optionally filter by tag.",
+        responses: {
+            200: {
+                description: "Page of media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(MediaPageResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid cursor or limit",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            403: {
+                description: "API key is not attached to a user account",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) {
+            return c.json(
+                {
+                    error: "API key required. Pass via Authorization: Bearer <key> or ?key=<key>",
+                },
+                401,
+            );
+        }
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+        if (authResult.userId === null) {
+            return c.json(
+                { error: "This API key is not attached to a user account" },
+                403,
+            );
+        }
+
+        const url = new URL(c.req.url);
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const cursorParam = url.searchParams.get("cursor");
+        let cursor: { createdAt: Date; id: string } | undefined;
+        if (cursorParam) {
+            try {
+                cursor = decodeCursor(cursorParam);
+            } catch {
+                return c.json({ error: "Invalid cursor" }, 400);
+            }
+        }
+
+        const db = getDb(c.env.DB);
+        const page = await listUserMedia(db, {
+            ownerUserId: authResult.userId,
+            tag: url.searchParams.get("tag") ?? undefined,
+            limit,
+            cursor,
+        });
+
+        return c.json(await toPageResponse(db, page));
+    },
+);
+
+api.get(
+    "/tags/:tag",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "Browse media by tag",
+        description:
+            "Public gallery listing for a tag, newest first. No authentication required.",
+        security: [],
+        responses: {
+            200: {
+                description: "Page of media items",
+                content: {
+                    "application/json": {
+                        schema: resolver(MediaPageResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid cursor or limit",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const tag = c.req.param("tag");
+        const url = new URL(c.req.url);
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const cursorParam = url.searchParams.get("cursor");
+        let cursor: { createdAt: Date; id: string } | undefined;
+        if (cursorParam) {
+            try {
+                cursor = decodeCursor(cursorParam);
+            } catch {
+                return c.json({ error: "Invalid cursor" }, 400);
+            }
+        }
+
+        const db = getDb(c.env.DB);
+        const page = await listByTag(db, { tag, limit, cursor });
+
+        return c.json(await toPageResponse(db, page));
     },
 );
 
@@ -462,8 +847,11 @@ app.get("/", (c) => {
         service: DOMAIN,
         version: "1.0.0",
         endpoints: {
-            upload: "POST /upload (requires API key)",
+            upload: "POST /upload (requires API key; optional tags/prompt/model)",
             retrieve: "GET /:hash",
+            metadata: "GET /:hash/metadata",
+            myMedia: "GET /me/media (requires user-owned API key)",
+            tagGallery: "GET /tags/:tag (public)",
             docs: "GET /openapi.json",
         },
         limits: {

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -92,20 +92,6 @@ function collectTags(getAll: (key: string) => string[]): string[] {
     return splitTags(getAll("tags"));
 }
 
-function unsupportedParameterError(parameter: string): { error: string } {
-    return { error: `Unsupported parameter: "${parameter}".` };
-}
-
-function findUnsupportedParameter(
-    parameters: Iterable<string>,
-    allowed: Set<string>,
-): string | null {
-    for (const parameter of new Set(parameters)) {
-        if (!allowed.has(parameter)) return parameter;
-    }
-    return null;
-}
-
 interface UploadMetadata {
     tags: string[];
     prompt: string | null;
@@ -256,25 +242,6 @@ const MediaPageResponseSchema = z.object({
 });
 
 const api = new Hono<{ Bindings: Env }>();
-const UploadQueryParameters = new Set(["key", "tags", "prompt", "model"]);
-const UploadFormFields = new Set([
-    "file",
-    "tags",
-    "prompt",
-    "model",
-    // Accepted only to ignore spoofed ownership metadata; attribution uses the verified key.
-    "owner",
-    "app",
-    "byopClientKeyId",
-]);
-const UploadJsonFields = new Set([
-    "data",
-    "contentType",
-    "name",
-    "tags",
-    "prompt",
-    "model",
-]);
 
 api.post(
     "/upload",
@@ -338,16 +305,6 @@ api.post(
 
         const requestContentType = c.req.header("content-type") || "";
         const queryUrl = new URL(c.req.url);
-        const unsupportedQueryParameter = findUnsupportedParameter(
-            queryUrl.searchParams.keys(),
-            UploadQueryParameters,
-        );
-        if (unsupportedQueryParameter) {
-            return c.json(
-                unsupportedParameterError(unsupportedQueryParameter),
-                400,
-            );
-        }
         const rawTags = collectTags((key) => queryUrl.searchParams.getAll(key));
         let rawPrompt = queryUrl.searchParams.get("prompt");
         let rawModel = queryUrl.searchParams.get("model");
@@ -374,16 +331,6 @@ api.post(
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
 
-                const unsupportedFormField = findUnsupportedParameter(
-                    formData.keys(),
-                    UploadFormFields,
-                );
-                if (unsupportedFormField) {
-                    return c.json(
-                        unsupportedParameterError(unsupportedFormField),
-                        400,
-                    );
-                }
                 rawTags.push(
                     ...collectTags((key) =>
                         formData
@@ -414,16 +361,6 @@ api.post(
                     model?: string;
                 }>();
 
-                const unsupportedJsonField = findUnsupportedParameter(
-                    Object.keys(body),
-                    UploadJsonFields,
-                );
-                if (unsupportedJsonField) {
-                    return c.json(
-                        unsupportedParameterError(unsupportedJsonField),
-                        400,
-                    );
-                }
                 if (!body.data) {
                     return c.json(
                         { error: "Missing 'data' field in JSON body" },

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -8,11 +8,10 @@ import {
     clampLimit,
     decodeCursor,
     getDb,
-    InvalidTagError,
     listByTag,
     listUserMedia,
     normalizeTags,
-    TooManyTagsError,
+    TagError,
     tagsForItems,
     upsertUploadCatalogItem,
 } from "./catalog.ts";
@@ -42,7 +41,6 @@ interface AuthResult {
     type: string;
     name: string | null;
     userId: string | null;
-    keyId: string;
     byopClientKeyId: string | null;
 }
 
@@ -109,15 +107,8 @@ function validateMetadata(
     try {
         tags = normalizeTags(rawTags);
     } catch (error) {
-        if (error instanceof InvalidTagError) {
-            throw new MetadataValidationError(
-                `Invalid tag: "${error.tag}". Tags must match ${TAG_PATTERN_DESCRIPTION}.`,
-            );
-        }
-        if (error instanceof TooManyTagsError) {
-            throw new MetadataValidationError(
-                `Too many tags: ${error.count} (max 8).`,
-            );
+        if (error instanceof TagError) {
+            throw new MetadataValidationError(error.message);
         }
         throw error;
     }
@@ -138,9 +129,6 @@ function validateMetadata(
 
     return { tags, prompt, model };
 }
-
-const TAG_PATTERN_DESCRIPTION =
-    "lowercase letters, digits, and _.:+- (not leading), max 128 chars";
 
 function hasMetadata(metadata: UploadMetadata): boolean {
     return (
@@ -452,7 +440,6 @@ api.post(
                     ownerUserId: authResult.userId,
                     appKeyId: authResult.byopClientKeyId,
                     locator: hash,
-                    contentHash: hash,
                     contentType,
                     size: fileBuffer.byteLength,
                     model: metadata.model,
@@ -497,7 +484,7 @@ api.get(
         tags: ["media.pollinations.ai"],
         summary: "List your cataloged media",
         description:
-            "List media items owned by the authenticated user, newest first. Optionally filter by tag.",
+            "List media items owned by the authenticated user, newest first. Optionally filter by tag. Upload-backed items reference storage that expires 30 days after their last upload — an expired item keeps its catalog entry, but its url 404s until the same content is re-uploaded.",
         responses: {
             200: {
                 description: "Page of media items",
@@ -578,7 +565,7 @@ api.get(
         tags: ["media.pollinations.ai"],
         summary: "Browse media by tag",
         description:
-            "Public gallery listing for a tag, newest first. No authentication required.",
+            "Public gallery listing for a tag, ordered by when each item was tagged, newest first. No authentication required. Upload-backed items reference storage that expires 30 days after their last upload — an expired item keeps its catalog entry, but its url 404s until the same content is re-uploaded.",
         security: [],
         responses: {
             200: {

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -92,8 +92,18 @@ function collectTags(getAll: (key: string) => string[]): string[] {
     return splitTags(getAll("tags"));
 }
 
-function tagAliasError(): { error: string } {
-    return { error: 'Use "tags" instead of "tag".' };
+function unsupportedParameterError(parameter: string): { error: string } {
+    return { error: `Unsupported parameter: "${parameter}".` };
+}
+
+function findUnsupportedParameter(
+    parameters: Iterable<string>,
+    allowed: Set<string>,
+): string | null {
+    for (const parameter of new Set(parameters)) {
+        if (!allowed.has(parameter)) return parameter;
+    }
+    return null;
 }
 
 interface UploadMetadata {
@@ -246,6 +256,25 @@ const MediaPageResponseSchema = z.object({
 });
 
 const api = new Hono<{ Bindings: Env }>();
+const UploadQueryParameters = new Set(["key", "tags", "prompt", "model"]);
+const UploadFormFields = new Set([
+    "file",
+    "tags",
+    "prompt",
+    "model",
+    // Accepted only to ignore spoofed ownership metadata; attribution uses the verified key.
+    "owner",
+    "app",
+    "byopClientKeyId",
+]);
+const UploadJsonFields = new Set([
+    "data",
+    "contentType",
+    "name",
+    "tags",
+    "prompt",
+    "model",
+]);
 
 api.post(
     "/upload",
@@ -309,8 +338,15 @@ api.post(
 
         const requestContentType = c.req.header("content-type") || "";
         const queryUrl = new URL(c.req.url);
-        if (queryUrl.searchParams.has("tag")) {
-            return c.json(tagAliasError(), 400);
+        const unsupportedQueryParameter = findUnsupportedParameter(
+            queryUrl.searchParams.keys(),
+            UploadQueryParameters,
+        );
+        if (unsupportedQueryParameter) {
+            return c.json(
+                unsupportedParameterError(unsupportedQueryParameter),
+                400,
+            );
         }
         const rawTags = collectTags((key) => queryUrl.searchParams.getAll(key));
         let rawPrompt = queryUrl.searchParams.get("prompt");
@@ -338,8 +374,15 @@ api.post(
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
 
-                if (formData.has("tag")) {
-                    return c.json(tagAliasError(), 400);
+                const unsupportedFormField = findUnsupportedParameter(
+                    formData.keys(),
+                    UploadFormFields,
+                );
+                if (unsupportedFormField) {
+                    return c.json(
+                        unsupportedParameterError(unsupportedFormField),
+                        400,
+                    );
                 }
                 rawTags.push(
                     ...collectTags((key) =>
@@ -371,8 +414,15 @@ api.post(
                     model?: string;
                 }>();
 
-                if ("tag" in body) {
-                    return c.json(tagAliasError(), 400);
+                const unsupportedJsonField = findUnsupportedParameter(
+                    Object.keys(body),
+                    UploadJsonFields,
+                );
+                if (unsupportedJsonField) {
+                    return c.json(
+                        unsupportedParameterError(unsupportedJsonField),
+                        400,
+                    );
                 }
                 if (!body.data) {
                     return c.json(

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -78,19 +78,22 @@ function mediaUrl(hash: string): string {
 const MAX_PROMPT_LENGTH = 2000;
 const MAX_MODEL_LENGTH = 128;
 
-// Splits a comma-separated `tags` value and merges it with repeated `tag`
-// params. Accepts the same shape whether it came from a query string,
-// multipart form field, or JSON body field.
-function collectTags(
-    getAll: (key: string) => string[],
-    get: (key: string) => string | null | undefined,
-): string[] {
-    const tags = [...getAll("tag")];
-    const tagsParam = get("tags");
-    if (tagsParam) {
-        tags.push(...tagsParam.split(","));
+// Splits comma-separated `tags` values. Accepts the same field name whether it
+// came from a query string, multipart form field, or JSON body field.
+function splitTags(values: string[]): string[] {
+    const tags: string[] = [];
+    for (const value of values) {
+        tags.push(...value.split(","));
     }
     return tags;
+}
+
+function collectTags(getAll: (key: string) => string[]): string[] {
+    return splitTags(getAll("tags"));
+}
+
+function tagAliasError(): { error: string } {
+    return { error: 'Use "tags" instead of "tag".' };
 }
 
 interface UploadMetadata {
@@ -306,10 +309,10 @@ api.post(
 
         const requestContentType = c.req.header("content-type") || "";
         const queryUrl = new URL(c.req.url);
-        const rawTags = collectTags(
-            (key) => queryUrl.searchParams.getAll(key),
-            (key) => queryUrl.searchParams.get(key),
-        );
+        if (queryUrl.searchParams.has("tag")) {
+            return c.json(tagAliasError(), 400);
+        }
+        const rawTags = collectTags((key) => queryUrl.searchParams.getAll(key));
         let rawPrompt = queryUrl.searchParams.get("prompt");
         let rawModel = queryUrl.searchParams.get("model");
 
@@ -335,19 +338,17 @@ api.post(
                 contentType = file.type || detectContentType(file.name);
                 fileName = file.name;
 
+                if (formData.has("tag")) {
+                    return c.json(tagAliasError(), 400);
+                }
                 rawTags.push(
-                    ...collectTags(
-                        (key) =>
-                            formData
-                                .getAll(key)
-                                .filter(
-                                    (value): value is string =>
-                                        typeof value === "string",
-                                ),
-                        (key) => {
-                            const value = formData.get(key);
-                            return typeof value === "string" ? value : null;
-                        },
+                    ...collectTags((key) =>
+                        formData
+                            .getAll(key)
+                            .filter(
+                                (value): value is string =>
+                                    typeof value === "string",
+                            ),
                     ),
                 );
                 rawPrompt =
@@ -365,12 +366,14 @@ api.post(
                     data: string;
                     contentType?: string;
                     name?: string;
-                    tag?: string | string[];
                     tags?: string;
                     prompt?: string;
                     model?: string;
                 }>();
 
+                if ("tag" in body) {
+                    return c.json(tagAliasError(), 400);
+                }
                 if (!body.data) {
                     return c.json(
                         { error: "Missing 'data' field in JSON body" },
@@ -398,19 +401,7 @@ api.post(
                 contentType = body.contentType || "application/octet-stream";
                 fileName = body.name;
 
-                rawTags.push(
-                    ...collectTags(
-                        (key) => {
-                            if (key !== "tag") return [];
-                            if (Array.isArray(body.tag)) return body.tag;
-                            return body.tag ? [body.tag] : [];
-                        },
-                        (key) => {
-                            if (key === "tags") return body.tags ?? null;
-                            return null;
-                        },
-                    ),
-                );
+                if (body.tags) rawTags.push(...splitTags([body.tags]));
                 rawPrompt = rawPrompt ?? body.prompt ?? null;
                 rawModel = rawModel ?? body.model ?? null;
             } else {

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -486,15 +486,15 @@ describe("media.pollinations.ai", () => {
         );
     });
 
-    it("rejects the singular tag alias", async () => {
+    it("rejects unsupported upload parameters", async () => {
         const res = await uploadViaForm("pk_alice", {
-            fileName: "singular-tag.png",
+            fileName: "unsupported-param.png",
             bytes: variant(30),
             extraFields: { tag: "legacy" },
         });
         expect(res.status).toBe(400);
         expect((res.body as { error: string }).error).toMatch(
-            /Use "tags" instead of "tag"/,
+            /Unsupported parameter: "tag"/,
         );
     });
 

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -486,16 +486,21 @@ describe("media.pollinations.ai", () => {
         );
     });
 
-    it("rejects unsupported upload parameters", async () => {
+    it("does not treat singular tag as catalog metadata", async () => {
         const res = await uploadViaForm("pk_alice", {
-            fileName: "unsupported-param.png",
+            fileName: "singular-tag-ignored.png",
             bytes: variant(30),
             extraFields: { tag: "legacy" },
         });
-        expect(res.status).toBe(400);
-        expect((res.body as { error: string }).error).toMatch(
-            /Unsupported parameter: "tag"/,
+        expect(res.status).toBe(200);
+        const upload = res.body as UploadResponse;
+        expect(upload.tags).toBeUndefined();
+
+        const galleryRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/legacy",
         );
+        const gallery = (await galleryRes.json()) as MediaPageResponse;
+        expect(gallery.items.map((i) => i.url)).not.toContain(upload.url);
     });
 
     it("rejects more than 8 tags with 400", async () => {

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -174,8 +174,8 @@ async function uploadViaForm(
         "file",
         pngFile(options.fileName ?? "test.png", options.bytes ?? TINY_PNG),
     );
-    for (const tag of options.tags ?? []) {
-        form.append("tag", tag);
+    if (options.tags && options.tags.length > 0) {
+        form.append("tags", options.tags.join(","));
     }
     if (options.prompt) form.append("prompt", options.prompt);
     if (options.model) form.append("model", options.model);
@@ -483,6 +483,18 @@ describe("media.pollinations.ai", () => {
         expect(leadingDash.status).toBe(400);
         expect((leadingDash.body as { error: string }).error).toMatch(
             /-leading/,
+        );
+    });
+
+    it("rejects the singular tag alias", async () => {
+        const res = await uploadViaForm("pk_alice", {
+            fileName: "singular-tag.png",
+            bytes: variant(30),
+            extraFields: { tag: "legacy" },
+        });
+        expect(res.status).toBe(400);
+        expect((res.body as { error: string }).error).toMatch(
+            /Use "tags" instead of "tag"/,
         );
     });
 

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -6,7 +6,7 @@ import {
     waitOnExecutionContext,
 } from "cloudflare:test";
 import { user as userTable } from "@shared/db/better-auth.ts";
-import { mediaItem } from "@shared/db/media-catalog.ts";
+import { mediaItem, mediaTag } from "@shared/db/media-catalog.ts";
 import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -59,7 +59,6 @@ const KEY_IDENTITIES: Record<
         type?: string;
         name?: string | null;
         userId?: string | null;
-        keyId?: string;
         byopClientKeyId?: string | null;
     }
 > = {
@@ -68,7 +67,6 @@ const KEY_IDENTITIES: Record<
         type: "publishable",
         name: "alice-key",
         userId: "user_alice",
-        keyId: "key_alice",
         byopClientKeyId: "pk_app_1",
     },
     pk_bob: {
@@ -76,7 +74,6 @@ const KEY_IDENTITIES: Record<
         type: "publishable",
         name: "bob-key",
         userId: "user_bob",
-        keyId: "key_bob",
         byopClientKeyId: null,
     },
     pk_nouser: {
@@ -84,7 +81,6 @@ const KEY_IDENTITIES: Record<
         type: "publishable",
         name: "service-key",
         userId: null,
-        keyId: "key_svc",
         byopClientKeyId: null,
     },
 };
@@ -564,6 +560,80 @@ describe("media.pollinations.ai", () => {
         expect(matches[0].tags.sort()).toEqual(["first-tag", "second-tag"]);
     });
 
+    it("re-uploading does not bump feed position; late tagging publishes at tag time", async () => {
+        const tag = "bump-tag";
+        const first = await uploadViaForm("pk_alice", {
+            fileName: "bump-a.png",
+            bytes: variant(60),
+            tags: [tag],
+        });
+        const second = await uploadViaForm("pk_alice", {
+            fileName: "bump-b.png",
+            bytes: variant(61),
+            tags: [tag],
+        });
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        const a = first.body as UploadResponse;
+        const b = second.body as UploadResponse;
+
+        // Backdate deterministically: a older than b, in both tables.
+        const db = drizzle(env.DB);
+        const backdate = async (locator: string, epochSeconds: number) => {
+            const when = new Date(epochSeconds * 1000);
+            const [item] = await db
+                .select({ id: mediaItem.id })
+                .from(mediaItem)
+                .where(eq(mediaItem.locator, locator));
+            await db
+                .update(mediaItem)
+                .set({ createdAt: when })
+                .where(eq(mediaItem.id, item.id));
+            await db
+                .update(mediaTag)
+                .set({ createdAt: when })
+                .where(eq(mediaTag.itemId, item.id));
+        };
+        await backdate(a.id, 1000);
+        await backdate(b.id, 2000);
+
+        // Re-upload a (same bytes, same tag): neither its createdAt nor its
+        // gallery position may change.
+        const again = await uploadViaForm("pk_alice", {
+            fileName: "bump-a.png",
+            bytes: variant(60),
+            tags: [tag],
+        });
+        expect(again.status).toBe(200);
+
+        const galleryRes = await SELF.fetch(
+            `https://media.pollinations.ai/tags/${tag}`,
+        );
+        const gallery = (await galleryRes.json()) as MediaPageResponse;
+        const urls = gallery.items.map((i) => i.url);
+        expect(urls).toEqual([b.url, a.url]);
+        const aItem = gallery.items.find((i) => i.url === a.url);
+        expect(new Date(aItem?.createdAt as string).getTime()).toBe(1000_000);
+
+        // Late publish: tagging a into a new tag now makes it that gallery's
+        // freshest entry while its createdAt still reflects first upload.
+        const late = await uploadViaForm("pk_alice", {
+            fileName: "bump-a.png",
+            bytes: variant(60),
+            tags: ["bump-late"],
+        });
+        expect(late.status).toBe(200);
+        const lateRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/bump-late",
+        );
+        const lateGallery = (await lateRes.json()) as MediaPageResponse;
+        expect(lateGallery.items).toHaveLength(1);
+        expect(lateGallery.items[0].url).toBe(a.url);
+        expect(new Date(lateGallery.items[0].createdAt).getTime()).toBe(
+            1000_000,
+        );
+    });
+
     it("paginates a tag gallery newest-first with a keyset cursor", async () => {
         const tag = "pagination-tag";
         const uploads: UploadResponse[] = [];
@@ -580,13 +650,23 @@ describe("media.pollinations.ai", () => {
         // Uploads can land within the same wall-clock second (createdAt is
         // second-resolution), which would make "newest first" ambiguous.
         // Force distinct, strictly increasing timestamps directly in D1 so
-        // the ordering assertions below are deterministic.
+        // the ordering assertions below are deterministic. The gallery sorts
+        // by tag time (media_tag.created_at), so backdate both tables.
         const db = drizzle(env.DB);
         for (let i = 0; i < uploads.length; i++) {
+            const when = new Date((1000 + i) * 1000);
+            const [item] = await db
+                .select({ id: mediaItem.id })
+                .from(mediaItem)
+                .where(eq(mediaItem.locator, uploads[i].id));
             await db
                 .update(mediaItem)
-                .set({ createdAt: new Date((1000 + i) * 1000) })
-                .where(eq(mediaItem.locator, uploads[i].id));
+                .set({ createdAt: when })
+                .where(eq(mediaItem.id, item.id));
+            await db
+                .update(mediaTag)
+                .set({ createdAt: when })
+                .where(eq(mediaTag.itemId, item.id));
         }
 
         const page1Res = await SELF.fetch(

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -1,11 +1,16 @@
 import {
     createExecutionContext,
+    env,
     fetchMock,
     SELF,
     waitOnExecutionContext,
 } from "cloudflare:test";
+import { user as userTable } from "@shared/db/better-auth.ts";
+import { mediaItem } from "@shared/db/media-catalog.ts";
 import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import app from "../src/index";
 
 // 1x1 red PNG (67 bytes)
@@ -24,14 +29,71 @@ interface UploadResponse {
     contentType: string;
     size: number;
     duplicate: boolean;
+    tags?: string[];
 }
 
-const VALID_KEY = "pk_test_key_123";
+interface MediaItemResponse {
+    id: string;
+    url: string;
+    kind: string;
+    contentType: string;
+    size: number | null;
+    tags: string[];
+    prompt: string | null;
+    model: string | null;
+    createdAt: string;
+}
+
+interface MediaPageResponse {
+    items: MediaItemResponse[];
+    nextCursor: string | null;
+}
+
+// Kept for the pre-existing tests that don't care about identity.
+const VALID_KEY = "pk_alice";
+
+const KEY_IDENTITIES: Record<
+    string,
+    {
+        valid: boolean;
+        type?: string;
+        name?: string | null;
+        userId?: string | null;
+        keyId?: string;
+        byopClientKeyId?: string | null;
+    }
+> = {
+    pk_alice: {
+        valid: true,
+        type: "publishable",
+        name: "alice-key",
+        userId: "user_alice",
+        keyId: "key_alice",
+        byopClientKeyId: "pk_app_1",
+    },
+    pk_bob: {
+        valid: true,
+        type: "publishable",
+        name: "bob-key",
+        userId: "user_bob",
+        keyId: "key_bob",
+        byopClientKeyId: null,
+    },
+    pk_nouser: {
+        valid: true,
+        type: "publishable",
+        name: "service-key",
+        userId: null,
+        keyId: "key_svc",
+        byopClientKeyId: null,
+    },
+};
 
 function createMediaEnv(bucket = createTestR2Bucket()) {
     return {
         MEDIA_BUCKET: bucket,
         MAX_FILE_SIZE: "52428800",
+        DB: env.DB,
     };
 }
 
@@ -41,19 +103,100 @@ function mockAuth() {
     fetchMock
         .get("https://gen.pollinations.ai")
         .intercept({ path: "/account/key" })
-        .reply(
-            200,
-            JSON.stringify({
-                valid: true,
-                type: "publishable",
-                name: "test-user",
-            }),
-            { headers: { "content-type": "application/json" } },
-        )
+        .reply(({ headers }) => {
+            const headerBag = headers as Record<string, string>;
+            const authHeader =
+                headerBag.authorization ?? headerBag.Authorization ?? "";
+            const key = authHeader.replace(/^Bearer /, "");
+            const identity = KEY_IDENTITIES[key];
+            if (!identity) {
+                return {
+                    statusCode: 200,
+                    data: JSON.stringify({ valid: false }),
+                    responseOptions: {
+                        headers: { "content-type": "application/json" },
+                    },
+                };
+            }
+            return {
+                statusCode: 200,
+                data: JSON.stringify(identity),
+                responseOptions: {
+                    headers: { "content-type": "application/json" },
+                },
+            };
+        })
         .persist();
 }
 
+async function seedUsers() {
+    const db = drizzle(env.DB);
+    const now = new Date();
+    for (const id of ["user_alice", "user_bob"]) {
+        await db
+            .insert(userTable)
+            .values({
+                id,
+                name: id,
+                email: `${id}@test.com`,
+                createdAt: now,
+                updatedAt: now,
+            })
+            .onConflictDoNothing({ target: userTable.id });
+    }
+}
+
+function pngFile(name: string, bytes: Uint8Array = TINY_PNG): File {
+    return new File([bytes], name, { type: "image/png" });
+}
+
+// Distinct byte content per upload so hashes (and therefore catalog rows)
+// differ even when reusing the same base PNG.
+function variant(seed: number): Uint8Array {
+    const bytes = new Uint8Array(TINY_PNG);
+    bytes[bytes.length - 1] = seed & 0xff;
+    return bytes;
+}
+
+async function uploadViaForm(
+    key: string,
+    options: {
+        fileName?: string;
+        bytes?: Uint8Array;
+        tags?: string[];
+        prompt?: string;
+        model?: string;
+        extraFields?: Record<string, string>;
+    } = {},
+): Promise<{ status: number; body: UploadResponse | { error: string } }> {
+    const form = new FormData();
+    form.append(
+        "file",
+        pngFile(options.fileName ?? "test.png", options.bytes ?? TINY_PNG),
+    );
+    for (const tag of options.tags ?? []) {
+        form.append("tag", tag);
+    }
+    if (options.prompt) form.append("prompt", options.prompt);
+    if (options.model) form.append("model", options.model);
+    for (const [field, value] of Object.entries(options.extraFields ?? {})) {
+        form.append(field, value);
+    }
+
+    const res = await SELF.fetch("https://media.pollinations.ai/upload", {
+        method: "POST",
+        body: form,
+        headers: { Authorization: `Bearer ${key}` },
+    });
+    const body = (await res.json()) as UploadResponse | { error: string };
+    return { status: res.status, body };
+}
+
 describe("media.pollinations.ai", () => {
+    beforeAll(async () => {
+        await seedUsers();
+    });
+
     beforeEach(() => {
         mockAuth();
     });
@@ -142,7 +285,7 @@ describe("media.pollinations.ai", () => {
 
     it("refreshes uploaded media TTL on aged GET", async () => {
         const bucket = createTestR2Bucket();
-        const env = createMediaEnv(bucket);
+        const mediaEnv = createMediaEnv(bucket);
         const uploadCtx = createExecutionContext();
 
         const uploadRes = await app.fetch(
@@ -154,7 +297,7 @@ describe("media.pollinations.ai", () => {
                     "Content-Type": "image/png",
                 },
             }),
-            env,
+            mediaEnv,
             uploadCtx,
         );
         await waitOnExecutionContext(uploadCtx);
@@ -166,7 +309,7 @@ describe("media.pollinations.ai", () => {
         const getCtx = createExecutionContext();
         const getRes = await app.fetch(
             new Request(`https://media.pollinations.ai/${upload.id}`),
-            env,
+            mediaEnv,
             getCtx,
         );
         const body = new Uint8Array(await getRes.arrayBuffer());
@@ -217,5 +360,238 @@ describe("media.pollinations.ai", () => {
             "https://media.pollinations.ai/0000000000000000",
         );
         expect(res.status).toBe(404);
+    });
+
+    it("tagged upload is visible in public tag gallery and in /me/media, without owner fields", async () => {
+        const { status, body } = await uploadViaForm("pk_alice", {
+            fileName: "gallery-a.png",
+            bytes: variant(1),
+            tags: ["Sunset "],
+        });
+        expect(status).toBe(200);
+        const upload = body as UploadResponse;
+        expect(upload.tags).toEqual(["sunset"]);
+
+        const galleryRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/sunset",
+        );
+        expect(galleryRes.status).toBe(200);
+        const gallery = (await galleryRes.json()) as MediaPageResponse;
+        expect(gallery.items.map((i) => i.url)).toContain(upload.url);
+        for (const item of gallery.items) {
+            expect(item).not.toHaveProperty("ownerUserId");
+            expect(item).not.toHaveProperty("appKeyId");
+        }
+
+        const meRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            {
+                headers: { Authorization: "Bearer pk_alice" },
+            },
+        );
+        expect(meRes.status).toBe(200);
+        const me = (await meRes.json()) as MediaPageResponse;
+        expect(me.items.map((i) => i.url)).toContain(upload.url);
+        for (const item of me.items) {
+            expect(item).not.toHaveProperty("ownerUserId");
+            expect(item).not.toHaveProperty("appKeyId");
+        }
+    });
+
+    it("untagged upload appears in /me/media but not in an unrelated tag gallery", async () => {
+        const { status, body } = await uploadViaForm("pk_alice", {
+            fileName: "untagged.png",
+            bytes: variant(2),
+        });
+        expect(status).toBe(200);
+        const upload = body as UploadResponse;
+        expect(upload.tags).toBeUndefined();
+
+        const meRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            {
+                headers: { Authorization: "Bearer pk_alice" },
+            },
+        );
+        const me = (await meRes.json()) as MediaPageResponse;
+        expect(me.items.map((i) => i.url)).toContain(upload.url);
+
+        const galleryRes = await SELF.fetch(
+            "https://media.pollinations.ai/tags/some-other-tag",
+        );
+        const gallery = (await galleryRes.json()) as MediaPageResponse;
+        expect(gallery.items.map((i) => i.url)).not.toContain(upload.url);
+    });
+
+    it("ignores spoofed identity fields in the upload form", async () => {
+        const alice = await uploadViaForm("pk_alice", {
+            fileName: "spoof-alice.png",
+            bytes: variant(3),
+            tags: ["spoof-test"],
+            extraFields: {
+                owner: "user_bob",
+                app: "pk_app_evil",
+                byopClientKeyId: "pk_app_evil",
+            },
+        });
+        expect(alice.status).toBe(200);
+        const aliceUpload = alice.body as UploadResponse;
+
+        const bob = await uploadViaForm("pk_bob", {
+            fileName: "spoof-bob.png",
+            bytes: variant(4),
+            tags: ["spoof-test"],
+        });
+        expect(bob.status).toBe(200);
+        const bobUpload = bob.body as UploadResponse;
+
+        const aliceMediaRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            { headers: { Authorization: "Bearer pk_alice" } },
+        );
+        const aliceMedia = (await aliceMediaRes.json()) as MediaPageResponse;
+        const aliceUrls = aliceMedia.items.map((i) => i.url);
+        expect(aliceUrls).toContain(aliceUpload.url);
+        expect(aliceUrls).not.toContain(bobUpload.url);
+
+        const bobMediaRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            { headers: { Authorization: "Bearer pk_bob" } },
+        );
+        const bobMedia = (await bobMediaRes.json()) as MediaPageResponse;
+        const bobUrls = bobMedia.items.map((i) => i.url);
+        expect(bobUrls).toContain(bobUpload.url);
+        expect(bobUrls).not.toContain(aliceUpload.url);
+    });
+
+    it("rejects invalid tags with 400", async () => {
+        const upperCase = await uploadViaForm("pk_alice", {
+            fileName: "bad-tag-1.png",
+            bytes: variant(5),
+            tags: ["UPPER CASE!"],
+        });
+        expect(upperCase.status).toBe(400);
+        expect((upperCase.body as { error: string }).error).toMatch(
+            /UPPER CASE!/,
+        );
+
+        const leadingDash = await uploadViaForm("pk_alice", {
+            fileName: "bad-tag-2.png",
+            bytes: variant(6),
+            tags: ["-leading"],
+        });
+        expect(leadingDash.status).toBe(400);
+        expect((leadingDash.body as { error: string }).error).toMatch(
+            /-leading/,
+        );
+    });
+
+    it("rejects more than 8 tags with 400", async () => {
+        const tags = Array.from({ length: 9 }, (_, i) => `tag${i}`);
+        const res = await uploadViaForm("pk_alice", {
+            fileName: "too-many-tags.png",
+            bytes: variant(7),
+            tags,
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it("service key without a user is rejected when metadata is supplied, but plain uploads still work", async () => {
+        const withTag = await uploadViaForm("pk_nouser", {
+            fileName: "nouser-tagged.png",
+            bytes: variant(8),
+            tags: ["should-fail"],
+        });
+        expect(withTag.status).toBe(400);
+        expect((withTag.body as { error: string }).error).toMatch(
+            /cataloging requires a user-owned API key/,
+        );
+
+        const plain = await uploadViaForm("pk_nouser", {
+            fileName: "nouser-plain.png",
+            bytes: variant(9),
+        });
+        expect(plain.status).toBe(200);
+        const upload = plain.body as UploadResponse;
+        expect(upload.tags).toBeUndefined();
+    });
+
+    it("re-uploading the same file with an additional tag merges tags into one item", async () => {
+        const first = await uploadViaForm("pk_alice", {
+            fileName: "merge.png",
+            bytes: variant(10),
+            tags: ["first-tag"],
+        });
+        expect(first.status).toBe(200);
+        const firstUpload = first.body as UploadResponse;
+
+        const second = await uploadViaForm("pk_alice", {
+            fileName: "merge.png",
+            bytes: variant(10),
+            tags: ["second-tag"],
+        });
+        expect(second.status).toBe(200);
+        const secondUpload = second.body as UploadResponse;
+        expect(secondUpload.id).toBe(firstUpload.id);
+        expect(secondUpload.duplicate).toBe(true);
+
+        const meRes = await SELF.fetch(
+            "https://media.pollinations.ai/me/media",
+            {
+                headers: { Authorization: "Bearer pk_alice" },
+            },
+        );
+        const me = (await meRes.json()) as MediaPageResponse;
+        const matches = me.items.filter((i) => i.url === firstUpload.url);
+        expect(matches).toHaveLength(1);
+        expect(matches[0].tags.sort()).toEqual(["first-tag", "second-tag"]);
+    });
+
+    it("paginates a tag gallery newest-first with a keyset cursor", async () => {
+        const tag = "pagination-tag";
+        const uploads: UploadResponse[] = [];
+        for (let i = 0; i < 3; i++) {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: `page-${i}.png`,
+                bytes: variant(20 + i),
+                tags: [tag],
+            });
+            expect(status).toBe(200);
+            uploads.push(body as UploadResponse);
+        }
+
+        // Uploads can land within the same wall-clock second (createdAt is
+        // second-resolution), which would make "newest first" ambiguous.
+        // Force distinct, strictly increasing timestamps directly in D1 so
+        // the ordering assertions below are deterministic.
+        const db = drizzle(env.DB);
+        for (let i = 0; i < uploads.length; i++) {
+            await db
+                .update(mediaItem)
+                .set({ createdAt: new Date((1000 + i) * 1000) })
+                .where(eq(mediaItem.locator, uploads[i].id));
+        }
+
+        const page1Res = await SELF.fetch(
+            `https://media.pollinations.ai/tags/${tag}?limit=2`,
+        );
+        expect(page1Res.status).toBe(200);
+        const page1 = (await page1Res.json()) as MediaPageResponse;
+        expect(page1.items).toHaveLength(2);
+        expect(page1.nextCursor).not.toBeNull();
+        // Newest first: the most recently uploaded item leads the page.
+        expect(page1.items[0].url).toBe(uploads[2].url);
+        expect(page1.items[1].url).toBe(uploads[1].url);
+
+        const page2Res = await SELF.fetch(
+            `https://media.pollinations.ai/tags/${tag}?limit=2&cursor=${encodeURIComponent(
+                page1.nextCursor as string,
+            )}`,
+        );
+        expect(page2Res.status).toBe(200);
+        const page2 = (await page2Res.json()) as MediaPageResponse;
+        expect(page2.items).toHaveLength(1);
+        expect(page2.items[0].url).toBe(uploads[0].url);
+        expect(page2.nextCursor).toBeNull();
     });
 });

--- a/media.pollinations.ai/test/setup/apply-migrations.ts
+++ b/media.pollinations.ai/test/setup/apply-migrations.ts
@@ -1,0 +1,6 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+
+// Setup files run outside isolated storage, and may be run multiple times.
+// `applyD1Migrations()` only applies migrations that haven't already been
+// applied, therefore it is safe to call this function here.
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);

--- a/media.pollinations.ai/vitest.config.ts
+++ b/media.pollinations.ai/vitest.config.ts
@@ -1,22 +1,40 @@
+import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import {
+    defineWorkersConfig,
+    readD1Migrations,
+} from "@cloudflare/vitest-pool-workers/config";
 
 const sharedSrc = fileURLToPath(new URL("../shared/", import.meta.url));
 
-export default defineWorkersConfig({
-    resolve: {
-        alias: {
-            "@shared": sharedSrc,
+export default defineWorkersConfig(async () => {
+    const migrationsPath = path.join(
+        __dirname,
+        "../enter.pollinations.ai/drizzle",
+    );
+    const migrations = await readD1Migrations(migrationsPath);
+
+    return {
+        resolve: {
+            alias: {
+                "@shared": sharedSrc,
+            },
         },
-    },
-    test: {
-        poolOptions: {
-            workers: {
-                singleWorker: true,
-                wrangler: {
-                    configPath: "./wrangler.toml",
+        test: {
+            setupFiles: ["./test/setup/apply-migrations.ts"],
+            poolOptions: {
+                workers: {
+                    singleWorker: true,
+                    wrangler: {
+                        configPath: "./wrangler.toml",
+                    },
+                    miniflare: {
+                        bindings: {
+                            TEST_MIGRATIONS: migrations,
+                        },
+                    },
                 },
             },
         },
-    },
+    };
 });

--- a/media.pollinations.ai/wrangler.toml
+++ b/media.pollinations.ai/wrangler.toml
@@ -15,6 +15,12 @@ MAX_FILE_SIZE = "52428800"  # 50MB in bytes
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media-dev"
 
+[[env.development.d1_databases]]
+binding = "DB"
+database_name = "development-pollinations-enter-db"
+database_id = "2b844596-9890-4a2e-9da9-6c65681fa24d"
+migrations_dir = "../enter.pollinations.ai/drizzle"
+
 # Production environment
 [env.production]
 name = "pollinations-media-prod"
@@ -31,12 +37,25 @@ custom_domain = true
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media"
 
+[[env.production.d1_databases]]
+remote = true
+binding = "DB"
+database_name = "production-pollinations-enter-db"
+database_id = "fc771b05-4e24-48bf-980c-d09f21279bd1"
+migrations_dir = "../enter.pollinations.ai/drizzle"
+
 [vars]
 MAX_FILE_SIZE = "52428800"  # 50MB in bytes
 
 [[r2_buckets]]
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "development-pollinations-enter-db"
+database_id = "2b844596-9890-4a2e-9da9-6c65681fa24d"
+migrations_dir = "../enter.pollinations.ai/drizzle"
 
 # Dev server settings
 [dev]

--- a/shared/db/media-catalog.ts
+++ b/shared/db/media-catalog.ts
@@ -1,0 +1,61 @@
+// Media catalog: queryable metadata for stored media (uploads now,
+// generations later). Blobs stay in R2 — these tables only index them.
+// One row per (owner, locator); public discovery is strictly opt-in via tags.
+
+import {
+    index,
+    integer,
+    sqliteTable,
+    text,
+    uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { user } from "./better-auth.ts";
+
+export const mediaItem = sqliteTable(
+    "media_item",
+    {
+        id: text("id").primaryKey(),
+        // What produced the bytes: direct upload today, gen catalog-by-reference later.
+        kind: text("kind", { enum: ["upload", "generation"] }).notNull(),
+        // upload: 16-hex content hash on media.pollinations.ai
+        // generation: canonical gen.pollinations.ai URL (catalog params stripped)
+        locator: text("locator").notNull(),
+        contentHash: text("content_hash"),
+        // Server-attested from the verified API key — never from request params.
+        ownerUserId: text("owner_user_id").references(() => user.id, {
+            onDelete: "cascade",
+        }),
+        appKeyId: text("app_key_id"),
+        contentType: text("content_type").notNull(),
+        size: integer("size"),
+        model: text("model"),
+        prompt: text("prompt"),
+        createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    },
+    (table) => [
+        uniqueIndex("idx_media_item_owner_locator").on(
+            table.ownerUserId,
+            table.locator,
+        ),
+        index("idx_media_item_owner_created").on(
+            table.ownerUserId,
+            table.createdAt,
+        ),
+    ],
+);
+
+export const mediaTag = sqliteTable(
+    "media_tag",
+    {
+        itemId: text("item_id")
+            .notNull()
+            .references(() => mediaItem.id, { onDelete: "cascade" }),
+        tag: text("tag").notNull(),
+        // Denormalized from media_item for newest-first tag listings.
+        createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    },
+    (table) => [
+        uniqueIndex("idx_media_tag_item_tag").on(table.itemId, table.tag),
+        index("idx_media_tag_tag_created").on(table.tag, table.createdAt),
+    ],
+);

--- a/shared/db/media-catalog.ts
+++ b/shared/db/media-catalog.ts
@@ -20,7 +20,6 @@ export const mediaItem = sqliteTable(
         // upload: 16-hex content hash on media.pollinations.ai
         // generation: canonical gen.pollinations.ai URL (catalog params stripped)
         locator: text("locator").notNull(),
-        contentHash: text("content_hash"),
         // Server-attested from the verified API key — never from request params.
         ownerUserId: text("owner_user_id").references(() => user.id, {
             onDelete: "cascade",


### PR DESCRIPTION
- Adds `media_item`/`media_tag` tables to **enter's D1** (`shared/db/media-catalog.ts`, migration `0035`) — same DB gen already binds, so catalog rows join with `user` and PR 2 can wire `?tag=` on gen URLs with a direct insert
- `/account/key` response gains server-attested `userId`/`keyId`/`byopClientKeyId` — media stamps ownership from these, never from request params (spoof-proof, tested)
- `POST /upload`: optional `tag`/`tags`/`prompt`/`model` via query, multipart form, or JSON body; strict validation (lowercase slug tags, max 8, 400 on invalid); every user-owned upload is cataloged, metadata on userless keys → 400
- `GET /me/media?tag=&limit=&cursor=` — personal library (403 for keys without a user); `GET /tags/:tag` — public gallery; newest-first keyset pagination, no owner fields exposed
- Catalog D1 write awaited inline — failure = 500, no silent drops
- Tests: 15 pass (7 pre-existing + 8 new: spoofing, tag validation, tag merge on re-upload, pagination); migrations applied via enter's drizzle dir in vitest-pool-workers

Deploy notes:
- Migration must be applied via enter's `npm run migrate:staging` / `migrate:production` **before** deploying the media worker
- Workers deploy on `production` branch push, not `main`
- `media.pollinations.ai` is not an npm workspace member; its duplicate `drizzle-orm` copy causes tsc nominal-type noise against `shared/db` (runtime + vitest unaffected; CI has no tsc gate) — follow-up candidate: add media to root workspaces

Design context: follows the tag-only public-discovery thesis from #11321 (API redesigned for simplicity). Likes/reactions and gen `?tag=` wiring are follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)