### PR TITLE
fix: switch flux provider from fireworks to vast.ai

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -316,7 +316,7 @@ export const IMAGE_SERVICES = {
     "flux": {
         aliases: [],
         modelId: "flux",
-        provider: "fireworks",
+        provider: "vast",
         brand: "Black Forest Labs",
         category: "image",
         addedDate: new Date("2025-10-07").getTime(),
@@ -325,8 +325,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.0014, // per image
         },
         title: "Flux Schnell",
-        description:
-            "Flux Schnell - Fast high-quality image generation (Fireworks)",
+        description: "Flux Schnell - Fast high-quality image generation",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },


### PR DESCRIPTION
Flux has run primarily on Vast.ai RTX 5090s since 2026-07-02 (#12171), with Fireworks now only a fallback path. The registry still listed fireworks as the provider.

- registry \`provider\` field: fireworks -> vast
- drop the stale "(Fireworks)" attribution from the description