### PR TITLE
fix: catgpt bot — durable selfie URL, nanobanana-2-lite, catch-up + CLI ask

### DIFF
--- a/apps/catgpt-bot/bot.ts
+++ b/apps/catgpt-bot/bot.ts
@@ -19,8 +19,10 @@ const AUTH = API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {};
 
 const ORIGINAL_CATGPT =
     "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/original-catgpt.png";
-const SELFIE_CATGPT = "https://media.pollinations.ai/657d58ee4c9c22d7";
-const MODEL = "nanobanana";
+// must be a durable URL — media.pollinations.ai uploads expire after 30 days (broke twice: #10826 + Jul 2026)
+const SELFIE_CATGPT =
+    "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/main/apps/catgpt/images/selfie-catgpt.png";
+const MODEL = "nanobanana-2-lite";
 
 function log(...args: any[]) {
     console.log(`[${new Date().toISOString()}]`, ...args);
@@ -160,6 +162,58 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
     }
 }
 
+async function catchUpUnanswered(client: Client): Promise<void> {
+    const channel = await client.channels.fetch(CHANNEL_ID);
+    if (!channel || !("messages" in channel)) return;
+    const messages = await channel.messages.fetch({ limit: 50 });
+    const botId = client.user!.id;
+    const answered = new Set<string>();
+    for (const m of messages.values()) {
+        // only a comic attachment counts as answered — the 😾 error fallback doesn't
+        if (
+            m.author.id === botId &&
+            m.reference?.messageId &&
+            m.attachments.size > 0
+        )
+            answered.add(m.reference.messageId);
+    }
+    const pending = [...messages.values()]
+        .filter(
+            (m) =>
+                !m.author.bot &&
+                !answered.has(m.id) &&
+                m.content.trim() &&
+                !m.content.trim().startsWith("!") &&
+                !m.content.includes("couldn't be bothered"),
+        )
+        .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
+        .slice(-5);
+    log(`Catch-up: ${pending.length} unanswered message(s)`);
+    for (const m of pending) {
+        await handleMessage(m, client).catch((err) =>
+            logError(`Catch-up failed for ${m.id}:`, err.message),
+        );
+    }
+}
+
+// CLI one-shot: tsx bot.ts ask "question" [avatarUrl] — posts a comic to the channel and exits
+async function cliAsk(
+    client: Client,
+    question: string,
+    avatarUrl: string | null,
+): Promise<void> {
+    const catReply = await generateCatReply(question, avatarUrl);
+    const prompt = createPrompt(question, catReply, Boolean(avatarUrl));
+    const imageBuffer = await fetchImage(buildImageUrl(prompt, avatarUrl));
+    const channel = await client.channels.fetch(CHANNEL_ID);
+    if (!channel || !("send" in channel))
+        throw new Error("channel not sendable");
+    await channel.send({
+        files: [new AttachmentBuilder(imageBuffer, { name: "catgpt.png" })],
+    });
+    log(`CLI comic posted for "${question}" → "${catReply}"`);
+}
+
 if (!TOKEN || !CHANNEL_ID) {
     console.error("Missing BOT_TOKEN_CATGPT or CATGPT_CHANNEL_ID");
     process.exit(1);
@@ -193,12 +247,29 @@ process.on("SIGINT", () => {
 
 client.on("error", (err) => logError("Discord error:", err.message));
 client.once(Events.ClientReady, (c) => {
+    log(
+        `CatGPT bot online as ${c.user.tag} — channel ${CHANNEL_ID} (PID ${process.pid})`,
+    );
+    if (process.argv[2] === "ask") {
+        const question = process.argv[3];
+        if (!question) {
+            console.error('Usage: bot.ts ask "question" [avatarUrl]');
+            process.exit(1);
+        }
+        cliAsk(client, question, process.argv[4] || null)
+            .then(() => process.exit(0))
+            .catch((err) => {
+                logError("CLI ask failed:", err.message);
+                process.exit(1);
+            });
+        return;
+    }
     c.user.setPresence({
         status: "online",
         activities: [{ name: "Ask me anything 😾" }],
     });
-    log(
-        `CatGPT bot online as ${c.user.tag} — channel ${CHANNEL_ID} (PID ${process.pid})`,
+    catchUpUnanswered(client).catch((err) =>
+        logError("Catch-up error:", err.message),
     );
 });
 client.on(Events.MessageCreate, (msg) => {


### PR DESCRIPTION
- Fixes catgpt image 400s: selfie reference URL on media.pollinations.ai expired (R2 30-day lifecycle, second occurrence after #10826) — now uses durable GitHub raw URL
- Switches comic model to nanobanana-2-lite
- On startup, answers up to 5 recent unanswered messages in the channel (😾 error-fallback replies don't count as answered)
- Adds one-shot CLI trigger: `tsx bot.ts ask "question" [avatarUrl]`

Already deployed live on enter-services EC2 and verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)