### PR TITLE
fix: harden community endpoint URL validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2026-07-16
+
+- Hardened community endpoint URL validation to reject link-local, private IPv6, IPv4-mapped loopback, and unspecified IP hosts before proxying upstream requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## 2026-07-16
-
-- Hardened community endpoint URL validation to reject link-local, private IPv6, IPv4-mapped loopback, and unspecified IP hosts before proxying upstream requests.

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -235,6 +235,24 @@ describe("community endpoint helpers", () => {
         expect(() =>
             normalizeCommunityEndpointBaseUrl("https://localhost/v1"),
         ).toThrow("Endpoint URL cannot target a private host");
+        for (const hostname of [
+            "0.0.0.0",
+            "10.0.0.1",
+            "127.0.0.1",
+            "169.254.169.254",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.1.1",
+            "[::1]",
+            "[::ffff:127.0.0.1]",
+            "[fc00::1]",
+            "[fd00::1]",
+            "[fe80::1]",
+        ]) {
+            expect(() =>
+                normalizeCommunityEndpointBaseUrl(`https://${hostname}/v1`),
+            ).toThrow("Endpoint URL cannot target a private host");
+        }
     });
 
     it("uses the community endpoint description as the model title", () => {

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -243,11 +243,13 @@ describe("community endpoint helpers", () => {
             "172.16.0.1",
             "172.31.255.255",
             "192.168.1.1",
+            "[::]",
             "[::1]",
             "[::ffff:127.0.0.1]",
             "[fc00::1]",
             "[fd00::1]",
             "[fe80::1]",
+            "[fe8f::1]",
         ]) {
             expect(() =>
                 normalizeCommunityEndpointBaseUrl(`https://${hostname}/v1`),

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -219,16 +219,41 @@ export function communityModelDefinition(
 }
 
 function isBlockedHostname(hostname: string): boolean {
-    const host = hostname.toLowerCase();
+    const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
     if (host === "localhost" || host.endsWith(".localhost")) return true;
     if (host.endsWith(".local")) return true;
-    if (host === "::1" || host === "[::1]") return true;
-    if (host.startsWith("127.") || host.startsWith("10.")) return true;
-    if (host.startsWith("192.168.")) return true;
-    const match172 = host.match(/^172\.(\d+)\./);
-    if (match172) {
-        const second = Number(match172[1]);
-        if (second >= 16 && second <= 31) return true;
+    if (host === "::1") return true;
+    if (host === "0.0.0.0") return true;
+
+    const mappedIpv4 = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    const ipv4 =
+        host.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1] ??
+        (mappedIpv4
+            ? [
+                  Number.parseInt(mappedIpv4[1], 16) >> 8,
+                  Number.parseInt(mappedIpv4[1], 16) & 255,
+                  Number.parseInt(mappedIpv4[2], 16) >> 8,
+                  Number.parseInt(mappedIpv4[2], 16) & 255,
+              ].join(".")
+            : host);
+    const octets = ipv4.split(".").map(Number);
+    if (
+        octets.length === 4 &&
+        octets.every(
+            (octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255,
+        )
+    ) {
+        const [first, second] = octets;
+        if (first === 10 || first === 127) return true;
+        if (first === 169 && second === 254) return true;
+        if (first === 172 && second >= 16 && second <= 31) return true;
+        if (first === 192 && second === 168) return true;
     }
+
+    if (host.includes(":")) {
+        if (host.startsWith("fc") || host.startsWith("fd")) return true;
+        if (host.startsWith("fe80:")) return true;
+    }
+
     return false;
 }

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -222,7 +222,7 @@ function isBlockedHostname(hostname: string): boolean {
     const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
     if (host === "localhost" || host.endsWith(".localhost")) return true;
     if (host.endsWith(".local")) return true;
-    if (host === "::1") return true;
+    if (host === "::" || host === "::1") return true;
     if (host === "0.0.0.0") return true;
 
     const mappedIpv4 = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
@@ -252,7 +252,7 @@ function isBlockedHostname(hostname: string): boolean {
 
     if (host.includes(":")) {
         if (host.startsWith("fc") || host.startsWith("fd")) return true;
-        if (host.startsWith("fe80:")) return true;
+        if (/^fe8[0-9a-f]:/.test(host)) return true;
     }
 
     return false;


### PR DESCRIPTION
## Summary

- Harden community endpoint URL validation against private/link-local upstream hosts.
- Block cloud metadata/link-local IPv4 (`169.254.0.0/16`), unspecified IPv4, private IPv6, IPv6 link-local, and canonicalized IPv4-mapped IPv6 loopback/private hosts.
- Add regression coverage for blocked host forms in the existing community endpoint test file.

## Root cause

Community endpoint registration normalized URLs and rejected obvious private hosts, but the host denylist did not cover link-local/cloud metadata addresses or several IPv6/private host encodings. A user-configured endpoint could therefore point the server-side probe/proxy path at internal metadata or private network hosts.

## Validation

- `npx --no-install biome check --write shared/community-endpoints.ts gen.pollinations.ai/src/community-endpoints.test.ts`
- `npx --no-install vitest run src/community-endpoints.test.ts --testNamePattern="normalizes OpenAI-compatible endpoint URLs"`
- `npx --no-install vitest run src/community-endpoints.test.ts` — 20/20 passed
