### PR TITLE
fix: switch gemini-3.1-flash-lite to GA model id (preview retired)

### DIFF
--- a/.claude/skills/provider-billing/providers/gcp.md
+++ b/.claude/skills/provider-billing/providers/gcp.md
@@ -362,7 +362,7 @@ GCP uses long-form region names (`us-central1`, `europe-west1`, `asia-northeast1
 | `gemini-3-flash-preview` | `us-central1` |
 | `gemini-3.1-pro-preview` | `us-central1` |
 | `gemini-2.5-flash-lite` | `global` (Vertex global endpoint) |
-| `gemini-3.1-flash-lite-preview` | `us-central1` |
+| `gemini-3.1-flash-lite` | `global` (Vertex global endpoint) |
 | `gemini-2.5-pro` | `us-central1` |
 
 The `global` region is a special Vertex-only endpoint that multiplexes across regions — used for models that have global deployment. Cost shows up under `location.location = 'global'` in the billing export.

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -221,7 +221,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "gemini-flash-lite-3.1",
-        config: portkeyConfig["gemini-3.1-flash-lite-preview"],
+        config: portkeyConfig["gemini-3.1-flash-lite"],
         transform: pipe(
             sanitizeToolSchemas,
             createGeminiThinkingTransform("v3-flash"),
@@ -246,7 +246,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "gemini-search-fast",
-        config: portkeyConfig["gemini-3.1-flash-lite-preview"],
+        config: portkeyConfig["gemini-3.1-flash-lite"],
         transform: pipe(
             sanitizeToolSchemas,
             createGeminiToolsTransform(["google_search"]),

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -240,8 +240,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         "gemini-2.5-flash-lite",
         "global",
     ),
-    "gemini-3.1-flash-lite-preview": createVertexGeminiConfig(
-        "gemini-3.1-flash-lite-preview",
+    // The gemini-3.1-flash-lite-preview publisher model was retired by Google
+    // (404 as of 2026-07); only the GA id resolves.
+    "gemini-3.1-flash-lite": createVertexGeminiConfig(
+        "gemini-3.1-flash-lite",
         "global",
     ),
     "gemini-3.5-flash": createVertexGeminiConfig("gemini-3.5-flash", "global"),

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -432,7 +432,7 @@ export const TEXT_SERVICES = {
             "gemini-3.1-flash-lite-preview",
             "gemini-flash-lite",
         ],
-        modelId: "gemini-3.1-flash-lite-preview",
+        modelId: "gemini-3.1-flash-lite",
         provider: "google",
         brand: "Google",
         category: "text",
@@ -685,14 +685,14 @@ export const TEXT_SERVICES = {
     },
     "gemini-search-fast": {
         aliases: ["gemini-3.1-flash-lite-search"],
-        modelId: "gemini-3.1-flash-lite-preview",
+        modelId: "gemini-3.1-flash-lite",
         provider: "google",
         brand: "Google",
         category: "text",
         addedDate: new Date("2026-05-26").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // Vertex base rates for gemini-3.1-flash-lite-preview. Grounding fee
+        // Vertex base rates for gemini-3.1-flash-lite. Grounding fee
         // dropped to $14/1K queries on Gemini 3 (vs $35/1K on 2.x), with 5K
         // free queries/month shared across all Gemini 3 models; absorbed by
         // Pollinations.


### PR DESCRIPTION
- Google retired the `gemini-3.1-flash-lite-preview` Vertex publisher model → `gemini-flash-lite-3.1` and `gemini-search-fast` returned 502 (upstream 404) in production
- Switch portkey config + registry `modelId` to GA id `gemini-3.1-flash-lite` (verified working via direct Vertex probe with the prod SA, `global` location)
- Old `-preview` alias kept in registry for existing callers
- Probed all other Vertex Gemini models: only flash-lite preview was retired

🤖 Generated with [Claude Code](https://claude.com/claude-code)