### PR TITLE
docs: embed polli CLI demo video in Scalar docs + README

### DIFF
--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -171,9 +171,7 @@ const DOC_TAG_NAV_ICON_HTML: Record<string, string> = Object.fromEntries(
 
 const BYOP_DOCS = BYOP_MD.trim();
 
-const CLI_DOCS = CLI_README.replace(/^# .*\n+/, "")
-    .replace(/^https:\/\/github\.com\/user-attachments\/assets\/[^\n]+\n+/m, "")
-    .trim();
+const CLI_DOCS = CLI_README.replace(/^# .*\n+/, "").trim();
 
 const MCP_DOCS = MCP_README.replace(/^# .*\n+/, "").trim();
 

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -4,7 +4,9 @@ The Pollinations CLI — for humans, AI agents, and everything in between.
 
 Generate text, images, audio, video from the terminal. Backed by the [Pollinations API](https://gen.pollinations.ai).
 
-https://github.com/user-attachments/assets/6b200d95-d734-469c-9fe5-3e63549778fe
+<video src="https://github.com/user-attachments/assets/6b200d95-d734-469c-9fe5-3e63549778fe" controls muted loop playsinline width="720">
+  <a href="https://github.com/user-attachments/assets/6b200d95-d734-469c-9fe5-3e63549778fe">▶️ Watch the demo</a>
+</video>
 
 ```bash
 npx @pollinations/cli gen image "a cat in space" --output cat.png

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -4,8 +4,8 @@ The Pollinations CLI — for humans, AI agents, and everything in between.
 
 Generate text, images, audio, video from the terminal. Backed by the [Pollinations API](https://gen.pollinations.ai).
 
-<video src="https://github.com/user-attachments/assets/6b200d95-d734-469c-9fe5-3e63549778fe" controls muted loop playsinline width="720">
-  <a href="https://github.com/user-attachments/assets/6b200d95-d734-469c-9fe5-3e63549778fe">▶️ Watch the demo</a>
+<video src="https://github.com/user-attachments/assets/c3ff5c45-672c-4c45-9027-7743d32f9785" controls muted loop playsinline width="720">
+  <a href="https://github.com/user-attachments/assets/c3ff5c45-672c-4c45-9027-7743d32f9785">▶️ Watch the demo</a>
 </video>
 
 ```bash


### PR DESCRIPTION
Embeds the polli CLI demo video in the Scalar API docs (it was stripped before) while keeping it working on the GitHub README.

- README: bare attachment URL → `<video>` tag with a fallback `<a>` inside it. Player renders on GitHub + Scalar; the link only surfaces where the tag is stripped (e.g. npm).
- `docs.ts`: dropped the `CLI_DOCS` strip that removed the video line, so it flows into the Scalar CLI tag (`/docs#tag/cli`) and the `/docs/guides/cli` page.

**Verified:** GitHub Markdown API preserves the `<video>` tag; `marked` keeps the block intact for the guide page.

**Follow-up (needs a manual upload):** the current asset is `.mov` (QuickTime) — plays only in Safari, broken in Chrome/Firefox. A remuxed web MP4 (H.264/AAC, faststart, no quality loss) is ready. Drag it into a comment here to get a fresh `user-attachments` URL and I'll swap it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)