### PR TITLE
feat: promote GPT-5.6 models

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -25,6 +25,18 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
+        date: "2026-07-15",
+        dateLabel: "Limited time",
+        emoji: "☀️",
+        title: "GPT-5.6 launch promotion",
+        description:
+            "Try GPT-5.6 Sol, Terra, and Luna at half the provider price for a limited time.",
+        details: [
+            "Per 1M input/output tokens: Sol 2.50/15 Pollen, Terra 1.25/7.50 Pollen, Luna 0.50/3 Pollen.",
+            "Choose a GPT-5.6 model from the [Models tab](/models) and start building.",
+        ],
+    },
+    {
         date: "2026-06-30",
         dateLabel: "Now live",
         emoji: "🎯",

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -388,10 +388,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000001,
     },
     "price": {
-      "completionTextTokens": 0.0000045,
-      "promptCacheWriteTokens": 0.0000009375,
-      "promptCachedTokens": 0.000000075,
-      "promptTextTokens": 0.00000075,
+      "completionTextTokens": 0.000003,
+      "promptCacheWriteTokens": 0.000000625,
+      "promptCachedTokens": 0.00000005,
+      "promptTextTokens": 0.0000005,
     },
   },
   "gpt-5.6-sol": {
@@ -402,10 +402,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000005,
     },
     "price": {
-      "completionTextTokens": 0.0000225,
-      "promptCacheWriteTokens": 0.0000046875,
-      "promptCachedTokens": 0.000000375,
-      "promptTextTokens": 0.00000375,
+      "completionTextTokens": 0.000015,
+      "promptCacheWriteTokens": 0.000003125,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.0000025,
     },
   },
   "gpt-5.6-terra": {
@@ -416,10 +416,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000025,
     },
     "price": {
-      "completionTextTokens": 0.00001125,
-      "promptCacheWriteTokens": 0.00000234375,
-      "promptCachedTokens": 0.0000001875,
-      "promptTextTokens": 0.000001875,
+      "completionTextTokens": 0.0000075,
+      "promptCacheWriteTokens": 0.0000015625,
+      "promptCachedTokens": 0.000000125,
+      "promptTextTokens": 0.00000125,
     },
   },
   "gpt-image-2": {
@@ -430,10 +430,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000005,
     },
     "price": {
-      "completionImageTokens": 0.00003,
-      "promptCachedTokens": 0.00000125,
-      "promptImageTokens": 0.000008,
-      "promptTextTokens": 0.000005,
+      "completionImageTokens": 0.0000225,
+      "promptCachedTokens": 0.0000009375,
+      "promptImageTokens": 0.000006,
+      "promptTextTokens": 0.00000375,
     },
   },
   "gpt-realtime-2": {

--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -114,7 +114,7 @@ test("GPT-5.5 is available without paid-only gating", () => {
     expect(definition.paidOnly).toBeUndefined();
 });
 
-test("GPT-5.6 ChatGPT models are quest-eligible at the Azure multiplier", () => {
+test("GPT-5.6 models are quest-eligible at the promotional multiplier", () => {
     for (const model of [
         "gpt-5.6-sol",
         "gpt-5.6-terra",
@@ -124,7 +124,7 @@ test("GPT-5.6 ChatGPT models are quest-eligible at the Azure multiplier", () => 
 
         expect(definition.provider).toBe("azure");
         expect(definition.paidOnly).toBeUndefined();
-        expect(definition.priceMultiplier).toBe(0.75);
+        expect(definition.priceMultiplier).toBe(0.5);
     }
 });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -153,7 +153,7 @@ export const TEXT_SERVICES = {
         brand: "OpenAI",
         category: "text",
         addedDate: new Date("2026-07-10").getTime(),
-        priceMultiplier: 0.75,
+        priceMultiplier: 0.5,
         cost: {
             promptTextTokens: perMillion(5.0),
             promptCachedTokens: perMillion(0.5),
@@ -177,7 +177,7 @@ export const TEXT_SERVICES = {
         brand: "OpenAI",
         category: "text",
         addedDate: new Date("2026-07-10").getTime(),
-        priceMultiplier: 0.75,
+        priceMultiplier: 0.5,
         cost: {
             promptTextTokens: perMillion(2.5),
             promptCachedTokens: perMillion(0.25),
@@ -201,7 +201,7 @@ export const TEXT_SERVICES = {
         brand: "OpenAI",
         category: "text",
         addedDate: new Date("2026-07-10").getTime(),
-        priceMultiplier: 0.75,
+        priceMultiplier: 0.5,
         cost: {
             promptTextTokens: perMillion(1.0),
             promptCachedTokens: perMillion(0.1),


### PR DESCRIPTION
- Sets GPT-5.6 Sol, Terra, and Luna pricing to 0.5× provider cost.
- Adds a limited-time Enter dashboard announcement with the promotional rates.
- Updates pricing assertions and effective-price snapshots.
- Validates all three models with live local requests and focused billing tests.