### PR TITLE
fix: streamline root documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,57 +58,33 @@ curl "http://localhost:8788/image/test?model=flux" -H "Authorization: Bearer $TO
 curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKEN" ...
 ```
 
-## API Quick Reference
+See `./APIDOCS.md` for endpoints and `.claude/skills/enter-services/SKILL.md` for service workflows.
 
-- Image: `GET gen.pollinations.ai/image/{prompt}` (bearer token)
-- Text (OpenAI): `POST gen.pollinations.ai/v1/chat/completions` with `{model, messages}` (bearer token)
-- Simple text: `GET gen.pollinations.ai/text/{prompt}?key=...`
-- Audio: `GET gen.pollinations.ai/audio/{text}?voice=nova&key=...`
-- Models: `/image/models`, `/v1/models`
-- See `./APIDOCS.md`, `.claude/skills/enter-services/SKILL.md`
+## YAGNI
 
-## ⚠️ YAGNI — You Aren't Gonna Need It (CRITICAL)
-
-**Follow YAGNI religiously:**
+Implement only what the current task needs:
 
 - Only implement what's needed now. Remove unused functions.
 - No speculative abstractions, "just in case" helpers, preemptive test utils/wrappers.
-- No backward-compat fallbacks — clean breaks beat bloat. When changing tokens/headers/APIs, update all consumers at once.
+- Avoid speculative compatibility layers. Preserve public API compatibility unless the task explicitly approves a coordinated breaking change.
 - When user says "keep it simple" — one function, one price, one config. Simplest thing that works.
 
 ## Tinybird Deployment Safety
 
-**CRITICAL — These rules apply whenever deploying to Tinybird:**
-
-- Two workspaces: `pollinations_enter` (prod) and `pollinations_enter_staging` (staging + dev + local). Pipes and datasources must be deployed to **both** — no CI auto-deploy yet, tracked in #11127.
-- Use the Tinybird **Forward CLI** as `tb` (not Classic).
-- Do not rely on `.tinyb` for workspace selection. Always pass `TB_TOKEN` from `secrets/{staging,prod}.vars.json` and `--host https://api.europe-west2.gcp.tinybird.co`.
-- Always validate and deploy to **staging first**, verify, then prod only when requested.
-- Validate first: `tb --cloud --host "$TB_HOST" deployment create --check --no-allow-destructive-operations`
-- Deploy staging: `tb --cloud --host "$TB_HOST" deployment create --wait --no-allow-destructive-operations`
-- Verify staging: `tb --staging --cloud --host "$TB_HOST" endpoint ls` and `tb --cloud --host "$TB_HOST" deployment ls`
-- Never `--allow-destructive-operations` without explicit permission
-- Never `tb push` (deprecated). Avoid `tb deploy`; use explicit `deployment create` commands so promotion is never accidental.
-- Never use `--auto` or `deployment promote` without explicit permission.
-- Always `--cloud` (otherwise CLI hits Tinybird Local/Docker)
-- Run from `enter.pollinations.ai/observability`
-- Verify all consumers within a workspace before modifying a pipe (pipes are NOT cross-workspace; each workspace has its own copy)
-- If validation reports datasource or pipe deletion, stop. Restore the missing definition or ask before deleting; do not override with destructive flags.
-- Forward materialized views cannot use `UNION`; split sources into separate materialized pipes writing to the same datasource.
-- Timeouts: use `uniq()` not `uniqExact()`; avoid CTE+JOIN; single-pass queries; for large time ranges use `start_date` parameter week-by-week
-- Full procedure: `.claude/skills/tinybird-deploy/SKILL.md`
+- Work from `enter.pollinations.ai/observability` with the Forward CLI, `--cloud`, the explicit Europe West host, and the correct workspace token.
+- Validate and deploy to staging first. Deploy to production only when requested.
+- Never use destructive operations, `tb push`, `--auto`, or promotion without explicit permission.
+- Stop if validation reports datasource or pipe deletion.
+- Pipes are workspace-local; verify consumers in each workspace.
+- Follow `.claude/skills/tinybird-deploy/SKILL.md` for commands and query constraints.
 
 ## Code Style & Workflow
 
 - Modern JS/TS, ES modules (all `.js` are ESM). Follow existing formatting. Comment complex logic.
 - Run `npx biome check --write <file>` after edits and before commits.
-- Before implementing: verify assumptions on web (APIs change), read related files, check related PRs/issues, check existing utilities in `shared/` before writing new ones (auth, queue, registry, SSE parsing, retry wrappers), confirm branch via `git branch --show-current`.
+- Before editing, inspect related code, search existing utilities in `shared/`, confirm the branch, and verify unstable external APIs against primary documentation when relevant.
 - When continuing prior work: read relevant code first; identify clear next steps.
 - Don't reimplement existing logic — search first.
-- When adding a React browser/IIFE bundle, grep bundled dependencies'
-  published dist for `react/jsx-runtime` and `react-dom` imports before
-  choosing shim vs external; transitive deps such as `@ark-ui/react` Portal can
-  reintroduce externals the package source does not import.
 
 ## Common Mistakes to Avoid
 
@@ -118,8 +94,6 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - Don't run `pytest`; use `npm run test` or `npx vitest run`.
 - Don't create `.md` docs unless asked.
 - Always use absolute paths.
-- Don't edit files manually during a Claude Code session (busts cache).
-- Don't run `/compact` unless necessary (busts cache).
 - Don't let searches run wild — use targeted paths.
 - Don't modify test files to make tests pass — fix the code.
 - Run `npm run decrypt-vars` before tests in enter.pollinations.ai.
@@ -128,10 +102,7 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 
 ## Testing
 
-Commands:
-- enter.pollinations.ai: `cd enter.pollinations.ai && npm run test` (vitest + CF Workers pool)
-- gen.pollinations.ai: `cd gen.pollinations.ai && npm run test` (vitest + CF Workers pool)
-- image.pollinations.ai: `cd image.pollinations.ai && npm run test` (vitest)
+Run `npm run test` with the working directory set to `enter.pollinations.ai/`, `gen.pollinations.ai/`, or `image.pollinations.ai/`.
 
 Run individually — full suite is slow:
 ```bash
@@ -142,7 +113,7 @@ npx vitest run test/file.test.ts
 - Test real code, not mocks — use direct imports. Don't create mock infrastructure.
 - Read existing tests before adding; prefer extending existing files; follow existing conventions.
 - Snapshots (enter): VCR-style, replayed by default. `TEST_VCR_MODE=record` to record; default `replay-or-record`.
-- `.testingtokens` contains: `ENTER_API_TOKEN_LOCAL`, `ENTER_API_TOKEN_REMOTE`, `ENTER_TOKEN`, `GITHUB_TOKEN`.
+- Local or CI setups may provide `enter.pollinations.ai/.testingtokens`; never commit it.
 - Production API tests should hit `gen.pollinations.ai`.
 
 ## Architecture & Common Tasks
@@ -155,37 +126,26 @@ npx vitest run test/file.test.ts
 - API docs: strictly technical, no marketing; link dynamic endpoints (e.g. `/models`) vs hardcoded lists; no internal impl/env vars; minimal examples for both simplified and OpenAI-compatible endpoints.
 - Security: never expose keys/secrets; use env vars; validate input.
 - Temp scratch files go in `temp/` clearly labeled.
-- Shrinking large snapshots: video/image snapshots can be 10–30 MB because stream chunks store raw binary as text (`TextDecoder` output in `vcr.ts:289`). To shrink: replace `response.body.data` array with one tiny chunk `[{"data": "<minimal-bytes>", "delay": 1}]`. For mp4, a valid 20-byte ftyp box is `\x00\x00\x00\x14ftypisom\x00\x00\x00\x00isom` (use `bytes.decode('latin-1')` in Python). Tests only check headers/status, not media content.
 
 ## Workflow Orchestration
 
 - Plan mode for any non-trivial task (3+ steps or architectural). If things go sideways, STOP and re-plan. Write specs upfront.
 - Use subagents liberally for research, exploration, parallel analysis — one task per subagent.
-- After user correction: propose an AGENTS.md update capturing the pattern; iterate until mistake rate drops.
+- Propose an AGENTS.md change only for a durable, repeated repository-specific failure mode.
 - Never mark complete without proving it works — run tests, check logs, diff vs main when relevant.
 - Non-trivial changes: ask "is there a more elegant way?" If fix feels hacky, redo elegantly. Skip for obvious fixes.
 - Bug reports: just fix them — point at logs/errors/failing tests and resolve. Fix failing CI without being asked how.
 
-## Task Management
-
-1. Plan first (todos or plan mode). 2. Verify plan before implementing. 3. Track progress. 4. Summarize changes. 5. Capture lessons in AGENTS.md.
-
 ## Compact Instructions
 
 Preserve during compaction: modified files + line numbers, all code/diffs/impl details, test output + errors + command results, full plan + progress + pending, user preferences/corrections this session, architectural decisions + rationale.
-
-## Core Principles
-
-- Simplicity first — minimal code impact.
-- No laziness — find root causes, no temp fixes, senior standards.
-- Minimal impact — touch only what's necessary.
 
 ## Git Workflow
 
 - "send to git" = git status, diff, branch, commit all, push, PR description.
 - Verify branch: `git branch --show-current` and confirm if unsure (branch mix-ups are a recurring mistake).
 - Avoid force pushes (`--force`, `--force-with-lease`) — prefer follow-up commits.
-- Run biome check before committing.
+- Run `npx biome check --write <file>` on changed supported files before committing.
 - If PR already merged: open a new branch/PR for follow-ups.
 
 ## Communication Style
@@ -198,7 +158,7 @@ Be concise. PRs/comments/issues: bullets, <200 words, no fluff.
 
 ## GitHub Labels
 
-Only use established labels (check with `mcp1_list_issues`). Don't create new labels ad-hoc; keep names consistent.
+Check existing repository labels before applying one. Do not create labels ad hoc.
 
 ## Contributor Attribution
 

--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -1,4 +1,6 @@
-BYOP (Bring Your Own Pollen) lets your users authorize your app to spend their own Pollen on Pollinations requests. Your publishable App Key (`pk_...`) identifies the app; after approval, Pollinations returns a scoped user key (`sk_...`) for API calls.
+# Bring Your Own Pollen (BYOP)
+
+BYOP lets users authorize your app to spend their Pollen on Pollinations requests. Your publishable App Key (`pk_...`) identifies the app; after approval, Pollinations returns a scoped user key (`sk_...`) for API calls.
 
 Users stay in control of their balance, budgets, and revocation; your app never has to pay for their usage.
 
@@ -6,19 +8,7 @@ Users stay in control of their balance, budgets, and revocation; your app never 
 
 An **App Key** (`pk_...`) is the publishable key your app sends users to Pollinations with. Without one, the consent screen falls back to the redirect hostname and traffic isn't attributed to your account.
 
-To create one, go to [enter.pollinations.ai](https://enter.pollinations.ai) → **Create New App Key**:
-
-<p align="left"><img src="https://media.pollinations.ai/1133540dc4c19635" alt="Edit App Key" width="420"></p>
-
-Set the **Name** (shows on the consent screen). For web apps, add at least one **Redirect URI** (your exact callback URL). The key you get back is your `client_id` (a `pk_...` publishable key; the legacy name `app_key` is still accepted).
-
-When a user lands on the consent screen signed-out, they're prompted to continue with GitHub:
-
-<p align="left"><img src="https://media.pollinations.ai/fbc04dd1c77dbfd8" alt="Authorize — signed out" width="420"></p>
-
-Once signed in, they review the requested access and confirm:
-
-<p align="left"><img src="https://media.pollinations.ai/a7e4a1e9c5f48b8d" alt="Authorize — signed in" width="420"></p>
+Create an App Key at [enter.pollinations.ai](https://enter.pollinations.ai) under **Create New App Key**. Set the name shown on the consent screen and, for web apps, add the exact callback URL as a **Redirect URI**. The resulting `pk_...` key is your `client_id`; the legacy name `app_key` is also accepted.
 
 ## Developer Earnings
 
@@ -141,37 +131,11 @@ https://myapp.com/callback#api_key=sk_abc123xyz
 
 Fragment, not query param — never hits server logs. 🔒 If you passed `state`, it's echoed back: `#api_key=sk_...&state=...`. On denial the fragment is `#error=access_denied&state=...`.
 
-### Code
-
-```javascript
-// Send user to auth
-const params = new URLSearchParams({
-  redirect_uri: location.href,
-  client_id: 'pk_yourkey',
-});
-window.location.href = `https://enter.pollinations.ai/authorize?${params}`;
-
-// Grab key from URL after redirect
-const apiKey = new URLSearchParams(location.hash.slice(1)).get('api_key');
-
-// Use their pollen
-fetch('https://gen.pollinations.ai/v1/chat/completions', {
-  method: 'POST',
-  headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-  body: JSON.stringify({ model: 'openai', messages: [{ role: 'user', content: 'yo' }] })
-});
-```
-
 ## 🖥️ CLIs & Headless Apps (Device Flow)
 
 Same authorize screen, but the user opens a browser separately. Your CLI polls for the key.
 
-**Where this fits:**
-- **Discord / Telegram / WhatsApp bots** — bot DMs the code, user approves in browser, bot gets their key
-- **CLI tools** — `pollinations login` opens a browser, CLI waits for approval
-- **MCP servers** — AI agent requests access, user approves from their browser
-- **Raspberry Pi / IoT** — headless device displays a code, user approves on their phone
-- **VS Code extensions** — extension shows the code, user approves in browser
+Use this flow for CLIs, bots, MCP servers, extensions, and headless devices.
 
 ```bash
 # 1. request a device code (pass your app_key as client_id for attribution)
@@ -199,7 +163,7 @@ curl -X POST https://enter.pollinations.ai/api/oauth/token \
   -d 'device_code=...'
 ```
 
-## 👤 Who's Using This Key?
+## 👤 User info
 
 Once you have the user-authorized `sk_...` key, you can check who it belongs to:
 
@@ -211,9 +175,3 @@ curl https://enter.pollinations.ai/api/device/userinfo \
 ```
 
 `/api/oauth/userinfo` returns the same standard OIDC userinfo shape. `name` and `email` are included only when the key carries the `profile` scope.
-
----
-
-🕐 User-authorized keys default to 7 days. Users can revoke anytime from the dashboard.
-
-[edit this doc](https://github.com/pollinations/pollinations/edit/main/BRING_YOUR_OWN_POLLEN.md) · *h/t [Puter.js](https://docs.puter.com/user-pays-model/) for the idea*

--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -1,6 +1,6 @@
 # Bring Your Own Pollen (BYOP)
 
-BYOP lets users authorize your app to spend their Pollen on Pollinations requests. Your publishable App Key (`pk_...`) identifies the app; after approval, Pollinations returns a scoped user key (`sk_...`) for API calls.
+BYOP (Bring Your Own Pollen) lets your users authorize your app to spend their own Pollen on Pollinations requests. Your publishable App Key (`pk_...`) identifies the app; after approval, Pollinations returns a scoped user key (`sk_...`) for API calls.
 
 Users stay in control of their balance, budgets, and revocation; your app never has to pay for their usage.
 
@@ -8,7 +8,19 @@ Users stay in control of their balance, budgets, and revocation; your app never 
 
 An **App Key** (`pk_...`) is the publishable key your app sends users to Pollinations with. Without one, the consent screen falls back to the redirect hostname and traffic isn't attributed to your account.
 
-Create an App Key at [enter.pollinations.ai](https://enter.pollinations.ai) under **Create New App Key**. Set the name shown on the consent screen and, for web apps, add the exact callback URL as a **Redirect URI**. The resulting `pk_...` key is your `client_id`; the legacy name `app_key` is also accepted.
+To create one, go to [enter.pollinations.ai](https://enter.pollinations.ai) → **Create New App Key**:
+
+<p align="left"><img src="https://media.pollinations.ai/1133540dc4c19635" alt="Edit App Key" width="420"></p>
+
+Set the **Name** (shows on the consent screen). For web apps, add at least one **Redirect URI** (your exact callback URL). The key you get back is your `client_id` (a `pk_...` publishable key; the legacy name `app_key` is still accepted).
+
+When a user lands on the consent screen signed-out, they're prompted to continue with GitHub:
+
+<p align="left"><img src="https://media.pollinations.ai/fbc04dd1c77dbfd8" alt="Authorize — signed out" width="420"></p>
+
+Once signed in, they review the requested access and confirm:
+
+<p align="left"><img src="https://media.pollinations.ai/a7e4a1e9c5f48b8d" alt="Authorize — signed in" width="420"></p>
 
 ## Developer Earnings
 
@@ -131,11 +143,37 @@ https://myapp.com/callback#api_key=sk_abc123xyz
 
 Fragment, not query param — never hits server logs. 🔒 If you passed `state`, it's echoed back: `#api_key=sk_...&state=...`. On denial the fragment is `#error=access_denied&state=...`.
 
+### Code
+
+```javascript
+// Send user to auth
+const params = new URLSearchParams({
+  redirect_uri: location.href,
+  client_id: 'pk_yourkey',
+});
+window.location.href = `https://enter.pollinations.ai/authorize?${params}`;
+
+// Grab key from URL after redirect
+const apiKey = new URLSearchParams(location.hash.slice(1)).get('api_key');
+
+// Use their pollen
+fetch('https://gen.pollinations.ai/v1/chat/completions', {
+  method: 'POST',
+  headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify({ model: 'openai', messages: [{ role: 'user', content: 'yo' }] })
+});
+```
+
 ## 🖥️ CLIs & Headless Apps (Device Flow)
 
 Same authorize screen, but the user opens a browser separately. Your CLI polls for the key.
 
-Use this flow for CLIs, bots, MCP servers, extensions, and headless devices.
+**Where this fits:**
+- **Discord / Telegram / WhatsApp bots** — bot DMs the code, user approves in browser, bot gets their key
+- **CLI tools** — `pollinations login` opens a browser, CLI waits for approval
+- **MCP servers** — AI agent requests access, user approves from their browser
+- **Raspberry Pi / IoT** — headless device displays a code, user approves on their phone
+- **VS Code extensions** — extension shows the code, user approves in browser
 
 ```bash
 # 1. request a device code (pass your app_key as client_id for attribution)
@@ -163,7 +201,7 @@ curl -X POST https://enter.pollinations.ai/api/oauth/token \
   -d 'device_code=...'
 ```
 
-## 👤 User info
+## 👤 Who's Using This Key?
 
 Once you have the user-authorized `sk_...` key, you can check who it belongs to:
 
@@ -175,3 +213,9 @@ curl https://enter.pollinations.ai/api/device/userinfo \
 ```
 
 `/api/oauth/userinfo` returns the same standard OIDC userinfo shape. `name` and `email` are included only when the key carries the `profile` scope.
+
+---
+
+🕐 User-authorized keys default to 7 days. Users can revoke anytime from the dashboard.
+
+[edit this doc](https://github.com/pollinations/pollinations/edit/main/BRING_YOUR_OWN_POLLEN.md) · *h/t [Puter.js](https://docs.puter.com/user-pays-model/) for the idea*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -105,7 +105,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within
@@ -113,10 +113,6 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org). 
-
-The version 2.0, available at [Contributor Covenant v2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
-
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html). Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at [Contributor Covenant Translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,116 +1,48 @@
 # Contributing to pollinations.ai
 
-Thank you for considering contributing to the pollinations.ai project! We are thrilled to have you join our community and help us enhance this exciting project. Your contributions are vital to improving our project and expanding its capabilities.
+Choose an [open issue](https://github.com/pollinations/pollinations/issues), confirm its requirements, and implement the smallest complete solution. Bug fixes, focused features, tests, and documentation improvements are welcome.
 
-## How to Contribute
+## Submit an app
 
-We have multiple projects under the `pollinations.ai` umbrella, and each project has its own set of issues. To make a meaningful contribution:
+Built an app with Pollinations? Review [what makes a good submission](./apps/README.md#what-makes-a-good-app-submission) and use the [app submission form](https://github.com/pollinations/pollinations/issues/new?template=tier-app-submission.yml). Maintainers and automation handle the directory entry.
 
-### 1. Explore Projects and Issues
+## Development workflow
 
-Before you start, please refer to the main `README.md` file of the `pollinations.ai` repository. It lists all the insights and provides an overview. There are dedicated issues from versatile topics under the repository [Issues](https://github.com/pollinations/pollinations/issues) section.
+1. Fork and clone the repository:
 
-Look for issues that interest you and feel free to tackle them!
+   ```bash
+   git clone https://github.com/your-username/pollinations.git
+   ```
 
-### 2. Understand the Issue and Build an MVP
+2. Create a focused branch:
 
-Once you've selected an issue, take the time to thoroughly understand its requirements. For code contributions, focus on building a **Minimum Viable Product (MVP)** that addresses the core problem or implements the key feature described in the issue.
+   ```bash
+   git checkout -b fix/short-description
+   ```
 
-### 3. Documentation Contributions
+3. Make and test your changes. See [DEVELOP.md](./DEVELOP.md) for setup instructions.
 
-We are in profound need of members who can help enhance our documentation. If you possess experience in data science, machine learning, LLMs (Large Language Models), or Stable Diffusion, your insights will be invaluable. You can contribute by:
+4. Format changed JavaScript, TypeScript, JSON, and JSONC files:
 
-- Improving existing documentation to be clearer and more comprehensive.
-- Writing new guides or tutorials that explain complex concepts or workflows.
-- Providing practical examples of how to use different features of pollinations.ai.
-- Creating explanations for the underlying data science and ML principles.
+   ```bash
+   npx biome check --write <changed-file>
+   ```
 
-### 4. Build Apps with pollinations.ai
+5. Commit and push your branch:
 
-Want to build something cool? Check out our **[apps folder](./apps/README.md)**!
+   ```bash
+   git commit -m "fix: describe the change"
+   git push origin fix/short-description
+   ```
 
-**How it works:**
+6. Open a pull request that explains the change, its verification, and the issue it addresses. Use `Fixes #123` when the pull request should close an issue.
 
-1. **Propose your app idea** by creating a GitHub issue using the "SubmitApp" template
-2. Describe what you want to build and which pollinations.ai APIs you'll use
-3. Get feedback from maintainers
-4. Build your app and submit a PR
+## Pull request checklist
 
-Create apps using pollinations.ai APIs and get them featured. Each app lives in its own folder with clear docs. Perfect for:
+- Follow the surrounding code style and reuse existing utilities.
+- Keep the change focused on the issue.
+- Run the relevant service tests.
+- Document non-obvious behavior and public API changes.
+- Never commit secrets or API keys.
 
-- Creative tools (meme generators, art tools)
-- Productivity apps (thumbnail creators, content generators)
-- Fun projects (games, quizzes)
-- Developer tools (API playgrounds, dashboards)
-
-See the [apps README](./apps/README.md) for detailed guidelines and templates.
-
-### 5. Code Contributions
-
-If you're interested in coding, we enthusiastically welcome contributions in the following areas:
-
-- **Bug Fixes:** Identifying and resolving issues that hinder the project's functionality.
-- **Feature Enhancements:** Adding new capabilities or improving existing ones.
-- **Code Optimization:** Refactoring and improving the efficiency, readability, and maintainability of the codebase.
-- **New Functionalities:** Developing innovative features that expand the project's scope.
-
-### A Short Hands-on for a Quick Contribution Flow
-
-1. Submit at least one meaningful pull request that gets merged into the repository.
-2. Ensure the pull request follows the project's contribution guidelines.
-3. The contribution can be related to bug fixes, feature additions, or documentation improvements.
-
-Once your pull request is merged, you will automatically be issued the badge!
-
-## Getting Started
-
-1.  **Fork the Repository**: Click on the "Fork" button at the top right of the repository page to create your own copy of the project under your GitHub account.
-
-2.  **Clone Your Fork**: Clone your forked repository to your local machine. Replace `your-username` with your GitHub username.
-
-    ```bash
-    git clone https://github.com/your-username/pollinations.git
-    ```
-
-3.  **Create a Branch for Your Work**: Create a new branch for your specific contribution. It's good practice to name your branch related to the issue you're addressing (e.g., `fix/bug-description` or `feat/new-feature-name`).
-
-    ```bash
-    git checkout -b my-feature-branch
-    ```
-
-4.  **Make Your Changes**: Implement your changes, focusing on the MVP for the chosen issue.
-
-5.  **Commit Your Changes**: Commit your changes with a clear and descriptive message.
-
-    ```bash
-    git commit -m "feat: Implement new feature for issue #XYZ"
-    ```
-
-    (Replace "XYZ" with the actual issue number)
-
-6.  **Push Your Changes**: Push your local branch with your changes to your forked repository on GitHub.
-
-    ```bash
-    git push origin my-feature-branch
-    ```
-
-7.  **Create a Pull Request (PR)**: Go to the original `pollinations/pollinations` repository on GitHub. You will see an option to create a Pull Request from your recently pushed branch.
-    - **Crucially:** Link your PR to the original issue it addresses (e.g., "Closes #XYZ" in your PR description).
-    - Ensure your PR clearly explains the changes you've made and how they resolve the issue.
-
-## Guidelines
-
-Follow the Coding Style: Write your code using the same style and rules that the project already uses. This helps keep the code consistent and easy to read for everyone.
-
-**Code Formatting**: We use [Biome](https://biomejs.dev/) for code formatting and linting. Before submitting your PR:
-- Run `npm run format` to auto-format your code
-- Run `npm run lint` to check for issues
-- Our CI will automatically check formatting on changed files
-
-Write Clear Commit Messages: When saving your changes (committing), write messages that clearly and simply explain what you did and why.
-
-Document Your Changes Well: Add comments to your code where needed to explain how it works. If you are updating or adding documentation, make sure it is clear and accurate.
-
-Test Your Work: If you can, write and run tests to check that your changes work correctly and do not break anything else.
-
-Thank You! Thank you for contributing! Your help makes the pollinations.ai project stronger and more useful for the community. Happy coding!
+For questions, use [GitHub Discussions](https://github.com/pollinations/pollinations/discussions) or [Discord](https://discord.gg/pollinations-ai-885844321461485618).

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,11 +1,11 @@
-# Setup the development environment
+# Development
 
+## Secrets
 
-##### SOPS
-We use [sops](https://github.com/getsops/sops) with [age](https://github.com/FiloSottile/age) encryption for secrets management.
+We use [SOPS](https://github.com/getsops/sops) with [age](https://github.com/FiloSottile/age) encryption.
 
-###### Installation
-Install sops via your package manager:
+### Install SOPS
+
 ```bash
 # macOS
 brew install sops
@@ -13,61 +13,43 @@ brew install sops
 # Linux (see https://github.com/getsops/sops/releases)
 ```
 
-Set up your SOPS age key:
+Put your age key where SOPS expects it:
+
 ```bash
 mkdir -p $HOME/.config/sops/age/
 mv /path/to/keys.txt $HOME/.config/sops/age/
 ```
 
-By default, sops will look for your key file in `$HOME/.config/sops/age/keys.txt`. If you want to use a different location, set `SOPS_AGE_KEY_FILE` to your preferred path.
+The default path is `$HOME/.config/sops/age/keys.txt`. Set `SOPS_AGE_KEY_FILE` to use another path.
 
-To decrypt service env files, run the command that matches the service:
-```bash
-sops --output-type dotenv decrypt secrets/dev.vars.json > .dev.vars   # enter.pollinations.ai
-sops --output-type dotenv decrypt secrets/env.json > .env             # generation service secrets
-``` 
+Each service stores encrypted variables in `secrets/{dev,staging,prod}.vars.json`. From `enter.pollinations.ai/` or `gen.pollinations.ai/`, run `npm run decrypt-vars` to prepare local variables. Use `sops edit secrets/<environment>.vars.json` to edit an encrypted file.
 
-The variables are kept encrypted in `**/secrets/*.json`. If you need to edit them, run `sops edit /secrets/file.json`. This will open an editor and when you save the file, write it to the encrypted file. `enter.pollinations.ai` uses `secrets/{dev,staging,prod}.vars.json` for app/runtime secrets; `tools/scripts/rotation/secrets.vars.json` is only for local operator admin credentials used by rotation scripts. (hint: set the editor env variable: `export EDITOR=/path/to/your/editor` to open with your favorite editor)
+`tools/scripts/rotation/secrets.vars.json` contains only local operator credentials for rotation scripts.
 
+### Common SOPS commands
 
-###### Common SOPS commands:
 | Command | Description |
 | :--- | :--- |
 | `sops -d secrets/dev.vars.json` | View decrypted content |
-| `sops edit secrets/dev.vars.json` | Edit encrypted file directly (set `EDITOR` env var) |
-| `sops -e .dev.vars > secrets/dev.vars.json` | Encrypt .env → .encrypted.env |
+| `sops edit secrets/dev.vars.json` | Edit an encrypted file |
+| `sops -e .dev.vars > secrets/dev.vars.json` | Encrypt local variables |
 
+Set `EDITOR` if SOPS should open a specific editor.
 
-##### Running Multiple Services
-
-To run multiple services simultaneously during development:
+## Run services
 
 ```bash
-# Install dependencies for all services
 npm run install:all
 
-# Run all services (enter, gen) with auto-restart
+# Run enter and gen
 npm run dev
 
-# Run individual services
+# Or run one service
 npm run dev:enter
 npm run dev:gen
 ```
 
-The `npm run dev` command uses `concurrently` to run all services with colored output and automatic restart on failure.
-
-##### Debugging
-For verbose logging and debugging across all services, you can use:
-
-```bash
-DEBUG=* npm start
-```
-
-This will enable comprehensive debug output to help troubleshoot issues during development.
-
----
-
-# Architecture Overview
+## Architecture
 
 Current-state architecture diagrams for pollinations.ai infrastructure and model routing.
 
@@ -283,9 +265,3 @@ graph TD
     classDef social fill:#713F12,color:#FEFCE8,stroke:#FACC15,stroke-width:1px
     classDef cicd fill:#374151,color:#F3F4F6,stroke:#9CA3AF,stroke-width:1px
 ```
-
-Billing history: Polar handled pack billing and free daily tier subscriptions
-before the Stripe/D1 migration at the end of January 2026. The remaining Polar
-runtime and webhook integration was removed on May 2, 2026. Read-only historical
-query notes remain in
-`.claude/skills/provider-billing/providers/polar.md`.

--- a/README.md
+++ b/README.md
@@ -32,19 +32,6 @@
 | [🗺️ World Weaver](https://github.com/MrMegnis/world-generator) | Generate worlds with AI using GPT-5.4, render scenes with gpt-image-2, and create videos with ltx-2 via pollinations.ai unified API. | [@MrMegnis](https://github.com/MrMegnis) |
 
 [Browse all apps →](apps/GREENHOUSE.md)
-## 🚀 New Unified API — Now Live
-
-We've launched **https://gen.pollinations.ai** — a single endpoint for all your AI generation needs: text, images, audio, video — all in one place.
-
-### What's New
-
-- **Unified endpoint** — single API at `gen.pollinations.ai` for all generation
-- **Pollen credits** — simple pay-as-you-go system ($1 ≈ 1 Pollen)
-- **All models, one place** — Flux, GPT, Claude, Gemini, Seedream, and more
-- **API keys** — secret keys for model usage, app keys for tracking BYOP apps.
-- **CLI** — `npx @pollinations/cli` for humans and AI agents ([source](packages/polli-cli))
-
-> Get started at [enter.pollinations.ai](https://enter.pollinations.ai) and check out the [API docs](https://gen.pollinations.ai/docs)
 
 ## 🆕 Latest News
 
@@ -82,30 +69,18 @@ We've launched **https://gen.pollinations.ai** — a single endpoint for all you
  </picture>
 </a>
 
-### Quick Start (3 Steps)
-
-1️⃣ **Get your API key**  
-Sign up at [enter.pollinations.ai](https://enter.pollinations.ai) to generate your key.
-
-2️⃣ **Choose what you want to generate**  
-Pollinations supports:
-- 🖼 Images  
-- 📝 Text  
-- 🔊 Audio  
-- 🎬 Video  
-
-3️⃣ **Make your first request**  
-Use one of the examples below to generate your first AI output in seconds.
-
-
 ## 🚀 Getting Started
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pollinations/pollinations)
 
+Get an API key from [enter.pollinations.ai](https://enter.pollinations.ai), then choose an endpoint below.
+
 ### Image Generation
 
 ```bash
-curl 'https://gen.pollinations.ai/image/a%20beautiful%20sunset' -o image.jpg
+curl 'https://gen.pollinations.ai/image/a%20beautiful%20sunset' \
+  -H "Authorization: Bearer $POLLINATIONS_KEY" \
+  -o image.jpg
 ```
 
 Or visit [pollinations.ai](https://pollinations.ai) for an interactive experience.
@@ -113,7 +88,8 @@ Or visit [pollinations.ai](https://pollinations.ai) for an interactive experienc
 ### Text Generation
 
 ```bash
-curl 'https://gen.pollinations.ai/text/Hello%20world'
+curl 'https://gen.pollinations.ai/text/Hello%20world' \
+  -H "Authorization: Bearer $POLLINATIONS_KEY"
 ```
 
 ### Audio Generation
@@ -134,7 +110,7 @@ curl 'https://gen.pollinations.ai/v1/audio/speech' \
   -o speech.mp3
 ```
 
-Available voices: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`, plus [30+ ElevenLabs voices](https://gen.pollinations.ai/docs).
+See the [API documentation](APIDOCS.md) for available voices and models.
 
 ### MCP Server for AI Assistants
 
@@ -211,65 +187,6 @@ export POLLINATIONS_API_KEY=sk_...
 
 See [full API docs](APIDOCS.md) for detailed authentication information.
 
-## 🖥️ How to Use
-
-### Web Interface
-
-Our web interface is user-friendly and doesn't require any technical knowledge. Simply visit [https://pollinations.ai](https://pollinations.ai) and start creating!
-
-### API
-
-Use our API directly in your browser or applications:
-
-    https://pollinations.ai/p/a_cozy_pixel_art_robot_and_bee_in_a_digital_garden_8-bit_warm_stardew_valley_vibes
-
-Replace the description with your own, and you'll get a unique image based on your words!
-
-Here's an example of a generated image:
-
-<p align="center"><img src="https://media.pollinations.ai/589dc7f43393c30a" alt="Pixel art robot and bee in a cozy digital garden — Stardew Valley vibes" width="800" height="340" /></p>
-
-<p align="center"><img src="https://media.pollinations.ai/7317bd94b97edde2" alt="Robot holding generated image saying I CAN SEE, nomnom creature eating prompt text" width="800" height="340" /></p>
-
-## 🎨 Examples
-
-### Image Generation
-
-Python code to download the generated image:
-
-    import requests
-
-    def download_image(prompt):
-        url = f"https://pollinations.ai/p/{prompt}"
-        response = requests.get(url)
-        with open('generated_image.jpg', 'wb') as file:
-            file.write(response.content)
-        print('Image downloaded!')
-
-    download_image("a_cozy_pixel_art_robot_and_bee_in_a_digital_garden_8-bit_warm_stardew_valley_vibes")
-
-### Text Generation
-
-To generate text:
-
-    https://gen.pollinations.ai/text/What%20is%20artificial%20intelligence?
-
-### Audio Generation
-
-Generate speech from text:
-
-    https://gen.pollinations.ai/audio/Hello%20from%20Pollinations?voice=alloy&key=YOUR_API_KEY
-
-Or use the OpenAI TTS-compatible endpoint:
-
-```bash
-curl 'https://gen.pollinations.ai/v1/audio/speech' \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer YOUR_API_KEY' \
-  -d '{"model": "tts-1", "input": "Hello from Pollinations!", "voice": "alloy"}' \
-  -o speech.mp3
-```
-
 ## 🛠️ Integration
 
 ### SDK
@@ -278,115 +195,25 @@ Check out our [Pollinations SDK](./packages/sdk/README.md) for Node.js, browser,
 
 ## Architecture
 
-```mermaid
-%%{init: {'theme': 'dark', 'themeVariables': { 'background': '#1a1a1a', 'primaryColor': '#2a2a2a', 'primaryBorderColor': '#555555', 'primaryTextColor': '#eeeeee', 'lineColor': '#00e5ff', 'clusterBkg': 'transparent', 'clusterBorder': '#888888', 'fontSize': '13px', 'fontFamily': 'Inter, system-ui, sans-serif'}}}%%
-
-graph LR
-    subgraph CLIENTS["Clients / Apps"]
-        Q[Bots - Discord, Telegram, WhatsApp]
-        N[30+ Mobile and Web Apps]
-        A[pollinations.ai Web Frontend]
-        R[AI Agents - Qwen, Sillytavern, ...]
-        AI[AI Assistants - Claude]
-        MCP[MCP Server]
-    end
-
-    AI --> MCP
-    Q --> GEN
-    N --> GEN
-    A --> GEN
-    R --> GEN
-    MCP --> GEN
-
-    GEN["gen.pollinations.ai"]:::cfWorker --> ENTER["enter.pollinations.ai Gateway"]:::cfWorker
-
-    ENTER --> IMG["Image Service"]:::ec2
-    ENTER --> AUD["Audio Service"]:::ec2
-
-    IMG --> CF["Cloudflare Worker with R2 Cache"]:::cfWorkerLight
-    CF --> B["image-origin.pollinations.ai"]:::ec2
-    B --> D["FLUX / GPT Image / Seedream - GPU VMs"]:::gpuNode
-
-    AUD --> EL["ElevenLabs TTS API"]:::provider
-
-    GEN --> SC["Scaleway API"]:::provider
-    GEN --> DS["Deepseek API"]:::provider
-    GEN --> G["Azure-hosted LLMs"]:::provider
-    GEN --> CFM["Cloudflare AI"]:::provider
-
-    style CLIENTS fill:none,stroke:#888,stroke-width:2px,stroke-dasharray: 5 5
-
-    linkStyle default stroke-width:3px,stroke:#00E5FF
-
-    classDef cfWorker fill:#E65100,color:#fff,stroke:#FFB300,stroke-width:2px,font-weight:bold
-    classDef cfWorkerLight fill:#BF360C,color:#fff,stroke:#FFB300,stroke-width:1px
-    classDef ec2 fill:#1F2937,color:#fff,stroke:#F59E0B,stroke-width:2px
-    classDef gpuNode fill:#064E3B,stroke:#34D399,color:#ECFDF5,stroke-width:2px
-    classDef provider fill:#1E3A8A,stroke:#60A5FA,color:#EFF6FF,stroke-width:1px
-```
-
-## 🔮 Future Developments
-
-We're constantly exploring new ways to push the boundaries of AI-driven content creation. Some areas we're excited about include:
-
-- Digital Twins: Creating interactive AI-driven avatars
-- Music Video Generation: Combining AI-generated visuals with music for unique video experiences
-- Real-time AI-driven Visual Experiences: Projects like our Dreamachine, which create immersive, personalized visual journeys
-
-## 🌍 Our Vision
-
-pollinations.ai envisions a future where AI technology is:
-
-- **Open & Accessible**: We believe AI should be available to everyone — earn Pollen by contributing, no credit card required
-
-- **Transparent & Ethical**: Our open-source approach ensures transparency in how our models work and behave
-
-- **Community-Driven**: We're building a platform where developers, creators, and AI enthusiasts can collaborate and innovate
-
-- **Interconnected**: We're creating an ecosystem where AI services can seamlessly work together, fostering innovation through composability
-
-- **Evolving**: We embrace the rapid evolution of AI technology while maintaining our commitment to openness and accessibility
-
-We're committed to developing AI technology that serves humanity while respecting ethical boundaries and promoting responsible innovation. Join us in shaping the future of AI.
+See [DEVELOP.md](./DEVELOP.md#architecture) for the current service diagrams.
 
 ## 🤝 Community and Development
 
-We believe in community-driven development. You can contribute to pollinations.ai in several ways:
-
-1. **Coding Assistant**: The easiest way to contribute! Just [create a GitHub issue](https://github.com/pollinations/pollinations/issues/new) describing the feature you'd like to see implemented. The [MentatBot AI assistant](https://mentat.ai/) will analyze and implement it directly! No coding required - just describe what you want.
-
-2. **Project Submissions**: Have you built something with pollinations.ai? [Use our project submission template](https://github.com/pollinations/pollinations/issues/new?template=project-submission.yml) (labeled as **APPS**) to share it with the community and get it featured in our README.
-
-3. **Feature Requests & Bug Reports**: Have an idea or found a bug? [Open an issue](https://github.com/pollinations/pollinations/issues/new) and let us know. Our team and the MentatBot assistant will review it.
-
-4. **Community Engagement**: Join our vibrant [Discord community](https://discord.gg/pollinations-ai-885844321461485618) to:
-   - Share your creations
-   - Get support and help others
-   - Collaborate with fellow AI enthusiasts
-   - Discuss feature ideas before creating issues
-
-For any questions or support, please visit our [Discord channel](https://discord.gg/pollinations-ai-885844321461485618) or create an issue on our [GitHub repository](https://github.com/pollinations/pollinations).
+- [Contribute code or documentation](CONTRIBUTING.md)
+- [Report a bug or request a feature](https://github.com/pollinations/pollinations/issues/new)
+- [Submit an app](https://github.com/pollinations/pollinations/issues/new?template=tier-app-submission.yml)
+- [Join the Discord community](https://discord.gg/pollinations-ai-885844321461485618)
 
 ## 🗂️ Project Structure
 
-Our codebase is organized into several key folders, each serving a specific purpose in the pollinations.ai ecosystem:
-
-- [`pollinations.ai/`](./app/): The main React application for the Pollinations.ai website.
-
-- [`image.pollinations.ai/`](./image.pollinations.ai/): Backend service for image generation and caching with Cloudflare Workers and R2 storage.
-
-- [`gen.pollinations.ai/`](./gen.pollinations.ai/): Cloudflare Worker for API routing, auth handoff, text generation, and caching.
-
-- [`packages/polli-cli/`](./packages/polli-cli/): The Pollinations CLI — for humans, AI agents, and everything in between.
-
-- [`packages/sdk/`](./packages/sdk/): SDK NPM library with pollinations ready functions for Pollinations.ai.
-
-- [`packages/mcp/`](./packages/mcp/): Model Context Protocol (MCP) server for AI assistants like Claude to generate images directly.
-
-- [`opencode-pollinations-plugin`](https://github.com/fkom13/opencode-pollinations-plugin): This is `open-code-pollinations-plugin`, a plugin for OpenCode that integrates Pollinations.ai's inference capabilities directly into the OpenCode environment, built by our community member [@fkom13](https://github.com/fkom13).
-
-
-This structure encompasses the frontend website, backend services for image and text generation, and integrations like the Discord bot and MCP server, providing a comprehensive framework for the pollinations.ai platform.
+- [`pollinations.ai/`](./pollinations.ai/): React frontend
+- [`enter.pollinations.ai/`](./enter.pollinations.ai/): Authentication and billing gateway
+- [`gen.pollinations.ai/`](./gen.pollinations.ai/): API routing and generation worker
+- [`image.pollinations.ai/`](./image.pollinations.ai/): Image GPU and backend assets
+- [`packages/polli-cli/`](./packages/polli-cli/): Command-line client
+- [`packages/sdk/`](./packages/sdk/): JavaScript SDK and React hooks
+- [`packages/mcp/`](./packages/mcp/): MCP server
+- [`shared/`](./shared/): Shared authentication, registry, and queue code
 
 For development setup and environment management, see [DEVELOP.md](./DEVELOP.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,92 +1,50 @@
-## 📢 Security Policy for pollinations.ai
+# Security Policy
 
-Hi there! First off, thank you for caring about the stability and safety of pollinations.ai. We deeply appreciate folks like you who want to help keep our ecosystem healthy. Our team is committed to making pollinations.ai a safe, privacy-first space for everyone to explore AI creativity.
+## Report a vulnerability
 
----
+Report security vulnerabilities privately. Do not open a public issue, discussion, or pull request.
 
-## 🛡️ Reporting Security Vulnerabilities
+- Email [hello@pollinations.ai](mailto:hello@pollinations.ai).
+- Or contact a maintainer on [Discord](https://discord.gg/pollinations-ai-885844321461485618).
 
-If you’ve spotted a security vulnerability anywhere in our code, APIs, or infrastructure, here’s how you can help us protect the community:
+Include:
 
-1. **Reach Out Privately**  
-   Please **don’t** make a public GitHub issue, comment, or post in discussions about vulnerabilities! Instead, reach out to us in one of these ways:
-   - Email us at [hello@pollinations.ai](mailto:hello@pollinations.ai)
-   - Or DM a maintainer directly on [Discord](https://discord.gg/pollinations-ai-885844321461485618).
-2. **What to Include**  
-   The more detail you can provide, the faster we can fix things. Here’s what helps us:
+- a clear description of the issue;
+- steps to reproduce or a proof of concept;
+- the potential impact; and
+- suggested mitigations, if available.
 
-   - A clear description of what you found
-   - Proof of Concept or steps to reproduce, if possible
-   - Why it matters and what an attacker could potentially do
-   - Any ideas for fixes or mitigations (always welcome!)
+We aim to acknowledge reports within 72 hours and will coordinate disclosure after remediation when appropriate. With your consent, we will credit your report; you may also remain anonymous.
 
-3. **How We Respond**  
-   We do our absolute best to reply within **72 hours** and will keep you updated as we investigate and patch the issue. Once it’s fixed, we’ll publish a public advisory and, with your consent, give you credit for the find.
+## Scope
 
-4. **Recognition**  
-   Security-minded contributors keep us strong! With your permission, we’re happy to mention you in our thanks—just let us know if you’d prefer to stay anonymous.
+This policy covers the [`pollinations/pollinations`](https://github.com/pollinations/pollinations) repository, including:
 
----
+- the Pollinations website and frontend;
+- API, backend, caching, and billing services; and
+- the SDK, MCP server, CLI, and repository-hosted apps and bots.
 
-## 📋 Scope of This Policy
+Report third-party vulnerabilities to their maintainers unless the issue comes from Pollinations' integration.
 
-This policy covers everything in the [`pollinations/pollinations`](https://github.com/pollinations/pollinations) repository, including:
+## Examples of vulnerabilities
 
-- The main `pollinations.ai` website and React frontend
-- Backend and CDN/caching systems for image and text generation
-- Model Context Protocol (MCP), Software Development Kit (SDK), Pollinations-CLI & our community bots and server.
+- Remote code execution, privilege escalation, or command injection
+- Authentication or authorization bypasses
+- Sensitive-data or secret exposure
+- Denial-of-service, rate-limit, or billing bypasses
+- Prompt injection that crosses an authorization boundary, exposes sensitive data, or invokes privileged tools
+- Demonstrated supply-chain attacks
+- Exposed debug endpoints or insecure configuration
+- CI/CD and deployment pipeline vulnerabilities
 
-_If you discover something in third-party code, let their maintainers know unless it’s a problem because of our integration._
+## Out of scope
 
----
+- Self-XSS
+- Exceeding normal API rate limits without a new exploit
+- Bugs limited to unrelated third-party projects
+- Social engineering
+- Feature requests, moderation feedback, or model-output preferences
 
-## 🏷️ What Counts as a Vulnerability?
+For general questions, use [GitHub Discussions](https://github.com/pollinations/pollinations/discussions). Never post sensitive security information publicly.
 
-We’d especially like to hear about:
-
-- Remote code execution, privilege escalation, or command injection in any system
-- Ways to bypass authentication or access control (like APIs or dashboards)
-- Leaks of sensitive data, including user input/history, logs, or info in error messages
-- API abuse resulting in denial of service, rate limit bypass, or billing manipulation
-- Prompt injection/model escape in AI endpoints (especially if it produces unsafe or privileged output)
-- Proven supply chain attacks from dependencies
-- Misconfigurations (debug endpoints left open, secrets in logs or code)
-- Issues with our CI/CD or deployment pipeline security
-
----
-
-## ⛔ What’s Not in Scope
-
-While we love feedback, these are _not_ considered security vulnerabilities for this project:
-
-- Self-XSS (you attacking your own browser)
-- DoS from just going past normal API rate limits (unless it’s a new exploit)
-- Bugs exclusive to other, unrelated projects
-- Social engineering targeting our team/community
-- Feature requests, moderation tweaks, or other changes to how the model thinks/responds
-
----
-
-## 📣 A Note on Conduct
-
-pollinations.ai thrives on kindness, respect, and constructive collaboration. Please always treat others well. If you suspect someone is acting in bad faith or discover an urgent exploit, contact us privately right away.
-
-For general questions, hop into a GitHub discussion—but **never** share sensitive security info in public spaces.
-
----
-
-## 🙏 Thanks
-
-We can’t say this enough: **thank you** for helping make pollinations.ai a safer hub for creative ai. Every tip, every report, every patch makes a real difference!
-
-— with gratitude,  
-the pollinations.ai maintainers & community team
-
----
-
-**For truly urgent or sensitive security issues:**  
-Always use private contact (email/Discord) as public posts may go unnoticed!
-
----
-
-_(Last updated: 2026-04-23)_
+_Last updated: 2026-07-12_


### PR DESCRIPTION
- Removes duplicated onboarding, stale architecture copy, and generic promotional prose from the root README.
- Rewrites contributor and security guidance with current submission, formatting, and reporting instructions.
- Simplifies BYOP, development, and agent guidance while preserving protocol and safety requirements.
- Keeps generated API documentation and automation-managed README sections untouched.

Checks:
- `git diff --check`
- Verified relative link targets across all nine root Markdown files

Note: the commit hook reported that `lefthook` is unavailable locally; the commit completed successfully.