### PR TITLE
fix: correct misleading reactivation copy on disabled model card

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -81,7 +81,8 @@ export function CommunityEndpointCard({
                                 "Deactivated due to repeated failures."}
                         </span>
                         <span className="text-sm">
-                            Edit, test, then save the model to reactivate it.
+                            Reactivation requires a maintainer — reach out on
+                            Discord.
                         </span>
                     </div>
                 </Alert>


### PR DESCRIPTION
## Summary
- Disabled model card said "Edit, test, then save the model to reactivate it" -- checked `/:id/update` in community-endpoints.ts and it never clears `disabledAt`, so this told owners to do something that doesn't work
- Corrected to say reactivation needs a maintainer (matches CYCLE.md's existing rule -- monitor never self-serves reactivation either)

## Test plan
- [x] Verified no test asserts on the old copy string
- [ ] Visual check on staging (a model was deactivated there earlier this session to preview the card)