### PR TITLE
fix: install shared media deploy dependencies

### DIFF
--- a/.github/workflows/deploy-media-cloudflare.yml
+++ b/.github/workflows/deploy-media-cloudflare.yml
@@ -32,7 +32,10 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install dependencies
+      - name: Install shared dependencies
+        run: npm install --workspace shared --include-workspace-root=false
+
+      - name: Install media dependencies
         run: npm install
         working-directory: ./media.pollinations.ai
 


### PR DESCRIPTION
- Installs the `shared` workspace dependencies before the Media package dependencies.
- Lets Wrangler resolve `drizzle-orm` imports from sibling `shared/` schema files.
- Verified in a clean checkout: Media 29/29 and production Wrangler dry-run pass.