### PR TITLE
fix: verify D1 Tinybird sync with exact counts

### DIFF
--- a/.github/workflows/d1-tinybird-sync.yml
+++ b/.github/workflows/d1-tinybird-sync.yml
@@ -32,6 +32,7 @@ jobs:
           DATASOURCE: ${{ matrix.datasource }}
           EXPORT_TOKEN: ${{ secrets.D1_EXPORT_TOKEN }}
           TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_SYNC_TOKEN }}
+          TINYBIRD_READ_TOKEN: ${{ secrets.TINYBIRD_READ_TOKEN }}
           TINYBIRD_HOST: https://api.europe-west2.gcp.tinybird.co
         run: |
           set -euo pipefail
@@ -108,13 +109,38 @@ jobs:
             echo "::error::$DATASOURCE replacement failed with HTTP $http_code"
             exit 1
           fi
+          if ! jq -e --arg datasource "$DATASOURCE" \
+            '.datasource.name == $datasource' "$import_file" \
+            >/dev/null; then
+            echo "::error::$DATASOURCE replacement returned an invalid response"
+            exit 1
+          fi
 
-          imported_rows=$(jq -r '.statistics.row_count // -1' "$import_file")
-          quarantine_rows=$(jq -r '.quarantine_rows // -1' "$import_file")
-          invalid_lines=$(jq -r '.invalid_lines // 0' "$import_file")
-          if [ "$imported_rows" -ne "$total_rows" ] || \
-             [ "$quarantine_rows" -ne 0 ] || [ "$invalid_lines" -ne 0 ]; then
-            echo "::error::$DATASOURCE validation failed: expected=$total_rows imported=$imported_rows quarantined=$quarantine_rows invalid=$invalid_lines"
+          verification_file="$RUNNER_TEMP/$DATASOURCE-verification.json"
+          query="SELECT (SELECT count() FROM $DATASOURCE) AS imported_rows, (SELECT count() FROM ${DATASOURCE}_quarantine) AS quarantine_rows FORMAT JSON"
+          http_code=$(curl -sS --max-time 30 -G -o "$verification_file" -w "%{http_code}" \
+            "$TINYBIRD_HOST/v0/sql" \
+            -H "Authorization: Bearer $TINYBIRD_READ_TOKEN" \
+            --data-urlencode "q=$query")
+
+          if [ "$http_code" != "200" ]; then
+            echo "::error::$DATASOURCE verification failed with HTTP $http_code"
+            exit 1
+          fi
+          if ! jq -e \
+            '(.data | type) == "array" and (.data | length) == 1
+             and (.data[0].imported_rows | type == "number")
+             and (.data[0].quarantine_rows | type == "number")' \
+            "$verification_file" \
+            >/dev/null; then
+            echo "::error::$DATASOURCE verification returned an invalid response"
+            exit 1
+          fi
+
+          imported_rows=$(jq -r '.data[0].imported_rows' "$verification_file")
+          quarantine_rows=$(jq -r '.data[0].quarantine_rows' "$verification_file")
+          if [ "$imported_rows" -ne "$total_rows" ] || [ "$quarantine_rows" -ne 0 ]; then
+            echo "::error::$DATASOURCE validation failed: expected=$total_rows imported=$imported_rows quarantined=$quarantine_rows"
             exit 1
           fi
 


### PR DESCRIPTION
- Replaces the undocumented multipart-response row-count check that returned `imported=-1`.
- Verifies the synchronous replacement response identifies the expected datasource.
- Uses the existing `TINYBIRD_READ_TOKEN` to query exact datasource and quarantine counts after replacement.
- Keeps Tinybird response bodies and D1 row contents out of public logs.
- Validated with actionlint, embedded Bash syntax checks, response fixtures, and live aggregate-only Tinybird queries; the full branch workflow run is the merge gate.