### PR TITLE
docs: canonical model names in docs, sdk jsdoc, mcp descriptions

### DIFF
--- a/gen.pollinations.ai/src/docs/apidocs-recipes.md
+++ b/gen.pollinations.ai/src/docs/apidocs-recipes.md
@@ -56,7 +56,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="openai",
+    model="gpt-5.4-nano",
     messages=[{"role": "user", "content": "Summarise the theory of relativity in one sentence."}],
 )
 print(response.choices[0].message.content)
@@ -79,7 +79,7 @@ const response = await client.chat.completions.create({
 console.log(response.choices[0].message.content);
 ```
 
-Model IDs come from `GET /v1/models`. Anything `openai`, `claude`, `mistral`, `deepseek`, etc. routes to the corresponding provider on our side — you don't need separate keys per provider.
+Model IDs come from `GET /v1/models`. Anything `gpt-5.4-nano`, `claude-sonnet-4.6`, `mistral-small-4`, `deepseek-v4-flash`, etc. routes to the corresponding provider on our side — you don't need separate keys per provider.
 
 ## 🌊 Streaming chat completions
 
@@ -91,7 +91,7 @@ Set `stream: true` to receive Server-Sent Events (SSE) deltas as the model write
 curl -N "https://gen.pollinations.ai/v1/chat/completions" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model":"openai","stream":true,"messages":[{"role":"user","content":"Count to five, one word per line."}]}'
+  -d '{"model":"gpt-5.4-nano","stream":true,"messages":[{"role":"user","content":"Count to five, one word per line."}]}'
 ```
 
 `-N` disables curl's output buffering so deltas appear as they arrive. Each event is a line of the form `data: {…}` terminated by `data: [DONE]`.
@@ -100,7 +100,7 @@ curl -N "https://gen.pollinations.ai/v1/chat/completions" \
 
 ```python
 stream = client.chat.completions.create(
-    model="openai",
+    model="gpt-5.4-nano",
     stream=True,
     messages=[{"role": "user", "content": "Count to five, one word per line."}],
 )
@@ -114,14 +114,14 @@ When `stream: true` is set, usage info still arrives on the final chunk (`stream
 
 ## 🖼️ Vision: passing images into chat
 
-Models that accept image input (`openai`, `claude`, `gemini`, …) use the standard OpenAI multimodal `content` shape — an array of typed parts instead of a plain string.
+Models that accept image input (`gpt-5.4-nano`, `claude-sonnet-4.6`, `gemini-3.5-flash`, …) use the standard OpenAI multimodal `content` shape — an array of typed parts instead of a plain string.
 
 ```bash
 curl "https://gen.pollinations.ai/v1/chat/completions" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "openai",
+    "model": "gpt-5.4-nano",
     "messages": [{
       "role": "user",
       "content": [
@@ -146,7 +146,7 @@ Three endpoints accept `multipart/form-data` request bodies. Each has its own fi
 curl -X POST "https://gen.pollinations.ai/v1/audio/transcriptions" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -F "file=@./recording.mp3" \
-  -F "model=openai-audio" \
+  -F "model=gpt-audio-mini" \
   -F "response_format=verbose_json" \
   -F "temperature=0"
 ```
@@ -160,11 +160,11 @@ curl -X POST "https://gen.pollinations.ai/v1/images/edits" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -F "image=@./photo.png" \
   -F "prompt=replace the sky with a sunset" \
-  -F "model=kontext" \
+  -F "model=flux-kontext" \
   -F "size=1024x1024"
 ```
 
-Repeat `-F "image=@…"` to pass multiple reference images on models that accept them (`seedream`, `nanobanana`, `klein`).
+Repeat `-F "image=@…"` to pass multiple reference images on models that accept them (`seedream-4`, `nanobanana`, `flux-klein`).
 
 **Upload arbitrary media** to the content-addressed store. Returns a `https://media.pollinations.ai/<hash>` URL you can pass anywhere a remote image, audio, or video URL is accepted.
 

--- a/gen.pollinations.ai/src/docs/embeddings.md
+++ b/gen.pollinations.ai/src/docs/embeddings.md
@@ -7,8 +7,8 @@ Generate vector embeddings with an OpenAI-compatible response format.
 | `POST /v1/embeddings` | OpenAI-compatible embeddings endpoint |
 | `GET /embeddings/models` | Embedding models with pricing and modalities |
 
-`gemini-2` supports text, image, audio, and video inputs. `openai-3-small` and `openai-3-large` are text-only models.
+`gemini-embedding-2` supports text, image, audio, and video inputs. `text-embedding-3-small` and `text-embedding-3-large` are text-only models.
 
-String batch input supports up to 32 items. `task_type` is Gemini-only. Dimensions are model-specific: `openai-3-small` supports up to 1536; `gemini-2` and `openai-3-large` support up to 3072; `qwen3-embedding-8b` supports up to 4096.
+String batch input supports up to 32 items. `task_type` is Gemini-only. Dimensions are model-specific: `text-embedding-3-small` supports up to 1536; `gemini-embedding-2` and `text-embedding-3-large` support up to 3072; `qwen3-embedding-8b` supports up to 4096.
 
 **Embedding models:** {{EMBEDDING_MODELS}}

--- a/gen.pollinations.ai/src/docs/image-generation.md
+++ b/gen.pollinations.ai/src/docs/image-generation.md
@@ -3,7 +3,7 @@
 Generate images from text prompts via a simple GET request. Returns JPEG or PNG.
 
 ```
-https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux
+https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux-schnell
 ```
 
 **Available models:** {{IMAGE_MODELS}}

--- a/gen.pollinations.ai/src/docs/quick-start.md
+++ b/gen.pollinations.ai/src/docs/quick-start.md
@@ -5,14 +5,14 @@
 ```python
 from openai import OpenAI
 client = OpenAI(base_url="https://gen.pollinations.ai", api_key="YOUR_API_KEY")
-response = client.chat.completions.create(model="openai", messages=[{"role": "user", "content": "Hello!"}])
+response = client.chat.completions.create(model="gpt-5.4-nano", messages=[{"role": "user", "content": "Hello!"}])
 print(response.choices[0].message.content)
 ```
 
 ### Image (URL — no code needed)
 
 ```
-https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux
+https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux-schnell
 ```
 
 ### Audio (cURL)
@@ -28,7 +28,7 @@ curl "https://gen.pollinations.ai/audio/Hello%20world?voice=nova" \
 curl https://gen.pollinations.ai/v1/embeddings \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model":"openai-3-small","input":"Hello world","dimensions":512}'
+  -d '{"model":"text-embedding-3-small","input":"Hello world","dimensions":512}'
 ```
 
 See `GET /v1/models` for every text, image, audio, video, and embedding model available.

--- a/gen.pollinations.ai/src/docs/safety.md
+++ b/gen.pollinations.ai/src/docs/safety.md
@@ -14,7 +14,7 @@ curl https://gen.pollinations.ai/v1/chat/completions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Pollinations-Safe: privacy" \
-  -d '{"model":"openai","messages":[{"role":"user","content":"email me at a@example.com"}]}'
+  -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"email me at a@example.com"}]}'
 ```
 
 Large requests check the latest 50,000 text characters, across up to 25 text parts, in one safety call.

--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -15,7 +15,7 @@ On Gemini, Claude, and Nova models, a large static prompt prefix can be cached s
 
 ```json
 {
-  "model": "gemini-fast",
+  "model": "gemini-2.5-flash-lite",
   "messages": [
     {
       "role": "system",
@@ -32,8 +32,8 @@ On Gemini, Claude, and Nova models, a large static prompt prefix can be cached s
 }
 ```
 
-**Gemini** — the prefix must be at least ~2,048 tokens (~4,096 on Gemini 3 models). Requests with tools are not cached — including built-in tools, so `gemini`, `gemini-3-flash`, `gemini-large`, and the search variants only cache when tools are disabled (`"tools": []`) or a JSON `response_format` is set; `gemini-fast` and `gemini-flash-lite-3.1` cache by default. Cache creates bill at the standard input rate plus a storage fee for the 1-hour TTL ($1 per 1M cached tokens on Flash models, $4.50 on Pro); hits bill at ~10% of input. The storage fee means caching pays off only when the prefix is reused often — roughly a dozen reuses per hour on the cheapest models.
+**Gemini** — the prefix must be at least ~2,048 tokens (~4,096 on Gemini 3 models). Requests with tools are not cached — including built-in tools, so `gemini-3.5-flash`, `gemini-3-flash`, `gemini-3.1-pro`, and the search variants only cache when tools are disabled (`"tools": []`) or a JSON `response_format` is set; `gemini-2.5-flash-lite` and `gemini-3.1-flash-lite` cache by default. Cache creates bill at the standard input rate plus a storage fee for the 1-hour TTL ($1 per 1M cached tokens on Flash models, $4.50 on Pro); hits bill at ~10% of input. The storage fee means caching pays off only when the prefix is reused often — roughly a dozen reuses per hour on the cheapest models.
 
-**Claude** — all Claude models cache. The prefix must be at least 4,096 tokens (1,024 on `claude` and `claude-fable-5`); tools are fine. Cache creates bill at 1.25× the input rate (no storage fee); hits bill at 10% of input. The cache lives ~5 minutes, refreshed on each hit.
+**Claude** — all Claude models cache. The prefix must be at least 4,096 tokens (1,024 on `claude-sonnet-4.6` and `claude-fable-5`); tools are fine. Cache creates bill at 1.25× the input rate (no storage fee); hits bill at 10% of input. The cache lives ~5 minutes, refreshed on each hit.
 
-**Nova** — `nova` and `nova-fast` cache. The prefix must be at least ~1,000 tokens (up to 20K tokens cacheable). Cache creates are free; hits bill at 25% of input. ~5-minute TTL.
+**Nova** — `nova-2-lite` and `nova-micro` cache. The prefix must be at least ~1,000 tokens (up to 20K tokens cacheable). Cache creates are free; hits bill at 25% of input. ~5-minute TTL.

--- a/gen.pollinations.ai/src/docs/video-generation.md
+++ b/gen.pollinations.ai/src/docs/video-generation.md
@@ -3,7 +3,7 @@
 Generate videos from text prompts or reference images. Returns MP4.
 
 ```
-https://gen.pollinations.ai/video/sunset%20timelapse?model=veo&duration=4
+https://gen.pollinations.ai/video/sunset%20timelapse?model=veo-3.1-fast&duration=4
 ```
 
 **Available models:** {{VIDEO_MODELS}}

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -28,7 +28,7 @@ export const CODE_SAMPLES: Record<
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "openai",
+    "model": "gpt-5.4-nano",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'`,
         },
@@ -43,7 +43,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="openai",
+    model="gpt-5.4-nano",
     messages=[{"role": "user", "content": "Hello!"}]
 )
 print(response.choices[0].message.content)`,
@@ -59,7 +59,7 @@ const client = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-  model: "openai",
+  model: "gpt-5.4-nano",
   messages: [{ role: "user", content: "Hello!" }],
 });
 console.log(response.choices[0].message.content);`,
@@ -69,7 +69,7 @@ console.log(response.choices[0].message.content);`,
         {
             label: "cURL",
             lang: "Shell",
-            source: `curl "https://gen.pollinations.ai/text/Write%20a%20haiku?model=openai" \\
+            source: `curl "https://gen.pollinations.ai/text/Write%20a%20haiku?model=gpt-5.4-nano" \\
   -H "Authorization: Bearer YOUR_API_KEY"`,
         },
         {
@@ -79,7 +79,7 @@ console.log(response.choices[0].message.content);`,
 
 response = requests.get(
     "https://gen.pollinations.ai/text/Write a haiku",
-    params={"model": "openai"},
+    params={"model": "gpt-5.4-nano"},
     headers={"Authorization": "Bearer YOUR_API_KEY"},
 )
 print(response.text)`,
@@ -88,7 +88,7 @@ print(response.text)`,
             label: "JavaScript",
             lang: "JavaScript",
             source: `const response = await fetch(
-  "https://gen.pollinations.ai/text/Write%20a%20haiku?model=openai",
+  "https://gen.pollinations.ai/text/Write%20a%20haiku?model=gpt-5.4-nano",
   { headers: { Authorization: "Bearer YOUR_API_KEY" } },
 );
 console.log(await response.text());`,
@@ -99,17 +99,17 @@ console.log(await response.text());`,
             label: "HTML",
             lang: "HTML",
             source: `<!-- No code needed — use as an image URL -->
-<img src="https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux" />`,
+<img src="https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux-schnell" />`,
         },
         {
             label: "cURL",
             lang: "Shell",
             source: `# Generate an image
-curl "https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux" \\
+curl "https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux-schnell" \\
   -H "Authorization: Bearer YOUR_API_KEY" -o image.jpg
 
 # Generate a video
-curl "https://gen.pollinations.ai/image/a%20sunset%20timelapse?model=veo&duration=4" \\
+curl "https://gen.pollinations.ai/image/a%20sunset%20timelapse?model=veo-3.1-fast&duration=4" \\
   -H "Authorization: Bearer YOUR_API_KEY" -o video.mp4`,
         },
         {
@@ -119,7 +119,7 @@ curl "https://gen.pollinations.ai/image/a%20sunset%20timelapse?model=veo&duratio
 
 response = requests.get(
     "https://gen.pollinations.ai/image/a cat in space",
-    params={"model": "flux"},
+    params={"model": "flux-schnell"},
     headers={"Authorization": "Bearer YOUR_API_KEY"},
 )
 with open("image.jpg", "wb") as f:
@@ -129,7 +129,7 @@ with open("image.jpg", "wb") as f:
             label: "JavaScript",
             lang: "JavaScript",
             source: `const response = await fetch(
-  "https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux",
+  "https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux-schnell",
   { headers: { Authorization: "Bearer YOUR_API_KEY" } },
 );
 const blob = await response.blob();`,
@@ -139,7 +139,7 @@ const blob = await response.blob();`,
         {
             label: "cURL",
             lang: "Shell",
-            source: `curl "https://gen.pollinations.ai/video/a%20sunset%20timelapse?model=veo&duration=4" \\
+            source: `curl "https://gen.pollinations.ai/video/a%20sunset%20timelapse?model=veo-3.1-fast&duration=4" \\
   -H "Authorization: Bearer YOUR_API_KEY" -o video.mp4`,
         },
         {
@@ -149,7 +149,7 @@ const blob = await response.blob();`,
 
 response = requests.get(
     "https://gen.pollinations.ai/video/a sunset timelapse",
-    params={"model": "veo", "duration": 4},
+    params={"model": "veo-3.1-fast", "duration": 4},
     headers={"Authorization": "Bearer YOUR_API_KEY"},
 )
 with open("video.mp4", "wb") as f:
@@ -159,7 +159,7 @@ with open("video.mp4", "wb") as f:
             label: "JavaScript",
             lang: "JavaScript",
             source: `const response = await fetch(
-  "https://gen.pollinations.ai/video/a%20sunset%20timelapse?model=veo&duration=4",
+  "https://gen.pollinations.ai/video/a%20sunset%20timelapse?model=veo-3.1-fast&duration=4",
   { headers: { Authorization: "Bearer YOUR_API_KEY" } },
 );
 const blob = await response.blob();`,
@@ -174,7 +174,7 @@ curl "https://gen.pollinations.ai/audio/Hello%20world?voice=nova" \\
   -H "Authorization: Bearer YOUR_API_KEY" -o speech.mp3
 
 # Generate music (ElevenLabs)
-curl "https://gen.pollinations.ai/audio/upbeat%20jazz?model=elevenmusic&duration=30" \\
+curl "https://gen.pollinations.ai/audio/upbeat%20jazz?model=eleven-music&duration=30" \\
   -H "Authorization: Bearer YOUR_API_KEY" -o music.mp3
 
 # Generate music (ACE-Step, open-source)
@@ -501,7 +501,7 @@ export const RESPONSE_EXAMPLES: Record<string, unknown> = {
         id: "chatcmpl-abc123",
         object: "chat.completion",
         created: 1700000000,
-        model: "openai",
+        model: "gpt-5.4-nano",
         choices: [
             {
                 index: 0,
@@ -522,19 +522,19 @@ export const RESPONSE_EXAMPLES: Record<string, unknown> = {
         object: "list",
         data: [
             {
-                id: "openai",
+                id: "gpt-5.4-nano",
                 object: "model",
                 created: 1700000000,
                 owned_by: "pollinations",
             },
             {
-                id: "claude",
+                id: "claude-sonnet-4.6",
                 object: "model",
                 created: 1700000000,
                 owned_by: "pollinations",
             },
             {
-                id: "gemini",
+                id: "gemini-3.5-flash",
                 object: "model",
                 created: 1700000000,
                 owned_by: "pollinations",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -623,13 +623,13 @@ export const proxyRoutes = new Hono<Env>()
             description: [
                 "Generate vector embeddings with an OpenAI-compatible response format.",
                 "",
-                "**Models:** `gemini-2` supports text, image, audio, and video inputs. `openai-3-small` and `openai-3-large` are text-only models.",
+                "**Models:** `gemini-embedding-2` supports text, image, audio, and video inputs. `text-embedding-3-small` and `text-embedding-3-large` are text-only models.",
                 "",
                 "**Input:** Pass a string, an array of up to 32 strings, or Gemini multimodal content parts (`text`, `image_url`, `input_audio`, `video_url`) in the `input` field.",
                 "",
-                "**Task types:** `task_type` is Gemini-only. For example, use `RETRIEVAL_QUERY` or `CLASSIFICATION` with `gemini-2`.",
+                "**Task types:** `task_type` is Gemini-only. For example, use `RETRIEVAL_QUERY` or `CLASSIFICATION` with `gemini-embedding-2`.",
                 "",
-                "**Dimensions:** Defaults are model-specific. `qwen3-embedding-8b` supports up to 4096 dimensions; `gemini-2` and `openai-3-large` support up to 3072; `openai-3-small` supports up to 1536.",
+                "**Dimensions:** Defaults are model-specific. `qwen3-embedding-8b` supports up to 4096 dimensions; `gemini-embedding-2` and `text-embedding-3-large` support up to 3072; `text-embedding-3-small` supports up to 1536.",
             ].join("\n"),
             responses: {
                 200: {
@@ -910,7 +910,7 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
                 "",
-                "**Music generation:** Set `model=elevenmusic`, `acestep`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.",
+                "**Music generation:** Set `model=eleven-music`, `acestep`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `eleven-music` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.",
             ].join("\n"),
             responses: {
                 200: {
@@ -929,7 +929,7 @@ export const proxyRoutes = new Hono<Env>()
             z.object({
                 text: z.string().min(1).meta({
                     description:
-                        "Text to convert to speech, or a music description when model=elevenmusic",
+                        "Text to convert to speech, or a music description when model=eleven-music",
                     example: "Hello, welcome to Pollinations!",
                 }),
             }),
@@ -955,7 +955,7 @@ export const proxyRoutes = new Hono<Env>()
                     }),
                 model: z.string().optional().meta({
                     description:
-                        "Audio model: TTS (default) or elevenmusic for music generation",
+                        "Audio model: TTS (default) or eleven-music for music generation",
                     example: "tts-1",
                 }),
                 duration: z
@@ -965,7 +965,7 @@ export const proxyRoutes = new Hono<Env>()
                     .pipe(z.number().min(0.5).max(300).optional())
                     .meta({
                         description:
-                            "Music duration in seconds, 3-300 (elevenmusic only)",
+                            "Music duration in seconds, 3-300 (eleven-music only)",
                         example: "30",
                     }),
                 seconds: z.coerce.number().min(1).max(380).optional().meta({
@@ -988,7 +988,7 @@ export const proxyRoutes = new Hono<Env>()
                     .transform((v) => v === "true")
                     .meta({
                         description:
-                            "If true, guarantees instrumental output (elevenmusic only)",
+                            "If true, guarantees instrumental output (eleven-music only)",
                         example: "false",
                     }),
                 style: z.string().optional().meta({
@@ -998,7 +998,7 @@ export const proxyRoutes = new Hono<Env>()
                 }),
                 instruct: z.string().optional().meta({
                     description:
-                        "Emotion/style instruction (qwen-tts-instruct only)",
+                        "Emotion/style instruction (qwen3-tts-instruct only)",
                     example: "speak softly and warmly",
                 }),
                 loop: z

--- a/gen.pollinations.ai/src/schemas/embeddings.ts
+++ b/gen.pollinations.ai/src/schemas/embeddings.ts
@@ -59,7 +59,7 @@ export const CreateEmbeddingRequestSchema = z
     .object({
         model: z.string().default(DEFAULT_EMBEDDING_MODEL).meta({
             description: "Embedding model to use",
-            example: "gemini-2",
+            example: "gemini-embedding-2",
         }),
         input: z
             .union([
@@ -74,7 +74,7 @@ export const CreateEmbeddingRequestSchema = z
             }),
         dimensions: z.number().int().min(128).max(4096).optional().meta({
             description:
-                "Output embedding dimensions (128-4096). Model-specific limits apply; openai-3-small supports up to 1536.",
+                "Output embedding dimensions (128-4096). Model-specific limits apply; text-embedding-3-small supports up to 1536.",
             example: 768,
         }),
         task_type: z

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -28,7 +28,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list.",
+                "Model to use. **Image:** flux-schnell, z-image-turbo, gpt-image-1-mini, flux-kontext, seedream-5-lite, seedream-5-pro, nanobanana, nanobanana-pro, flux-klein. **Video:** veo-3.1-fast, seedance, seedance-pro, wan-2.6, nova-reel. See /image/models for full list.",
         }),
     width: z.coerce.number().int().nonnegative().optional().default(1024).meta({
         description:
@@ -53,7 +53,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .default(0)
         .meta({
             description:
-                "Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter.",
+                "Seed for reproducible results. Use -1 for random. Supported by: flux-schnell, z-image-turbo, seedream-4, flux-klein, seedance, nova-reel. Other models ignore this parameter.",
         }),
     safe: SafeSchema,
     quality: z
@@ -62,7 +62,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .default("medium")
         .meta({
             description:
-                "Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`.",
+                "Image quality level. Only supported by `gpt-image-1-mini`, `gpt-image-1.5`, and `gpt-image-2`.",
         }),
     image: z
         .string()
@@ -89,17 +89,17 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
+                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (flux-kontext, gpt-image-1-mini, seedream-4, flux-klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo-3.1-fast`, `seedance`, `seedance-2.0`, and `wan-2.2`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:
-            "Generate image with transparent background. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`.",
+            "Generate image with transparent background. Only supported by `gpt-image-1-mini`, `gpt-image-1.5`, and `gpt-image-2`.",
     }),
 
     // Video-specific params
     duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:
-            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
+            "Video duration in seconds. Only applies to video models. `veo-3.1-fast`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan-2.6`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
     }),
     aspectRatio: z.string().optional().meta({
         description:
@@ -107,7 +107,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     }),
     audio: z.coerce.boolean().optional().default(false).meta({
         description:
-            "Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo`, set to `true` to enable audio.",
+            "Generate audio for the video. Only applies to video models. Note: `wan-2.6` generates audio regardless of this flag. For `veo-3.1-fast`, set to `true` to enable audio.",
     }),
 });
 

--- a/gen.pollinations.ai/src/text/transforms/createReasoningEffortTransform.ts
+++ b/gen.pollinations.ai/src/text/transforms/createReasoningEffortTransform.ts
@@ -15,7 +15,7 @@ const log = debug("pollinations:transforms:reasoning-effort");
  *   with a 400 (Fireworks MiniMax-M2 and similar). Off-requests are dropped so
  *   the model keeps its always-on default; `minimal` maps to `low`.
  * - `"strip"`: model has no reasoning mode and errors when the param is
- *   forwarded (mistral-large 500; OpenRouter non-reasoning models 400; the
+ *   forwarded (mistral-large-3 500; OpenRouter non-reasoning models 400; the
  *   non-reasoning Grok deployment 500). The param is removed entirely.
  */
 export type ReasoningCapability = "toggle" | "mandatory" | "strip";

--- a/packages/mcp/src/index.js
+++ b/packages/mcp/src/index.js
@@ -43,23 +43,23 @@ Get your API key at: https://enter.pollinations.ai
 - **generateImageUrl** - Get a shareable URL for an image (without API key)
 - **generateImage** - Generate an image and get base64 data
 - **generateImageBatch** - Generate multiple images in parallel (best with sk_ keys)
-- **generateVideo** - Generate videos using veo, seedance, or seedance-pro
+- **generateVideo** - Generate videos using veo-3.1-fast, seedance-pro, or seedance-2.0
 - **generateVideoUrl** - Get a shareable URL for a video (without API key)
 - **describeImage** - Analyze/describe an image using vision AI
-- **analyzeVideo** - Analyze YouTube videos or video URLs using gemini-large
+- **analyzeVideo** - Analyze YouTube videos or video URLs using gemini-3.1-pro
 - **listImageModels** - List all available image/video models (dynamic)
 
 ### Text Generation
 - **generateText** - Simple text generation from a prompt
 - **chatCompletion** - OpenAI-compatible chat completions with tool calling
-- **webSearch** - Search the web using perplexity or gemini-search
+- **webSearch** - Search the web using sonar or gemini search models
 - **listTextModels** - List all available text models (dynamic)
 - **getPricing** - Get model pricing info (cost per token/image)
 
 ### Audio
 - **respondAudio** - AI responds to your prompt with speech
 - **sayText** - Text-to-speech (verbatim)
-- **transcribeAudio** - Transcribe audio using gemini-large
+- **transcribeAudio** - Transcribe audio using gemini-3.1-pro
 - **listAudioVoices** - List available voices (dynamic)
 
 ### Authentication
@@ -77,11 +77,11 @@ All requests go through: https://gen.pollinations.ai
 ## Tips
 - Models are fetched dynamically from the API - always up to date!
 - Use listImageModels/listTextModels to see available options
-- Image-to-image: Use the 'image' parameter with kontext or seedream models
+- Image-to-image: Use the 'image' parameter with flux-kontext or seedream models
 - Video generation: use listImageModels for live videoCapabilities, including start/end-frame and audio support
-- Web search: Use webSearch with perplexity-fast, perplexity-reasoning, or gemini-search
-- Audio transcription: Use transcribeAudio with gemini-large
-- Reasoning: Use kimi, perplexity-reasoning, openai-large, gemini-large`;
+- Web search: Use webSearch with sonar, sonar-reasoning-pro, or gemini-3.5-flash-search
+- Audio transcription: Use transcribeAudio with gemini-3.1-pro
+- Reasoning: Use kimi-k2.6, sonar-reasoning-pro, gpt-5.5, gemini-3.1-pro`;
 
 /**
  * Start the MCP server with STDIO transport

--- a/packages/mcp/src/services/audioService.js
+++ b/packages/mcp/src/services/audioService.js
@@ -309,7 +309,7 @@ const audioModelSchema = z
     .string()
     .optional()
     .describe(
-        "Audio model override (e.g. 'elevenlabs', 'openai-audio'). " +
+        "Audio model override (e.g. 'eleven-v3', 'gpt-audio-mini'). " +
             "Defaults to the current primary TTS model from the registry.",
     );
 
@@ -367,7 +367,7 @@ export const audioTools = [
 
     [
         "transcribeAudio",
-        "Transcribe audio from a URL. Uses gemini-large for accurate speech-to-text transcription.",
+        "Transcribe audio from a URL. Uses gemini-3.1-pro for accurate speech-to-text transcription.",
         {
             audioUrl: z
                 .string()
@@ -382,7 +382,7 @@ export const audioTools = [
                 .string()
                 .optional()
                 .describe(
-                    "Model to use (default: 'gemini-large'). Also supports: gemini, openai-audio",
+                    "Model to use (default: 'gemini-3.1-pro'). Also supports: gemini-3.5-flash, gpt-audio-mini",
                 ),
         },
         transcribeAudio,

--- a/packages/mcp/src/services/imageService.js
+++ b/packages/mcp/src/services/imageService.js
@@ -583,9 +583,9 @@ const imageParamsSchema = {
         .string()
         .optional()
         .describe(
-            "Image model to use. Options: flux (default, fast), turbo (ultra-fast), gptimage (OpenAI), " +
-                "kontext (context-aware, supports i2i), seedream/seedream-pro (high quality, supports i2i), " +
-                "nanobanana/nanobanana-pro (Gemini-based), zimage (experimental). Use listImageModels for full list.",
+            "Image model to use. Options: flux-schnell (default, fast), z-image-turbo (ultra-fast), gpt-image-1-mini (OpenAI), " +
+                "flux-kontext (context-aware, supports i2i), seedream-4/seedream-4.5-pro (high quality, supports i2i), " +
+                "nanobanana/nanobanana-pro (Gemini-based). Use listImageModels for full list.",
         ),
     width: z
         .number()
@@ -632,7 +632,7 @@ const imageParamsSchema = {
         .optional()
         .describe(
             "Reference image URL(s) for image-to-image generation. Separate multiple URLs with | or comma.\n" +
-                "I2I models: seedream-pro, nanobanana-pro, nanobanana, gptimage, seedream (all multi-image), kontext (single image).\n" +
+                "I2I models: seedream-4.5-pro, nanobanana-pro, nanobanana, gpt-image-1-mini, seedream-4 (all multi-image), flux-kontext (single image).\n" +
                 "Put this parameter last in URL or URL-encode it.",
         ),
     transparent: z
@@ -657,7 +657,7 @@ const videoParamsSchema = {
         .string()
         .optional()
         .describe(
-            "Video model (default: 'veo'). Common options: veo, seedance, seedance-2.0, wan, wan-fast. " +
+            "Video model (default: 'veo-3.1-fast'). Common options: veo-3.1-fast, seedance-pro, seedance-2.0, wan-2.6, wan-2.2. " +
                 "Use listImageModels to see the full live list — models are validated against the registry.",
         ),
     duration: z
@@ -715,7 +715,7 @@ export const imageTools = [
     [
         "generateImage",
         "Generate an image from a text prompt and return the base64-encoded image data. " +
-            "Full control over all generation parameters. Supports image-to-image with kontext, seedream, nanobanana models.",
+            "Full control over all generation parameters. Supports image-to-image with flux-kontext, seedream, nanobanana models.",
         imageParamsSchema,
         generateImage,
     ],
@@ -798,8 +798,8 @@ export const imageTools = [
                 .string()
                 .optional()
                 .describe(
-                    "Vision-capable model to use (default: 'openai'). " +
-                        "Options: openai, gemini, claude, grok - all support vision",
+                    "Vision-capable model to use (default: 'gpt-5.4-nano'). " +
+                        "Options: gpt-5.4-nano, gemini-3.5-flash, claude-sonnet-4.6, grok-4.20 - all support vision",
                 ),
         },
         describeImage,
@@ -807,7 +807,7 @@ export const imageTools = [
     [
         "analyzeVideo",
         "Analyze a video using AI. Supports YouTube URLs and direct video links. " +
-            "Uses gemini-large for native video understanding (frames + audio). " +
+            "Uses gemini-3.1-pro for native video understanding (frames + audio). " +
             "Great for video summarization, content analysis, and Q&A about videos.",
         {
             videoUrl: z
@@ -827,8 +827,8 @@ export const imageTools = [
                 .string()
                 .optional()
                 .describe(
-                    "Model to use (default: 'gemini-large'). " +
-                        "gemini-large and gemini support native video input",
+                    "Model to use (default: 'gemini-3.1-pro'). " +
+                        "gemini-3.1-pro and gemini-3.5-flash support native video input",
                 ),
         },
         analyzeVideo,

--- a/packages/mcp/src/services/textService.js
+++ b/packages/mcp/src/services/textService.js
@@ -306,8 +306,8 @@ async function listTextModels(_params) {
                 advanced:
                     "Use chatCompletion for multi-turn conversations, tool calling, audio output",
                 reasoning:
-                    "True reasoning models: kimi, perplexity-reasoning, openai-large, gemini-large. Use reasoning_effort",
-                audio: "Use openai-audio with modalities=['text','audio'] for voice output",
+                    "True reasoning models: kimi-k2.6, sonar-reasoning-pro, gpt-5.5, gemini-3.1-pro. Use reasoning_effort",
+                audio: "Use gpt-audio-mini with modalities=['text','audio'] for voice output",
             },
         };
 
@@ -433,13 +433,13 @@ const textParamsSchema = {
         .string()
         .optional()
         .describe(
-            "Text model to use (default: 'openai'). Popular options:\n" +
-                "- openai/openai-fast/openai-large: GPT models (balanced/fast/powerful)\n" +
-                "- claude/claude-fast/claude-large: Anthropic Claude models\n" +
-                "- gemini/gemini-fast/gemini-large: Google Gemini models\n" +
-                "- deepseek: Advanced reasoning model\n" +
-                "- grok: xAI's Grok model\n" +
-                "- mistral, qwen-coder, perplexity-fast, perplexity-reasoning\n" +
+            "Text model to use (default: 'gpt-5.4-nano'). Popular options:\n" +
+                "- gpt-5.4-nano/gpt-5-nano/gpt-5.5: GPT models (balanced/fast/powerful)\n" +
+                "- claude-sonnet-4.6/claude-haiku-4.5/claude-opus-4.8: Anthropic Claude models\n" +
+                "- gemini-3.5-flash/gemini-2.5-flash-lite/gemini-3.1-pro: Google Gemini models\n" +
+                "- deepseek-v4-flash: Advanced reasoning model\n" +
+                "- grok-4.20: xAI's Grok model\n" +
+                "- mistral-small-4, qwen3-coder, sonar, sonar-reasoning-pro\n" +
                 "Use listTextModels for complete list.",
         ),
     seed: z
@@ -596,7 +596,7 @@ const chatParamsSchema = {
         .string()
         .optional()
         .describe(
-            "Text model (default: 'openai'). See listTextModels for all options",
+            "Text model (default: 'gpt-5.4-nano'). See listTextModels for all options",
         ),
     temperature: z
         .number()

--- a/packages/mcp/src/utils/coreUtils.js
+++ b/packages/mcp/src/utils/coreUtils.js
@@ -130,7 +130,7 @@ export async function fetchJsonWithAuth(url, options = {}) {
  * Consolidates the shared boilerplate across describeImage/analyzeVideo/transcribeAudio.
  *
  * @param {Object} args
- * @param {string} args.model - Model name (e.g. "openai", "gemini-large")
+ * @param {string} args.model - Model name (e.g. "gpt-5.4-nano", "gemini-3.1-pro")
  * @param {string} args.prompt - Text prompt to pair with the media
  * @param {"image_url"|"video_url"|"input_audio"} args.mediaType - Content-block kind
  * @param {string} args.mediaUrl - URL of the media to analyze

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -451,7 +451,7 @@ export class Pollinations {
      * ```ts
      * const result = await pollinations.imageEdit('Make the sky purple', {
      *   image: 'https://example.com/photo.jpg',
-     *   model: 'flux',
+     *   model: 'flux-schnell',
      * });
      * ```
      */
@@ -527,7 +527,7 @@ export class Pollinations {
      * // Single image, size string (OpenAI style)
      * const img = await pollinations.imageGenerate('A cute robot', {
      *   size: '1024x1024',
-     *   model: 'flux',
+     *   model: 'flux-schnell',
      * });
      *
      * // Multiple images
@@ -688,7 +688,7 @@ export class Pollinations {
      *
      * @example
      * ```ts
-     * const url = await pollinations.videoUrl('A cat playing piano', { model: 'veo', duration: 4 });
+     * const url = await pollinations.videoUrl('A cat playing piano', { model: 'veo-3.1-fast', duration: 4 });
      * ```
      */
     async videoUrl(
@@ -1111,7 +1111,7 @@ export class Pollinations {
      * const { buffer } = await pollinations.audio('Hello, how are you today?', { voice: 'nova' });
      *
      * // Music generation
-     * const { buffer } = await pollinations.audio('upbeat jazz', { model: 'elevenmusic', duration: 30 });
+     * const { buffer } = await pollinations.audio('upbeat jazz', { model: 'eleven-music', duration: 30 });
      * ```
      */
     async audio(
@@ -1429,7 +1429,7 @@ export class Pollinations {
      * ```ts
      * const url = pollinations.authorizeUrl({
      *   redirectUrl: 'https://myapp.com/callback',
-     *   models: ['flux', 'openai'],
+     *   models: ['flux-schnell', 'gpt-5.4-nano'],
      *   budget: 10,
      *   permissions: ['profile', 'usage'],
      * });

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -227,7 +227,7 @@ export async function imageGenerate(
  *
  * @example
  * ```ts
- * const url = await videoUrl('A bird flying', { model: 'veo', duration: 4 });
+ * const url = await videoUrl('A bird flying', { model: 'veo-3.1-fast', duration: 4 });
  * ```
  */
 export async function videoUrl(
@@ -406,7 +406,7 @@ export async function* chatStream(
  *
  * @example
  * ```ts
- * const convo = conversation({ model: 'openai' });
+ * const convo = conversation({ model: 'gpt-5.4-nano' });
  * convo.system('You are a helpful assistant');
  * const response = await convo.say('Hello!');
  * ```
@@ -429,7 +429,7 @@ export function conversation(options?: ChatOptions): Conversation {
  * await audio.saveToFile('speech.mp3');
  *
  * // Music generation
- * const music = await generateAudio('upbeat jazz', { model: 'elevenmusic', duration: 30 });
+ * const music = await generateAudio('upbeat jazz', { model: 'eleven-music', duration: 30 });
  * await music.saveToFile('jazz.mp3');
  *
  * // Multiple variations
@@ -541,7 +541,7 @@ export async function upload(
  * ```ts
  * const url = authorizeUrl({
  *   redirectUrl: 'https://myapp.com/callback',
- *   models: ['flux', 'openai'],
+ *   models: ['flux-schnell', 'gpt-5.4-nano'],
  *   budget: 10,
  * });
  * ```

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -39,7 +39,7 @@ export type ImageReasoningMode = "fast" | "balanced" | "pro";
 
 /** Options for image generation */
 export interface ImageGenerateOptions extends RequestOptions {
-    /** Image model to use (default: 'zimage') */
+    /** Image model to use (default: 'z-image-turbo') */
     model?: ImageModel;
     /** Image width in pixels (default: 1024) */
     width?: number;
@@ -67,7 +67,7 @@ export interface ImageGenerateOptions extends RequestOptions {
 
 /** Options for image editing (POST /v1/images/edits) */
 export interface ImageEditOptions extends RequestOptions {
-    /** Image model to use (default: 'flux') */
+    /** Image model to use (default: 'flux-schnell') */
     model?: ImageModel;
     /** Source image URL(s) for editing */
     image?: string | string[];
@@ -89,7 +89,7 @@ export interface ImageResponse {
 
 /** Options for video generation */
 export interface VideoGenerateOptions extends RequestOptions {
-    /** Video model to use (default: 'veo') */
+    /** Video model to use (default: 'veo-3.1-fast') */
     model?: VideoModel;
     /** Duration in seconds (1-30, varies by model) */
     duration?: number;
@@ -200,7 +200,7 @@ export interface Message {
 
 /** Options for simple text generation */
 export interface TextGenerateOptions extends RequestOptions {
-    /** Text model to use (default: 'openai') */
+    /** Text model to use (default: 'gpt-5.4-nano') */
     model?: TextModel;
     /** System prompt to set context */
     systemPrompt?: string;
@@ -258,7 +258,7 @@ export type BuiltInToolType =
 
 /** Options for chat completions (POST endpoint) */
 export interface ChatOptions extends RequestOptions {
-    /** Text model to use (default: 'openai') */
+    /** Text model to use (default: 'gpt-5.4-nano') */
     model?: TextModel;
     /** Temperature 0-2 (default: 1) */
     temperature?: number;
@@ -431,15 +431,15 @@ export type AudioVoice = string;
 export type AudioFormat = "wav" | "mp3" | "flac" | "opus" | "pcm16";
 
 /** Dedicated audio/music model */
-export type AudioModel = "elevenlabs" | "elevenmusic" | "acestep" | string;
+export type AudioModel = "eleven-v3" | "eleven-music" | "acestep" | string;
 
 /** Options for text-to-speech generation (GET /audio/{text} or POST /v1/audio/speech) */
 export interface AudioGenerateOptions extends RequestOptions {
     /** Voice to use (default: 'alloy') */
     voice?: AudioVoice;
-    /** Audio model to use (default: 'elevenlabs') */
+    /** Audio model to use (default: 'eleven-v3') */
     model?: AudioModel;
-    /** Duration in seconds (for music models like elevenmusic, acestep) */
+    /** Duration in seconds (for music models like eleven-music, acestep) */
     duration?: number;
     /** Seed for reproducibility */
     seed?: number;
@@ -879,7 +879,7 @@ export interface UserInfo {
 
 /** Options for POST /v1/images/generations */
 export interface ImageGenerateV1Options extends RequestOptions {
-    /** Image model to use (default: 'zimage') */
+    /** Image model to use (default: 'z-image-turbo') */
     model?: ImageModel;
     /** Size string like "1024x1024". Alternative to width + height. */
     size?: string;


### PR DESCRIPTION
Copy-only follow-up to #12342 — no runtime behavior changes. Stacked on that branch; after it merges this reduces to pure text.

- gen docs (`src/docs/*.md`), docs-samples, and schema/OpenAPI description strings now name canonical model ids (`gpt-5.4-nano`, `flux-schnell`, `veo-3.1-fast`, `eleven-music`, …)
- SDK JSDoc defaults/examples and the `AudioModel` type union updated to canonical names
- MCP tool descriptions, server banner, and comments updated; stale non-existent names in descriptions (`turbo`, bare `seedance`) replaced with real ids

Legacy aliases keep resolving; they are just no longer the documented face.