### PR TITLE
feat: no-code prompt agents (systemPrompt + tools + MCP)

### DIFF
--- a/.claude/skills/create-agent/SKILL.md
+++ b/.claude/skills/create-agent/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: create-agent
+description: "Create and register a no-code prompt agent on Pollinations — a system prompt over a base model, with optional built-in tools and MCP servers, deployed and billed by the platform. Use when asked to build, deploy, or register a Pollinations agent, bee, or my-model of kind agent."
+allowed-tools: Bash(polli *)
+---
+
+# Create a Pollinations agent
+
+A **prompt agent** is the simplest agent on Pollinations: a system prompt over a
+base model, plus optional tools. You write no code — you declare a config and the
+platform deploys and runs a template worker for you, billing callers your declared
+prices. This is one of three registration modes for `my-models`:
+
+| Mode | You provide | Platform does |
+|---|---|---|
+| **prompt agent** | `{ systemPrompt, baseModel, tools?, mcpServers? }` | Deploys a managed worker running a tool-calling loop on your key |
+| **source** | a single-file worker | Deploys your worker |
+| **baseUrl** | a URL + bearer token you host | Proxies to your endpoint |
+
+Use a prompt agent when you want an agent without hosting anything. Use `source`
+or `baseUrl` when you need custom code (see the `polli` skill).
+
+## Requirements
+
+- An invite-only account with community endpoints enabled (`communityEndpointsAllowed: true`).
+- An API key with the `account:keys` permission, or an authenticated dashboard session.
+- `polli` logged in: `polli auth login` (or `printf '%s' "$KEY" | polli auth login --with-token`).
+
+## The config
+
+Write a JSON file with the agent's config:
+
+```json
+{
+  "systemPrompt": "You are a terse SQL tutor. Answer in at most three sentences.",
+  "baseModel": "openai",
+  "tools": ["web_search", "image"],
+  "mcpServers": [
+    { "name": "docs", "url": "https://mcp.example.com/rpc", "auth": "optional-bearer" }
+  ]
+}
+```
+
+Fields:
+
+- **systemPrompt** (required) — the agent's instructions. Prepended to every conversation.
+- **baseModel** (required) — the Pollinations model the loop calls. It **must support
+  tool-calling** if you declare any `tools` or `mcpServers`. Check `polli models --type text`;
+  `openai` is a safe tool-capable default. A prompt-only agent (no tools) works with any text model.
+- **tools** (optional) — built-in tools the platform runs on your key. Supported:
+  - `web_search` — searches the web and returns relevant facts.
+  - `image` — generates an image from a prompt and returns its URL.
+- **mcpServers** (optional) — MCP servers **you host**; the agent calls them over HTTP
+  (Streamable-HTTP JSON-RPC). Each: `name` (lowercase, namespaces its tools as
+  `mcp__<name>__<tool>`), `url`, optional `auth` (sent as a bearer token). The code
+  runs on your infra — the platform is just a client.
+
+## Register it
+
+```bash
+polli my-models create \
+  --name sql-tutor \
+  --prompt-agent ./agent.json \
+  --completion-text-price 0.1 \
+  --tool-price web_search=0.002 \
+  --tool-price mcp_call=0.01
+```
+
+- `--name` — the model id becomes `<your-github>/<name>`.
+- Price flags set what **callers** pay you. Per-token: `--prompt-text-price`,
+  `--completion-text-price`, etc. Per tool call: `--tool-price <name>=<pollen>`.
+  Built-in tools bill under their own name (`web_search`, `image`); every MCP call
+  bills under `mcp_call`. You keep 75% of what callers pay, minus the platform's
+  internal costs for the tools' own model/image calls.
+- No `--bearer-token` and no `--base-url`/`--source` — a prompt agent manages its own.
+  The endpoint's `kind` defaults to `agent`.
+
+The response includes the model id. It becomes callable through the gateway within
+~60 seconds (registry cache).
+
+## Test a billed call
+
+Call it like any model, as a **different** user (or with a different key) so billing runs:
+
+```bash
+polli --key "$CALLER_KEY" gen text "How do I find duplicate rows?" --model <your-github>/sql-tutor
+```
+
+Or via the OpenAI-compatible endpoint:
+
+```bash
+curl https://gen.pollinations.ai/v1/chat/completions \
+  -H "Authorization: Bearer $CALLER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<your-github>/sql-tutor","messages":[{"role":"user","content":"find duplicate rows"}]}'
+```
+
+The response `usage` includes `tool_call_counts` (e.g. `{"web_search": 1}`) — that's
+what your `--tool-price` fees bill against.
+
+## Manage
+
+```bash
+polli my-models list                    # your agents and models
+polli my-models delete <id>             # retires the worker and revokes its minted key
+```
+
+To change a prompt agent's config, delete and recreate it (config edits redeploy the
+whole template). Price and metadata updates work in place via `polli my-models update <id>`.
+
+## How it works (for debugging)
+
+- The platform deploys a fixed template worker with your config injected as secret
+  bindings, and mints a dedicated `sk_` key for the agent's internal calls. That key
+  is never returned and is revoked when you delete the agent.
+- Each request runs a bounded tool-calling loop: call the base model with your tools →
+  if it emits tool calls, run them (built-in tools hit Pollinations; MCP tools hit your
+  server) → feed results back → repeat, up to a fixed step ceiling → return the answer.
+- If a call errors (bad base model, unreachable MCP server), the agent returns a 502
+  with the upstream error — check the message and your config.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -352,12 +352,16 @@ export function CommunityEndpointDialog({
     }
 
     const isPromptAgent = form.mode === "prompt-agent";
+    const isSource = form.mode === "source";
+    // Source and prompt-agent are both platform-deployed: the worker doesn't
+    // exist until saved, so there is no create-time endpoint to test.
+    const isManagedDeploy = isPromptAgent || isSource;
     const returnedFields = returnedPriceFields(testState);
-    // Prompt agents have no endpoint to test, so their base text price fields
-    // are always shown; external endpoints reveal price fields from the test.
+    // Managed deploys can't be tested at create time, so their base text price
+    // fields are always shown; external endpoints reveal fields from the test.
     const visiblePriceKeys = new Set([
         ...visiblePriceFieldKeys(savedPriceKeys, returnedFields),
-        ...(isPromptAgent ? PROMPT_AGENT_PRICE_KEYS : []),
+        ...(isManagedDeploy ? PROMPT_AGENT_PRICE_KEYS : []),
     ]);
     const hasVisiblePriceFields = visiblePriceKeys.size > 0;
     const hasValidVisiblePrices = hasValidVisibleFormPrices(
@@ -368,7 +372,8 @@ export function CommunityEndpointDialog({
         hasPositivePriceInput(form, field),
     );
     // Prompt agents must carry positive base text pricing (there is no test to
-    // observe usage), so require the forced keys to be set.
+    // observe usage). Source deploys may bill via tool fees only or be free, so
+    // their base prices are shown but not required.
     const hasRequiredPromptAgentPrices =
         !isPromptAgent ||
         COMMUNITY_ENDPOINT_PRICE_FIELDS.filter((field) =>
@@ -386,14 +391,19 @@ export function CommunityEndpointDialog({
               );
     const hasValidToolFees = form.toolFees.every(isValidToolFeeRow);
     const hasValidMcpServers = form.mcpServers.every(isValidMcpRow);
-    // The external endpoint path keeps its full baseUrl + test + token gate;
-    // the prompt-agent path validates the no-code config instead.
+    // Each mechanism gates differently: external keeps its baseUrl + test +
+    // token requirement; source needs worker code; prompt agent validates its
+    // no-code config.
+    const sourceWithinLimit =
+        new TextEncoder().encode(form.source).length <= MAX_SOURCE_BYTES;
     const modeRequirementsMet = isPromptAgent
         ? form.systemPrompt.trim() !== "" &&
           form.baseModel.trim() !== "" &&
           hasValidMcpServers &&
           hasRequiredPromptAgentPrices
-        : form.baseUrl.trim() !== "" && saveRequirementMet;
+        : isSource
+          ? form.source.trim() !== "" && sourceWithinLimit
+          : form.baseUrl.trim() !== "" && saveRequirementMet;
     const canSubmit =
         !isSubmitting &&
         form.name.trim() !== "" &&
@@ -427,6 +437,15 @@ export function CommunityEndpointDialog({
                             </code>{" "}
                             model. Pollinations hosts and runs it.
                         </>
+                    ) : isSource ? (
+                        <>
+                            Upload a single-file worker; Pollinations deploys
+                            and hosts it as a{" "}
+                            <code>
+                                {"{username}"}/{"{model-id}"}
+                            </code>{" "}
+                            model with your own per-1M-token pricing.
+                        </>
                     ) : (
                         <>
                             Register an OpenAI-compatible endpoint as a{" "}
@@ -454,16 +473,24 @@ export function CommunityEndpointDialog({
                             helper={
                                 isPromptAgent
                                     ? "Pollinations deploys and runs a prompt agent for you — no endpoint or token needed."
-                                    : "Point at your own OpenAI-compatible endpoint. You host and run it."
+                                    : isSource
+                                      ? "Upload a single-file worker; Pollinations deploys and hosts it — no token needed."
+                                      : "Point at your own OpenAI-compatible endpoint. You host and run it."
                             }
                             alignLabelRow
                         >
                             <div className="flex flex-wrap gap-2">
                                 <ToggleButton
-                                    active={!isPromptAgent}
+                                    active={form.mode === "external"}
                                     onClick={() => updateMode("external")}
                                 >
                                     External endpoint
+                                </ToggleButton>
+                                <ToggleButton
+                                    active={isSource}
+                                    onClick={() => updateMode("source")}
+                                >
+                                    Upload worker code
                                 </ToggleButton>
                                 <ToggleButton
                                     active={isPromptAgent}
@@ -564,7 +591,15 @@ export function CommunityEndpointDialog({
                         />
                     )}
 
-                    {!isPromptAgent && (
+                    {isSource && (
+                        <SourceFields
+                            name={form.name}
+                            source={form.source}
+                            onChange={updateForm}
+                        />
+                    )}
+
+                    {form.mode === "external" && (
                         <>
                             <div className="grid gap-4 sm:grid-cols-2">
                                 <FieldStack
@@ -887,6 +922,66 @@ export function CommunityEndpointDialog({
                 </div>
             </form>
         </Dialog>
+    );
+}
+
+// Matches SourceSchema.max on the backend (1 MiB single-ES-module worker).
+const MAX_SOURCE_BYTES = 1_048_576;
+
+// Upload-worker-code registration: the owner pastes a single-file worker that
+// Pollinations deploys and hosts. Editable in both create and edit (the update
+// endpoint accepts `source` and redeploys).
+function SourceFields({
+    name,
+    source,
+    onChange,
+}: {
+    name: string;
+    source: string;
+    onChange: (key: keyof EndpointFormState, value: string) => void;
+}) {
+    const byteLength = new TextEncoder().encode(source).length;
+    const overLimit = byteLength > MAX_SOURCE_BYTES;
+    const modelId = name.trim() || "my-model";
+    return (
+        <div className="space-y-4">
+            <FieldStack
+                label="Worker source"
+                helper="A single ES-module worker exposing POST /v1/chat/completions. Deployed to a Pollinations-managed Cloudflare Worker."
+                alignLabelRow
+            >
+                <Textarea
+                    name="community-worker-source"
+                    value={source}
+                    placeholder={
+                        "export default {\n  async fetch(request, env) {\n    // return an OpenAI-compatible chat completion\n  },\n};"
+                    }
+                    rows={12}
+                    spellCheck={false}
+                    error={overLimit}
+                    className="font-mono text-sm"
+                    onChange={(e) => onChange("source", e.target.value)}
+                />
+                <p
+                    className={cn(
+                        "mt-1 text-xs",
+                        overLimit
+                            ? "text-intent-danger-text"
+                            : "text-theme-text-muted",
+                    )}
+                >
+                    {(byteLength / 1024).toFixed(1)} KiB / 1024 KiB
+                    {overLimit && " — worker source exceeds the 1 MiB limit"}
+                </p>
+            </FieldStack>
+
+            <Alert intent="info">
+                Prefer the CLI for larger workers or files on disk:
+                <code className="mt-1 block whitespace-pre-wrap break-all font-mono text-xs">
+                    polli my-models create --name {modelId} --source ./worker.js
+                </code>
+            </Alert>
+        </div>
     );
 }
 

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -11,9 +11,13 @@ import {
     IconButton,
     Input,
     ScrollArea,
+    Textarea,
     XIcon,
 } from "@pollinations/ui";
-import type { CommunityEndpointKind } from "@shared/community-endpoints.ts";
+import {
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    type CommunityEndpointKind,
+} from "@shared/community-endpoints.ts";
 import { COMMUNITY_TOOL_NAME_PATTERN } from "@shared/registry/community-billing.ts";
 import type { FormEvent, ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -22,6 +26,7 @@ import {
     formWithVisiblePrices,
     hasPositivePriceInput,
     hasValidVisibleFormPrices,
+    PROMPT_AGENT_PRICE_KEYS,
     PriceGroups,
     returnedPriceFields,
     savedEndpointPriceKeys,
@@ -32,11 +37,16 @@ import {
     type CommunityEndpoint,
     type CommunityEndpointTestResponse,
     type EndpointFormState,
+    type EndpointMode,
     type EndpointPayload,
     emptyForm,
     endpointToForm,
     idleAction,
+    MCP_SERVER_NAME_PATTERN,
+    type McpServerRow,
     nextFormState,
+    PROMPT_AGENT_BUILTIN_TOOLS,
+    type PromptAgentBuiltinTool,
     providerModelHelper,
     readError,
     type ToolFeeRow,
@@ -48,6 +58,24 @@ const CAPABILITY_TOGGLES = [
     { key: "search", label: "Web search" },
     { key: "reasoning", label: "Reasoning" },
 ] as const;
+
+const BUILTIN_TOOL_LABELS: Record<PromptAgentBuiltinTool, string> = {
+    web_search: "Web search",
+    image: "Image",
+};
+
+function isValidMcpRow(row: McpServerRow): boolean {
+    const name = row.name.trim();
+    const url = row.url.trim();
+    // Fully-empty rows are dropped on submit, so treat them as valid here.
+    if (!name && !url && !row.auth.trim()) return true;
+    try {
+        new URL(url);
+    } catch {
+        return false;
+    }
+    return MCP_SERVER_NAME_PATTERN.test(name);
+}
 
 function isValidToolFeeRow(row: ToolFeeRow): boolean {
     const price = Number(row.price.trim());
@@ -126,6 +154,57 @@ export function CommunityEndpointDialog({
 
     function updateKind(kind: CommunityEndpointKind): void {
         setForm((current) => ({ ...current, kind }));
+    }
+
+    // Switching to prompt-agent mode defaults the kind to agent (a no-code
+    // agent is an agent); switching back to external restores the model default.
+    function updateMode(mode: EndpointMode): void {
+        setForm((current) => ({
+            ...current,
+            mode,
+            kind: mode === "prompt-agent" ? "agent" : "model",
+        }));
+        setTestState(idleAction);
+        setError(null);
+    }
+
+    function toggleBuiltinTool(tool: PromptAgentBuiltinTool): void {
+        setForm((current) => ({
+            ...current,
+            builtinTools: current.builtinTools.includes(tool)
+                ? current.builtinTools.filter((t) => t !== tool)
+                : [...current.builtinTools, tool],
+        }));
+    }
+
+    function updateMcpServer(
+        index: number,
+        key: keyof McpServerRow,
+        value: string,
+    ): void {
+        setForm((current) => ({
+            ...current,
+            mcpServers: current.mcpServers.map((row, i) =>
+                i === index ? { ...row, [key]: value } : row,
+            ),
+        }));
+    }
+
+    function addMcpServer(): void {
+        setForm((current) => ({
+            ...current,
+            mcpServers: [
+                ...current.mcpServers,
+                { name: "", url: "", auth: "" },
+            ],
+        }));
+    }
+
+    function removeMcpServer(index: number): void {
+        setForm((current) => ({
+            ...current,
+            mcpServers: current.mcpServers.filter((_, i) => i !== index),
+        }));
     }
 
     function toggleCapability(key: "tools" | "search" | "reasoning"): void {
@@ -272,11 +351,14 @@ export function CommunityEndpointDialog({
         }
     }
 
+    const isPromptAgent = form.mode === "prompt-agent";
     const returnedFields = returnedPriceFields(testState);
-    const visiblePriceKeys = visiblePriceFieldKeys(
-        savedPriceKeys,
-        returnedFields,
-    );
+    // Prompt agents have no endpoint to test, so their base text price fields
+    // are always shown; external endpoints reveal price fields from the test.
+    const visiblePriceKeys = new Set([
+        ...visiblePriceFieldKeys(savedPriceKeys, returnedFields),
+        ...(isPromptAgent ? PROMPT_AGENT_PRICE_KEYS : []),
+    ]);
     const hasVisiblePriceFields = visiblePriceKeys.size > 0;
     const hasValidVisiblePrices = hasValidVisibleFormPrices(
         form,
@@ -285,6 +367,13 @@ export function CommunityEndpointDialog({
     const hasRequiredReturnedPrices = returnedFields.every((field) =>
         hasPositivePriceInput(form, field),
     );
+    // Prompt agents must carry positive base text pricing (there is no test to
+    // observe usage), so require the forced keys to be set.
+    const hasRequiredPromptAgentPrices =
+        !isPromptAgent ||
+        COMMUNITY_ENDPOINT_PRICE_FIELDS.filter((field) =>
+            PROMPT_AGENT_PRICE_KEYS.has(field.key),
+        ).every((field) => hasPositivePriceInput(form, field));
     const testRequirementMet =
         testState.status === "success" && returnedFields.length > 0;
     const saveRequirementMet = isEdit || (testRequirementMet && hasToken);
@@ -296,15 +385,23 @@ export function CommunityEndpointDialog({
                   model.toLowerCase().includes(providerModelQuery),
               );
     const hasValidToolFees = form.toolFees.every(isValidToolFeeRow);
+    const hasValidMcpServers = form.mcpServers.every(isValidMcpRow);
+    // The external endpoint path keeps its full baseUrl + test + token gate;
+    // the prompt-agent path validates the no-code config instead.
+    const modeRequirementsMet = isPromptAgent
+        ? form.systemPrompt.trim() !== "" &&
+          form.baseModel.trim() !== "" &&
+          hasValidMcpServers &&
+          hasRequiredPromptAgentPrices
+        : form.baseUrl.trim() !== "" && saveRequirementMet;
     const canSubmit =
         !isSubmitting &&
         form.name.trim() !== "" &&
-        form.baseUrl.trim() !== "" &&
         hasVisiblePriceFields &&
         hasValidVisiblePrices &&
         hasRequiredReturnedPrices &&
         hasValidToolFees &&
-        saveRequirementMet;
+        modeRequirementsMet;
 
     return (
         <Dialog
@@ -320,11 +417,25 @@ export function CommunityEndpointDialog({
                     {isEdit ? "Edit Model" : "Add Model"}
                 </DialogTitle>
                 <p className="mt-1 text-sm text-theme-text-muted">
-                    Register an OpenAI-compatible endpoint as a{" "}
-                    <code>
-                        {"{username}"}/{"{model-id}"}
-                    </code>{" "}
-                    model with your own per-1M-token pricing.
+                    {isPromptAgent ? (
+                        <>
+                            Deploy a no-code agent — a system prompt over a base
+                            model, with optional built-in tools and MCP servers
+                            — as a{" "}
+                            <code>
+                                {"{username}"}/{"{model-id}"}
+                            </code>{" "}
+                            model. Pollinations hosts and runs it.
+                        </>
+                    ) : (
+                        <>
+                            Register an OpenAI-compatible endpoint as a{" "}
+                            <code>
+                                {"{username}"}/{"{model-id}"}
+                            </code>{" "}
+                            model with your own per-1M-token pricing.
+                        </>
+                    )}
                 </p>
             </div>
 
@@ -336,6 +447,33 @@ export function CommunityEndpointDialog({
             >
                 <ScrollArea className="min-h-0 flex-1 space-y-4 overscroll-contain px-6 pb-2">
                     {error && <Alert intent="danger">{error}</Alert>}
+
+                    {!isEdit && (
+                        <FieldStack
+                            label="How to register"
+                            helper={
+                                isPromptAgent
+                                    ? "Pollinations deploys and runs a prompt agent for you — no endpoint or token needed."
+                                    : "Point at your own OpenAI-compatible endpoint. You host and run it."
+                            }
+                            alignLabelRow
+                        >
+                            <div className="flex flex-wrap gap-2">
+                                <ToggleButton
+                                    active={!isPromptAgent}
+                                    onClick={() => updateMode("external")}
+                                >
+                                    External endpoint
+                                </ToggleButton>
+                                <ToggleButton
+                                    active={isPromptAgent}
+                                    onClick={() => updateMode("prompt-agent")}
+                                >
+                                    Prompt agent
+                                </ToggleButton>
+                            </div>
+                        </FieldStack>
+                    )}
 
                     <div className="grid gap-4 sm:grid-cols-2">
                         <FieldStack
@@ -414,197 +552,236 @@ export function CommunityEndpointDialog({
                         </FieldStack>
                     </div>
 
-                    <div className="grid gap-4 sm:grid-cols-2">
-                        <FieldStack
-                            label="Endpoint URL"
-                            helper="OpenAI-compatible /v1 base URL or full chat completions URL."
-                            alignLabelRow
-                        >
-                            <Input
-                                name="community-endpoint-url"
-                                type="url"
-                                inputMode="url"
-                                value={form.baseUrl}
-                                placeholder="https://api.example.com/v1"
-                                autoComplete="off"
-                                autoCapitalize="none"
-                                spellCheck={false}
-                                required
-                                onChange={(e) =>
-                                    updateForm("baseUrl", e.target.value)
-                                }
-                            />
-                        </FieldStack>
-                        <FieldStack
-                            label="Provider model ID"
-                            helper={providerModelHelper(
-                                modelOptions,
-                                modelListState,
-                            )}
-                            alignLabelRow
-                            action={
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    intent="info"
-                                    className="shrink-0 text-sm"
-                                    disabled={
-                                        !hasToken ||
-                                        form.baseUrl.trim() === "" ||
-                                        modelListState.status === "loading"
-                                    }
-                                    onClick={() => void handleFetchModels()}
+                    {isPromptAgent && (
+                        <PromptAgentFields
+                            form={form}
+                            isEdit={isEdit}
+                            onChange={updateForm}
+                            onToggleTool={toggleBuiltinTool}
+                            onAddMcp={addMcpServer}
+                            onUpdateMcp={updateMcpServer}
+                            onRemoveMcp={removeMcpServer}
+                        />
+                    )}
+
+                    {!isPromptAgent && (
+                        <>
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <FieldStack
+                                    label="Endpoint URL"
+                                    helper="OpenAI-compatible /v1 base URL or full chat completions URL."
+                                    alignLabelRow
                                 >
-                                    {modelListState.status === "loading"
-                                        ? "Fetching…"
-                                        : "Fetch models"}
-                                </Button>
-                            }
-                        >
-                            {modelOptions.length > 0 ? (
-                                <Dropdown
-                                    align="end"
-                                    open={providerModelMenuOpen}
-                                    onOpenChange={setProviderModelMenuOpen}
-                                    className="w-[var(--reference-width)] min-w-0 p-1"
-                                    trigger={(menuOpen) => (
-                                        <div className="relative w-full">
-                                            <Input
-                                                name="community-upstream-id"
-                                                value={form.upstreamModel}
-                                                placeholder="gpt-4o-mini"
-                                                className="w-full pr-10"
-                                                autoComplete="off"
-                                                autoCapitalize="none"
-                                                spellCheck={false}
-                                                data-lpignore="true"
-                                                data-1p-ignore="true"
-                                                data-bwignore="true"
-                                                onChange={(e) =>
-                                                    updateForm(
-                                                        "upstreamModel",
-                                                        e.target.value,
-                                                    )
-                                                }
-                                            />
-                                            <ChevronIcon
-                                                expanded={menuOpen}
-                                                className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted transition-transform"
-                                            />
-                                        </div>
+                                    <Input
+                                        name="community-endpoint-url"
+                                        type="url"
+                                        inputMode="url"
+                                        value={form.baseUrl}
+                                        placeholder="https://api.example.com/v1"
+                                        autoComplete="off"
+                                        autoCapitalize="none"
+                                        spellCheck={false}
+                                        required
+                                        onChange={(e) =>
+                                            updateForm(
+                                                "baseUrl",
+                                                e.target.value,
+                                            )
+                                        }
+                                    />
+                                </FieldStack>
+                                <FieldStack
+                                    label="Provider model ID"
+                                    helper={providerModelHelper(
+                                        modelOptions,
+                                        modelListState,
                                     )}
-                                >
-                                    {(close) =>
-                                        visibleModelOptions.length > 0 ? (
-                                            <ScrollArea className="max-h-64">
-                                                <div className="flex flex-col">
-                                                    {visibleModelOptions.map(
-                                                        (model) => (
-                                                            <DropdownItem
-                                                                key={model}
-                                                                className={
-                                                                    form.upstreamModel ===
-                                                                    model
-                                                                        ? "bg-theme-bg-active font-medium text-theme-text-strong"
-                                                                        : undefined
-                                                                }
-                                                                onClick={() => {
-                                                                    updateForm(
-                                                                        "upstreamModel",
-                                                                        model,
-                                                                    );
-                                                                    close();
-                                                                }}
-                                                            >
-                                                                <span className="truncate font-mono">
-                                                                    {model}
-                                                                </span>
-                                                            </DropdownItem>
-                                                        ),
-                                                    )}
-                                                </div>
-                                            </ScrollArea>
-                                        ) : (
-                                            <p className="m-0 px-2 py-2 text-sm text-theme-text-soft">
-                                                No fetched models match.
-                                            </p>
-                                        )
+                                    alignLabelRow
+                                    action={
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            intent="info"
+                                            className="shrink-0 text-sm"
+                                            disabled={
+                                                !hasToken ||
+                                                form.baseUrl.trim() === "" ||
+                                                modelListState.status ===
+                                                    "loading"
+                                            }
+                                            onClick={() =>
+                                                void handleFetchModels()
+                                            }
+                                        >
+                                            {modelListState.status === "loading"
+                                                ? "Fetching…"
+                                                : "Fetch models"}
+                                        </Button>
                                     }
-                                </Dropdown>
-                            ) : (
+                                >
+                                    {modelOptions.length > 0 ? (
+                                        <Dropdown
+                                            align="end"
+                                            open={providerModelMenuOpen}
+                                            onOpenChange={
+                                                setProviderModelMenuOpen
+                                            }
+                                            className="w-[var(--reference-width)] min-w-0 p-1"
+                                            trigger={(menuOpen) => (
+                                                <div className="relative w-full">
+                                                    <Input
+                                                        name="community-upstream-id"
+                                                        value={
+                                                            form.upstreamModel
+                                                        }
+                                                        placeholder="gpt-4o-mini"
+                                                        className="w-full pr-10"
+                                                        autoComplete="off"
+                                                        autoCapitalize="none"
+                                                        spellCheck={false}
+                                                        data-lpignore="true"
+                                                        data-1p-ignore="true"
+                                                        data-bwignore="true"
+                                                        onChange={(e) =>
+                                                            updateForm(
+                                                                "upstreamModel",
+                                                                e.target.value,
+                                                            )
+                                                        }
+                                                    />
+                                                    <ChevronIcon
+                                                        expanded={menuOpen}
+                                                        className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted transition-transform"
+                                                    />
+                                                </div>
+                                            )}
+                                        >
+                                            {(close) =>
+                                                visibleModelOptions.length >
+                                                0 ? (
+                                                    <ScrollArea className="max-h-64">
+                                                        <div className="flex flex-col">
+                                                            {visibleModelOptions.map(
+                                                                (model) => (
+                                                                    <DropdownItem
+                                                                        key={
+                                                                            model
+                                                                        }
+                                                                        className={
+                                                                            form.upstreamModel ===
+                                                                            model
+                                                                                ? "bg-theme-bg-active font-medium text-theme-text-strong"
+                                                                                : undefined
+                                                                        }
+                                                                        onClick={() => {
+                                                                            updateForm(
+                                                                                "upstreamModel",
+                                                                                model,
+                                                                            );
+                                                                            close();
+                                                                        }}
+                                                                    >
+                                                                        <span className="truncate font-mono">
+                                                                            {
+                                                                                model
+                                                                            }
+                                                                        </span>
+                                                                    </DropdownItem>
+                                                                ),
+                                                            )}
+                                                        </div>
+                                                    </ScrollArea>
+                                                ) : (
+                                                    <p className="m-0 px-2 py-2 text-sm text-theme-text-soft">
+                                                        No fetched models match.
+                                                    </p>
+                                                )
+                                            }
+                                        </Dropdown>
+                                    ) : (
+                                        <Input
+                                            name="community-upstream-id"
+                                            value={form.upstreamModel}
+                                            placeholder="gpt-4o-mini"
+                                            autoComplete="off"
+                                            autoCapitalize="none"
+                                            spellCheck={false}
+                                            data-lpignore="true"
+                                            data-1p-ignore="true"
+                                            data-bwignore="true"
+                                            onFocus={() => {
+                                                if (modelOptions.length > 0) {
+                                                    setProviderModelMenuOpen(
+                                                        true,
+                                                    );
+                                                }
+                                            }}
+                                            onChange={(e) =>
+                                                updateForm(
+                                                    "upstreamModel",
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                    )}
+                                </FieldStack>
+                            </div>
+
+                            <FieldStack
+                                label="API bearer token"
+                                helper={
+                                    isEdit
+                                        ? "Leave blank to keep the saved token. Enter a token to fetch models, test, or replace it."
+                                        : "Stored encrypted and sent as Authorization: Bearer to your endpoint."
+                                }
+                                alignLabelRow
+                            >
                                 <Input
-                                    name="community-upstream-id"
-                                    value={form.upstreamModel}
-                                    placeholder="gpt-4o-mini"
-                                    autoComplete="off"
+                                    name="community-api-bearer-token"
+                                    type="password"
+                                    value={form.bearerToken}
+                                    placeholder={
+                                        isEdit ? "Re-enter token" : undefined
+                                    }
+                                    autoComplete="new-password"
                                     autoCapitalize="none"
-                                    spellCheck={false}
                                     data-lpignore="true"
                                     data-1p-ignore="true"
                                     data-bwignore="true"
-                                    onFocus={() => {
-                                        if (modelOptions.length > 0) {
-                                            setProviderModelMenuOpen(true);
-                                        }
-                                    }}
+                                    required={!isEdit}
                                     onChange={(e) =>
                                         updateForm(
-                                            "upstreamModel",
+                                            "bearerToken",
                                             e.target.value,
                                         )
                                     }
                                 />
-                            )}
-                        </FieldStack>
-                    </div>
+                            </FieldStack>
 
-                    <FieldStack
-                        label="API bearer token"
-                        helper={
-                            isEdit
-                                ? "Leave blank to keep the saved token. Enter a token to fetch models, test, or replace it."
-                                : "Stored encrypted and sent as Authorization: Bearer to your endpoint."
-                        }
-                        alignLabelRow
-                    >
-                        <Input
-                            name="community-api-bearer-token"
-                            type="password"
-                            value={form.bearerToken}
-                            placeholder={isEdit ? "Re-enter token" : undefined}
-                            autoComplete="new-password"
-                            autoCapitalize="none"
-                            data-lpignore="true"
-                            data-1p-ignore="true"
-                            data-bwignore="true"
-                            required={!isEdit}
-                            onChange={(e) =>
-                                updateForm("bearerToken", e.target.value)
-                            }
-                        />
-                    </FieldStack>
-
-                    <div className="flex flex-wrap items-center gap-3">
-                        <Button
-                            type="button"
-                            intent="info"
-                            onClick={() => void handleTest()}
-                            disabled={
-                                !hasToken ||
-                                form.baseUrl.trim() === "" ||
-                                testState.status === "loading"
-                            }
-                        >
-                            {testState.status === "loading"
-                                ? "Testing…"
-                                : "Test endpoint"}
-                        </Button>
-                        {testState.status === "error" && testState.message && (
-                            <p className="text-sm text-intent-danger-text">
-                                {testState.message}
-                            </p>
-                        )}
-                    </div>
+                            <div className="flex flex-wrap items-center gap-3">
+                                <Button
+                                    type="button"
+                                    intent="info"
+                                    onClick={() => void handleTest()}
+                                    disabled={
+                                        !hasToken ||
+                                        form.baseUrl.trim() === "" ||
+                                        testState.status === "loading"
+                                    }
+                                >
+                                    {testState.status === "loading"
+                                        ? "Testing…"
+                                        : "Test endpoint"}
+                                </Button>
+                                {testState.status === "error" &&
+                                    testState.message && (
+                                        <p className="text-sm text-intent-danger-text">
+                                            {testState.message}
+                                        </p>
+                                    )}
+                            </div>
+                        </>
+                    )}
 
                     <PriceGroups
                         form={form}
@@ -615,7 +792,11 @@ export function CommunityEndpointDialog({
 
                     <FieldStack
                         label="Tool fees"
-                        helper="Pollen charged per tool call, billed from the usage.tool_call_counts your endpoint reports (e.g. web_search)."
+                        helper={
+                            isPromptAgent
+                                ? "Pollen charged per tool call the agent makes. Use the built-in tool names (web_search, image) or mcp_call for MCP tools."
+                                : "Pollen charged per tool call, billed from the usage.tool_call_counts your endpoint reports (e.g. web_search)."
+                        }
                         alignLabelRow
                         action={
                             <Button
@@ -706,5 +887,191 @@ export function CommunityEndpointDialog({
                 </div>
             </form>
         </Dialog>
+    );
+}
+
+// The no-code prompt-agent config: a system prompt over a base model, plus
+// optional built-in tools and MCP servers. In edit mode this config is
+// read-only — the update endpoint does not accept prompt-agent changes, so the
+// owner recreates the agent to change it.
+function PromptAgentFields({
+    form,
+    isEdit,
+    onChange,
+    onToggleTool,
+    onAddMcp,
+    onUpdateMcp,
+    onRemoveMcp,
+}: {
+    form: EndpointFormState;
+    isEdit: boolean;
+    onChange: (key: keyof EndpointFormState, value: string) => void;
+    onToggleTool: (tool: PromptAgentBuiltinTool) => void;
+    onAddMcp: () => void;
+    onUpdateMcp: (
+        index: number,
+        key: keyof McpServerRow,
+        value: string,
+    ) => void;
+    onRemoveMcp: (index: number) => void;
+}) {
+    return (
+        <div className="space-y-4">
+            {isEdit && (
+                <Alert intent="info">
+                    A prompt agent&rsquo;s configuration is fixed after
+                    creation. To change the system prompt, base model, tools, or
+                    MCP servers, delete this agent and create a new one.
+                </Alert>
+            )}
+
+            <FieldStack
+                label="System prompt"
+                helper="The agent's instructions, sent as the system message on every call."
+                alignLabelRow
+            >
+                <Textarea
+                    name="prompt-agent-system-prompt"
+                    value={form.systemPrompt}
+                    placeholder="You are a helpful assistant that…"
+                    rows={6}
+                    maxLength={8000}
+                    disabled={isEdit}
+                    onChange={(e) => onChange("systemPrompt", e.target.value)}
+                />
+            </FieldStack>
+
+            <FieldStack
+                label="Base model"
+                helper="A Pollinations model id the agent runs on, e.g. openai or claude."
+                alignLabelRow
+            >
+                <Input
+                    name="prompt-agent-base-model"
+                    value={form.baseModel}
+                    placeholder="openai"
+                    autoComplete="off"
+                    autoCapitalize="none"
+                    spellCheck={false}
+                    disabled={isEdit}
+                    onChange={(e) => onChange("baseModel", e.target.value)}
+                />
+            </FieldStack>
+
+            <FieldStack
+                label="Built-in tools"
+                helper="Tools the agent can call. Fees are charged per call under the tool name."
+                alignLabelRow
+            >
+                <div className="flex flex-wrap gap-2">
+                    {PROMPT_AGENT_BUILTIN_TOOLS.map((tool) => (
+                        <ToggleButton
+                            key={tool}
+                            active={form.builtinTools.includes(tool)}
+                            onClick={() => !isEdit && onToggleTool(tool)}
+                        >
+                            {BUILTIN_TOOL_LABELS[tool]}
+                        </ToggleButton>
+                    ))}
+                </div>
+            </FieldStack>
+
+            <FieldStack
+                label="MCP servers"
+                helper="Streamable-HTTP MCP servers whose tools the agent can call (billed as mcp_call)."
+                alignLabelRow
+                action={
+                    !isEdit && (
+                        <Button
+                            type="button"
+                            size="sm"
+                            intent="info"
+                            className="shrink-0 text-sm"
+                            onClick={onAddMcp}
+                        >
+                            Add MCP server
+                        </Button>
+                    )
+                }
+            >
+                {form.mcpServers.length > 0 && (
+                    <div className="grid gap-2">
+                        {form.mcpServers.map((row, index) => (
+                            <div
+                                // biome-ignore lint/suspicious/noArrayIndexKey: rows have no stable id until named
+                                key={index}
+                                className="flex items-center gap-2"
+                            >
+                                <Input
+                                    name={`prompt-agent-mcp-name-${index}`}
+                                    value={row.name}
+                                    placeholder="my-server"
+                                    autoComplete="off"
+                                    autoCapitalize="none"
+                                    spellCheck={false}
+                                    className="w-40 shrink-0"
+                                    disabled={isEdit}
+                                    onChange={(e) =>
+                                        onUpdateMcp(
+                                            index,
+                                            "name",
+                                            e.target.value,
+                                        )
+                                    }
+                                />
+                                <Input
+                                    name={`prompt-agent-mcp-url-${index}`}
+                                    type="url"
+                                    inputMode="url"
+                                    value={row.url}
+                                    placeholder="https://mcp.example.com"
+                                    autoComplete="off"
+                                    autoCapitalize="none"
+                                    spellCheck={false}
+                                    className="flex-1"
+                                    disabled={isEdit}
+                                    onChange={(e) =>
+                                        onUpdateMcp(
+                                            index,
+                                            "url",
+                                            e.target.value,
+                                        )
+                                    }
+                                />
+                                <Input
+                                    name={`prompt-agent-mcp-auth-${index}`}
+                                    type="password"
+                                    value={row.auth}
+                                    placeholder="Bearer token (optional)"
+                                    autoComplete="off"
+                                    data-lpignore="true"
+                                    data-1p-ignore="true"
+                                    data-bwignore="true"
+                                    className="w-48 shrink-0"
+                                    disabled={isEdit}
+                                    onChange={(e) =>
+                                        onUpdateMcp(
+                                            index,
+                                            "auth",
+                                            e.target.value,
+                                        )
+                                    }
+                                />
+                                {!isEdit && (
+                                    <IconButton
+                                        intent="danger"
+                                        title="Remove MCP server"
+                                        tooltip="Remove MCP server"
+                                        onClick={() => onRemoveMcp(index)}
+                                    >
+                                        <XIcon className="h-4 w-4" />
+                                    </IconButton>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </FieldStack>
+        </div>
     );
 }

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -50,8 +50,11 @@ export function CommunityEndpoints({ onChange }: CommunityEndpointsProps) {
         payload: EndpointPayload,
         bearerToken: string,
     ): Promise<void> {
+        // A bearer token is only meaningful for self-hosted baseUrl endpoints;
+        // prompt agents mint their own worker token, and the schema rejects an
+        // empty-string token, so only attach it when one was entered.
         const response = await apiClient.account["my-models"].$post({
-            json: { ...payload, bearerToken },
+            json: bearerToken ? { ...payload, bearerToken } : payload,
         });
         if (!response.ok) throw new Error(await readError(response));
         await loadEndpoints();

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -299,6 +299,14 @@ export function savedEndpointPriceKeys(
     );
 }
 
+// A prompt agent runs a base text model, so its callers are always billed on
+// prompt/completion text tokens. There is no endpoint to test, so these two
+// price fields are shown unconditionally in prompt-agent mode.
+export const PROMPT_AGENT_PRICE_KEYS: Set<PriceFieldKey> = new Set([
+    "promptTextPrice",
+    "completionTextPrice",
+]);
+
 export function returnedPriceFields(testState: ActionState): PriceField[] {
     if (testState.status !== "success") return [];
     return COMMUNITY_ENDPOINT_PRICE_FIELDS.filter((field) =>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -12,6 +12,25 @@ type EndpointFormPrices = Record<CommunityEndpointPriceKey, string>;
 
 export type ToolFeeRow = { name: string; price: string };
 
+// The two ways to register: point at a self-hosted OpenAI-compatible endpoint
+// (external) or have the platform deploy a no-code prompt agent (prompt-agent).
+export type EndpointMode = "external" | "prompt-agent";
+
+// Built-in tools a prompt agent can be granted; mirrors PROMPT_AGENT_BUILTIN_TOOLS
+// on the backend.
+export const PROMPT_AGENT_BUILTIN_TOOLS = ["web_search", "image"] as const;
+export type PromptAgentBuiltinTool =
+    (typeof PROMPT_AGENT_BUILTIN_TOOLS)[number];
+
+export type McpServerRow = { name: string; url: string; auth: string };
+
+export type PromptAgentConfig = {
+    systemPrompt: string;
+    baseModel: string;
+    tools: PromptAgentBuiltinTool[];
+    mcpServers: { name: string; url: string; auth?: string }[];
+};
+
 export type CommunityEndpoint = {
     id: string;
     modelId: string;
@@ -19,6 +38,9 @@ export type CommunityEndpoint = {
     description: string | null;
     baseUrl: string;
     upstreamModel: string;
+    // No-code prompt-agent config, present only when the endpoint is a prompt
+    // agent; null for self-hosted / source-deployed endpoints.
+    promptAgent: PromptAgentConfig | null;
     toolPrices: Record<string, number>;
     disabled: boolean;
     disabledReason: string | null;
@@ -27,11 +49,17 @@ export type CommunityEndpoint = {
     CommunityEndpointPrices;
 
 export type EndpointFormState = {
+    mode: EndpointMode;
     name: string;
     description: string;
     baseUrl: string;
     upstreamModel: string;
     bearerToken: string;
+    // Prompt-agent fields; only read when mode === "prompt-agent".
+    systemPrompt: string;
+    baseModel: string;
+    builtinTools: PromptAgentBuiltinTool[];
+    mcpServers: McpServerRow[];
     kind: CommunityEndpointKind;
     tools: boolean;
     search: boolean;
@@ -42,7 +70,9 @@ export type EndpointFormState = {
 export type EndpointPayload = {
     name: string;
     description: string;
-    baseUrl: string;
+    // Exactly one of baseUrl / promptAgent is sent, per the create mode.
+    baseUrl?: string;
+    promptAgent?: PromptAgentConfig;
     upstreamModel: string;
     kind: CommunityEndpointKind;
     tools: boolean;
@@ -72,11 +102,16 @@ const emptyPriceForm = Object.fromEntries(
 ) as EndpointFormPrices;
 
 export const emptyForm: EndpointFormState = {
+    mode: "external",
     name: "",
     description: "",
     baseUrl: "",
     upstreamModel: "",
     bearerToken: "",
+    systemPrompt: "",
+    baseModel: "",
+    builtinTools: [],
+    mcpServers: [],
     kind: "model",
     tools: false,
     search: false,
@@ -110,12 +145,22 @@ export function isValidPriceInput(value: string): boolean {
 }
 
 export function endpointToForm(endpoint: CommunityEndpoint): EndpointFormState {
+    const promptAgent = endpoint.promptAgent;
     return {
+        mode: promptAgent ? "prompt-agent" : "external",
         name: endpoint.name,
         description: endpoint.description ?? "",
         baseUrl: endpoint.baseUrl,
         upstreamModel: endpoint.upstreamModel,
         bearerToken: "",
+        systemPrompt: promptAgent?.systemPrompt ?? "",
+        baseModel: promptAgent?.baseModel ?? "",
+        builtinTools: promptAgent?.tools ?? [],
+        mcpServers: (promptAgent?.mcpServers ?? []).map((server) => ({
+            name: server.name,
+            url: server.url,
+            auth: server.auth ?? "",
+        })),
         kind: endpoint.kind,
         tools: endpoint.tools,
         search: endpoint.search,
@@ -201,19 +246,76 @@ function toolFeesToPayload(rows: ToolFeeRow[]): Record<string, number> {
     return toolPrices;
 }
 
+// Mirrors the backend McpServerSchema name pattern (lowercase alphanumeric with
+// _ or -, max 40 chars) so client and server reject the same names.
+export const MCP_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,39}$/;
+
+// Validates and trims the MCP server rows, dropping fully-empty rows and the
+// optional auth. Mirrors the backend McpServerSchema so the API rejects the
+// same inputs.
+function mcpServersToPayload(
+    rows: McpServerRow[],
+): PromptAgentConfig["mcpServers"] {
+    const servers: PromptAgentConfig["mcpServers"] = [];
+    for (const row of rows) {
+        const name = row.name.trim();
+        const url = row.url.trim();
+        const auth = row.auth.trim();
+        if (!name && !url && !auth) continue;
+        if (!MCP_SERVER_NAME_PATTERN.test(name)) {
+            throw new Error(
+                `MCP server name "${name}" must be lowercase alphanumeric with _ or - (max 40 chars)`,
+            );
+        }
+        if (!url) {
+            throw new Error(`MCP server "${name}" needs a URL`);
+        }
+        servers.push(auth ? { name, url, auth } : { name, url });
+    }
+    return servers;
+}
+
+function toPromptAgentConfig(form: EndpointFormState): PromptAgentConfig {
+    const systemPrompt = form.systemPrompt.trim();
+    if (!systemPrompt) {
+        throw new Error("System prompt is required for a prompt agent");
+    }
+    const baseModel = form.baseModel.trim();
+    if (!baseModel) {
+        throw new Error("Base model is required for a prompt agent");
+    }
+    return {
+        systemPrompt,
+        baseModel,
+        tools: form.builtinTools,
+        mcpServers: mcpServersToPayload(form.mcpServers),
+    };
+}
+
 export function toEndpointPayload(form: EndpointFormState): EndpointPayload {
     const modelName = form.name.trim();
-    return {
+    const shared = {
         name: modelName,
         description: form.description.trim(),
-        baseUrl: form.baseUrl.trim(),
-        upstreamModel: form.upstreamModel.trim() || modelName,
         kind: form.kind,
         tools: form.tools,
         search: form.search,
         reasoning: form.reasoning,
         toolPrices: toolFeesToPayload(form.toolFees),
         ...formPricesToPayload(form),
+    };
+    if (form.mode === "prompt-agent") {
+        return {
+            ...shared,
+            // The template runs the base model; there is no separate upstream id.
+            upstreamModel: modelName,
+            promptAgent: toPromptAgentConfig(form),
+        };
+    }
+    return {
+        ...shared,
+        baseUrl: form.baseUrl.trim(),
+        upstreamModel: form.upstreamModel.trim() || modelName,
     };
 }
 

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -12,9 +12,10 @@ type EndpointFormPrices = Record<CommunityEndpointPriceKey, string>;
 
 export type ToolFeeRow = { name: string; price: string };
 
-// The two ways to register: point at a self-hosted OpenAI-compatible endpoint
-// (external) or have the platform deploy a no-code prompt agent (prompt-agent).
-export type EndpointMode = "external" | "prompt-agent";
+// The three ways to register: point at a self-hosted OpenAI-compatible endpoint
+// (external), upload worker code the platform deploys and hosts (source), or
+// have the platform run a no-code prompt agent (prompt-agent).
+export type EndpointMode = "external" | "source" | "prompt-agent";
 
 // Built-in tools a prompt agent can be granted; mirrors PROMPT_AGENT_BUILTIN_TOOLS
 // on the backend.
@@ -38,6 +39,9 @@ export type CommunityEndpoint = {
     description: string | null;
     baseUrl: string;
     upstreamModel: string;
+    // Worker source for platform-deployed endpoints; null when self-hosted or a
+    // prompt agent (whose config is surfaced separately as `promptAgent`).
+    source: string | null;
     // No-code prompt-agent config, present only when the endpoint is a prompt
     // agent; null for self-hosted / source-deployed endpoints.
     promptAgent: PromptAgentConfig | null;
@@ -55,6 +59,8 @@ export type EndpointFormState = {
     baseUrl: string;
     upstreamModel: string;
     bearerToken: string;
+    // Worker source; only read when mode === "source".
+    source: string;
     // Prompt-agent fields; only read when mode === "prompt-agent".
     systemPrompt: string;
     baseModel: string;
@@ -70,8 +76,9 @@ export type EndpointFormState = {
 export type EndpointPayload = {
     name: string;
     description: string;
-    // Exactly one of baseUrl / promptAgent is sent, per the create mode.
+    // Exactly one of baseUrl / source / promptAgent is sent, per the create mode.
     baseUrl?: string;
+    source?: string;
     promptAgent?: PromptAgentConfig;
     upstreamModel: string;
     kind: CommunityEndpointKind;
@@ -108,6 +115,7 @@ export const emptyForm: EndpointFormState = {
     baseUrl: "",
     upstreamModel: "",
     bearerToken: "",
+    source: "",
     systemPrompt: "",
     baseModel: "",
     builtinTools: [],
@@ -146,13 +154,21 @@ export function isValidPriceInput(value: string): boolean {
 
 export function endpointToForm(endpoint: CommunityEndpoint): EndpointFormState {
     const promptAgent = endpoint.promptAgent;
+    // A non-prompt-agent endpoint with stored worker source is source-deployed;
+    // otherwise it's a self-hosted external endpoint.
+    const mode: EndpointMode = promptAgent
+        ? "prompt-agent"
+        : endpoint.source
+          ? "source"
+          : "external";
     return {
-        mode: promptAgent ? "prompt-agent" : "external",
+        mode,
         name: endpoint.name,
         description: endpoint.description ?? "",
         baseUrl: endpoint.baseUrl,
         upstreamModel: endpoint.upstreamModel,
         bearerToken: "",
+        source: endpoint.source ?? "",
         systemPrompt: promptAgent?.systemPrompt ?? "",
         baseModel: promptAgent?.baseModel ?? "",
         builtinTools: promptAgent?.tools ?? [],
@@ -310,6 +326,18 @@ export function toEndpointPayload(form: EndpointFormState): EndpointPayload {
             // The template runs the base model; there is no separate upstream id.
             upstreamModel: modelName,
             promptAgent: toPromptAgentConfig(form),
+        };
+    }
+    if (form.mode === "source") {
+        const source = form.source.trim();
+        if (!source) {
+            throw new Error("Worker source is required for a source deploy");
+        }
+        return {
+            ...shared,
+            // The deployed worker is the model; there is no separate upstream id.
+            upstreamModel: modelName,
+            source,
         };
     }
     return {

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -27,6 +27,11 @@ import {
     testCommunityEndpoint,
 } from "../services/community-endpoint-openai.ts";
 import {
+    buildPromptAgentDeploy,
+    PromptAgentSchema,
+    parseStoredPromptAgent,
+} from "../services/prompt-agent.ts";
+import {
     communityWorkerScriptName,
     deleteCommunityWorker,
     deployCommunityWorker,
@@ -106,6 +111,7 @@ const CreateEndpointSchema = z
         ...EndpointFieldsSchema,
         baseUrl: EndpointFieldsSchema.baseUrl.optional(),
         source: SourceSchema.optional(),
+        promptAgent: PromptAgentSchema.optional(),
         kind: KindSchema.optional().default("model"),
         tools: z
             .boolean()
@@ -132,11 +138,15 @@ const CreateEndpointSchema = z
     })
     .refine(
         (input) =>
-            (input.baseUrl === undefined) !== (input.source === undefined),
-        { message: "Provide exactly one of baseUrl or source" },
+            [input.baseUrl, input.source, input.promptAgent].filter(
+                (value) => value !== undefined,
+            ).length === 1,
+        { message: "Provide exactly one of baseUrl, source, or promptAgent" },
     )
     .refine(
-        (input) => input.source !== undefined || Boolean(input.bearerToken),
+        // A bearer token is only meaningful for self-hosted baseUrl endpoints;
+        // source and promptAgent deploys mint and manage their own worker token.
+        (input) => input.baseUrl === undefined || Boolean(input.bearerToken),
         {
             message: "bearerToken is required when registering with baseUrl",
         },
@@ -193,8 +203,11 @@ const CommunityEndpointResponseSchema = z.object({
         .string()
         .nullable()
         .describe(
-            "Worker source for platform-deployed endpoints; null when self-hosted.",
+            "Worker source for platform-deployed endpoints; null when self-hosted or a prompt agent.",
         ),
+    promptAgent: PromptAgentSchema.nullable().describe(
+        "No-code agent config when this endpoint is a prompt agent; null otherwise.",
+    ),
     upstreamModel: z.string(),
     kind: KindSchema,
     tools: z.boolean(),
@@ -290,13 +303,19 @@ async function requireOwnerGithubUsername(
 }
 
 function toResponse(row: CommunityEndpointRow, ownerGithubUsername: string) {
+    // A prompt agent stores its config (and the minted key id) in `source`;
+    // surface the config as `promptAgent` and never expose the raw blob or the
+    // internal key id. Its platform-owned template is not user source, so
+    // `source` reads as null for prompt agents.
+    const storedPromptAgent = parseStoredPromptAgent(row.source);
     return {
         id: row.id,
         modelId: communityModelId(ownerGithubUsername, row.name),
         name: row.name,
         description: row.description,
         baseUrl: row.baseUrl,
-        source: row.source,
+        source: storedPromptAgent ? null : row.source,
+        promptAgent: storedPromptAgent?.promptAgent ?? null,
         upstreamModel: row.upstreamModel,
         kind: row.kind,
         tools: row.tools,
@@ -490,13 +509,25 @@ export const communityEndpointsRoutes = new Hono<Env>()
             );
             await ensureModelNameAvailable(db, user.id, input.name);
             const id = crypto.randomUUID();
-            // For source deploys the stored bearer token IS the worker auth
-            // token: gen sends it to the (public) workers.dev URL and the
-            // worker checks it, so direct callers without it are rejected.
-            // The caller's own bearerToken is ignored in this mode.
-            const deployConfig =
-                input.source !== undefined
-                    ? requireWorkerDeployConfig(c.env)
+            // Source and promptAgent both deploy a Pollinations-managed worker:
+            // the stored bearer token IS the generated worker auth token that
+            // gen sends to the (public) workers.dev URL, so direct callers
+            // without it are rejected. A prompt agent additionally deploys the
+            // fixed template with the owner's config injected as bindings.
+            const isManagedDeploy =
+                input.source !== undefined || input.promptAgent !== undefined;
+            const deployConfig = isManagedDeploy
+                ? requireWorkerDeployConfig(c.env)
+                : null;
+            const promptAgentDeploy =
+                deployConfig && input.promptAgent !== undefined
+                    ? await buildPromptAgentDeploy({
+                          authClient: c.var.auth.client,
+                          dbBinding: c.env.DB,
+                          userId: user.id,
+                          agentName: input.name,
+                          config: input.promptAgent,
+                      })
                     : null;
             const workerAuthToken = deployConfig
                 ? crypto.randomUUID().replaceAll("-", "")
@@ -505,14 +536,26 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 ? await deployCommunityWorker(
                       deployConfig,
                       communityWorkerScriptName(id),
-                      input.source as string,
+                      promptAgentDeploy?.source ?? (input.source as string),
                       workerAuthToken as string,
+                      promptAgentDeploy?.extraBindings,
                   )
                 : normalizeInputBaseUrl(input.baseUrl ?? "");
             // Guaranteed present in baseUrl mode by CreateEndpointSchema.
             const bearerToken =
                 workerAuthToken ??
                 normalizeInputBearerToken(input.bearerToken ?? "");
+            // Prompt agents default to the agent kind; source/baseUrl keep the
+            // caller's choice (which itself defaults to "model").
+            const kind =
+                input.promptAgent !== undefined && input.kind === "model"
+                    ? "agent"
+                    : input.kind;
+            // Prompt agents store their structured config (+ minted key id) in
+            // the source column; source deploys store the raw worker source.
+            const storedSource = promptAgentDeploy
+                ? promptAgentDeploy.storedSource
+                : (input.source ?? null);
             try {
                 const [row] = await db
                     .insert(schema.communityEndpoint)
@@ -522,13 +565,13 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         name: input.name,
                         description: input.description || null,
                         baseUrl,
-                        source: input.source ?? null,
+                        source: storedSource,
                         upstreamModel: input.upstreamModel ?? input.name,
                         bearerTokenCiphertext: await encryptSecret(
                             bearerToken,
                             c.env.BETTER_AUTH_SECRET,
                         ),
-                        kind: input.kind,
+                        kind,
                         tools: input.tools,
                         search: input.search,
                         reasoning: input.reasoning,
@@ -541,12 +584,18 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 return c.json(toResponse(row, ownerGithubUsername));
             } catch (error) {
                 // The worker is live but the row failed — remove the orphan so
-                // there's no callable script without a backing endpoint.
+                // there's no callable script without a backing endpoint, and
+                // revoke the prompt agent's minted key.
                 if (deployConfig) {
                     await deleteCommunityWorker(
                         deployConfig,
                         communityWorkerScriptName(id),
                     );
+                }
+                if (promptAgentDeploy) {
+                    await db
+                        .delete(schema.apikey)
+                        .where(eq(schema.apikey.id, promptAgentDeploy.keyId));
                 }
                 throw error;
             }
@@ -702,6 +751,12 @@ export const communityEndpointsRoutes = new Hono<Env>()
             > = {
                 updatedAt: new Date(),
             };
+            // Switching a prompt agent to a baseUrl or source endpoint retires
+            // its worker (below) and must also revoke its minted owner key so
+            // it can no longer spend.
+            const previousPromptAgent = parseStoredPromptAgent(endpoint.source);
+            const switchingAway =
+                input.baseUrl !== undefined || input.source !== undefined;
             if (input.name !== undefined) update.name = input.name;
             if (input.description !== undefined) {
                 update.description = input.description || null;
@@ -720,7 +775,8 @@ export const communityEndpointsRoutes = new Hono<Env>()
             }
             if (input.source !== undefined) {
                 // Redeploy the same id-keyed script with a fresh auth token;
-                // the token becomes the stored bearer token gen sends.
+                // the token becomes the stored bearer token gen sends. A prompt
+                // agent's template bindings are dropped by this overwrite.
                 const deployConfig = requireWorkerDeployConfig(c.env);
                 const workerAuthToken = crypto.randomUUID().replaceAll("-", "");
                 update.baseUrl = await deployCommunityWorker(
@@ -768,6 +824,13 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     ),
                 )
                 .returning();
+            // Revoke the old prompt agent's minted key after the row no longer
+            // references it (the worker was already retired above).
+            if (previousPromptAgent && switchingAway) {
+                await db
+                    .delete(schema.apikey)
+                    .where(eq(schema.apikey.id, previousPromptAgent.keyId));
+            }
             return c.json(toResponse(row, ownerGithubUsername));
         },
     )
@@ -812,6 +875,14 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     requireWorkerDeployConfig(c.env),
                     communityWorkerScriptName(endpoint.id),
                 );
+            }
+            // Prompt agents mint a dedicated owner key injected into the worker;
+            // remove it so it can no longer spend once the agent is gone.
+            const storedPromptAgent = parseStoredPromptAgent(endpoint.source);
+            if (storedPromptAgent) {
+                await db
+                    .delete(schema.apikey)
+                    .where(eq(schema.apikey.id, storedPromptAgent.keyId));
             }
             await db
                 .delete(schema.communityEndpoint)

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -527,6 +527,10 @@ export const communityEndpointsRoutes = new Hono<Env>()
                           userId: user.id,
                           agentName: input.name,
                           config: input.promptAgent,
+                          genBaseUrl:
+                              (c.env as { GEN_BASE_URL?: string })
+                                  .GEN_BASE_URL ??
+                              "https://gen.pollinations.ai",
                       })
                     : null;
             const workerAuthToken = deployConfig

--- a/enter.pollinations.ai/src/services/prompt-agent-template.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-template.ts
@@ -21,9 +21,17 @@
 //   TOOLS_JSON       JSON array of built-in tool names, e.g. ["web_search","image"]
 //   MCP_JSON         JSON array of { name, url, auth? } MCP servers
 //   POLLINATIONS_KEY owner sk_ key used for every internal gen/image/model call
+//   GEN_BASE_URL     the gateway origin the key is valid against (env-specific:
+//                    prod uses gen.pollinations.ai, staging its own gen). The
+//                    minted key only works against the env that issued it, so
+//                    this MUST match — a prod URL with a staging key 401s.
 //   BEE_AUTH_TOKEN   shared token the community proxy sends; blocks direct callers
 export const PROMPT_AGENT_TEMPLATE_SOURCE = String.raw`
-const GEN = "https://gen.pollinations.ai";
+// The gateway origin the owner key is valid against, injected per environment.
+// Falls back to production if the binding is unset.
+function genBase(env) {
+    return env.GEN_BASE_URL || "https://gen.pollinations.ai";
+}
 // An agentic-step ceiling, NOT a retry/timeout: each fetch below is one-shot and
 // throws on error. This only bounds how many tool rounds one request may take so
 // a looping model can't run up unbounded cost on the owner's key.
@@ -35,6 +43,7 @@ const MAX_TOOL_ROUNDS = 8;
 function builtinTools(env) {
     const key = env.POLLINATIONS_KEY;
     const authHeader = { authorization: "Bearer " + key };
+    const GEN = genBase(env);
     return {
         web_search: {
             schema: {
@@ -232,7 +241,7 @@ function addUsage(usage, part) {
 async function callModel(env, model, messages, toolSchemas) {
     const body = { model, messages };
     if (toolSchemas.length > 0) body.tools = toolSchemas;
-    const res = await fetch(GEN + "/v1/chat/completions", {
+    const res = await fetch(genBase(env) + "/v1/chat/completions", {
         method: "POST",
         headers: {
             "content-type": "application/json",

--- a/enter.pollinations.ai/src/services/prompt-agent-template.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-template.ts
@@ -1,0 +1,384 @@
+// Platform-authored template worker for NO-CODE prompt agents.
+//
+// A beginner registers `{ systemPrompt, baseModel, tools, mcpServers }` and no
+// code. The platform deploys THIS fixed module (via the same source-deploy path
+// as user-written bees), injecting the config as env bindings. The worker runs a
+// bounded OpenAI tool-calling loop on the owner's key: it calls the base model
+// with the declared tools, executes any tool calls (built-in tools hit our own
+// gen/image endpoints; MCP tools go to the owner's MCP server over HTTP), feeds
+// results back, and repeats until the model answers. It returns the standard
+// chat.completion shape with summed usage plus `usage.tool_call_counts`, so the
+// owner's declared per-call `toolPrices` bill exactly as for any community
+// endpoint (readReportedToolCallCount in shared/registry/community-billing.ts).
+//
+// Unlike queen-bee this runs directly in the Worker — there is no user code to
+// isolate, so no sandbox. The source below is the deployed artifact verbatim;
+// keep it self-contained (no imports) and valid as a single ES module.
+
+// Bindings the platform injects at deploy time (all secret_text):
+//   SYSTEM_PROMPT    the agent's system prompt
+//   BASE_MODEL       the Pollinations model id the loop calls
+//   TOOLS_JSON       JSON array of built-in tool names, e.g. ["web_search","image"]
+//   MCP_JSON         JSON array of { name, url, auth? } MCP servers
+//   POLLINATIONS_KEY owner sk_ key used for every internal gen/image/model call
+//   BEE_AUTH_TOKEN   shared token the community proxy sends; blocks direct callers
+export const PROMPT_AGENT_TEMPLATE_SOURCE = String.raw`
+const GEN = "https://gen.pollinations.ai";
+// An agentic-step ceiling, NOT a retry/timeout: each fetch below is one-shot and
+// throws on error. This only bounds how many tool rounds one request may take so
+// a looping model can't run up unbounded cost on the owner's key.
+const MAX_TOOL_ROUNDS = 8;
+
+// --- built-in tools -------------------------------------------------------
+// Each entry is { schema (OpenAI function def the base model sees), run (executes
+// the call, returns a string result) }. run() throws on upstream error.
+function builtinTools(env) {
+    const key = env.POLLINATIONS_KEY;
+    const authHeader = { authorization: "Bearer " + key };
+    return {
+        web_search: {
+            schema: {
+                type: "function",
+                function: {
+                    name: "web_search",
+                    description:
+                        "Search the web and return concise relevant results for a query.",
+                    parameters: {
+                        type: "object",
+                        properties: {
+                            query: {
+                                type: "string",
+                                description: "The search query.",
+                            },
+                        },
+                        required: ["query"],
+                    },
+                },
+            },
+            async run(args, usage) {
+                const res = await fetch(GEN + "/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        "content-type": "application/json",
+                        ...authHeader,
+                    },
+                    body: JSON.stringify({
+                        model: "openai-fast",
+                        messages: [
+                            {
+                                role: "user",
+                                content:
+                                    "Search the web and list the most relevant facts for: " +
+                                    String(args?.query ?? ""),
+                            },
+                        ],
+                    }),
+                });
+                if (!res.ok)
+                    throw new Error(
+                        "web_search " + res.status + ": " + (await res.text()),
+                    );
+                const data = await res.json();
+                addUsage(usage, data.usage);
+                return data.choices?.[0]?.message?.content ?? "";
+            },
+        },
+        image: {
+            schema: {
+                type: "function",
+                function: {
+                    name: "image",
+                    description:
+                        "Generate an image from a text prompt and return its URL.",
+                    parameters: {
+                        type: "object",
+                        properties: {
+                            prompt: {
+                                type: "string",
+                                description: "The image description.",
+                            },
+                        },
+                        required: ["prompt"],
+                    },
+                },
+            },
+            async run(args) {
+                const prompt = encodeURIComponent(String(args?.prompt ?? ""));
+                const url = GEN + "/image/" + prompt;
+                const res = await fetch(url, { headers: authHeader });
+                if (!res.ok)
+                    throw new Error(
+                        "image " + res.status + ": " + (await res.text()),
+                    );
+                return res.url || url;
+            },
+        },
+    };
+}
+
+// --- MCP client (Streamable HTTP JSON-RPC) --------------------------------
+// Minimal client: initialize -> tools/list -> tools/call. One fetch per call,
+// throws on error. Tool names are namespaced mcp__<server>__<tool> so multiple
+// servers (and built-ins) never collide.
+function mcpToolName(serverName, toolName) {
+    return "mcp__" + serverName + "__" + toolName;
+}
+
+async function mcpRpc(server, method, params) {
+    const headers = {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+    };
+    if (server.auth) headers.authorization = "Bearer " + server.auth;
+    const res = await fetch(server.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method,
+            params: params ?? {},
+        }),
+    });
+    if (!res.ok)
+        throw new Error(
+            "mcp " + server.name + " " + method + " " + res.status + ": " +
+                (await res.text()),
+        );
+    // Streamable HTTP may answer with a single JSON body or an SSE stream; for a
+    // one-shot request/response we accept either and read the first JSON-RPC
+    // message out of the body.
+    const text = await res.text();
+    const message = parseJsonRpc(text);
+    if (message.error)
+        throw new Error(
+            "mcp " + server.name + " " + method + " error: " +
+                JSON.stringify(message.error),
+        );
+    return message.result;
+}
+
+function parseJsonRpc(text) {
+    const trimmed = text.trim();
+    if (trimmed.startsWith("{")) return JSON.parse(trimmed);
+    // SSE framing: pull the JSON out of the last "data:" line.
+    let payload = "";
+    for (const line of trimmed.split("\n")) {
+        const l = line.trim();
+        if (l.startsWith("data:")) payload = l.slice(5).trim();
+    }
+    if (!payload) throw new Error("mcp: empty response body");
+    return JSON.parse(payload);
+}
+
+async function loadMcpTools(servers) {
+    const tools = {};
+    for (const server of servers) {
+        await mcpRpc(server, "initialize", {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "pollinations-prompt-agent", version: "1.0" },
+        });
+        const list = await mcpRpc(server, "tools/list", {});
+        for (const tool of list?.tools ?? []) {
+            const name = mcpToolName(server.name, tool.name);
+            tools[name] = {
+                schema: {
+                    type: "function",
+                    function: {
+                        name,
+                        description: tool.description ?? "",
+                        parameters: tool.inputSchema ?? {
+                            type: "object",
+                            properties: {},
+                        },
+                    },
+                },
+                async run(args) {
+                    const result = await mcpRpc(server, "tools/call", {
+                        name: tool.name,
+                        arguments: args ?? {},
+                    });
+                    return stringifyMcpResult(result);
+                },
+            };
+        }
+    }
+    return tools;
+}
+
+function stringifyMcpResult(result) {
+    const content = result?.content;
+    if (Array.isArray(content)) {
+        return content
+            .map((part) =>
+                part?.type === "text"
+                    ? part.text
+                    : JSON.stringify(part),
+            )
+            .join("\n");
+    }
+    return JSON.stringify(result ?? {});
+}
+
+// --- usage accounting -----------------------------------------------------
+function addUsage(usage, part) {
+    if (!part) return;
+    usage.prompt_tokens += part.prompt_tokens ?? 0;
+    usage.completion_tokens += part.completion_tokens ?? 0;
+}
+
+// --- the tool loop --------------------------------------------------------
+async function callModel(env, model, messages, toolSchemas) {
+    const body = { model, messages };
+    if (toolSchemas.length > 0) body.tools = toolSchemas;
+    const res = await fetch(GEN + "/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: "Bearer " + env.POLLINATIONS_KEY,
+        },
+        body: JSON.stringify(body),
+    });
+    if (!res.ok)
+        throw new Error(
+            "base model " + res.status + ": " + (await res.text()),
+        );
+    return res.json();
+}
+
+async function runAgent(env, userMessages) {
+    const builtinNames = JSON.parse(env.TOOLS_JSON || "[]");
+    const mcpServers = JSON.parse(env.MCP_JSON || "[]");
+    const available = builtinTools(env);
+    const tools = {};
+    for (const name of builtinNames) {
+        if (available[name]) tools[name] = available[name];
+    }
+    Object.assign(tools, await loadMcpTools(mcpServers));
+    const toolSchemas = Object.values(tools).map((t) => t.schema);
+
+    const messages = [];
+    if (env.SYSTEM_PROMPT)
+        messages.push({ role: "system", content: env.SYSTEM_PROMPT });
+    for (const m of userMessages) messages.push(m);
+
+    const usage = { prompt_tokens: 0, completion_tokens: 0 };
+    const toolCallCounts = {};
+
+    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+        const data = await callModel(env, env.BASE_MODEL, messages, toolSchemas);
+        addUsage(usage, data.usage);
+        const choice = data.choices?.[0];
+        const message = choice?.message ?? { role: "assistant", content: "" };
+        const calls = message.tool_calls;
+        // Key on tool_calls PRESENCE, not finish_reason: providers mislabel the
+        // reason string, but the presence of tool_calls is unambiguous.
+        if (!Array.isArray(calls) || calls.length === 0) {
+            return { content: message.content ?? "", usage, toolCallCounts };
+        }
+        messages.push(message);
+        for (const call of calls) {
+            const name = call.function?.name;
+            const tool = tools[name];
+            let result;
+            if (!tool) {
+                result = "Error: unknown tool " + name;
+            } else {
+                let args = {};
+                try {
+                    args = JSON.parse(call.function?.arguments || "{}");
+                } catch {
+                    args = {};
+                }
+                result = await tool.run(args, usage);
+                toolCallCounts[billedToolName(name)] =
+                    (toolCallCounts[billedToolName(name)] ?? 0) + 1;
+            }
+            messages.push({
+                role: "tool",
+                tool_call_id: call.id,
+                content: typeof result === "string" ? result : String(result),
+            });
+        }
+    }
+    // Hit the round ceiling without a final answer — return what we have rather
+    // than loop forever on the owner's key.
+    return {
+        content:
+            "The agent reached its maximum number of tool-use steps without a final answer.",
+        usage,
+        toolCallCounts,
+    };
+}
+
+// MCP tools bill under a single "mcp_call" line; built-ins bill under their own
+// name. Owners declare matching toolPrices to charge for either.
+function billedToolName(name) {
+    return name.startsWith("mcp__") ? "mcp_call" : name;
+}
+
+function isAuthorized(request, env) {
+    if (!env.BEE_AUTH_TOKEN) return true;
+    return (
+        request.headers.get("authorization") ===
+        "Bearer " + env.BEE_AUTH_TOKEN
+    );
+}
+
+export default {
+    async fetch(request, env) {
+        const url = new URL(request.url);
+        if (
+            request.method === "POST" &&
+            url.pathname.endsWith("/chat/completions")
+        ) {
+            if (!isAuthorized(request, env)) {
+                return Response.json(
+                    { error: { message: "Unauthorized" } },
+                    { status: 401 },
+                );
+            }
+            const body = await request.json();
+            const userMessages = Array.isArray(body.messages)
+                ? body.messages
+                : [];
+            try {
+                const out = await runAgent(env, userMessages);
+                return Response.json({
+                    id: "chatcmpl-" + crypto.randomUUID(),
+                    object: "chat.completion",
+                    created: Math.floor(Date.now() / 1000),
+                    model: env.BASE_MODEL,
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: out.content },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: out.usage.prompt_tokens,
+                        completion_tokens: out.usage.completion_tokens,
+                        total_tokens:
+                            out.usage.prompt_tokens + out.usage.completion_tokens,
+                        tool_call_counts: out.toolCallCounts,
+                    },
+                });
+            } catch (err) {
+                return Response.json(
+                    { error: { message: String(err) } },
+                    { status: 502 },
+                );
+            }
+        }
+        if (url.pathname.endsWith("/models")) {
+            return Response.json({
+                object: "list",
+                data: [{ id: env.BASE_MODEL, object: "model" }],
+            });
+        }
+        return new Response("not found", { status: 404 });
+    },
+};
+`;

--- a/enter.pollinations.ai/src/services/prompt-agent-template.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-template.ts
@@ -275,7 +275,12 @@ async function runAgent(env, userMessages) {
         // Key on tool_calls PRESENCE, not finish_reason: providers mislabel the
         // reason string, but the presence of tool_calls is unambiguous.
         if (!Array.isArray(calls) || calls.length === 0) {
-            return { content: message.content ?? "", usage, toolCallCounts };
+            return {
+                content: message.content ?? "",
+                usage,
+                toolCallCounts,
+                finishReason: "stop",
+            };
         }
         messages.push(message);
         for (const call of calls) {
@@ -291,7 +296,16 @@ async function runAgent(env, userMessages) {
                 } catch {
                     args = {};
                 }
-                result = await tool.run(args, usage);
+                // A tool failure is fed back to the model as the tool result so
+                // it can recover (try another tool, answer without it) rather
+                // than failing the whole request. This is NOT a retry — the
+                // failed call is not re-attempted; the error is surfaced. The
+                // call is still counted (the owner's tool ran).
+                try {
+                    result = await tool.run(args, usage);
+                } catch (err) {
+                    result = "Error: " + String(err);
+                }
                 toolCallCounts[billedToolName(name)] =
                     (toolCallCounts[billedToolName(name)] ?? 0) + 1;
             }
@@ -303,12 +317,14 @@ async function runAgent(env, userMessages) {
         }
     }
     // Hit the round ceiling without a final answer — return what we have rather
-    // than loop forever on the owner's key.
+    // than loop forever on the owner's key. finish_reason is "length": the
+    // response was cut off by a limit, not a natural stop.
     return {
         content:
             "The agent reached its maximum number of tool-use steps without a final answer.",
         usage,
         toolCallCounts,
+        finishReason: "length",
     };
 }
 
@@ -324,6 +340,64 @@ function isAuthorized(request, env) {
         request.headers.get("authorization") ===
         "Bearer " + env.BEE_AUTH_TOKEN
     );
+}
+
+function buildUsage(out) {
+    return {
+        prompt_tokens: out.usage.prompt_tokens,
+        completion_tokens: out.usage.completion_tokens,
+        total_tokens: out.usage.prompt_tokens + out.usage.completion_tokens,
+        tool_call_counts: out.toolCallCounts,
+    };
+}
+
+// The internal tool loop is not itself streamed; we run it to completion and
+// frame the final answer as a two-chunk SSE stream (content delta, then a
+// finish+usage chunk) so OpenAI streaming clients work. The usage — including
+// tool_call_counts — rides the final event where the gateway reads it for
+// billing (track.ts scans stream events for the one carrying usage).
+function streamResponse(id, created, model, out) {
+    const enc = new TextEncoder();
+    const send = (controller, payload) =>
+        controller.enqueue(
+            enc.encode("data: " + JSON.stringify(payload) + "\n\n"),
+        );
+    const stream = new ReadableStream({
+        start(controller) {
+            send(controller, {
+                id,
+                object: "chat.completion.chunk",
+                created,
+                model,
+                choices: [
+                    {
+                        index: 0,
+                        delta: { role: "assistant", content: out.content },
+                        finish_reason: null,
+                    },
+                ],
+            });
+            send(controller, {
+                id,
+                object: "chat.completion.chunk",
+                created,
+                model,
+                choices: [
+                    { index: 0, delta: {}, finish_reason: out.finishReason },
+                ],
+                usage: buildUsage(out),
+            });
+            controller.enqueue(enc.encode("data: [DONE]\n\n"));
+            controller.close();
+        },
+    });
+    return new Response(stream, {
+        headers: {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+        },
+    });
 }
 
 export default {
@@ -343,27 +417,26 @@ export default {
             const userMessages = Array.isArray(body.messages)
                 ? body.messages
                 : [];
+            const id = "chatcmpl-" + crypto.randomUUID();
+            const created = Math.floor(Date.now() / 1000);
             try {
                 const out = await runAgent(env, userMessages);
+                if (body.stream) {
+                    return streamResponse(id, created, env.BASE_MODEL, out);
+                }
                 return Response.json({
-                    id: "chatcmpl-" + crypto.randomUUID(),
+                    id,
                     object: "chat.completion",
-                    created: Math.floor(Date.now() / 1000),
+                    created,
                     model: env.BASE_MODEL,
                     choices: [
                         {
                             index: 0,
                             message: { role: "assistant", content: out.content },
-                            finish_reason: "stop",
+                            finish_reason: out.finishReason,
                         },
                     ],
-                    usage: {
-                        prompt_tokens: out.usage.prompt_tokens,
-                        completion_tokens: out.usage.completion_tokens,
-                        total_tokens:
-                            out.usage.prompt_tokens + out.usage.completion_tokens,
-                        tool_call_counts: out.toolCallCounts,
-                    },
+                    usage: buildUsage(out),
                 });
             } catch (err) {
                 return Response.json(

--- a/enter.pollinations.ai/src/services/prompt-agent.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent.ts
@@ -105,6 +105,9 @@ export async function buildPromptAgentDeploy(input: {
     userId: string;
     agentName: string;
     config: PromptAgentConfig;
+    // The gateway origin the minted key is valid against (this environment's
+    // gen). Injected so a staging-minted key calls staging gen, not prod.
+    genBaseUrl: string;
 }): Promise<{
     source: string;
     storedSource: string;
@@ -123,6 +126,7 @@ export async function buildPromptAgentDeploy(input: {
         { name: "TOOLS_JSON", text: JSON.stringify(input.config.tools) },
         { name: "MCP_JSON", text: JSON.stringify(input.config.mcpServers) },
         { name: "POLLINATIONS_KEY", text: key },
+        { name: "GEN_BASE_URL", text: input.genBaseUrl },
     ];
     return {
         source: PROMPT_AGENT_TEMPLATE_SOURCE,

--- a/enter.pollinations.ai/src/services/prompt-agent.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent.ts
@@ -1,0 +1,136 @@
+// Provisioning for NO-CODE prompt agents. A prompt agent is registered as
+// `{ systemPrompt, baseModel, tools, mcpServers }` with no user code: the
+// platform deploys the fixed prompt-agent-template worker (reusing the
+// source-deploy path) with the config injected as env bindings, and mints a
+// dedicated owner sk_ key the template uses for its internal gen/image calls.
+//
+// The structured config is stored in the endpoint's `source` column as JSON so
+// the existing `source !== null` gating drives create-rollback, update-redeploy,
+// and delete-cleanup uniformly. The minted key's id is stored alongside so it
+// can be removed when the agent is deleted.
+import { createApiKeyForUser } from "@shared/auth/api-key-creation.ts";
+import { z } from "zod";
+import { PROMPT_AGENT_TEMPLATE_SOURCE } from "./prompt-agent-template.ts";
+
+export const PROMPT_AGENT_BUILTIN_TOOLS = ["web_search", "image"] as const;
+
+const McpServerSchema = z.object({
+    // Namespaces the server's tools (mcp__<name>__<tool>); lowercase to match
+    // the community tool-name pattern so its fees can be declared.
+    name: z
+        .string()
+        .trim()
+        .regex(
+            /^[a-z0-9][a-z0-9_-]{0,39}$/,
+            "MCP server name must be lowercase alphanumeric with _ or - (max 40 chars)",
+        ),
+    url: z.string().url(),
+    auth: z.string().min(1).optional(),
+});
+
+export const PromptAgentSchema = z
+    .object({
+        systemPrompt: z.string().trim().min(1).max(8000),
+        baseModel: z.string().trim().min(1).max(253),
+        tools: z
+            .array(z.enum(PROMPT_AGENT_BUILTIN_TOOLS))
+            .max(PROMPT_AGENT_BUILTIN_TOOLS.length)
+            .optional()
+            .default([]),
+        mcpServers: z.array(McpServerSchema).max(8).optional().default([]),
+    })
+    .describe(
+        "No-code agent config: a system prompt over a base model, with optional built-in tools and MCP servers. The platform deploys and runs it; no worker source or bearerToken is needed.",
+    );
+
+export type PromptAgentConfig = z.infer<typeof PromptAgentSchema>;
+
+// The blob persisted in the endpoint's `source` column. `keyId` lets delete
+// remove the minted owner key; the plaintext key itself lives only in the
+// deployed worker's binding, never in D1.
+type StoredPromptAgent = {
+    promptAgent: PromptAgentConfig;
+    keyId: string;
+};
+
+export function parseStoredPromptAgent(
+    source: string | null,
+): StoredPromptAgent | null {
+    if (!source) return null;
+    try {
+        const parsed = JSON.parse(source) as Partial<StoredPromptAgent>;
+        if (!parsed?.promptAgent || typeof parsed.keyId !== "string") {
+            return null;
+        }
+        return parsed as StoredPromptAgent;
+    } catch {
+        return null;
+    }
+}
+
+function serializeStoredPromptAgent(stored: StoredPromptAgent): string {
+    return JSON.stringify(stored);
+}
+
+type AuthClient = Parameters<typeof createApiKeyForUser>[0]["authClient"];
+
+// Mints a dedicated owner sk_ key for the agent's internal calls and returns
+// the plaintext key (for injection) plus its id (for later deletion). The key
+// carries no account permissions — it only spends the owner's balance on
+// gen/image calls, exactly like the owner calling the API themselves.
+async function mintOwnerKey(
+    authClient: AuthClient,
+    dbBinding: D1Database,
+    userId: string,
+    agentName: string,
+): Promise<{ key: string; keyId: string }> {
+    const created = await createApiKeyForUser({
+        authClient,
+        dbBinding,
+        userId,
+        name: `prompt-agent:${agentName}`,
+        type: "secret",
+        allowAccountKeysPermission: false,
+        defaultCreatedVia: "prompt-agent",
+    });
+    return { key: created.key, keyId: created.id };
+}
+
+// Builds the deploy inputs for a prompt agent: the template source, the secret
+// bindings the template reads, and the blob to store in `source`. Mints the
+// owner key as a side effect.
+export async function buildPromptAgentDeploy(input: {
+    authClient: AuthClient;
+    dbBinding: D1Database;
+    userId: string;
+    agentName: string;
+    config: PromptAgentConfig;
+}): Promise<{
+    source: string;
+    storedSource: string;
+    extraBindings: { name: string; text: string }[];
+    keyId: string;
+}> {
+    const { key, keyId } = await mintOwnerKey(
+        input.authClient,
+        input.dbBinding,
+        input.userId,
+        input.agentName,
+    );
+    const extraBindings = [
+        { name: "SYSTEM_PROMPT", text: input.config.systemPrompt },
+        { name: "BASE_MODEL", text: input.config.baseModel },
+        { name: "TOOLS_JSON", text: JSON.stringify(input.config.tools) },
+        { name: "MCP_JSON", text: JSON.stringify(input.config.mcpServers) },
+        { name: "POLLINATIONS_KEY", text: key },
+    ];
+    return {
+        source: PROMPT_AGENT_TEMPLATE_SOURCE,
+        storedSource: serializeStoredPromptAgent({
+            promptAgent: input.config,
+            keyId,
+        }),
+        extraBindings,
+        keyId,
+    };
+}

--- a/enter.pollinations.ai/src/services/worker-deploy.ts
+++ b/enter.pollinations.ai/src/services/worker-deploy.ts
@@ -72,11 +72,17 @@ async function cfApi(
 // token to reject direct public callers — the workers.dev URL is public, so
 // without it anyone with the URL could bypass the gateway's billing and, for
 // agents, spend the owner's key.
+//
+// `extraBindings` are additional secret_text bindings injected alongside
+// BEE_AUTH_TOKEN — used by platform-authored templates (e.g. the prompt-agent
+// template) to receive their config (system prompt, base model, owner key, …).
+// User-written source deploys pass none.
 export async function deployCommunityWorker(
     config: WorkerDeployConfig,
     scriptName: string,
     source: string,
     authToken: string,
+    extraBindings: { name: string; text: string }[] = [],
 ): Promise<string> {
     const form = new FormData();
     form.set(
@@ -90,6 +96,11 @@ export async function deployCommunityWorker(
                     name: "BEE_AUTH_TOKEN",
                     text: authToken,
                 },
+                ...extraBindings.map((binding) => ({
+                    type: "secret_text",
+                    name: binding.name,
+                    text: binding.text,
+                })),
             ],
         }),
     );

--- a/enter.pollinations.ai/test/prompt-agent-template.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-template.test.ts
@@ -33,6 +33,7 @@ const BASE_ENV = {
     TOOLS_JSON: JSON.stringify(["web_search"]),
     MCP_JSON: "[]",
     POLLINATIONS_KEY: "sk_test",
+    GEN_BASE_URL: "https://gen.test.example",
     BEE_AUTH_TOKEN: "secret-token",
 };
 
@@ -118,6 +119,15 @@ describe("prompt-agent template", () => {
         // web_search ran once and its usage summed into the total.
         expect(json.usage.tool_call_counts).toEqual({ web_search: 1 });
         expect(json.usage.prompt_tokens).toBeGreaterThan(10);
+        // Calls the injected gateway (the minted key is only valid there), not
+        // the hardcoded production origin.
+        for (const call of fetchMock.mock.calls) {
+            const url =
+                typeof call[0] === "string"
+                    ? call[0]
+                    : (call[0] as Request).url;
+            expect(url.startsWith("https://gen.test.example")).toBe(true);
+        }
     });
 
     it("streams SSE with usage on the final chunk when stream:true", async () => {

--- a/enter.pollinations.ai/test/prompt-agent-template.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-template.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PROMPT_AGENT_TEMPLATE_SOURCE } from "../src/services/prompt-agent-template.ts";
+
+// Load the template (a self-contained ES module string) as a real module and
+// drive its default fetch handler, mocking global fetch so the base-model and
+// tool calls are controllable. This exercises the tool loop, streaming SSE
+// framing, and tool-error recovery for real rather than by string match.
+type AgentModule = {
+    default: {
+        fetch: (
+            request: Request,
+            env: Record<string, string>,
+        ) => Promise<Response>;
+    };
+};
+
+async function loadTemplate(): Promise<AgentModule["default"]> {
+    // The template is a single-file ES module string. The Workers test pool
+    // can't dynamically import a data: URL, so evaluate the body directly:
+    // rewrite `export default {` to `return {` and run it in a function scope.
+    // The template has no imports, so nothing else needs resolving.
+    const body = PROMPT_AGENT_TEMPLATE_SOURCE.replace(
+        /export default \{/,
+        "return {",
+    );
+    const factory = new Function(`${body}`);
+    return factory() as AgentModule["default"];
+}
+
+const BASE_ENV = {
+    SYSTEM_PROMPT: "You are a test agent.",
+    BASE_MODEL: "openai",
+    TOOLS_JSON: JSON.stringify(["web_search"]),
+    MCP_JSON: "[]",
+    POLLINATIONS_KEY: "sk_test",
+    BEE_AUTH_TOKEN: "secret-token",
+};
+
+function chatRequest(body: Record<string, unknown>): Request {
+    return new Request("https://bee.example.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: "Bearer secret-token",
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+describe("prompt-agent template", () => {
+    beforeEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("rejects callers without the auth token", async () => {
+        const agent = await loadTemplate();
+        const res = await agent.fetch(
+            new Request("https://bee.example.com/v1/chat/completions", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ messages: [] }),
+            }),
+            BASE_ENV,
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it("runs the tool loop and returns a chat.completion with tool_call_counts", async () => {
+        // web_search runs as an internal chat call, so every completions call
+        // after the first tool-requesting turn returns content.
+        let n = 0;
+        const fetchMock = vi.fn(async () => {
+            n++;
+            if (n === 1) {
+                return Response.json({
+                    choices: [
+                        {
+                            message: {
+                                role: "assistant",
+                                content: "",
+                                tool_calls: [
+                                    {
+                                        id: "c1",
+                                        function: {
+                                            name: "web_search",
+                                            arguments: '{"query":"x"}',
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    usage: { prompt_tokens: 10, completion_tokens: 5 },
+                });
+            }
+            return Response.json({
+                choices: [{ message: { role: "assistant", content: "done" } }],
+                usage: { prompt_tokens: 4, completion_tokens: 2 },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const agent = await loadTemplate();
+        const res = await agent.fetch(
+            chatRequest({ messages: [{ role: "user", content: "hi" }] }),
+            BASE_ENV,
+        );
+        expect(res.status).toBe(200);
+        const json = (await res.json()) as {
+            choices: { message: { content: string }; finish_reason: string }[];
+            usage: {
+                prompt_tokens: number;
+                tool_call_counts: Record<string, number>;
+            };
+        };
+        expect(json.choices[0].message.content).toBe("done");
+        expect(json.choices[0].finish_reason).toBe("stop");
+        // web_search ran once and its usage summed into the total.
+        expect(json.usage.tool_call_counts).toEqual({ web_search: 1 });
+        expect(json.usage.prompt_tokens).toBeGreaterThan(10);
+    });
+
+    it("streams SSE with usage on the final chunk when stream:true", async () => {
+        const fetchMock = vi.fn(async () =>
+            Response.json({
+                choices: [
+                    { message: { role: "assistant", content: "hello world" } },
+                ],
+                usage: { prompt_tokens: 6, completion_tokens: 4 },
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const agent = await loadTemplate();
+        const res = await agent.fetch(
+            chatRequest({
+                messages: [{ role: "user", content: "hi" }],
+                stream: true,
+            }),
+            BASE_ENV,
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("text/event-stream");
+        const text = await res.text();
+        const events = text
+            .split("\n\n")
+            .map((block) => block.replace(/^data: /, "").trim())
+            .filter((line) => line.length > 0);
+        expect(events.at(-1)).toBe("[DONE]");
+        const dataEvents = events
+            .filter((e) => e !== "[DONE]")
+            .map((e) => JSON.parse(e));
+        // First chunk carries the content delta; final chunk carries the
+        // finish_reason and usage (where the gateway reads tool_call_counts).
+        expect(dataEvents[0].choices[0].delta.content).toBe("hello world");
+        const finalChunk = dataEvents.at(-1);
+        expect(finalChunk.choices[0].finish_reason).toBe("stop");
+        expect(finalChunk.usage.tool_call_counts).toEqual({});
+        expect(finalChunk.usage.prompt_tokens).toBe(6);
+    });
+
+    it("feeds a failing tool's error back to the model instead of 502", async () => {
+        let n = 0;
+        const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+            const url = new URL(
+                typeof input === "string" ? input : (input as Request).url,
+            );
+            n++;
+            // First turn: ask for the image tool.
+            if (n === 1) {
+                return Response.json({
+                    choices: [
+                        {
+                            message: {
+                                role: "assistant",
+                                content: "",
+                                tool_calls: [
+                                    {
+                                        id: "c1",
+                                        function: {
+                                            name: "image",
+                                            arguments: '{"prompt":"cat"}',
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    usage: { prompt_tokens: 3, completion_tokens: 1 },
+                });
+            }
+            // The image tool hits /image/* and fails.
+            if (url.pathname.startsWith("/image/")) {
+                return new Response("upstream boom", { status: 500 });
+            }
+            // Next model turn recovers and answers.
+            return Response.json({
+                choices: [
+                    {
+                        message: {
+                            role: "assistant",
+                            content: "sorry, image failed",
+                        },
+                    },
+                ],
+                usage: { prompt_tokens: 2, completion_tokens: 2 },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const agent = await loadTemplate();
+        const res = await agent.fetch(
+            chatRequest({
+                messages: [{ role: "user", content: "draw a cat" }],
+            }),
+            { ...BASE_ENV, TOOLS_JSON: JSON.stringify(["image"]) },
+        );
+        // A tool failure does not fail the request.
+        expect(res.status).toBe(200);
+        const json = (await res.json()) as {
+            choices: { message: { content: string } }[];
+            usage: { tool_call_counts: Record<string, number> };
+        };
+        expect(json.choices[0].message.content).toBe("sorry, image failed");
+        // The (failed) tool call is still counted — the owner's tool ran.
+        expect(json.usage.tool_call_counts).toEqual({ image: 1 });
+    });
+});

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -103,6 +103,9 @@ TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events
 STRIPE_MODE = "live"
 STRIPE_SUCCESS_URL = "https://enter.pollinations.ai"
 BETTER_AUTH_URL = "https://enter.pollinations.ai"
+# Gateway origin injected into prompt-agent workers; the minted owner key is
+# only valid against this environment's gen, so it must match the deploy env.
+GEN_BASE_URL = "https://gen.pollinations.ai"
 # Stripe Payment Method Configurations (live)
 STRIPE_AUTO_TOP_UP_PMC_ID = "pmc_1TVU4T7rcjS3l7trqtBuve71"
 # Single broad checkout PMC; Stripe filters methods by buyer currency/country.
@@ -137,6 +140,8 @@ TINYBIRD_STRIPE_INGEST_URL = "https://api.europe-west2.gcp.tinybird.co/v0/events
 STRIPE_MODE = "sandbox"
 STRIPE_SUCCESS_URL = "https://staging.enter.pollinations.ai"
 BETTER_AUTH_URL = "https://staging.enter.pollinations.ai"
+# Staging gen gateway; the minted owner key is only valid against staging gen.
+GEN_BASE_URL = "https://staging.gen.pollinations.ai"
 STRIPE_AUTO_TOP_UP_PMC_ID = "pmc_1TUpob6O03AauPe8EgmA4mvg"
 # Single broad checkout PMC; Stripe filters methods by buyer currency/country.
 STRIPE_PMC = "pmc_1SrYT96O03AauPe8ijLy6sZU"

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1918,6 +1918,7 @@ fixtureTest(
             "TOOLS_JSON",
             "MCP_JSON",
             "POLLINATIONS_KEY",
+            "GEN_BASE_URL",
         ]) {
             expect(bindingByName[name]).toMatchObject({ type: "secret_text" });
         }

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1810,3 +1810,153 @@ fixtureTest(
         );
     },
 );
+
+fixtureTest(
+    "deploys the prompt-agent template with config bindings and a minted owner key",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `bee-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const cfRequests: Request[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            const url = new URL(request.url);
+            if (url.hostname !== "api.cloudflare.com") {
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }
+            cfRequests.push(request.clone() as Request);
+            if (
+                request.method === "GET" &&
+                url.pathname.endsWith("/workers/subdomain")
+            ) {
+                return Response.json({
+                    success: true,
+                    result: { subdomain: "staging-sub" },
+                });
+            }
+            return Response.json({ success: true, result: {} });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const deployEnv = {
+            ...env,
+            CF_WORKER_DEPLOY_ACCOUNT_ID: "cf-account",
+            CF_WORKER_DEPLOY_API_TOKEN: "cf-deploy-token",
+        };
+        const enterApi = await createEnterCommunityApi();
+        const cookie = await signedSessionCookie(sessionToken);
+        const promptAgent = {
+            systemPrompt: "You are a terse SQL tutor.",
+            baseModel: "openai-fast",
+            tools: ["web_search"],
+            mcpServers: [{ name: "docs", url: "https://mcp.example.com/rpc" }],
+        };
+        // No source, no baseUrl, no bearerToken — a prompt agent manages its own.
+        const createResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    name: modelName,
+                    promptAgent,
+                    completionTextPrice: 0.1,
+                    toolPrices: { web_search: 0.002 },
+                }),
+            }),
+            deployEnv,
+        );
+        expect(createResponse.status).toBe(200);
+        const created = (await createResponse.json()) as {
+            id: string;
+            kind: string;
+            source: string | null;
+            promptAgent: typeof promptAgent | null;
+        };
+        // Prompt agents default to the agent kind, never expose their raw
+        // source blob, and surface the config as promptAgent.
+        expect(created.kind).toBe("agent");
+        expect(created.source).toBeNull();
+        expect(created.promptAgent).toMatchObject({
+            systemPrompt: "You are a terse SQL tutor.",
+            baseModel: "openai-fast",
+            tools: ["web_search"],
+        });
+
+        const scriptName = `bee-${created.id}`;
+        const putRequest = cfRequests.find(
+            (request) => request.method === "PUT",
+        );
+        if (!putRequest) throw new Error("No worker upload PUT captured");
+        const form = await putRequest.formData();
+        const metadata = JSON.parse(String(form.get("metadata")));
+        const bindingByName = Object.fromEntries(
+            (metadata.bindings ?? []).map((b: { name: string }) => [b.name, b]),
+        );
+        // The template config is injected as secret_text bindings alongside the
+        // auth token, and the minted owner key is present (never returned).
+        for (const name of [
+            "BEE_AUTH_TOKEN",
+            "SYSTEM_PROMPT",
+            "BASE_MODEL",
+            "TOOLS_JSON",
+            "MCP_JSON",
+            "POLLINATIONS_KEY",
+        ]) {
+            expect(bindingByName[name]).toMatchObject({ type: "secret_text" });
+        }
+        expect(bindingByName.SYSTEM_PROMPT.text).toBe(
+            "You are a terse SQL tutor.",
+        );
+        expect(bindingByName.BASE_MODEL.text).toBe("openai-fast");
+        expect(JSON.parse(bindingByName.TOOLS_JSON.text)).toEqual([
+            "web_search",
+        ]);
+        expect(JSON.parse(bindingByName.MCP_JSON.text)).toEqual([
+            { name: "docs", url: "https://mcp.example.com/rpc" },
+        ]);
+        expect(bindingByName.POLLINATIONS_KEY.text).toMatch(/^sk_/);
+        // The deployed module is the platform template, not user source.
+        await expect((form.get("index.mjs") as File).text()).resolves.toContain(
+            "MAX_TOOL_ROUNDS",
+        );
+
+        // Delete retires the worker (its source is non-null) like any deploy.
+        cfRequests.length = 0;
+        const deleteResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${created.id}`,
+                {
+                    method: "DELETE",
+                    headers: { Cookie: cookie },
+                },
+            ),
+            deployEnv,
+        );
+        expect(deleteResponse.status).toBe(200);
+        const deleteWorkerCall = cfRequests.find(
+            (request) => request.method === "DELETE",
+        );
+        if (!deleteWorkerCall) throw new Error("No worker DELETE captured");
+        expect(new URL(deleteWorkerCall.url).pathname).toBe(
+            `/client/v4/accounts/cf-account/workers/scripts/${scriptName}`,
+        );
+    },
+);

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -119,6 +119,19 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
         }
     }
 
+    if (opts.promptAgent !== undefined) {
+        try {
+            body.promptAgent = JSON.parse(
+                readFileSync(String(opts.promptAgent), "utf8"),
+            );
+        } catch (err) {
+            printError(
+                `Failed to read/parse --prompt-agent JSON file: ${err instanceof Error ? err.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    }
+
     if (opts.kind !== undefined) {
         if (opts.kind !== "model" && opts.kind !== "agent") {
             printError("--kind must be 'model' or 'agent'");
@@ -149,16 +162,23 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
     }
 
     if (includeRequired) {
-        for (const required of ["name", "bearerToken"]) {
-            if (!body[required]) {
-                printError(
-                    `--${required.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} is required`,
-                );
-                process.exit(1);
-            }
+        if (!body.name) {
+            printError("--name is required");
+            process.exit(1);
         }
-        if (!body.baseUrl === !body.source) {
-            printError("Provide exactly one of --base-url or --source");
+        const modeCount = [body.baseUrl, body.source, body.promptAgent].filter(
+            (value) => value !== undefined,
+        ).length;
+        if (modeCount !== 1) {
+            printError(
+                "Provide exactly one of --base-url, --source, or --prompt-agent",
+            );
+            process.exit(1);
+        }
+        // A bearer token is only meaningful for a self-hosted --base-url
+        // endpoint; source and prompt-agent deploys mint their own.
+        if (body.baseUrl !== undefined && !body.bearerToken) {
+            printError("--bearer-token is required with --base-url");
             process.exit(1);
         }
     }
@@ -212,8 +232,12 @@ const create = addPriceOptions(
                 "--source <file>",
                 "Worker source file to deploy as a hosted endpoint (instead of --base-url)",
             )
+            .option(
+                "--prompt-agent <file>",
+                "JSON config file for a no-code prompt agent: { systemPrompt, baseModel, tools?, mcpServers? }",
+            )
             .option("--upstream-model <model>", "Upstream model id")
-            .requiredOption("--bearer-token <token>", "Upstream bearer token"),
+            .option("--bearer-token <token>", "Upstream bearer token"),
     ),
 ).action(async (opts) => {
     const key = requireKey();


### PR DESCRIPTION
Stacked on #12263. Adds the beginner rung of the hosted-agents ladder: register an agent with a config, no code.

## What
- **New `promptAgent` mode** on `my-models`: `{ systemPrompt, baseModel, tools, mcpServers }`. The platform deploys a fixed template worker with the config injected as bindings and mints a dedicated owner `sk_` key for its internal calls — the caller writes no code.
- **Template tool loop** (`prompt-agent-template.ts`): calls the base model with the declared tools; runs built-in `web_search`/`image` against our gen/image endpoints; calls MCP servers over Streamable-HTTP JSON-RPC; feeds results back; bounded by a fixed step ceiling (an agentic-step bound, not a retry). Emits `usage.tool_call_counts`.
- **Billing unchanged**: per-tool fees bill on `tool_call_counts` exactly as for any community endpoint (MCP calls bill under `mcp_call`).
- **Reuses the source-deploy path**: `extraBindings` on `deployCommunityWorker`; config stored as JSON in `source` so create-rollback, switch-away, and delete cleanup work uniformly; delete/switch-away revokes the minted key.
- `kind` defaults to `agent`; response surfaces `promptAgent` and never the raw blob or key id.
- **CLI + skill**: `polli my-models create --prompt-agent <file>`; a `create-agent` skill teaching an AI to stand one up.

## Trust model
No arbitrary user code runs on our key at any level: prompt (nothing external), built-in tools (our infra), MCP (the user's own server, we're just a client). The `BEE_AUTH_TOKEN` gate + invite-only allowlist are the boundary.

## Test
- New gen integration test asserts the template deploys with all config bindings, the minted `sk_`, `kind: agent`, `promptAgent` surfaced (no raw blob), and delete retires the worker.
- All 23 gen + 3 enter community-endpoint tests pass; enter/gen/cli tsc clean; biome clean.

Addresses #11373

🤖 Generated with [Claude Code](https://claude.com/claude-code)