### PR TITLE
fix: restore gen production edge rate limiter

### DIFF
--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -96,6 +96,11 @@ bucket_name = "pollinations-images"
 binding = "TEXT_BUCKET"
 bucket_name = "pollinations-text-enter"
 
+[[env.production.ratelimits]]
+name = "EDGE_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 10000, period = 10 }
+
 [[env.production.durable_objects.bindings]]
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"


### PR DESCRIPTION
- Merges the restored `EDGE_RATE_LIMITER` production binding from `main`.
- Brings production back in sync after the emergency disable.
- No other file changes versus production.