### PR TITLE
Skip Pages cutover for worker-target apps

### DIFF
--- a/apps/_scripts/deploy.sh
+++ b/apps/_scripts/deploy.sh
@@ -105,10 +105,14 @@ for i in $(seq 1 30); do
     sleep 10
 done
 
-# Step 7: Public cutover after origin verification
-echo ""
-echo "🔀 Cutting over public domain..."
-node "$SCRIPT_DIR/deploy-app.js" "$APP_NAME" --phase=cutover
+# Step 7: Public cutover after origin verification. Pages apps only —
+# worker apps bind <sub>.pollinations.ai via their own wrangler.toml routes,
+# so the Pages cutover (deploy-app.js) doesn't apply to them.
+if [ "$DEPLOY_TARGET" != "worker" ]; then
+    echo ""
+    echo "🔀 Cutting over public domain..."
+    node "$SCRIPT_DIR/deploy-app.js" "$APP_NAME" --phase=cutover
+fi
 
 # Step 8: Verify the public URL serves through the direct Pages custom domain
 echo ""


### PR DESCRIPTION
`deploy.sh` ran the Pages-only cutover (`deploy-app.js --phase=cutover`, which calls `getPagesProject apps-<sub>`) for **every** app. Worker apps have no Pages project, so it 404s:

```
cutover failed: Get project apps-websim failed: Project not found (8000007)
```

Worker apps (e.g. websim) already bind `<sub>.pollinations.ai` themselves via `wrangler.toml` custom-domain routes — same as enter/gen — so the Pages cutover doesn't apply to them.

- Skip `--phase=cutover` when `deployTarget == worker`
- Fixes the red `Deploy App (Automatic)` on any run that deploys a worker app; websim itself was never down (HTTP 200)

Surfaced by the app-deploy that ran on the brand-assets merge; unrelated to that change.