### PR TITLE
feat: add community model price floor

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -15,7 +15,6 @@ import { useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
 import {
     formWithVisiblePrices,
-    hasPositivePriceInput,
     hasValidVisibleFormPrices,
     PriceGroups,
     returnedPriceFields,
@@ -198,13 +197,9 @@ export function CommunityEndpointDialog({
         savedPriceKeys,
         returnedFields,
     );
-    const hasVisiblePriceFields = visiblePriceKeys.size > 0;
     const hasValidVisiblePrices = hasValidVisibleFormPrices(
         form,
         visiblePriceKeys,
-    );
-    const hasRequiredReturnedPrices = returnedFields.every((field) =>
-        hasPositivePriceInput(form, field),
     );
     const testRequirementMet =
         testState.status === "success" && returnedFields.length > 0;
@@ -220,9 +215,7 @@ export function CommunityEndpointDialog({
         !isSubmitting &&
         form.name.trim() !== "" &&
         form.baseUrl.trim() !== "" &&
-        hasVisiblePriceFields &&
         hasValidVisiblePrices &&
-        hasRequiredReturnedPrices &&
         saveRequirementMet;
 
     return (

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -9,7 +9,10 @@ import {
     TableHeaderCell,
     TableRow,
 } from "@pollinations/ui";
-import { COMMUNITY_ENDPOINT_PRICE_FIELDS } from "@shared/community-endpoints.ts";
+import {
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+} from "@shared/community-endpoints.ts";
 import { PRICE_ICON } from "../models/model-icons.tsx";
 import type { PriceKind } from "../models/types.ts";
 import {
@@ -34,8 +37,6 @@ type PriceFormRow = {
 
 type PriceCellState = {
     observed: boolean;
-    missing: boolean;
-    nonPositive: boolean;
     invalid: boolean;
 };
 
@@ -111,17 +112,7 @@ function PriceRow({
     const outputState = row.outputField
         ? priceCellState(row.outputField, form, testState)
         : null;
-    const hasError =
-        Boolean(
-            inputState?.invalid ||
-                inputState?.missing ||
-                inputState?.nonPositive,
-        ) ||
-        Boolean(
-            outputState?.invalid ||
-                outputState?.missing ||
-                outputState?.nonPositive,
-        );
+    const hasError = Boolean(inputState?.invalid || outputState?.invalid);
     const returned = Boolean(inputState?.observed || outputState?.observed);
 
     return (
@@ -180,7 +171,7 @@ function PriceInputCell({
     }
 
     const inputId = `community-${field.key}`;
-    const hasError = state.invalid || state.missing || state.nonPositive;
+    const hasError = state.invalid;
 
     return (
         <TableCell align="right" className="w-40 align-top">
@@ -205,11 +196,8 @@ function PriceInputCell({
                 />
                 {hasError && (
                     <p className="mt-1 text-right text-xs text-intent-danger-text">
-                        {state.invalid
-                            ? "Use a dot decimal like 0.1"
-                            : state.nonPositive
-                              ? "Must be greater than 0"
-                              : "Required for returned usage"}
+                        0 (free) or at least{" "}
+                        {MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M
                     </p>
                 )}
             </div>
@@ -225,18 +213,9 @@ function priceCellState(
     const observed =
         observedUsageValue(testState.usage, testState.billableUsage, field) !==
         null;
-    const value = form[field.key];
-    const trimmedValue = value.trim();
-    const invalid = !isValidPriceInput(value);
     return {
         observed,
-        missing: observed && trimmedValue === "",
-        nonPositive:
-            observed &&
-            trimmedValue !== "" &&
-            !invalid &&
-            Number(trimmedValue) <= 0,
-        invalid,
+        invalid: !isValidPriceInput(form[field.key]),
     };
 }
 
@@ -327,14 +306,6 @@ export function formWithVisiblePrices(
         }
     }
     return next;
-}
-
-export function hasPositivePriceInput(
-    form: EndpointFormState,
-    field: PriceField,
-): boolean {
-    const value = form[field.key].trim();
-    return value !== "" && isValidPriceInput(value) && Number(value) > 0;
 }
 
 export function hasValidVisibleFormPrices(

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -1,8 +1,8 @@
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
-    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     type CommunityEndpointPriceKey,
     type CommunityEndpointPrices,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
 } from "@shared/community-endpoints.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -1,5 +1,6 @@
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     type CommunityEndpointPriceKey,
     type CommunityEndpointPrices,
 } from "@shared/community-endpoints.ts";
@@ -84,7 +85,10 @@ export function isValidPriceInput(value: string): boolean {
     if (!trimmed) return true;
     if (trimmed.includes(",")) return false;
     const parsed = Number(trimmed);
-    return Number.isFinite(parsed) && parsed >= 0;
+    return (
+        Number.isFinite(parsed) &&
+        (parsed === 0 || parsed >= MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS)
+    );
 }
 
 export function endpointToForm(endpoint: CommunityEndpoint): EndpointFormState {
@@ -109,7 +113,9 @@ function formPricesToPayload(form: EndpointFormState): CommunityEndpointPrices {
     return Object.fromEntries(
         COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => {
             if (!isValidPriceInput(form[field.key])) {
-                throw new Error("Prices must use dot decimals, e.g. 0.1");
+                throw new Error(
+                    `Prices must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens, using a dot decimal`,
+                );
             }
             return [field.key, pricePerMillionToPerToken(form[field.key])];
         }),

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,5 +1,7 @@
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MIN_COMMUNITY_PRICE_PER_TOKEN,
     type CommunityEndpointPriceKey,
     communityEndpointPrices,
     communityModelId,
@@ -25,7 +27,17 @@ import {
 } from "../services/community-endpoint-openai.ts";
 import { hasDirectAccountPermission } from "./account-permissions.ts";
 
-const PriceSchema = z.number().finite().min(0);
+const PriceSchema = z
+    .number()
+    .finite()
+    .min(0)
+    .refine(
+        (price) =>
+            price === 0 || price >= MIN_COMMUNITY_PRICE_PER_TOKEN,
+        {
+            message: `Price must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_TOKEN} per token (${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens)`,
+        },
+    );
 const CreatePriceFieldsSchema = Object.fromEntries(
     COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
         field.key,

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,11 +1,11 @@
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
-    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
-    MIN_COMMUNITY_PRICE_PER_TOKEN,
     type CommunityEndpointPriceKey,
     communityEndpointPrices,
     communityModelId,
     isCommunityEndpointOwnerAllowed,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
@@ -31,13 +31,9 @@ const PriceSchema = z
     .number()
     .finite()
     .min(0)
-    .refine(
-        (price) =>
-            price === 0 || price >= MIN_COMMUNITY_PRICE_PER_TOKEN,
-        {
-            message: `Price must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_TOKEN} per token (${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens)`,
-        },
-    );
+    .refine((price) => price === 0 || price >= MIN_COMMUNITY_PRICE_PER_TOKEN, {
+        message: `Price must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_TOKEN} per token (${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens)`,
+    });
 const CreatePriceFieldsSchema = Object.fromEntries(
     COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
         field.key,

--- a/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
@@ -13,9 +13,7 @@ describe("community endpoint price input", () => {
         expect(isValidPriceInput("")).toBe(true);
         expect(isValidPriceInput("0")).toBe(true);
         expect(
-            isValidPriceInput(
-                String(MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS),
-            ),
+            isValidPriceInput(String(MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS)),
         ).toBe(true);
         expect(
             pricePerMillionToPerToken(

--- a/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
@@ -1,0 +1,37 @@
+import {
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MIN_COMMUNITY_PRICE_PER_TOKEN,
+} from "@shared/community-endpoints.ts";
+import { describe, expect, it } from "vitest";
+import {
+    isValidPriceInput,
+    pricePerMillionToPerToken,
+} from "../frontend/src/components/community-endpoints/types.ts";
+
+describe("community endpoint price input", () => {
+    it("accepts free and minimum prices", () => {
+        expect(isValidPriceInput("")).toBe(true);
+        expect(isValidPriceInput("0")).toBe(true);
+        expect(
+            isValidPriceInput(
+                String(MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS),
+            ),
+        ).toBe(true);
+        expect(
+            pricePerMillionToPerToken(
+                String(MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS),
+            ),
+        ).toBe(MIN_COMMUNITY_PRICE_PER_TOKEN);
+    });
+
+    it("rejects positive prices below the minimum and malformed values", () => {
+        expect(
+            isValidPriceInput(
+                String(MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS / 10),
+            ),
+        ).toBe(false);
+        expect(isValidPriceInput("-1")).toBe(false);
+        expect(isValidPriceInput("0,1")).toBe(false);
+        expect(isValidPriceInput("not-a-price")).toBe(false);
+    });
+});

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -9,6 +9,8 @@ import {
     communityOpenAIBaseUrl,
     isCommunityEndpointOwnerAllowed,
     legacyCommunityModelId,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
     parseCommunityModelId,
@@ -1289,6 +1291,88 @@ fixtureTest(
         expect(secondList.data).toHaveLength(1);
         expect(secondList.data[0]).not.toHaveProperty("bearerToken");
         expect(secondList.data[0]).not.toHaveProperty("bearerTokenCiphertext");
+    },
+);
+
+fixtureTest(
+    "accepts free and minimum community prices while rejecting smaller positive prices",
+    async () => {
+        const ownerGithubUsername = `price-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        const cookie = await signedSessionCookie(sessionToken);
+        const enterApi = await createEnterCommunityApi();
+        const createResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    name: "price-floor-test",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-4.1-mini",
+                    bearerToken: "sk_saved_token",
+                    promptTextPrice: 0,
+                }),
+            }),
+        );
+        expect(createResponse.status).toBe(200);
+        const created = (await createResponse.json()) as {
+            id: string;
+            promptTextPrice: number;
+        };
+        expect(created.promptTextPrice).toBe(0);
+
+        const updatePrice = (price: number) =>
+            fetchEnterApi(
+                enterApi,
+                new Request(
+                    `http://localhost:3000/api/community-endpoints/${created.id}/update`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            Cookie: cookie,
+                        },
+                        body: JSON.stringify({ promptTextPrice: price }),
+                    },
+                ),
+            );
+
+        const minimumResponse = await updatePrice(
+            MIN_COMMUNITY_PRICE_PER_TOKEN,
+        );
+        expect(minimumResponse.status).toBe(200);
+        await expect(minimumResponse.json()).resolves.toMatchObject({
+            promptTextPrice: MIN_COMMUNITY_PRICE_PER_TOKEN,
+        });
+
+        const belowMinimumResponse = await updatePrice(
+            MIN_COMMUNITY_PRICE_PER_TOKEN / 10,
+        );
+        expect(belowMinimumResponse.status).toBe(400);
+        expect(await belowMinimumResponse.text()).toContain(
+            `${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens`,
+        );
+
+        const negativeResponse = await updatePrice(
+            -MIN_COMMUNITY_PRICE_PER_TOKEN,
+        );
+        expect(negativeResponse.status).toBe(400);
     },
 );
 

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -8,6 +8,10 @@ import {
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
+// Zero is free; positive owner-declared prices start at this floor.
+export const MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS = 0.000001;
+export const MIN_COMMUNITY_PRICE_PER_TOKEN =
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
 const BEARER_PREFIX = /^Bearer(?:\s+|$)/i;
 
 const COMMUNITY_PRICE_FIELD_BY_USAGE_TYPE = {


### PR DESCRIPTION
## What

- Adds one shared positive price floor: `0.000001` Pollen per 1M tokens (`1e-12` per token).
- Keeps `0` and blank dashboard prices explicitly free.
- Enforces the floor in the API and dashboard, so CLI and direct callers receive the same server validation.
- Adds API and form boundary tests for free, exact-floor, below-floor, negative, and malformed values.

## Why

Prevents misleading non-zero prices that are effectively too small to be meaningful while preserving free community models.

## Impact

No migration or repricing. Existing rows are unchanged; the floor applies when a price is created or updated.

## Checks

- `npx vitest run src/community-endpoints.test.ts`
- `npx vitest run test/community-endpoint-price-input.test.ts`
- Enter and Gen typechecks
- Biome formatting and diff checks