### PR TITLE
feat: queen-bee reference agent (sandbox container runtime)

### DIFF
--- a/bees/queen-bee/Dockerfile
+++ b/bees/queen-bee/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/cloudflare/sandbox:0.12.3

--- a/bees/queen-bee/README.md
+++ b/bees/queen-bee/README.md
@@ -26,11 +26,20 @@ Validated end-to-end (routing + exact two-tier billing) in
 ```bash
 npm install
 npx wrangler secret put POLLINATIONS_KEY   # owner sk_ key used for internal calls
+npx wrangler secret put BEE_AUTH_TOKEN      # shared token; blocks direct public callers
 npm run deploy                             # first deploy provisions the container image (~2-3 min)
 ```
 
 Requires a Cloudflare account with Containers access. `nodejs_compat` is
 mandatory — the sandbox SDK imports Node builtins.
+
+The workers.dev URL is public. `BEE_AUTH_TOKEN` is the shared secret the
+community proxy sends as the bearer token; the worker rejects any
+`/chat/completions` request without it, so direct callers can't run the agent
+on your key. Set the same value as the model's bearer token when registering
+(below). If `BEE_AUTH_TOKEN` is unset the worker accepts all callers — only
+acceptable for throwaway testing. (Under source-based deploy the platform
+generates and injects this token for you.)
 
 ## Register as a community model
 
@@ -38,13 +47,13 @@ mandatory — the sandbox SDK imports Node builtins.
 polli my-models create \
   --name queen-bee \
   --base-url https://queen-bee.<your-subdomain>.workers.dev/v1 \
-  --bearer-token unused \
+  --bearer-token "$BEE_AUTH_TOKEN" \
   --kind agent \
   --prompt-text-price 0.000002 \
   --completion-text-price 0.00001 \
   --tool-price sandbox_run=0.005
 ```
 
-The worker does not check the bearer token; the trust boundary is the
-invite-only community-model allowlist. The owner's key is visible to the
-agent code running in the container — only run code you wrote.
+The trust boundary is the invite-only community-model allowlist plus the
+`BEE_AUTH_TOKEN` on the endpoint. The owner's key is visible to the agent code
+running in the container — only run code you wrote.

--- a/bees/queen-bee/README.md
+++ b/bees/queen-bee/README.md
@@ -1,0 +1,50 @@
+# Queen Bee
+
+Reference community agent that runs its logic inside a Cloudflare Sandbox
+container. Serves the OpenAI chat-completions shape, so it can be registered
+as a community model and routed/billed through `gen.pollinations.ai`.
+Validated end-to-end (routing + exact two-tier billing) in
+[#11373](https://github.com/pollinations/pollinations/issues/11373).
+
+## How it works
+
+- Each `POST /v1/chat/completions` spins up a **fresh sandbox** (one container
+  per run — sandbox sessions are not a security boundary), writes the agent
+  script into it, and `exec`s it with Node.
+- The agent script makes real internal gen calls (`openai-fast` search step,
+  `gemini-fast` answer step) using the owner's `POLLINATIONS_KEY`, then prints
+  a JSON result to stdout.
+- The worker sums the internal usage into the response `usage` and reports
+  `usage.tool_call_counts: { sandbox_run: 1 }`, so a registered `toolPrices`
+  fee of `sandbox_run` is billed per request on top of the owner's per-token
+  prices.
+- The sandbox is destroyed in `finally`; containers bill active-CPU only, so
+  time spent awaiting LLM responses is near-free.
+
+## Deploy
+
+```bash
+npm install
+npx wrangler secret put POLLINATIONS_KEY   # owner sk_ key used for internal calls
+npm run deploy                             # first deploy provisions the container image (~2-3 min)
+```
+
+Requires a Cloudflare account with Containers access. `nodejs_compat` is
+mandatory — the sandbox SDK imports Node builtins.
+
+## Register as a community model
+
+```bash
+polli my-models create \
+  --name queen-bee \
+  --base-url https://queen-bee.<your-subdomain>.workers.dev/v1 \
+  --bearer-token unused \
+  --kind agent \
+  --prompt-text-price 0.000002 \
+  --completion-text-price 0.00001 \
+  --tool-price sandbox_run=0.005
+```
+
+The worker does not check the bearer token; the trust boundary is the
+invite-only community-model allowlist. The owner's key is visible to the
+agent code running in the container — only run code you wrote.

--- a/bees/queen-bee/package.json
+++ b/bees/queen-bee/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "queen-bee",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "deploy": "wrangler deploy"
+    },
+    "dependencies": {
+        "@cloudflare/sandbox": "0.12.3"
+    },
+    "devDependencies": {
+        "wrangler": "^4.0.0"
+    }
+}

--- a/bees/queen-bee/src/index.ts
+++ b/bees/queen-bee/src/index.ts
@@ -1,0 +1,123 @@
+// Queen Bee: an OpenAI-compatible community agent whose work runs inside a
+// Cloudflare Sandbox container. Each request gets a fresh sandbox (one
+// sandbox per run — sessions are not a security boundary), the agent script
+// executes real internal gen calls with the owner's key, and the sandbox is
+// destroyed afterwards. Validated end-to-end with exact billing in #11373.
+import { getSandbox, Sandbox } from "@cloudflare/sandbox";
+
+export { Sandbox };
+
+type Env = {
+    Sandbox: DurableObjectNamespace;
+    POLLINATIONS_KEY: string;
+};
+
+// Runs INSIDE the container. Reads QUESTION + POLLINATIONS_KEY from env,
+// makes two real gen calls (search step + answer step), prints JSON to stdout.
+const AGENT_SCRIPT = `
+const GEN = "https://gen.pollinations.ai/v1/chat/completions";
+
+async function callGen(model, prompt) {
+    const res = await fetch(GEN, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: \`Bearer \${process.env.POLLINATIONS_KEY}\`,
+            "user-agent": "queen-bee/1.0",
+        },
+        body: JSON.stringify({ model, messages: [{ role: "user", content: prompt }] }),
+    });
+    if (!res.ok) throw new Error(\`gen \${model} \${res.status}: \${await res.text()}\`);
+    const data = await res.json();
+    return { content: data.choices?.[0]?.message?.content ?? "", usage: data.usage ?? {} };
+}
+
+const question = process.env.QUESTION ?? "hello";
+const search = await callGen("openai-fast", \`You are a search tool. List 3 one-line facts relevant to: \${question}\`);
+const answer = await callGen("gemini-fast", \`Search results:\\n\${search.content}\\n\\nUsing these results, answer briefly: \${question}\`);
+process.stdout.write(JSON.stringify({
+    content: answer.content,
+    prompt_tokens: (search.usage.prompt_tokens ?? 0) + (answer.usage.prompt_tokens ?? 0),
+    completion_tokens: (search.usage.completion_tokens ?? 0) + (answer.usage.completion_tokens ?? 0),
+    internal_calls: [
+        { model: "openai-fast", usage: search.usage },
+        { model: "gemini-fast", usage: answer.usage },
+    ],
+}));
+`;
+
+export default {
+    async fetch(request: Request, env: Env): Promise<Response> {
+        const url = new URL(request.url);
+        if (
+            request.method === "POST" &&
+            url.pathname.endsWith("/chat/completions")
+        ) {
+            const body = (await request.json()) as {
+                messages?: { role: string; content: string }[];
+            };
+            const question =
+                body.messages?.filter((m) => m.role === "user").pop()
+                    ?.content ?? "hello";
+
+            const sandbox = getSandbox(env.Sandbox, crypto.randomUUID());
+            try {
+                await sandbox.writeFile("/workspace/agent.mjs", AGENT_SCRIPT);
+                const result = await sandbox.exec("node /workspace/agent.mjs", {
+                    env: {
+                        QUESTION: question,
+                        POLLINATIONS_KEY: env.POLLINATIONS_KEY,
+                    },
+                });
+                if (result.exitCode !== 0) {
+                    throw new Error(
+                        `agent exited ${result.exitCode}: ${result.stderr}`,
+                    );
+                }
+                const out = JSON.parse(result.stdout) as {
+                    content: string;
+                    prompt_tokens: number;
+                    completion_tokens: number;
+                    internal_calls: unknown[];
+                };
+                return Response.json({
+                    id: `chatcmpl-${crypto.randomUUID()}`,
+                    object: "chat.completion",
+                    created: Math.floor(Date.now() / 1000),
+                    model: "queen-bee-v1",
+                    choices: [
+                        {
+                            index: 0,
+                            message: {
+                                role: "assistant",
+                                content: out.content,
+                            },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: out.prompt_tokens,
+                        completion_tokens: out.completion_tokens,
+                        total_tokens: out.prompt_tokens + out.completion_tokens,
+                        tool_call_counts: { sandbox_run: 1 },
+                        internal_calls: out.internal_calls,
+                    },
+                });
+            } catch (err) {
+                return Response.json(
+                    { error: { message: String(err) } },
+                    { status: 502 },
+                );
+            } finally {
+                await sandbox.destroy();
+            }
+        }
+        if (url.pathname.endsWith("/models")) {
+            return Response.json({
+                object: "list",
+                data: [{ id: "queen-bee-v1", object: "model" }],
+            });
+        }
+        return new Response("not found", { status: 404 });
+    },
+};

--- a/bees/queen-bee/src/index.ts
+++ b/bees/queen-bee/src/index.ts
@@ -10,7 +10,19 @@ export { Sandbox };
 type Env = {
     Sandbox: DurableObjectNamespace;
     POLLINATIONS_KEY: string;
+    // Injected by the platform on source deploy; the community proxy sends it
+    // as the bearer token. The workers.dev URL is public, so without this
+    // check anyone with the URL could run the agent on the owner's key,
+    // bypassing gateway billing.
+    BEE_AUTH_TOKEN?: string;
 };
+
+function isAuthorized(request: Request, env: Env): boolean {
+    if (!env.BEE_AUTH_TOKEN) return true;
+    return (
+        request.headers.get("authorization") === `Bearer ${env.BEE_AUTH_TOKEN}`
+    );
+}
 
 // Runs INSIDE the container. Reads QUESTION + POLLINATIONS_KEY from env,
 // makes two real gen calls (search step + answer step), prints JSON to stdout.
@@ -53,6 +65,12 @@ export default {
             request.method === "POST" &&
             url.pathname.endsWith("/chat/completions")
         ) {
+            if (!isAuthorized(request, env)) {
+                return Response.json(
+                    { error: { message: "Unauthorized" } },
+                    { status: 401 },
+                );
+            }
             const body = (await request.json()) as {
                 messages?: { role: string; content: string }[];
             };

--- a/bees/queen-bee/wrangler.jsonc
+++ b/bees/queen-bee/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+    "name": "queen-bee",
+    "main": "src/index.ts",
+    "compatibility_date": "2026-01-01",
+    "compatibility_flags": ["nodejs_compat"],
+    "workers_dev": true,
+    "containers": [
+        {
+            "class_name": "Sandbox",
+            "image": "./Dockerfile",
+            "instance_type": "basic",
+            "max_instances": 2
+        }
+    ],
+    "durable_objects": {
+        "bindings": [
+            {
+                "class_name": "Sandbox",
+                "name": "Sandbox"
+            }
+        ]
+    },
+    "migrations": [
+        {
+            "tag": "v1",
+            "new_sqlite_classes": ["Sandbox"]
+        }
+    ]
+}


### PR DESCRIPTION
Addresses #11373 (S5 Queen Bees). Independent of the S1–S4 stack — commits the staging-validated prototype as a deployable reference under `bees/queen-bee/`.

- Adds OpenAI-compatible agent worker that runs its logic inside a fresh Cloudflare Sandbox container per request (`@cloudflare/sandbox` 0.12.3, `nodejs_compat`), destroyed in `finally`
- Agent script executes two real internal gen calls with the owner's `POLLINATIONS_KEY` secret; worker sums internal usage and reports `usage.tool_call_counts: {sandbox_run: 1}` for per-run tool fees
- Adds wrangler config (containers + Sandbox DO + sqlite migration), Dockerfile, README with deploy + `polli my-models` registration steps
- Validated end-to-end on staging as `queen-bee-s5`: routing + exact two-tier billing incl. sandbox_run fee (https://github.com/pollinations/pollinations/issues/11373#issuecomment-4896576485)

Not included (deferred productization): bee manifest, snapshot warm-starts, egress-proxy credential injection — the owner key is visible to code in the container, so this is a run-your-own-code reference only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)