### PR TITLE
fix: actually disable tier refill cron (crons = [])

### DIFF
--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -71,6 +71,12 @@ STRIPE_PMC = "pmc_1SrYT96O03AauPe8ijLy6sZU"
 
 [env.production]
 
+# Explicitly detach cron schedules. Deleting the [triggers] block leaves
+# previously-deployed crons attached (crons undefined = unchanged); only
+# `crons = []` removes them. See Cloudflare Workers cron-triggers docs.
+[env.production.triggers]
+crons = []
+
 [env.production.observability]
 enabled = true
 head_sampling_rate = 1
@@ -108,6 +114,10 @@ STRIPE_AUTO_TOP_UP_PMC_ID = "pmc_1TVU4T7rcjS3l7trqtBuve71"
 # Single broad checkout PMC; Stripe filters methods by buyer currency/country.
 STRIPE_PMC = "pmc_1SrY4O7rcjS3l7trnGXDTuat"
 [env.staging]
+
+# See production note above: explicit empty crons detaches the schedule.
+[env.staging.triggers]
+crons = []
 
 [[env.staging.routes]]
 pattern = "staging.enter.myceli.ai"


### PR DESCRIPTION
## Problem

PR #12019 ("disable tier refill cron") deleted the `[triggers]` blocks from `wrangler.toml`. Per [Cloudflare docs](https://developers.cloudflare.com/workers/wrangler/configuration/#triggers), an **undefined** `crons` property leaves previously-deployed schedules attached — **only `crons = []` detaches them**. So the hourly tier refill has kept running.

## Evidence it's still running (live prod, 2026-07-06)

- Prod D1 `MAX(last_tier_grant)` = current to the second; **92,760 users** refilled in the last 65 min (105,179 tier users total).
- Staging D1 last grant at the top of the current hour.
- Both `pollinations-enter-production` and `pollinations-enter-staging` still have `*/15 * * * *` attached despite 8+ deploys since #12019.

## Fix

- Add `[env.production.triggers] crons = []`
- Add `[env.staging.triggers] crons = []`

Detaches the schedules the documented way.

## Deploy note

Config change alone does nothing until deployed per env; cron changes take up to ~15 min to propagate. Deploy staging first, verify no new `last_tier_grant` after the top of the next hour, then prod.

Addresses the regression from #12019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)