### PR TITLE
chore: sync Myceli custom domains

### DIFF
--- a/.github/workflows/deploy-portkey-gateway.yml
+++ b/.github/workflows/deploy-portkey-gateway.yml
@@ -33,6 +33,8 @@ jobs:
           PORTKEY_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
           PORTKEY_PRODUCTION_HOST: portkey.myceli.ai
           PORTKEY_PRODUCTION_ZONE: myceli.ai
+          PORTKEY_PUBLIC_HOST: portkey.pollinations.ai
+          PORTKEY_PUBLIC_ZONE: pollinations.ai
           PORTKEY_COMMIT: ${{ github.event.inputs.commit }}
           PORTKEY_ENV: production
         run: |

--- a/apps/websim/wrangler.toml
+++ b/apps/websim/wrangler.toml
@@ -3,7 +3,8 @@ main = "worker.js"
 compatibility_date = "2026-05-01"
 
 routes = [
-  { pattern = "websim.myceli.ai", zone_name = "myceli.ai", custom_domain = true }
+  { pattern = "websim.myceli.ai", zone_name = "myceli.ai", custom_domain = true },
+  { pattern = "websim.pollinations.ai", zone_name = "pollinations.ai", custom_domain = true }
 ]
 
 [assets]

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -86,6 +86,11 @@ pattern = "enter.myceli.ai"
 zone_name = "myceli.ai"
 custom_domain = true
 
+[[env.production.routes]]
+pattern = "enter.pollinations.ai"
+zone_name = "pollinations.ai"
+custom_domain = true
+
 [[env.production.d1_databases]]
 remote = true
 binding = "DB"
@@ -122,6 +127,11 @@ crons = []
 [[env.staging.routes]]
 pattern = "staging.enter.myceli.ai"
 zone_name = "myceli.ai"
+custom_domain = true
+
+[[env.staging.routes]]
+pattern = "staging.enter.pollinations.ai"
+zone_name = "pollinations.ai"
 custom_domain = true
 
 [[env.staging.d1_databases]]

--- a/gen.pollinations.ai/scripts/deploy-portkey.sh
+++ b/gen.pollinations.ai/scripts/deploy-portkey.sh
@@ -16,6 +16,8 @@ ENVIRONMENT="${PORTKEY_ENV:-production}"
 PORTKEY_ACCOUNT_ID="${PORTKEY_ACCOUNT_ID:-b6ec751c0862027ba269faf7029b2501}"
 PORTKEY_PRODUCTION_HOST="${PORTKEY_PRODUCTION_HOST:-portkey.myceli.ai}"
 PORTKEY_PRODUCTION_ZONE="${PORTKEY_PRODUCTION_ZONE:-myceli.ai}"
+PORTKEY_PUBLIC_HOST="${PORTKEY_PUBLIC_HOST:-portkey.pollinations.ai}"
+PORTKEY_PUBLIC_ZONE="${PORTKEY_PUBLIC_ZONE:-pollinations.ai}"
 
 echo "🚀 Deploying Portkey Gateway"
 echo "   Commit: $PORTKEY_COMMIT"
@@ -39,7 +41,7 @@ fi
 echo "✓ Verified commit: $ACTUAL_COMMIT"
 
 if [ "$ENVIRONMENT" = "production" ]; then
-    echo "Rewriting production route to ${PORTKEY_PRODUCTION_HOST}..."
+    echo "Rewriting production routes to ${PORTKEY_PRODUCTION_HOST} and ${PORTKEY_PUBLIC_HOST}..."
     node <<'NODE'
 const fs = require("fs");
 
@@ -55,7 +57,8 @@ if (!/^account_id\s*=/.test(config)) {
 
 config = config.replace(
     /\{ pattern = "portkey\.pollinations\.ai", custom_domain = true \}/,
-    `{ pattern = "${process.env.PORTKEY_PRODUCTION_HOST}", zone_name = "${process.env.PORTKEY_PRODUCTION_ZONE}", custom_domain = true }`,
+    `{ pattern = "${process.env.PORTKEY_PRODUCTION_HOST}", zone_name = "${process.env.PORTKEY_PRODUCTION_ZONE}", custom_domain = true },
+    { pattern = "${process.env.PORTKEY_PUBLIC_HOST}", zone_name = "${process.env.PORTKEY_PUBLIC_ZONE}", custom_domain = true }`,
 );
 
 fs.writeFileSync(path, config);

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -68,6 +68,11 @@ pattern = "gen.myceli.ai"
 zone_name = "myceli.ai"
 custom_domain = true
 
+[[env.production.routes]]
+pattern = "gen.pollinations.ai"
+zone_name = "pollinations.ai"
+custom_domain = true
+
 [[env.production.services]]
 binding = "ENTER"
 service = "pollinations-enter-production"
@@ -118,6 +123,11 @@ binding = "IMAGES"
 [[env.staging.routes]]
 pattern = "staging.gen.myceli.ai"
 zone_name = "myceli.ai"
+custom_domain = true
+
+[[env.staging.routes]]
+pattern = "staging.gen.pollinations.ai"
+zone_name = "pollinations.ai"
 custom_domain = true
 
 [[env.staging.services]]

--- a/media.pollinations.ai/wrangler.toml
+++ b/media.pollinations.ai/wrangler.toml
@@ -27,6 +27,11 @@ pattern = "media.myceli.ai"
 zone_name = "myceli.ai"
 custom_domain = true
 
+[[env.production.routes]]
+pattern = "media.pollinations.ai"
+zone_name = "pollinations.ai"
+custom_domain = true
+
 [[env.production.r2_buckets]]
 binding = "MEDIA_BUCKET"
 bucket_name = "pollinations-media"

--- a/pollinations.ai/wrangler.toml
+++ b/pollinations.ai/wrangler.toml
@@ -13,8 +13,7 @@ not_found_handling = "single-page-application"
 # Non-HTML responses are passed through unchanged (see src/worker.ts).
 run_worker_first = true
 
-# Public hostname is pollinations.ai, served by the pollinations-myceli-proxy
-# worker in the old account, which forwards to pollinations.myceli.ai (below).
+# Public hostnames are attached directly in the Myceli account.
 [env.production]
 
 [[env.production.routes]]
@@ -22,9 +21,29 @@ pattern = "pollinations.myceli.ai"
 zone_name = "myceli.ai"
 custom_domain = true
 
+[[env.production.routes]]
+pattern = "pollinations.ai"
+zone_name = "pollinations.ai"
+custom_domain = true
+
+[[env.production.routes]]
+pattern = "www.pollinations.ai"
+zone_name = "pollinations.ai"
+custom_domain = true
+
 [env.staging]
 
 [[env.staging.routes]]
 pattern = "staging.pollinations.myceli.ai"
 zone_name = "myceli.ai"
+custom_domain = true
+
+[[env.staging.routes]]
+pattern = "staging.myceli.ai"
+zone_name = "myceli.ai"
+custom_domain = true
+
+[[env.staging.routes]]
+pattern = "staging.pollinations.ai"
+zone_name = "pollinations.ai"
 custom_domain = true


### PR DESCRIPTION
## Summary
- add direct pollinations.ai custom-domain routes to the Myceli gen, enter, media, and main-site Worker configs
- add staging public routes for gen, enter, and the main site to match the live Myceli Worker domains
- add websim.pollinations.ai to the websim Worker config
- preserve both portkey.myceli.ai and portkey.pollinations.ai in the Portkey deploy script/workflow

## Live Cloudflare inventory checked
Account: b6ec751c0862027ba269faf7029b2501

Repo-owned domains covered by this PR:
- pollinations.ai, www.pollinations.ai, pollinations.myceli.ai
- staging.pollinations.ai, staging.myceli.ai, staging.pollinations.myceli.ai
- enter.pollinations.ai, enter.myceli.ai, staging.enter.pollinations.ai, staging.enter.myceli.ai
- gen.pollinations.ai, gen.myceli.ai, staging.gen.pollinations.ai, staging.gen.myceli.ai
- media.pollinations.ai, media.myceli.ai
- websim.pollinations.ai, websim.myceli.ai
- portkey.pollinations.ai, portkey.myceli.ai via deploy script
- kpi.myceli.ai was already present and unchanged

Live domains not covered because no tracked Wrangler config/source was found here:
- image.pollinations.ai / image.myceli.ai on pollinations-image-cache
- text.pollinations.ai / text.myceli.ai on pollinations-text-cache

## Verification
- Cloudflare Workers custom-domain API inventory for the Myceli account
- git diff --check
- bash -n gen.pollinations.ai/scripts/deploy-portkey.sh
- gen: npx wrangler deploy --env production --dry-run
- enter: npm run build:production --workspace pollinations-enter, then npx wrangler deploy --config dist/pollinations_enter/wrangler.json --dry-run
- media: npx wrangler deploy --env production --dry-run
- main site: npm run build:production, then npx wrangler deploy --config dist/pollinations_ai/wrangler.json --dry-run
- websim: npm run build, then npx wrangler deploy worker.js --dry-run