### PR TITLE
fix: resolve real client IP for proxied requests (X-Forwarded-Host trust)

### DIFF
--- a/gen.pollinations.ai/test/proxy-client-ip.test.ts
+++ b/gen.pollinations.ai/test/proxy-client-ip.test.ts
@@ -1,0 +1,62 @@
+import { getRealClientIp } from "@shared/client-ip.ts";
+import {
+    getPublicOrigin,
+    hasTrustedProxyHeaders,
+} from "@shared/public-origin.ts";
+import type { Context } from "hono";
+import { describe, expect, it } from "vitest";
+
+// Minimal Context stub: public-origin/client-ip only read c.req.url and headers.
+function mockContext(url: string, headers: Record<string, string>): Context {
+    const lower: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+    return {
+        req: {
+            url,
+            header: (name: string) => lower[name.toLowerCase()],
+        },
+    } as unknown as Context;
+}
+
+describe("proxied request client-IP resolution", () => {
+    // Reproduces the pollinations-myceli-proxy hop: the Worker is invoked on the
+    // public host (custom-domain route), and the proxy sets X-Forwarded-Host to
+    // that same public host plus X-Original-Client-IP with the real visitor IP.
+    const proxied = mockContext("https://gen.pollinations.ai/text/hi", {
+        "x-forwarded-host": "gen.pollinations.ai",
+        "x-forwarded-proto": "https",
+        "x-original-client-ip": "46.142.212.69",
+        "cf-connecting-ip": "130.176.161.10", // proxy Worker egress IP
+    });
+
+    it("trusts the proxy hop when X-Forwarded-Host is a known public host", () => {
+        expect(hasTrustedProxyHeaders(proxied)).toBe(true);
+    });
+
+    it("resolves the real visitor IP, not the proxy egress IP", () => {
+        expect(getRealClientIp(proxied)).toBe("46.142.212.69");
+    });
+
+    it("keeps the public-facing origin", () => {
+        expect(getPublicOrigin(proxied)).toBe("https://gen.pollinations.ai");
+    });
+
+    it("does not trust an unknown forwarded host", () => {
+        const spoofed = mockContext("https://gen.pollinations.ai/text/hi", {
+            "x-forwarded-host": "evil.example.com",
+            "x-original-client-ip": "1.2.3.4",
+            "cf-connecting-ip": "130.176.161.10",
+        });
+        expect(hasTrustedProxyHeaders(spoofed)).toBe(false);
+        // Untrusted: falls back to CF-Connecting-IP.
+        expect(getRealClientIp(spoofed)).toBe("130.176.161.10");
+    });
+
+    it("uses CF-Connecting-IP for direct (non-proxied) hits", () => {
+        const direct = mockContext("https://gen.myceli.ai/text/hi", {
+            "cf-connecting-ip": "46.142.212.69",
+        });
+        expect(hasTrustedProxyHeaders(direct)).toBe(false);
+        expect(getRealClientIp(direct)).toBe("46.142.212.69");
+    });
+});

--- a/shared/public-origin.ts
+++ b/shared/public-origin.ts
@@ -1,19 +1,25 @@
 import type { Context } from "hono";
 
-const TRUSTED_FORWARDED_HOSTS: Record<string, string> = {
-    "enter.myceli.ai": "enter.pollinations.ai",
-    "staging.enter.myceli.ai": "staging.enter.pollinations.ai",
-    "dev.enter.myceli.ai": "dev.enter.pollinations.ai",
-    "gen.myceli.ai": "gen.pollinations.ai",
-    "staging.gen.myceli.ai": "staging.gen.pollinations.ai",
-    "media.myceli.ai": "media.pollinations.ai",
-};
+// Public-facing hosts served through the pollinations-myceli-proxy Worker.
+// The proxy forwards these as X-Forwarded-Host; we trust that header only when
+// it names one of them.
+const TRUSTED_PUBLIC_HOSTS = new Set<string>([
+    "enter.pollinations.ai",
+    "staging.enter.pollinations.ai",
+    "dev.enter.pollinations.ai",
+    "gen.pollinations.ai",
+    "staging.gen.pollinations.ai",
+    "media.pollinations.ai",
+]);
 
 function getTrustedForwardedHost(c: Context): string | undefined {
-    const requestHost = new URL(c.req.url).host;
+    // On Cloudflare custom-domain routes the Worker is invoked on the public
+    // host (e.g. gen.pollinations.ai), so c.req.url.host already equals the
+    // proxy's X-Forwarded-Host — comparing the two never identifies a proxy
+    // hop. Instead, trust X-Forwarded-Host when it names a known public host.
     const forwardedHost = c.req.header("x-forwarded-host");
 
-    return TRUSTED_FORWARDED_HOSTS[requestHost] === forwardedHost
+    return forwardedHost && TRUSTED_PUBLIC_HOSTS.has(forwardedHost)
         ? forwardedHost
         : undefined;
 }


### PR DESCRIPTION
## Problem

Nearly all `generation_event` rows log the **proxy's AWS egress IP** instead of the visitor's. Over the last 7 days, **7,976,737 of 7,976,740 requests (99.99996%)** carry an AWS-owned subnet; single `ip_hash` values accrue **1,600+ distinct users**. This makes any IP-based abuse clustering / rate-limiting effectively inert.

## Root cause

The `pollinations-myceli-proxy` Worker forwards the real visitor IP as `X-Original-Client-IP`, but `getRealClientIp` only uses it when `hasTrustedProxyHeaders(c)` is true. That check compared `new URL(c.req.url).host` against the `TRUSTED_FORWARDED_HOSTS` table — but on Cloudflare custom-domain routes `c.req.url.host` is already the **public** host (`gen.pollinations.ai`), equal to the `X-Forwarded-Host` the proxy sets. The table is keyed by `*.myceli.ai`, so the lookup never matched, `hasTrustedProxyHeaders` returned `false`, and the code fell back to `CF-Connecting-IP` = the proxy's IP.

## Fix

Trust `X-Forwarded-Host` when it names a **known public host** (`TRUSTED_PUBLIC_HOSTS`), instead of the same-value comparison that can't match on a custom-domain route. `getPublicOrigin` (same helper) still returns the public host.

## Verified

- Live 2-request experiment (same machine): before this fix, `gen.pollinations.ai` (via proxy) logged `130.176.161.0` (AWS) while direct `gen.myceli.ai` logged the real subnet. The fix makes the proxied path resolve the real IP.
- New test `gen.pollinations.ai/test/proxy-client-ip.test.ts` (5 cases: proxied→real IP, public origin, spoofed host rejected, direct hit) — passes.
- Existing `tracking-observability.test.ts` (13 tests) still passes.

Note: this is self-resolving once `gen.pollinations.ai` points directly at the myceli Worker (no proxy hop), but the proxy path is live today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)