### PR TITLE
fix: remove legacy deploy workflow name

### DIFF
--- a/.github/workflows/docs-regenerate-api-reference.yml
+++ b/.github/workflows/docs-regenerate-api-reference.yml
@@ -6,10 +6,7 @@ name: Docs / Regenerate API reference
 # deploys from the `production` branch, not `main`).
 on:
   workflow_run:
-    # Keep the old name until production contains the renamed deploy workflow.
-    workflows:
-      - Deploy gen.pollinations.ai
-      - Deploy / gen.pollinations.ai
+    workflows: ["Deploy / gen.pollinations.ai"]
     types:
       - completed
     branches:


### PR DESCRIPTION
- Removes the temporary `Deploy gen.pollinations.ai` compatibility entry.
- Keeps API-reference regeneration listening only to `Deploy / gen.pollinations.ai`.
- Follows successful production deploy and dependent docs-workflow verification.
- Validated with `actionlint` and `git diff --check`.
