### PR TITLE
fix: split Veo pricing by resolution

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -532,6 +532,7 @@ This is acceptable. What's NOT acceptable is silently dropping a separately-bill
 - [ ] No 5xx in [error-path matrix](#76-error-paths--every-malformed-request-must-return-4xx-never-opaque-5xx)
 - [ ] Burst test passed at expected production concurrency
 - [ ] PR description notes any docs/upstream discrepancies found and any bundled-modality choices
+- [ ] `APIDOCS.md` is untouched. It is regenerated from the live OpenAPI schema after production deploy; update source schemas/routes instead.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,8 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - Don't modify test files to make tests pass — fix the code.
 - Run `npm run decrypt-vars` before tests in enter.pollinations.ai.
 - Test API keys in `enter.pollinations.ai/.testingtokens`.
-- Request PR reviews by including lowercase `polly` in a PR comment.
+- Before model changes, read and follow `.claude/skills/model-management/SKILL.md`.
+- Don't request PR reviews or comment `polly` unless the user explicitly asks.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,9 +160,10 @@ npx vitest run test/file.test.ts
 - Frontend → `pollinations.ai/`; image/text/gen gateway → `gen.pollinations.ai/`; image GPU backends → `image.pollinations.ai/`; SDK/React → `packages/sdk/`; MCP → `packages/mcp/`.
 - Text models: add config in `gen.pollinations.ai/src/text/configs/modelConfigs.ts`, entry in `gen.pollinations.ai/src/text/availableModels.ts`. Provider configs (Portkey/Bedrock/OpenAI-compat) in `gen.pollinations.ai/src/text/configs/providerConfigs.ts`.
 - Image models: handler in `gen.pollinations.ai/src/image/`, register in `shared/registry/image.ts`.
-- Update API docs + model registry for new models.
+- Update the model registry and OpenAPI source schemas/routes for new models.
 - API changes: maintain backward compatibility; document; handle errors.
-- API docs: strictly technical, no marketing; link dynamic endpoints (e.g. `/models`) vs hardcoded lists; no internal impl/env vars; minimal examples for both simplified and OpenAI-compatible endpoints.
+- Never edit or regenerate `APIDOCS.md` in a feature PR. It is generated from the live OpenAPI schema after a successful production deploy by `.github/workflows/docs-regenerate-api-reference.yml`, which opens a separate docs PR. Make documentation changes in the source schemas, routes, introductions, or recipes instead.
+- API docs source text: strictly technical, no marketing; link dynamic endpoints (e.g. `/models`) vs hardcoded lists; no internal impl/env vars; minimal examples for both simplified and OpenAI-compatible endpoints.
 - Security: never expose keys/secrets; use env vars; validate input.
 - Temp scratch files go in `temp/` clearly labeled.
 - Shrinking large snapshots: video/image snapshots can be 10–30 MB because stream chunks store raw binary as text (`TextDecoder` output in `vcr.ts:289`). To shrink: replace `response.body.data` array with one tiny chunk `[{"data": "<minimal-bytes>", "delay": 1}]`. For mp4, a valid 20-byte ftyp box is `\x00\x00\x00\x14ftypisom\x00\x00\x00\x00isom` (use `bytes.decode('latin-1')` in Python). Tests only check headers/status, not media content.

--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -446,13 +446,13 @@ Browse all available models and their capabilities at [`/image/models`](https://
 | Param | In | Type | Description |
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text description of the image to generate |
-| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
-| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
-| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
+| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
+| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
+| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
 | `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
 | `quality` | `query` | `"low"` \| `"medium"` \| `"high"` \| `"hd"` | Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`. · default: `"medium"` |
-| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
+| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
 | `transparent` | `query` | `boolean` | Generate image with transparent background. Only supported by `gptimage` and `gptimage-large`. · default: `false` |
 
 <sub>`*` = required parameter</sub>
@@ -536,7 +536,7 @@ curl -X POST "https://gen.pollinations.ai/v1/images/edits" \
 
 Generate a video from a text prompt. Returns MP4.
 
-**Available models:** `veo`, `veo-1080p`, `seedance-pro`, `seedance-2.0`, `wan`, `wan-fast`, `wan-pro`, `wan-pro-1080p`, `grok-video-pro`, `ltx-2`, `p-video-720p`, `p-video-1080p`, `nova-reel`.
+**Available models:** `veo`, `seedance-pro`, `seedance-2.0`, `wan`, `wan-fast`, `wan-pro`, `wan-pro-1080p`, `grok-video-pro`, `ltx-2`, `p-video-720p`, `p-video-1080p`, `nova-reel`.
 
 Use `duration` to set video length, `aspectRatio` for orientation, and `audio` where the selected model supports audio output.
 
@@ -549,15 +549,15 @@ Browse all available models and their `video_capabilities` at [`/image/models`](
 | Param | In | Type | Description |
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text description of the video to generate |
-| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
-| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
-| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
+| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
+| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
+| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
 | `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
-| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
-| `duration` | `query` | `integer` | Video duration in seconds. Only applies to video models. `veo` and `veo-1080p`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6). · range: `1…120` |
+| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
+| `duration` | `query` | `integer` | Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6). · range: `1…120` |
 | `aspectRatio` | `query` | `string` | Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by width/height. |
-| `audio` | `query` | `boolean` | Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo` and `veo-1080p`, set to `true` to enable audio. · default: `false` |
+| `audio` | `query` | `boolean` | Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo`, set to `true` to enable audio. · default: `false` |
 
 <sub>`*` = required parameter</sub>
 

--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -446,13 +446,13 @@ Browse all available models and their capabilities at [`/image/models`](https://
 | Param | In | Type | Description |
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text description of the image to generate |
-| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
-| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
-| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
+| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
+| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
+| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
 | `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
 | `quality` | `query` | `"low"` \| `"medium"` \| `"high"` \| `"hd"` | Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`. · default: `"medium"` |
-| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
+| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
 | `transparent` | `query` | `boolean` | Generate image with transparent background. Only supported by `gptimage` and `gptimage-large`. · default: `false` |
 
 <sub>`*` = required parameter</sub>
@@ -536,7 +536,7 @@ curl -X POST "https://gen.pollinations.ai/v1/images/edits" \
 
 Generate a video from a text prompt. Returns MP4.
 
-**Available models:** `veo`, `seedance-pro`, `seedance-2.0`, `wan`, `wan-fast`, `wan-pro`, `wan-pro-1080p`, `grok-video-pro`, `ltx-2`, `p-video-720p`, `p-video-1080p`, `nova-reel`.
+**Available models:** `veo`, `veo-1080p`, `seedance-pro`, `seedance-2.0`, `wan`, `wan-fast`, `wan-pro`, `wan-pro-1080p`, `grok-video-pro`, `ltx-2`, `p-video-720p`, `p-video-1080p`, `nova-reel`.
 
 Use `duration` to set video length, `aspectRatio` for orientation, and `audio` where the selected model supports audio output.
 
@@ -549,15 +549,15 @@ Browse all available models and their `video_capabilities` at [`/image/models`](
 | Param | In | Type | Description |
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text description of the video to generate |
-| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
-| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
-| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p). · default: `1024` |
+| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
+| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
+| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
 | `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
-| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
-| `duration` | `query` | `integer` | Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6). · range: `1…120` |
+| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
+| `duration` | `query` | `integer` | Video duration in seconds. Only applies to video models. `veo` and `veo-1080p`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6). · range: `1…120` |
 | `aspectRatio` | `query` | `string` | Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by width/height. |
-| `audio` | `query` | `boolean` | Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo`, set to `true` to enable audio. · default: `false` |
+| `audio` | `query` | `boolean` | Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo` and `veo-1080p`, set to `true` to enable audio. · default: `false` |
 
 <sub>`*` = required parameter</sub>
 

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1268,10 +1268,22 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "veo": {
     "cost": {
-      "completionVideoSeconds": 0.15,
+      "completionAudioSeconds": 0.02,
+      "completionVideoSeconds": 0.08,
     },
     "price": {
-      "completionVideoSeconds": 0.15,
+      "completionAudioSeconds": 0.02,
+      "completionVideoSeconds": 0.08,
+    },
+  },
+  "veo-1080p": {
+    "cost": {
+      "completionAudioSeconds": 0.02,
+      "completionVideoSeconds": 0.1,
+    },
+    "price": {
+      "completionAudioSeconds": 0.02,
+      "completionVideoSeconds": 0.1,
     },
   },
   "wan": {

--- a/gen.pollinations.ai/src/image/createAndReturnVideos.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnVideos.ts
@@ -14,6 +14,7 @@ import {
 import { callSeedanceProAPI } from "./models/seedanceReplicateVideoModel.ts";
 import { callSeedanceV2API } from "./models/seedanceV2VideoModel.ts";
 import {
+    callVeo1080pAPI,
     callVeoAPI,
     type VideoGenerationResult,
 } from "./models/veoVideoModel.ts";
@@ -42,6 +43,9 @@ export async function createAndReturnVideo(
     switch (safeParams.model) {
         case "veo":
             result = await callVeoAPI(prompt, safeParams);
+            break;
+        case "veo-1080p":
+            result = await callVeo1080pAPI(prompt, safeParams);
             break;
         case "seedance-pro":
             result = await callSeedanceProAPI(prompt, safeParams);

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -47,7 +47,7 @@ export interface VideoGenerationResult {
         usage: {
             completionVideoSeconds?: number; // For Veo, Wan (billed by seconds)
             completionVideoTokens?: number; // For Seedance (billed by tokens)
-            completionAudioSeconds?: number; // For Wan audio (billed by seconds)
+            completionAudioSeconds?: number; // Output audio billed by seconds
             totalTokenCount?: number;
         };
     };
@@ -71,12 +71,18 @@ interface VeoOperationResponse {
 }
 
 /**
- * Generates a video using Veo 3.1 Fast API
+ * Generates a video using a fixed-resolution Veo 3.1 Fast tier.
+ * Resolution is selected by model name, not inferred from dimensions, so the
+ * upstream request always matches the registry rate.
+ * @param {"720p" | "1080p"} resolution - Fixed upstream resolution
+ * @param {"veo" | "veo-1080p"} actualModel - Registry model used for billing
  * @param {string} prompt - The prompt for video generation
  * @param {ImageParams} safeParams - The parameters for video generation
  * @returns {Promise<VideoGenerationResult>}
  */
-export const callVeoAPI = async (
+const generateVeoVideo = async (
+    resolution: "720p" | "1080p",
+    actualModel: "veo" | "veo-1080p",
     prompt: string,
     safeParams: ImageParams,
 ): Promise<VideoGenerationResult> => {
@@ -102,18 +108,11 @@ export const callVeoAPI = async (
     // Audio is disabled by default - user must explicitly pass audio=true to enable
     const generateAudio = safeParams.audio === true;
 
-    // Calculate resolution and aspect ratio from width/height or aspectRatio
-    const { aspectRatio, resolution: resolutionUpper } =
-        calculateVideoResolution({
-            width: safeParams.width,
-            height: safeParams.height,
-            aspectRatio: safeParams.aspectRatio,
-            defaultResolution: "720P",
-        });
-    const resolution = resolutionUpper.toLowerCase() as
-        | "480p"
-        | "720p"
-        | "1080p";
+    const { aspectRatio } = calculateVideoResolution({
+        width: safeParams.width,
+        height: safeParams.height,
+        aspectRatio: safeParams.aspectRatio,
+    });
 
     // Check for input image (image-to-video)
     const hasImage = safeParams.image && safeParams.image.length > 0;
@@ -224,13 +223,30 @@ export const callVeoAPI = async (
         mimeType: "video/mp4",
         durationSeconds: durationSeconds,
         trackingData: {
-            actualModel: "veo",
+            actualModel,
             usage: {
                 completionVideoSeconds: durationSeconds,
+                ...(generateAudio
+                    ? { completionAudioSeconds: durationSeconds }
+                    : {}),
             },
         },
     };
 };
+
+/** Veo 3.1 Fast at 720p ($0.08/s video + $0.02/s audio when enabled). */
+export const callVeoAPI = (
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<VideoGenerationResult> =>
+    generateVeoVideo("720p", "veo", prompt, safeParams);
+
+/** Veo 3.1 Fast at 1080p ($0.10/s video + $0.02/s audio when enabled). */
+export const callVeo1080pAPI = (
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<VideoGenerationResult> =>
+    generateVeoVideo("1080p", "veo-1080p", prompt, safeParams);
 
 /**
  * Poll Veo operation until completion using fetchPredictOperation

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -28,11 +28,11 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance, seedance-pro, wan, nova-reel. See /image/models for full list.",
+                "Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list.",
         }),
     width: z.coerce.number().int().nonnegative().optional().default(1024).meta({
         description:
-            "Width in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p).",
+            "Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution.",
     }),
     height: z.coerce
         .number()
@@ -42,7 +42,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .default(1024)
         .meta({
             description:
-                "Height in pixels. For images, exact pixels. For video models, mapped to nearest resolution tier (480p/720p/1080p).",
+                "Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution.",
         }),
     seed: z.coerce
         .number()
@@ -89,7 +89,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
+                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:
@@ -99,7 +99,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     // Video-specific params
     duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:
-            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
+            "Video duration in seconds. Only applies to video models. `veo` and `veo-1080p`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
     }),
     aspectRatio: z.string().optional().meta({
         description:
@@ -107,7 +107,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     }),
     audio: z.coerce.boolean().optional().default(false).meta({
         description:
-            "Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo`, set to `true` to enable audio.",
+            "Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo` and `veo-1080p`, set to `true` to enable audio.",
     }),
 });
 

--- a/gen.pollinations.ai/test/image/veoVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/veoVideoModel.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { syncImageEnv } from "../../src/image/env.ts";
+import {
+    callVeo1080pAPI,
+    callVeoAPI,
+} from "../../src/image/models/veoVideoModel.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
+
+const baseParams: ImageParams = {
+    model: "veo",
+    width: 1280,
+    height: 720,
+    dimensionsExplicit: true,
+    seed: 42,
+    safe: false,
+    quality: "medium",
+    image: [],
+    transparent: false,
+    reasoning: "balanced",
+    audio: true,
+    duration: 4,
+};
+
+function mockVeoFetch(requests: Array<Record<string, unknown>>) {
+    return vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (url, init) => {
+            const href = typeof url === "string" ? url : url.toString();
+            if (href.endsWith(":predictLongRunning")) {
+                requests.push(
+                    JSON.parse(init?.body as string) as Record<string, unknown>,
+                );
+                return Response.json({
+                    name: "projects/test/locations/us-central1/publishers/google/models/veo-3.1-fast-generate-001/operations/test-operation",
+                });
+            }
+            if (href.endsWith(":fetchPredictOperation")) {
+                return Response.json({
+                    done: true,
+                    response: {
+                        videos: [
+                            {
+                                bytesBase64Encoded:
+                                    Buffer.from("test-video").toString(
+                                        "base64",
+                                    ),
+                                mimeType: "video/mp4",
+                            },
+                        ],
+                    },
+                });
+            }
+            return new Response("unexpected URL", { status: 404 });
+        });
+}
+
+function setGoogleEnv() {
+    syncImageEnv({ GOOGLE_PROJECT_ID: "test-project" } as CloudflareBindings, [
+        "GOOGLE_PROJECT_ID",
+    ]);
+    vi.spyOn(googleCloudAuth, "getAccessToken").mockResolvedValue("test-token");
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("veoVideoModel fixed-resolution tiers", () => {
+    it("locks veo to 720p and omits audio usage when disabled", async () => {
+        setGoogleEnv();
+        const requests: Array<Record<string, unknown>> = [];
+        mockVeoFetch(requests);
+
+        const result = await callVeoAPI("a calm ocean at sunrise", {
+            ...baseParams,
+            width: 1920,
+            height: 1080,
+            audio: false,
+        });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0].parameters).toMatchObject({
+            resolution: "720p",
+            generateAudio: false,
+        });
+        expect(result.trackingData).toEqual({
+            actualModel: "veo",
+            usage: { completionVideoSeconds: 4 },
+        });
+    });
+
+    it("locks veo-1080p to 1080p and reports enabled audio", async () => {
+        setGoogleEnv();
+        const requests: Array<Record<string, unknown>> = [];
+        mockVeoFetch(requests);
+
+        const result = await callVeo1080pAPI("a calm ocean at sunrise", {
+            ...baseParams,
+            model: "veo-1080p",
+            width: 1280,
+            height: 720,
+        });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0].parameters).toMatchObject({
+            resolution: "1080p",
+            generateAudio: true,
+        });
+        expect(result.trackingData).toEqual({
+            actualModel: "veo-1080p",
+            usage: {
+                completionVideoSeconds: 4,
+                completionAudioSeconds: 4,
+            },
+        });
+    });
+});

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -360,7 +360,7 @@ export const IMAGE_SERVICES = {
             completionAudioSeconds: 0.02, // per sec when audio is enabled
         },
         title: "Veo 3.1 Fast 720p",
-        description: "Veo 3.1 Fast - Fast text-to-video with audio (720p)",
+        description: "Fast text-to-video with optional audio at 720p",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
@@ -380,7 +380,7 @@ export const IMAGE_SERVICES = {
             completionAudioSeconds: 0.02, // per sec when audio is enabled
         },
         title: "Veo 3.1 Fast 1080p",
-        description: "Veo 3.1 Fast - Fast text-to-video with audio (1080p)",
+        description: "Fast text-to-video with optional audio at 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -347,7 +347,7 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
     },
     "veo": {
-        aliases: ["veo-3.1-fast", "video"],
+        aliases: ["veo-3.1-fast", "veo-720p", "video"],
         modelId: "veo",
         provider: "google",
         brand: "Google",
@@ -356,10 +356,31 @@ export const IMAGE_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            completionVideoSeconds: 0.15, // per sec
+            completionVideoSeconds: 0.08, // per sec (720p video)
+            completionAudioSeconds: 0.02, // per sec when audio is enabled
         },
-        title: "Veo 3.1 Fast",
-        description: "Veo 3.1 Fast - Fast text-to-video with audio (preview)",
+        title: "Veo 3.1 Fast 720p",
+        description: "Veo 3.1 Fast - Fast text-to-video with audio (720p)",
+        inputModalities: ["text", "image"],
+        outputModalities: ["video"],
+        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        maxReferenceImages: 2, // Video keyframe slots: start + end.
+    },
+    "veo-1080p": {
+        aliases: ["veo-3.1-fast-1080p", "veo-1080"],
+        modelId: "veo-1080p",
+        provider: "google",
+        brand: "Google",
+        category: "video",
+        addedDate: new Date("2026-07-15").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            completionVideoSeconds: 0.1, // per sec (1080p video)
+            completionAudioSeconds: 0.02, // per sec when audio is enabled
+        },
+        title: "Veo 3.1 Fast 1080p",
+        description: "Veo 3.1 Fast - Fast text-to-video with audio (1080p)",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],


### PR DESCRIPTION
- Splits Veo 3.1 Fast into fixed `veo` (720p) and `veo-1080p` tiers.
- Meters official Google rates exactly: $0.08/s or $0.10/s video plus $0.02/s only when audio is enabled.
- Locks upstream resolution to the selected model and records audio usage only for audio-enabled output.
- Uses capability-only model descriptions and updates OpenAPI source schemas without touching generated `APIDOCS.md`.
- Requires the model-management skill for model changes and makes automated review requests opt-in.
- Validated with Biome, TypeScript, docs checks, 281 focused tests, and real local-token E2E generations: 720p audio $0.40, 1080p audio $0.48, and 720p silent $0.32.