### PR TITLE
fix: validate synchronous D1 Tinybird replacement

### DIFF
--- a/.github/workflows/d1-tinybird-sync.yml
+++ b/.github/workflows/d1-tinybird-sync.yml
@@ -109,46 +109,13 @@ jobs:
             exit 1
           fi
 
-          job_id=$(jq -r '.job_id // .import_id // .id // empty' "$import_file")
-          if [ -z "$job_id" ]; then
-            echo "::error::$DATASOURCE replacement did not return a job ID"
+          imported_rows=$(jq -r '.statistics.row_count // -1' "$import_file")
+          quarantine_rows=$(jq -r '.quarantine_rows // -1' "$import_file")
+          invalid_lines=$(jq -r '.invalid_lines // 0' "$import_file")
+          if [ "$imported_rows" -ne "$total_rows" ] || \
+             [ "$quarantine_rows" -ne 0 ] || [ "$invalid_lines" -ne 0 ]; then
+            echo "::error::$DATASOURCE validation failed: expected=$total_rows imported=$imported_rows quarantined=$quarantine_rows invalid=$invalid_lines"
             exit 1
           fi
 
-          for poll in $(seq 1 180); do
-            job_file="$RUNNER_TEMP/$DATASOURCE-job.json"
-            http_code=$(curl -sS --max-time 30 -o "$job_file" -w "%{http_code}" \
-              "$TINYBIRD_HOST/v0/jobs/$job_id" \
-              -H "Authorization: Bearer $TINYBIRD_TOKEN")
-            if [ "$http_code" != "200" ]; then
-              echo "::error::$DATASOURCE job check failed with HTTP $http_code"
-              exit 1
-            fi
-
-            status=$(jq -r '.status // empty' "$job_file")
-            if [ "$status" = "done" ]; then
-              imported_rows=$(jq -r '.statistics.row_count // -1' "$job_file")
-              quarantine_rows=$(jq -r '.quarantine_rows // -1' "$job_file")
-              invalid_lines=$(jq -r '.invalid_lines // -1' "$job_file")
-              if [ "$imported_rows" -ne "$total_rows" ] || \
-                 [ "$quarantine_rows" -ne 0 ] || [ "$invalid_lines" -ne 0 ]; then
-                echo "::error::$DATASOURCE validation failed: expected=$total_rows imported=$imported_rows quarantined=$quarantine_rows invalid=$invalid_lines"
-                exit 1
-              fi
-              echo "::notice::$DATASOURCE replaced atomically: $total_rows rows across $pages pages"
-              exit 0
-            fi
-            if [ "$status" = "error" ] || [ "$status" = "cancelled" ]; then
-              echo "::error::$DATASOURCE replacement job $status"
-              exit 1
-            fi
-            if [ "$status" != "waiting" ] && [ "$status" != "working" ] && \
-               [ "$status" != "cancelling" ]; then
-              echo "::error::$DATASOURCE replacement job returned status '$status'"
-              exit 1
-            fi
-            sleep 5
-          done
-
-          echo "::error::$DATASOURCE replacement job timed out"
-          exit 1
+          echo "::notice::$DATASOURCE replaced atomically: $total_rows rows across $pages pages"


### PR DESCRIPTION
- Treats multipart `mode=replace` uploads as synchronous Tinybird operations.
- Removes the invalid `/v0/jobs/<datasource-id>` polling that made all five jobs fail after successful replacement in [run 29250993475](https://github.com/pollinations/pollinations/actions/runs/29250993475).
- Validates imported, quarantined, and invalid counts directly from the replacement response without logging response bodies.
- Production verification found every exported row present across all five datasources with zero quarantine rows.
- Validated with actionlint, embedded Bash syntax checking, and `git diff --check`.