### PR TITLE
fix: Model Monitor scrolls as one page (no nested scrollbars)

### DIFF
--- a/apps/model-monitor/index.html
+++ b/apps/model-monitor/index.html
@@ -62,7 +62,7 @@
 
     <title>Model Monitor | pollinations.ai</title>
   </head>
-  <body class="polli-ui-shell">
+  <body class="m-0 bg-app-bg p-0">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/apps/model-monitor/index.html
+++ b/apps/model-monitor/index.html
@@ -62,7 +62,7 @@
 
     <title>Model Monitor | pollinations.ai</title>
   </head>
-  <body class="m-0 bg-app-bg p-0">
+  <body class="bg-app-bg">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -564,7 +564,7 @@ function App() {
                     onChange={setTypeFilter}
                 />
 
-                <Surface variant="card" className="overflow-x-auto p-0">
+                <Surface variant="card" className="w-fit min-w-full p-0">
                     <Table>
                         <TableHead>
                             <tr>

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -564,7 +564,7 @@ function App() {
                     onChange={setTypeFilter}
                 />
 
-                <Surface variant="card" className="overflow-hidden p-0">
+                <Surface variant="card" className="overflow-x-auto p-0">
                     <Table>
                         <TableHead>
                             <tr>
@@ -699,7 +699,7 @@ function App() {
                                                     {model.type}
                                                 </ModalityChip>
                                             </TableCell>
-                                            <TableCell className="w-full max-w-0">
+                                            <TableCell className="w-full min-w-[12rem] max-w-0">
                                                 <div className="flex min-w-0 items-center gap-2">
                                                     <span className="truncate font-medium text-theme-text-strong">
                                                         {model.name}

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -18,7 +18,6 @@ import {
     TableHead,
     TableHeaderCell,
     TableRow,
-    Tooltip,
 } from "@pollinations/ui";
 import { ModalityChip } from "@pollinations/ui/gen";
 import { useState } from "react";
@@ -497,11 +496,11 @@ function App() {
         : sortedModels;
 
     return (
-        <div className="min-h-dvh bg-app-bg text-theme-text-base">
+        <div className="min-h-dvh min-w-fit bg-app-bg text-theme-text-base">
             <AppHeader
                 navLabel="Model Monitor links"
                 autoHide
-                innerClassName="polli:max-w-6xl"
+                innerClassName="polli:max-w-6xl polli:flex-row polli:items-center polli:justify-between"
             >
                 {EXTERNAL_LINKS.map((link) => (
                     <HeaderLink key={link.href} {...link} />
@@ -510,10 +509,10 @@ function App() {
             </AppHeader>
             <main
                 className={cn(
-                    "mx-auto flex min-h-full w-full min-w-0 max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
+                    "mx-auto flex min-h-full w-full min-w-fit max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
                 )}
             >
-                <section className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <section className="flex flex-row items-end justify-between gap-3">
                     <div className="flex min-w-0 flex-col gap-1">
                         <Heading
                             as="h1"
@@ -637,15 +636,7 @@ function App() {
                                     align="right"
                                 />
                                 <SortableTh
-                                    label={
-                                        <Tooltip
-                                            triggerAs="span"
-                                            stopClickPropagation={false}
-                                            content="Completion tokens per second of full request duration. Cache hits are excluded."
-                                        >
-                                            tok/s
-                                        </Tooltip>
-                                    }
+                                    label="tok/s"
                                     sortKey="tps"
                                     currentSort={sort}
                                     onSort={handleSort}

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -22,7 +22,7 @@ import {
     Tooltip,
 } from "@pollinations/ui";
 import { ModalityChip } from "@pollinations/ui/gen";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useModelMonitor } from "./hooks/useModelMonitor";
 
 const WINDOW_OPTIONS = [
@@ -369,7 +369,6 @@ function App() {
 
     const [sort, setSort] = useState({ key: "requests", asc: false });
     const [typeFilter, setTypeFilter] = useState(null);
-    const scrollAreaRef = useRef(null);
     const catalogUnavailable = endpointStatus.catalog === false;
 
     const handleSort = (key) => {
@@ -499,366 +498,350 @@ function App() {
         : sortedModels;
 
     return (
-        <div className="h-dvh bg-app-bg text-theme-text-base">
-            <ScrollArea ref={scrollAreaRef} axis="y" className="h-full">
-                <AppHeader
-                    navLabel="Model Monitor links"
-                    autoHide
-                    scrollTargetRef={scrollAreaRef}
-                    innerClassName={adminMode ? "polli:max-w-6xl" : undefined}
-                >
-                    {EXTERNAL_LINKS.map((link) => (
-                        <HeaderLink key={link.href} {...link} />
-                    ))}
-                    <ColorModeToggle />
-                </AppHeader>
-                <main
-                    className={cn(
-                        "mx-auto flex min-h-full w-full min-w-0 flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
-                        adminMode ? "max-w-6xl" : "max-w-5xl",
-                    )}
-                >
-                    <section className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                        <div className="flex min-w-0 flex-col gap-1">
-                            <Heading
-                                as="h1"
-                                size="title"
-                                className="polli-model-monitor-title polli:m-0 polli:text-theme-text-strong"
-                            >
-                                Model Monitor
-                            </Heading>
-                            <p className="m-0 max-w-3xl text-base leading-relaxed text-theme-text-base">
-                                Real-time health monitoring for Pollinations AI
-                                models.
-                            </p>
-                        </div>
-                        <div className="flex flex-col items-start gap-2 sm:items-end">
-                            <WindowTabs
-                                value={aggregationWindow}
-                                onChange={setAggregationWindow}
-                            />
-                            <p className="m-0 text-xs leading-normal text-theme-text-soft">
-                                Data as of:{" "}
-                                {lastUpdated?.toLocaleTimeString("en-GB", {
-                                    timeZone: "UTC",
-                                    hour: "2-digit",
-                                    minute: "2-digit",
-                                    second: "2-digit",
-                                }) || "-"}{" "}
-                                UTC
-                            </p>
-                        </div>
-                    </section>
-
-                    {error && (
-                        <Alert intent="danger" title="Monitor error">
-                            {error}
-                        </Alert>
-                    )}
-
-                    {catalogUnavailable && (
-                        <Alert
-                            intent="warning"
-                            title="Model catalog unavailable"
+        <div className="min-h-dvh bg-app-bg text-theme-text-base">
+            <AppHeader
+                navLabel="Model Monitor links"
+                autoHide
+                innerClassName={adminMode ? "polli:max-w-6xl" : undefined}
+            >
+                {EXTERNAL_LINKS.map((link) => (
+                    <HeaderLink key={link.href} {...link} />
+                ))}
+                <ColorModeToggle />
+            </AppHeader>
+            <main
+                className={cn(
+                    "mx-auto flex min-h-full w-full min-w-0 flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
+                    adminMode ? "max-w-6xl" : "max-w-5xl",
+                )}
+            >
+                <section className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div className="flex min-w-0 flex-col gap-1">
+                        <Heading
+                            as="h1"
+                            size="title"
+                            className="polli-model-monitor-title polli:m-0 polli:text-theme-text-strong"
                         >
-                            Showing observed Tinybird traffic only until the
-                            live model catalog responds.
-                        </Alert>
-                    )}
+                            Model Monitor
+                        </Heading>
+                        <p className="m-0 max-w-3xl text-base leading-relaxed text-theme-text-base">
+                            Real-time health monitoring for Pollinations AI
+                            models.
+                        </p>
+                    </div>
+                    <div className="flex flex-col items-start gap-2 sm:items-end">
+                        <WindowTabs
+                            value={aggregationWindow}
+                            onChange={setAggregationWindow}
+                        />
+                        <p className="m-0 text-xs leading-normal text-theme-text-soft">
+                            Data as of:{" "}
+                            {lastUpdated?.toLocaleTimeString("en-GB", {
+                                timeZone: "UTC",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                                second: "2-digit",
+                            }) || "-"}{" "}
+                            UTC
+                        </p>
+                    </div>
+                </section>
 
-                    <CategoryTabs
-                        models={models}
-                        value={typeFilter}
-                        onChange={setTypeFilter}
-                    />
+                {error && (
+                    <Alert intent="danger" title="Monitor error">
+                        {error}
+                    </Alert>
+                )}
 
-                    <Surface variant="card" className="overflow-hidden p-0">
-                        <ScrollArea axis="x">
-                            <Table className="min-w-[960px]">
-                                <TableHead>
-                                    <tr>
+                {catalogUnavailable && (
+                    <Alert intent="warning" title="Model catalog unavailable">
+                        Showing observed Tinybird traffic only until the live
+                        model catalog responds.
+                    </Alert>
+                )}
+
+                <CategoryTabs
+                    models={models}
+                    value={typeFilter}
+                    onChange={setTypeFilter}
+                />
+
+                <Surface variant="card" className="overflow-hidden p-0">
+                    <ScrollArea axis="x">
+                        <Table className="min-w-[960px]">
+                            <TableHead>
+                                <tr>
+                                    <SortableTh
+                                        label="Type"
+                                        sortKey="type"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                    />
+                                    <SortableTh
+                                        label="Model"
+                                        sortKey="name"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                    />
+                                    <SortableTh
+                                        label="Status"
+                                        sortKey="status"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                    />
+                                    {adminMode && (
                                         <SortableTh
-                                            label="Type"
-                                            sortKey="type"
+                                            label="Provider"
+                                            sortKey="provider"
                                             currentSort={sort}
                                             onSort={handleSort}
                                         />
-                                        <SortableTh
-                                            label="Model"
-                                            sortKey="name"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                        />
-                                        <SortableTh
-                                            label="Status"
-                                            sortKey="status"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                        />
-                                        {adminMode && (
-                                            <SortableTh
-                                                label="Provider"
-                                                sortKey="provider"
-                                                currentSort={sort}
-                                                onSort={handleSort}
-                                            />
-                                        )}
-                                        <SortableTh
-                                            label="Reqs (+4xx)"
-                                            sortKey="requests"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label="Success"
-                                            sortKey="ok2xx"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label="5xx"
-                                            sortKey="errors"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label="4xx"
-                                            sortKey="user4xx"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label="Avg"
-                                            sortKey="avg"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label="P95"
-                                            sortKey="p95"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                        <SortableTh
-                                            label={
-                                                <Tooltip
-                                                    triggerAs="span"
-                                                    stopClickPropagation={false}
-                                                    content="Completion tokens per second of full request duration. Cache hits are excluded."
-                                                >
-                                                    Speed
-                                                </Tooltip>
-                                            }
-                                            sortKey="tps"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                            align="right"
-                                        />
-                                    </tr>
-                                </TableHead>
-                                <TableBody>
-                                    {filteredModels.length === 0 ? (
-                                        <TableRow>
-                                            <TableCell
-                                                colSpan={adminMode ? 11 : 10}
-                                                align="center"
-                                                className="py-8 text-theme-text-muted"
+                                    )}
+                                    <SortableTh
+                                        label="Reqs (+4xx)"
+                                        sortKey="requests"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                    <SortableTh
+                                        label="Success"
+                                        sortKey="ok2xx"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                    <SortableTh
+                                        label="5xx"
+                                        sortKey="errors"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                    <SortableTh
+                                        label="4xx"
+                                        sortKey="user4xx"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                    <SortableTh
+                                        label="Avg"
+                                        sortKey="avg"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                    <SortableTh
+                                        label="P95"
+                                        sortKey="p95"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                    <SortableTh
+                                        label={
+                                            <Tooltip
+                                                triggerAs="span"
+                                                stopClickPropagation={false}
+                                                content="Completion tokens per second of full request duration. Cache hits are excluded."
                                             >
-                                                {lastUpdated
-                                                    ? "No models found"
-                                                    : "Loading models..."}
-                                            </TableCell>
-                                        </TableRow>
-                                    ) : (
-                                        filteredModels.map((model) => {
-                                            const stats = model.stats;
-                                            const total =
-                                                stats?.total_requests || 0;
-                                            const total5xx =
-                                                stats?.errors_5xx || 0;
-                                            const total4xx =
-                                                stats?.errors_4xx || 0;
-                                            const nonUserErrorTotal =
-                                                total - total4xx;
-                                            const pct4xx =
-                                                total > 0
-                                                    ? (total4xx / total) * 100
-                                                    : 0;
-                                            const avgSec = stats?.avg_latency_ms
-                                                ? stats.avg_latency_ms / 1000
-                                                : null;
-                                            const p95Sec = stats?.latency_p95_ms
-                                                ? stats.latency_p95_ms / 1000
-                                                : null;
-                                            const health =
-                                                computeHealthStatus(stats);
+                                                Speed
+                                            </Tooltip>
+                                        }
+                                        sortKey="tps"
+                                        currentSort={sort}
+                                        onSort={handleSort}
+                                        align="right"
+                                    />
+                                </tr>
+                            </TableHead>
+                            <TableBody>
+                                {filteredModels.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell
+                                            colSpan={adminMode ? 11 : 10}
+                                            align="center"
+                                            className="py-8 text-theme-text-muted"
+                                        >
+                                            {lastUpdated
+                                                ? "No models found"
+                                                : "Loading models..."}
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    filteredModels.map((model) => {
+                                        const stats = model.stats;
+                                        const total =
+                                            stats?.total_requests || 0;
+                                        const total5xx = stats?.errors_5xx || 0;
+                                        const total4xx = stats?.errors_4xx || 0;
+                                        const nonUserErrorTotal =
+                                            total - total4xx;
+                                        const pct4xx =
+                                            total > 0
+                                                ? (total4xx / total) * 100
+                                                : 0;
+                                        const avgSec = stats?.avg_latency_ms
+                                            ? stats.avg_latency_ms / 1000
+                                            : null;
+                                        const p95Sec = stats?.latency_p95_ms
+                                            ? stats.latency_p95_ms / 1000
+                                            : null;
+                                        const health =
+                                            computeHealthStatus(stats);
 
-                                            return (
-                                                <TableRow
-                                                    key={`${model.type}-${model.name}`}
-                                                    intent={rowIntent(health)}
-                                                >
-                                                    <TableCell>
-                                                        <ModalityChip
-                                                            modality={
-                                                                model.type
-                                                            }
-                                                            size="sm"
-                                                            className="text-micro font-bold uppercase tracking-wide"
-                                                        >
-                                                            {model.type}
-                                                        </ModalityChip>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <div className="flex items-center gap-2">
-                                                            <span className="font-medium text-theme-text-strong">
-                                                                {model.name}
+                                        return (
+                                            <TableRow
+                                                key={`${model.type}-${model.name}`}
+                                                intent={rowIntent(health)}
+                                            >
+                                                <TableCell>
+                                                    <ModalityChip
+                                                        modality={model.type}
+                                                        size="sm"
+                                                        className="text-micro font-bold uppercase tracking-wide"
+                                                    >
+                                                        {model.type}
+                                                    </ModalityChip>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="font-medium text-theme-text-strong">
+                                                            {model.name}
+                                                        </span>
+                                                        {model.title && (
+                                                            <span className="max-w-[24rem] truncate text-xs text-theme-text-muted">
+                                                                {model.title}
                                                             </span>
-                                                            {model.title && (
-                                                                <span className="max-w-[24rem] truncate text-xs text-theme-text-muted">
-                                                                    {
-                                                                        model.title
-                                                                    }
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="flex flex-wrap items-center gap-1">
+                                                        <StatusBadge
+                                                            stats={stats}
+                                                        />
+                                                        <CatalogStatusBadge
+                                                            status={
+                                                                model.catalogStatus
+                                                            }
+                                                        />
+                                                    </div>
+                                                </TableCell>
+                                                {adminMode && (
+                                                    <TableCell muted>
+                                                        {model.provider || "-"}
+                                                    </TableCell>
+                                                )}
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                    muted
+                                                >
+                                                    {total > 0 ? (
+                                                        <>
+                                                            {nonUserErrorTotal.toLocaleString()}
+                                                            {total4xx > 0 && (
+                                                                <span className="ml-1 text-xs text-theme-text-muted">
+                                                                    (
+                                                                    {total.toLocaleString()}
+                                                                    )
                                                                 </span>
                                                             )}
-                                                        </div>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <div className="flex flex-wrap items-center gap-1">
-                                                            <StatusBadge
-                                                                stats={stats}
-                                                            />
-                                                            <CatalogStatusBadge
-                                                                status={
-                                                                    model.catalogStatus
-                                                                }
-                                                            />
-                                                        </div>
-                                                    </TableCell>
-                                                    {adminMode && (
-                                                        <TableCell muted>
-                                                            {model.provider ||
-                                                                "-"}
-                                                        </TableCell>
+                                                        </>
+                                                    ) : (
+                                                        "-"
                                                     )}
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                        muted
-                                                    >
-                                                        {total > 0 ? (
-                                                            <>
-                                                                {nonUserErrorTotal.toLocaleString()}
-                                                                {total4xx >
-                                                                    0 && (
-                                                                    <span className="ml-1 text-xs text-theme-text-muted">
-                                                                        (
-                                                                        {total.toLocaleString()}
-                                                                        )
-                                                                    </span>
-                                                                )}
-                                                            </>
-                                                        ) : (
-                                                            "-"
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                        className={get2xxColor(
-                                                            stats?.status_2xx ||
-                                                                0,
-                                                            nonUserErrorTotal,
-                                                        )}
-                                                    >
-                                                        {formatPercent(
-                                                            stats?.status_2xx ||
-                                                                0,
-                                                            nonUserErrorTotal,
-                                                            true,
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                    >
-                                                        {total5xx > 0 ? (
-                                                            <span className="font-semibold text-intent-danger-text">
-                                                                {total5xx}
-                                                            </span>
-                                                        ) : (
-                                                            <span className="text-theme-text-muted">
-                                                                -
-                                                            </span>
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                        muted
-                                                    >
-                                                        {pct4xx > 0
-                                                            ? pct4xx < 1
-                                                                ? `${pct4xx.toFixed(1)}%`
-                                                                : `${Math.round(pct4xx)}%`
-                                                            : "-"}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                        className={
-                                                            avgSec
-                                                                ? getLatencyColor(
-                                                                      avgSec,
-                                                                  )
-                                                                : "text-theme-text-muted"
-                                                        }
-                                                    >
-                                                        {avgSec
-                                                            ? `${avgSec.toFixed(1)}s`
-                                                            : "-"}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                        className={
-                                                            p95Sec
-                                                                ? getLatencyColor(
-                                                                      p95Sec,
-                                                                  )
-                                                                : "text-theme-text-muted"
-                                                        }
-                                                    >
-                                                        {p95Sec
-                                                            ? `${p95Sec.toFixed(1)}s`
-                                                            : "-"}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        numeric
-                                                        muted
-                                                    >
-                                                        {stats?.tokens_per_second !=
-                                                        null
-                                                            ? `${stats.tokens_per_second.toFixed(1)} tok/s`
-                                                            : "-"}
-                                                    </TableCell>
-                                                </TableRow>
-                                            );
-                                        })
-                                    )}
-                                </TableBody>
-                            </Table>
-                        </ScrollArea>
-                    </Surface>
-                </main>
-            </ScrollArea>
+                                                </TableCell>
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                    className={get2xxColor(
+                                                        stats?.status_2xx || 0,
+                                                        nonUserErrorTotal,
+                                                    )}
+                                                >
+                                                    {formatPercent(
+                                                        stats?.status_2xx || 0,
+                                                        nonUserErrorTotal,
+                                                        true,
+                                                    )}
+                                                </TableCell>
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                >
+                                                    {total5xx > 0 ? (
+                                                        <span className="font-semibold text-intent-danger-text">
+                                                            {total5xx}
+                                                        </span>
+                                                    ) : (
+                                                        <span className="text-theme-text-muted">
+                                                            -
+                                                        </span>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                    muted
+                                                >
+                                                    {pct4xx > 0
+                                                        ? pct4xx < 1
+                                                            ? `${pct4xx.toFixed(1)}%`
+                                                            : `${Math.round(pct4xx)}%`
+                                                        : "-"}
+                                                </TableCell>
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                    className={
+                                                        avgSec
+                                                            ? getLatencyColor(
+                                                                  avgSec,
+                                                              )
+                                                            : "text-theme-text-muted"
+                                                    }
+                                                >
+                                                    {avgSec
+                                                        ? `${avgSec.toFixed(1)}s`
+                                                        : "-"}
+                                                </TableCell>
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                    className={
+                                                        p95Sec
+                                                            ? getLatencyColor(
+                                                                  p95Sec,
+                                                              )
+                                                            : "text-theme-text-muted"
+                                                    }
+                                                >
+                                                    {p95Sec
+                                                        ? `${p95Sec.toFixed(1)}s`
+                                                        : "-"}
+                                                </TableCell>
+                                                <TableCell
+                                                    align="right"
+                                                    numeric
+                                                    muted
+                                                >
+                                                    {stats?.tokens_per_second !=
+                                                    null
+                                                        ? `${stats.tokens_per_second.toFixed(1)} tok/s`
+                                                        : "-"}
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })
+                                )}
+                            </TableBody>
+                        </Table>
+                    </ScrollArea>
+                </Surface>
+            </main>
         </div>
     );
 }

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -5,7 +5,6 @@ import {
     Button,
     Chip,
     ColorModeToggle,
-    cn,
     DiscordIcon,
     ExternalLinkButton,
     GitHubIcon,
@@ -507,11 +506,7 @@ function App() {
                 ))}
                 <ColorModeToggle />
             </AppHeader>
-            <main
-                className={cn(
-                    "mx-auto flex min-h-full w-full min-w-fit max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
-                )}
-            >
+            <main className="mx-auto flex w-full min-w-fit max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7">
                 <section className="flex flex-row items-end justify-between gap-3">
                     <div className="flex min-w-0 flex-col gap-1">
                         <Heading
@@ -563,7 +558,7 @@ function App() {
                     onChange={setTypeFilter}
                 />
 
-                <Surface variant="card" className="w-fit min-w-full p-0">
+                <Surface variant="card" className="p-0">
                     <Table>
                         <TableHead>
                             <tr>
@@ -594,7 +589,11 @@ function App() {
                                     />
                                 )}
                                 <SortableTh
-                                    label="Reqs"
+                                    label={
+                                        <span title="Requests excluding client errors (4xx)">
+                                            Reqs
+                                        </span>
+                                    }
                                     sortKey="requests"
                                     currentSort={sort}
                                     onSort={handleSort}
@@ -636,7 +635,11 @@ function App() {
                                     align="right"
                                 />
                                 <SortableTh
-                                    label="tok/s"
+                                    label={
+                                        <span title="Completion tokens per second over the full request duration (not pure decode speed). Cache hits excluded.">
+                                            tok/s
+                                        </span>
+                                    }
                                     sortKey="tps"
                                     currentSort={sort}
                                     onSort={handleSort}
@@ -692,11 +695,16 @@ function App() {
                                             </TableCell>
                                             <TableCell className="w-full min-w-[12rem] max-w-0">
                                                 <div className="flex min-w-0 items-center gap-2">
-                                                    <span className="truncate font-medium text-theme-text-strong">
+                                                    {/* The name is the row's identity — never truncate it;
+                                                        the muted title is the flexible part. */}
+                                                    <span className="whitespace-nowrap font-medium text-theme-text-strong">
                                                         {model.name}
                                                     </span>
                                                     {model.title && (
-                                                        <span className="truncate text-xs text-theme-text-muted">
+                                                        <span
+                                                            className="min-w-0 truncate text-xs text-theme-text-muted"
+                                                            title={model.title}
+                                                        >
                                                             {model.title}
                                                         </span>
                                                     )}

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -595,7 +595,7 @@ function App() {
                                     />
                                 )}
                                 <SortableTh
-                                    label="Reqs (+4xx)"
+                                    label="Reqs"
                                     sortKey="requests"
                                     currentSort={sort}
                                     onSort={handleSort}
@@ -733,20 +733,9 @@ function App() {
                                                 numeric
                                                 muted
                                             >
-                                                {total > 0 ? (
-                                                    <>
-                                                        {nonUserErrorTotal.toLocaleString()}
-                                                        {total4xx > 0 && (
-                                                            <span className="ml-1 text-xs text-theme-text-muted">
-                                                                (
-                                                                {total.toLocaleString()}
-                                                                )
-                                                            </span>
-                                                        )}
-                                                    </>
-                                                ) : (
-                                                    "-"
-                                                )}
+                                                {total > 0
+                                                    ? nonUserErrorTotal.toLocaleString()
+                                                    : "-"}
                                             </TableCell>
                                             <TableCell
                                                 align="right"

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -643,7 +643,7 @@ function App() {
                                             stopClickPropagation={false}
                                             content="Completion tokens per second of full request duration. Cache hits are excluded."
                                         >
-                                            Speed
+                                            tok/s
                                         </Tooltip>
                                     }
                                     sortKey="tps"
@@ -811,7 +811,9 @@ function App() {
                                             >
                                                 {stats?.tokens_per_second !=
                                                 null
-                                                    ? `${stats.tokens_per_second.toFixed(1)} tok/s`
+                                                    ? stats.tokens_per_second.toFixed(
+                                                          1,
+                                                      )
                                                     : "-"}
                                             </TableCell>
                                         </TableRow>

--- a/apps/model-monitor/src/App.jsx
+++ b/apps/model-monitor/src/App.jsx
@@ -10,7 +10,6 @@ import {
     ExternalLinkButton,
     GitHubIcon,
     Heading,
-    ScrollArea,
     Surface,
     TabButton,
     Table,
@@ -502,7 +501,7 @@ function App() {
             <AppHeader
                 navLabel="Model Monitor links"
                 autoHide
-                innerClassName={adminMode ? "polli:max-w-6xl" : undefined}
+                innerClassName="polli:max-w-6xl"
             >
                 {EXTERNAL_LINKS.map((link) => (
                     <HeaderLink key={link.href} {...link} />
@@ -511,8 +510,7 @@ function App() {
             </AppHeader>
             <main
                 className={cn(
-                    "mx-auto flex min-h-full w-full min-w-0 flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
-                    adminMode ? "max-w-6xl" : "max-w-5xl",
+                    "mx-auto flex min-h-full w-full min-w-0 max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7",
                 )}
             >
                 <section className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
@@ -567,279 +565,272 @@ function App() {
                 />
 
                 <Surface variant="card" className="overflow-hidden p-0">
-                    <ScrollArea axis="x">
-                        <Table className="min-w-[960px]">
-                            <TableHead>
-                                <tr>
+                    <Table>
+                        <TableHead>
+                            <tr>
+                                <SortableTh
+                                    label="Type"
+                                    sortKey="type"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                />
+                                <SortableTh
+                                    label="Model"
+                                    sortKey="name"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                />
+                                <SortableTh
+                                    label="Status"
+                                    sortKey="status"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                />
+                                {adminMode && (
                                     <SortableTh
-                                        label="Type"
-                                        sortKey="type"
+                                        label="Provider"
+                                        sortKey="provider"
                                         currentSort={sort}
                                         onSort={handleSort}
                                     />
-                                    <SortableTh
-                                        label="Model"
-                                        sortKey="name"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                    />
-                                    <SortableTh
-                                        label="Status"
-                                        sortKey="status"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                    />
-                                    {adminMode && (
-                                        <SortableTh
-                                            label="Provider"
-                                            sortKey="provider"
-                                            currentSort={sort}
-                                            onSort={handleSort}
-                                        />
-                                    )}
-                                    <SortableTh
-                                        label="Reqs (+4xx)"
-                                        sortKey="requests"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                    <SortableTh
-                                        label="Success"
-                                        sortKey="ok2xx"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                    <SortableTh
-                                        label="5xx"
-                                        sortKey="errors"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                    <SortableTh
-                                        label="4xx"
-                                        sortKey="user4xx"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                    <SortableTh
-                                        label="Avg"
-                                        sortKey="avg"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                    <SortableTh
-                                        label="P95"
-                                        sortKey="p95"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                    <SortableTh
-                                        label={
-                                            <Tooltip
-                                                triggerAs="span"
-                                                stopClickPropagation={false}
-                                                content="Completion tokens per second of full request duration. Cache hits are excluded."
-                                            >
-                                                Speed
-                                            </Tooltip>
-                                        }
-                                        sortKey="tps"
-                                        currentSort={sort}
-                                        onSort={handleSort}
-                                        align="right"
-                                    />
-                                </tr>
-                            </TableHead>
-                            <TableBody>
-                                {filteredModels.length === 0 ? (
-                                    <TableRow>
-                                        <TableCell
-                                            colSpan={adminMode ? 11 : 10}
-                                            align="center"
-                                            className="py-8 text-theme-text-muted"
+                                )}
+                                <SortableTh
+                                    label="Reqs (+4xx)"
+                                    sortKey="requests"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                                <SortableTh
+                                    label="Success"
+                                    sortKey="ok2xx"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                                <SortableTh
+                                    label="5xx"
+                                    sortKey="errors"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                                <SortableTh
+                                    label="4xx"
+                                    sortKey="user4xx"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                                <SortableTh
+                                    label="Avg"
+                                    sortKey="avg"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                                <SortableTh
+                                    label="P95"
+                                    sortKey="p95"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                                <SortableTh
+                                    label={
+                                        <Tooltip
+                                            triggerAs="span"
+                                            stopClickPropagation={false}
+                                            content="Completion tokens per second of full request duration. Cache hits are excluded."
                                         >
-                                            {lastUpdated
-                                                ? "No models found"
-                                                : "Loading models..."}
-                                        </TableCell>
-                                    </TableRow>
-                                ) : (
-                                    filteredModels.map((model) => {
-                                        const stats = model.stats;
-                                        const total =
-                                            stats?.total_requests || 0;
-                                        const total5xx = stats?.errors_5xx || 0;
-                                        const total4xx = stats?.errors_4xx || 0;
-                                        const nonUserErrorTotal =
-                                            total - total4xx;
-                                        const pct4xx =
-                                            total > 0
-                                                ? (total4xx / total) * 100
-                                                : 0;
-                                        const avgSec = stats?.avg_latency_ms
-                                            ? stats.avg_latency_ms / 1000
-                                            : null;
-                                        const p95Sec = stats?.latency_p95_ms
-                                            ? stats.latency_p95_ms / 1000
-                                            : null;
-                                        const health =
-                                            computeHealthStatus(stats);
+                                            Speed
+                                        </Tooltip>
+                                    }
+                                    sortKey="tps"
+                                    currentSort={sort}
+                                    onSort={handleSort}
+                                    align="right"
+                                />
+                            </tr>
+                        </TableHead>
+                        <TableBody>
+                            {filteredModels.length === 0 ? (
+                                <TableRow>
+                                    <TableCell
+                                        colSpan={adminMode ? 11 : 10}
+                                        align="center"
+                                        className="py-8 text-theme-text-muted"
+                                    >
+                                        {lastUpdated
+                                            ? "No models found"
+                                            : "Loading models..."}
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                filteredModels.map((model) => {
+                                    const stats = model.stats;
+                                    const total = stats?.total_requests || 0;
+                                    const total5xx = stats?.errors_5xx || 0;
+                                    const total4xx = stats?.errors_4xx || 0;
+                                    const nonUserErrorTotal = total - total4xx;
+                                    const pct4xx =
+                                        total > 0
+                                            ? (total4xx / total) * 100
+                                            : 0;
+                                    const avgSec = stats?.avg_latency_ms
+                                        ? stats.avg_latency_ms / 1000
+                                        : null;
+                                    const p95Sec = stats?.latency_p95_ms
+                                        ? stats.latency_p95_ms / 1000
+                                        : null;
+                                    const health = computeHealthStatus(stats);
 
-                                        return (
-                                            <TableRow
-                                                key={`${model.type}-${model.name}`}
-                                                intent={rowIntent(health)}
-                                            >
-                                                <TableCell>
-                                                    <ModalityChip
-                                                        modality={model.type}
-                                                        size="sm"
-                                                        className="text-micro font-bold uppercase tracking-wide"
-                                                    >
-                                                        {model.type}
-                                                    </ModalityChip>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <div className="flex items-center gap-2">
-                                                        <span className="font-medium text-theme-text-strong">
-                                                            {model.name}
+                                    return (
+                                        <TableRow
+                                            key={`${model.type}-${model.name}`}
+                                            intent={rowIntent(health)}
+                                        >
+                                            <TableCell>
+                                                <ModalityChip
+                                                    modality={model.type}
+                                                    size="sm"
+                                                    className="text-micro font-bold uppercase tracking-wide"
+                                                >
+                                                    {model.type}
+                                                </ModalityChip>
+                                            </TableCell>
+                                            <TableCell className="w-full max-w-0">
+                                                <div className="flex min-w-0 items-center gap-2">
+                                                    <span className="truncate font-medium text-theme-text-strong">
+                                                        {model.name}
+                                                    </span>
+                                                    {model.title && (
+                                                        <span className="truncate text-xs text-theme-text-muted">
+                                                            {model.title}
                                                         </span>
-                                                        {model.title && (
-                                                            <span className="max-w-[24rem] truncate text-xs text-theme-text-muted">
-                                                                {model.title}
+                                                    )}
+                                                </div>
+                                            </TableCell>
+                                            <TableCell>
+                                                <div className="flex flex-wrap items-center gap-1">
+                                                    <StatusBadge
+                                                        stats={stats}
+                                                    />
+                                                    <CatalogStatusBadge
+                                                        status={
+                                                            model.catalogStatus
+                                                        }
+                                                    />
+                                                </div>
+                                            </TableCell>
+                                            {adminMode && (
+                                                <TableCell muted>
+                                                    {model.provider || "-"}
+                                                </TableCell>
+                                            )}
+                                            <TableCell
+                                                align="right"
+                                                numeric
+                                                muted
+                                            >
+                                                {total > 0 ? (
+                                                    <>
+                                                        {nonUserErrorTotal.toLocaleString()}
+                                                        {total4xx > 0 && (
+                                                            <span className="ml-1 text-xs text-theme-text-muted">
+                                                                (
+                                                                {total.toLocaleString()}
+                                                                )
                                                             </span>
                                                         )}
-                                                    </div>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <div className="flex flex-wrap items-center gap-1">
-                                                        <StatusBadge
-                                                            stats={stats}
-                                                        />
-                                                        <CatalogStatusBadge
-                                                            status={
-                                                                model.catalogStatus
-                                                            }
-                                                        />
-                                                    </div>
-                                                </TableCell>
-                                                {adminMode && (
-                                                    <TableCell muted>
-                                                        {model.provider || "-"}
-                                                    </TableCell>
+                                                    </>
+                                                ) : (
+                                                    "-"
                                                 )}
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                    muted
-                                                >
-                                                    {total > 0 ? (
-                                                        <>
-                                                            {nonUserErrorTotal.toLocaleString()}
-                                                            {total4xx > 0 && (
-                                                                <span className="ml-1 text-xs text-theme-text-muted">
-                                                                    (
-                                                                    {total.toLocaleString()}
-                                                                    )
-                                                                </span>
-                                                            )}
-                                                        </>
-                                                    ) : (
-                                                        "-"
-                                                    )}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                    className={get2xxColor(
-                                                        stats?.status_2xx || 0,
-                                                        nonUserErrorTotal,
-                                                    )}
-                                                >
-                                                    {formatPercent(
-                                                        stats?.status_2xx || 0,
-                                                        nonUserErrorTotal,
-                                                        true,
-                                                    )}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                >
-                                                    {total5xx > 0 ? (
-                                                        <span className="font-semibold text-intent-danger-text">
-                                                            {total5xx}
-                                                        </span>
-                                                    ) : (
-                                                        <span className="text-theme-text-muted">
-                                                            -
-                                                        </span>
-                                                    )}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                    muted
-                                                >
-                                                    {pct4xx > 0
-                                                        ? pct4xx < 1
-                                                            ? `${pct4xx.toFixed(1)}%`
-                                                            : `${Math.round(pct4xx)}%`
-                                                        : "-"}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                    className={
-                                                        avgSec
-                                                            ? getLatencyColor(
-                                                                  avgSec,
-                                                              )
-                                                            : "text-theme-text-muted"
-                                                    }
-                                                >
-                                                    {avgSec
-                                                        ? `${avgSec.toFixed(1)}s`
-                                                        : "-"}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                    className={
-                                                        p95Sec
-                                                            ? getLatencyColor(
-                                                                  p95Sec,
-                                                              )
-                                                            : "text-theme-text-muted"
-                                                    }
-                                                >
-                                                    {p95Sec
-                                                        ? `${p95Sec.toFixed(1)}s`
-                                                        : "-"}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    numeric
-                                                    muted
-                                                >
-                                                    {stats?.tokens_per_second !=
-                                                    null
-                                                        ? `${stats.tokens_per_second.toFixed(1)} tok/s`
-                                                        : "-"}
-                                                </TableCell>
-                                            </TableRow>
-                                        );
-                                    })
-                                )}
-                            </TableBody>
-                        </Table>
-                    </ScrollArea>
+                                            </TableCell>
+                                            <TableCell
+                                                align="right"
+                                                numeric
+                                                className={get2xxColor(
+                                                    stats?.status_2xx || 0,
+                                                    nonUserErrorTotal,
+                                                )}
+                                            >
+                                                {formatPercent(
+                                                    stats?.status_2xx || 0,
+                                                    nonUserErrorTotal,
+                                                    true,
+                                                )}
+                                            </TableCell>
+                                            <TableCell align="right" numeric>
+                                                {total5xx > 0 ? (
+                                                    <span className="font-semibold text-intent-danger-text">
+                                                        {total5xx}
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-theme-text-muted">
+                                                        -
+                                                    </span>
+                                                )}
+                                            </TableCell>
+                                            <TableCell
+                                                align="right"
+                                                numeric
+                                                muted
+                                            >
+                                                {pct4xx > 0
+                                                    ? pct4xx < 1
+                                                        ? `${pct4xx.toFixed(1)}%`
+                                                        : `${Math.round(pct4xx)}%`
+                                                    : "-"}
+                                            </TableCell>
+                                            <TableCell
+                                                align="right"
+                                                numeric
+                                                className={
+                                                    avgSec
+                                                        ? getLatencyColor(
+                                                              avgSec,
+                                                          )
+                                                        : "text-theme-text-muted"
+                                                }
+                                            >
+                                                {avgSec
+                                                    ? `${avgSec.toFixed(1)}s`
+                                                    : "-"}
+                                            </TableCell>
+                                            <TableCell
+                                                align="right"
+                                                numeric
+                                                className={
+                                                    p95Sec
+                                                        ? getLatencyColor(
+                                                              p95Sec,
+                                                          )
+                                                        : "text-theme-text-muted"
+                                                }
+                                            >
+                                                {p95Sec
+                                                    ? `${p95Sec.toFixed(1)}s`
+                                                    : "-"}
+                                            </TableCell>
+                                            <TableCell
+                                                align="right"
+                                                numeric
+                                                muted
+                                                className="whitespace-nowrap"
+                                            >
+                                                {stats?.tokens_per_second !=
+                                                null
+                                                    ? `${stats.tokens_per_second.toFixed(1)} tok/s`
+                                                    : "-"}
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })
+                            )}
+                        </TableBody>
+                    </Table>
                 </Surface>
             </main>
         </div>

--- a/apps/model-monitor/src/index.css
+++ b/apps/model-monitor/src/index.css
@@ -5,9 +5,3 @@
         font-size: 3rem;
     }
 }
-
-/* The page scrolls with the window in both axes; the shared shell's
-   overflow-x: hidden would clip the table on narrow viewports. */
-html.polli-ui-root {
-    overflow-x: auto;
-}

--- a/apps/model-monitor/src/index.css
+++ b/apps/model-monitor/src/index.css
@@ -5,3 +5,9 @@
         font-size: 3rem;
     }
 }
+
+/* The page scrolls with the window in both axes; the shared shell's
+   overflow-x: hidden would clip the table on narrow viewports. */
+html.polli-ui-root {
+    overflow-x: auto;
+}

--- a/apps/model-monitor/src/index.css
+++ b/apps/model-monitor/src/index.css
@@ -5,3 +5,8 @@
         font-size: 3rem;
     }
 }
+/* One scroll context: the window. If the table is wider than the screen the
+   whole page pans right; the shared shell's overflow-x: hidden would clip it. */
+html.polli-ui-root {
+    overflow-x: auto;
+}

--- a/apps/model-monitor/src/index.css
+++ b/apps/model-monitor/src/index.css
@@ -5,8 +5,3 @@
         font-size: 3rem;
     }
 }
-/* One scroll context: the window. If the table is wider than the screen the
-   whole page pans right; the shared shell's overflow-x: hidden would clip it. */
-html.polli-ui-root {
-    overflow-x: auto;
-}

--- a/packages/ui/src/styles/app.css
+++ b/packages/ui/src/styles/app.css
@@ -72,11 +72,10 @@
 }
 
 @layer base {
-    html.polli-ui-root {
-        /* color-scheme is owned by tokens.css (:root = light, .dark = dark)
-           so adding class `dark` to <html> flips native controls too. */
-        overflow-x: hidden;
-    }
+    /* color-scheme is owned by tokens.css (:root = light, .dark = dark)
+       so adding class `dark` to <html> flips native controls too.
+       No overflow rules on html: document-flow apps scroll with the window;
+       polli-ui-shell / polli-ui-body opt into their own clipping below. */
 
     html.polli-ui-root *,
     html.polli-ui-root ::before,

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -230,7 +230,12 @@
  * the `.ts` / `.tsx` files is picked up. Add `@source inline(...)` here
  * only if you introduce a class constructed dynamically (template
  * literal, runtime concatenation) that can't be detected statically.
+ *
+ * Exception: classes that apps pass INTO package components (e.g.
+ * AppHeader innerClassName) live in app source, which this build never
+ * scans — polli:* utilities used that way must be listed here.
  */
+@source inline("polli:max-w-6xl polli:flex-row");
 
 /* Respect the OS "reduce motion" setting app-wide: collapse transitions and
    animations to near-instant (the drawer slide, slider transforms, etc.). */


### PR DESCRIPTION
- Removes all nested scroll containers in the Model Monitor: the window is the only scroller (both axes)
- Drops the `polli-ui-shell` body class — it sets `body{overflow:hidden; height:100dvh}`, which forced the app into an inner-scroller shell
- Model column is the flexible one (`w-full min-w-[12rem] max-w-0` + truncate): on desktop the table fits the page exactly; on narrow screens the whole page pans right and the card grows with the table
- **packages/ui**: removes `overflow-x: hidden` from `html.polli-ui-root` — audited every consumer (enter dashboard swaps to shell dynamically; enter document-flow routes use `polli-ui-body` which self-clips; playground/websim never set `polli-ui-root`; pollinations.ai doesn't use these classes) — no consumer relies on the html-level clip
- Reqs column drops the "(+4xx)" bracket totals (the 4xx % column carries that); Speed column header is now "tok/s" so rows show bare numbers
- Verified with Playwright at 375/900/1200/1440px: zero inner scrollers, no clipping, truncation and tok/s sorting work

Preview deploy: https://fix-monitor-double-scroll.apps-model-monitor-52l.pages.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)