### PR TITLE
fix: harden Vast Flux deployment and canary checks

### DIFF
--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,39 +1,40 @@
 # GPU Instances
 
-Last updated: 2026-07-02
+Last updated: 2026-07-13
 
 ## Capacity Summary
 
 | Model | Workers | GPUs | Provider | Cost/hr | Status |
 |-------|---------|------|----------|---------|--------|
-| Flux (FP4) | 1 (+1 stopped spare) | RTX 5090 | Vast.ai | ~$0.43/hr | **ACTIVE — production** (Fireworks fallback) |
+| Flux (FP4) | 1 | RTX 5090 | Vast.ai | $0.3744/hr | **ACTIVE — production** (Fireworks fallback) |
 | Z-Image | 3 | 4090 + 2x 3090 | RunPod | (see runpodctl) | **ACTIVE — production** |
 | Klein 4B | 1 | 1x RTX A5000 | RunPod | $0.27 | **ACTIVE** |
 | LTX-2 + ACE-Step + Sana | 1 | GH200 | Lambda Labs | — | **ACTIVE** |
 
 ## Provider: Vast.ai — Flux (RTX 5090, FP4)
 
-Two single-GPU instances on different hosts (host redundancy), each fronted by
-a Cloudflare Tunnel. Flux routes pool-first with automatic Fireworks fallback
+One single-GPU instance fronted by a Cloudflare Tunnel. Flux routes pool-first
+with automatic Fireworks fallback
 (`gen.pollinations.ai/src/image/createAndReturnImages.ts` → `callFluxWithFallback`).
 
-| Worker | Vast instance | Tunnel hostname | SSH |
-|--------|--------------|-----------------|-----|
-| flux-vast-01 | 43575766 (California) | `flux-vast-01.pollinations.ai` | `ssh -p 21972 -i ~/.ssh/pollinations_services_2026 root@192.220.55.116` |
-| flux-vast-02 | 43594918 (US) — **STOPPED spare** (2026-07-02; disk-only cost; provisioned + models cached; `vastai start instance` then start the `flux` screen — GPU may be taken while stopped, then re-provision) | `flux-vast-02.pollinations.ai` | `ssh -p 10576 -i ~/.ssh/pollinations_services_2026 root@137.175.76.24` (port changes on restart) |
+| Worker | Vast instance | GPU | Listed rate | Status |
+|--------|---------------|-----|-------------|--------|
+| flux-vast-03 | 44731147 | RTX 5090 | $0.374444/hr | Active; replace its temporary quick tunnel with a named tunnel before the next cutover |
 
 > Instance IDs/IPs/ports change on recreate — check `vastai show instances`.
-> CRITICAL: workers MUST be behind a Cloudflare tunnel; the gen worker cannot
-> fetch() raw-IP/non-standard-port origins (NAT'd `http://IP:PORT` URLs
-> silently fall back to Fireworks).
+> CRITICAL: workers MUST be behind a named Cloudflare tunnel created in the
+> authoritative Pollinations account. The gen Worker cannot fetch a Vast
+> raw-IP/non-standard-port origin, and a successful registry heartbeat alone
+> does not prove the data path works. Fireworks can hide either failure.
 
 **Provision a new instance** (see `nunchaku/setup-vast.sh` header for all env):
 ```bash
 vastai search offers 'gpu_name=RTX_5090 num_gpus=1 verified=true rentable=true reliability>0.99 duration>=30 inet_down>=500 cpu_cores>=8 disk_space>=60' --order dph_total
 vastai create instance <OFFER> --image "vastai/base-image:cuda-13.0.2-cudnn-devel-ubuntu24.04-py312" --disk 60 --ssh --direct --env '-p 8765:8765'
 vastai attach ssh <INSTANCE> "$(cat ~/.ssh/pollinations_services_2026.pub)"
-# copy the pollinations.ai account cert (e.g. from an existing worker) to ~/.cloudflared/cert.pem, then:
-PLN_GPU_TOKEN=... HF_TOKEN=... TUNNEL_NAME=flux-vast-NN GIT_BRANCH=main bash setup-vast.sh
+# First create a remote tunnel + hostname routing to localhost:8765 in Cloudflare, then:
+PLN_GPU_TOKEN=... HF_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... \
+PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai GIT_BRANCH=main bash setup-vast.sh
 ```
 Gotchas (all hit in practice): rent hosts with `duration>=30`; verify
 `intended_status=running` after create (GPU can be taken between create/start);
@@ -48,13 +49,13 @@ instances and destroying the loser is cheap (~$0.40/hr each).
 
 **Health / restart:**
 ```bash
-curl -s https://flux-vast-01.pollinations.ai/docs -o /dev/null -w "%{http_code}\n"   # worker up
+curl -s https://<named-tunnel-hostname>/docs -o /dev/null -w "%{http_code}\n"   # control-plane only
 curl -s https://gen.pollinations.ai/register -H "Authorization: Bearer $PLN_GPU_TOKEN"  # registry
 # on the instance: screen -r flux / screen -r cloudflared; logs /tmp/flux.log /tmp/cloudflared.log
+POLLINATIONS_API_KEY=... bash image.pollinations.ai/nunchaku/verify-vast.sh  # required before cutover
 ```
 
 **Key behavior:** FP4 nunchaku, 4 steps, full 1024x1024 (`MAX_PIXELS=1048576`);
-~2.3s/image, ~1,900 img/hr sustained per GPU; baseline JPEG output;
 `QUEUE_LIMIT=10` sheds load with 503 → gateway falls back to Fireworks.
 
 ## Provider: RunPod

--- a/image.pollinations.ai/nunchaku/.gitignore
+++ b/image.pollinations.ai/nunchaku/.gitignore
@@ -154,6 +154,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.flux
 .venv
 env/
 venv/

--- a/image.pollinations.ai/nunchaku/README.md
+++ b/image.pollinations.ai/nunchaku/README.md
@@ -1,118 +1,65 @@
-# Flux Schnell Server (Nunchaku)
+# Flux Schnell on Vast.ai
 
-Fast Flux image generation server using [MIT-HAN-LAB's Nunchaku](https://github.com/mit-han-lab/nunchaku) quantization for RTX 4090 GPUs.
+The production Flux worker runs FLUX.1 Schnell with Nunchaku FP4 on a single
+RTX 5090. Vast instances are containers without systemd, so
+[`setup-vast.sh`](./setup-vast.sh) installs the pinned runtime and supervises
+the model server and Cloudflare Tunnel in `screen` restart loops.
 
-## Quick Start
+## Cloudflare preparation
 
-Deploy to a fresh Ubuntu 24.04 instance with RTX 4090 GPUs:
+Create a remotely-managed tunnel in the authoritative Pollinations Cloudflare
+account before provisioning the Vast host:
 
-```bash
-HF_TOKEN=your_huggingface_token \
-WORKER_NUM=1 \
-PUBLIC_IP=52.205.25.210 \
-GPU0_PUBLIC_PORT=27235 \
-GPU1_PUBLIC_PORT=30830 \
-bash setup.sh
-```
+1. Route a stable hostname such as `flux-vast-NN.pollinations.ai` to
+   `http://localhost:8765`.
+2. Copy the tunnel token. Do not copy `cert.pem` to a rental host; it can create
+   tunnels and DNS records for the account. A remotely-managed tunnel only
+   needs its scoped token to run. See [Cloudflare tunnel tokens](https://developers.cloudflare.com/tunnel/advanced/tunnel-tokens/).
 
-The script takes ~20 minutes and will:
-1. Install CUDA 12.8 and Python dev headers
-2. Create Python venv with PyTorch + dependencies
-3. Build nunchaku from source for RTX 4090
-4. Create and start systemd services for each GPU
+The stable tunnel is required because the gen Cloudflare Worker cannot route to
+a Vast NAT address on a non-standard port.
 
-## Current Workers (Nov 2025)
+## Deploy
 
-| Worker | SSH Host | Public IP | GPU 0 Port | GPU 1 Port |
-|--------|----------|-----------|------------|------------|
-| 1 | `ionet-flux-1` | 52.205.25.210 | 27235 | 30830 |
-| 2 | `ionet-flux-2` | 52.205.25.210 | 20884 | - |
-| 3 | `ionet-flux-3` | 54.185.175.109 | 29108 | - |
-| 4 | `ionet-flux-4` | 52.205.25.210 | 29309 | - |
-
-## API
-
-### Generate Image
+On a fresh Vast RTX 5090 instance:
 
 ```bash
-curl -X POST http://<IP>:<PORT>/generate \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "prompt": "a cute cat",
-    "width": 1024,
-    "height": 1024,
-    "num_inference_steps": 4,
-    "seed": 42
-  }' \
-  --output image.png
+PLN_GPU_TOKEN=... \
+HF_TOKEN=... \
+CLOUDFLARED_TUNNEL_TOKEN=... \
+PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
+bash setup-vast.sh
 ```
 
-### Health Check
+The tunnel token is written to a mode `0600` token file and is not included in
+the `cloudflared` process arguments. Model and server settings are persisted in
+the ignored `.env.flux` file.
+
+## Verify before traffic cutover
+
+A healthy `/docs` response and registry heartbeat are control-plane checks;
+they do not prove that `gen.pollinations.ai` can reach the tunnel. Fireworks can
+otherwise hide a broken Vast route.
+
+Run the end-to-end canary on the Vast host with a valid Pollinations API key:
 
 ```bash
-curl http://<IP>:<PORT>/health
+POLLINATIONS_API_KEY=... bash verify-vast.sh
 ```
 
-## Management
+The canary creates a unique uncached prompt, generates it directly on Vast and
+through the public Flux route with the same seed, and compares decoded pixels.
+Do not destroy the old worker until this passes on the replacement.
 
-### Check Status
+## Operations
 
 ```bash
-# On the worker
-sudo systemctl status ionet-flux-worker1-gpu0 ionet-flux-worker1-gpu1
-
-# View logs
-sudo journalctl -u ionet-flux-worker1-gpu0 -u ionet-flux-worker1-gpu1 -f
+tail -f /tmp/flux.log
+tail -f /tmp/cloudflared.log
+screen -r flux
+screen -r cloudflared
 ```
 
-### Restart Services
-
-```bash
-sudo systemctl restart ionet-flux-worker1-gpu0 ionet-flux-worker1-gpu1
-```
-
-### Update Code
-
-```bash
-cd ~/pollinations && git pull
-sudo systemctl restart ionet-flux-worker1-gpu0 ionet-flux-worker1-gpu1
-```
-
-## Requirements
-
-- Ubuntu 24.04
-- NVIDIA RTX 4090 GPU(s)
-- ~50GB disk space
-- HuggingFace token with access to Flux models
-
-## Docker
-
-Build and run with Docker:
-
-```bash
-# Build (takes 15-20 min due to nunchaku compilation)
-docker build -t flux-schnell-nunchaku .
-
-# Run on GPU 0
-docker run --gpus '"device=0"' -p 8000:8000 \
-  -e HF_TOKEN=your_huggingface_token \
-  flux-schnell-nunchaku
-
-# Run on specific GPU with custom port
-docker run --gpus '"device=1"' -p 8001:8000 \
-  -e HF_TOKEN=your_token \
-  -e PORT=8000 \
-  -e PUBLIC_IP=52.205.25.210 \
-  -e PUBLIC_PORT=8001 \
-  flux-schnell-nunchaku
-```
-
-**Note:** The Dockerfile builds nunchaku for RTX 4090 (SM 8.9). For other GPUs, modify `TORCH_CUDA_ARCH_LIST` in the Dockerfile.
-
-## Files
-
-- `setup.sh` - Main deployment script (for bare metal)
-- `Dockerfile` - Container build (for Docker/K8s)
-- `server.py` - FastAPI server
-- `requirements.txt` - Python dependencies
-- `safety_checker/` - NSFW content filter
+The setup defaults are `QUEUE_LIMIT=10`, `MAX_PIXELS=1048576`, and
+`mit-han-lab/svdq-fp4-flux.1-schnell`. Override them only through the documented
+environment variables in `setup-vast.sh`.

--- a/image.pollinations.ai/nunchaku/setup-vast.sh
+++ b/image.pollinations.ai/nunchaku/setup-vast.sh
@@ -6,11 +6,10 @@
 # (server.py exits on CUDA errors and expects its supervisor to restart it).
 #
 # IMPORTANT — Cloudflare Tunnel required: the gen worker (Cloudflare Worker)
-# cannot fetch() raw-IP/non-standard-port origins, so a NAT'd http://IP:PORT
-# heartbeat URL is unreachable from routing. Set TUNNEL_NAME and place the
-# pollinations.ai account cert at ~/.cloudflared/cert.pem — this script then
-# creates/routes/runs the tunnel and the worker advertises
-# https://$TUNNEL_NAME.pollinations.ai.
+# cannot fetch() raw-IP/non-standard-port origins. Create a remotely-managed
+# tunnel and its public hostname in the authoritative Cloudflare account before
+# running this script. The Vast host only receives the scoped tunnel token; do
+# not copy a Cloudflare account certificate onto a rental host.
 #
 # Tested against vastai/base-image:cuda-13.0.2-cudnn-devel-ubuntu24.04-py312.
 # The prebuilt nunchaku wheel bundles SM 7.5/8.0/8.6/8.9/120 kernels, so the
@@ -19,20 +18,22 @@
 # Usage (on the instance):
 #   PLN_GPU_TOKEN=... \
 #   HF_TOKEN=... \
-#   TUNNEL_NAME=flux-vast-NN \
+#   CLOUDFLARED_TUNNEL_TOKEN=... \
+#   PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
 #   bash setup-vast.sh
 #
+# Required env details:
+#   HF_TOKEN          black-forest-labs/FLUX.1-schnell is gated (accept-terms);
+#                     token must belong to an account that accepted. Lives in
+#                     enter.pollinations.ai/.testingtokens
+#
 # Optional env:
-#   HF_TOKEN          REQUIRED in practice: black-forest-labs/FLUX.1-schnell is
-#                     gated (accept-terms); token must belong to an account
-#                     that accepted. Lives in enter.pollinations.ai/.testingtokens
 #   QUANT_MODEL_PATH  default mit-han-lab/svdq-fp4-flux.1-schnell (Blackwell);
 #                     use mit-han-lab/svdq-int4-flux.1-schnell on Ada GPUs
 #   MAX_PIXELS        default 1048576 (1024x1024, matches FP4/5090);
 #                     use 810000 on RTX 4090
 #   QUEUE_LIMIT       default 10 (server.py sheds load with 503 beyond this;
 #                     gateway then falls back to Fireworks)
-#   PUBLIC_IP/PUBLIC_PORT  only for tunnel-less setups (no TUNNEL_NAME)
 #   SERVICE_TYPE      default flux
 #   GIT_BRANCH        default main
 #   SKIP_CLONE        use files already in $WORK_DIR (hosts w/ broken GitHub egress)
@@ -51,14 +52,21 @@ SUDO=""
 
 log() { echo -e "\033[0;32m[setup-vast]\033[0m $1"; }
 
-if [ -z "$PLN_GPU_TOKEN" ] || { [ -z "$TUNNEL_NAME" ] && [ -z "$PUBLIC_PORT" ]; }; then
-    echo "Usage: PLN_GPU_TOKEN=... TUNNEL_NAME=flux-vast-NN bash setup-vast.sh" >&2
+if [ -z "$PLN_GPU_TOKEN" ] || [ -z "$HF_TOKEN" ] || [ -z "$CLOUDFLARED_TUNNEL_TOKEN" ] || [ -z "$PUBLIC_HOSTNAME" ]; then
+    echo "Usage: PLN_GPU_TOKEN=... HF_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai bash setup-vast.sh" >&2
     exit 1
 fi
 
+case "$PUBLIC_HOSTNAME" in
+    *[!A-Za-z0-9.-]*)
+        echo "PUBLIC_HOSTNAME must be a hostname, without a scheme or path" >&2
+        exit 1
+        ;;
+esac
+
 log "Installing system packages..."
 $SUDO apt-get update -qq
-$SUDO apt-get install -y -qq git screen python3.12-venv python3.12-dev
+$SUDO apt-get install -y -qq curl git screen python3.12-venv python3.12-dev
 
 # CUDA forward-compat libs (shipped in cuda-13 images) fail on GeForce when the
 # host driver is older than the toolkit (CUDA Error 804) — always use the host
@@ -70,34 +78,27 @@ if ls /usr/local/cuda*/compat/libcuda.so* >/dev/null 2>&1; then
     $SUDO ldconfig
 fi
 
-if [ -n "$TUNNEL_NAME" ]; then
-    if [ ! -f "$HOME/.cloudflared/cert.pem" ]; then
-        echo "TUNNEL_NAME set but $HOME/.cloudflared/cert.pem missing (pollinations.ai account cert)" >&2
-        exit 1
-    fi
-    if ! command -v cloudflared >/dev/null; then
-        log "Installing cloudflared..."
-        curl -sL --retry 5 -o /tmp/cloudflared.deb \
-            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
-        $SUDO dpkg -i /tmp/cloudflared.deb >/dev/null
-    fi
-    log "Creating tunnel $TUNNEL_NAME → $TUNNEL_NAME.pollinations.ai..."
-    cloudflared tunnel create "$TUNNEL_NAME" 2>&1 | tail -1 || true
-    cloudflared tunnel route dns --overwrite-dns "$TUNNEL_NAME" "$TUNNEL_NAME.pollinations.ai" 2>&1 | tail -1
-    TID=$(cloudflared tunnel list -o json | python3 -c "import json,sys; print([t['id'] for t in json.load(sys.stdin) if t['name']=='$TUNNEL_NAME'][0])")
-    cat > "$HOME/.cloudflared/config.yml" <<CFG
-tunnel: $TID
-credentials-file: $HOME/.cloudflared/$TID.json
-ingress:
-  - hostname: $TUNNEL_NAME.pollinations.ai
-    service: http://localhost:$PORT
-  - service: http_status:404
-CFG
-    screen -S cloudflared -X quit 2>/dev/null || true
-    screen -dmS cloudflared bash -c "while true; do cloudflared tunnel run $TUNNEL_NAME 2>&1 | tee -a /tmp/cloudflared.log; sleep 5; done"
-    PUBLIC_IP="$TUNNEL_NAME.pollinations.ai"
-    PUBLIC_PORT=443
+if ! command -v cloudflared >/dev/null || \
+    ! cloudflared tunnel run --help 2>&1 | grep -q -- '--token-file'; then
+    log "Installing cloudflared..."
+    curl -fsSL --retry 5 -o /tmp/cloudflared.deb \
+        https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+    $SUDO dpkg -i /tmp/cloudflared.deb >/dev/null
 fi
+
+# token-file keeps the remotely-managed tunnel token out of process listings.
+# It requires cloudflared 2025.4.0 or newer; fresh hosts install latest above.
+TUNNEL_TOKEN_FILE="$HOME/.cloudflared/tunnel-token"
+install -d -m 700 "$HOME/.cloudflared"
+printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
+chmod 600 "$TUNNEL_TOKEN_FILE"
+unset CLOUDFLARED_TUNNEL_TOKEN
+
+log "Starting Cloudflare Tunnel for $PUBLIC_HOSTNAME..."
+screen -S cloudflared -X quit 2>/dev/null || true
+screen -dmS cloudflared bash -c "while true; do cloudflared tunnel run --token-file '$TUNNEL_TOKEN_FILE' 2>&1 | tee -a /tmp/cloudflared.log; sleep 5; done"
+PUBLIC_IP="$PUBLIC_HOSTNAME"
+PUBLIC_PORT=443
 
 # Some Vast hosts have unreliable egress to GitHub; SKIP_CLONE=1 uses files
 # already placed in $WORK_DIR (e.g. scp'd from the operator's machine).
@@ -141,18 +142,19 @@ python -c "from nunchaku import NunchakuFluxTransformer2dModel; print('nunchaku 
 python -c "import torch; assert torch.cuda.is_available(); print('CUDA OK:', torch.cuda.get_device_name(0))"
 
 log "Writing run environment to $NUNCHAKU_DIR/.env.flux..."
-cat > "$NUNCHAKU_DIR/.env.flux" <<EOF
-${HF_TOKEN:+export HF_TOKEN=$HF_TOKEN}
-export PLN_GPU_TOKEN=$PLN_GPU_TOKEN
-export PORT=$PORT
-export PUBLIC_PORT=$PUBLIC_PORT
-export SERVICE_TYPE=$SERVICE_TYPE
-export QUANT_MODEL_PATH=$QUANT_MODEL_PATH
-export MAX_PIXELS=$MAX_PIXELS
-export QUEUE_LIMIT=${QUEUE_LIMIT:-10}
-export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
-${PUBLIC_IP:+export PUBLIC_IP=$PUBLIC_IP}
-EOF
+{
+    printf 'export HF_TOKEN=%q\n' "$HF_TOKEN"
+    printf 'export PLN_GPU_TOKEN=%q\n' "$PLN_GPU_TOKEN"
+    printf 'export PORT=%q\n' "$PORT"
+    printf 'export PUBLIC_PORT=%q\n' "$PUBLIC_PORT"
+    printf 'export PUBLIC_IP=%q\n' "$PUBLIC_IP"
+    printf 'export SERVICE_TYPE=%q\n' "$SERVICE_TYPE"
+    printf 'export QUANT_MODEL_PATH=%q\n' "$QUANT_MODEL_PATH"
+    printf 'export MAX_PIXELS=%q\n' "$MAX_PIXELS"
+    printf 'export QUEUE_LIMIT=%q\n' "${QUEUE_LIMIT:-10}"
+    printf 'export CUDA_VISIBLE_DEVICES=%q\n' "${CUDA_VISIBLE_DEVICES:-0}"
+    printf 'export HF_XET_HIGH_PERFORMANCE=1\n'
+} > "$NUNCHAKU_DIR/.env.flux"
 chmod 600 "$NUNCHAKU_DIR/.env.flux"
 
 log "Starting server in screen session 'flux' (restart loop, log: /tmp/flux.log)..."
@@ -166,3 +168,4 @@ log "  Logs:       tail -f /tmp/flux.log"
 log "  Attach:     screen -r flux   (detach: Ctrl+A, D)"
 log "  Local test: curl -s localhost:$PORT/docs >/dev/null && echo up"
 log "  Registered: curl -s https://gen.pollinations.ai/register | grep -o '$SERVICE_TYPE[^,]*'"
+log "  Canary:     POLLINATIONS_API_KEY=... bash verify-vast.sh"

--- a/image.pollinations.ai/nunchaku/verify-vast.sh
+++ b/image.pollinations.ai/nunchaku/verify-vast.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Run on the Vast host after setup-vast.sh. This makes the same deterministic
+# request directly and through gen.pollinations.ai, then compares decoded image
+# pixels. A registry heartbeat or public /docs check alone does not prove that a
+# Cloudflare Worker can reach the tunnel; the public request may silently use a
+# fallback provider.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env.flux}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Missing $ENV_FILE; run setup-vast.sh first" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+: "${POLLINATIONS_API_KEY:?Set POLLINATIONS_API_KEY to a valid API key}"
+: "${PLN_GPU_TOKEN:?PLN_GPU_TOKEN missing from $ENV_FILE}"
+: "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
+
+CANARY_DIR=$(mktemp -d)
+trap 'rm -rf "$CANARY_DIR"' EXIT
+
+PROMPT="vast-canary-$(date +%s)"
+SEED="${SEED:-424242}"
+WIDTH="${WIDTH:-512}"
+HEIGHT="${HEIGHT:-512}"
+PUBLIC_URL="https://gen.pollinations.ai/image/$PROMPT?model=flux&width=$WIDTH&height=$HEIGHT&seed=$SEED&nologo=true"
+
+echo "Checking local server and registered hostname..."
+curl -fsS --max-time 10 "http://localhost:${PORT:-8765}/docs" >/dev/null
+curl -fsS --max-time 10 https://gen.pollinations.ai/register \
+    -H "Authorization: Bearer $PLN_GPU_TOKEN" | grep -Fq "https://$PUBLIC_IP"
+
+echo "Generating the direct Vast reference..."
+curl -fsS --max-time 180 "https://$PUBLIC_IP/generate" \
+    -H "Content-Type: application/json" \
+    -H "x-backend-token: $PLN_GPU_TOKEN" \
+    --data "{\"prompts\":[\"$PROMPT\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
+    > "$CANARY_DIR/direct.json"
+
+python - "$CANARY_DIR/direct.json" "$CANARY_DIR/direct.jpg" <<'PY'
+import base64
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    response = json.load(source)
+with open(sys.argv[2], "wb") as image:
+    image.write(base64.b64decode(response[0]["image"]))
+PY
+
+echo "Generating through the public Flux route..."
+curl -fsS --max-time 180 "$PUBLIC_URL" \
+    -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+    > "$CANARY_DIR/public.jpg"
+
+python - "$CANARY_DIR/direct.jpg" "$CANARY_DIR/public.jpg" <<'PY'
+import sys
+from PIL import Image, ImageChops, ImageStat
+
+with Image.open(sys.argv[1]) as direct_image, Image.open(sys.argv[2]) as public_image:
+    direct = direct_image.convert("RGB")
+    public = public_image.convert("RGB")
+    if direct.size != public.size:
+        raise SystemExit(f"FAIL: dimensions differ: Vast={direct.size}, public={public.size}")
+    rms = sum(ImageStat.Stat(ImageChops.difference(direct, public)).rms) / 3
+    if rms > 12:
+        raise SystemExit(
+            f"FAIL: public image differs from Vast reference (RMS={rms:.2f}); fallback may be active"
+        )
+    print(f"PASS: public Flux matched Vast reference (RMS={rms:.2f})")
+PY


### PR DESCRIPTION
- Runs a pre-created, remotely managed Cloudflare Tunnel from a scoped token file instead of copying an account certificate onto Vast hosts.
- Persists shell-escaped Flux settings, enables high-performance Hugging Face downloads, and ignores the secret-bearing `.env.flux` file.
- Adds a deterministic production-path canary that compares direct Vast output with `gen.pollinations.ai` output so Fireworks cannot mask a broken route.
- Updates the Flux runbook with the active RTX 5090, current listed rate, and canary-before-cutover procedure.

Checks: `bash -n` on both scripts, validation failure-path tests, secret-pattern scan, `git diff --check`.