### PR TITLE
fix(sdk): remove automatic retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18370,7 +18370,7 @@
     },
     "packages/sdk": {
       "name": "@pollinations/sdk",
-      "version": "5.1.0-alpha.3",
+      "version": "5.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@pollinations/sdk` will be documented in this file.
 
+## [5.1.0-alpha.4] - 2026-07-14
+
+### Removed (Breaking)
+- Removed automatic request retries and the `maxRetries` client option.
+
+### Changed
+- Seed values, including `-1`, are passed through for the API to resolve.
+- Video duration validation is left to each model's API contract.
+- `PollinationsError.retryAfter` reflects only the server's `Retry-After` header.
+
 ## [5.1.0-alpha.3] - 2026-07-10
 
 ### Removed (Breaking)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -7,7 +7,7 @@ Official SDK for [pollinations.ai](https://pollinations.ai) - Generate images, t
 
 > [!WARNING]
 > **The `alpha` release line (`5.1.0-alpha.x`) is unstable and breakage-prone.**
-> It ships the in-progress rebuild (model-catalog helper, `./client` subpath, provider changes) and its API may change between alpha versions without notice. The stable `latest` line is `5.0.0`. Opt into the alpha only deliberately, and pin an exact version.
+> It ships the in-progress rebuild (model-catalog helper and provider changes) and its API may change between alpha versions without notice. The stable `latest` line is `5.0.0`. Opt into the alpha only deliberately, and pin an exact version.
 
 ## Installation
 
@@ -21,7 +21,7 @@ Alpha (in-progress rebuild — pin an exact version):
 
 ```bash
 npm install @pollinations/sdk@alpha
-# or pin exactly: npm install @pollinations/sdk@5.1.0-alpha.3
+# or pin exactly: npm install @pollinations/sdk@5.1.0-alpha.4
 ```
 
 ### CDN / `<script>` tag
@@ -419,7 +419,7 @@ const videos = await generateVideo('ocean waves', { n: 2, duration: 4 });
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `model` | string | `'veo'` | `'veo'`, `'seedance'`, `'wan'`, `'ltx-2'`, etc. |
-| `duration` | number | - | Duration in seconds (1-30, varies by model) |
+| `duration` | number | - | Duration in seconds (supported range varies by model) |
 | `aspectRatio` | string | - | e.g. `'16:9'`, `'9:16'`, `'1:1'` |
 | `seed` | number | random | Reproducible results |
 | `audio` | boolean | `false` | Include audio (`wan` always has audio) |
@@ -593,15 +593,10 @@ Publishable keys (`pk_`) have rate limits. Use a secret key (`sk_`) for unlimite
 
 ### Network Errors
 
-The SDK automatically retries failed requests up to 3 times. To customize:
-
-```javascript
-import { Pollinations } from '@pollinations/sdk';
-
-const client = new Pollinations({
-  maxRetries: 5,  // Retry up to 5 times
-});
-```
+The SDK returns network and API errors directly and does not retry requests
+automatically. A timed-out generation may still complete and incur usage.
+Callers can inspect `PollinationsError.retryAfter` when deciding how to handle
+rate limits.
 
 ## Links
 

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.1.0-alpha.3",
+  "version": "5.1.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/sdk",
-      "version": "5.1.0-alpha.3",
+      "version": "5.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.1.0-alpha.3",
+  "version": "5.1.0-alpha.4",
   "description": "Official SDK for pollinations.ai - Generate images, videos, audio, and text with ease",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -2,15 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Pollinations } from "./client.js";
 import { PollinationsError } from "./types.js";
 
-// ---------------------------------------------------------------------------
-// Characterization tests for client.ts.
-//
-// These lock the CURRENT behavior of the retry loop, per-attempt seed
-// recomputation, chat vs chatStream seed handling, and imageEdit response
-// resolution. They are written to pass against the UNREFACTORED client and
-// must continue to pass byte-for-byte after the dedup refactor.
-// ---------------------------------------------------------------------------
-
 // Build a minimal Response-like object good enough for the client paths.
 function makeResponse(
     body: unknown,
@@ -66,11 +57,10 @@ function makeResponse(
     return resp as unknown as Response;
 }
 
-function newClient(overrides: Record<string, unknown> = {}) {
+function newClient() {
     return new Pollinations({
         apiKey: "sk_test",
         baseUrl: "https://example.test",
-        ...overrides,
     });
 }
 
@@ -97,178 +87,119 @@ function bodyOf(call: unknown[]): Record<string, unknown> {
     return JSON.parse(init.body as string) as Record<string, unknown>;
 }
 
-describe("Pollinations.image — retry behavior (characterization)", () => {
-    it("retries a retriable failure then succeeds; counts attempts", async () => {
+describe("Pollinations request attempts", () => {
+    it("does not retry uploads after a network failure", async () => {
         const client = newClient();
-
-        // First attempt: network error (retriable). Second: success.
-        fetchMock
-            .mockRejectedValueOnce(new Error("boom"))
-            .mockResolvedValueOnce(
-                makeResponse(null, {
-                    kind: "binary",
-                    contentType: "image/png",
-                }),
-            );
-
-        const result = await client.image("a cat");
-        expect(result.contentType).toBe("image/png");
-        // 1 failed + 1 succeeded = 2 fetch attempts.
-        expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    it("retries up to maxRetries on persistent retriable failure", async () => {
-        const client = newClient({ maxRetries: 3 });
-
         fetchMock.mockRejectedValue(new Error("boom"));
 
-        await expect(client.image("a cat")).rejects.toThrow("boom");
-        // Exactly maxRetries attempts.
-        expect(fetchMock).toHaveBeenCalledTimes(3);
+        await expect(client.upload(new ArrayBuffer(8))).rejects.toThrow("boom");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it("does NOT retry a non-retriable error (e.g. 400)", async () => {
-        const client = newClient({ maxRetries: 3 });
-
+    it("returns API errors directly with server-provided Retry-After", async () => {
+        const client = newClient();
         fetchMock.mockResolvedValue(
             makeResponse(
-                { error: { message: "bad", code: "INVALID_INPUT" } },
-                { ok: false, status: 400 },
+                { error: { message: "slow down", code: "RATE_LIMITED" } },
+                {
+                    ok: false,
+                    status: 429,
+                    headers: { "Retry-After": "900" },
+                },
             ),
         );
 
-        await expect(client.image("a cat")).rejects.toBeInstanceOf(
-            PollinationsError,
-        );
-        // Non-retriable => single attempt, no retry.
+        await expect(client.image("a cat")).rejects.toMatchObject({
+            code: "RATE_LIMITED",
+            status: 429,
+            retryAfter: 900,
+        });
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
-});
 
-describe("Pollinations — per-attempt seed recomputation (characterization)", () => {
-    it("image: attempt 0 sends no seed (resolveSeed(undefined)), retry sends a fresh random seed", async () => {
-        const client = newClient({ maxRetries: 2 });
-
-        // Force randomSeed() deterministic for the retry attempt.
-        const randSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-        fetchMock
-            .mockRejectedValueOnce(new Error("boom"))
-            .mockResolvedValueOnce(
-                makeResponse(null, {
-                    kind: "binary",
-                    contentType: "image/png",
-                }),
-            );
-
-        await client.image("a cat"); // no explicit seed
-
-        const url0 = fetchMock.mock.calls[0][0] as string;
-        const url1 = fetchMock.mock.calls[1][0] as string;
-
-        // Attempt 0: resolveSeed(undefined) === undefined => no seed param.
-        expect(seedFromUrl(url0)).toBeNull();
-        // Attempt 1: randomSeed() => concrete number, present and differs.
-        const seed1 = seedFromUrl(url1);
-        expect(seed1).not.toBeNull();
-        expect(Number.isNaN(Number(seed1))).toBe(false);
-        randSpy.mockRestore();
-    });
-
-    it("image: explicit seed -1 resolves to a concrete number on attempt 0, fresh random on retry", async () => {
-        const client = newClient({ maxRetries: 2 });
-
-        // Math.random sequence: first for resolveSeed(-1) on attempt 0,
-        // second for randomSeed() on attempt 1.
-        const randSpy = vi
-            .spyOn(Math, "random")
-            .mockReturnValueOnce(0.1)
-            .mockReturnValueOnce(0.9);
-
-        fetchMock
-            .mockRejectedValueOnce(new Error("boom"))
-            .mockResolvedValueOnce(
-                makeResponse(null, {
-                    kind: "binary",
-                    contentType: "image/png",
-                }),
-            );
-
-        await client.image("a cat", { seed: -1 });
-
-        const seed0 = seedFromUrl(fetchMock.mock.calls[0][0] as string);
-        const seed1 = seedFromUrl(fetchMock.mock.calls[1][0] as string);
-
-        // -1 resolves to a concrete number on attempt 0 (not "-1").
-        expect(seed0).not.toBeNull();
-        expect(seed0).not.toBe("-1");
-        // Retry recomputes a fresh random seed that differs.
-        expect(seed1).not.toBeNull();
-        expect(seed1).not.toBe(seed0);
-        randSpy.mockRestore();
-    });
-
-    it("text: attempt 0 omits seed (undefined stripped), retry sends a fresh random seed in the body", async () => {
-        const client = newClient({ maxRetries: 2 });
-
-        fetchMock
-            .mockRejectedValueOnce(new Error("boom"))
-            .mockResolvedValueOnce(
-                makeResponse({ choices: [{ message: { content: "hi" } }] }),
-            );
-
-        const out = await client.text("hello"); // no explicit seed
-        expect(out).toBe("hi");
-
-        const body0 = bodyOf(fetchMock.mock.calls[0]);
-        const body1 = bodyOf(fetchMock.mock.calls[1]);
-
-        // Attempt 0: seed undefined => stripped from body.
-        expect("seed" in body0).toBe(false);
-        // Attempt 1: randomSeed() => concrete number present.
-        expect(typeof body1.seed).toBe("number");
-    });
-});
-
-describe("Pollinations.chat vs chatStream — seed resolution (characterization)", () => {
-    it("chat() resolves a raw -1 seed into a concrete number in the request body", async () => {
+    it("does not invent Retry-After when the header is absent", async () => {
         const client = newClient();
-        const randSpy = vi.spyOn(Math, "random").mockReturnValue(0.25);
-
         fetchMock.mockResolvedValue(
-            makeResponse({ choices: [{ message: { content: "ok" } }] }),
+            makeResponse(
+                { error: { message: "slow down", code: "RATE_LIMITED" } },
+                { ok: false, status: 429 },
+            ),
         );
 
-        await client.chat([{ role: "user", content: "hi" }], { seed: -1 });
+        let error: PollinationsError | undefined;
+        try {
+            await client.image("a cat");
+        } catch (caught) {
+            if (caught instanceof PollinationsError) error = caught;
+        }
 
-        const body = bodyOf(fetchMock.mock.calls[0]);
-        // chat resolves -1 to a concrete random number.
-        expect(typeof body.seed).toBe("number");
-        expect(body.seed).not.toBe(-1);
-        randSpy.mockRestore();
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error?.retryAfter).toBeUndefined();
     });
+});
 
-    it("chatStream() preserves a raw -1 seed unchanged (no resolveSeed)", async () => {
+describe("Pollinations seed handling", () => {
+    it("passes seed and model-specific video duration through URL requests", async () => {
         const client = newClient();
-
         fetchMock.mockResolvedValue(
-            makeResponse('data: {"choices":[{"delta":{"content":"x"}}]}\n', {
-                kind: "stream",
-                contentType: "text/event-stream",
+            makeResponse(null, {
+                kind: "binary",
+                contentType: "application/octet-stream",
             }),
         );
 
-        const it = client.chatStream([{ role: "user", content: "hi" }], {
+        await client.image("a cat", { seed: -1 });
+        await client.video("a long scene", {
+            model: "nova-reel",
+            duration: 120,
             seed: -1,
         });
-        // Drain the generator so the fetch is issued.
-        for await (const _ of it) {
-            // consume
+
+        const imageUrl = fetchMock.mock.calls[0][0] as string;
+        const videoUrl = new URL(fetchMock.mock.calls[1][0] as string);
+        expect(seedFromUrl(imageUrl)).toBe("-1");
+        expect(videoUrl.searchParams.get("seed")).toBe("-1");
+        expect(videoUrl.searchParams.get("duration")).toBe("120");
+    });
+
+    it("passes seed through text and chat requests consistently", async () => {
+        const client = newClient();
+        const stream = 'data: {"choices":[{"delta":{"content":"x"}}]}\n';
+        fetchMock
+            .mockResolvedValueOnce(
+                makeResponse({ choices: [{ message: { content: "ok" } }] }),
+            )
+            .mockResolvedValueOnce(
+                makeResponse(stream, {
+                    kind: "stream",
+                    contentType: "text/event-stream",
+                }),
+            )
+            .mockResolvedValueOnce(
+                makeResponse({ choices: [{ message: { content: "ok" } }] }),
+            )
+            .mockResolvedValueOnce(
+                makeResponse(stream, {
+                    kind: "stream",
+                    contentType: "text/event-stream",
+                }),
+            );
+
+        await client.text("hello", { seed: -1 });
+        for await (const _ of client.textStream("hello", { seed: -1 })) {
+            // consume stream
+        }
+        await client.chat([{ role: "user", content: "hi" }], { seed: -1 });
+        for await (const _ of client.chatStream(
+            [{ role: "user", content: "hi" }],
+            { seed: -1 },
+        )) {
+            // consume stream
         }
 
-        const body = bodyOf(fetchMock.mock.calls[0]);
-        // chatStream passes the raw seed through untouched.
-        expect(body.seed).toBe(-1);
+        expect(fetchMock.mock.calls.map((call) => bodyOf(call).seed)).toEqual([
+            -1, -1, -1, -1,
+        ]);
     });
 
     it("chat() serializes the standard reasoning effort option", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -45,15 +45,10 @@ const DEFAULT_BASE_URL = "https://gen.pollinations.ai";
 export const AUTH_BASE_URL = "https://enter.pollinations.ai";
 const DEVICE_FLOW_CLIENT_ID = "pk_NgBAArhUeGvSRFba";
 const DEVICE_FLOW_DEFAULT_SCOPE = "generate keys usage";
-const DEFAULT_MAX_RETRIES = 3;
-const MAX_INT32 = 2147483647;
 // Default timeouts in milliseconds
 const DEFAULT_TIMEOUT = 300_000; // 5min for text/chat
 const DEFAULT_IMAGE_TIMEOUT = 600_000; // 10min for images
 const DEFAULT_VIDEO_TIMEOUT = 600_000; // 10min for videos
-
-// HTTP status codes that should NOT be retried
-const NON_RETRIABLE_CODES = [400, 401, 402, 403, 404, 422];
 
 // Helper to get env var (works in Node.js, Deno, Bun, and edge runtimes)
 function getEnvVar(name: string): string | undefined {
@@ -77,40 +72,9 @@ function getEnvVar(name: string): string | undefined {
     return undefined;
 }
 
-// Generate a random seed (0 to MAX_INT32)
-function randomSeed(): number {
-    return Math.floor(Math.random() * MAX_INT32);
-}
-
-// Resolve seed: if -1, generate random; otherwise use as-is
-function resolveSeed(seed: number | undefined): number | undefined {
-    if (seed === -1) {
-        return randomSeed();
-    }
-    return seed;
-}
-
-// Sleep helper for retry delays
+// Sleep helper for device-flow polling
 function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// Exponential backoff delay: 1s, 2s, 4s
-function getRetryDelay(attempt: number, retryAfterSeconds?: number): number {
-    if (retryAfterSeconds !== undefined && retryAfterSeconds > 0) {
-        return retryAfterSeconds * 1000;
-    }
-    return 2 ** attempt * 1000;
-}
-
-// Check if an error should be retried
-function isRetriableError(error: unknown): boolean {
-    if (error instanceof PollinationsError) {
-        // Don't retry client errors (4xx except rate limits)
-        return !NON_RETRIABLE_CODES.includes(error.status);
-    }
-    // Network errors, timeouts, etc. are retriable
-    return true;
 }
 
 // Fetch with timeout using AbortController
@@ -222,7 +186,6 @@ function parseSSEBuffer<T>(
 export class Pollinations {
     private apiKey: string;
     private baseUrl: string;
-    private maxRetries: number;
     private textTimeout: number;
     private imageTimeout: number;
     private videoTimeout: number;
@@ -241,7 +204,6 @@ export class Pollinations {
 
         this.apiKey = apiKey;
         this.baseUrl = config.baseUrl?.replace(/\/$/, "") || DEFAULT_BASE_URL;
-        this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
 
         // Allow timeout to be a default fallback for all types
         const defaultTimeout = config.timeout ?? DEFAULT_TIMEOUT;
@@ -309,42 +271,6 @@ export class Pollinations {
         return body;
     }
 
-    /**
-     * Run `fn` with exponential-backoff retries on retriable errors.
-     * `attempt` is passed into `fn` so callers can recompute per-attempt
-     * state (e.g. a fresh random seed) on each try.
-     */
-    private async withRetries<T>(
-        fn: (attempt: number) => Promise<T>,
-        fallbackMessage: string,
-    ): Promise<T> {
-        let lastError: Error = new Error(fallbackMessage);
-
-        for (let attempt = 0; attempt < this.maxRetries; attempt++) {
-            try {
-                return await fn(attempt);
-            } catch (err) {
-                lastError = err as Error;
-
-                // Don't retry non-retriable errors (400, 401, 403, 404, 422)
-                if (!isRetriableError(err)) {
-                    throw lastError;
-                }
-
-                if (attempt < this.maxRetries - 1) {
-                    // Use Retry-After from rate limit errors, otherwise exponential backoff
-                    const retryAfter =
-                        err instanceof PollinationsError
-                            ? err.retryAfter
-                            : undefined;
-                    await sleep(getRetryDelay(attempt, retryAfter));
-                }
-            }
-        }
-
-        throw lastError;
-    }
-
     // ============================================================================
     // Image Generation
     // ============================================================================
@@ -353,13 +279,12 @@ export class Pollinations {
     private buildImageUrl(
         prompt: string,
         options: ImageGenerateOptions = {},
-        seed?: number,
     ): string {
         const params: Record<string, unknown> = {
             model: options.model || "zimage",
             width: options.width,
             height: options.height,
-            seed: seed !== undefined ? seed : resolveSeed(options.seed),
+            seed: options.seed,
             safe: options.safe,
             quality: options.quality,
             image: options.referenceImage,
@@ -394,7 +319,6 @@ export class Pollinations {
 
     /**
      * Generate an image and return it as binary data.
-     * Automatically retries up to 3 times with exponential backoff on retriable failures.
      *
      * @example
      * ```ts
@@ -414,29 +338,23 @@ export class Pollinations {
             );
         }
 
-        return this.withRetries(async (attempt) => {
-            // Generate new seed for each retry (or use resolved seed on first attempt)
-            const seed =
-                attempt === 0 ? resolveSeed(options.seed) : randomSeed();
-            const url = this.buildImageUrl(prompt, options, seed);
+        const url = this.buildImageUrl(prompt, options);
+        const response = await fetchWithTimeout(
+            url,
+            { headers: this.getHeaders() },
+            this.imageTimeout,
+            options.signal,
+        );
 
-            const response = await fetchWithTimeout(
-                url,
-                { headers: this.getHeaders() },
-                this.imageTimeout,
-                options.signal,
-            );
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
-            if (!response.ok) {
-                await this.handleErrorResponse(response);
-            }
+        const buffer = await response.arrayBuffer();
+        const contentType =
+            response.headers.get("content-type") || "image/jpeg";
 
-            const buffer = await response.arrayBuffer();
-            const contentType =
-                response.headers.get("content-type") || "image/jpeg";
-
-            return { buffer, contentType, url: stripKeyFromUrl(url) };
-        }, "Unknown error during image generation");
+        return { buffer, contentType, url: stripKeyFromUrl(url) };
     }
 
     // ============================================================================
@@ -561,7 +479,7 @@ export class Pollinations {
         if (options.responseFormat)
             body.response_format = options.responseFormat;
         if (options.reasoning !== undefined) body.reasoning = options.reasoning;
-        if (options.seed !== undefined) body.seed = resolveSeed(options.seed);
+        if (options.seed !== undefined) body.seed = options.seed;
         if (options.quality) body.quality = options.quality;
 
         const response = await fetchWithTimeout(
@@ -645,32 +563,18 @@ export class Pollinations {
     // Video Generation
     // ============================================================================
 
-    private validateVideoDuration(_model: string, duration?: number): void {
-        if (duration === undefined) return;
-
-        if (duration < 1 || duration > 30) {
-            throw new PollinationsError(
-                `Invalid duration: ${duration}. Must be between 1-30 seconds.`,
-                "INVALID_DURATION",
-                400,
-            );
-        }
-    }
-
     /** Build video URL with all params (internal use) */
     private buildVideoUrl(
         prompt: string,
         options: VideoGenerateOptions = {},
-        seed?: number,
     ): string {
         const model = options.model || "veo";
-        this.validateVideoDuration(model, options.duration);
 
         const params: Record<string, unknown> = {
             model,
             duration: options.duration,
             aspectRatio: options.aspectRatio,
-            seed: seed !== undefined ? seed : resolveSeed(options.seed),
+            seed: options.seed,
             audio: options.audio,
             image: options.referenceImage,
             safe: options.safe,
@@ -701,7 +605,6 @@ export class Pollinations {
 
     /**
      * Generate a video and return it as binary data.
-     * Automatically retries up to 3 times with exponential backoff on retriable failures.
      * Note: Video generation can take several minutes - timeout is set to 10 minutes.
      *
      * @example
@@ -721,28 +624,22 @@ export class Pollinations {
             );
         }
 
-        return this.withRetries(async (attempt) => {
-            const seed =
-                attempt === 0 ? resolveSeed(options.seed) : randomSeed();
-            const url = this.buildVideoUrl(prompt, options, seed);
+        const url = this.buildVideoUrl(prompt, options);
+        const response = await fetchWithTimeout(
+            url,
+            { headers: this.getHeaders() },
+            this.videoTimeout,
+            options.signal,
+        );
 
-            const response = await fetchWithTimeout(
-                url,
-                { headers: this.getHeaders() },
-                this.videoTimeout,
-                options.signal,
-            );
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
-            if (!response.ok) {
-                await this.handleErrorResponse(response);
-            }
+        const buffer = await response.arrayBuffer();
+        const contentType = response.headers.get("content-type") || "video/mp4";
 
-            const buffer = await response.arrayBuffer();
-            const contentType =
-                response.headers.get("content-type") || "video/mp4";
-
-            return { buffer, contentType, url: stripKeyFromUrl(url) };
-        }, "Unknown error during video generation");
+        return { buffer, contentType, url: stripKeyFromUrl(url) };
     }
 
     // ============================================================================
@@ -751,7 +648,6 @@ export class Pollinations {
 
     /**
      * Generate text from a prompt.
-     * Automatically retries up to 3 times with exponential backoff on retriable failures.
      *
      * @example
      * ```ts
@@ -771,61 +667,55 @@ export class Pollinations {
             );
         }
 
-        return this.withRetries(async (attempt) => {
-            const seed =
-                attempt === 0 ? resolveSeed(options.seed) : randomSeed();
+        const messages: Message[] = [];
 
-            const messages: Message[] = [];
+        if (options.systemPrompt) {
+            messages.push({
+                role: "system",
+                content: options.systemPrompt,
+            });
+        }
+        messages.push({ role: "user", content: prompt });
 
-            if (options.systemPrompt) {
-                messages.push({
-                    role: "system",
-                    content: options.systemPrompt,
-                });
-            }
-            messages.push({ role: "user", content: prompt });
+        const body: Record<string, unknown> = {
+            messages,
+            model: options.model || "openai",
+            temperature: options.temperature,
+            max_tokens: options.maxTokens,
+            frequency_penalty: options.frequencyPenalty,
+            presence_penalty: options.presencePenalty,
+            seed: options.seed,
+            stream: false,
+            private: options.private,
+        };
 
-            const body: Record<string, unknown> = {
-                messages,
-                model: options.model || "openai",
-                temperature: options.temperature,
-                max_tokens: options.maxTokens,
-                frequency_penalty: options.frequencyPenalty,
-                presence_penalty: options.presencePenalty,
-                seed,
-                stream: false,
-                private: options.private,
-            };
+        if (options.json) {
+            body.response_format = { type: "json_object" };
+        }
 
-            if (options.json) {
-                body.response_format = { type: "json_object" };
-            }
+        this.stripUndefined(body);
 
-            this.stripUndefined(body);
+        const response = await fetchWithTimeout(
+            `${this.baseUrl}/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: this.getHeaders("application/json"),
+                body: JSON.stringify(body),
+            },
+            this.textTimeout,
+            options.signal,
+        );
 
-            const response = await fetchWithTimeout(
-                `${this.baseUrl}/v1/chat/completions`,
-                {
-                    method: "POST",
-                    headers: this.getHeaders("application/json"),
-                    body: JSON.stringify(body),
-                },
-                this.textTimeout,
-                options.signal,
-            );
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
-            if (!response.ok) {
-                await this.handleErrorResponse(response);
-            }
-
-            const data = (await response.json()) as ChatResponse;
-            return data.choices[0]?.message?.content || "";
-        }, "Unknown error during text generation");
+        const data = (await response.json()) as ChatResponse;
+        return data.choices[0]?.message?.content || "";
     }
 
     /**
      * Generate text with streaming response.
-     * Automatically retries on connection failure before streaming starts.
      *
      * @example
      * ```ts
@@ -871,25 +761,20 @@ export class Pollinations {
 
         this.stripUndefined(body);
 
-        // Retry connection establishment; the body is built once above.
-        const response = await this.withRetries(async () => {
-            const res = await fetchWithTimeout(
-                `${this.baseUrl}/v1/chat/completions`,
-                {
-                    method: "POST",
-                    headers: this.getHeaders("application/json"),
-                    body: JSON.stringify(body),
-                },
-                this.textTimeout,
-                options.signal,
-            );
+        const response = await fetchWithTimeout(
+            `${this.baseUrl}/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: this.getHeaders("application/json"),
+                body: JSON.stringify(body),
+            },
+            this.textTimeout,
+            options.signal,
+        );
 
-            if (!res.ok) {
-                await this.handleErrorResponse(res);
-            }
-
-            return res;
-        }, "Unknown error during text stream");
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
         const reader = response.body?.getReader();
         if (!reader) {
@@ -924,16 +809,11 @@ export class Pollinations {
     // Chat Completions (OpenAI-compatible)
     // ============================================================================
 
-    /**
-     * Build the shared chat-completions request body (undefined fields stripped).
-     * `seed` is passed in explicitly so callers control resolution:
-     * `chat()` passes a per-attempt resolved seed, `chatStream()` passes the
-     * raw `options.seed` unchanged.
-     */
+    /** Build the shared chat-completions request body. */
     private buildChatBody(
         messages: Message[],
         options: Omit<ChatOptions, "stream">,
-        { stream, seed }: { stream: boolean; seed: number | undefined },
+        stream: boolean,
     ): Record<string, unknown> {
         return this.stripUndefined({
             messages,
@@ -945,7 +825,7 @@ export class Pollinations {
             presence_penalty: options.presencePenalty,
             repetition_penalty: options.repetitionPenalty,
             stop: options.stop,
-            seed,
+            seed: options.seed,
             stream,
             stream_options: options.streamOptions,
             response_format: options.responseFormat,
@@ -966,7 +846,6 @@ export class Pollinations {
 
     /**
      * Create a chat completion (OpenAI-compatible).
-     * Automatically retries up to 3 times with exponential backoff on retriable failures.
      *
      * @example
      * ```ts
@@ -988,37 +867,27 @@ export class Pollinations {
             );
         }
 
-        return this.withRetries(async (attempt) => {
-            const seed =
-                attempt === 0 ? resolveSeed(options.seed) : randomSeed();
+        const body = this.buildChatBody(messages, options, false);
+        const response = await fetchWithTimeout(
+            `${this.baseUrl}/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: this.getHeaders("application/json"),
+                body: JSON.stringify(body),
+            },
+            this.textTimeout,
+            options.signal,
+        );
 
-            const body = this.buildChatBody(messages, options, {
-                stream: false,
-                seed,
-            });
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
-            const response = await fetchWithTimeout(
-                `${this.baseUrl}/v1/chat/completions`,
-                {
-                    method: "POST",
-                    headers: this.getHeaders("application/json"),
-                    body: JSON.stringify(body),
-                },
-                this.textTimeout,
-                options.signal,
-            );
-
-            if (!response.ok) {
-                await this.handleErrorResponse(response);
-            }
-
-            return response.json() as Promise<ChatResponse>;
-        }, "Unknown error during chat completion");
+        return response.json() as Promise<ChatResponse>;
     }
 
     /**
      * Create a streaming chat completion.
-     * Automatically retries on connection failure before streaming starts.
      *
      * @example
      * ```ts
@@ -1042,32 +911,21 @@ export class Pollinations {
             );
         }
 
-        // chatStream preserves the raw seed (no per-attempt resolution) and
-        // builds the body once before the connection-retry loop.
-        const body = this.buildChatBody(messages, options, {
-            stream: true,
-            seed: options.seed,
-        });
+        const body = this.buildChatBody(messages, options, true);
+        const response = await fetchWithTimeout(
+            `${this.baseUrl}/v1/chat/completions`,
+            {
+                method: "POST",
+                headers: this.getHeaders("application/json"),
+                body: JSON.stringify(body),
+            },
+            this.textTimeout,
+            options.signal,
+        );
 
-        // Retry connection establishment; the body is built once above.
-        const response = await this.withRetries(async () => {
-            const res = await fetchWithTimeout(
-                `${this.baseUrl}/v1/chat/completions`,
-                {
-                    method: "POST",
-                    headers: this.getHeaders("application/json"),
-                    body: JSON.stringify(body),
-                },
-                this.textTimeout,
-                options.signal,
-            );
-
-            if (!res.ok) {
-                await this.handleErrorResponse(res);
-            }
-
-            return res;
-        }, "Unknown error during chat stream");
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
         const reader = response.body?.getReader();
         if (!reader) {
@@ -1130,10 +988,7 @@ export class Pollinations {
             voice: options.voice,
             model: options.model,
             duration: options.duration,
-            seed:
-                options.seed !== undefined
-                    ? resolveSeed(options.seed)
-                    : undefined,
+            seed: options.seed,
         };
 
         const queryString = this.buildQueryParams(params);
@@ -1327,40 +1182,36 @@ export class Pollinations {
         if (options.temperature !== undefined)
             formData.append("temperature", String(options.temperature));
 
-        return this.withRetries<
+        const headers = this.getHeaders();
+        // Don't set Content-Type - fetch sets it with boundary for FormData
+
+        const response = await fetchWithTimeout(
+            `${this.baseUrl}/v1/audio/transcriptions`,
+            {
+                method: "POST",
+                headers,
+                body: formData,
+            },
+            this.textTimeout,
+            options.signal,
+        );
+
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
+
+        if (
+            options.responseFormat === "text" ||
+            options.responseFormat === "srt" ||
+            options.responseFormat === "vtt"
+        ) {
+            const text = await response.text();
+            return { text };
+        }
+
+        return response.json() as Promise<
             TranscriptionResponse | TranscriptionVerboseResponse
-        >(async () => {
-            const headers = this.getHeaders();
-            // Don't set Content-Type - fetch sets it with boundary for FormData
-
-            const response = await fetchWithTimeout(
-                `${this.baseUrl}/v1/audio/transcriptions`,
-                {
-                    method: "POST",
-                    headers,
-                    body: formData,
-                },
-                this.textTimeout,
-                options.signal,
-            );
-
-            if (!response.ok) {
-                await this.handleErrorResponse(response);
-            }
-
-            if (
-                options.responseFormat === "text" ||
-                options.responseFormat === "srt" ||
-                options.responseFormat === "vtt"
-            ) {
-                const text = await response.text();
-                return { text };
-            }
-
-            return response.json() as Promise<
-                TranscriptionResponse | TranscriptionVerboseResponse
-            >;
-        }, "Unknown error during transcription");
+        >;
     }
 
     // ============================================================================
@@ -1397,24 +1248,22 @@ export class Pollinations {
 
         const headers = this.getHeaders();
 
-        return this.withRetries(async () => {
-            const response = await fetchWithTimeout(
-                `https://media.pollinations.ai/upload`,
-                {
-                    method: "POST",
-                    headers,
-                    body: formData,
-                },
-                this.imageTimeout,
-                options.signal,
-            );
+        const response = await fetchWithTimeout(
+            `https://media.pollinations.ai/upload`,
+            {
+                method: "POST",
+                headers,
+                body: formData,
+            },
+            this.imageTimeout,
+            options.signal,
+        );
 
-            if (!response.ok) {
-                await this.handleErrorResponse(response);
-            }
+        if (!response.ok) {
+            await this.handleErrorResponse(response);
+        }
 
-            return response.json() as Promise<UploadResponse>;
-        }, "Unknown error during upload");
+        return response.json() as Promise<UploadResponse>;
     }
 
     // ============================================================================

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -1,12 +1,5 @@
 import { PollinationsError } from "./types.js";
 
-// Default Retry-After delay for rate-limit errors when the header is missing
-// or malformed (seconds)
-const DEFAULT_RETRY_AFTER = 60;
-// Cap honored Retry-After so a malicious or misconfigured upstream
-// cannot force the client into an indefinite sleep.
-const MAX_RETRY_AFTER_SECONDS = 300;
-
 // Parse Retry-After header (can be seconds or HTTP date)
 function parseRetryAfter(response: Response): number | undefined {
     const retryAfter = response.headers.get("Retry-After");
@@ -18,7 +11,7 @@ function parseRetryAfter(response: Response): number | undefined {
     // retry delay.
     const seconds = Number(retryAfter);
     if (Number.isFinite(seconds) && seconds >= 0) {
-        return Math.min(seconds, MAX_RETRY_AFTER_SECONDS);
+        return seconds;
     }
 
     // Try parsing as HTTP date
@@ -72,10 +65,7 @@ export async function pollinationsErrorFromResponse(
             : undefined;
     const requestId =
         typeof nested.requestId === "string" ? nested.requestId : undefined;
-    const retryAfter =
-        response.status === 429
-            ? (parseRetryAfter(response) ?? DEFAULT_RETRY_AFTER)
-            : parseRetryAfter(response);
+    const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(
         message,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3,8 +3,6 @@ export interface PollinationsConfig {
     apiKey?: string;
     /** Base URL for the API (defaults to https://gen.pollinations.ai) */
     baseUrl?: string;
-    /** Maximum number of retry attempts (default: 3) */
-    maxRetries?: number;
     /** Default timeout in ms for all requests (default: 300000 = 5min) */
     timeout?: number;
     /** Timeout in ms for text requests (default: 300000 = 5min) */
@@ -91,7 +89,7 @@ export interface ImageResponse {
 export interface VideoGenerateOptions extends RequestOptions {
     /** Video model to use (default: 'veo') */
     model?: VideoModel;
-    /** Duration in seconds (1-30, varies by model) */
+    /** Duration in seconds (supported range varies by model) */
     duration?: number;
     /** Aspect ratio (e.g., '16:9', '9:16', '1:1') */
     aspectRatio?: string;
@@ -924,7 +922,7 @@ export class PollinationsError extends Error {
     status: number;
     details?: Record<string, unknown>;
     requestId?: string;
-    /** Retry-After value in seconds (for 429 rate limit errors) */
+    /** Retry-After header value in seconds */
     retryAfter?: number;
 
     constructor(


### PR DESCRIPTION
- Removes automatic SDK retries and the public `maxRetries` option to avoid duplicate generation, upload, and billing after ambiguous failures.
- Passes seeds through to Gen and removes stale client-side video duration validation.
- Preserves server-provided `Retry-After` metadata without SDK-owned fallback policy.
- Bumps `@pollinations/sdk` to `5.1.0-alpha.4`.
- Checks: Biome, typecheck, 28 tests, and package build.