### PR TITLE
ci: isolate gen production deployment token

### DIFF
--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run database migrations
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GEN }}
         run: npm run migrate:production --workspace pollinations-enter
 
       - name: Setup SOPS
@@ -56,16 +56,16 @@ jobs:
       # the few seconds between deploy and push, which self-heals.
       - name: Deploy to Cloudflare
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GEN }}
         run: npm run deploy:production --workspace pollinations-gen
 
       - name: Push generation secrets
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GEN }}
         run: npm run push-secrets:production --workspace pollinations-gen
 
       - name: Apply R2 lifecycle rules
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GEN }}
         run: npm run apply-lifecycle:production --workspace pollinations-gen

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,15 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - No backward-compat fallbacks — clean breaks beat bloat. When changing tokens/headers/APIs, update all consumers at once.
 - When user says "keep it simple" — one function, one price, one config. Simplest thing that works.
 
+## Cloudflare Production Deployment Safety
+
+**CRITICAL — production Cloudflare deployments must always run through GitHub Actions:**
+
+- Use the service's production deployment workflow, such as `Deploy / gen.pollinations.ai`; use `workflow_dispatch` when path filters do not trigger it.
+- Never run `wrangler deploy --env production`, a production deployment npm script, or a direct production Worker upload from a local machine or agent session.
+- If CI credentials lack a required permission, update the scoped GitHub Actions secret and rerun the workflow. Never bypass CI with a local Cloudflare OAuth session.
+- After the workflow succeeds, verify the active Worker version and required bindings before testing production traffic.
+
 ## Tinybird Deployment Safety
 
 **CRITICAL — These rules apply whenever deploying to Tinybird:**


### PR DESCRIPTION
- Routes the gen production deployment through a dedicated `CLOUDFLARE_API_TOKEN_GEN` GitHub Actions secret.
- Leaves the shared Cloudflare token and all unrelated deployment workflows unchanged.
- Requires production Cloudflare deployments to run through GitHub Actions, never local Wrangler or OAuth.
- Documents manual workflow dispatch and post-deployment version/binding verification.

Root cause: the shared CI token lacked Workers VPC permission, and replacing it with a narrowly scoped gen token could break unrelated workflows.

Validation:
- GitHub secret presence verified without reading its value.
- `actionlint .github/workflows/deploy-gen-cloudflare.yml`
- `git diff --check`
