### PR TITLE
chore: enable gen worker observability

### DIFF
--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -60,6 +60,10 @@ run_worker_first = ["/", "/manifest.webmanifest"]
 # Production routes
 [env.production]
 
+[env.production.observability]
+enabled = true
+head_sampling_rate = 1
+
 [env.production.images]
 binding = "IMAGES"
 


### PR DESCRIPTION
- Enables production Workers observability for gen at 100% sampling.
- Keeps the production edge rate limiter removed; `EDGE_RATE_LIMITER` remains only in staging/test.
- Already deployed directly to production as Worker version `45455499-7cf5-417d-85ae-d28aef314f75`.
- Validated with production build, Wrangler dry-run, deployed binding list, and `/models` smoke test.