### PR TITLE
feat: allowlist JustScriptzz + riofndev + solarnode-developement for community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -24,6 +24,9 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     216855486, // Bakhshi7889
     64634725, // vendouple
     182555207, // YoannDev90
+    195966113, // JustScriptzz
+    113566110, // riofndev
+    188266626, // solarnode-developement
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds JustScriptzz (195966113), riofndev (113566110), solarnode-developement (188266626) to COMMUNITY_MODEL_ALLOWED_GITHUB_IDS
- Next batch from the Community models whitelist Discord thread (the three marked waiting on 2026-07-03)
- solarnode-developement spelling verified via GitHub API (display name xyzprojectz = archary.dev; the -development spelling 404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)