### PR TITLE
fix: inject real viewer IP via CloudFront function for gen.pollinations.ai

### DIFF
--- a/gen.pollinations.ai/test/proxy-client-ip.test.ts
+++ b/gen.pollinations.ai/test/proxy-client-ip.test.ts
@@ -59,4 +59,22 @@ describe("proxied request client-IP resolution", () => {
         expect(hasTrustedProxyHeaders(direct)).toBe(false);
         expect(getRealClientIp(direct)).toBe("46.142.212.69");
     });
+
+    // The CloudFront pln-gen-viewer-ip function overwrites X-Original-Client-IP
+    // with event.viewer.ip before the request leaves the edge, so any value a
+    // client tried to spoof is gone by the time the Worker trusts the header.
+    // From the Worker's perspective it simply reads the (already-overwritten)
+    // value — this documents that a trusted hop's X-Original-Client-IP is
+    // authoritative even though the raw header name is client-controllable.
+    it("uses the CloudFront-injected client IP on a trusted hop", () => {
+        const viaCloudFront = mockContext(
+            "https://gen.pollinations.ai/text/hi",
+            {
+                "x-forwarded-host": "gen.pollinations.ai",
+                "x-original-client-ip": "46.142.212.69", // injected by CloudFront fn
+                "cf-connecting-ip": "64.252.67.10", // Origin Shield egress IP
+            },
+        );
+        expect(getRealClientIp(viaCloudFront)).toBe("46.142.212.69");
+    });
 });

--- a/infra/cloudfront/README.md
+++ b/infra/cloudfront/README.md
@@ -1,0 +1,49 @@
+# CloudFront: gen.pollinations.ai
+
+AWS CloudFront in front of the `gen.pollinations.ai` Cloudflare Worker.
+
+- **Account:** `301235909293` (CLI profile `admin`, region `us-east-1`)
+- **Distribution:** `E35MFLKOJK04O7` — aliases `gen.pollinations.ai`, `gen-aws.pollinations.ai`
+- **Origin:** `gen.myceli.ai` (Worker `pollinations-gen-production`)
+
+```
+viewer ──▶ CloudFront ──▶ Origin Shield (us-east-1) ──▶ gen.myceli.ai
+             └─ viewer-request fn: pln-gen-viewer-ip (stamps real viewer IP)
+```
+
+**Origin Shield (us-east-1):** routes all origin fetches through IAD to avoid a
+Cloudflare edge stall at East-Asia colos that hung requests (499/TTFB=0).
+Rollback: `OriginShield.Enabled=false`.
+
+**`pln-gen-viewer-ip`** (`gen-viewer-request.js`): Origin Shield collapses
+viewers to shared `64.252.x` IPs, so this stamps the real `event.viewer.ip` into
+`X-Original-Client-IP` at the edge. The Worker trusts it (see
+`shared/client-ip.ts`); the function overwrites any client-spoofed value.
+
+**Do not change the origin request policy** — `Managed-AllViewerExceptHostHeader`
+keeps `Host: gen.myceli.ai` (Cloudflare routes on it) and forwards the injected
+header.
+
+**Logs** → CloudWatch `/cloudfront/gen-pollinations` + S3
+`pollinations-cf-logs-301235909293`. ⚠️ contain `sk_`/`pk_` keys — keep restricted.
+
+## Deploy the function
+
+```bash
+PROFILE=admin REGION=us-east-1 FN=pln-gen-viewer-ip
+
+# update code + publish (create-function/associate only needed first time)
+ETAG=$(aws cloudfront describe-function --name $FN --stage DEVELOPMENT \
+  --profile $PROFILE --region $REGION --query ETag --output text)
+aws cloudfront update-function --name $FN --if-match "$ETAG" \
+  --function-config '{"Comment":"real viewer IP for gen.pollinations.ai","Runtime":"cloudfront-js-2.0"}' \
+  --function-code fileb://infra/cloudfront/gen-viewer-request.js \
+  --profile $PROFILE --region $REGION
+ETAG=$(aws cloudfront describe-function --name $FN --stage DEVELOPMENT \
+  --profile $PROFILE --region $REGION --query ETag --output text)
+aws cloudfront publish-function --name $FN --if-match "$ETAG" \
+  --profile $PROFILE --region $REGION
+```
+
+Associate (first time): add to distribution `DefaultCacheBehavior`:
+`FunctionAssociations = {Quantity:1, Items:[{FunctionARN:.../function/pln-gen-viewer-ip, EventType:viewer-request}]}`.

--- a/infra/cloudfront/gen-viewer-request.js
+++ b/infra/cloudfront/gen-viewer-request.js
@@ -1,0 +1,26 @@
+// CloudFront viewer-request function for the gen.pollinations.ai distribution.
+//
+// Function name: pln-gen-viewer-ip
+// Runtime:       cloudfront-js-2.0
+// Distribution:  E35MFLKOJK04O7 (gen.pollinations.ai -> origin gen.myceli.ai)
+// Event type:    viewer-request (DefaultCacheBehavior)
+//
+// Why: the distribution runs with Origin Shield (us-east-1), which collapses
+// every viewer to a handful of shared 64.252.x egress IPs by the time the
+// request reaches the origin Worker. That destroys per-client IP data used for
+// rate limiting and abuse detection. This function stamps the true viewer IP
+// into X-Original-Client-IP at the edge, before Origin Shield. The origin
+// Worker trusts that header only when X-Forwarded-Host is a known public host
+// (see shared/public-origin.ts + shared/client-ip.ts), and CloudFront's
+// AllViewerExceptHostHeader origin-request policy forwards function-added
+// headers to the origin.
+//
+// Security: this unconditionally overwrites any client-supplied
+// X-Original-Client-IP, so the value the origin trusts always comes from
+// CloudFront, never from the caller.
+//
+// See infra/cloudfront/README.md to (re)deploy.
+function handler(event) {
+    event.request.headers["x-original-client-ip"] = { value: event.viewer.ip };
+    return event.request;
+}

--- a/shared/client-ip.ts
+++ b/shared/client-ip.ts
@@ -2,11 +2,18 @@ import type { Context } from "hono";
 import { hasTrustedProxyHeaders } from "./public-origin.ts";
 
 /**
- * Resolve the real visitor IP. When the worker is reached via the
- * pollinations-myceli-proxy in the old Cloudflare account, CF-Connecting-IP is the
- * proxy Worker's IP — useless for rate limiting or abuse detection. The proxy
- * forwards the original visitor IP as X-Original-Client-IP, which we prefer
- * when present.
+ * Resolve the real visitor IP. When the worker is reached through a trusted
+ * proxy hop, CF-Connecting-IP is the proxy's egress IP — useless for rate
+ * limiting or abuse detection — so we prefer X-Original-Client-IP instead.
+ * Two trusted proxies set that header (both gated by hasTrustedProxyHeaders,
+ * which only trusts a known X-Forwarded-Host):
+ *   - pollinations-myceli-proxy (old Cloudflare account Worker) forwards it.
+ *   - AWS CloudFront in front of gen.pollinations.ai injects it via the
+ *     `pln-gen-viewer-ip` viewer-request function (event.viewer.ip). Without
+ *     this, Origin Shield collapses every client to a handful of 64.252.x
+ *     egress IPs. The function overwrites any client-supplied value, so a
+ *     spoofed X-Original-Client-IP cannot survive the CloudFront hop.
+ *     See infra/cloudfront/README.md for the full stack.
  *
  * For direct hits (e.g. *.myceli.ai), only CF-Connecting-IP is present and
  * already correct.


### PR DESCRIPTION
## What

- Adds CloudFront viewer-request function `pln-gen-viewer-ip` (`infra/cloudfront/`) that stamps `event.viewer.ip` into `X-Original-Client-IP` before Origin Shield.
- Documents the full gen CloudFront stack (distribution config, Origin Shield, logging) in `infra/cloudfront/README.md`.
- Adds a test for the CloudFront-injected client-IP case.
- Small comment update in `shared/client-ip.ts`.

## Why

Origin Shield (us-east-1, added to fix the East-Asia hang) collapses every client to ~5 shared `64.252.x` egress IPs by the time the request reaches the Worker — breaking per-client rate limiting and abuse detection. The function restores the real viewer IP at the edge. It overwrites any client-supplied value, so the trusted header can't be spoofed through CloudFront.

## Deploy

- **Function is already live** (deployed + associated on distribution `E35MFLKOJK04O7`, 2026-07-07 14:41Z). This PR is the source + docs of record.
- **No Worker runtime change** — `getRealClientIp` already prefers `X-Original-Client-IP` on trusted hops (#12282). No production sync needed.

## Verified in prod

- Spoofed `x-original-client-ip: 9.9.9.9` → Tinybird recorded my real subnet `46.142.212.0`, not the spoof.
- Traffic flipped from 100% `64.252.x` to real diverse client subnets; last 3 min = 2,907 real vs 0 shield.
- No health regression across the deploy boundary (volume/5xx/latency steady); 499s stayed at healthy ~1% with no East-Asia concentration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)