### PR TITLE
feat: generic reactions for the media catalog (likes and beyond)

### DIFF
--- a/enter.pollinations.ai/drizzle/0036_media_reactions.sql
+++ b/enter.pollinations.ai/drizzle/0036_media_reactions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `media_reaction` (
+	`item_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`reaction` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `media_item`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_media_reaction_item_user_reaction` ON `media_reaction` (`item_id`,`user_id`,`reaction`);

--- a/enter.pollinations.ai/drizzle/meta/0036_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,1760 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "42ea8b11-b9aa-4af3-9064-49b4daa618e1",
+  "prevId": "988e38a5-9d8e-4b78-882c-d4cac21b52f2",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator": {
+          "name": "locator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_locator": {
+          "name": "idx_media_item_owner_locator",
+          "columns": [
+            "owner_user_id",
+            "locator"
+          ],
+          "isUnique": true
+        },
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_reaction": {
+      "name": "media_reaction",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_reaction_item_user_reaction": {
+          "name": "idx_media_reaction_item_user_reaction",
+          "columns": [
+            "item_id",
+            "user_id",
+            "reaction"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "media_reaction_item_id_media_item_id_fk": {
+          "name": "media_reaction_item_id_media_item_id_fk",
+          "tableFrom": "media_reaction",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_reaction_user_id_user_id_fk": {
+          "name": "media_reaction_user_id_user_id_fk",
+          "tableFrom": "media_reaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_created": {
+          "name": "idx_media_tag_tag_created",
+          "columns": [
+            "tag",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1783347338031,
       "tag": "0035_media_catalog",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1783352422737,
+      "tag": "0036_media_reactions",
+      "breakpoints": true
     }
   ]
 }

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -3,9 +3,13 @@
 // awaited inline on the upload path (no waitUntil): a D1 failure surfaces as
 // a 500 rather than silently dropping catalog data.
 
-import { mediaItem, mediaTag } from "@shared/db/media-catalog.ts";
+import {
+    mediaItem,
+    mediaReaction,
+    mediaTag,
+} from "@shared/db/media-catalog.ts";
 import type { SQL } from "drizzle-orm";
-import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 
 export type CatalogDb = ReturnType<typeof drizzle>;
@@ -31,6 +35,32 @@ export class TooManyTagsError extends Error {
         super(`Too many tags: ${count} (max ${MAX_TAGS})`);
         this.name = "TooManyTagsError";
     }
+}
+
+// Reaction kinds are an open slug vocabulary ("like", "heart", "bookmark",
+// ...): lowercase letters/digits, then `_-` allowed after the first char,
+// max 32 chars.
+export const REACTION_PATTERN = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export class InvalidReactionError extends Error {
+    constructor(public readonly reaction: string) {
+        super(`Invalid reaction: "${reaction}"`);
+        this.name = "InvalidReactionError";
+    }
+}
+
+/**
+ * Normalize (trim + lowercase) and validate a reaction kind. Throws
+ * InvalidReactionError naming the submitted value on mismatch.
+ */
+export function normalizeReaction(raw: string): string {
+    const reaction = raw.trim().toLowerCase();
+    if (!REACTION_PATTERN.test(reaction)) {
+        // Name the value as submitted (pre-lowercase) so the error is
+        // unambiguous about which input was rejected.
+        throw new InvalidReactionError(raw.trim());
+    }
+    return reaction;
 }
 
 /**
@@ -295,6 +325,154 @@ export async function tagsForItems(
             existing.push(row.tag);
         } else {
             byItem.set(row.itemId, [row.tag]);
+        }
+    }
+    return byItem;
+}
+
+/** Fetch a single catalog item by id, or null if it doesn't exist. */
+export async function getItemById(
+    db: CatalogDb,
+    id: string,
+): Promise<CatalogItem | null> {
+    const [row] = await db
+        .select({
+            id: mediaItem.id,
+            kind: mediaItem.kind,
+            locator: mediaItem.locator,
+            contentType: mediaItem.contentType,
+            size: mediaItem.size,
+            model: mediaItem.model,
+            prompt: mediaItem.prompt,
+            createdAt: mediaItem.createdAt,
+        })
+        .from(mediaItem)
+        .where(eq(mediaItem.id, id))
+        .limit(1);
+    return row ?? null;
+}
+
+/**
+ * React to an item on behalf of a user. Idempotent: repeating the same
+ * reaction kind is a no-op.
+ */
+export async function addReaction(
+    db: CatalogDb,
+    itemId: string,
+    userId: string,
+    reaction: string,
+): Promise<void> {
+    await db
+        .insert(mediaReaction)
+        .values({ itemId, userId, reaction, createdAt: new Date() })
+        .onConflictDoNothing({
+            target: [
+                mediaReaction.itemId,
+                mediaReaction.userId,
+                mediaReaction.reaction,
+            ],
+        });
+}
+
+/**
+ * Remove a user's reaction of one kind from an item. Idempotent: removing
+ * a reaction that isn't there is a no-op.
+ */
+export async function removeReaction(
+    db: CatalogDb,
+    itemId: string,
+    userId: string,
+    reaction: string,
+): Promise<void> {
+    await db
+        .delete(mediaReaction)
+        .where(
+            and(
+                eq(mediaReaction.itemId, itemId),
+                eq(mediaReaction.userId, userId),
+                eq(mediaReaction.reaction, reaction),
+            ),
+        );
+}
+
+/** Count reactions of one kind for a single item. */
+export async function reactionCountForItem(
+    db: CatalogDb,
+    itemId: string,
+    reaction: string,
+): Promise<number> {
+    const [row] = await db
+        .select({ count: count() })
+        .from(mediaReaction)
+        .where(
+            and(
+                eq(mediaReaction.itemId, itemId),
+                eq(mediaReaction.reaction, reaction),
+            ),
+        );
+    return row?.count ?? 0;
+}
+
+/**
+ * Count reactions for a page of item ids in one grouped query, keyed by
+ * item id, then by reaction kind.
+ */
+export async function reactionCountsForItems(
+    db: CatalogDb,
+    itemIds: string[],
+): Promise<Map<string, Record<string, number>>> {
+    const byItem = new Map<string, Record<string, number>>();
+    if (itemIds.length === 0) return byItem;
+
+    const rows = await db
+        .select({
+            itemId: mediaReaction.itemId,
+            reaction: mediaReaction.reaction,
+            count: count(),
+        })
+        .from(mediaReaction)
+        .where(inArray(mediaReaction.itemId, itemIds))
+        .groupBy(mediaReaction.itemId, mediaReaction.reaction);
+
+    for (const row of rows) {
+        const existing = byItem.get(row.itemId);
+        if (existing) {
+            existing[row.reaction] = row.count;
+        } else {
+            byItem.set(row.itemId, { [row.reaction]: row.count });
+        }
+    }
+    return byItem;
+}
+
+/** A user's reaction kinds for a page of item ids, in one query. */
+export async function userReactionsForItems(
+    db: CatalogDb,
+    itemIds: string[],
+    userId: string,
+): Promise<Map<string, string[]>> {
+    const byItem = new Map<string, string[]>();
+    if (itemIds.length === 0) return byItem;
+
+    const rows = await db
+        .select({
+            itemId: mediaReaction.itemId,
+            reaction: mediaReaction.reaction,
+        })
+        .from(mediaReaction)
+        .where(
+            and(
+                inArray(mediaReaction.itemId, itemIds),
+                eq(mediaReaction.userId, userId),
+            ),
+        );
+
+    for (const row of rows) {
+        const existing = byItem.get(row.itemId);
+        if (existing) {
+            existing.push(row.reaction);
+        } else {
+            byItem.set(row.itemId, [row.reaction]);
         }
     }
     return byItem;

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -330,26 +330,35 @@ export async function tagsForItems(
     return byItem;
 }
 
-/** Fetch a single catalog item by id, or null if it doesn't exist. */
-export async function getItemById(
+// A user may hold at most this many distinct reaction kinds on one item —
+// the vocabulary is open, so without a cap one user could grow D1 unbounded
+// by inventing kinds. Mirrors MAX_TAGS.
+export const MAX_REACTION_KINDS_PER_ITEM = 8;
+
+/**
+ * Whether a user may react to an item: it must be their own, or publicly
+ * discoverable (carries at least one tag). Untagged items owned by someone
+ * else are private — callers should answer 404 (not 403) so a leaked item
+ * id isn't confirmed to exist.
+ */
+export async function isItemReactable(
     db: CatalogDb,
-    id: string,
-): Promise<CatalogItem | null> {
+    itemId: string,
+    userId: string,
+): Promise<boolean> {
     const [row] = await db
-        .select({
-            id: mediaItem.id,
-            kind: mediaItem.kind,
-            locator: mediaItem.locator,
-            contentType: mediaItem.contentType,
-            size: mediaItem.size,
-            model: mediaItem.model,
-            prompt: mediaItem.prompt,
-            createdAt: mediaItem.createdAt,
-        })
+        .select({ ownerUserId: mediaItem.ownerUserId })
         .from(mediaItem)
-        .where(eq(mediaItem.id, id))
+        .where(eq(mediaItem.id, itemId))
         .limit(1);
-    return row ?? null;
+    if (!row) return false;
+    if (row.ownerUserId === userId) return true;
+    const [tagged] = await db
+        .select({ itemId: mediaTag.itemId })
+        .from(mediaTag)
+        .where(eq(mediaTag.itemId, itemId))
+        .limit(1);
+    return tagged !== undefined;
 }
 
 /**

--- a/media.pollinations.ai/src/catalog.ts
+++ b/media.pollinations.ai/src/catalog.ts
@@ -363,24 +363,29 @@ export async function isItemReactable(
 
 /**
  * React to an item on behalf of a user. Idempotent: repeating the same
- * reaction kind is a no-op.
+ * reaction kind is a no-op. The per-user kind cap is enforced inside the
+ * INSERT itself (not check-then-insert) so concurrent requests can't race
+ * past it — each D1 statement is atomic. Returns true if a row was written;
+ * false means either an idempotent repeat or a refused over-cap kind
+ * (callers disambiguate by reading the user's kinds).
  */
 export async function addReaction(
     db: CatalogDb,
     itemId: string,
     userId: string,
     reaction: string,
-): Promise<void> {
-    await db
-        .insert(mediaReaction)
-        .values({ itemId, userId, reaction, createdAt: new Date() })
-        .onConflictDoNothing({
-            target: [
-                mediaReaction.itemId,
-                mediaReaction.userId,
-                mediaReaction.reaction,
-            ],
-        });
+): Promise<boolean> {
+    // created_at matches the column's { mode: "timestamp" } storage (seconds).
+    const result = await db.run(sql`
+        insert into ${mediaReaction} (item_id, user_id, reaction, created_at)
+        select ${itemId}, ${userId}, ${reaction}, ${Math.floor(Date.now() / 1000)}
+        where (
+            select count(*) from ${mediaReaction}
+            where item_id = ${itemId} and user_id = ${userId}
+        ) < ${MAX_REACTION_KINDS_PER_ITEM}
+        on conflict (item_id, user_id, reaction) do nothing
+    `);
+    return result.meta.changes > 0;
 }
 
 /**

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -5,16 +5,24 @@ import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi";
 import { z } from "zod";
 import type { CatalogItem, CatalogPage } from "./catalog.ts";
 import {
+    addReaction,
     clampLimit,
     decodeCursor,
     getDb,
+    getItemById,
+    InvalidReactionError,
     InvalidTagError,
     listByTag,
     listUserMedia,
+    normalizeReaction,
     normalizeTags,
+    reactionCountForItem,
+    reactionCountsForItems,
+    removeReaction,
     TooManyTagsError,
     tagsForItems,
     upsertUploadCatalogItem,
+    userReactionsForItems,
 } from "./catalog.ts";
 
 const DOMAIN = "media.pollinations.ai";
@@ -143,6 +151,9 @@ function validateMetadata(
 const TAG_PATTERN_DESCRIPTION =
     "lowercase letters, digits, and _.:+- (not leading), max 128 chars";
 
+const REACTION_PATTERN_DESCRIPTION =
+    "lowercase letters, digits, and _- (not leading), max 32 chars";
+
 function hasMetadata(metadata: UploadMetadata): boolean {
     return (
         metadata.tags.length > 0 ||
@@ -163,11 +174,15 @@ interface MediaItemResponse {
     prompt: string | null;
     model: string | null;
     createdAt: string;
+    reactions: Record<string, number>;
+    myReactions?: string[];
 }
 
 function toItemResponse(
     item: CatalogItem,
     tagsByItem: Map<string, string[]>,
+    reactionsByItem: Map<string, Record<string, number>>,
+    myReactionsByItem: Map<string, string[]> | null,
 ): MediaItemResponse {
     return {
         id: item.id,
@@ -179,19 +194,38 @@ function toItemResponse(
         prompt: item.prompt,
         model: item.model,
         createdAt: item.createdAt.toISOString(),
+        reactions: reactionsByItem.get(item.id) ?? {},
+        ...(myReactionsByItem
+            ? { myReactions: myReactionsByItem.get(item.id) ?? [] }
+            : {}),
     };
 }
 
+// `myReactionsUserId` is the authenticated user's id when myReactions should
+// be computed and included, or null when it should be omitted entirely (no
+// key, or a valid key with no attached user).
 async function toPageResponse(
     db: ReturnType<typeof getDb>,
     page: CatalogPage,
+    myReactionsUserId: string | null,
 ): Promise<{ items: MediaItemResponse[]; nextCursor: string | null }> {
-    const tagsByItem = await tagsForItems(
-        db,
-        page.items.map((item) => item.id),
-    );
+    const itemIds = page.items.map((item) => item.id);
+    const [tagsByItem, reactionsByItem, myReactionsByItem] = await Promise.all([
+        tagsForItems(db, itemIds),
+        reactionCountsForItems(db, itemIds),
+        myReactionsUserId
+            ? userReactionsForItems(db, itemIds, myReactionsUserId)
+            : Promise.resolve(null),
+    ]);
     return {
-        items: page.items.map((item) => toItemResponse(item, tagsByItem)),
+        items: page.items.map((item) =>
+            toItemResponse(
+                item,
+                tagsByItem,
+                reactionsByItem,
+                myReactionsByItem,
+            ),
+        ),
         nextCursor: page.nextCursor,
     };
 }
@@ -232,6 +266,17 @@ const MediaItemResponseSchema = z.object({
     prompt: z.string().nullable(),
     model: z.string().nullable(),
     createdAt: z.string().describe("ISO-8601 timestamp"),
+    reactions: z
+        .record(z.string(), z.number().int())
+        .describe(
+            "Reaction counts by kind (e.g. {like: 3}). {} when the item has no reactions.",
+        ),
+    myReactions: z
+        .array(z.string())
+        .optional()
+        .describe(
+            "Reaction kinds the authenticated caller gave this item. Present only when computable: always on /me/media, and on /tags/:tag only when an API key with an attached user was supplied.",
+        ),
 });
 
 const MediaPageResponseSchema = z.object({
@@ -240,6 +285,19 @@ const MediaPageResponseSchema = z.object({
         .string()
         .nullable()
         .describe("Opaque cursor for the next page, null when exhausted"),
+});
+
+const ReactionResponseSchema = z.object({
+    reaction: z.string().describe("Normalized reaction kind"),
+    reacted: z
+        .boolean()
+        .describe("true after adding the reaction, false after removing it"),
+    count: z
+        .number()
+        .int()
+        .describe(
+            "Total reactions of this kind on this item after the mutation",
+        ),
 });
 
 const api = new Hono<{ Bindings: Env }>();
@@ -590,7 +648,7 @@ api.get(
             cursor,
         });
 
-        return c.json(await toPageResponse(db, page));
+        return c.json(await toPageResponse(db, page, authResult.userId));
     },
 );
 
@@ -600,7 +658,7 @@ api.get(
         tags: ["media.pollinations.ai"],
         summary: "Browse media by tag",
         description:
-            "Public gallery listing for a tag, newest first. No authentication required.",
+            "Public gallery listing for a tag, newest first. Authentication is optional: pass an API key to get `myReactions` on each item.",
         security: [],
         responses: {
             200: {
@@ -613,6 +671,12 @@ api.get(
             },
             400: {
                 description: "Invalid cursor or limit",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            401: {
+                description: "API key supplied but invalid or expired",
                 content: {
                     "application/json": { schema: resolver(ErrorSchema) },
                 },
@@ -633,10 +697,207 @@ api.get(
             }
         }
 
+        // Auth is optional here, but if a key IS supplied it must be valid —
+        // an invalid key fails fast rather than silently falling back to
+        // anonymous browsing.
+        let myReactionsUserId: string | null = null;
+        const apiKey = extractApiKey(c.req.raw);
+        if (apiKey) {
+            const authResult = await verifyApiKey(apiKey);
+            if (!authResult) {
+                return c.json({ error: "Invalid or expired API key" }, 401);
+            }
+            myReactionsUserId = authResult.userId;
+        }
+
         const db = getDb(c.env.DB);
         const page = await listByTag(db, { tag, limit, cursor });
 
-        return c.json(await toPageResponse(db, page));
+        return c.json(await toPageResponse(db, page, myReactionsUserId));
+    },
+);
+
+api.put(
+    "/media/:id/reactions/:reaction",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "React to a media item",
+        description:
+            "Add a reaction (e.g. `like`, `heart`, `bookmark`) to a catalog item by its id (the `id` field from /me/media or /tags/:tag, not the content hash). Idempotent: repeating the same reaction is a no-op.",
+        responses: {
+            200: {
+                description:
+                    "Current reaction state and total count for this kind",
+                content: {
+                    "application/json": {
+                        schema: resolver(ReactionResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid reaction kind",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            403: {
+                description: "API key is not attached to a user account",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            404: {
+                description: "Media item not found",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) {
+            return c.json(
+                {
+                    error: "API key required. Pass via Authorization: Bearer <key> or ?key=<key>",
+                },
+                401,
+            );
+        }
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+        if (authResult.userId === null) {
+            return c.json(
+                { error: "This API key is not attached to a user account" },
+                403,
+            );
+        }
+
+        let reaction: string;
+        try {
+            reaction = normalizeReaction(c.req.param("reaction"));
+        } catch (error) {
+            if (error instanceof InvalidReactionError) {
+                return c.json(
+                    {
+                        error: `Invalid reaction: "${error.reaction}". Reactions must match ${REACTION_PATTERN_DESCRIPTION}.`,
+                    },
+                    400,
+                );
+            }
+            throw error;
+        }
+
+        const id = c.req.param("id");
+        const db = getDb(c.env.DB);
+        const item = await getItemById(db, id);
+        if (!item) {
+            return c.json({ error: "Media item not found" }, 404);
+        }
+
+        await addReaction(db, id, authResult.userId, reaction);
+        const count = await reactionCountForItem(db, id, reaction);
+        return c.json({ reaction, reacted: true, count });
+    },
+);
+
+api.delete(
+    "/media/:id/reactions/:reaction",
+    describeRoute({
+        tags: ["media.pollinations.ai"],
+        summary: "Remove a reaction from a media item",
+        description:
+            "Remove your reaction of one kind from a catalog item by its id (the `id` field from /me/media or /tags/:tag, not the content hash). Idempotent: removing a reaction you haven't given is a no-op.",
+        responses: {
+            200: {
+                description:
+                    "Current reaction state and total count for this kind",
+                content: {
+                    "application/json": {
+                        schema: resolver(ReactionResponseSchema),
+                    },
+                },
+            },
+            400: {
+                description: "Invalid reaction kind",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            401: {
+                description: "Missing or invalid API key",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            403: {
+                description: "API key is not attached to a user account",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+            404: {
+                description: "Media item not found",
+                content: {
+                    "application/json": { schema: resolver(ErrorSchema) },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const apiKey = extractApiKey(c.req.raw);
+        if (!apiKey) {
+            return c.json(
+                {
+                    error: "API key required. Pass via Authorization: Bearer <key> or ?key=<key>",
+                },
+                401,
+            );
+        }
+        const authResult = await verifyApiKey(apiKey);
+        if (!authResult) {
+            return c.json({ error: "Invalid or expired API key" }, 401);
+        }
+        if (authResult.userId === null) {
+            return c.json(
+                { error: "This API key is not attached to a user account" },
+                403,
+            );
+        }
+
+        let reaction: string;
+        try {
+            reaction = normalizeReaction(c.req.param("reaction"));
+        } catch (error) {
+            if (error instanceof InvalidReactionError) {
+                return c.json(
+                    {
+                        error: `Invalid reaction: "${error.reaction}". Reactions must match ${REACTION_PATTERN_DESCRIPTION}.`,
+                    },
+                    400,
+                );
+            }
+            throw error;
+        }
+
+        const id = c.req.param("id");
+        const db = getDb(c.env.DB);
+        const item = await getItemById(db, id);
+        if (!item) {
+            return c.json({ error: "Media item not found" }, 404);
+        }
+
+        await removeReaction(db, id, authResult.userId, reaction);
+        const count = await reactionCountForItem(db, id, reaction);
+        return c.json({ reaction, reacted: false, count });
     },
 );
 
@@ -836,7 +1097,7 @@ app.use(
     "*",
     cors({
         origin: "*",
-        allowMethods: ["GET", "POST", "HEAD", "OPTIONS"],
+        allowMethods: ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization"],
         exposeHeaders: ["X-Content-Hash", "X-Content-Size"],
     }),
@@ -851,7 +1112,11 @@ app.get("/", (c) => {
             retrieve: "GET /:hash",
             metadata: "GET /:hash/metadata",
             myMedia: "GET /me/media (requires user-owned API key)",
-            tagGallery: "GET /tags/:tag (public)",
+            tagGallery:
+                "GET /tags/:tag (public; optional API key for myReactions)",
+            react: "PUT /media/:id/reactions/:reaction (requires user-owned API key)",
+            unreact:
+                "DELETE /media/:id/reactions/:reaction (requires user-owned API key)",
             docs: "GET /openapi.json",
         },
         limits: {

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -9,11 +9,12 @@ import {
     clampLimit,
     decodeCursor,
     getDb,
-    getItemById,
     InvalidReactionError,
     InvalidTagError,
+    isItemReactable,
     listByTag,
     listUserMedia,
+    MAX_REACTION_KINDS_PER_ITEM,
     normalizeReaction,
     normalizeTags,
     reactionCountForItem,
@@ -723,7 +724,7 @@ api.put(
         tags: ["media.pollinations.ai"],
         summary: "React to a media item",
         description:
-            "Add a reaction (e.g. `like`, `heart`, `bookmark`) to a catalog item by its id (the `id` field from /me/media or /tags/:tag, not the content hash). Idempotent: repeating the same reaction is a no-op.",
+            "Add a reaction (e.g. `like`, `heart`, `bookmark`) to a catalog item by its id (the `id` field from /me/media or /tags/:tag, not the content hash). Reactable items are your own plus anything publicly tagged; others answer 404. Idempotent: repeating the same reaction is a no-op. At most 8 distinct reaction kinds per user per item.",
         responses: {
             200: {
                 description:
@@ -798,9 +799,24 @@ api.put(
 
         const id = c.req.param("id");
         const db = getDb(c.env.DB);
-        const item = await getItemById(db, id);
-        if (!item) {
+        if (!(await isItemReactable(db, id, authResult.userId))) {
             return c.json({ error: "Media item not found" }, 404);
+        }
+
+        const existingKinds =
+            (await userReactionsForItems(db, [id], authResult.userId)).get(
+                id,
+            ) ?? [];
+        if (
+            !existingKinds.includes(reaction) &&
+            existingKinds.length >= MAX_REACTION_KINDS_PER_ITEM
+        ) {
+            return c.json(
+                {
+                    error: `Too many distinct reactions on this item (max ${MAX_REACTION_KINDS_PER_ITEM} kinds per user).`,
+                },
+                400,
+            );
         }
 
         await addReaction(db, id, authResult.userId, reaction);
@@ -815,7 +831,7 @@ api.delete(
         tags: ["media.pollinations.ai"],
         summary: "Remove a reaction from a media item",
         description:
-            "Remove your reaction of one kind from a catalog item by its id (the `id` field from /me/media or /tags/:tag, not the content hash). Idempotent: removing a reaction you haven't given is a no-op.",
+            "Remove your reaction of one kind from a catalog item by its id (the `id` field from /me/media or /tags/:tag, not the content hash). Reactable items are your own plus anything publicly tagged; others answer 404. Idempotent: removing a reaction you haven't given is a no-op.",
         responses: {
             200: {
                 description:
@@ -890,8 +906,7 @@ api.delete(
 
         const id = c.req.param("id");
         const db = getDb(c.env.DB);
-        const item = await getItemById(db, id);
-        if (!item) {
+        if (!(await isItemReactable(db, id, authResult.userId))) {
             return c.json({ error: "Media item not found" }, 404);
         }
 

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -781,23 +781,24 @@ api.put(
             return c.json({ error: "Media item not found" }, 404);
         }
 
-        const existingKinds =
-            (await userReactionsForItems(db, [id], authResult.userId)).get(
-                id,
-            ) ?? [];
-        if (
-            !existingKinds.includes(reaction) &&
-            existingKinds.length >= MAX_REACTION_KINDS_PER_ITEM
-        ) {
-            return c.json(
-                {
-                    error: `Too many distinct reactions on this item (max ${MAX_REACTION_KINDS_PER_ITEM} kinds per user).`,
-                },
-                400,
-            );
+        const added = await addReaction(db, id, authResult.userId, reaction);
+        if (!added) {
+            // Zero rows written: either an idempotent repeat of a kind this
+            // user already holds, or the atomic kind cap inside addReaction
+            // refused a new kind. Only the second is an error.
+            const existingKinds =
+                (await userReactionsForItems(db, [id], authResult.userId)).get(
+                    id,
+                ) ?? [];
+            if (!existingKinds.includes(reaction)) {
+                return c.json(
+                    {
+                        error: `Too many distinct reactions on this item (max ${MAX_REACTION_KINDS_PER_ITEM} kinds per user).`,
+                    },
+                    400,
+                );
+            }
         }
-
-        await addReaction(db, id, authResult.userId, reaction);
         const count = await reactionCountForItem(db, id, reaction);
         return c.json({ reaction, reacted: true, count });
     },

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -42,11 +42,19 @@ interface MediaItemResponse {
     prompt: string | null;
     model: string | null;
     createdAt: string;
+    reactions: Record<string, number>;
+    myReactions?: string[];
 }
 
 interface MediaPageResponse {
     items: MediaItemResponse[];
     nextCursor: string | null;
+}
+
+interface ReactionResponse {
+    reaction: string;
+    reacted: boolean;
+    count: number;
 }
 
 // Kept for the pre-existing tests that don't care about identity.
@@ -593,5 +601,281 @@ describe("media.pollinations.ai", () => {
         expect(page2.items).toHaveLength(1);
         expect(page2.items[0].url).toBe(uploads[0].url);
         expect(page2.nextCursor).toBeNull();
+    });
+
+    describe("reactions", () => {
+        // Upload response `id` is the content hash, not the catalog item id.
+        // Look the item up via /me/media (as the owner) to get its catalog id.
+        async function catalogIdFor(
+            ownerKey: string,
+            uploadUrl: string,
+        ): Promise<string> {
+            const res = await SELF.fetch(
+                "https://media.pollinations.ai/me/media",
+                { headers: { Authorization: `Bearer ${ownerKey}` } },
+            );
+            const page = (await res.json()) as MediaPageResponse;
+            const item = page.items.find((i) => i.url === uploadUrl);
+            if (!item) throw new Error(`item not found for ${uploadUrl}`);
+            return item.id;
+        }
+
+        function reactionUrl(itemId: string, reaction: string): string {
+            return `https://media.pollinations.ai/media/${itemId}/reactions/${reaction}`;
+        }
+
+        it("like, repeat like, and visibility via /tags/:tag (anonymous vs authenticated)", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "like-flow.png",
+                bytes: variant(30),
+                tags: ["like-flow-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            const likeRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect(likeRes.status).toBe(200);
+            expect((await likeRes.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: true,
+                count: 1,
+            });
+
+            // Repeat like is idempotent.
+            const likeAgainRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect(likeAgainRes.status).toBe(200);
+            expect((await likeAgainRes.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: true,
+                count: 1,
+            });
+
+            // Anonymous tag browsing: reaction counts present, no myReactions.
+            const anonRes = await SELF.fetch(
+                "https://media.pollinations.ai/tags/like-flow-tag",
+            );
+            expect(anonRes.status).toBe(200);
+            const anon = (await anonRes.json()) as MediaPageResponse;
+            const anonItem = anon.items.find((i) => i.id === itemId);
+            expect(anonItem?.reactions).toEqual({ like: 1 });
+            expect(anonItem).not.toHaveProperty("myReactions");
+
+            // Bob (the reactor) sees "like" in myReactions.
+            const bobRes = await SELF.fetch(
+                "https://media.pollinations.ai/tags/like-flow-tag",
+                { headers: { Authorization: "Bearer pk_bob" } },
+            );
+            const bobPage = (await bobRes.json()) as MediaPageResponse;
+            expect(
+                bobPage.items.find((i) => i.id === itemId)?.myReactions,
+            ).toEqual(["like"]);
+
+            // Alice (no reactions) gets an empty myReactions.
+            const aliceRes = await SELF.fetch(
+                "https://media.pollinations.ai/tags/like-flow-tag",
+                { headers: { Authorization: "Bearer pk_alice" } },
+            );
+            const alicePage = (await aliceRes.json()) as MediaPageResponse;
+            expect(
+                alicePage.items.find((i) => i.id === itemId)?.myReactions,
+            ).toEqual([]);
+        });
+
+        it("unlike and repeat unlike are idempotent", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "unlike-flow.png",
+                bytes: variant(31),
+                tags: ["unlike-flow-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+
+            const unlikeRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "DELETE",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect(unlikeRes.status).toBe(200);
+            expect((await unlikeRes.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: false,
+                count: 0,
+            });
+
+            // Repeat unlike is idempotent.
+            const unlikeAgainRes = await SELF.fetch(
+                reactionUrl(itemId, "like"),
+                {
+                    method: "DELETE",
+                    headers: { Authorization: "Bearer pk_bob" },
+                },
+            );
+            expect(unlikeAgainRes.status).toBe(200);
+            expect((await unlikeAgainRes.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: false,
+                count: 0,
+            });
+        });
+
+        it("two different likers accumulate to 2, reflected in owner's /me/media", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "two-likers.png",
+                bytes: variant(32),
+                tags: ["two-likers-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            const aliceLike = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_alice" },
+            });
+            expect((await aliceLike.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: true,
+                count: 1,
+            });
+
+            const bobLike = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect((await bobLike.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: true,
+                count: 2,
+            });
+
+            const meRes = await SELF.fetch(
+                "https://media.pollinations.ai/me/media",
+                { headers: { Authorization: "Bearer pk_alice" } },
+            );
+            const me = (await meRes.json()) as MediaPageResponse;
+            const meItem = me.items.find((i) => i.id === itemId);
+            expect(meItem?.reactions).toEqual({ like: 2 });
+            expect(meItem?.myReactions).toEqual(["like"]);
+        });
+
+        it("multiple reaction kinds from one user coexist on an item", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "multi-kind.png",
+                bytes: variant(34),
+                tags: ["multi-kind-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            for (const kind of ["like", "bookmark"]) {
+                const res = await SELF.fetch(reactionUrl(itemId, kind), {
+                    method: "PUT",
+                    headers: { Authorization: "Bearer pk_bob" },
+                });
+                expect((await res.json()) as ReactionResponse).toEqual({
+                    reaction: kind,
+                    reacted: true,
+                    count: 1,
+                });
+            }
+            await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_alice" },
+            });
+
+            const bobRes = await SELF.fetch(
+                "https://media.pollinations.ai/tags/multi-kind-tag",
+                { headers: { Authorization: "Bearer pk_bob" } },
+            );
+            const bobPage = (await bobRes.json()) as MediaPageResponse;
+            const bobItem = bobPage.items.find((i) => i.id === itemId);
+            expect(bobItem?.reactions).toEqual({ like: 2, bookmark: 1 });
+            expect(bobItem?.myReactions?.sort()).toEqual(["bookmark", "like"]);
+        });
+
+        it("PUT /media/:id/reactions/like with a nonexistent item id returns 404", async () => {
+            const randomId = crypto.randomUUID();
+            const res = await SELF.fetch(reactionUrl(randomId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_alice" },
+            });
+            expect(res.status).toBe(404);
+            expect((await res.json()) as { error: string }).toEqual({
+                error: "Media item not found",
+            });
+        });
+
+        it("rejects an invalid reaction kind with 400, naming it", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "bad-kind.png",
+                bytes: variant(35),
+                tags: ["bad-kind-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            const res = await SELF.fetch(
+                reactionUrl(itemId, encodeURIComponent("UPPER!")),
+                {
+                    method: "PUT",
+                    headers: { Authorization: "Bearer pk_alice" },
+                },
+            );
+            expect(res.status).toBe(400);
+            expect(((await res.json()) as { error: string }).error).toMatch(
+                /UPPER!/,
+            );
+        });
+
+        it("auth failures: missing/unknown/no-user keys on react, and unknown key on /tags/:tag", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "auth-fail.png",
+                bytes: variant(33),
+                tags: ["auth-fail-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            const noKeyRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+            });
+            expect(noKeyRes.status).toBe(401);
+
+            const unknownKeyRes = await SELF.fetch(
+                reactionUrl(itemId, "like"),
+                {
+                    method: "PUT",
+                    headers: { Authorization: "Bearer pk_unknown" },
+                },
+            );
+            expect(unknownKeyRes.status).toBe(401);
+
+            const noUserRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_nouser" },
+            });
+            expect(noUserRes.status).toBe(403);
+
+            const tagUnknownKeyRes = await SELF.fetch(
+                "https://media.pollinations.ai/tags/auth-fail-tag",
+                { headers: { Authorization: "Bearer pk_unknown" } },
+            );
+            expect(tagUnknownKeyRes.status).toBe(401);
+        });
     });
 });

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -841,6 +841,66 @@ describe("media.pollinations.ai", () => {
             );
         });
 
+        it("cannot react to another user's untagged (private) item, but the owner can", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "private-react.png",
+                bytes: variant(36),
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            // 404 (not 403) so the leaked id isn't confirmed to exist.
+            const bobRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect(bobRes.status).toBe(404);
+
+            const aliceRes = await SELF.fetch(reactionUrl(itemId, "like"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_alice" },
+            });
+            expect(aliceRes.status).toBe(200);
+            expect((await aliceRes.json()) as ReactionResponse).toEqual({
+                reaction: "like",
+                reacted: true,
+                count: 1,
+            });
+        });
+
+        it("caps distinct reaction kinds per user per item at 8", async () => {
+            const { status, body } = await uploadViaForm("pk_alice", {
+                fileName: "cap-kinds.png",
+                bytes: variant(37),
+                tags: ["cap-kinds-tag"],
+            });
+            expect(status).toBe(200);
+            const upload = body as UploadResponse;
+            const itemId = await catalogIdFor("pk_alice", upload.url);
+
+            for (let i = 0; i < 8; i++) {
+                const res = await SELF.fetch(reactionUrl(itemId, `kind-${i}`), {
+                    method: "PUT",
+                    headers: { Authorization: "Bearer pk_bob" },
+                });
+                expect(res.status).toBe(200);
+            }
+
+            const overCap = await SELF.fetch(reactionUrl(itemId, "kind-8"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect(overCap.status).toBe(400);
+
+            // Repeating an existing kind is not a new kind — still idempotent.
+            const repeat = await SELF.fetch(reactionUrl(itemId, "kind-0"), {
+                method: "PUT",
+                headers: { Authorization: "Bearer pk_bob" },
+            });
+            expect(repeat.status).toBe(200);
+        });
+
         it("auth failures: missing/unknown/no-user keys on react, and unknown key on /tags/:tag", async () => {
             const { status, body } = await uploadViaForm("pk_alice", {
                 fileName: "auth-fail.png",

--- a/shared/db/media-catalog.ts
+++ b/shared/db/media-catalog.ts
@@ -59,3 +59,29 @@ export const mediaTag = sqliteTable(
         index("idx_media_tag_tag_created").on(table.tag, table.createdAt),
     ],
 );
+
+export const mediaReaction = sqliteTable(
+    "media_reaction",
+    {
+        itemId: text("item_id")
+            .notNull()
+            .references(() => mediaItem.id, { onDelete: "cascade" }),
+        userId: text("user_id")
+            .notNull()
+            .references(() => user.id, { onDelete: "cascade" }),
+        // Open slug vocabulary ("like", "heart", "bookmark", ...) —
+        // validated at the API layer.
+        reaction: text("reaction").notNull(),
+        createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    },
+    (table) => [
+        // A user can give multiple different reactions to one item, but each
+        // kind at most once. Leading column (itemId) also serves
+        // count-by-item queries.
+        uniqueIndex("idx_media_reaction_item_user_reaction").on(
+            table.itemId,
+            table.userId,
+            table.reaction,
+        ),
+    ],
+);


### PR DESCRIPTION
Stacked on #12252 (base = `feat/media-catalog-d1`; retargets to main when that merges). Sibling of #12256.

- Adds `media_reaction` table (migration `0036`): generic reaction system, not likes-specific — open slug vocabulary per kind (`like`, `heart`, `bookmark`, ...), each user gives an item at most one of each kind, cascade FKs to `media_item` and `user`
- `PUT`/`DELETE /media/:id/reactions/:reaction` — idempotent both ways, returns `{reaction, reacted, count}`; 400 invalid kind (slug, max 32 chars), 401/403/404; `:id` is the catalog item id from `/me/media` / `/tags/:tag`
- List items gain `reactions: {like: 3, bookmark: 1}` (always, `{}` when none) and `myReactions: ["like"]` for authenticated callers; `/tags/:tag` auth is now optional — no key stays public, an invalid key fails fast with 401 (no silent anonymous fallback)
- All per-page reaction data batched: one grouped-count query + one my-reactions query per page
- CORS gains PUT/DELETE for browser clients
- Tests: 22 pass (15 pre-existing + 7 new: like/unlike idempotency, two likers, multi-kind coexistence, 404/400/401/403 matrix)

Deploy note: migration 0036 must be applied via enter's `npm run migrate:staging` / `migrate:production` before deploying the media worker (stacks on 0035 from #12252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)