### PR TITLE
feat: dashboard form + badges for community kind/capabilities/tool fees

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -2,6 +2,7 @@ import {
     Alert,
     CardIcon,
     CheckIcon,
+    Chip,
     ClipboardIcon,
     CopyButton,
     ExternalLinkIcon,
@@ -39,10 +40,20 @@ export function CommunityEndpointCard({
         >
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0">
-                    <div className="flex min-w-0 items-center gap-2">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
                         <h3 className="min-w-0 truncate text-base font-semibold text-theme-text-strong">
                             {endpoint.name}
                         </h3>
+                        {endpoint.kind === "agent" && (
+                            <Chip intent="news" size="sm">
+                                Agent
+                            </Chip>
+                        )}
+                        {capabilityLabels(endpoint).map((label) => (
+                            <Chip key={label} intent="neutral" size="sm">
+                                {label}
+                            </Chip>
+                        ))}
                     </div>
                     {endpoint.description && (
                         <p className="mt-1 text-sm text-theme-text-muted">
@@ -114,9 +125,41 @@ export function CommunityEndpointCard({
                         value={<CommunityPriceBadges group={group} />}
                     />
                 ))}
+                {Object.keys(endpoint.toolPrices).length > 0 && (
+                    <CommunityDetailRow
+                        icon={<CardIcon className="h-3.5 w-3.5" />}
+                        label="Tool fees"
+                        value={
+                            <span className="flex min-w-0 flex-wrap items-center gap-1">
+                                {Object.entries(endpoint.toolPrices)
+                                    .sort(([a], [b]) => a.localeCompare(b))
+                                    .map(([name, price]) => (
+                                        <Chip
+                                            key={name}
+                                            intent="neutral"
+                                            size="sm"
+                                        >
+                                            <span className="font-mono">
+                                                {name}
+                                            </span>
+                                            {price} / call
+                                        </Chip>
+                                    ))}
+                            </span>
+                        }
+                    />
+                )}
             </div>
         </Surface>
     );
+}
+
+function capabilityLabels(endpoint: CommunityEndpoint): string[] {
+    const labels: string[] = [];
+    if (endpoint.tools) labels.push("Tools");
+    if (endpoint.search) labels.push("Web search");
+    if (endpoint.reasoning) labels.push("Reasoning");
+    return labels;
 }
 
 type CommunityDetailRowProps = {

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -2,14 +2,19 @@ import {
     Alert,
     Button,
     ChevronIcon,
+    cn,
     Dialog,
     DialogTitle,
     Dropdown,
     DropdownItem,
     FieldStack,
+    IconButton,
     Input,
     ScrollArea,
+    XIcon,
 } from "@pollinations/ui";
+import type { CommunityEndpointKind } from "@shared/community-endpoints.ts";
+import { COMMUNITY_TOOL_NAME_PATTERN } from "@shared/registry/community-billing.ts";
 import type { FormEvent, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
@@ -34,8 +39,47 @@ import {
     nextFormState,
     providerModelHelper,
     readError,
+    type ToolFeeRow,
     toEndpointPayload,
 } from "./types.ts";
+
+const CAPABILITY_TOGGLES = [
+    { key: "tools", label: "Tools" },
+    { key: "search", label: "Web search" },
+    { key: "reasoning", label: "Reasoning" },
+] as const;
+
+function isValidToolFeeRow(row: ToolFeeRow): boolean {
+    const price = Number(row.price.trim());
+    return (
+        COMMUNITY_TOOL_NAME_PATTERN.test(row.name.trim()) &&
+        Number.isFinite(price) &&
+        price > 0
+    );
+}
+
+function ToggleButton({
+    active,
+    onClick,
+    children,
+}: {
+    active: boolean;
+    onClick: () => void;
+    children: ReactNode;
+}) {
+    return (
+        <Button
+            type="button"
+            size="sm"
+            intent={active ? "info" : undefined}
+            aria-pressed={active}
+            className={cn("text-sm", !active && "opacity-70")}
+            onClick={onClick}
+        >
+            {children}
+        </Button>
+    );
+}
 
 type CommunityEndpointDialogProps = {
     /** Present in edit mode (prefills the form); omit to create. */
@@ -79,6 +123,41 @@ export function CommunityEndpointDialog({
 
     const hasToken = form.bearerToken.trim().length > 0;
     const tokenForRequest = { bearerToken: form.bearerToken.trim() };
+
+    function updateKind(kind: CommunityEndpointKind): void {
+        setForm((current) => ({ ...current, kind }));
+    }
+
+    function toggleCapability(key: "tools" | "search" | "reasoning"): void {
+        setForm((current) => ({ ...current, [key]: !current[key] }));
+    }
+
+    function updateToolFee(
+        index: number,
+        key: keyof ToolFeeRow,
+        value: string,
+    ): void {
+        setForm((current) => ({
+            ...current,
+            toolFees: current.toolFees.map((row, i) =>
+                i === index ? { ...row, [key]: value } : row,
+            ),
+        }));
+    }
+
+    function addToolFee(): void {
+        setForm((current) => ({
+            ...current,
+            toolFees: [...current.toolFees, { name: "", price: "" }],
+        }));
+    }
+
+    function removeToolFee(index: number): void {
+        setForm((current) => ({
+            ...current,
+            toolFees: current.toolFees.filter((_, i) => i !== index),
+        }));
+    }
 
     function updateForm(key: keyof EndpointFormState, value: string): void {
         setForm((current) => nextFormState(current, key, value));
@@ -216,6 +295,7 @@ export function CommunityEndpointDialog({
             : modelOptions.filter((model) =>
                   model.toLowerCase().includes(providerModelQuery),
               );
+    const hasValidToolFees = form.toolFees.every(isValidToolFeeRow);
     const canSubmit =
         !isSubmitting &&
         form.name.trim() !== "" &&
@@ -223,6 +303,7 @@ export function CommunityEndpointDialog({
         hasVisiblePriceFields &&
         hasValidVisiblePrices &&
         hasRequiredReturnedPrices &&
+        hasValidToolFees &&
         saveRequirementMet;
 
     return (
@@ -290,6 +371,46 @@ export function CommunityEndpointDialog({
                                     updateForm("description", e.target.value)
                                 }
                             />
+                        </FieldStack>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <FieldStack
+                            label="Type"
+                            helper="Agents run multi-step or tool-using logic behind the chat-completions shape."
+                            alignLabelRow
+                        >
+                            <div className="flex gap-2">
+                                <ToggleButton
+                                    active={form.kind === "model"}
+                                    onClick={() => updateKind("model")}
+                                >
+                                    Model
+                                </ToggleButton>
+                                <ToggleButton
+                                    active={form.kind === "agent"}
+                                    onClick={() => updateKind("agent")}
+                                >
+                                    Agent
+                                </ToggleButton>
+                            </div>
+                        </FieldStack>
+                        <FieldStack
+                            label="Capabilities"
+                            helper="Declared metadata shown in the model catalog."
+                            alignLabelRow
+                        >
+                            <div className="flex flex-wrap gap-2">
+                                {CAPABILITY_TOGGLES.map(({ key, label }) => (
+                                    <ToggleButton
+                                        key={key}
+                                        active={form[key]}
+                                        onClick={() => toggleCapability(key)}
+                                    >
+                                        {label}
+                                    </ToggleButton>
+                                ))}
+                            </div>
                         </FieldStack>
                     </div>
 
@@ -491,6 +612,75 @@ export function CommunityEndpointDialog({
                         visiblePriceKeys={visiblePriceKeys}
                         onChange={updateForm}
                     />
+
+                    <FieldStack
+                        label="Tool fees"
+                        helper="Pollen charged per tool call, billed from the usage.tool_call_counts your endpoint reports (e.g. web_search)."
+                        alignLabelRow
+                        action={
+                            <Button
+                                type="button"
+                                size="sm"
+                                intent="info"
+                                className="shrink-0 text-sm"
+                                onClick={addToolFee}
+                            >
+                                Add tool fee
+                            </Button>
+                        }
+                    >
+                        {form.toolFees.length > 0 && (
+                            <div className="grid gap-2">
+                                {form.toolFees.map((row, index) => (
+                                    <div
+                                        // biome-ignore lint/suspicious/noArrayIndexKey: rows have no stable id until named
+                                        key={index}
+                                        className="flex items-center gap-2"
+                                    >
+                                        <Input
+                                            name={`community-tool-fee-name-${index}`}
+                                            value={row.name}
+                                            placeholder="web_search"
+                                            autoComplete="off"
+                                            autoCapitalize="none"
+                                            spellCheck={false}
+                                            className="flex-1"
+                                            onChange={(e) =>
+                                                updateToolFee(
+                                                    index,
+                                                    "name",
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                        <Input
+                                            name={`community-tool-fee-price-${index}`}
+                                            value={row.price}
+                                            placeholder="0.005"
+                                            inputMode="decimal"
+                                            autoComplete="off"
+                                            className="w-32"
+                                            onChange={(e) =>
+                                                updateToolFee(
+                                                    index,
+                                                    "price",
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                        <IconButton
+                                            intent="danger"
+                                            title="Remove tool fee"
+                                            tooltip="Remove tool fee"
+                                            onClick={() => removeToolFee(index)}
+                                        >
+                                            <XIcon className="h-4 w-4" />
+                                        </IconButton>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </FieldStack>
                 </ScrollArea>
 
                 <div className="flex shrink-0 justify-end gap-2 p-6 pt-4">

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -1,11 +1,16 @@
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    type CommunityEndpointCapabilityFlags,
+    type CommunityEndpointKind,
     type CommunityEndpointPriceKey,
     type CommunityEndpointPrices,
 } from "@shared/community-endpoints.ts";
+import { COMMUNITY_TOOL_NAME_PATTERN } from "@shared/registry/community-billing.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 
 type EndpointFormPrices = Record<CommunityEndpointPriceKey, string>;
+
+export type ToolFeeRow = { name: string; price: string };
 
 export type CommunityEndpoint = {
     id: string;
@@ -14,10 +19,12 @@ export type CommunityEndpoint = {
     description: string | null;
     baseUrl: string;
     upstreamModel: string;
+    toolPrices: Record<string, number>;
     disabled: boolean;
     disabledReason: string | null;
     disabledAt: string | null;
-} & CommunityEndpointPrices;
+} & CommunityEndpointCapabilityFlags &
+    CommunityEndpointPrices;
 
 export type EndpointFormState = {
     name: string;
@@ -25,6 +32,11 @@ export type EndpointFormState = {
     baseUrl: string;
     upstreamModel: string;
     bearerToken: string;
+    kind: CommunityEndpointKind;
+    tools: boolean;
+    search: boolean;
+    reasoning: boolean;
+    toolFees: ToolFeeRow[];
 } & EndpointFormPrices;
 
 export type EndpointPayload = {
@@ -32,6 +44,11 @@ export type EndpointPayload = {
     description: string;
     baseUrl: string;
     upstreamModel: string;
+    kind: CommunityEndpointKind;
+    tools: boolean;
+    search: boolean;
+    reasoning: boolean;
+    toolPrices: Record<string, number>;
 } & CommunityEndpointPrices;
 
 export type CommunityEndpointUsage = Record<string, unknown>;
@@ -60,6 +77,11 @@ export const emptyForm: EndpointFormState = {
     baseUrl: "",
     upstreamModel: "",
     bearerToken: "",
+    kind: "model",
+    tools: false,
+    search: false,
+    reasoning: false,
+    toolFees: [],
     ...emptyPriceForm,
 };
 
@@ -94,6 +116,13 @@ export function endpointToForm(endpoint: CommunityEndpoint): EndpointFormState {
         baseUrl: endpoint.baseUrl,
         upstreamModel: endpoint.upstreamModel,
         bearerToken: "",
+        kind: endpoint.kind,
+        tools: endpoint.tools,
+        search: endpoint.search,
+        reasoning: endpoint.reasoning,
+        toolFees: Object.entries(endpoint.toolPrices)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([name, price]) => ({ name, price: String(price) })),
         ...(Object.fromEntries(
             COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
                 field.key,
@@ -150,6 +179,28 @@ export function observedUsageValue(
         : null;
 }
 
+// Whole-map semantics: the API replaces toolPrices with what we send, so an
+// empty map (all rows removed) clears saved fees.
+function toolFeesToPayload(rows: ToolFeeRow[]): Record<string, number> {
+    const toolPrices: Record<string, number> = {};
+    for (const row of rows) {
+        const name = row.name.trim();
+        const price = Number(row.price.trim());
+        if (!COMMUNITY_TOOL_NAME_PATTERN.test(name)) {
+            throw new Error(
+                `Tool name "${name}" must be lowercase alphanumeric with _ or - (max 40 chars)`,
+            );
+        }
+        if (!Number.isFinite(price) || price <= 0) {
+            throw new Error(
+                `Tool fee for "${name}" must be a positive Pollen amount per call`,
+            );
+        }
+        toolPrices[name] = price;
+    }
+    return toolPrices;
+}
+
 export function toEndpointPayload(form: EndpointFormState): EndpointPayload {
     const modelName = form.name.trim();
     return {
@@ -157,6 +208,11 @@ export function toEndpointPayload(form: EndpointFormState): EndpointPayload {
         description: form.description.trim(),
         baseUrl: form.baseUrl.trim(),
         upstreamModel: form.upstreamModel.trim() || modelName,
+        kind: form.kind,
+        tools: form.tools,
+        search: form.search,
+        reasoning: form.reasoning,
+        toolPrices: toolFeesToPayload(form.toolFees),
         ...formPricesToPayload(form),
     };
 }


### PR DESCRIPTION
Stacked on #12261 (base: `feat/community-docs-catalog`).

- Adds Model/Agent toggle and Tools/Web search/Reasoning capability toggles to the community model dialog
- Adds tool-fees editor (tool name + Pollen per call); whole-map replace semantics — removing all rows clears fees
- Endpoint card shows Agent chip, capability chips, and tool-fee chips (polly suggestion on #12253)
- Invalid tool-fee rows disable submit; name pattern mirrors the API's `COMMUNITY_TOOL_NAME_PATTERN`

Addresses #11373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)