### PR TITLE
feat: add connected app OAuth lifecycle

### DIFF
--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -109,7 +109,7 @@ curl -X POST https://enter.pollinations.ai/api/oauth/token \
 
 The authorization code is single-use and expires after 10 minutes. Token responses use RFC 6749 error objects such as `invalid_grant`, `invalid_request`, and `unsupported_grant_type`.
 
-Scopes: `profile` (name + email), `usage` (account balance + usage), `keys` (account admin — create/list/revoke keys). The response's `scope` echoes what the user actually granted, which may be narrower than requested. Generation needs no scope — spending is bounded by the budget and expiry the user approved. There are no refresh tokens; re-run the flow when the key expires. Issued keys appear in the user's dashboard like any other API key and can be edited or revoked there at any time — revocation is immediate.
+Scopes: `profile` (name + email), `usage` (account balance + usage), `keys` (account admin — create/list/revoke keys). The response's `scope` echoes what the user actually granted, which may be narrower than requested. Generation needs no scope — spending is bounded by the budget and expiry the user approved. There are no refresh tokens; re-run the flow when the key expires. Issued keys appear under **Connected Apps** in the user's dashboard and can be disconnected there at any time.
 
 ### 3. Call Pollinations
 
@@ -124,6 +124,17 @@ fetch('https://gen.pollinations.ai/v1/chat/completions', {
 ```
 
 See `apps/oauth-client-demo/` for a zero-dependency reference client.
+
+### 4. Disconnect
+
+Revoke the delegated key when the user disconnects your app. The endpoint
+returns success even when the token was already invalid or revoked.
+
+```bash
+curl -X POST https://enter.pollinations.ai/api/oauth/revoke \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'token=sk_user_authorized_key'
+```
 
 ## ⚙️ Legacy Web Apps (Fragment Flow)
 

--- a/apps/oauth-client-demo/README.md
+++ b/apps/oauth-client-demo/README.md
@@ -1,9 +1,9 @@
-# Sign in with Pollinations — demo client
+# Connect Pollinations — demo client
 
 Minimal OAuth 2.1 client (authorization code + PKCE S256, public client, no
 client secret) against `enter.pollinations.ai`. Zero dependencies, Node ≥ 18.
-This is the reference for third-party sites integrating "Log in with
-Pollinations" — the same shape alp.anondrop.net-style clients use.
+This is the reference for third-party sites connecting a Pollinations account
+for delegated API access.
 
 ## Register a client
 
@@ -32,8 +32,10 @@ Env vars: `CLIENT_ID` (required), `ISSUER` (default
   `code_verifier`; the access token is an opaque `sk_` key.
 - **Userinfo**: `Bearer` call to the advertised `userinfo_endpoint`.
 - **Delegated API access**: a chat completion against `gen.pollinations.ai`
-  paid from the signed-in user's pollen, within the budget/expiry they
+  paid from the connected user's pollen, within the budget/expiry they
   approved on the consent screen.
+- **Disconnect**: revokes the delegated key through the advertised RFC 7009
+  endpoint instead of only clearing the app's local session.
 
 Sessions and pending logins are in-memory — restart logs everyone out. That is
 intentional; this is a protocol demo, not a production template.

--- a/apps/oauth-client-demo/package.json
+++ b/apps/oauth-client-demo/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "type": "module",
-    "description": "Minimal 'Sign in with Pollinations' OAuth 2.1 client (authorization code + PKCE)",
+    "description": "Minimal 'Connect Pollinations' OAuth 2.1 client (authorization code + PKCE)",
     "engines": { "node": ">=18" },
     "scripts": {
         "start": "node server.js"

--- a/apps/oauth-client-demo/server.js
+++ b/apps/oauth-client-demo/server.js
@@ -1,5 +1,5 @@
 /**
- * "Sign in with Pollinations" demo client.
+ * "Connect Pollinations" demo client.
  *
  * A minimal OAuth 2.1 client (authorization-code + PKCE S256, public client)
  * against enter.pollinations.ai — the same integration shape a third-party
@@ -44,7 +44,7 @@ function escapeHtml(value) {
 
 function page(body) {
     return `<!doctype html><html><head><meta charset="utf-8">
-<title>Sign in with Pollinations — demo client</title>
+<title>Connect Pollinations — demo client</title>
 <style>
   body{font-family:system-ui,sans-serif;max-width:640px;margin:3rem auto;padding:0 1rem;line-height:1.5}
   a.button,button{display:inline-block;background:#111;color:#fff;border:0;border-radius:8px;
@@ -76,7 +76,7 @@ function getSession(req) {
         : { sid: null, session: null };
 }
 
-async function handleLogin(res) {
+async function handleConnect(res) {
     const meta = await discover();
     // Drop abandoned logins so the map can't grow unbounded.
     for (const [state, login] of pending) {
@@ -105,22 +105,22 @@ async function handleCallback(res, query) {
     const login = pending.get(state);
     pending.delete(state);
 
+    if (!login) {
+        return send(
+            res,
+            400,
+            page(
+                `<p class="err">Unknown or reused <code>state</code> — possible CSRF, connection aborted.</p>
+             <a class="button" href="/">Back</a>`,
+            ),
+        );
+    }
     if (query.get("error")) {
         return send(
             res,
             400,
             page(
                 `<p class="err">Authorization failed: <b>${escapeHtml(query.get("error"))}</b></p>
-             <a class="button" href="/">Back</a>`,
-            ),
-        );
-    }
-    if (!login) {
-        return send(
-            res,
-            400,
-            page(
-                `<p class="err">Unknown or reused <code>state</code> — possible CSRF, login aborted.</p>
              <a class="button" href="/">Back</a>`,
             ),
         );
@@ -207,14 +207,14 @@ function handleHome(res, session) {
     if (!session) {
         const configured = CLIENT_ID
             ? ""
-            : `<p class="err">Set <code>CLIENT_ID=pk_...</code> before logging in (see README).</p>`;
+            : `<p class="err">Set <code>CLIENT_ID=pk_...</code> before connecting (see README).</p>`;
         return send(
             res,
             200,
             page(
-                `<p>This app signs you in with your Pollinations account via
-             OAuth 2.1 (authorization code + PKCE).</p>${configured}
-             <a class="button" href="/login">Sign in with Pollinations</a>`,
+                `<p>This app connects your Pollinations account for delegated
+             API access via OAuth 2.1 (authorization code + PKCE).</p>${configured}
+             <a class="button" href="/connect">Connect Pollinations</a>`,
             ),
         );
     }
@@ -222,7 +222,7 @@ function handleHome(res, session) {
         res,
         200,
         page(
-            `<p>Signed in as <b>${escapeHtml(
+            `<p>Connected as <b>${escapeHtml(
                 session.profile?.preferred_username ||
                     session.profile?.name ||
                     session.profile?.sub ||
@@ -237,9 +237,27 @@ function handleHome(res, session) {
              ),
          )}</pre>
          <form method="post" action="/generate"><button type="submit">Generate a greeting (spends pollen)</button></form>
-         <p><a href="/logout">Log out</a></p>`,
+         <form method="post" action="/disconnect"><button type="submit">Disconnect Pollinations</button></form>
+         <p><a href="/logout">Forget local session</a></p>`,
         ),
     );
+}
+
+async function handleDisconnect(res, sid, session) {
+    if (!session) return redirect(res, "/");
+    const meta = await discover();
+    const revokeRes = await fetch(meta.revocation_endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ token: session.accessToken }),
+    });
+    if (!revokeRes.ok) {
+        throw new Error(`Disconnect failed: HTTP ${revokeRes.status}`);
+    }
+    if (sid) sessions.delete(sid);
+    redirect(res, "/", {
+        "Set-Cookie": "sid=; Max-Age=0; Path=/",
+    });
 }
 
 const server = createServer(async (req, res) => {
@@ -249,8 +267,8 @@ const server = createServer(async (req, res) => {
         if (url.pathname === "/" && req.method === "GET") {
             return handleHome(res, session);
         }
-        if (url.pathname === "/login" && req.method === "GET") {
-            return await handleLogin(res);
+        if (url.pathname === "/connect" && req.method === "GET") {
+            return await handleConnect(res);
         }
         if (url.pathname === "/callback" && req.method === "GET") {
             return await handleCallback(res, url.searchParams);
@@ -258,6 +276,9 @@ const server = createServer(async (req, res) => {
         if (url.pathname === "/generate" && req.method === "POST") {
             if (!session) return redirect(res, "/");
             return await handleGenerate(res, session);
+        }
+        if (url.pathname === "/disconnect" && req.method === "POST") {
+            return await handleDisconnect(res, sid, session);
         }
         if (url.pathname === "/logout" && req.method === "GET") {
             if (sid) sessions.delete(sid);

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
@@ -208,7 +208,8 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                                 use after consent.
                             </li>
                             <li>
-                                We return a scoped API key in the URL fragment.
+                                Pollinations returns a short-lived code that
+                                your app exchanges using PKCE.
                             </li>
                             <li>
                                 Use that key for API requests paid with the

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -48,14 +48,25 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     onCreate,
     onUpdate,
     onDelete,
+    onDisconnect,
 }) => {
     const [deleteId, setDeleteId] = useState<string | null>(null);
+    const [disconnectClientId, setDisconnectClientId] = useState<string | null>(
+        null,
+    );
     const [editingKey, setEditingKey] = useState<ApiKey | null>(null);
 
     async function handleDelete(): Promise<void> {
         if (deleteId) {
             await onDelete(deleteId);
             setDeleteId(null);
+        }
+    }
+
+    async function handleDisconnect(): Promise<void> {
+        if (disconnectClientId) {
+            await onDisconnect(disconnectClientId);
+            setDisconnectClientId(null);
         }
     }
 
@@ -67,8 +78,20 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
         (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
-    const sortedApiKeys = sortedKeys.filter((apiKey) => !isAppKey(apiKey));
+    const connectedKeys = sortedKeys.filter((apiKey) => apiKey.byopClientKeyId);
+    const sortedApiKeys = sortedKeys.filter(
+        (apiKey) => !isAppKey(apiKey) && !apiKey.byopClientKeyId,
+    );
     const sortedAppKeys = sortedKeys.filter(isAppKey);
+    const connectedApps = Array.from(
+        connectedKeys.reduce((groups, key) => {
+            const clientId = key.byopClientKeyId as string;
+            const group = groups.get(clientId) ?? [];
+            group.push(key);
+            groups.set(clientId, group);
+            return groups;
+        }, new Map<string, ApiKey[]>()),
+    );
 
     function renderKeyCard(apiKey: ApiKey) {
         const isPublishable = isPublishableKey(apiKey);
@@ -285,6 +308,59 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                         </span>
                     </p>
                 </Section>
+                <Section title="Connected Apps" framed>
+                    <div className="flex flex-col gap-4">
+                        {!connectedApps.length && (
+                            <Surface className="p-6 text-center">
+                                <AppIcon className="mx-auto mb-2 h-8 w-8 text-theme-text-muted" />
+                                <p className="font-semibold text-ink-900 text-lg mb-2">
+                                    No connected apps
+                                </p>
+                                <p className="text-sm text-theme-text-muted">
+                                    Apps you authorize to use your Pollinations
+                                    account will appear here.
+                                </p>
+                            </Surface>
+                        )}
+                        {connectedApps.map(([clientId, keys]) => (
+                            <div
+                                key={clientId}
+                                className="rounded-xl border border-divider p-3"
+                            >
+                                <div className="mb-3 flex items-center gap-2 px-1">
+                                    <AppIcon className="h-4 w-4 text-theme-text-muted" />
+                                    <span className="font-medium">
+                                        {keys[0]?.name || "Connected app"}
+                                    </span>
+                                    <Chip size="sm">
+                                        {keys.length} access key
+                                        {keys.length === 1 ? "" : "s"}
+                                    </Chip>
+                                    <span className="flex-1" />
+                                    <IconButton
+                                        intent="danger"
+                                        title="Disconnect app"
+                                        tooltip="Disconnect app"
+                                        tooltipAlign="center"
+                                        tooltipClampToViewport={false}
+                                        onClick={() =>
+                                            setDisconnectClientId(clientId)
+                                        }
+                                    >
+                                        <XIcon className="h-4 w-4" />
+                                    </IconButton>
+                                </div>
+                                <div className="flex flex-col gap-3">
+                                    {keys.map(renderKeyCard)}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    <p className="mt-4 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                        Disconnecting an app immediately revokes every access
+                        key you granted to it.
+                    </p>
+                </Section>
                 <Section
                     title="App"
                     framed
@@ -321,8 +397,8 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                         <p className="flex items-start gap-1.5">
                             <GlobeIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                             <span>
-                                For apps where users sign in with their own
-                                Pollinations account and spend their own Pollen.
+                                For apps where users connect their Pollinations
+                                account and spend their own Pollen.
                             </span>
                         </p>
                         <p className="flex items-start gap-1.5">
@@ -346,6 +422,14 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                 deleteId={deleteId}
                 onConfirm={handleDelete}
                 onCancel={() => setDeleteId(null)}
+            />
+            <DeleteConfirmation
+                deleteId={disconnectClientId}
+                title="Disconnect App"
+                message="Disconnect this app and revoke every access key you granted to it?"
+                confirmLabel="Disconnect"
+                onConfirm={handleDisconnect}
+                onCancel={() => setDisconnectClientId(null)}
             />
             {editingKey && (
                 <EditApiKeyDialog

--- a/enter.pollinations.ai/frontend/src/components/keys/key-delete-confirmation.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-delete-confirmation.tsx
@@ -5,30 +5,33 @@ interface DeleteConfirmationProps {
     deleteId: string | null;
     onConfirm: () => void;
     onCancel: () => void;
+    title?: string;
+    message?: string;
+    confirmLabel?: string;
 }
 
 export const DeleteConfirmation: FC<DeleteConfirmationProps> = ({
     deleteId,
     onConfirm,
     onCancel,
+    title = "Delete API Key",
+    message = "Are you sure you want to delete this API key? This action cannot be undone.",
+    confirmLabel = "Delete",
 }) => (
     <Dialog
         open={!!deleteId}
         onOpenChange={(open) => !open && onCancel()}
-        title="Delete API Key"
+        title={title}
         size="sm"
         contentClassName="p-6"
     >
-        <p className="mb-6 mt-4">
-            Are you sure you want to delete this API key? This action cannot be
-            undone.
-        </p>
+        <p className="mb-6 mt-4">{message}</p>
         <div className="flex gap-2 justify-end">
             <Button type="button" onClick={onCancel}>
                 Cancel
             </Button>
             <Button type="button" intent="danger" onClick={onConfirm}>
-                Delete
+                {confirmLabel}
             </Button>
         </div>
     </Dialog>

--- a/enter.pollinations.ai/frontend/src/components/keys/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/keys/types.ts
@@ -25,6 +25,7 @@ export interface ApiKeyManagerProps {
     onCreate: (formData: CreateApiKey) => Promise<CreateApiKeyResponse>;
     onUpdate: (id: string, updates: ApiKeyUpdateParams) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
+    onDisconnect: (clientId: string) => Promise<void>;
 }
 
 export type CreateApiKey = {

--- a/enter.pollinations.ai/frontend/src/routes/index.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/index.tsx
@@ -200,6 +200,16 @@ function RouteComponent() {
         router.invalidate();
     }
 
+    async function handleDisconnectApp(clientId: string): Promise<void> {
+        const response = await apiClient["api-keys"].connections[
+            ":clientId"
+        ].$delete({ param: { clientId } });
+        if (!response.ok) {
+            throw new Error("Failed to disconnect app");
+        }
+        router.invalidate();
+    }
+
     async function handleUpdateApiKey(
         id: string,
         updates: {
@@ -307,6 +317,7 @@ function RouteComponent() {
                     onCreate={handleCreateApiKey}
                     onUpdate={handleUpdateApiKey}
                     onDelete={handleDeleteApiKey}
+                    onDisconnect={handleDisconnectApp}
                 />
             )}
             {activePage === "models" && (

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -288,6 +288,23 @@ export const apiKeysRoutes = new Hono<Env>()
             });
         },
     )
+    .delete("/connections/:clientId", async (c) => {
+        const user = c.var.auth.requireUser();
+        const clientId = c.req.param("clientId");
+        const db = drizzle(c.env.DB, { schema });
+        const revoked = await db
+            .delete(schema.apikey)
+            .where(
+                and(
+                    eq(schema.apikey.userId, user.id),
+                    eq(schema.apikey.byopClientKeyId, clientId),
+                ),
+            )
+            .returning({ id: schema.apikey.id });
+
+        setPrivateNoStoreHeaders(c);
+        return c.json({ revoked: revoked.length });
+    })
     /**
      * Update an API key's permissions.
      * Uses auth.api.updateApiKey() which supports server-only fields like permissions.

--- a/enter.pollinations.ai/src/routes/oauth.ts
+++ b/enter.pollinations.ai/src/routes/oauth.ts
@@ -1,10 +1,14 @@
 import { PKCE_S256_CHALLENGE_REGEX } from "@shared/auth/authorize-config.ts";
 import { redirectUriMatchesAllowlistExact } from "@shared/auth/redirect-uri.ts";
+import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
+import { and, eq, gt, like, lt } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
+import { createAuth } from "../auth.ts";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import {
@@ -16,7 +20,7 @@ import {
 } from "./device.ts";
 import { getRedirectUris } from "./metadata-utils.ts";
 
-const KV_TTL = 600; // 10 minutes — codes are single-use and short-lived
+const CODE_TTL_MS = 10 * 60 * 1000;
 const CODE_LENGTH = 40;
 export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
@@ -70,12 +74,13 @@ const CreateCodeSchema = z.object({
 /**
  * OAuth 2.1 authorization-code grant with PKCE (S256 only), layered on the
  * same trust model as the device flow: the consent page mints the sk_ in the
- * browser and hands it to the server, which parks it in KV behind a
+ * browser and hands it to the server, which parks it in D1 behind a
  * single-use authorization code. The legacy fragment (#api_key=) flow is
  * untouched — this is an additional issuance path, not a replacement.
  *
  * POST /code     — called by the consent page after the user approves
  * POST /token    — code+PKCE (and device_code) exchange, RFC 6749 §3.2
+ * POST /revoke   — revoke a delegated secret key, RFC 7009
  * GET  /userinfo — alias of /api/device/userinfo for discovery metadata
  */
 export const oauthRoutes = new Hono<Env>()
@@ -123,8 +128,22 @@ export const oauthRoutes = new Hono<Env>()
                 codeChallenge: body.codeChallenge,
                 expiresIn: body.expiresIn ?? null,
             };
-            await c.env.KV.put(`oauth-code:${code}`, JSON.stringify(stored), {
-                expirationTtl: KV_TTL,
+            const db = drizzle(c.env.DB, { schema });
+            const now = new Date();
+            await db
+                .delete(schema.verification)
+                .where(
+                    and(
+                        like(schema.verification.identifier, "oauth-code:%"),
+                        lt(schema.verification.expiresAt, now),
+                    ),
+                );
+            const codeId = `oauth-code:${code}`;
+            await db.insert(schema.verification).values({
+                id: codeId,
+                identifier: codeId,
+                value: JSON.stringify(stored),
+                expiresAt: new Date(now.getTime() + CODE_TTL_MS),
             });
 
             return c.json({ code });
@@ -164,18 +183,33 @@ export const oauthRoutes = new Hono<Env>()
             );
         }
 
-        const kvKey = `oauth-code:${body.code}`;
-        const stored = (await c.env.KV.get(kvKey, "json")) as StoredCode | null;
-        if (!stored) {
+        const db = drizzle(c.env.DB, { schema });
+        const [consumed] = await db
+            .delete(schema.verification)
+            .where(
+                and(
+                    eq(schema.verification.id, `oauth-code:${body.code}`),
+                    gt(schema.verification.expiresAt, new Date()),
+                ),
+            )
+            .returning({ payload: schema.verification.value });
+        if (!consumed) {
             return tokenError(
                 c,
                 "invalid_grant",
                 "Code unknown, expired, or already used.",
             );
         }
-        // Single use (OAuth 2.1 §4.1.3): burn the code before validating so a
-        // failed attempt can't be retried against the same code.
-        await c.env.KV.delete(kvKey);
+        let stored: StoredCode;
+        try {
+            stored = JSON.parse(consumed.payload) as StoredCode;
+        } catch {
+            return tokenError(
+                c,
+                "invalid_grant",
+                "Malformed authorization code",
+            );
+        }
 
         if (body.client_id !== stored.clientId) {
             // Public clients never authenticate here (token auth "none"), so
@@ -200,6 +234,33 @@ export const oauthRoutes = new Hono<Env>()
             ...(stored.expiresIn != null && { expires_in: stored.expiresIn }),
             ...(stored.scope != null && { scope: stored.scope }),
         });
+    })
+    .post("/revoke", async (c) => {
+        c.header("Cache-Control", "no-store");
+        const body = await parseFormOrJsonBody(c);
+        if (body.token?.startsWith("sk_")) {
+            const result = await createAuth(c.env).api.verifyApiKey({
+                body: { key: body.token },
+            });
+            const keyId =
+                result.valid && typeof result.key?.id === "string"
+                    ? result.key.id
+                    : null;
+            if (keyId) {
+                const db = drizzle(c.env.DB, { schema });
+                await db
+                    .delete(schema.apikey)
+                    .where(
+                        and(
+                            eq(schema.apikey.id, keyId),
+                            eq(schema.apikey.prefix, "sk"),
+                        ),
+                    );
+            }
+        }
+
+        // RFC 7009 deliberately does not reveal whether the token existed.
+        return c.body(null, 200);
     })
     .get(
         "/userinfo",

--- a/enter.pollinations.ai/src/routes/well-known.ts
+++ b/enter.pollinations.ai/src/routes/well-known.ts
@@ -19,6 +19,7 @@ export const wellKnownRoutes = new Hono<Env>().get(
             issuer: origin,
             authorization_endpoint: `${origin}/authorize`,
             token_endpoint: `${origin}/api/oauth/token`,
+            revocation_endpoint: `${origin}/api/oauth/revoke`,
             userinfo_endpoint: `${origin}/api/oauth/userinfo`,
             device_authorization_endpoint: `${origin}/api/device/code`,
             scopes_supported: [...CONSENT_PERMISSIONS],

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -1444,6 +1444,79 @@ describe("API Key Management", () => {
         });
     });
 
+    describe("DELETE /api/api-keys/connections/:clientId", () => {
+        test("revokes only the current user's keys for that app", async ({
+            sessionToken,
+        }) => {
+            const create = async (body: Record<string, unknown>) => {
+                const response = await SELF.fetch(
+                    "http://localhost:3000/api/api-keys",
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            Cookie: `better-auth.session_token=${sessionToken}`,
+                        },
+                        body: JSON.stringify(body),
+                    },
+                );
+                expect(response.status).toBe(200);
+                return response.json();
+            };
+
+            const app = await create({
+                name: "connected-app",
+                type: "publishable",
+                metadata: {
+                    redirectUris: ["https://connected.example/callback"],
+                },
+            });
+            const connectionInput = {
+                name: "connected-app",
+                type: "secret",
+                metadata: {
+                    requestedClientId: app.key,
+                    redirectUri: "https://connected.example/callback",
+                    redirectOrigin: "https://connected.example",
+                },
+            };
+            const first = await create(connectionInput);
+            const second = await create(connectionInput);
+            const unrelated = await create({
+                name: "unrelated",
+                type: "secret",
+            });
+
+            const disconnect = await SELF.fetch(
+                `http://localhost:3000/api/api-keys/connections/${app.id}`,
+                {
+                    method: "DELETE",
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+            expect(disconnect.status).toBe(200);
+            expect(await disconnect.json()).toEqual({ revoked: 2 });
+
+            const list = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+            const ids = (
+                (await list.json()) as { data: Array<{ id: string }> }
+            ).data.map((key) => key.id);
+            expect(ids).not.toContain(first.id);
+            expect(ids).not.toContain(second.id);
+            expect(ids).toContain(app.id);
+            expect(ids).toContain(unrelated.id);
+        }, 30000);
+    });
+
     describe("Permission enforcement", () => {
         test("should reject expired keys", async ({ auth, sessionToken }) => {
             // Create a key that expires immediately

--- a/enter.pollinations.ai/test/oauth-code.test.ts
+++ b/enter.pollinations.ai/test/oauth-code.test.ts
@@ -22,7 +22,7 @@ async function s256(verifier: string): Promise<string> {
         .replace(/=+$/, "");
 }
 
-/** Park an authorization code in KV the way POST /api/oauth/code does. */
+/** Store an authorization code the way POST /api/oauth/code does. */
 async function putCode(
     code: string,
     overrides: Record<string, unknown> = {},
@@ -36,8 +36,13 @@ async function putCode(
         expiresIn: 604800,
         ...overrides,
     };
-    await env.KV.put(`oauth-code:${code}`, JSON.stringify(stored), {
-        expirationTtl: 600,
+    const db = drizzle(env.DB, { schema });
+    const codeId = `oauth-code:${code}`;
+    await db.insert(schema.verification).values({
+        id: codeId,
+        identifier: codeId,
+        value: JSON.stringify(stored),
+        expiresAt: new Date(Date.now() + 600_000),
     });
 }
 
@@ -69,6 +74,7 @@ describe("OAuth authorization server metadata", () => {
         expect(meta.issuer).toBe(BASE);
         expect(meta.authorization_endpoint).toBe(`${BASE}/authorize`);
         expect(meta.token_endpoint).toBe(`${BASE}/api/oauth/token`);
+        expect(meta.revocation_endpoint).toBe(`${BASE}/api/oauth/revoke`);
         expect(meta.userinfo_endpoint).toBe(`${BASE}/api/oauth/userinfo`);
         expect(meta.device_authorization_endpoint).toBe(
             `${BASE}/api/device/code`,
@@ -121,6 +127,23 @@ describe("POST /api/oauth/token (authorization_code + PKCE)", () => {
         expect(res.status).toBe(200);
         const body = (await res.json()) as { access_token: string };
         expect(body.access_token).toBe("sk_test_access_token");
+    });
+
+    test("concurrent exchanges consume a code exactly once", async () => {
+        const code = crypto.randomUUID();
+        await putCode(code);
+        const [first, second] = await Promise.all([
+            SELF.fetch(
+                `${BASE}/api/oauth/token`,
+                formPost(validTokenParams(code)),
+            ),
+            SELF.fetch(
+                `${BASE}/api/oauth/token`,
+                formPost(validTokenParams(code)),
+            ),
+        ]);
+
+        expect([first.status, second.status].sort()).toEqual([200, 400]);
     });
 
     test("omitting redirect_uri is rejected (RFC 6749 §4.1.3)", async () => {
@@ -269,6 +292,71 @@ describe("POST /api/oauth/token (authorization_code + PKCE)", () => {
         expect(res.status).toBe(200);
         const body = (await res.json()) as { scope?: string };
         expect(body.scope).toBe("");
+    });
+});
+
+describe("POST /api/oauth/revoke", () => {
+    test("revokes a delegated secret key", async ({ sessionToken, mocks }) => {
+        await mocks.enable("tinybird", "github");
+        const createRes = await SELF.fetch(`${BASE}/api/api-keys`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({ name: "revoke-me", type: "secret" }),
+        });
+        const created = (await createRes.json()) as { key: string };
+
+        const revokeRes = await SELF.fetch(`${BASE}/api/oauth/revoke`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ token: created.key }),
+        });
+        expect(revokeRes.status).toBe(200);
+        expect(revokeRes.headers.get("Cache-Control")).toBe("no-store");
+
+        const userinfo = await SELF.fetch(`${BASE}/api/oauth/userinfo`, {
+            headers: { Authorization: `Bearer ${created.key}` },
+        });
+        expect(userinfo.status).toBe(401);
+    }, 30000);
+
+    test("does not revoke public app keys", async ({ sessionToken, mocks }) => {
+        await mocks.enable("tinybird", "github");
+        const createRes = await SELF.fetch(`${BASE}/api/api-keys`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                name: "public-client",
+                type: "publishable",
+            }),
+        });
+        const created = (await createRes.json()) as { key: string };
+
+        const revokeRes = await SELF.fetch(`${BASE}/api/oauth/revoke`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ token: created.key }),
+        });
+        expect(revokeRes.status).toBe(200);
+
+        const userinfo = await SELF.fetch(`${BASE}/api/oauth/userinfo`, {
+            headers: { Authorization: `Bearer ${created.key}` },
+        });
+        expect(userinfo.status).toBe(200);
+    }, 30000);
+
+    test("returns success for an unknown token", async () => {
+        const response = await SELF.fetch(`${BASE}/api/oauth/revoke`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ token: "sk_unknown" }),
+        });
+        expect(response.status).toBe(200);
     });
 });
 

--- a/gen.pollinations.ai/src/docs/apidocs-recipes.md
+++ b/gen.pollinations.ai/src/docs/apidocs-recipes.md
@@ -29,7 +29,7 @@ The header is preferred for everything except browser flows that can't set custo
 
 `401 UNAUTHORIZED` always means key missing or invalid. `402 PAYMENT_REQUIRED` means the key authenticated but the account or per-key budget is exhausted — see [Error Responses](#-error-responses).
 
-## 🔓 Sign in with Pollinations (OAuth 2.1)
+## 🔓 Connect Pollinations (OAuth 2.1)
 
 Third-party apps can obtain an API key on behalf of a Pollinations user — the OAuth 2.1 authorization-code flow with PKCE (S256) for web apps, or the device flow (RFC 8628) for CLIs. Register a **publishable App Key** (`pk_…`) with your redirect URIs at [enter.pollinations.ai](https://enter.pollinations.ai); the `pk_` key is your `client_id` (public client, no secret), and the issued access token is an opaque `sk_` key bound to the budget, expiry, and scopes the user approved.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18327,7 +18327,7 @@
     },
     "packages/sdk": {
       "name": "@pollinations/sdk",
-      "version": "5.1.0-alpha.2",
+      "version": "5.1.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@pollinations/sdk` will be documented in this file.
 
+## [5.1.0-alpha.3] - 2026-07-10
+
+### Changed
+- `PolliProvider` now uses authorization code + PKCE instead of receiving a
+  delegated key in the callback fragment.
+- Adds `disconnect()` to revoke the delegated key; `logout()` remains a local
+  sign-out.
+
 ## [5.1.0-alpha.2] - 2026-07-02
 
 ### Changed

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -156,8 +156,8 @@ console.log(`Logged in as ${me.name} (${me.tier})`);
 
 ### React auth provider
 
-React apps can use the `@pollinations/sdk/react` subpath for shared login
-state. The provider only owns the session token and OAuth flow; account data is
+React apps can use the `@pollinations/sdk/react` subpath for shared connection
+state. The provider only owns the delegated token and OAuth flow; account data is
 loaded by opt-in hooks.
 
 ```tsx
@@ -168,16 +168,16 @@ import {
 } from '@pollinations/sdk/react';
 
 function AccountStatus() {
-  const { isLoggedIn, login, logout } = useAuth();
+  const { isLoggedIn, login, disconnect } = useAuth();
   const { data: profile } = useAccountProfile({ enabled: isLoggedIn });
 
   if (!isLoggedIn) {
-    return <button onClick={() => login()}>Log in</button>;
+    return <button onClick={() => void login()}>Connect Pollinations</button>;
   }
 
   return (
-    <button onClick={logout}>
-      Log out{profile?.name ? ` ${profile.name}` : ''}
+    <button onClick={() => void disconnect()}>
+      Disconnect{profile?.name ? ` ${profile.name}` : ''}
     </button>
   );
 }
@@ -200,7 +200,8 @@ SDK response shapes plus `{ isLoading, error, refresh }`.
 `PolliProvider` is **SSR-safe** but is a **client component** (it uses `useState` / `useEffect` and reads from `window.localStorage`):
 
 - **First paint contract**: state starts `null` on both server and client, so initial HTML always renders as logged-out. No hydration mismatch.
-- **Hydration**: after mount, the provider reads the session token from storage (default `localStorage`) and parses any `#api_key=…&state=…` fragment from an OAuth redirect. No account data is fetched until an account hook is mounted.
+- **Hydration**: after mount, the provider reads the delegated token from storage (default `localStorage`) or exchanges an OAuth authorization code using its saved PKCE verifier. No account data is fetched until an account hook is mounted.
+- **Disconnect vs. logout**: `disconnect()` revokes the delegated token and clears it locally. `logout()` only clears local state.
 - **Next.js App Router**: mount the provider inside a client component. Either put it in a file with `"use client"` at the top, or wrap a small client subtree from a server component:
 
   ```tsx

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.1.0-alpha.2",
+  "version": "5.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/sdk",
-      "version": "5.1.0-alpha.2",
+      "version": "5.1.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.1.0-alpha.2",
+  "version": "5.1.0-alpha.3",
   "description": "Official SDK for pollinations.ai - Generate images, videos, audio, and text with ease",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/src/react/PolliProvider.test.tsx
+++ b/packages/sdk/src/react/PolliProvider.test.tsx
@@ -1,15 +1,19 @@
 import { act, create } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthActionsValue } from "./contexts.js";
 import { useAuthActions } from "./hooks.js";
 import { PolliProvider } from "./PolliProvider.js";
 import type { StorageAdapter } from "./storage.js";
 
-function memoryStorage(): StorageAdapter {
-    const values = new Map<string, string>();
+function memoryStorage(initial: Record<string, string> = {}): StorageAdapter & {
+    snapshot: () => Record<string, string>;
+} {
+    const values = new Map(Object.entries(initial));
     return {
         getItem: (key) => values.get(key) ?? null,
         setItem: (key, value) => values.set(key, value),
         removeItem: (key) => values.delete(key),
+        snapshot: () => Object.fromEntries(values),
     };
 }
 
@@ -27,19 +31,26 @@ function stubWindow(href: string) {
         },
     };
     vi.stubGlobal("window", win);
+    return win;
 }
 
-async function renderProvider(appKey: string) {
+async function renderProvider(appKey: string, storage = memoryStorage()) {
+    let actions: AuthActionsValue | null = null;
+    function GrabActions() {
+        actions = useAuthActions();
+        return null;
+    }
     await act(async () => {
         create(
-            <PolliProvider appKey={appKey} storage={memoryStorage()}>
-                <div />
+            <PolliProvider appKey={appKey} storage={storage}>
+                <GrabActions />
             </PolliProvider>,
         );
     });
+    return { storage, getActions: () => actions };
 }
 
-describe("PolliProvider setup guidance", () => {
+describe("PolliProvider", () => {
     afterEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
@@ -60,29 +71,105 @@ describe("PolliProvider setup guidance", () => {
 
     it("persists the key to the provided storage", async () => {
         stubWindow("https://app.example/");
-        const spy: StorageAdapter = {
-            getItem: vi.fn(() => null),
-            setItem: vi.fn(),
-            removeItem: vi.fn(),
-        };
-        let setApiKey: ((key: string | null) => void) | null = null;
-        function Grab() {
-            setApiKey = useAuthActions().setApiKey;
-            return null;
-        }
+        const { storage, getActions } = await renderProvider("pk_test");
+
+        act(() => getActions()?.setApiKey("sk_live"));
+
+        expect(storage.snapshot()["polli:pk_test:token"]).toBe("sk_live");
+    });
+
+    it("starts authorization code flow with PKCE", async () => {
+        const win = stubWindow("https://app.example/callback?keep=1");
+        const { storage, getActions } = await renderProvider("pk_test");
 
         await act(async () => {
-            create(
-                <PolliProvider appKey="pk_test" storage={spy}>
-                    <Grab />
-                </PolliProvider>,
-            );
+            await getActions()?.login({ permissions: ["profile"] });
         });
-        act(() => setApiKey?.("sk_live"));
 
-        expect(spy.setItem).toHaveBeenCalledWith(
-            "polli:pk_test:token",
-            "sk_live",
+        const authorizationUrl = new URL(
+            (win.location as { href: string }).href,
         );
+        expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
+        expect(authorizationUrl.searchParams.get("client_id")).toBe("pk_test");
+        expect(authorizationUrl.searchParams.get("scope")).toBe("profile");
+        expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+            "S256",
+        );
+        expect(authorizationUrl.searchParams.get("code_challenge")).toMatch(
+            /^[A-Za-z0-9_-]{43}$/,
+        );
+
+        const pending = JSON.parse(
+            storage.snapshot()["polli:pk_test:oauth_pending"],
+        );
+        expect(pending.codeVerifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+        expect(pending.redirectUri).toBe("https://app.example/callback?keep=1");
+        expect(authorizationUrl.searchParams.get("state")).toBe(pending.state);
+    });
+
+    it("exchanges the callback code and stores the delegated key", async () => {
+        const win = stubWindow(
+            "https://app.example/callback?keep=1&code=oauth-code&state=state",
+        );
+        const storage = memoryStorage({
+            "polli:pk_test:oauth_pending": JSON.stringify({
+                state: "state",
+                codeVerifier: "verifier",
+                redirectUri: "https://app.example/callback?keep=1",
+            }),
+        });
+        const fetchMock = vi.fn(
+            async (_input: RequestInfo | URL, _init?: RequestInit) =>
+                Response.json({ access_token: "sk_delegated" }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await renderProvider("pk_test", storage);
+
+        await vi.waitFor(() =>
+            expect(storage.snapshot()["polli:pk_test:token"]).toBe(
+                "sk_delegated",
+            ),
+        );
+        expect(
+            storage.snapshot()["polli:pk_test:oauth_pending"],
+        ).toBeUndefined();
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://enter.pollinations.ai/api/oauth/token",
+            expect.objectContaining({ method: "POST" }),
+        );
+        const request = fetchMock.mock.calls[0]?.[1];
+        if (!request) throw new Error("Expected token exchange request");
+        expect(String(request.body)).toContain("code=oauth-code");
+        expect(String(request.body)).toContain("code_verifier=verifier");
+        expect(
+            (win.history as { replaceState: ReturnType<typeof vi.fn> })
+                .replaceState,
+        ).toHaveBeenCalledWith({}, "", "/callback?keep=1");
+    });
+
+    it("disconnects by revoking the delegated key", async () => {
+        stubWindow("https://app.example/");
+        const storage = memoryStorage({
+            "polli:pk_test:token": "sk_delegated",
+        });
+        const fetchMock = vi.fn(
+            async () => new Response(null, { status: 200 }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+        const { getActions } = await renderProvider("pk_test", storage);
+
+        await vi.waitFor(() =>
+            expect(getActions()?.disconnect).toBeTypeOf("function"),
+        );
+        await act(async () => {
+            await getActions()?.disconnect();
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://enter.pollinations.ai/api/oauth/revoke",
+            expect.objectContaining({ method: "POST" }),
+        );
+        expect(storage.snapshot()["polli:pk_test:token"]).toBeUndefined();
     });
 });

--- a/packages/sdk/src/react/PolliProvider.tsx
+++ b/packages/sdk/src/react/PolliProvider.tsx
@@ -68,11 +68,15 @@ function buildAuthorizeUrl(args: {
     models?: readonly string[];
     budget?: number;
     expiry?: number;
+    codeChallenge: string;
 }): string {
     const params = new URLSearchParams();
     params.set("redirect_uri", args.redirectUrl);
     params.set("client_id", args.appKey);
     params.set("state", args.state);
+    params.set("response_type", "code");
+    params.set("code_challenge", args.codeChallenge);
+    params.set("code_challenge_method", "S256");
     if (args.permissions.length > 0) {
         params.set("scope", args.permissions.join(" "));
     }
@@ -86,6 +90,25 @@ function buildAuthorizeUrl(args: {
         params.set("expiry", String(args.expiry));
     }
     return `${args.enterUrl}/authorize?${params.toString()}`;
+}
+
+function base64Url(bytes: Uint8Array): string {
+    return btoa(String.fromCharCode(...bytes))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+}
+
+async function createPkce(): Promise<{
+    verifier: string;
+    challenge: string;
+}> {
+    const verifier = base64Url(crypto.getRandomValues(new Uint8Array(32)));
+    const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(verifier),
+    );
+    return { verifier, challenge: base64Url(new Uint8Array(digest)) };
 }
 
 function currentRedirectUrl(): string | null {
@@ -143,8 +166,8 @@ function warnAuthSetup(appKey: string, redirectUrl: string | null): void {
 /**
  * Provides Pollinations auth state to descendants. Wrap your app once at the
  * root. Holds the delegated API key, handles the OAuth callback, and exposes
- * login/logout. Account data is fetched by opt-in hooks so apps only request
- * the data they render.
+ * connect, local logout, and revocation actions. Account data is fetched by
+ * opt-in hooks so apps only request the data they render.
  */
 export function PolliProvider({
     appKey,
@@ -163,7 +186,7 @@ export function PolliProvider({
     );
     const resolvedApiBaseUrl = apiBaseUrl ?? `${enterUrl}/api`;
     const storageKey = `polli:${appKey}:token`;
-    const stateStorageKey = `polli:${appKey}:oauth_state`;
+    const pendingStorageKey = `polli:${appKey}:oauth_pending`;
 
     const defaultPermissions = useMemo<readonly AccountPermission[]>(
         () => permissions ?? [],
@@ -192,49 +215,103 @@ export function PolliProvider({
         [storage, storageKey],
     );
 
-    // Hydrate API key from storage + capture URL fragment after redirect.
+    // Hydrate API key from storage or exchange an OAuth code after redirect.
     useEffect(() => {
-        if (typeof window === "undefined") {
-            setIsHydrated(true);
-            return;
+        let cancelled = false;
+        async function hydrate() {
+            if (typeof window === "undefined") {
+                setIsHydrated(true);
+                return;
+            }
+
+            const result = consumeOAuthCallback(
+                window.location,
+                storage,
+                pendingStorageKey,
+            );
+            if (result.cleanedUrl) {
+                window.history.replaceState({}, "", result.cleanedUrl);
+            }
+            if (result.invalidState) {
+                console.warn(
+                    "[PolliProvider] dropping auth response with missing or mismatched state",
+                );
+                setError(new Error("Invalid OAuth state"));
+            } else if (result.error) {
+                console.warn(
+                    `[PolliProvider] auth error: ${result.error}${
+                        result.errorDescription
+                            ? ` — ${result.errorDescription}`
+                            : ""
+                    }`,
+                );
+                setError(new Error(result.errorDescription ?? result.error));
+            } else if (
+                result.code &&
+                result.codeVerifier &&
+                result.redirectUri
+            ) {
+                try {
+                    const response = await fetch(
+                        `${enterUrl.replace(/\/+$/, "")}/api/oauth/token`,
+                        {
+                            method: "POST",
+                            headers: {
+                                "Content-Type":
+                                    "application/x-www-form-urlencoded",
+                            },
+                            body: new URLSearchParams({
+                                grant_type: "authorization_code",
+                                code: result.code,
+                                client_id: appKey,
+                                redirect_uri: result.redirectUri,
+                                code_verifier: result.codeVerifier,
+                            }),
+                        },
+                    );
+                    storage.removeItem(pendingStorageKey);
+                    const token = (await response.json().catch(() => ({}))) as {
+                        access_token?: string;
+                        error?: string;
+                        error_description?: string;
+                    };
+                    if (!response.ok || !token.access_token) {
+                        throw new Error(
+                            token.error_description ||
+                                token.error ||
+                                "OAuth token exchange failed",
+                        );
+                    }
+                    if (!cancelled) updateApiKey(token.access_token);
+                } catch (err) {
+                    if (!cancelled) {
+                        setError(
+                            err instanceof Error ? err : new Error(String(err)),
+                        );
+                    }
+                }
+            } else {
+                const stored = storage.getItem(storageKey);
+                if (stored) setApiKey(stored);
+            }
+            if (!cancelled) setIsHydrated(true);
         }
 
-        const result = consumeOAuthCallback(
-            window.location,
-            storage,
-            stateStorageKey,
-        );
-        if (result.cleanedUrl) {
-            window.history.replaceState({}, "", result.cleanedUrl);
-        }
-        if (result.invalidState) {
-            console.warn(
-                "[PolliProvider] dropping auth response with missing or mismatched state",
-            );
-            setError(new Error("Invalid OAuth state"));
-        }
-        if (result.error) {
-            console.warn(
-                `[PolliProvider] auth error: ${result.error}${
-                    result.errorDescription
-                        ? ` — ${result.errorDescription}`
-                        : ""
-                }`,
-            );
-            setError(new Error(result.errorDescription ?? result.error));
-        }
-        if (result.apiKey) {
-            updateApiKey(result.apiKey);
-            setIsHydrated(true);
-            return;
-        }
-        const stored = storage.getItem(storageKey);
-        if (stored) setApiKey(stored);
-        setIsHydrated(true);
-    }, [stateStorageKey, storage, updateApiKey, storageKey]);
+        void hydrate();
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        appKey,
+        enterUrl,
+        pendingStorageKey,
+        storage,
+        updateApiKey,
+        storageKey,
+    ]);
 
     const login = useCallback(
-        (request?: AuthorizeRequest) => {
+        async (request?: AuthorizeRequest) => {
             if (typeof window === "undefined") return;
             const currentUrl = currentRedirectUrl();
             if (!currentUrl) return;
@@ -246,7 +323,15 @@ export function PolliProvider({
                       )
                     : [...defaultPermissions];
             const state = crypto.randomUUID();
-            storage.setItem(stateStorageKey, state);
+            const pkce = await createPkce();
+            storage.setItem(
+                pendingStorageKey,
+                JSON.stringify({
+                    state,
+                    codeVerifier: pkce.verifier,
+                    redirectUri: currentUrl,
+                }),
+            );
             window.location.href = buildAuthorizeUrl({
                 enterUrl,
                 appKey,
@@ -256,6 +341,7 @@ export function PolliProvider({
                 models: request?.models ?? defaultModels,
                 budget: request?.budget ?? defaultBudget,
                 expiry: request?.expiry ?? defaultExpiry,
+                codeChallenge: pkce.challenge,
             });
         },
         [
@@ -263,7 +349,7 @@ export function PolliProvider({
             appKey,
             defaultPermissions,
             storage,
-            stateStorageKey,
+            pendingStorageKey,
             defaultModels,
             defaultBudget,
             defaultExpiry,
@@ -274,6 +360,24 @@ export function PolliProvider({
         updateApiKey(null);
     }, [updateApiKey]);
 
+    const disconnect = useCallback(async () => {
+        if (!apiKey) return;
+        const response = await fetch(
+            `${enterUrl.replace(/\/+$/, "")}/api/oauth/revoke`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: new URLSearchParams({ token: apiKey }),
+            },
+        );
+        if (!response.ok) {
+            throw new Error("Failed to disconnect Pollinations account");
+        }
+        updateApiKey(null);
+    }, [apiKey, enterUrl, updateApiKey]);
+
     const authValue = useMemo<AuthContextValue>(
         () => ({
             apiKey,
@@ -282,6 +386,7 @@ export function PolliProvider({
             error,
             login,
             logout,
+            disconnect,
             setApiKey: updateApiKey,
             enterUrl,
             apiBaseUrl: resolvedApiBaseUrl,
@@ -292,6 +397,7 @@ export function PolliProvider({
             error,
             login,
             logout,
+            disconnect,
             updateApiKey,
             enterUrl,
             resolvedApiBaseUrl,

--- a/packages/sdk/src/react/contexts.ts
+++ b/packages/sdk/src/react/contexts.ts
@@ -25,8 +25,10 @@ export interface AuthorizeRequest {
 }
 
 export interface AuthActionsValue {
-    login: (request?: AuthorizeRequest) => void;
+    login: (request?: AuthorizeRequest) => Promise<void>;
     logout: () => void;
+    /** Revoke the delegated key and clear the local connection. */
+    disconnect: () => Promise<void>;
     setApiKey: (apiKey: string | null) => void;
     /** Resolved enter URL, useful for top-up / dashboard links. */
     enterUrl: string;

--- a/packages/sdk/src/react/hooks.test.tsx
+++ b/packages/sdk/src/react/hooks.test.tsx
@@ -47,6 +47,7 @@ function authValue(
         error: null,
         login: vi.fn(),
         logout: vi.fn(),
+        disconnect: vi.fn(),
         setApiKey: vi.fn(),
         enterUrl: "https://enter.example",
         apiBaseUrl: "https://enter.example/api",

--- a/packages/sdk/src/react/hooks.ts
+++ b/packages/sdk/src/react/hooks.ts
@@ -65,13 +65,13 @@ export function useAuthState(): AuthStateValue {
     );
 }
 
-/** Stable login/logout refs and provider config. */
+/** Stable connect/logout/disconnect refs and provider config. */
 export function useAuthActions(): AuthActionsValue {
-    const { login, logout, setApiKey, enterUrl, apiBaseUrl } =
+    const { login, logout, disconnect, setApiKey, enterUrl, apiBaseUrl } =
         useRequiredAuth();
     return useMemo(
-        () => ({ login, logout, setApiKey, enterUrl, apiBaseUrl }),
-        [login, logout, setApiKey, enterUrl, apiBaseUrl],
+        () => ({ login, logout, disconnect, setApiKey, enterUrl, apiBaseUrl }),
+        [login, logout, disconnect, setApiKey, enterUrl, apiBaseUrl],
     );
 }
 

--- a/packages/sdk/src/react/oauth.test.ts
+++ b/packages/sdk/src/react/oauth.test.ts
@@ -4,136 +4,109 @@ import { consumeOAuthCallback } from "./oauth.js";
 function makeStorage(initial: Record<string, string> = {}) {
     const data = new Map(Object.entries(initial));
     return {
-        getItem: (k: string) => data.get(k) ?? null,
-        setItem: (k: string, v: string) => {
-            data.set(k, v);
-        },
-        removeItem: (k: string) => {
-            data.delete(k);
-        },
+        getItem: (key: string) => data.get(key) ?? null,
+        setItem: (key: string, value: string) => data.set(key, value),
+        removeItem: (key: string) => data.delete(key),
         snapshot: () => Object.fromEntries(data),
     };
 }
 
-const STATE_KEY = "polli:test:oauth_state";
-const baseLoc = { pathname: "/", search: "", hash: "" };
+const PENDING_KEY = "polli:test:oauth_pending";
+const pending = JSON.stringify({
+    state: "abc",
+    codeVerifier: "verifier",
+    redirectUri: "https://app.example/callback?keep=1",
+});
+const baseLocation = { pathname: "/callback", search: "", hash: "#route" };
 
 describe("consumeOAuthCallback", () => {
-    it("returns empty when hash is missing", () => {
-        const r = consumeOAuthCallback(baseLoc, makeStorage(), STATE_KEY);
-        expect(r).toEqual({
+    it("returns empty when query has no OAuth response", () => {
+        const result = consumeOAuthCallback(
+            { ...baseLocation, search: "?keep=1" },
+            makeStorage(),
+            PENDING_KEY,
+        );
+        expect(result).toEqual({
             cleanedUrl: null,
-            apiKey: null,
+            code: null,
+            codeVerifier: null,
+            redirectUri: null,
             error: null,
             errorDescription: null,
             invalidState: false,
         });
     });
 
-    it("returns empty when hash has no auth params", () => {
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#/route?foo=bar" },
+    it("accepts a code when state matches and returns the PKCE exchange data", () => {
+        const storage = makeStorage({ [PENDING_KEY]: pending });
+        const result = consumeOAuthCallback(
+            {
+                ...baseLocation,
+                search: "?keep=1&code=oauth-code&state=abc",
+            },
+            storage,
+            PENDING_KEY,
+        );
+
+        expect(result.code).toBe("oauth-code");
+        expect(result.codeVerifier).toBe("verifier");
+        expect(result.redirectUri).toBe("https://app.example/callback?keep=1");
+        expect(result.cleanedUrl).toBe("/callback?keep=1#route");
+        expect(storage.snapshot()).toEqual({ [PENDING_KEY]: pending });
+    });
+
+    it("rejects a code when state mismatches and preserves pending state", () => {
+        const storage = makeStorage({ [PENDING_KEY]: pending });
+        const result = consumeOAuthCallback(
+            { ...baseLocation, search: "?code=oauth-code&state=wrong" },
+            storage,
+            PENDING_KEY,
+        );
+
+        expect(result.code).toBeNull();
+        expect(result.invalidState).toBe(true);
+        expect(storage.snapshot()).toEqual({ [PENDING_KEY]: pending });
+    });
+
+    it("rejects a planted code when no authorization is pending", () => {
+        const result = consumeOAuthCallback(
+            { ...baseLocation, search: "?code=oauth-code&state=abc" },
             makeStorage(),
-            STATE_KEY,
+            PENDING_KEY,
         );
-        expect(r.apiKey).toBeNull();
-        expect(r.cleanedUrl).toBeNull();
+        expect(result.invalidState).toBe(true);
     });
 
-    it("accepts api_key when state matches", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#api_key=pk_123&state=abc" },
+    it("returns an error and clears matching pending state", () => {
+        const storage = makeStorage({ [PENDING_KEY]: pending });
+        const result = consumeOAuthCallback(
+            {
+                ...baseLocation,
+                search: "?error=access_denied&error_description=user+denied&state=abc",
+            },
             storage,
-            STATE_KEY,
+            PENDING_KEY,
         );
-        expect(r.apiKey).toBe("pk_123");
-        expect(r.invalidState).toBe(false);
-        expect(r.cleanedUrl).toBe("/");
+
+        expect(result.error).toBe("access_denied");
+        expect(result.errorDescription).toBe("user denied");
+        expect(result.cleanedUrl).toBe("/callback#route");
         expect(storage.snapshot()).toEqual({});
     });
 
-    it("rejects api_key when state mismatches (and preserves stored state)", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#api_key=pk_123&state=BOGUS" },
-            storage,
-            STATE_KEY,
-        );
-        expect(r.apiKey).toBeNull();
-        expect(r.invalidState).toBe(true);
-        expect(storage.snapshot()).toEqual({ [STATE_KEY]: "abc" });
-    });
-
-    it("rejects api_key when no state is stored (planted URL)", () => {
-        const storage = makeStorage();
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#api_key=pk_123&state=anything" },
-            storage,
-            STATE_KEY,
-        );
-        expect(r.apiKey).toBeNull();
-        expect(r.invalidState).toBe(true);
-    });
-
-    it("preserves hash-router route prefix on cleanup", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#/dashboard?api_key=pk_123&state=abc" },
-            storage,
-            STATE_KEY,
-        );
-        expect(r.apiKey).toBe("pk_123");
-        expect(r.cleanedUrl).toBe("/#/dashboard");
-    });
-
-    it("preserves non-auth hash params on cleanup", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#api_key=pk_123&state=abc&foo=bar" },
-            storage,
-            STATE_KEY,
-        );
-        expect(r.cleanedUrl).toBe("/#foo=bar");
-    });
-
-    it("preserves pathname and search on cleanup", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
+    it("rejects an error when state mismatches and preserves pending state", () => {
+        const storage = makeStorage({ [PENDING_KEY]: pending });
+        const result = consumeOAuthCallback(
             {
-                pathname: "/app",
-                search: "?x=1",
-                hash: "#api_key=pk_123&state=abc",
+                ...baseLocation,
+                search: "?error=access_denied&state=wrong",
             },
             storage,
-            STATE_KEY,
+            PENDING_KEY,
         );
-        expect(r.cleanedUrl).toBe("/app?x=1");
-    });
 
-    it("returns error and clears state when error callback state matches", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
-            {
-                ...baseLoc,
-                hash: "#error=denied&error_description=user+denied&state=abc",
-            },
-            storage,
-            STATE_KEY,
-        );
-        expect(r.error).toBe("denied");
-        expect(r.errorDescription).toBe("user denied");
-        expect(storage.snapshot()).toEqual({});
-    });
-
-    it("returns error but preserves stored state when error state mismatches", () => {
-        const storage = makeStorage({ [STATE_KEY]: "abc" });
-        const r = consumeOAuthCallback(
-            { ...baseLoc, hash: "#error=denied&state=BOGUS" },
-            storage,
-            STATE_KEY,
-        );
-        expect(r.error).toBe("denied");
-        expect(storage.snapshot()).toEqual({ [STATE_KEY]: "abc" });
+        expect(result.error).toBeNull();
+        expect(result.invalidState).toBe(true);
+        expect(storage.snapshot()).toEqual({ [PENDING_KEY]: pending });
     });
 });

--- a/packages/sdk/src/react/oauth.ts
+++ b/packages/sdk/src/react/oauth.ts
@@ -1,38 +1,25 @@
 /**
- * Pure OAuth callback parser. Extracted from PolliProvider so it can be
- * unit-tested without React.
+ * Pure OAuth authorization-code callback parser for PolliProvider.
  *
- * Reads `window.location.hash` for the `api_key` / `error` / `state`
- * fragment params that `enter.pollinations.ai/authorize` redirects back
- * with. Validates the `state` parameter against the value the client
- * persisted at login() time (CSRF protection), then signals to the caller
- * what to do.
- *
- * Validate-then-clear semantics: state is only cleared from storage when
- * the callback genuinely matches a pending login. A spoofed callback with
- * a wrong state must NOT clear stored state — otherwise an attacker could
- * DoS the real callback by planting a bad URL.
+ * The pending PKCE verifier stays in the configured storage while Pollinations
+ * handles consent. On return, this validates state, removes OAuth query
+ * parameters from the URL, and gives the provider the values needed for the
+ * token exchange.
  */
 
+export interface PendingAuthorization {
+    state: string;
+    codeVerifier: string;
+    redirectUri: string;
+}
+
 export interface OAuthCallbackResult {
-    /**
-     * If auth params were present in the hash, the URL to replace
-     * `window.location` with via `history.replaceState`. Strips the auth
-     * params but preserves the route prefix (`#/dashboard`), any non-auth
-     * hash params, pathname, and search.
-     *
-     * `null` when no auth params were present (no rewrite needed).
-     */
     cleanedUrl: string | null;
-    /** Valid api_key from a callback whose `state` matched. */
-    apiKey: string | null;
-    /** OAuth error code, if the callback was an error response. */
+    code: string | null;
+    codeVerifier: string | null;
+    redirectUri: string | null;
     error: string | null;
     errorDescription: string | null;
-    /**
-     * `true` when an `api_key` was present but `state` did not match.
-     * Callers should warn but otherwise ignore (do NOT clear stored state).
-     */
     invalidState: boolean;
 }
 
@@ -49,62 +36,71 @@ interface OAuthStorage {
 
 const EMPTY: OAuthCallbackResult = {
     cleanedUrl: null,
-    apiKey: null,
+    code: null,
+    codeVerifier: null,
+    redirectUri: null,
     error: null,
     errorDescription: null,
     invalidState: false,
 };
 
+function readPendingAuthorization(
+    storage: OAuthStorage,
+    pendingStorageKey: string,
+): PendingAuthorization | null {
+    const raw = storage.getItem(pendingStorageKey);
+    if (!raw) return null;
+    try {
+        const pending = JSON.parse(raw) as Partial<PendingAuthorization>;
+        if (
+            typeof pending.state !== "string" ||
+            typeof pending.codeVerifier !== "string" ||
+            typeof pending.redirectUri !== "string"
+        ) {
+            return null;
+        }
+        return pending as PendingAuthorization;
+    } catch {
+        return null;
+    }
+}
+
 export function consumeOAuthCallback(
     location: ReadOnlyLocation,
     storage: OAuthStorage,
-    stateStorageKey: string,
+    pendingStorageKey: string,
 ): OAuthCallbackResult {
-    const rawHash = location.hash.startsWith("#")
-        ? location.hash.slice(1)
-        : location.hash;
-    if (!rawHash) return EMPTY;
-
-    // Hash-router apps use `#/route?param=…` — the route prefix sits before
-    // the `?`, params after. Treating the whole hash as params would
-    // mis-parse the route and the cleanup step below would strip it.
-    const queryIdx = rawHash.indexOf("?");
-    const routePrefix = queryIdx === -1 ? "" : rawHash.slice(0, queryIdx);
-    const paramString = queryIdx === -1 ? rawHash : rawHash.slice(queryIdx + 1);
-    const params = new URLSearchParams(paramString);
-
-    const key = params.get("api_key");
+    const params = new URLSearchParams(location.search);
+    const code = params.get("code");
     const error = params.get("error");
+    if (!code && !error) return EMPTY;
+
     const receivedState = params.get("state");
     const errorDescription = params.get("error_description");
-
-    if (!key && !error) return EMPTY;
-
-    for (const p of ["api_key", "state", "error", "error_description"]) {
-        params.delete(p);
+    for (const param of ["code", "state", "error", "error_description"]) {
+        params.delete(param);
     }
     const remaining = params.toString();
-    const newHash = remaining
-        ? routePrefix
-            ? `${routePrefix}?${remaining}`
-            : remaining
-        : routePrefix;
     const cleanedUrl =
-        location.pathname + location.search + (newHash ? `#${newHash}` : "");
+        location.pathname + (remaining ? `?${remaining}` : "") + location.hash;
+    const pending = readPendingAuthorization(storage, pendingStorageKey);
 
-    if (key) {
-        const expectedState = storage.getItem(stateStorageKey);
-        if (!expectedState || receivedState !== expectedState) {
+    if (code) {
+        if (!pending || receivedState !== pending.state) {
             return { ...EMPTY, cleanedUrl, invalidState: true };
         }
-        storage.removeItem(stateStorageKey);
-        return { ...EMPTY, cleanedUrl, apiKey: key };
+        return {
+            ...EMPTY,
+            cleanedUrl,
+            code,
+            codeVerifier: pending.codeVerifier,
+            redirectUri: pending.redirectUri,
+        };
     }
 
-    // error branch
-    const expectedState = storage.getItem(stateStorageKey);
-    if (expectedState && receivedState === expectedState) {
-        storage.removeItem(stateStorageKey);
+    if (!pending || receivedState !== pending.state) {
+        return { ...EMPTY, cleanedUrl, invalidState: true };
     }
+    storage.removeItem(pendingStorageKey);
     return { ...EMPTY, cleanedUrl, error, errorDescription };
 }


### PR DESCRIPTION
- Moves the React SDK from the legacy fragment callback to authorization code + PKCE.
- Adds RFC 7009-style delegated-key revocation and keeps `logout()` as local-only sign-out.
- Consumes authorization codes atomically and advertises the revocation endpoint in OAuth discovery.
- Groups delegated keys under Connected Apps with a bulk disconnect action, and updates demo/dashboard/docs wording.
- Checks: SDK tests/typecheck, Enter OAuth and Connected Apps tests, Enter frontend build, and Gen docs tests.