### PR TITLE
fix: dashboard models loading & readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ For any questions or support, please visit our [Discord channel](https://discord
 
 Our codebase is organized into several key folders, each serving a specific purpose in the pollinations.ai ecosystem:
 
-- [`pollinations.ai/`](./app/): The main React application for the Pollinations.ai website.
+- [`pollinations.ai/`](./pollinations.ai/): The main React application for the Pollinations.ai website.
 
 - [`image.pollinations.ai/`](./image.pollinations.ai/): Backend service for image generation and caching with Cloudflare Workers and R2 storage.
 

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -137,9 +137,17 @@ function buildRegistry(
 async function loadGenerationModelRegistry(
     dbBinding: CloudflareBindings["DB"] | undefined,
 ): Promise<GenerationModelRegistry> {
-    const communityEntries = (
-        await getCommunityModelRegistryEntries(dbBinding)
-    ).map(communityEntryToGenerationEntry);
+    let communityEntries: GenerationModelEntry[] = [];
+    try {
+        communityEntries = (
+            await getCommunityModelRegistryEntries(dbBinding)
+        ).map(communityEntryToGenerationEntry);
+    } catch (error) {
+        console.error(
+            "Failed to load community models from D1 database:",
+            error,
+        );
+    }
     return buildRegistry([...STATIC_ENTRIES, ...communityEntries]);
 }
 


### PR DESCRIPTION
This PR resolves two issues:
1. **Major Bug Fix**: Wraps community database query in `loadGenerationModelRegistry` in a `try/catch` block. This prevents D1 database timeouts or temporary failures from causing the entire `/models` API (and therefore the enter.pollinations.ai models dashboard) to return a 500 error, instead falling back gracefully to static models. (Fixes #12289 and #12280)
2. **Documentation Fix**: Corrected a broken link in the root `README.md` for the `pollinations.ai` React app (updated `./app/` to `./pollinations.ai/`).