### PR TITLE
feat: provider-neutral identity (handle + account-normalized github)

### DIFF
--- a/.github/scripts/app-validate-submission.js
+++ b/.github/scripts/app-validate-submission.js
@@ -37,7 +37,7 @@ async function main() {
                 "ISSUE_AUTHOR is required but was empty or undefined",
             );
         }
-        const cmd = `cd enter.pollinations.ai && npx wrangler d1 execute DB --remote --env production --command "SELECT id, tier FROM user WHERE LOWER(github_username) = LOWER('${safeUsername}');" --json`;
+        const cmd = `cd enter.pollinations.ai && npx wrangler d1 execute DB --remote --env production --command "SELECT u.id, u.tier FROM user u JOIN account a ON a.user_id = u.id AND a.provider_id = 'github' WHERE LOWER(a.username) = LOWER('${safeUsername}');" --json`;
         const output = execSync(cmd, {
             encoding: "utf-8",
             stdio: ["pipe", "pipe", "pipe"],

--- a/apps/operation/quest-dashboard/worker.js
+++ b/apps/operation/quest-dashboard/worker.js
@@ -6,7 +6,7 @@
 // Recent feed with attribution.
 const FEED_SQL = `
   SELECT r.id, r.quest_id, r.title, r.pollen_amount, r.balance_bucket,
-         r.earned_at, r.claimed_at, u.github_username, u.name, u.image
+         r.earned_at, r.claimed_at, u.handle AS github_username, u.name, u.image
     FROM rewards r LEFT JOIN user u ON u.id = r.user_id
    ORDER BY CASE WHEN r.earned_at > 10000000000 THEN r.earned_at ELSE r.earned_at * 1000 END DESC
    LIMIT 40`;
@@ -28,7 +28,7 @@ const TOT_SQL = `
     FROM rewards`;
 
 const TOP_SQL = `
-  SELECT u.github_username, u.name, u.image, COUNT(*) AS quests,
+  SELECT u.handle AS github_username, u.name, u.image, COUNT(*) AS quests,
          SUM(r.pollen_amount) AS pollen
     FROM rewards r LEFT JOIN user u ON u.id = r.user_id
    GROUP BY r.user_id ORDER BY pollen DESC LIMIT 8`;

--- a/enter.pollinations.ai/drizzle/0035_regular_natasha_romanoff.sql
+++ b/enter.pollinations.ai/drizzle/0035_regular_natasha_romanoff.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `account` ADD `username` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_account_provider_account` ON `account` (`provider_id`,`account_id`);--> statement-breakpoint
+ALTER TABLE `user` ADD `handle` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_user_handle_lower` ON `user` (lower("handle"));

--- a/enter.pollinations.ai/drizzle/0036_handle_backfill.sql
+++ b/enter.pollinations.ai/drizzle/0036_handle_backfill.sql
@@ -1,0 +1,19 @@
+-- Backfill provider-neutral handle + per-account username from the legacy
+-- user.github_username column. GitHub usernames are unique, so handles are unique.
+-- Idempotent: only fills rows that are still NULL.
+
+--> statement-breakpoint
+UPDATE `account`
+SET `username` = (
+  SELECT `user`.`github_username`
+  FROM `user`
+  WHERE `user`.`id` = `account`.`user_id`
+)
+WHERE `account`.`provider_id` = 'github'
+  AND `account`.`username` IS NULL;
+
+--> statement-breakpoint
+UPDATE `user`
+SET `handle` = `github_username`
+WHERE `handle` IS NULL
+  AND `github_username` IS NOT NULL;

--- a/enter.pollinations.ai/drizzle/meta/0035_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,1542 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "17c475bc-7141-4911-9607-2c40876ac03e",
+  "prevId": "b06b2fc4-e749-4253-90ba-e8da6ee5f553",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_handle_lower": {
+          "name": "idx_user_handle_lower",
+          "columns": [
+            "lower(\"handle\")"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_user_handle_lower": {
+        "columns": {
+          "lower(\"handle\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1783448082083,
       "tag": "0035_regular_natasha_romanoff",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1783448438606,
+      "tag": "0036_handle_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1782911825724,
       "tag": "0034_opposite_ultron",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1783448082083,
+      "tag": "0035_regular_natasha_romanoff",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/components/auth/app-attribution.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/app-attribution.tsx
@@ -2,6 +2,9 @@ import { InfoTip } from "@pollinations/ui";
 
 type Attribution = {
     appName?: string;
+    /** Provider-neutral handle — the canonical author display name. */
+    handle?: string | null;
+    /** Real GitHub login; present only when a GitHub account is linked. */
     githubUsername?: string;
     found?: boolean;
 };
@@ -22,6 +25,7 @@ export function AppAttribution({
     const displayName =
         attribution?.appName ??
         (isDeviceMode ? "A device" : redirectHostname || "An app");
+    const authorHandle = attribution?.handle || attribution?.githubUsername;
     const tipText = [
         "Same as copy-pasting an API key into their app.",
         "Only share with apps you trust.",
@@ -31,17 +35,23 @@ export function AppAttribution({
             <p className="text-theme-text-strong">
                 <span className="font-bold text-lg">{displayName}</span>
             </p>
-            {attribution?.githubUsername && (
+            {authorHandle && (
                 <p className="text-sm text-theme-text-base mt-1">
                     by{" "}
-                    <a
-                        href={`https://github.com/${attribution.githubUsername}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-medium underline hover:text-theme-text-strong"
-                    >
-                        @{attribution.githubUsername}
-                    </a>
+                    {attribution?.githubUsername ? (
+                        // Only link to github.com when a GitHub account is
+                        // actually linked — a bare handle gets plain text.
+                        <a
+                            href={`https://github.com/${attribution.githubUsername}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium underline hover:text-theme-text-strong"
+                        >
+                            @{authorHandle}
+                        </a>
+                    ) : (
+                        <span className="font-medium">@{authorHandle}</span>
+                    )}
                 </p>
             )}
             {!isDeviceMode && attribution?.appName && redirectHostname && (

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -46,6 +46,7 @@ type Attribution = {
     clientId?: string;
     userId?: string;
     userName?: string;
+    handle?: string | null;
     githubUsername?: string;
     appName?: string;
     redirectUris?: string[];
@@ -603,7 +604,7 @@ export function Authorize() {
                             />
                         )}
                         <span className="text-sm font-medium text-theme-text-strong truncate">
-                            {user.githubUsername || user.email}
+                            {user.handle || user.githubUsername || user.email}
                         </span>
                     </a>
                     <div className="inline-flex items-stretch rounded-full bg-theme-bg-pale border border-theme-border text-sm overflow-hidden shrink-0">

--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -50,7 +50,6 @@ const brandWordmarkMask: CSSProperties = {
 type DashboardShellProps = PropsWithChildren<{
     activePage: DashboardPage;
     navItems?: readonly DashboardNavItem[];
-    handle?: string | null;
     githubUsername?: string;
     githubAvatarUrl?: string;
     onPageChange: (page: DashboardPage) => void;

--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -50,6 +50,7 @@ const brandWordmarkMask: CSSProperties = {
 type DashboardShellProps = PropsWithChildren<{
     activePage: DashboardPage;
     navItems?: readonly DashboardNavItem[];
+    handle?: string | null;
     githubUsername?: string;
     githubAvatarUrl?: string;
     onPageChange: (page: DashboardPage) => void;

--- a/enter.pollinations.ai/frontend/src/routes/index.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/index.tsx
@@ -92,7 +92,7 @@ export const Route = createFileRoute("/")({
                   githubUsername?: string | null;
               })
             | undefined;
-        const githubUsername =
+        const displayName =
             profileResult?.handle ??
             profileResult?.githubUsername ??
             sessionUser?.githubUsername ??
@@ -100,7 +100,7 @@ export const Route = createFileRoute("/")({
 
         return {
             user: context.user,
-            githubUsername,
+            githubUsername: displayName,
             apiKeys,
             tierData,
             tierBalance,
@@ -118,7 +118,7 @@ function RouteComponent() {
     const router = useRouter();
     const {
         user,
-        githubUsername,
+        githubUsername: displayName,
         apiKeys,
         tierData,
         tierBalance,
@@ -253,7 +253,7 @@ function RouteComponent() {
     return (
         <DashboardShell
             activePage={activePage}
-            githubUsername={githubUsername}
+            githubUsername={displayName}
             githubAvatarUrl={user?.image || ""}
             onPageChange={handlePageChange}
             onSignOut={handleSignOut}

--- a/enter.pollinations.ai/frontend/src/routes/index.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/index.tsx
@@ -87,10 +87,16 @@ export const Route = createFileRoute("/")({
         const tierWeek = earningsTodayResult?.tierWeek ?? 0;
         // Prefer D1; session (KV-cached) may hold a stale username after relog.
         const sessionUser = context.user as
-            | (typeof context.user & { githubUsername?: string | null })
+            | (typeof context.user & {
+                  handle?: string | null;
+                  githubUsername?: string | null;
+              })
             | undefined;
         const githubUsername =
-            profileResult?.githubUsername ?? sessionUser?.githubUsername ?? "";
+            profileResult?.handle ??
+            profileResult?.githubUsername ??
+            sessionUser?.githubUsername ??
+            "";
 
         return {
             user: context.user,

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -81,6 +81,7 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
                 mapProfileToUser: (profile) => ({
                     githubId: profile.id,
                     githubUsername: profile.login,
+                    handle: profile.login,
                 }),
             },
         },

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -41,13 +41,14 @@ export function sanitizeHandle(raw: string): string {
 /**
  * Ensure a candidate handle is unique in the DB.
  * Tries candidate, candidate-1 … candidate-4 then falls back to candidate-<6 random chars>.
+ * All returned handles are capped at 39 chars (GitHub username max).
  */
 export async function ensureUniqueHandle(
     db: DrizzleD1Database<typeof betterAuthSchema>,
     candidate: string,
 ): Promise<string> {
     for (let i = 0; i < 5; i++) {
-        const attempt = i === 0 ? candidate : `${candidate}-${i}`;
+        const attempt = i === 0 ? candidate : `${candidate.slice(0, 37)}-${i}`;
         const clash = await db
             .select({ id: betterAuthSchema.user.id })
             .from(betterAuthSchema.user)
@@ -55,7 +56,10 @@ export async function ensureUniqueHandle(
             .get();
         if (!clash) return attempt;
     }
-    return `${candidate}-${crypto.randomUUID().slice(0, 6)}`;
+    return `${candidate.slice(0, 32)}-${crypto.randomUUID().slice(0, 6)}`.slice(
+        0,
+        39,
+    );
 }
 
 /**

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -19,8 +19,83 @@ import {
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
 import { admin, openAPI } from "better-auth/plugins";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { drizzle } from "drizzle-orm/d1";
+
+/**
+ * Sanitize a raw string into a valid handle:
+ * - lowercase, non-alphanumeric/hyphen chars become dashes
+ * - collapse consecutive dashes, strip leading/trailing dashes
+ * - cap at 39 chars (GitHub username max)
+ */
+export function sanitizeHandle(raw: string): string {
+    return raw
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 39);
+}
+
+/**
+ * Ensure a candidate handle is unique in the DB.
+ * Tries candidate, candidate-1 … candidate-4 then falls back to candidate-<6 random chars>.
+ */
+export async function ensureUniqueHandle(
+    db: DrizzleD1Database<typeof betterAuthSchema>,
+    candidate: string,
+): Promise<string> {
+    for (let i = 0; i < 5; i++) {
+        const attempt = i === 0 ? candidate : `${candidate}-${i}`;
+        const clash = await db
+            .select({ id: betterAuthSchema.user.id })
+            .from(betterAuthSchema.user)
+            .where(sql`lower(${betterAuthSchema.user.handle}) = ${attempt}`)
+            .get();
+        if (!clash) return attempt;
+    }
+    return `${candidate}-${crypto.randomUUID().slice(0, 6)}`;
+}
+
+/**
+ * For every new user that arrives without a handle (e.g. Google, email/password),
+ * derive one from the email local-part and ensure it is unique.
+ * GitHub signups are untouched — mapProfileToUser already set handle = profile.login.
+ */
+function handleFallbackPlugin(env: Cloudflare.Env): BetterAuthPlugin {
+    return {
+        id: "handle-fallback",
+        init: () => ({
+            options: {
+                databaseHooks: {
+                    user: {
+                        create: {
+                            before: async (user: GenericUser) => {
+                                const u = user as GenericUser & {
+                                    handle?: string | null;
+                                };
+                                if (u.handle) return { data: u };
+
+                                const db = drizzle(env.DB, {
+                                    schema: betterAuthSchema,
+                                });
+                                const localPart = u.email.split("@")[0] ?? "";
+                                const sanitized = sanitizeHandle(localPart);
+                                const candidate = sanitized || "user";
+                                const handle = await ensureUniqueHandle(
+                                    db,
+                                    candidate,
+                                );
+                                return { data: { ...u, handle } };
+                            },
+                        },
+                    },
+                },
+            } satisfies Partial<BetterAuthOptions>,
+        }),
+    } satisfies BetterAuthPlugin;
+}
 
 export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
     const db = drizzle(env.DB);
@@ -90,6 +165,7 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
             apiKeyPlugin,
             tierPlugin(env, ctx),
             stagingAccessPlugin(env),
+            handleFallbackPlugin(env),
             openAPIPlugin,
         ],
         telemetry: { enabled: false },

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -5,7 +5,10 @@ import {
     StagingAccessDeniedError,
 } from "@shared/auth/api-key.ts";
 import * as betterAuthSchema from "@shared/db/better-auth.ts";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    account as accountTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import { sendTierEventToTinybird } from "@shared/events.ts";
 import { AUTH_TRUSTED_ORIGINS } from "@shared/public-urls.ts";
 import { DEFAULT_TIER } from "@shared/tier-config.ts";
@@ -19,7 +22,7 @@ import {
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
 import { admin, openAPI } from "better-auth/plugins";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { drizzle } from "drizzle-orm/d1";
 
@@ -209,13 +212,17 @@ function tierPlugin(
 }
 
 /**
- * Sync github_username on every login.
+ * Sync github username on every login.
  * GitHub usernames are mutable — users can rename their account.
- * We fetch the current username from GitHub API using the immutable github_id
- * and update D1 if it changed. Non-blocking via waitUntil.
+ * We read the github `account` row (accountId = immutable GitHub numeric ID,
+ * username = last-known login), fetch the current login from GitHub API, and
+ * write back if it changed.
  *
- * GitHub is the only auth provider, so every user row has a github_id; we skip
- * the sync defensively if it is ever missing.
+ * Dual-write: updates both `account.username` (canonical, new) and
+ * `user.githubUsername` (legacy column) so a rollback stays lossless.
+ * `user.handle` is intentionally NOT touched — the handle is stable.
+ *
+ * Non-blocking via waitUntil.
  */
 function onAfterSessionCreate(
     env: Cloudflare.Env,
@@ -229,16 +236,24 @@ function onAfterSessionCreate(
             (async () => {
                 try {
                     const db = drizzle(env.DB);
-                    const [user] = await db
+
+                    // Read from the account row — accountId is the immutable
+                    // GitHub numeric user ID; username is the last-synced login.
+                    const [acct] = await db
                         .select({
-                            githubId: userTable.githubId,
-                            githubUsername: userTable.githubUsername,
+                            githubId: accountTable.accountId,
+                            username: accountTable.username,
                         })
-                        .from(userTable)
-                        .where(eq(userTable.id, session.userId))
+                        .from(accountTable)
+                        .where(
+                            and(
+                                eq(accountTable.userId, session.userId),
+                                eq(accountTable.providerId, "github"),
+                            ),
+                        )
                         .limit(1);
 
-                    const githubId = user?.githubId;
+                    const githubId = acct?.githubId;
                     if (!githubId) return;
 
                     const headers: Record<string, string> = {
@@ -261,10 +276,18 @@ function onAfterSessionCreate(
                     }
 
                     const profile = (await res.json()) as { login: string };
-                    if (
-                        profile.login &&
-                        profile.login !== user?.githubUsername
-                    ) {
+                    if (profile.login && profile.login !== acct?.username) {
+                        // Write account.username (canonical new column)
+                        await db
+                            .update(accountTable)
+                            .set({ username: profile.login })
+                            .where(
+                                and(
+                                    eq(accountTable.userId, session.userId),
+                                    eq(accountTable.providerId, "github"),
+                                ),
+                            );
+                        // Dual-write: keep legacy user.github_username in sync
                         await db
                             .update(userTable)
                             .set({ githubUsername: profile.login })

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -277,21 +277,24 @@ function onAfterSessionCreate(
 
                     const profile = (await res.json()) as { login: string };
                     if (profile.login && profile.login !== acct?.username) {
-                        // Write account.username (canonical new column)
-                        await db
-                            .update(accountTable)
-                            .set({ username: profile.login })
-                            .where(
-                                and(
-                                    eq(accountTable.userId, session.userId),
-                                    eq(accountTable.providerId, "github"),
+                        // Atomic dual-write: update both account.username (canonical)
+                        // and user.githubUsername (legacy) in a single batch transaction.
+                        // If either fails, the entire batch rolls back — no orphaned state.
+                        await db.batch([
+                            db
+                                .update(accountTable)
+                                .set({ username: profile.login })
+                                .where(
+                                    and(
+                                        eq(accountTable.userId, session.userId),
+                                        eq(accountTable.providerId, "github"),
+                                    ),
                                 ),
-                            );
-                        // Dual-write: keep legacy user.github_username in sync
-                        await db
-                            .update(userTable)
-                            .set({ githubUsername: profile.login })
-                            .where(eq(userTable.id, session.userId));
+                            db
+                                .update(userTable)
+                                .set({ githubUsername: profile.login })
+                                .where(eq(userTable.id, session.userId)),
+                        ]);
                     }
                 } catch (e) {
                     console.error(

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -66,9 +66,13 @@ export async function ensureUniqueHandle(
 }
 
 /**
- * For every new user that arrives without a handle (e.g. Google, email/password),
- * derive one from the email local-part and ensure it is unique.
- * GitHub signups are untouched — mapProfileToUser already set handle = profile.login.
+ * Normalises the handle for every new user before the row is written.
+ *
+ * - GitHub signups: `mapProfileToUser` sets `handle = profile.login`.
+ *   We still run it through `sanitizeHandle` (lowercases, strips bad chars)
+ *   and `ensureUniqueHandle` so a new GitHub user whose login collides with an
+ *   existing handle gets a suffix instead of hitting the unique index.
+ * - All other providers (Google, email/password, …): derive from email local-part.
  */
 function handleFallbackPlugin(env: Cloudflare.Env): BetterAuthPlugin {
     return {
@@ -82,13 +86,17 @@ function handleFallbackPlugin(env: Cloudflare.Env): BetterAuthPlugin {
                                 const u = user as GenericUser & {
                                     handle?: string | null;
                                 };
-                                if (u.handle) return { data: u };
-
                                 const db = drizzle(env.DB, {
                                     schema: betterAuthSchema,
                                 });
-                                const localPart = u.email.split("@")[0] ?? "";
-                                const sanitized = sanitizeHandle(localPart);
+                                // Use existing handle (e.g. from GitHub login) or fall back
+                                // to email local-part. sanitizeHandle lowercases so the
+                                // ensureUniqueHandle probe (`lower(handle) = ${attempt}`)
+                                // is always comparing equal-case strings.
+                                const raw = u.handle
+                                    ? u.handle
+                                    : (u.email.split("@")[0] ?? "");
+                                const sanitized = sanitizeHandle(raw);
                                 const candidate = sanitized || "user";
                                 const handle = await ensureUniqueHandle(
                                     db,

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -13,6 +13,7 @@ import { sendTierEventToTinybird } from "@shared/events.ts";
 import { AUTH_TRUSTED_ORIGINS } from "@shared/public-urls.ts";
 import { DEFAULT_TIER } from "@shared/tier-config.ts";
 import {
+    type Account,
     type BetterAuthOptions,
     type BetterAuthPlugin,
     betterAuth,
@@ -112,6 +113,50 @@ function handleFallbackPlugin(env: Cloudflare.Env): BetterAuthPlugin {
     } satisfies BetterAuthPlugin;
 }
 
+/**
+ * Sets `account.username` synchronously when a GitHub account row is created
+ * (fresh signup), so brand-new users have the live GitHub login available
+ * immediately — `/account/profile` and the APPS.md `LOWER(a.username)` join
+ * must not have to wait for the async login sync in `onAfterSessionCreate`.
+ *
+ * NOTE: this reads the legacy dual-written `user.github_username` column
+ * (written by `mapProfileToUser` and committed before better-auth creates the
+ * account row in the signup flow). When the identity contract PR drops that
+ * column, re-source this value (e.g. from the OAuth profile in context).
+ * Link flows where the user row has no github_username leave `username`
+ * unset — the async login sync remains the corrector there.
+ */
+export function onBeforeAccountCreate(env: Cloudflare.Env) {
+    return async (account: Account & { username?: string | null }) => {
+        if (account.providerId !== "github" || account.username) return;
+        const db = drizzle(env.DB);
+        const [row] = await db
+            .select({ githubUsername: userTable.githubUsername })
+            .from(userTable)
+            .where(eq(userTable.id, account.userId))
+            .limit(1);
+        if (!row?.githubUsername) return;
+        return { data: { ...account, username: row.githubUsername } };
+    };
+}
+
+function githubAccountUsernamePlugin(env: Cloudflare.Env): BetterAuthPlugin {
+    return {
+        id: "github-account-username",
+        init: () => ({
+            options: {
+                databaseHooks: {
+                    account: {
+                        create: {
+                            before: onBeforeAccountCreate(env),
+                        },
+                    },
+                },
+            } satisfies Partial<BetterAuthOptions>,
+        }),
+    } satisfies BetterAuthPlugin;
+}
+
 export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
     const db = drizzle(env.DB);
     const apiKeyPlugin = createApiKeyPlugin();
@@ -164,6 +209,9 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
         user: {
             additionalFields: authAdditionalFields.user,
         },
+        account: {
+            additionalFields: authAdditionalFields.account,
+        },
         socialProviders: {
             github: {
                 clientId: env.GITHUB_CLIENT_ID,
@@ -181,6 +229,7 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
             tierPlugin(env, ctx),
             stagingAccessPlugin(env),
             handleFallbackPlugin(env),
+            githubAccountUsernamePlugin(env),
             openAPIPlugin,
         ],
         telemetry: { enabled: false },

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -3,6 +3,7 @@ import {
     type ApiKeyType,
     createApiKeyForUser,
 } from "@shared/auth/api-key-creation.ts";
+import { getLinkedGithub } from "@shared/auth/github-account.ts";
 import { isCommunityEndpointOwnerAllowed } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import {
@@ -734,7 +735,16 @@ async function respondDetailedUsage(
 
 // Response schemas for OpenAPI documentation
 const profileResponseSchema = z.object({
-    githubUsername: z.string().nullable().describe("GitHub username if linked"),
+    handle: z
+        .string()
+        .nullable()
+        .describe("Public handle (provider-neutral, always returned)"),
+    githubUsername: z
+        .string()
+        .nullable()
+        .describe(
+            "@deprecated Use `handle` instead. GitHub username sourced from the linked GitHub account; null for non-GitHub users.",
+        ),
     image: z
         .string()
         .nullable()
@@ -886,7 +896,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Profile",
             description:
-                "Returns your account profile. GitHub username, profile image, current tier, next pollen refill timestamp, and community model access are always returned. Name and email are returned only when the API key has `account:profile`.",
+                "Returns your account profile. Handle, profile image, current tier, next pollen refill timestamp, and community model access are always returned. `githubUsername` is also returned (deprecated — use `handle`) and is sourced from the linked GitHub account. Name and email are returned only when the API key has `account:profile`.",
             responses: {
                 200: {
                     description: "User profile",
@@ -906,11 +916,10 @@ export const accountRoutes = new Hono<Env>()
             const includeProfilePII =
                 !apiKey || hasAccountReadPermission(apiKey, "profile");
 
-            const db = drizzle(c.env.DB);
+            const db = drizzle(c.env.DB, { schema });
             const users = await db
                 .select({
-                    githubId: userTable.githubId,
-                    githubUsername: userTable.githubUsername,
+                    handle: userTable.handle,
                     image: userTable.image,
                     tier: userTable.tier,
                     name: userTable.name,
@@ -925,13 +934,17 @@ export const accountRoutes = new Hono<Env>()
                 throw new HTTPException(404, { message: "User not found" });
             }
 
+            const gh = await getLinkedGithub(db, user.id);
+
             return c.json({
-                githubUsername: profile.githubUsername ?? null,
+                handle: profile.handle ?? null,
+                githubUsername: gh?.username ?? null, // deprecated; sourced from linked account
                 image: profile.image ?? null,
                 tier: profile.tier,
                 nextResetAt: getNextRefillAt(profile.tier),
-                communityEndpointsAllowed:
-                    isCommunityEndpointOwnerAllowed(profile),
+                communityEndpointsAllowed: isCommunityEndpointOwnerAllowed({
+                    githubId: gh?.githubId ?? null,
+                }),
                 ...(includeProfilePII && {
                     name: profile.name ?? null,
                     email: profile.email ?? null,

--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -16,6 +16,7 @@ async function resolveAttribution(
 ) {
     const meta = parseMetadata(keyRow.metadata);
     const user = await db.query.user.findFirst({
+        columns: { name: true, handle: true },
         where: eq(schema.user.id, keyRow.userId),
     });
     const redirectUris = getRedirectUris(meta);
@@ -24,7 +25,7 @@ async function resolveAttribution(
         clientId: keyRow.id,
         userId: keyRow.userId,
         userName: user?.name,
-        githubUsername: user?.githubUsername || undefined,
+        githubUsername: user?.handle || undefined, // deprecated field name; now sourced from handle
         appName: keyRow.name,
         redirectUris,
         earningsEnabled: meta.earningsEnabled === true,

--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -1,3 +1,4 @@
+import { getLinkedGithub } from "@shared/auth/github-account.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { eq } from "drizzle-orm";
@@ -19,13 +20,18 @@ async function resolveAttribution(
         columns: { name: true, handle: true },
         where: eq(schema.user.id, keyRow.userId),
     });
+    // Real GitHub login from the linked account row — undefined when the user
+    // has no linked GitHub account (or no synced username). The consent screen
+    // must only render a github.com link for actual GitHub identities.
+    const github = await getLinkedGithub(db, keyRow.userId);
     const redirectUris = getRedirectUris(meta);
     return {
         found: true as const,
         clientId: keyRow.id,
         userId: keyRow.userId,
         userName: user?.name,
-        githubUsername: user?.handle || undefined, // deprecated field name; now sourced from handle
+        handle: user?.handle || undefined,
+        githubUsername: github?.username || undefined,
         appName: keyRow.name,
         redirectUris,
         earningsEnabled: meta.earningsEnabled === true,
@@ -46,7 +52,7 @@ const AppLookupQuerySchema = z.object({
         .startsWith("pk_")
         .optional()
         .describe(
-            "Your publishable App Key (pk_...). When provided, the consent screen shows your app name and GitHub username. Canonical OAuth name.",
+            "Your publishable App Key (pk_...). When provided, the consent screen shows your app name and handle. Canonical OAuth name.",
         ),
     app_key: z
         .string()

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,3 +1,4 @@
+import { getLinkedGithub } from "@shared/auth/github-account.ts";
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
     type CommunityEndpointPriceKey,
@@ -142,37 +143,29 @@ async function requireCommunityEndpointAccess(
     db: Db,
     userId: string,
 ): Promise<void> {
-    const user = await db.query.user.findFirst({
-        columns: { githubId: true },
-        where: eq(schema.user.id, userId),
-    });
-
-    if (!isCommunityEndpointOwnerAllowed(user)) {
+    const gh = await getLinkedGithub(db, userId);
+    if (!isCommunityEndpointOwnerAllowed({ githubId: gh?.githubId ?? null })) {
         throw new HTTPException(403, {
             message: "Community endpoints are invite-only",
         });
     }
 }
 
-async function requireOwnerGithubUsername(
-    db: Db,
-    userId: string,
-): Promise<string> {
+async function requireOwnerHandle(db: Db, userId: string): Promise<string> {
     const owner = await db.query.user.findFirst({
-        columns: { githubUsername: true },
+        columns: { handle: true },
         where: eq(schema.user.id, userId),
     });
-    if (owner?.githubUsername) return owner.githubUsername;
+    if (owner?.handle) return owner.handle;
     throw new HTTPException(400, {
-        message:
-            "A GitHub username is required to register community endpoints",
+        message: "A handle is required to register community endpoints",
     });
 }
 
-function toResponse(row: CommunityEndpointRow, ownerGithubUsername: string) {
+function toResponse(row: CommunityEndpointRow, ownerHandle: string) {
     return {
         id: row.id,
-        modelId: communityModelId(ownerGithubUsername, row.name),
+        modelId: communityModelId(ownerHandle, row.name),
         name: row.name,
         description: row.description,
         baseUrl: row.baseUrl,
@@ -314,16 +307,13 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 user.id,
                 c.var.auth.apiKey,
             );
-            const ownerGithubUsername = await requireOwnerGithubUsername(
-                db,
-                user.id,
-            );
+            const ownerHandle = await requireOwnerHandle(db, user.id);
             const rows = await db.query.communityEndpoint.findMany({
                 where: eq(schema.communityEndpoint.ownerUserId, user.id),
                 orderBy: (endpoint, { desc }) => [desc(endpoint.createdAt)],
             });
             return c.json({
-                data: rows.map((row) => toResponse(row, ownerGithubUsername)),
+                data: rows.map((row) => toResponse(row, ownerHandle)),
             });
         },
     )
@@ -358,10 +348,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 user.id,
                 c.var.auth.apiKey,
             );
-            const ownerGithubUsername = await requireOwnerGithubUsername(
-                db,
-                user.id,
-            );
+            const ownerHandle = await requireOwnerHandle(db, user.id);
             await ensureModelNameAvailable(db, user.id, input.name);
             const id = crypto.randomUUID();
             const [row] = await db
@@ -382,7 +369,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     updatedAt: new Date(),
                 })
                 .returning();
-            return c.json(toResponse(row, ownerGithubUsername));
+            return c.json(toResponse(row, ownerHandle));
         },
     )
     .post(
@@ -518,10 +505,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 user.id,
                 c.var.auth.apiKey,
             );
-            const ownerGithubUsername = await requireOwnerGithubUsername(
-                db,
-                user.id,
-            );
+            const ownerHandle = await requireOwnerHandle(db, user.id);
             const endpoint = await requireOwnedEndpoint(db, id, user.id);
             await ensureModelNameAvailable(
                 db,
@@ -566,7 +550,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     ),
                 )
                 .returning();
-            return c.json(toResponse(row, ownerGithubUsername));
+            return c.json(toResponse(row, ownerHandle));
         },
     )
     .delete(

--- a/enter.pollinations.ai/src/routes/device.ts
+++ b/enter.pollinations.ai/src/routes/device.ts
@@ -355,7 +355,7 @@ export async function handleUserinfo(c: AuthedContext) {
             name: true,
             email: true,
             image: true,
-            githubUsername: true,
+            handle: true,
         },
     });
     if (!row) {
@@ -365,6 +365,6 @@ export async function handleUserinfo(c: AuthedContext) {
         sub: row.id,
         ...(includeProfilePII && { name: row.name, email: row.email }),
         picture: row.image,
-        preferred_username: row.githubUsername,
+        preferred_username: row.handle,
     });
 }

--- a/enter.pollinations.ai/src/services/quest-checker.ts
+++ b/enter.pollinations.ai/src/services/quest-checker.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "@logtape/logtape";
+import { getLinkedGithub } from "@shared/auth/github-account.ts";
 import { recordRewards } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { eq } from "drizzle-orm";
@@ -88,16 +89,20 @@ async function loadQuestUser(
     userId: string,
 ): Promise<QuestUser | null> {
     const rows = await db
-        .select({
-            id: schema.user.id,
-            githubId: schema.user.githubId,
-            githubUsername: schema.user.githubUsername,
-        })
+        .select({ id: schema.user.id })
         .from(schema.user)
         .where(eq(schema.user.id, userId))
         .limit(1);
 
-    return rows[0] ?? null;
+    const row = rows[0];
+    if (!row) return null;
+
+    const linked = await getLinkedGithub(db, userId);
+    return {
+        id: row.id,
+        githubId: linked?.githubId ?? null,
+        githubUsername: linked?.username ?? null,
+    };
 }
 
 async function findGroupRewardProposals(

--- a/enter.pollinations.ai/test/api-key-hydration.test.ts
+++ b/enter.pollinations.ai/test/api-key-hydration.test.ts
@@ -1,0 +1,43 @@
+import { env } from "cloudflare:test";
+import { authenticateApiKeyRequest } from "@shared/auth/api-key.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+test("resolved user hydrates githubId/githubUsername from the account row", async ({
+    apiKey,
+}) => {
+    const db = drizzle(env.DB, { schema });
+
+    // The fixture creates a user via GitHub OAuth; get that user's id.
+    const [u] = await db
+        .select({ id: schema.user.id })
+        .from(schema.user)
+        .limit(1);
+
+    // Replace any existing github account rows with one that has
+    // known, assertable values — so the hydration result is deterministic.
+    await db.delete(schema.account).where(eq(schema.account.userId, u.id));
+
+    await db.insert(schema.account).values({
+        id: "a-fixture-github-hydration",
+        accountId: "98765",
+        providerId: "github",
+        username: "fixtureuser",
+        userId: u.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const result = await authenticateApiKeyRequest({
+        request: new Request("http://localhost/", {
+            headers: { Authorization: `Bearer ${apiKey}` },
+        }),
+        env,
+    });
+
+    expect(result?.user?.githubId).toBe(98765);
+    expect(result?.user?.githubUsername).toBe("fixtureuser");
+});

--- a/enter.pollinations.ai/test/community-endpoints.test.ts
+++ b/enter.pollinations.ai/test/community-endpoints.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Handler-level tests for the community-endpoints route.
+ *
+ * Step 1 (failing): create handler returns modelId keyed on user.handle, even
+ * when user.githubUsername is null.  This drives the requireOwnerHandle migration.
+ */
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+const MY_MODELS = "http://localhost:3000/api/account/my-models";
+
+/**
+ * Seed the DB so that:
+ *  - user.handle = "testuser" (already set by GitHub OAuth signup fixture)
+ *  - user.githubUsername = null  (simulates identity-normalization migration)
+ *  - account row has an allowed githubId so access check passes
+ */
+async function seedAllowedUser(db: ReturnType<typeof drizzle<typeof schema>>) {
+    const [u] = await db
+        .select({ id: schema.user.id })
+        .from(schema.user)
+        .limit(1);
+
+    // Wipe githubUsername from the user row (handle stays as "testuser").
+    await db
+        .update(schema.user)
+        .set({ githubUsername: null })
+        .where(eq(schema.user.id, u.id));
+
+    // Replace the github account row with one that has an allowed github id.
+    await db.delete(schema.account).where(eq(schema.account.userId, u.id));
+    await db.insert(schema.account).values({
+        id: "a-allowed-github",
+        accountId: "36901823", // ElliotEtag — on the allowlist
+        providerId: "github",
+        username: null, // deliberately null to validate we use handle, not account.username
+        userId: u.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+}
+
+test(
+    "POST /my-models returns modelId keyed on handle when githubUsername is null",
+    { timeout: 30_000 },
+    async ({ sessionToken, mocks }) => {
+        await mocks.enable("github", "tinybird");
+
+        const db = drizzle(env.DB, { schema });
+        await seedAllowedUser(db);
+
+        const res = await SELF.fetch(MY_MODELS, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                name: "my-model",
+                baseUrl: "https://upstream.example.com/v1",
+                bearerToken: "sk-test-token",
+            }),
+        });
+
+        // Should be 200 if the handler uses handle; 400 if it still requires githubUsername
+        expect(res.status, await res.clone().text()).toBe(200);
+
+        const data = (await res.json()) as { modelId: string };
+        expect(data.modelId).toBe("testuser/my-model");
+    },
+);
+
+test(
+    "GET /my-models returns modelId keyed on handle for listed endpoints",
+    { timeout: 30_000 },
+    async ({ sessionToken, mocks }) => {
+        await mocks.enable("github", "tinybird");
+
+        const db = drizzle(env.DB, { schema });
+        await seedAllowedUser(db);
+
+        // First create one
+        const createRes = await SELF.fetch(MY_MODELS, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                name: "listed-model",
+                baseUrl: "https://upstream.example.com/v1",
+                bearerToken: "sk-test-token",
+            }),
+        });
+        expect(createRes.status, await createRes.clone().text()).toBe(200);
+
+        // Now list
+        const listRes = await SELF.fetch(MY_MODELS, {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        });
+        expect(listRes.status).toBe(200);
+
+        const { data } = (await listRes.json()) as {
+            data: { modelId: string }[];
+        };
+        expect(data.length).toBeGreaterThan(0);
+        expect(data[0].modelId).toBe("testuser/listed-model");
+    },
+);

--- a/enter.pollinations.ai/test/community-endpoints.test.ts
+++ b/enter.pollinations.ai/test/community-endpoints.test.ts
@@ -113,3 +113,61 @@ test(
         expect(data[0].modelId).toBe("testuser/listed-model");
     },
 );
+
+test(
+    "POST /my-models requires a handle",
+    { timeout: 30_000 },
+    async ({ sessionToken, mocks }) => {
+        await mocks.enable("github", "tinybird");
+
+        const db = drizzle(env.DB, { schema });
+
+        // Seed user with allowed GitHub account
+        const [u] = await db
+            .select({ id: schema.user.id })
+            .from(schema.user)
+            .limit(1);
+
+        // Set both handle and githubUsername to null to ensure guard is exercised
+        await db
+            .update(schema.user)
+            .set({ handle: null, githubUsername: null })
+            .where(eq(schema.user.id, u.id));
+
+        // Replace the github account row with one that has an allowed github id
+        await db.delete(schema.account).where(eq(schema.account.userId, u.id));
+        await db.insert(schema.account).values({
+            id: "a-allowed-github",
+            accountId: "36901823", // ElliotEtag — on the allowlist
+            providerId: "github",
+            username: null,
+            userId: u.id,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const res = await SELF.fetch(MY_MODELS, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                name: "my-model",
+                baseUrl: "https://upstream.example.com/v1",
+                bearerToken: "sk-test-token",
+            }),
+        });
+
+        // Should fail because handle is null
+        const text = await res.clone().text();
+        expect(res.status, text).toBe(400);
+
+        const data = (await res.json()) as {
+            error?: { message?: string };
+        };
+        expect(data.error?.message, text).toContain(
+            "A handle is required to register community endpoints",
+        );
+    },
+);

--- a/enter.pollinations.ai/test/github-account.test.ts
+++ b/enter.pollinations.ai/test/github-account.test.ts
@@ -1,0 +1,45 @@
+import { env } from "cloudflare:test";
+import { getLinkedGithub } from "@shared/auth/github-account.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, it } from "vitest";
+
+describe("getLinkedGithub", () => {
+    it("returns githubId + username for a linked github account", async () => {
+        const db = drizzle(env.DB, { schema });
+        const userId = "u-linked";
+        await db.insert(schema.user).values({
+            id: userId,
+            name: "t",
+            email: "u-linked@test.local",
+            handle: "octocat",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        await db.insert(schema.account).values({
+            id: "a-linked",
+            accountId: "12345",
+            providerId: "github",
+            username: "octocat",
+            userId,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const result = await getLinkedGithub(db, userId);
+        expect(result).toEqual({ githubId: 12345, username: "octocat" });
+    });
+
+    it("returns null for a user with no github account", async () => {
+        const db = drizzle(env.DB, { schema });
+        const userId = "u-nogithub";
+        await db.insert(schema.user).values({
+            id: userId,
+            name: "t",
+            email: "u-nogithub@test.local",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        expect(await getLinkedGithub(db, userId)).toBeNull();
+    });
+});

--- a/enter.pollinations.ai/test/integration/account-profile.test.ts
+++ b/enter.pollinations.ai/test/integration/account-profile.test.ts
@@ -3,7 +3,7 @@ import { describe, expect } from "vitest";
 import { test } from "../fixtures.ts";
 
 describe("GET /api/account/profile", () => {
-    test("session auth returns githubUsername, image, tier, nextResetAt, name, email", async ({
+    test("session auth returns handle, githubUsername, image, tier, nextResetAt, name, email", async ({
         sessionToken,
     }) => {
         const response = await SELF.fetch(
@@ -17,6 +17,7 @@ describe("GET /api/account/profile", () => {
 
         expect(response.status).toBe(200);
         const data = (await response.json()) as Record<string, unknown>;
+        expect(data).toHaveProperty("handle");
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
         expect(data).toHaveProperty("tier");
@@ -26,7 +27,7 @@ describe("GET /api/account/profile", () => {
         expect(data).toHaveProperty("email");
     });
 
-    test("api key without profile scope returns githubUsername, image, tier, nextResetAt (no name/email)", async ({
+    test("api key without profile scope returns handle, githubUsername, image, tier, nextResetAt (no name/email)", async ({
         apiKey,
     }) => {
         const response = await SELF.fetch(
@@ -36,6 +37,7 @@ describe("GET /api/account/profile", () => {
 
         expect(response.status).toBe(200);
         const data = (await response.json()) as Record<string, unknown>;
+        expect(data).toHaveProperty("handle");
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
         expect(data).toHaveProperty("tier");

--- a/enter.pollinations.ai/test/integration/account-profile.test.ts
+++ b/enter.pollinations.ai/test/integration/account-profile.test.ts
@@ -82,6 +82,7 @@ describe("GET /api/account/profile", () => {
 
         expect(response.status).toBe(200);
         const data = (await response.json()) as Record<string, unknown>;
+        expect(data).toHaveProperty("handle");
         expect(data).toHaveProperty("githubUsername");
         expect(data).toHaveProperty("image");
         expect(data).toHaveProperty("tier");

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -711,6 +711,95 @@ describe("API Key Management", () => {
             });
         });
 
+        test("returns handle and the real github login from the account row", async ({
+            sessionToken,
+        }) => {
+            const appResponse = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "attribution-app",
+                        type: "publishable",
+                    }),
+                },
+            );
+            expect(appResponse.status).toBe(200);
+            const appKey = await appResponse.json();
+
+            const db = drizzle(env.DB, { schema });
+            // githubUsername must mirror account.username (the live GitHub
+            // login), not user.handle. Simulate a GitHub-side rename so the
+            // two values diverge.
+            await db
+                .update(schema.account)
+                .set({ username: "renamed-login" })
+                .where(eq(schema.account.providerId, "github"));
+
+            const lookup = await SELF.fetch(
+                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}`,
+            );
+            expect(lookup.status).toBe(200);
+            const body = (await lookup.json()) as {
+                found: boolean;
+                handle?: string;
+                githubUsername?: string;
+            };
+            expect(body.found).toBe(true);
+            expect(body.handle).toBe("testuser");
+            const [acct] = await db
+                .select({ username: schema.account.username })
+                .from(schema.account)
+                .where(eq(schema.account.providerId, "github"));
+            expect(body.githubUsername).toBe(acct.username);
+            expect(body.githubUsername).toBe("renamed-login");
+        });
+
+        test("omits githubUsername but keeps handle when no github account is linked", async ({
+            sessionToken,
+        }) => {
+            const appResponse = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "no-github-app",
+                        type: "publishable",
+                    }),
+                },
+            );
+            expect(appResponse.status).toBe(200);
+            const appKey = await appResponse.json();
+
+            // Remove the github account row — future non-GitHub identities
+            // have a handle but no linked GitHub account.
+            const db = drizzle(env.DB, { schema });
+            await db
+                .delete(schema.account)
+                .where(eq(schema.account.providerId, "github"));
+
+            const lookup = await SELF.fetch(
+                `http://localhost:3000/api/app-lookup?client_id=${encodeURIComponent(appKey.key)}`,
+            );
+            expect(lookup.status).toBe(200);
+            const body = (await lookup.json()) as {
+                found: boolean;
+                handle?: string;
+                githubUsername?: string;
+            };
+            expect(body.found).toBe(true);
+            expect(body.handle).toBe("testuser");
+            expect(body.githubUsername).toBeUndefined();
+        });
+
         test("createApiKey enforces same flexible redirect_uri rules", async ({
             sessionToken,
         }) => {

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -1155,13 +1155,14 @@ test("quest check records elixpo intern easter egg once", async ({
 }) => {
     const db = drizzle(env.DB, { schema });
     const user = await getOnlyUser();
+    // Update the account row so getLinkedGithub returns the elixpo identity.
     await db
-        .update(schema.user)
+        .update(schema.account)
         .set({
-            githubId: 161_109_909,
-            githubUsername: "elixpo",
+            accountId: String(161_109_909),
+            username: "elixpo",
         })
-        .where(eq(schema.user.id, user.id));
+        .where(eq(schema.account.userId, user.id));
 
     mocks.github.state.user = {
         ...mocks.github.state.user,
@@ -1310,6 +1311,16 @@ test("two lazy GitHub issue bounties each record independently", async ({
         tier: "spore",
         tierBalance: 0,
         packBalance: 0,
+    });
+    // Insert account row so getLinkedGithub resolves for this user.
+    await db.insert(schema.account).values({
+        id: "community-issue-second-user-account",
+        accountId: String(secondGithubId),
+        providerId: "github",
+        username: "second-dev",
+        userId: "community-issue-second-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
     });
 
     const issues = [
@@ -1474,4 +1485,69 @@ test("account quest history accepts account usage permission", async ({
     await expect(response.json()).resolves.toMatchObject({
         rewards: [],
     });
+});
+
+test("github quest resolves from account row when user columns are null", async ({
+    mocks,
+    sessionToken: _sessionToken,
+}) => {
+    // Proves loadQuestUser reads githubId/githubUsername from the account table,
+    // not the legacy user.github_id / user.github_username columns.
+    const db = drizzle(env.DB, { schema });
+    await mocks.enable("github", "tinybird");
+
+    // Seed a second user whose user columns are null but who has a github account row.
+    const accountGithubId = 77777;
+    const accountGithubUsername = "account-only-user";
+    const userId = "account-github-identity-user";
+
+    await db.insert(schema.user).values({
+        id: userId,
+        name: "Account GitHub Identity User",
+        email: "account-github-identity@example.com",
+        emailVerified: false,
+        image: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        githubId: null,
+        githubUsername: null,
+        tier: "spore",
+        tierBalance: 0,
+        packBalance: 0,
+    });
+
+    // Insert the github account row: accountId is the GitHub numeric id as a string.
+    await db.insert(schema.account).values({
+        id: "account-github-identity-account",
+        accountId: String(accountGithubId),
+        providerId: "github",
+        username: accountGithubUsername,
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    // Seed a quest issue assigned to this github account.
+    const issueNumber = 4242;
+    seedQuestIssue(mocks.github.state, {
+        issueNumber,
+        title: "Account identity bounty",
+        goal: "Merge the linked PR.",
+        reward: 7,
+        assigneeGithubId: accountGithubId,
+        assigneeLogin: accountGithubUsername,
+        completedByPrNumber: issueNumber + 1000,
+    });
+
+    const result = await checkQuestsForUser(env, userId);
+    // The quest should resolve using the account row's github identity.
+    expect(result.recorded).toBeGreaterThanOrEqual(1);
+
+    const rewards = await db
+        .select({ questId: schema.rewards.questId })
+        .from(schema.rewards)
+        .where(eq(schema.rewards.userId, userId));
+    expect(
+        rewards.some((r) => r.questId === `github:issue:${issueNumber}`),
+    ).toBe(true);
 });

--- a/enter.pollinations.ai/test/signup-handle.test.ts
+++ b/enter.pollinations.ai/test/signup-handle.test.ts
@@ -1,0 +1,21 @@
+import { env } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+// After a GitHub OAuth signup the user row's handle should be set to
+// the GitHub login from the mocked profile ("testuser").
+test("github signup persists handle from profile.login", async ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    sessionToken: _sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+
+    const [u] = await db
+        .select({ handle: schema.user.handle })
+        .from(schema.user)
+        .limit(1);
+
+    expect(u.handle).toBe("testuser");
+});

--- a/enter.pollinations.ai/test/signup-handle.test.ts
+++ b/enter.pollinations.ai/test/signup-handle.test.ts
@@ -140,11 +140,43 @@ describe("ensureUniqueHandle", () => {
         await db.insert(schema.user).values(rows);
 
         const result = await ensureUniqueHandle(db, "full");
-        // Should be "full-<6 hex chars>" — not one of the 5 taken values
-        expect(result).toMatch(/^full-[a-f0-9-]{6,}$/);
+        // Should be "full-<exactly 6 hex chars>" — not one of the 5 taken values
+        expect(result).toMatch(/^full-[a-f0-9-]{6}$/);
         expect(["full", "full-1", "full-2", "full-3", "full-4"]).not.toContain(
             result,
         );
+    });
+
+    it("caps suffixed handles at 39 chars for a 39-char base candidate", async () => {
+        const db = drizzle(env.DB, { schema });
+
+        const maxHandle = "a".repeat(39);
+
+        // Seed the base handle and its -1 variant to force random path
+        await db.insert(schema.user).values([
+            {
+                id: "seed-cap0",
+                name: "Cap0",
+                email: "cap0@example.com",
+                emailVerified: false,
+                handle: maxHandle,
+                tier: "spore",
+            },
+            {
+                id: "seed-cap1",
+                name: "Cap1",
+                email: "cap1@example.com",
+                emailVerified: false,
+                handle: `${maxHandle.slice(0, 37)}-1`,
+                tier: "spore",
+            },
+        ]);
+
+        const result = await ensureUniqueHandle(db, maxHandle);
+        // Result should be capped at 39 chars and not equal to either taken value
+        expect(result.length).toBeLessThanOrEqual(39);
+        expect(result).not.toBe(maxHandle);
+        expect(result).not.toBe(`${maxHandle.slice(0, 37)}-1`);
     });
 
     it("is case-insensitive: TAKEN clashes with taken", async () => {

--- a/enter.pollinations.ai/test/signup-handle.test.ts
+++ b/enter.pollinations.ai/test/signup-handle.test.ts
@@ -1,7 +1,8 @@
 import { env } from "cloudflare:test";
 import * as schema from "@shared/db/better-auth.ts";
 import { drizzle } from "drizzle-orm/d1";
-import { expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import { ensureUniqueHandle, sanitizeHandle } from "../src/auth.ts";
 import { test } from "./fixtures.ts";
 
 // After a GitHub OAuth signup the user row's handle should be set to
@@ -18,4 +19,147 @@ test("github signup persists handle from profile.login", async ({
         .limit(1);
 
     expect(u.handle).toBe("testuser");
+});
+
+// ── sanitizeHandle ────────────────────────────────────────────────────────────
+
+describe("sanitizeHandle", () => {
+    it("lowercases input", () => {
+        expect(sanitizeHandle("Alice")).toBe("alice");
+    });
+
+    it("replaces dots and plus signs with dashes", () => {
+        expect(sanitizeHandle("alice.bob+tag")).toBe("alice-bob-tag");
+    });
+
+    it("collapses consecutive invalid chars into a single dash", () => {
+        expect(sanitizeHandle("alice..bob")).toBe("alice-bob");
+    });
+
+    it("strips leading and trailing dashes", () => {
+        expect(sanitizeHandle(".alice.")).toBe("alice");
+    });
+
+    it("caps at 39 characters", () => {
+        const long = "a".repeat(50);
+        expect(sanitizeHandle(long).length).toBe(39);
+    });
+
+    it("returns empty string when all chars are invalid", () => {
+        expect(sanitizeHandle("!@#$%^&*()")).toBe("");
+    });
+
+    it("handles slashes (URL-unsafe chars become dashes)", () => {
+        expect(sanitizeHandle("foo/bar")).toBe("foo-bar");
+    });
+
+    it("preserves valid alphanumeric and hyphen chars", () => {
+        expect(sanitizeHandle("my-handle-123")).toBe("my-handle-123");
+    });
+
+    it("handles mixed uppercase and symbols", () => {
+        expect(sanitizeHandle("Hello.World+42")).toBe("hello-world-42");
+    });
+});
+
+// ── ensureUniqueHandle ────────────────────────────────────────────────────────
+
+describe("ensureUniqueHandle", () => {
+    it("returns the candidate when no clash exists", async () => {
+        const db = drizzle(env.DB, { schema });
+        const result = await ensureUniqueHandle(db, "newuser");
+        expect(result).toBe("newuser");
+    });
+
+    it("appends -1 when the base handle is taken", async () => {
+        const db = drizzle(env.DB, { schema });
+
+        // Seed a user with handle "taken"
+        await db.insert(schema.user).values({
+            id: "seed-1",
+            name: "Seed User",
+            email: "seed1@example.com",
+            emailVerified: false,
+            handle: "taken",
+            tier: "spore",
+        });
+
+        const result = await ensureUniqueHandle(db, "taken");
+        expect(result).toBe("taken-1");
+    });
+
+    it("increments suffix until a free slot is found", async () => {
+        const db = drizzle(env.DB, { schema });
+
+        // Occupy "multi", "multi-1", "multi-2"
+        await db.insert(schema.user).values([
+            {
+                id: "seed-m0",
+                name: "M0",
+                email: "m0@example.com",
+                emailVerified: false,
+                handle: "multi",
+                tier: "spore",
+            },
+            {
+                id: "seed-m1",
+                name: "M1",
+                email: "m1@example.com",
+                emailVerified: false,
+                handle: "multi-1",
+                tier: "spore",
+            },
+            {
+                id: "seed-m2",
+                name: "M2",
+                email: "m2@example.com",
+                emailVerified: false,
+                handle: "multi-2",
+                tier: "spore",
+            },
+        ]);
+
+        const result = await ensureUniqueHandle(db, "multi");
+        expect(result).toBe("multi-3");
+    });
+
+    it("falls back to random suffix when 0-4 are all taken", async () => {
+        const db = drizzle(env.DB, { schema });
+
+        // Occupy "full", "full-1", "full-2", "full-3", "full-4"
+        const rows = ["full", "full-1", "full-2", "full-3", "full-4"].map(
+            (handle, i) => ({
+                id: `seed-f${i}`,
+                name: `F${i}`,
+                email: `f${i}@example.com`,
+                emailVerified: false as const,
+                handle,
+                tier: "spore",
+            }),
+        );
+        await db.insert(schema.user).values(rows);
+
+        const result = await ensureUniqueHandle(db, "full");
+        // Should be "full-<6 hex chars>" — not one of the 5 taken values
+        expect(result).toMatch(/^full-[a-f0-9-]{6,}$/);
+        expect(["full", "full-1", "full-2", "full-3", "full-4"]).not.toContain(
+            result,
+        );
+    });
+
+    it("is case-insensitive: TAKEN clashes with taken", async () => {
+        const db = drizzle(env.DB, { schema });
+
+        await db.insert(schema.user).values({
+            id: "seed-ci",
+            name: "CI User",
+            email: "ci@example.com",
+            emailVerified: false,
+            handle: "UPPER",
+            tier: "spore",
+        });
+
+        const result = await ensureUniqueHandle(db, "upper");
+        expect(result).toBe("upper-1");
+    });
 });

--- a/enter.pollinations.ai/test/signup-handle.test.ts
+++ b/enter.pollinations.ai/test/signup-handle.test.ts
@@ -1,12 +1,13 @@
-import { env } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
 import { ensureUniqueHandle, sanitizeHandle } from "../src/auth.ts";
 import { test } from "./fixtures.ts";
 
 // After a GitHub OAuth signup the user row's handle should be set to
-// the GitHub login from the mocked profile ("testuser").
+// the sanitized (lowercased) GitHub login from the mocked profile ("testuser").
 test("github signup persists handle from profile.login", async ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sessionToken: _sessionToken,
@@ -19,6 +20,130 @@ test("github signup persists handle from profile.login", async ({
         .limit(1);
 
     expect(u.handle).toBe("testuser");
+});
+
+// ── handleFallbackPlugin integration ─────────────────────────────────────────
+
+/**
+ * Exercises the full better-auth hook chain for a non-GitHub user created via
+ * the admin `create-user` endpoint. The hook must fire and assign a handle
+ * derived from the email local-part.
+ *
+ * Level achieved: end-to-end through the real better-auth hook chain via HTTP
+ * (POST /api/auth/admin/create-user). We elevate the OAuth user to `admin`
+ * role in D1 so their signed session cookie (from the `sessionToken` fixture)
+ * has permission to call `createUser`. This avoids bootstrapping raw unsigned
+ * sessions, which better-auth's HMAC-signed cookie would reject.
+ */
+test("handleFallbackPlugin derives handle from email local-part for non-GitHub user", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+
+    // Promote the OAuth user to admin role so they can call /admin/create-user.
+    await db.update(schema.user).set({ role: "admin" });
+
+    const res = await SELF.fetch(
+        "http://localhost:3000/api/auth/admin/create-user",
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                email: "alice.bob@example.com",
+                name: "Alice Bob",
+            }),
+        },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: { handle: string } };
+    // sanitizeHandle("alice.bob") → "alice-bob"
+    expect(body.user.handle).toBe("alice-bob");
+});
+
+/**
+ * Exercises Fix 1: a new GitHub signup whose login (after sanitisation)
+ * collides case-insensitively with an existing handle must receive a
+ * suffixed handle instead of hitting the unique index constraint.
+ *
+ * The mock GitHub user's login is "testuser" (lowercase). We seed a user
+ * with a mixed-case handle "TestUser" which normalises to the same value,
+ * then run the full OAuth signup flow and assert the new user gets
+ * "testuser-1".
+ *
+ * Level achieved: full OAuth callback flow via HTTP through the real
+ * better-auth hook chain. The collision is engineered by seeding the
+ * handle before the signup occurs.
+ */
+test("github signup with colliding handle gets suffixed handle", async ({
+    mocks,
+}) => {
+    const db = drizzle(env.DB, { schema });
+
+    // Seed a user that holds the "testuser" handle (mixed case — the index is
+    // on lower(handle) so this is a case-insensitive collision).
+    await db.insert(schema.user).values({
+        id: "seed-collision",
+        name: "Prior TestUser",
+        email: "prior-testuser@example.com",
+        emailVerified: false,
+        handle: "TestUser",
+        tier: "spore",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    // Run the full GitHub OAuth flow. The mock returns login = "testuser",
+    // which sanitizeHandle lowercases to "testuser" — a collision with the
+    // seeded handle. handleFallbackPlugin must suffix it.
+    await mocks.enable("github", "tinybird");
+
+    const signupResponse = await SELF.fetch(
+        "http://localhost:3000/api/auth/sign-in/social",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ provider: "github" }),
+        },
+    );
+    expect(signupResponse.status).toBe(200);
+    const signupData = (await signupResponse.json()) as { url: string };
+    const signupCookies = signupResponse.headers.get("Set-Cookie");
+    if (!signupCookies) throw new Error("Set-Cookie header missing");
+
+    const state = new URL(signupData.url).searchParams.get("state");
+    if (!state) throw new Error("state param missing");
+
+    const callbackUrl = new URL(
+        "http://localhost:3000/api/auth/callback/github",
+    );
+    callbackUrl.searchParams.set("code", "test-code");
+    callbackUrl.searchParams.set("state", state);
+
+    const callbackResponse = await SELF.fetch(callbackUrl.toString(), {
+        method: "GET",
+        headers: {
+            "User-Agent": "Mozilla/5.0 (compatible; test-browser)",
+            Accept: "text/html,application/xhtml+xml",
+            Cookie: signupCookies,
+        },
+        redirect: "manual",
+    });
+    expect(callbackResponse.status).toBe(302);
+    await callbackResponse.text();
+    mocks.clear();
+
+    // Find the newly created GitHub user (github_id = 12345, per mock).
+    const [newUser] = await db
+        .select({ handle: schema.user.handle, githubId: schema.user.githubId })
+        .from(schema.user)
+        .where(eq(schema.user.githubId, 12345));
+
+    // Must have received a suffix rather than colliding with "TestUser".
+    expect(newUser.handle).toBe("testuser-1");
 });
 
 // ── sanitizeHandle ────────────────────────────────────────────────────────────

--- a/enter.pollinations.ai/test/signup-handle.test.ts
+++ b/enter.pollinations.ai/test/signup-handle.test.ts
@@ -3,7 +3,11 @@ import * as schema from "@shared/db/better-auth.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
-import { ensureUniqueHandle, sanitizeHandle } from "../src/auth.ts";
+import {
+    ensureUniqueHandle,
+    onBeforeAccountCreate,
+    sanitizeHandle,
+} from "../src/auth.ts";
 import { test } from "./fixtures.ts";
 
 // After a GitHub OAuth signup the user row's handle should be set to
@@ -20,6 +24,96 @@ test("github signup persists handle from profile.login", async ({
         .limit(1);
 
     expect(u.handle).toBe("testuser");
+});
+
+/**
+ * Fix: `account.username` must be populated synchronously by the
+ * `account.create.before` hook at GitHub signup — NOT by the async
+ * `onAfterSessionCreate` login sync (waitUntil + GitHub API).
+ *
+ * Isolation from the async sync: the sync fetches `GET /user/{githubId}`
+ * (here `/user/12345`) from the GitHub mock before it can write anything.
+ * The sessionToken fixture's trailing `mocks.clear()` awaits all in-flight
+ * mock requests, so by the time this test body runs, any sync fetch that
+ * went through the mock is settled and recorded in `state.requests`.
+ * Asserting `/user/12345` was never requested proves the sync never
+ * obtained a login — the value below can only come from the create hook.
+ */
+test("github signup sets account.username synchronously at account creation", async ({
+    sessionToken: _sessionToken,
+    mocks,
+}) => {
+    const db = drizzle(env.DB, { schema });
+
+    const [acct] = await db
+        .select({ username: schema.account.username })
+        .from(schema.account)
+        .where(eq(schema.account.providerId, "github"))
+        .limit(1);
+
+    expect(acct.username).toBe("testuser");
+
+    // The async login sync endpoint must not have been hit — see docblock.
+    const syncRequests = mocks.github.state.requests.filter(
+        (r) => r.path === "/user/12345",
+    );
+    expect(syncRequests).toEqual([]);
+});
+
+// ── onBeforeAccountCreate (github-account-username plugin) ───────────────────
+
+describe("onBeforeAccountCreate", () => {
+    const baseAccount = {
+        id: "acct-hook-test",
+        accountId: "999999",
+        providerId: "github",
+        userId: "hook-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+
+    const seedUser = async (githubUsername: string | null) => {
+        const db = drizzle(env.DB, { schema });
+        await db.insert(schema.user).values({
+            id: "hook-user",
+            name: "Hook User",
+            email: "hook-user@example.com",
+            emailVerified: false,
+            handle: "hook-user",
+            githubUsername,
+            tier: "spore",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+    };
+
+    it("fills username from the user's legacy github_username column", async () => {
+        await seedUser("GhLogin");
+        const hook = onBeforeAccountCreate(env);
+        const result = await hook({ ...baseAccount });
+        expect(result).toMatchObject({ data: { username: "GhLogin" } });
+    });
+
+    it("leaves non-github accounts untouched", async () => {
+        await seedUser("GhLogin");
+        const hook = onBeforeAccountCreate(env);
+        const result = await hook({ ...baseAccount, providerId: "google" });
+        expect(result).toBeUndefined();
+    });
+
+    it("leaves username unset when the user row has no github_username", async () => {
+        await seedUser(null);
+        const hook = onBeforeAccountCreate(env);
+        const result = await hook({ ...baseAccount });
+        expect(result).toBeUndefined();
+    });
+
+    it("does not overwrite an already-populated username", async () => {
+        await seedUser("GhLogin");
+        const hook = onBeforeAccountCreate(env);
+        const result = await hook({ ...baseAccount, username: "existing" });
+        expect(result).toBeUndefined();
+    });
 });
 
 // ── handleFallbackPlugin integration ─────────────────────────────────────────

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -30,6 +30,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
+import { getCommunityModelRegistryEntries } from "./community-models.ts";
 import { resetGenerationModelRegistryCache } from "./model-registry.ts";
 import { communityEndpointGatewayContext } from "./text/communityEndpoint.ts";
 
@@ -1328,4 +1329,39 @@ fixtureTest("rejects a community model name containing a slash", async () => {
     );
 
     expect(response.status).toBe(400);
+});
+
+it("resolves community model registry entry from user.handle when githubUsername is null", async () => {
+    const handle = `handle-${crypto.randomUUID().slice(0, 8)}`;
+    const modelName = `model-${crypto.randomUUID().slice(0, 8)}`;
+    const expectedModelId = communityModelId(handle, modelName);
+
+    const ownerUserId = await createTestUser({
+        githubId: null,
+        githubUsername: null,
+        handle,
+    });
+    await db.insert(communityEndpointTable).values({
+        id: `endpoint-${crypto.randomUUID()}`,
+        ownerUserId,
+        name: modelName,
+        description: "Handle-only community endpoint",
+        baseUrl: "https://api.example.com/v1",
+        upstreamModel: "gpt-4.1-mini",
+        bearerTokenCiphertext: await encryptSecret(
+            "sk_saved_token",
+            env.BETTER_AUTH_SECRET,
+        ),
+        promptTextPrice: 0.1,
+        completionTextPrice: 0.1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const entries = await getCommunityModelRegistryEntries(env.DB);
+    const entry = entries.find((e) => e.id === expectedModelId);
+
+    expect(entry).toBeDefined();
+    expect(entry?.id).toBe(expectedModelId);
+    expect(entry?.communityEndpoint.modelId).toBe(expectedModelId);
 });

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -40,7 +40,7 @@ export async function getCommunityModelRegistryEntries(
         .select({
             id: schema.communityEndpoint.id,
             ownerUserId: schema.communityEndpoint.ownerUserId,
-            ownerGithubUsername: schema.user.githubUsername,
+            ownerHandle: schema.user.handle,
             name: schema.communityEndpoint.name,
             description: schema.communityEndpoint.description,
             baseUrl: schema.communityEndpoint.baseUrl,
@@ -65,11 +65,11 @@ export async function getCommunityModelRegistryEntries(
             schema.user,
             eq(schema.communityEndpoint.ownerUserId, schema.user.id),
         )
-        .where(isNotNull(schema.user.githubUsername));
+        .where(isNotNull(schema.user.handle));
 
     return rows.flatMap((row): CommunityModelRegistryEntry[] => {
-        if (!row.ownerGithubUsername) return [];
-        const modelId = communityModelId(row.ownerGithubUsername, row.name);
+        if (!row.ownerHandle) return [];
+        const modelId = communityModelId(row.ownerHandle, row.name);
         const communityEndpoint: CommunityEndpointRuntime = {
             id: row.id,
             ownerUserId: row.ownerUserId,

--- a/gen.pollinations.ai/src/docs/account.md
+++ b/gen.pollinations.ai/src/docs/account.md
@@ -6,7 +6,7 @@ Self-service endpoints for the authenticated user. All endpoints require authent
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /account/profile` | GitHub username, image, tier, reset time |
+| `GET /account/profile` | handle, image, tier, reset time |
 | `GET /account/balance` | Current pollen balance |
 | `GET /account/quests` | Read-only quest status |
 | `GET /account/usage` | Per-request usage history with costs |

--- a/gen.pollinations.ai/src/docs/account.md
+++ b/gen.pollinations.ai/src/docs/account.md
@@ -16,7 +16,7 @@ Self-service endpoints for the authenticated user. All endpoints require authent
 
 ### GET /account/profile
 
-Returns user profile. `githubUsername`, `image`, `tier`, and `nextResetAt` are always included. `name` and `email` are included only when the API key has `account:profile`.
+Returns user profile. `handle`, `image`, `tier`, and `nextResetAt` are always included. `name` and `email` are included only when the API key has `account:profile`. (`githubUsername` is also returned, deprecated — use `handle`)
 
 ### GET /account/balance
 

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -338,7 +338,7 @@ response = requests.get(
     headers={"Authorization": "Bearer YOUR_API_KEY"},
 )
 profile = response.json()
-print(profile["githubUsername"])`,
+print(profile["handle"])`,
         },
         {
             label: "JavaScript",
@@ -348,7 +348,7 @@ print(profile["githubUsername"])`,
   { headers: { Authorization: "Bearer YOUR_API_KEY" } },
 );
 const profile = await response.json();
-console.log(profile.githubUsername);`,
+console.log(profile.handle);`,
         },
     ],
     "get /account/key": [
@@ -545,7 +545,7 @@ export const RESPONSE_EXAMPLES: Record<string, unknown> = {
         balance: 42.5,
     },
     "get /account/profile": {
-        githubUsername: "janedeveloper",
+        handle: "janedeveloper",
         image: "https://avatars.example.com/jane.jpg",
         tier: "seed",
         nextResetAt: "2026-01-01T01:00:00Z",

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -21,6 +21,7 @@ type LoginOptions = {
 };
 
 interface ProfileResponse {
+    handle?: string | null;
     githubUsername?: string | null;
     image?: string | null;
 }
@@ -123,7 +124,7 @@ async function fetchProfileLabel(key: string): Promise<string | null> {
         apiKey: key,
     }).catch(() => null);
     if (!profile) return null;
-    return `Logged in as ${profile.githubUsername ?? "unknown"}`;
+    return `Logged in as ${profile.handle ?? profile.githubUsername ?? "unknown"}`;
 }
 
 const login = new Command("login")
@@ -269,7 +270,7 @@ export async function showAuthStatus(): Promise<void> {
     printResult({
         authenticated: true,
         key: masked,
-        name: profile.githubUsername ?? "unknown",
+        name: profile.handle ?? profile.githubUsername ?? "unknown",
         pollen: balance?.balance ?? "unknown",
     });
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1609,7 +1609,7 @@ export class Pollinations {
      * @example
      * ```ts
      * const profile = await pollinations.accountProfile();
-     * console.log(profile.githubUsername);
+     * console.log(profile.handle);
      * ```
      */
     async accountProfile(): Promise<AccountProfile> {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -574,6 +574,9 @@ export interface AuthorizeOptions {
 
 /** User profile information */
 export interface AccountProfile {
+    /** Provider-neutral public handle. Always returned. */
+    handle: string | null;
+    /** @deprecated Use `handle`. Present only for github-linked accounts. */
     githubUsername: string | null;
     image: string | null;
     /** Current tier level (e.g. `"spore"`, `"seed"`, `"flower"`, `"nectar"`). */
@@ -875,6 +878,9 @@ export interface UserInfo {
     sub?: string;
     name?: string;
     email?: string;
+    /** Provider-neutral public handle. */
+    handle?: string;
+    /** @deprecated Use `handle`. */
     githubUsername?: string;
     tier?: string;
     [key: string]: unknown;

--- a/packages/ui/src/modules/auth/UserName.tsx
+++ b/packages/ui/src/modules/auth/UserName.tsx
@@ -11,7 +11,7 @@ export function UserName({ className }: UserNameProps) {
     const { isLoggedIn } = useAuthState();
     const { data: profile } = useAccountProfile({ enabled: isLoggedIn });
     if (!isLoggedIn || !profile) return null;
-    const display = profile.name || profile.githubUsername;
+    const display = profile.name || profile.handle;
     if (!display) return null;
     return (
         <span data-polli="user-name" className={className}>

--- a/packages/ui/src/modules/auth/UserName.tsx
+++ b/packages/ui/src/modules/auth/UserName.tsx
@@ -3,15 +3,15 @@ import { useAccountProfile, useAuthState } from "@pollinations/sdk/react";
 export type UserNameProps = { className?: string };
 
 /**
- * Renders the user's display name. Falls back to GitHub username when the
- * `profile` scope was not granted (or `name` is empty). `null` when logged
- * out, or when neither name nor GitHub username is available.
+ * Renders the user's display name. Falls back to `handle`, then to
+ * `githubUsername` (legacy field, present only for GitHub-linked accounts).
+ * Returns `null` when logged out or when no display value is available.
  */
 export function UserName({ className }: UserNameProps) {
     const { isLoggedIn } = useAuthState();
     const { data: profile } = useAccountProfile({ enabled: isLoggedIn });
     if (!isLoggedIn || !profile) return null;
-    const display = profile.name || profile.handle;
+    const display = profile.name || profile.handle || profile.githubUsername;
     if (!display) return null;
     return (
         <span data-polli="user-name" className={className}>

--- a/pollinations.ai/src/hooks/useAuth.tsx
+++ b/pollinations.ai/src/hooks/useAuth.tsx
@@ -15,6 +15,7 @@ const ENTER_URL = "https://enter.pollinations.ai";
 const ACCOUNT_API_BASE = "https://enter.pollinations.ai/api";
 
 interface UserProfile {
+    handle: string | null;
     githubUsername: string | null;
     image: string | null;
 }
@@ -109,6 +110,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 );
                 const data = await response.json();
                 setProfile({
+                    handle: data.handle ?? null,
                     githubUsername: data.githubUsername,
                     image: data.image ?? null,
                 });

--- a/pollinations.ai/src/ui/components/UserMenu.tsx
+++ b/pollinations.ai/src/ui/components/UserMenu.tsx
@@ -39,7 +39,7 @@ export function UserMenu() {
         );
     }
 
-    const displayName = profile?.githubUsername || copy.defaultUsername;
+    const displayName = profile?.handle || copy.defaultUsername;
 
     return (
         <div ref={menuRef} className="relative">

--- a/pollinations.ai/src/ui/components/UserMenu.tsx
+++ b/pollinations.ai/src/ui/components/UserMenu.tsx
@@ -39,7 +39,8 @@ export function UserMenu() {
         );
     }
 
-    const displayName = profile?.handle || copy.defaultUsername;
+    const displayName =
+        profile?.handle || profile?.githubUsername || copy.defaultUsername;
 
     return (
         <div ref={menuRef} className="relative">

--- a/shared/auth/additional-fields.ts
+++ b/shared/auth/additional-fields.ts
@@ -8,6 +8,10 @@ export const authAdditionalFields = {
             type: "string",
             input: false,
         },
+        handle: {
+            type: "string",
+            input: false,
+        },
         tier: {
             type: "string",
             defaultValue: "spore",

--- a/shared/auth/additional-fields.ts
+++ b/shared/auth/additional-fields.ts
@@ -18,4 +18,14 @@ export const authAdditionalFields = {
             input: false,
         },
     },
+    account: {
+        // Live provider login (GitHub) — set synchronously at account
+        // creation and kept fresh by the login sync. Must be registered
+        // here or the adapter strips it from account writes.
+        username: {
+            type: "string",
+            required: false,
+            input: false,
+        },
+    },
 } as const;

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -266,10 +266,16 @@ export async function authenticateApiKeyRequest(opts: {
             : null,
     ]);
 
+    const parsedGithubId = githubAccount
+        ? Number(githubAccount.accountId)
+        : null;
     const userData: AuthUser | undefined = rawUser
         ? {
               ...rawUser,
-              githubId: githubAccount ? Number(githubAccount.accountId) : null,
+              githubId:
+                  parsedGithubId !== null && Number.isFinite(parsedGithubId)
+                      ? parsedGithubId
+                      : null,
               githubUsername: githubAccount?.username ?? null,
           }
         : undefined;

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { apiKey } from "better-auth/plugins";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { alias } from "drizzle-orm/sqlite-core";
 import * as schema from "../db/better-auth.ts";
@@ -9,7 +9,10 @@ import { parseGithubIdList } from "./github-id-list.ts";
 
 const PUBLISHABLE_KEY_PREFIX = "pk";
 
-export type AuthUser = typeof schema.user.$inferSelect;
+export type AuthUser = typeof schema.user.$inferSelect & {
+    githubId: number | null;
+    githubUsername: string | null;
+};
 
 export interface AuthenticatedApiKey {
     id: string;
@@ -224,7 +227,7 @@ export async function authenticateApiKeyRequest(opts: {
     const db = drizzle(opts.env.DB, { schema });
     const userId = typeof key.userId === "string" ? key.userId : undefined;
     const byopClientKey = alias(schema.apikey, "byop_client_key");
-    const [apiKeyExtra, userData] = await Promise.all([
+    const [apiKeyExtra, rawUser, githubAccount] = await Promise.all([
         db
             .select({
                 pollenBalance: schema.apikey.pollenBalance,
@@ -246,7 +249,30 @@ export async function authenticateApiKeyRequest(opts: {
                   .where(eq(schema.user.id, userId))
                   .get()
             : null,
+        userId
+            ? db
+                  .select({
+                      accountId: schema.account.accountId,
+                      username: schema.account.username,
+                  })
+                  .from(schema.account)
+                  .where(
+                      and(
+                          eq(schema.account.userId, userId),
+                          eq(schema.account.providerId, "github"),
+                      ),
+                  )
+                  .get()
+            : null,
     ]);
+
+    const userData: AuthUser | undefined = rawUser
+        ? {
+              ...rawUser,
+              githubId: githubAccount ? Number(githubAccount.accountId) : null,
+              githubUsername: githubAccount?.username ?? null,
+          }
+        : undefined;
 
     if (userData) {
         assertNotBanned(userData);

--- a/shared/auth/github-account.ts
+++ b/shared/auth/github-account.ts
@@ -1,0 +1,37 @@
+import { and, eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import * as schema from "../db/better-auth.ts";
+
+export interface LinkedGithub {
+    githubId: number;
+    username: string | null;
+}
+
+/**
+ * Resolve a user's linked GitHub account from the `account` table.
+ * `accountId` holds the immutable GitHub numeric id (as a string);
+ * `username` is the mutable login synced on login. Returns null when the
+ * user has no GitHub account linked (e.g. a Google-only user).
+ */
+export async function getLinkedGithub(
+    db: DrizzleD1Database<typeof schema>,
+    userId: string,
+): Promise<LinkedGithub | null> {
+    const row = await db
+        .select({
+            accountId: schema.account.accountId,
+            username: schema.account.username,
+        })
+        .from(schema.account)
+        .where(
+            and(
+                eq(schema.account.userId, userId),
+                eq(schema.account.providerId, "github"),
+            ),
+        )
+        .get();
+    if (!row) return null;
+    const githubId = Number(row.accountId);
+    if (!Number.isFinite(githubId)) return null;
+    return { githubId, username: row.username ?? null };
+}

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -36,6 +36,7 @@ export const user = sqliteTable("user", {
   banExpires: integer("ban_expires", { mode: "timestamp" }),
   githubId: integer("github_id"),
   githubUsername: text("github_username"),
+  handle: text("handle"),
   tier: text("tier").default("spore").notNull(),
   tierBalance: real("tier_balance"),
   packBalance: real("pack_balance"),
@@ -50,6 +51,9 @@ export const user = sqliteTable("user", {
   index("idx_user_auto_top_up_enabled").on(table.autoTopUpEnabled),
   // GitHub profile lookup for quest checks and account display.
   index("idx_user_github_id").on(table.githubId),
+  // Provider-neutral public handle: display name + community model-ID namespace.
+  // Case-insensitive uniqueness via a functional index on lower(handle).
+  uniqueIndex("idx_user_handle_lower").on(sql`lower(${table.handle})`),
 ]);
 
 export const session = sqliteTable("session", {
@@ -76,6 +80,7 @@ export const account = sqliteTable("account", {
   id: text("id").primaryKey(),
   accountId: text("account_id").notNull(),
   providerId: text("provider_id").notNull(),
+  username: text("username"),
   userId: text("user_id")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
@@ -98,6 +103,11 @@ export const account = sqliteTable("account", {
     .notNull(),
 }, (table) => [
   index("idx_account_user_id").on(table.userId),
+  // One provider subject maps to exactly one account row (multi-provider invariant).
+  uniqueIndex("idx_account_provider_account").on(
+    table.providerId,
+    table.accountId,
+  ),
 ]);
 
 export const verification = sqliteTable("verification", {

--- a/shared/test/fixtures/api-keys.ts
+++ b/shared/test/fixtures/api-keys.ts
@@ -17,6 +17,7 @@ export type CreateTestUserOptions = {
     packBalance?: number | null;
     githubId?: number | null;
     githubUsername?: string | null;
+    handle?: string | null;
 };
 
 export type CreateTestApiKeyOptions = {
@@ -46,6 +47,12 @@ export async function createTestUser(opts: CreateTestUserOptions = {}) {
         packBalance: opts.packBalance ?? 0,
         githubId: opts.githubId ?? null,
         githubUsername: opts.githubUsername ?? null,
+        // Mirror the production backfill: if handle is not explicitly set,
+        // default to githubUsername (which is always equal for existing users).
+        handle:
+            opts.handle !== undefined
+                ? opts.handle
+                : (opts.githubUsername ?? null),
         createdAt: new Date(),
         updatedAt: new Date(),
     });

--- a/shared/test/fixtures/api-keys.ts
+++ b/shared/test/fixtures/api-keys.ts
@@ -6,7 +6,10 @@ import {
     type CallerMetadata,
     createApiKeyForUser,
 } from "../../auth/api-key-creation.ts";
-import { user as userTable } from "../../db/better-auth.ts";
+import {
+    account as accountTable,
+    user as userTable,
+} from "../../db/better-auth.ts";
 
 export type CreateTestUserOptions = {
     id?: string;
@@ -56,6 +59,24 @@ export async function createTestUser(opts: CreateTestUserOptions = {}) {
         createdAt: new Date(),
         updatedAt: new Date(),
     });
+
+    // Mirror production: better-auth writes an account row for every GitHub
+    // user at signup. Without it, getLinkedGithub returns null and community-
+    // endpoint ownership checks resolve to 403.
+    if (opts.githubId != null) {
+        await db
+            .insert(accountTable)
+            .values({
+                id: `test-account-${userId}`,
+                accountId: String(opts.githubId),
+                providerId: "github",
+                username: opts.githubUsername ?? null,
+                userId,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            })
+            .onConflictDoNothing();
+    }
 
     return userId;
 }


### PR DESCRIPTION
- Adds `user.handle` — unique (case-insensitive), provider-neutral public handle, backfilled from `github_username` so every existing display string and community model ID stays byte-identical
- Normalizes GitHub identity into the better-auth `account` table: new `account.username` (synced on login, atomically dual-written), `UNIQUE(provider_id, account_id)` subject index, and a `getLinkedGithub` accessor
- Hydrates `githubId`/`githubUsername` onto the resolved `AuthUser` from the account join — gen's hot path (track, image, realtime) needs no changes and survives the future column drop
- Migrates every direct reader to `handle`/account: community model namespace + ownership check, account profile, quests, device userinfo, app attribution, SDK/UI/CLI display, app-validate script, quest-dashboard worker, enter dashboard
- Signup always assigns a handle: GitHub login (sanitized, collision-suffixed) or email local-part fallback for future non-GitHub providers
- Legacy `user.github_id`/`github_username` stay dual-written — this PR is the expand+migrate phase; the column drop lands in a follow-up PR after this bakes in production

Migrations: 0035 (additive columns + indexes), 0036 (idempotent backfill). Before syncing to production, run the pre-flight data checks (duplicate provider subjects, duplicate lower-cased github usernames, github users missing an account row) — the deploy pipeline applies migrations before the worker deploy, so stale duplicates would abort the release. Rollback is a plain revert: all legacy columns remain written.