### PR TITLE
docs: add install command to polli skill

### DIFF
--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash(polli *)
 
 Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video; transcribes speech; manages API keys, usage, quests, and invite-only my-models.
 
+Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
+
 ## When to use this skill
 
 - User asks to **generate an image / text / audio / video** via pollinations


### PR DESCRIPTION
- Adds `npm i -g @pollinations/cli@latest` to the polli SKILL.md.
- The skill assumed `polli` was already on PATH; the old `@pollinations_ai` scope now 404s, so documenting the current scope prevents a dead install command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)