### PR TITLE
fix: remove sixfingerdev from community model allowlist

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -17,7 +17,6 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     45744798, // Minor-fun
     178960782, // morriszdweck
     219871313, // mikl-shortcuts
-    229514703, // sixfingerdev
     45357531, // cemalgnlts
     123343834, // LynxUnbanned
     244879637, // Catniti


### PR DESCRIPTION
## Summary
- Owner exploited a per-token vs per-million-token unit confusion bug in community model pricing (no max-price validation in the schema) to extract ~$954 in reward payouts from disposable burner accounts (7+ accounts, Jul 10-12)
- Also self-farmed ~$138 more via a scripted self-call loop against their own model
- All 15 of their community models have been deactivated in production D1 (`disabled_by='maintainer'`)
- Their `tier_balance` has been corrected in production to remove the exploited income

## Test plan
- [x] Verified via direct D1 queries: all sixfingerdev community models now have `disabled_at` set
- [x] Verified balance write landed correctly
- [x] `npx biome check` clean on the changed file