### PR TITLE
fix: restore gen production edge rate limiter

### DIFF
--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -96,6 +96,11 @@ bucket_name = "pollinations-images"
 binding = "TEXT_BUCKET"
 bucket_name = "pollinations-text-enter"
 
+[[env.production.ratelimits]]
+name = "EDGE_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 10000, period = 10 }
+
 [[env.production.durable_objects.bindings]]
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"


### PR DESCRIPTION
- Restores the production `EDGE_RATE_LIMITER` binding removed during the incident.
- Keeps staging/test rate limiter config unchanged.
- Leaves custom-domain routing changes untouched.