### PR TITLE
feat: catalog fee surfacing + self-documenting community endpoint API

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -32,13 +32,17 @@ const PriceSchema = z.number().finite().min(0);
 const CreatePriceFieldsSchema = Object.fromEntries(
     COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
         field.key,
-        PriceSchema.optional().default(0),
+        PriceSchema.optional()
+            .default(0)
+            .describe(`${field.label} price in Pollen per token.`),
     ]),
 ) as unknown as Record<CommunityEndpointPriceKey, z.ZodType<number>>;
 const UpdatePriceFieldsSchema = Object.fromEntries(
     COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
         field.key,
-        PriceSchema.optional(),
+        PriceSchema.optional().describe(
+            `${field.label} price in Pollen per token.`,
+        ),
     ]),
 ) as unknown as Record<
     CommunityEndpointPriceKey,
@@ -46,17 +50,25 @@ const UpdatePriceFieldsSchema = Object.fromEntries(
 >;
 
 const CAPABILITY_FLAG_KEYS = ["tools", "search", "reasoning"] as const;
-const KindSchema = z.enum(COMMUNITY_ENDPOINT_KINDS);
+const KindSchema = z
+    .enum(COMMUNITY_ENDPOINT_KINDS)
+    .describe(
+        '"model" for a plain upstream model; "agent" for an endpoint that runs multi-step or tool-using logic behind the chat-completions shape.',
+    );
 // Whole-map semantics on update: sending toolPrices replaces the map; {} clears it.
-const ToolPricesSchema = z.record(
-    z
-        .string()
-        .regex(
-            COMMUNITY_TOOL_NAME_PATTERN,
-            "Tool names must be lowercase alphanumeric with _ or - (max 40 chars)",
-        ),
-    z.number().finite().positive(),
-);
+const ToolPricesSchema = z
+    .record(
+        z
+            .string()
+            .regex(
+                COMMUNITY_TOOL_NAME_PATTERN,
+                "Tool names must be lowercase alphanumeric with _ or - (max 40 chars)",
+            ),
+        z.number().finite().positive().describe("Pollen per call."),
+    )
+    .describe(
+        "Per-call tool fees, keyed by tool name (e.g. web_search). Each request is billed `fee × usage.tool_call_counts.<name>` as reported by the endpoint in its response usage object (on the final usage-bearing event for streams). On update the map is replaced whole; send {} to clear.",
+    );
 const EndpointFieldsSchema = {
     // No "/": the public model id is `<owner>/<name>`, so a slash in the name
     // would inject a second separator and let one model spoof another's id.
@@ -75,9 +87,21 @@ const EndpointFieldsSchema = {
 const CreateEndpointSchema = z.object({
     ...EndpointFieldsSchema,
     kind: KindSchema.optional().default("model"),
-    tools: z.boolean().optional().default(false),
-    search: z.boolean().optional().default(false),
-    reasoning: z.boolean().optional().default(false),
+    tools: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Declares tool/function-calling support (metadata only)."),
+    search: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Declares web-search capability (metadata only)."),
+    reasoning: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Declares reasoning/thinking support (metadata only)."),
     toolPrices: ToolPricesSchema.optional(),
     ...CreatePriceFieldsSchema,
 });
@@ -88,9 +112,18 @@ const UpdateEndpointSchema = z.object({
     upstreamModel: EndpointFieldsSchema.upstreamModel,
     bearerToken: EndpointFieldsSchema.bearerToken.optional(),
     kind: KindSchema.optional(),
-    tools: z.boolean().optional(),
-    search: z.boolean().optional(),
-    reasoning: z.boolean().optional(),
+    tools: z
+        .boolean()
+        .optional()
+        .describe("Declares tool/function-calling support (metadata only)."),
+    search: z
+        .boolean()
+        .optional()
+        .describe("Declares web-search capability (metadata only)."),
+    reasoning: z
+        .boolean()
+        .optional()
+        .describe("Declares reasoning/thinking support (metadata only)."),
     toolPrices: ToolPricesSchema.optional(),
     ...UpdatePriceFieldsSchema,
 });
@@ -375,7 +408,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Create My Model",
             description:
-                "Register an invite-only community text model. API keys require `account:keys` and an account with `communityEndpointsAllowed: true`. The upstream bearer token is encrypted and never returned.",
+                'Register an invite-only community text model or agent. API keys require `account:keys` and an account with `communityEndpointsAllowed: true`. The upstream bearer token is encrypted and never returned. Callers are billed your declared per-token prices plus any `toolPrices` fees; to charge tool fees the endpoint reports per-tool call counts in `usage.tool_call_counts` (e.g. `{"web_search": 2}`) on its response — for streams, on the final usage-bearing event.',
             responses: {
                 200: {
                     description: "Created community text model",

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -371,6 +371,44 @@ describe("community endpoint helpers", () => {
         ).toBeUndefined();
     });
 
+    it("marks resolver-priced fees dynamic and omits their static price", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/deep-research",
+            description: null,
+            ...communityEndpointPrices({}),
+        });
+        // A rule whose per-unit cost is read from the response at runtime
+        // (as Perplexity's request fee is) must not advertise a static price.
+        definition.billing = {
+            adjustments: [
+                {
+                    id: "provider.request.v1",
+                    description: "Provider-reported request cost",
+                    kind: "search_request",
+                    unit: "request",
+                    unitCost: 0.005,
+                    countUnits: () => 1,
+                    resolveUnitCost: () => 0.02,
+                },
+            ],
+        };
+        const info = modelInfoFromDefinition(
+            "voodoohop/deep-research",
+            definition,
+            { community: true },
+        );
+        expect(info.fees).toEqual([
+            {
+                id: "provider.request.v1",
+                kind: "search_request",
+                unit: "request",
+                dynamic: true,
+                description: "Provider-reported request cost",
+            },
+        ]);
+        expect(info.fees?.[0]).not.toHaveProperty("price");
+    });
+
     it("builds Portkey gateway context with the saved token", async () => {
         const secret = "test-secret";
         const endpoint: CommunityEndpointRuntime = {

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@shared/db/better-auth.ts";
 import { handleError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
+import { modelInfoFromDefinition } from "@shared/registry/model-info.ts";
 import { calculateUsageBilling } from "@shared/registry/registry.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
 import {
@@ -336,6 +337,38 @@ describe("community endpoint helpers", () => {
             ...communityEndpointPrices({}),
         });
         expect(plain.billing).toBeUndefined();
+    });
+
+    it("surfaces billing adjustments as fees in catalog model info", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/deep-research",
+            description: null,
+            toolPrices: { web_search: 0.005 },
+            ...communityEndpointPrices({ completionTextPrice: 0.000001 }),
+        });
+        const info = modelInfoFromDefinition(
+            "voodoohop/deep-research",
+            definition,
+            { community: true },
+        );
+        expect(info.fees).toEqual([
+            {
+                id: "community.tool.web_search.v1",
+                kind: "tool_call",
+                unit: "call",
+                price: "0.005",
+                description: expect.stringContaining("web_search"),
+            },
+        ]);
+
+        const plain = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            description: null,
+            ...communityEndpointPrices({}),
+        });
+        expect(
+            modelInfoFromDefinition("voodoohop/openai", plain).fees,
+        ).toBeUndefined();
     });
 
     it("builds Portkey gateway context with the saved token", async () => {

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -22,6 +22,20 @@ export const ModelCapabilitySchema = z.enum([
 
 export type ModelCapability = z.infer<typeof ModelCapabilitySchema>;
 
+// Per-unit fees billed on top of token pricing (billing adjustments): e.g.
+// Gemini grounded-search queries, Perplexity request fees, community
+// tool-call fees. Price is Pollen per unit as a fixed-point string, matching
+// the `pricing` map format.
+export const ModelFeeSchema = z.object({
+    id: z.string(),
+    kind: z.string(),
+    unit: z.string(),
+    price: z.string(),
+    description: z.string(),
+});
+
+export type ModelFee = z.infer<typeof ModelFeeSchema>;
+
 // Pricing uses registry field names directly, filtering out zero/undefined values
 // Fields: promptTextTokens, promptCachedTokens, promptCacheWriteTokens,
 //         promptAudioTokens, promptAudioSeconds, promptImageTokens,
@@ -45,6 +59,7 @@ export const ModelInfoSchema = z.object({
     pricing: z
         .record(z.string(), z.string())
         .and(z.object({ currency: z.literal("pollen") })),
+    fees: z.array(ModelFeeSchema).optional(),
     title: z.string(),
     description: z.string().optional(),
     input_modalities: z.array(z.string()).optional(),
@@ -87,6 +102,22 @@ type ModelInfoOptions = {
     community?: boolean;
 };
 
+// Adjustment prices are always unitCost × the model's uniform priceMultiplier
+// (see BillingAdjustment in registry.ts).
+function feesFromDefinition(
+    service: ModelDefinition<string>,
+): ModelFee[] | undefined {
+    const adjustments = service.billing?.adjustments;
+    if (!adjustments?.length) return undefined;
+    return adjustments.map((rule) => ({
+        id: rule.id,
+        kind: rule.kind,
+        unit: rule.unit,
+        price: toFixedPoint(rule.unitCost * service.priceMultiplier),
+        description: rule.description,
+    }));
+}
+
 function pricingInfoFromDefinition(
     priceDefinition: PriceDefinition,
 ): Record<string, string> & { currency: "pollen" } {
@@ -114,6 +145,7 @@ export function modelInfoFromDefinition(
         kind: service.kind,
         community: options.community || undefined,
         pricing: pricingInfoFromDefinition(getPriceDefinitionForModel(service)),
+        fees: feesFromDefinition(service),
         // User-facing metadata from service definition
         title: service.title,
         description: service.description,

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -24,13 +24,17 @@ export type ModelCapability = z.infer<typeof ModelCapabilitySchema>;
 
 // Per-unit fees billed on top of token pricing (billing adjustments): e.g.
 // Gemini grounded-search queries, Perplexity request fees, community
-// tool-call fees. Price is Pollen per unit as a fixed-point string, matching
-// the `pricing` map format.
+// tool-call fees. `price` is the per-unit fee in Pollen as a fixed-point
+// string (same format as `pricing`) for fees with a fixed cost. For fees
+// whose per-unit cost is resolved from the provider's response at runtime
+// (e.g. Perplexity's reported request cost), `dynamic` is true and `price`
+// is omitted — the static value would be misleading.
 export const ModelFeeSchema = z.object({
     id: z.string(),
     kind: z.string(),
     unit: z.string(),
-    price: z.string(),
+    price: z.string().optional(),
+    dynamic: z.boolean().optional(),
     description: z.string(),
 });
 
@@ -102,20 +106,33 @@ type ModelInfoOptions = {
     community?: boolean;
 };
 
-// Adjustment prices are always unitCost × the model's uniform priceMultiplier
-// (see BillingAdjustment in registry.ts).
+// Fixed-cost adjustment prices are unitCost × the model's uniform
+// priceMultiplier (see BillingAdjustment in registry.ts). Rules that carry a
+// `resolveUnitCost` resolver bill a per-request cost read from the provider
+// response, so no single static price is meaningful — mark them dynamic and
+// omit the price rather than expose the (misleading) static fallback.
 function feesFromDefinition(
     service: ModelDefinition<string>,
 ): ModelFee[] | undefined {
     const adjustments = service.billing?.adjustments;
     if (!adjustments?.length) return undefined;
-    return adjustments.map((rule) => ({
-        id: rule.id,
-        kind: rule.kind,
-        unit: rule.unit,
-        price: toFixedPoint(rule.unitCost * service.priceMultiplier),
-        description: rule.description,
-    }));
+    return adjustments.map((rule) =>
+        rule.resolveUnitCost
+            ? {
+                  id: rule.id,
+                  kind: rule.kind,
+                  unit: rule.unit,
+                  dynamic: true,
+                  description: rule.description,
+              }
+            : {
+                  id: rule.id,
+                  kind: rule.kind,
+                  unit: rule.unit,
+                  price: toFixedPoint(rule.unitCost * service.priceMultiplier),
+                  description: rule.description,
+              },
+    );
 }
 
 function pricingInfoFromDefinition(

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -520,7 +520,12 @@ const OpenAIModelSchema = z
         input_modalities: z.array(z.string()).optional(),
         output_modalities: z.array(z.string()).optional(),
         supported_endpoints: z.array(z.string()).optional(),
-        kind: z.enum(["model", "agent"]).optional(),
+        kind: z
+            .enum(["model", "agent"])
+            .optional()
+            .describe(
+                'Absent for plain models; "agent" marks endpoints running multi-step or tool-using logic behind the chat-completions shape.',
+            ),
         tools: z.boolean().optional(),
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),


### PR DESCRIPTION
Stacked on #12258 (base: `feat/community-tool-pricing`).

- Adds `fees` array to `/models` / `/text/models` entries, derived from billing adjustments: `{id, kind, unit, price, description}` — surfaces Gemini grounded-search fees, Perplexity request fees, and community `toolPrices` alongside token pricing
- Fee price = `unitCost × priceMultiplier` (fixed-point string, same format as the `pricing` map); field omitted when a model has no adjustments
- Adds `.describe()` to community endpoint zod schemas (kind, capability flags, toolPrices, per-token price fields) — APIDOCS.md is generated from the live OpenAPI spec post-deploy, so docs update themselves
- Create-route description documents the `usage.tool_call_counts` reporting convention
- Tests: fees mapping for community tool prices + absent-when-no-adjustments

Addresses #11373 (hosted agents: docs + catalog polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)