### PR TITLE
docs: finalize Klein Vast cutover

### DIFF
--- a/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
+++ b/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
@@ -29,7 +29,7 @@ const getKleinGenerateUrl = (): string => {
 const MAX_INPUT_IMAGES = 10;
 
 /**
- * Calls the Flux Klein API for image generation via RunPod pod (4B)
+ * Calls the self-hosted Flux Klein 4B API. Production uses the Vast VPC binding.
  */
 export const callFluxKleinAPI = async (
     prompt: string,

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -8,7 +8,7 @@ Last updated: 2026-07-14
 |-------|---------|------|----------|---------|--------|
 | Flux (FP4) | 1 | RTX 5090 | Vast.ai | $0.3744/hr | **ACTIVE — production** (Fireworks fallback) |
 | Z-Image | 3 | 4090 + 2x 3090 | RunPod | (see runpodctl) | **ACTIVE — production** |
-| Klein 4B | 1 active + 1 rollback | RTX 3090 + A5000 | Vast.ai + RunPod | $0.1656 active + $0.27 rollback | **ACTIVE — production on Vast** |
+| Klein 4B | 1 active + 1 rollback | RTX 3090 + A5000 | Vast.ai + RunPod | $0.1656 + $0.27 while rollback runs | **ACTIVE — Vast production; RunPod stop-ready** |
 | LTX-2 + ACE-Step + Sana | 1 | GH200 | Lambda Labs | — | **ACTIVE** |
 
 ## Provider: Vast.ai — Flux (RTX 5090, FP4)
@@ -113,6 +113,9 @@ curl -s http://127.0.0.1:8000/health
 - Three concurrent 512x512 requests all returned valid images.
 - Real 850x1100 production requests completed in 2.37–2.39s.
 - Cloudflare showed 4 healthy connections and 0 origin proxy errors.
+- Final soak verification observed `provider=vast`, `model_used=klein`,
+  successful production traffic, and zero 5xx; the Vast backend had accepted
+  521 requests with no recent 5xx.
 
 The successful canary sequence is: local health, authenticated generation,
 single-reference edit, multi-reference edit, 1024x1024 render, concurrent
@@ -150,6 +153,11 @@ curl -s https://jmrbmje2fyuy46-8000.proxy.runpod.net/health
 Keeping this pod running costs $0.27/hr in addition to Vast. Once the Vast
 deployment has met the desired soak period, stop the pod to remove that cost;
 retain its `KLEIN_URL` value for a manual restart-and-redeploy rollback.
+
+**Shutdown checklist:** stop the pod; do not terminate it. Then confirm Klein
+still reports `provider=vast`, a successful request reaches instance `44766948`,
+and the production status window remains free of 5xx. To roll back, restart the
+pod, verify its health endpoint, remove `KLEIN_VPC`, and deploy gen through CI.
 
 ### Z-Image pods
 


### PR DESCRIPTION
- Corrects the stale RunPod-specific Klein handler comment.
- Records the final Vast production soak verification and zero-5xx result.
- Marks the warm RunPod rollback as safe to stop and documents post-stop checks.
- Keeps `KLEIN_URL`, the existing image assets, and the resumable rollback path intact.

Validation:
- `npx biome check --write gen.pollinations.ai/src/image/models/fluxKleinModel.ts`
- `npm run typecheck --workspace pollinations-gen`
- Production status reported `provider=vast`, `model_used=klein`, successful traffic, and zero 5xx.
- Vast instance `44766948` was healthy with 521 backend requests and no recent 5xx.
