### PR TITLE
fix: update Buffer Instagram media payload

### DIFF
--- a/social/scripts/buffer_publish.py
+++ b/social/scripts/buffer_publish.py
@@ -133,20 +133,12 @@ def create_buffer_post_with_retry(
     return {"success": False, "error": "Max retries exceeded"}
 
 
-def _instagram_metadata(post_data: dict, image_urls: list) -> dict:
-    """Build Instagram post/carousel metadata block."""
-    metadata_block = post_data.get("metadata") or {}
-    stored_post_type = metadata_block.get("post_type")
-    if stored_post_type == "carousel" or len(image_urls) > 1:
-        instagram_type = "carousel"
-    else:
-        instagram_type = "post"
-    print(f"Instagram post type: {instagram_type}")
-    # Verified against Buffer GraphQL introspection: InstagramPostMetadataInput.type uses PostType,
-    # and PostType includes "post", "story", "reel", and "carousel".
+def _instagram_metadata(_post_data: dict, _image_urls: list) -> dict:
+    """Build Instagram post metadata; multiple assets create a carousel."""
+    print("Instagram post type: post")
     return {
         "instagram": {
-            "type": instagram_type,
+            "type": "post",
             "shouldShareToFeed": True,
         }
     }

--- a/social/scripts/buffer_utils.py
+++ b/social/scripts/buffer_utils.py
@@ -189,19 +189,15 @@ def create_buffer_post(
     if metadata:
         post_input["metadata"] = metadata
 
-    # Map media (REST used media[photo], GraphQL uses assets.images)
+    # Map media to Buffer's ordered GraphQL assets input.
     if media:
         photos = media.get("photos")  # list of URLs (for carousel)
         if photos:
-            post_input["assets"] = {
-                "images": [{"url": u} for u in photos]
-            }
+            post_input["assets"] = [{"image": {"url": url}} for url in photos]
         else:
             image_url = media.get("photo") or media.get("url")
             if image_url:
-                post_input["assets"] = {
-                    "images": [{"url": image_url}]
-                }
+                post_input["assets"] = [{"image": {"url": image_url}}]
 
     result = _graphql_request(
         access_token,


### PR DESCRIPTION
- Updates Buffer image and carousel payloads to the current ordered `assets` input.
- Uses Instagram post metadata for multi-image carousels; Buffer now rejects `type: carousel`.
- Preserves the existing single-image and multi-image publishing behavior.

Root cause: Buffer changed both its media input shape and accepted Instagram post types. Renewing the API key restores authentication, but the old mutation payload is no longer valid.

Checks:
- Buffer API authentication and all four configured channels verified read-only
- Single-image and carousel payload assertions passed
- Python compilation passed
- Live Instagram draft mutation tested and cleaned up
- `git diff --check` passed
