### PR TITLE
fix: repair media documentation links

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -224,12 +224,12 @@ Repeat `-F "image=@…"` to pass multiple reference images on models that accept
 **Upload arbitrary media** to the content-addressed store. Returns a `https://media.pollinations.ai/<hash>` URL you can pass anywhere a remote image, audio, or video URL is accepted.
 
 ```bash
-curl -X POST "https://gen.pollinations.ai/upload" \
+curl -X POST "https://media.pollinations.ai/upload" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -F "file=@./asset.png"
 ```
 
-The hash is derived from the bytes **and** the filename, so the same content uploaded under different names yields different URLs. Files are retained for 30 days; re-uploading resets the timer (and is a no-op if the hash already exists — the `duplicate` field in the response tells you which).
+The hash is derived from the bytes **and** the filename, so the same content uploaded under different names yields different URLs. Files are retained for 30 days. Re-uploading resets the timer, while the `duplicate` field reports whether the file already existed. Retrieving a file keeps it active.
 
 ## 💡 Tips
 
@@ -973,7 +973,7 @@ Upload an image, audio, or video file. Supports multipart/form-data, raw binary,
 💻 **Example**
 
 ```bash
-curl -X POST "https://gen.pollinations.ai/upload" \
+curl -X POST "https://media.pollinations.ai/upload" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -F "file=@./image.png"
 ```
@@ -997,7 +997,7 @@ Get a file by its content hash. Access keeps files from expiring.
 💻 **Example**
 
 ```bash
-curl "https://gen.pollinations.ai/a1b2c3d4e5f60718"
+curl "https://media.pollinations.ai/a1b2c3d4e5f60718"
 ```
 
 ---
@@ -1019,7 +1019,7 @@ Check existence and metadata without downloading the file.
 💻 **Example**
 
 ```bash
-curl -X HEAD "https://gen.pollinations.ai/a1b2c3d4e5f60718"
+curl -X HEAD "https://media.pollinations.ai/a1b2c3d4e5f60718"
 ```
 
 ---
@@ -1050,7 +1050,7 @@ Return file metadata (hash, content type, size, upload timestamp) as JSON withou
 💻 **Example**
 
 ```bash
-curl "https://gen.pollinations.ai/a1b2c3d4e5f60718/metadata"
+curl "https://media.pollinations.ai/a1b2c3d4e5f60718/metadata"
 ```
 
 ### Account

--- a/BRING_YOUR_OWN_POLLEN.md
+++ b/BRING_YOUR_OWN_POLLEN.md
@@ -8,17 +8,17 @@ An **App Key** (`pk_...`) is the publishable key your app sends users to Pollina
 
 To create one, go to [enter.pollinations.ai](https://enter.pollinations.ai) → **Create New App Key**:
 
-<p align="left"><img src="https://media.pollinations.ai/1133540dc4c19635" alt="Edit App Key" width="420"></p>
+<p align="left"><img src="https://media.pollinations.ai/28716f8fb8677eff" alt="Edit App Key" width="420"></p>
 
 Set the **Name** (shows on the consent screen). For web apps, add at least one **Redirect URI** (your exact callback URL). The key you get back is your `client_id` (a `pk_...` publishable key; the legacy name `app_key` is still accepted).
 
 When a user lands on the consent screen signed-out, they're prompted to continue with GitHub:
 
-<p align="left"><img src="https://media.pollinations.ai/fbc04dd1c77dbfd8" alt="Authorize — signed out" width="420"></p>
+<p align="left"><img src="https://media.pollinations.ai/f9fd70e72156ddec" alt="Authorize — signed out" width="420"></p>
 
 Once signed in, they review the requested access and confirm:
 
-<p align="left"><img src="https://media.pollinations.ai/a7e4a1e9c5f48b8d" alt="Authorize — signed in" width="420"></p>
+<p align="left"><img src="https://media.pollinations.ai/2ab9b5e0a2408e93" alt="Authorize — signed in" width="420"></p>
 
 ## Developer Earnings
 

--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -366,6 +366,16 @@ function isResponseExampleWorthwhile(ex: unknown): boolean {
     return true;
 }
 
+function operationBaseUrl(spec: Spec, path: string, op: Operation): string {
+    const pathItem = asObj(spec.paths[path]);
+    const server = [op.servers, pathItem.servers, spec.servers]
+        .flatMap(asArr)
+        .map(asObj)
+        .map((item) => asStr(item.url))
+        .find(Boolean);
+    return (server || BASE_URL).replace(/\/$/, "");
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Curl example
 // ────────────────────────────────────────────────────────────────────────────
@@ -380,7 +390,7 @@ function buildCurl(
     const params = visibleParams(path, asArr(op.parameters) as Schema[]);
     const queryParams = params.filter((p) => asObj(p).in === "query");
     const pathParams = params.filter((p) => asObj(p).in === "path");
-    let url = `${BASE_URL}${path}`;
+    let url = `${operationBaseUrl(spec, path, op)}${path}`;
     // Substitute path placeholders with real, URL-encoded sample values so
     // curl examples are copy-pasteable. Falls back to `:name` only when the
     // spec provides no example for the parameter.

--- a/gen.pollinations.ai/scripts/validate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/validate-apidocs.ts
@@ -7,6 +7,7 @@
  *     work, even if the example "looks" valid
  *   - no `model=<image-model>` appears inside a `/video/` curl example
  *   - public read examples (media retrieval) do not include `Authorization`
+ *   - media-storage examples use the media.pollinations.ai origin
  *
  * Exits non-zero on any failure so it can gate CI.
  */
@@ -35,6 +36,7 @@ const IMAGE_MODELS = new Set([
 
 // Public read endpoints whose curl examples must not show Authorization.
 const PUBLIC_READ_PATHS = ["/:hash", "/:hash/metadata"];
+const MEDIA_PATHS = new Set(["/upload", "/:hash", "/:hash/metadata"]);
 
 function slug(s: string): string {
     return s
@@ -113,6 +115,7 @@ function validate(md: string): Failure[] {
         const url = urlMatch ? urlMatch[1] : "";
         const methodMatch = firstLine.match(/-X\s+(\w+)/);
         const method = methodMatch ? methodMatch[1].toUpperCase() : "GET";
+        const parsedUrl = URL.parse(url);
 
         // Find the nearest preceding heading to give a useful failure path.
         const heading = findEnclosingHeading(lines, block.startLine);
@@ -154,6 +157,19 @@ function validate(md: string): Failure[] {
                 rule: "auth-on-public-read",
                 line: block.startLine,
                 message: `public read endpoint "${heading}" includes Authorization header in curl example`,
+            });
+        }
+
+        // 5. Media storage is hosted separately from the gen gateway.
+        if (
+            parsedUrl &&
+            MEDIA_PATHS.has(parsedUrl.pathname) &&
+            parsedUrl.origin !== "https://media.pollinations.ai"
+        ) {
+            failures.push({
+                rule: "wrong-media-origin",
+                line: block.startLine,
+                message: `media endpoint "${heading}" uses ${parsedUrl.origin} instead of https://media.pollinations.ai`,
             });
         }
     }

--- a/gen.pollinations.ai/src/docs/apidocs-recipes.md
+++ b/gen.pollinations.ai/src/docs/apidocs-recipes.md
@@ -169,12 +169,12 @@ Repeat `-F "image=@…"` to pass multiple reference images on models that accept
 **Upload arbitrary media** to the content-addressed store. Returns a `https://media.pollinations.ai/<hash>` URL you can pass anywhere a remote image, audio, or video URL is accepted.
 
 ```bash
-curl -X POST "https://gen.pollinations.ai/upload" \
+curl -X POST "https://media.pollinations.ai/upload" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -F "file=@./asset.png"
 ```
 
-The hash is derived from the bytes **and** the filename, so the same content uploaded under different names yields different URLs. Files are retained for 30 days; re-uploading resets the timer (and is a no-op if the hash already exists — the `duplicate` field in the response tells you which).
+The hash is derived from the bytes **and** the filename, so the same content uploaded under different names yields different URLs. Files are retained for 30 days. Re-uploading resets the timer, while the `duplicate` field reports whether the file already existed. Retrieving a file keeps it active.
 
 ## 💡 Tips
 


### PR DESCRIPTION
- Makes generated curl examples honor OpenAPI server precedence: operation, path, then root.
- Uses `media.pollinations.ai` for upload and retrieval examples instead of nonexistent gen routes.
- Corrects retention wording: duplicate uploads reset retention rather than becoming no-ops.
- Replaces three expired BYOP screenshots with current, verified media uploads.
- Adds validation that rejects media examples using the wrong origin.

Checks:
- `npm run docs:generate`
- `npm run docs:validate`
- `npm run typecheck`
- `npx vitest run test/docs.test.ts`
- New BYOP media URLs return `200 image/png`

Note: `lefthook` is unavailable locally; commits completed successfully.