### PR TITLE
Merge media docs fix into production

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -78,7 +78,7 @@ The header is preferred for everything except browser flows that can't set custo
 
 | Endpoint | Auth |
 |---|---|
-| `GET /{hash}`, `GET /{hash}/metadata`, `HEAD /{hash}` | None — content-addressed media URLs are public reads |
+| `GET /{id}`, `GET /{id}/metadata`, `HEAD /{id}` | None — media URLs are public reads |
 | `GET /models`, `GET /v1/models`, `GET /image/models`, `GET /text/models`, `GET /audio/models`, `GET /embeddings/models` | None — model catalogue is public. Sending a bearer key returns the same data; some endpoints add per-account fields when authenticated. |
 | Everything else | Bearer key required unless the endpoint documents `?key=` support |
 
@@ -221,7 +221,7 @@ curl -X POST "https://gen.pollinations.ai/v1/images/edits" \
 
 Repeat `-F "image=@…"` to pass multiple reference images on models that accept them (`seedream`, `nanobanana`, `klein`).
 
-**Upload arbitrary media** to the content-addressed store. Returns a `https://media.pollinations.ai/<hash>` URL you can pass anywhere a remote image, audio, or video URL is accepted.
+**Upload arbitrary media** to the media store (a separate host: `media.pollinations.ai`). Returns a `https://media.pollinations.ai/<id>` URL you can pass anywhere a remote image, audio, or video URL is accepted.
 
 ```bash
 curl -X POST "https://media.pollinations.ai/upload" \
@@ -229,7 +229,7 @@ curl -X POST "https://media.pollinations.ai/upload" \
   -F "file=@./asset.png"
 ```
 
-The hash is derived from the bytes **and** the filename, so the same content uploaded under different names yields different URLs. Files are retained for 30 days. Re-uploading resets the timer, while the `duplicate` field reports whether the file already existed. Retrieving a file keeps it active.
+Each upload gets its own unique id — re-uploading the same bytes yields a new URL. Files use a 30-day lifecycle from upload or the latest refresh. Retrieving the file body refreshes that lifecycle only when the object is at least 15 days old; metadata and HEAD requests do not refresh it. An optional `-F "tags=..."` field publishes the upload to those tags' public galleries (`GET https://media.pollinations.ai/media?tag=...`); untagged uploads stay unlisted.
 
 ## 💡 Tips
 
@@ -956,17 +956,30 @@ curl "https://gen.pollinations.ai/audio/models" \
 
 #### `POST` `/upload` — Upload media
 
-Upload an image, audio, or video file. Supports multipart/form-data, raw binary, or base64 JSON. Returns a content-addressed hash URL. The hash includes the filename, so the same content with different filenames gets different URLs. Files are retained for 30 days; re-uploading resets the timer.
+Upload an image, audio, or video file via multipart/form-data (field `file`) or application/json (base64 `data`). Returns a unique id and its retrieval URL; each upload gets its own id (re-uploading the same bytes yields a new one). Files are retained for 30 days.
+
+**Tags publish.** An optional `tags` field publishes the upload into each tag's public gallery (GET /media?tag=…), where anyone can see it. Untagged uploads stay unlisted: reachable only by their unguessable id URL, never listed anywhere. **Alpha:** the publish tagging is new and may still change.
+
+📥 **Request body** · `application/json`
+
+| Field | Type | Description |
+|---|---|---|
+| `data` * | `string` | Base64-encoded file bytes (with or without a data: prefix). |
+| `contentType` | `string` | MIME type; defaults to application/octet-stream. |
+| `name` | `string` | Filename; used for the download Content-Disposition. |
+| `tags` | `string` \| `string`[] | Tags (publish the upload to those tags' public galleries): a comma-separated string or an array of strings. |
+
+<sub>`*` = required field</sub>
 
 📤 **Response** · `200` · `application/json` — Upload successful
 
 | Field | Type | Description |
 |---|---|---|
-| `id` * | `string` | — |
-| `url` * | `string` | — |
+| `id` * | `string` | Unique media id (also the retrieval id) |
+| `url` * | `string` | Public retrieval URL |
 | `contentType` * | `string` | — |
-| `size` * | `integer` | — |
-| `duplicate` * | `boolean` | — |
+| `size` * | `integer` | File size in bytes |
+| `tags` | `string`[] | Tags the upload was published with; present only when tagged |
 
 <sub>`*` = required field</sub>
 
@@ -980,15 +993,85 @@ curl -X POST "https://media.pollinations.ai/upload" \
 
 ---
 
-#### `GET` `/{hash}` — Retrieve media
+#### `GET` `/media` — List a public tag gallery
 
-Get a file by its content hash. Access keeps files from expiring.
+List the public gallery for a tag: every published item carrying that tag, any owner, newest first. Tagging an upload is what publishes it, so galleries are fully public — no API key needed. `tag` is required.
+
+Items reference storage with a 30-day lifecycle. A GET refreshes the lifecycle once an object is at least 15 days old. An expired item keeps its catalog entry, but its url 404s. **Alpha:** this endpoint is new and its API may still change.
 
 ⚙️ **Parameters**
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `hash` * | `path` | `string` | — |
+| `tag` * | `query` | `string` | Required. The public gallery to list: items carrying this tag, any owner. |
+| `limit` | `query` | `integer` | Page size, 1–100. Omitted → 20. · range: `1…100` |
+| `cursor` | `query` | `string` | Opaque pagination cursor from a previous response's nextCursor. |
+
+<sub>`*` = required parameter</sub>
+
+📤 **Response** · `200` · `application/json` — Page of media items
+
+| Field | Type | Description |
+|---|---|---|
+| `items` * | `object`[] | — |
+| `items[].id` * | `string` | Catalog item id |
+| `items[].url` * | `string` | Public retrieval URL |
+| `items[].contentType` * | `string` | — |
+| `items[].size` * | `integer` \| `null` | File size in bytes |
+| `items[].tags` * | `string`[] | — |
+| `items[].createdAt` * | `string` | ISO-8601 timestamp |
+| `nextCursor` * | `string` \| `null` | Opaque cursor for the next page, null when exhausted. Treat it as a token: pass it back verbatim as `?cursor=` to fetch the next page — do not parse or construct it. |
+| `hasMore` * | `boolean` | true when more pages exist (nextCursor is non-null). Loop while hasMore is true. |
+
+<sub>`*` = required field</sub>
+
+💻 **Example**
+
+```bash
+curl "https://media.pollinations.ai/media?tag=:tag&limit=:limit"
+```
+
+---
+
+#### `DELETE` `/media/{id}` — Delete media
+
+Delete a published media item you own: the file, its catalog entry, and all its tags are removed, so it disappears from galleries and its URL 404s. Requires your **secret (`sk_`)** API key. Untagged uploads were never published, have no catalog entry, and can't be deleted — they use the same 30-day lifecycle, refreshed by a GET once they are at least 15 days old. **Alpha:** this endpoint is new and its API may still change.
+
+⚙️ **Parameters**
+
+| Param | In | Type | Description |
+|---|---|---|---|
+| `id` * | `path` | `string` | Media id (from the upload response or GET /media). |
+
+<sub>`*` = required parameter</sub>
+
+📤 **Response** · `200` · `application/json` — Item deleted
+
+| Field | Type | Description |
+|---|---|---|
+| `deleted` * | `"true"` | — |
+| `id` * | `string` | Id of the deleted media item |
+
+<sub>`*` = required field</sub>
+
+💻 **Example**
+
+```bash
+curl -X DELETE "https://media.pollinations.ai/media/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY"
+```
+
+---
+
+#### `GET` `/{id}` — Retrieve media
+
+Get a file by its id. Access keeps files from expiring.
+
+⚙️ **Parameters**
+
+| Param | In | Type | Description |
+|---|---|---|---|
+| `id` * | `path` | `string` | — |
 
 <sub>`*` = required parameter</sub>
 
@@ -997,12 +1080,12 @@ Get a file by its content hash. Access keeps files from expiring.
 💻 **Example**
 
 ```bash
-curl "https://media.pollinations.ai/a1b2c3d4e5f60718"
+curl "https://media.pollinations.ai/550e8400-e29b-41d4-a716-446655440000"
 ```
 
 ---
 
-#### `HEAD` `/{hash}` — Check if media exists
+#### `HEAD` `/{id}` — Check if media exists
 
 Check existence and metadata without downloading the file.
 
@@ -1010,29 +1093,29 @@ Check existence and metadata without downloading the file.
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `hash` * | `path` | `string` | — |
+| `id` * | `path` | `string` | — |
 
 <sub>`*` = required parameter</sub>
 
-📤 **Response** · `200` — File exists (headers include Content-Type, Content-Length, X-Content-Hash)
+📤 **Response** · `200` — File exists (headers include Content-Type, Content-Length, X-Content-Id)
 
 💻 **Example**
 
 ```bash
-curl -X HEAD "https://media.pollinations.ai/a1b2c3d4e5f60718"
+curl -X HEAD "https://media.pollinations.ai/550e8400-e29b-41d4-a716-446655440000"
 ```
 
 ---
 
-#### `GET` `/{hash}/metadata` — Get file metadata
+#### `GET` `/{id}/metadata` — Get file metadata
 
-Return file metadata (hash, content type, size, upload timestamp) as JSON without downloading the file body.
+Return file metadata (id, content type, size, upload timestamp) as JSON without downloading the file body.
 
 ⚙️ **Parameters**
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `hash` * | `path` | `string` | — |
+| `id` * | `path` | `string` | — |
 
 <sub>`*` = required parameter</sub>
 
@@ -1040,17 +1123,17 @@ Return file metadata (hash, content type, size, upload timestamp) as JSON withou
 
 | Field | Type | Description |
 |---|---|---|
-| `hash` * | `string` | — |
+| `id` * | `string` | Unique media id |
 | `contentType` * | `string` | — |
-| `size` * | `integer` | — |
-| `uploadedAt` | `string` | — |
+| `size` * | `integer` | File size in bytes |
+| `uploadedAt` | `string` | ISO-8601 upload timestamp, when recorded |
 
 <sub>`*` = required field</sub>
 
 💻 **Example**
 
 ```bash
-curl "https://media.pollinations.ai/a1b2c3d4e5f60718/metadata"
+curl "https://media.pollinations.ai/550e8400-e29b-41d4-a716-446655440000/metadata"
 ```
 
 ### Account
@@ -1708,6 +1791,8 @@ Returns information about the API key used in the request: validity, type (secre
 | `permissions.account` * | `string`[] \| `null` | List of account permissions, null = no account access |
 | `pollenBudget` * | `number` \| `null` | Remaining pollen budget for this key, null = unlimited (uses user balance) |
 | `rateLimitEnabled` * | `boolean` | Whether rate limiting is enabled for this key |
+| `userId` * | `string` \| `null` | Stable id of the user that owns this key — server-attested. |
+| `byopClientKeyId` * | `string` \| `null` | Publishable app key that minted this key via the BYOP authorize flow. Server-attested; clients cannot forge. |
 
 <sub>`*` = required field</sub>
 

--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -454,7 +454,11 @@ function buildCurl(
 
     const curatedMultipart = CURATED_MULTIPART[operationId];
 
-    if (jsonBody.schema) {
+    if (curatedMultipart) {
+        for (const [name, value] of curatedMultipart) {
+            segments.push(`-F "${name}=${value}"`);
+        }
+    } else if (jsonBody.schema) {
         const ex =
             CURATED_BODIES[operationId] ??
             pickExample(spec, asObj(jsonBody.schema), { compact: true });
@@ -462,10 +466,8 @@ function buildCurl(
             segments.push(`-H "Content-Type: application/json"`);
             segments.push(`-d '${JSON.stringify(ex)}'`);
         }
-    } else if (multipartBody.schema || curatedMultipart) {
-        const fields =
-            curatedMultipart ??
-            buildMultipartFields(spec, asObj(multipartBody.schema));
+    } else if (multipartBody.schema) {
+        const fields = buildMultipartFields(spec, asObj(multipartBody.schema));
         for (const [name, value] of fields) {
             segments.push(`-F "${name}=${value}"`);
         }


### PR DESCRIPTION
- Syncs the generated media API reference and upload-example generator fix to `production`.
- Documents UUID media ids, galleries, deletion, multipart/base64 uploads, and server-attested key identity.
- Generation and validation pass against the live production schema.