### PR TITLE
Merge media deploy hotfix into production

### DIFF
--- a/.github/workflows/deploy-media-cloudflare.yml
+++ b/.github/workflows/deploy-media-cloudflare.yml
@@ -32,7 +32,10 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install dependencies
+      - name: Install shared dependencies
+        run: npm install --workspace shared --include-workspace-root=false
+
+      - name: Install media dependencies
         run: npm install
         working-directory: ./media.pollinations.ai
 


### PR DESCRIPTION
- Promotes media deploy hotfix #12462 to `production`.
- Installs shared workspace dependencies before Media dependencies so Wrangler can resolve the shared Drizzle schemas.
- Clean-checkout Media tests and production dry-run pass.