### PR TITLE
fix: disable gen edge rate limiter

### DIFF
--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -91,11 +91,6 @@ bucket_name = "pollinations-images"
 binding = "TEXT_BUCKET"
 bucket_name = "pollinations-text-enter"
 
-[[env.production.ratelimits]]
-name = "EDGE_RATE_LIMITER"
-namespace_id = "1001"
-simple = { limit = 10000, period = 10 }
-
 [[env.production.durable_objects.bindings]]
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"


### PR DESCRIPTION
- Removes the production `EDGE_RATE_LIMITER` binding from `gen.pollinations.ai`.
- Lets the existing middleware skip Cloudflare native rate limiting when the binding is absent.
- Keeps staging/test rate limiter config unchanged.
- Validated with `npm run build:production` in `gen.pollinations.ai`.
