### PR TITLE
docs: align Tinybird token ownership

### DIFF
--- a/.claude/skills/enter-services/token-rotation.md
+++ b/.claude/skills/enter-services/token-rotation.md
@@ -21,15 +21,17 @@ Use when:
 | `PLN_GPU_TOKEN` | gen image + enter (ACE-Step) → GPU workers | image `env.json`, enter `{dev,staging,prod}.vars.json` | Wrangler (production, staging), RunPod pods (Flux+Z-Image, Klein), Lambda Labs GH200 (LTX-2, ACE-Step, Sana) |
 | `TINYBIRD_INGEST_TOKEN` | enter+gen runtime → Tinybird append | enter+gen `{dev,staging,prod}.vars.json` | Wrangler (production, staging) |
 | `TINYBIRD_READ_TOKEN` | enter/KPI/observability/app metrics → Tinybird read | enter `{dev,staging,prod}.vars.json`, kpi `env.json`, observability `secrets.vars.json` | GitHub secret `TINYBIRD_READ_TOKEN` |
-| `TINYBIRD_SYNC_TOKEN` | GitHub Actions + enter admin route → Tinybird sync writes | enter `{dev,staging,prod}.vars.json` | GitHub secret `TINYBIRD_SYNC_TOKEN`, Wrangler (production, staging) |
+| `TINYBIRD_SYNC_TOKEN` | GitHub Actions → Tinybird snapshot writes | — | GitHub secret `TINYBIRD_SYNC_TOKEN` |
 
-Each token is workspace-scoped: `prod.vars.json` files hold tokens for the
+Each Tinybird runtime token is workspace-scoped: `prod.vars.json` files hold tokens for the
 `pollinations_enter` workspace; `staging.vars.json`/`dev.vars.json` hold
 tokens for `pollinations_enter_staging`. Rotating the prod-workspace tokens
 does not rotate the staging-workspace tokens — do that side manually until
-this gains explicit workspace handling (tracked in #11127). The
-`TINYBIRD_SYNC_TOKEN` in staging/dev files still points at the prod workspace
-because no staging sync token exists yet (also #11127).
+this gains explicit workspace handling (tracked in #11127).
+
+`TINYBIRD_SYNC_TOKEN` is a GitHub Actions credential for prod snapshot
+replacement. It is not an Enter Worker secret and does not belong in Enter
+SOPS files.
 
 `TINYBIRD_LEGACY_READ_TOKEN` (consumed by `apps/operation/observability`)
 lives in the retired `pollinations_ai` workspace and has no rotation path —
@@ -44,10 +46,12 @@ the token.
   (see below) placed *before* the Wrangler update, so GPUs accept the new
   token before enter starts sending it.
 - **Tinybird tokens**: `POST /tokens/{name}/refresh` (in-place, immediate
-  invalidation — no create-before-delete window) plus a live `wrangler secret
-  put` to close the ~5s propagation gap. Needs `TINYBIRD_ADMIN_TOKEN`
-  (`tb --cloud token copy "admin token"`). Verify by writing one event to
-  Tinybird with the new ingest token.
+  invalidation — no create-before-delete window). Update the targets listed in
+  the inventory: runtime ingest/read tokens may require Worker deployment;
+  `TINYBIRD_SYNC_TOKEN` updates only the GitHub secret. Needs
+  `TINYBIRD_ADMIN_TOKEN` (`tb --cloud token copy "admin token"`). Verify by
+  writing one event with a new ingest token or running the relevant sync
+  workflow with a new sync token.
 - **Both sides of a trust boundary must update together.** A token correct in
   Wrangler but not yet on the consuming side (or vice versa) causes 403s or
   silent failures — see the table below.

--- a/.claude/skills/tinybird-deploy/SKILL.md
+++ b/.claude/skills/tinybird-deploy/SKILL.md
@@ -13,7 +13,7 @@ Deploy observability pipes and datasources to Tinybird Cloud.
 - Do **not** install or update this workflow with `pip install tinybird-cli`; that can put the Classic CLI first on PATH.
 - If `tb --cloud` is missing, or Tinybird says this is a Forward workspace but the CLI is Classic, fix PATH so `~/.local/bin` wins. The Classic CLI is kept only as `tb-classic`.
 - Run commands from `enter.pollinations.ai/observability`.
-- Prefer explicit `TB_TOKEN` + `--host` on every deploy command. Do not rely on `.tinyb` or `tb workspace use` for workspace selection.
+- Set `TB_TOKEN` explicitly to a token with `WORKSPACE:DEPLOY` for the target workspace, and pass `--host` on every deploy command. Do not rely on `.tinyb` or `tb workspace use` for workspace selection.
 
 ## Workspaces
 
@@ -24,9 +24,9 @@ Two workspaces, same region (`gcp-europe-west2`). Pipes and datasources must be 
 | `pollinations_enter` | production worker only | https://cloud.tinybird.co/gcp/europe-west2/pollinations_enter |
 | `pollinations_enter_staging` | staging worker + dev worker + local `npm run dev` | https://cloud.tinybird.co/gcp/europe-west2/pollinations_enter_staging |
 
-Workspace routing is token-scoped: same regional ingest URL, different Tinybird tokens per environment in `secrets/{prod,staging,dev}.vars.json`.
+Workspace routing is token-scoped: the same regional host serves both workspaces, and the token selects the workspace.
 
-The local `.tinyb` is gitignored and must not be trusted for prod/staging selection. For staging, set `TB_TOKEN` from `secrets/staging.vars.json`. For prod, set `TB_TOKEN` from `secrets/prod.vars.json`. Keep tokens out of logs.
+The local `.tinyb` is gitignored and must not be trusted for prod/staging selection. Set `TB_TOKEN` from an operator or CI secret store, not from Enter runtime SOPS files. Use a staging-workspace deploy token for staging and a prod-workspace deploy token for prod. Keep tokens out of logs.
 
 ## Directory Structure
 
@@ -48,18 +48,13 @@ enter.pollinations.ai/observability/
 
 # Commands
 
-Set the region once per shell session:
+Set the region once per shell session and require the staging deploy token to
+already be present in the environment:
 
 ```bash
 TB_HOST="https://api.europe-west2.gcp.tinybird.co"
-```
-
-Load the staging sync token without printing it:
-
-```bash
-TB_TOKEN="$(SOPS_AGE_KEY=$(security find-generic-password -a "$USER" -s sops-age-key -w 2>/dev/null || true) \
-  sops -d ../secrets/staging.vars.json | jq -r '.TINYBIRD_SYNC_TOKEN')"
-export TB_TOKEN
+: "${TB_TOKEN:?Set TB_TOKEN to a pollinations_enter_staging WORKSPACE:DEPLOY token}"
+export TB_HOST TB_TOKEN
 ```
 
 ## Step 1: Validate (Dry Run)
@@ -87,7 +82,7 @@ tb --cloud --host "$TB_HOST" deployment create --wait --no-allow-destructive-ope
 
 Never pass `--auto` or run `deployment promote` unless the user explicitly asks for promotion.
 
-Prod deploys use the same command shape with the prod token, but only after staging validation and verification. Deploying to both workspaces is still manual until #11127 is resolved.
+Prod deploys use the same command shape after explicitly replacing `TB_TOKEN` with a `pollinations_enter` deploy token, but only after staging validation and verification. Deploying to both workspaces is still manual until #11127 is resolved.
 
 ## Step 3: Verify
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 
 - Two workspaces: `pollinations_enter` (prod) and `pollinations_enter_staging` (staging + dev + local). Pipes and datasources must be deployed to **both** — no CI auto-deploy yet, tracked in #11127.
 - Use the Tinybird **Forward CLI** as `tb` (not Classic).
-- Do not rely on `.tinyb` for workspace selection. Always pass `TB_TOKEN` from `secrets/{staging,prod}.vars.json` and `--host https://api.europe-west2.gcp.tinybird.co`.
+- Do not rely on `.tinyb` for workspace selection. Always pass an explicit workspace-scoped `TB_TOKEN` with `WORKSPACE:DEPLOY` and `--host https://api.europe-west2.gcp.tinybird.co`; never source deploy credentials from Enter runtime secrets.
 - Always validate and deploy to **staging first**, verify, then prod only when requested.
 - Validate first: `tb --cloud --host "$TB_HOST" deployment create --check --no-allow-destructive-operations`
 - Deploy staging: `tb --cloud --host "$TB_HOST" deployment create --wait --no-allow-destructive-operations`


### PR DESCRIPTION
- Removes stale claims that `TINYBIRD_SYNC_TOKEN` lives in Enter SOPS or Worker secrets
- Documents the sync token as GitHub Actions-only for snapshot replacement
- Requires an explicit workspace-scoped `WORKSPACE:DEPLOY` token for Tinybird CLI deployments
- Leaves both active sync workflows unchanged

Validation: `git diff --check` and repository-wide token-reference audit.