### PR TITLE
feat: add GPT Realtime 2.1

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -454,6 +454,24 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000004,
     },
   },
+  "gpt-realtime-2.1": {
+    "cost": {
+      "completionAudioTokens": 0.000064,
+      "completionTextTokens": 0.000024,
+      "promptAudioTokens": 0.000032,
+      "promptCachedTokens": 0.0000004,
+      "promptImageTokens": 0.000005,
+      "promptTextTokens": 0.000004,
+    },
+    "price": {
+      "completionAudioTokens": 0.000064,
+      "completionTextTokens": 0.000024,
+      "promptAudioTokens": 0.000032,
+      "promptCachedTokens": 0.0000004,
+      "promptImageTokens": 0.000005,
+      "promptTextTokens": 0.000004,
+    },
+  },
   "gptimage": {
     "cost": {
       "completionImageTokens": 0.000008,

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -10,6 +10,7 @@ import {
     getModel3dModelsInfo,
     getRealtimeModelsInfo,
 } from "@shared/registry/model-info.ts";
+import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -276,7 +277,7 @@ const REALTIME_DOCS = [
     "",
     "| Endpoint | Description |",
     "|----------|-------------|",
-    "| `GET /v1/realtime` | WebSocket Realtime session (`model=gpt-realtime-2`) |",
+    `| \`GET /v1/realtime\` | WebSocket Realtime session (\`model=${DEFAULT_REALTIME_MODEL}\`) |`,
     "",
     "Requires an API key with positive balance. Server clients can use `Authorization: Bearer <key>`; browser WebSocket clients can use `?key=pk_...`.",
     "",
@@ -289,7 +290,7 @@ const REALTIME_DOCS = [
     "",
     "// Server: Bearer auth. Browser: append `&key=pk_...` instead (headers aren't settable).",
     "const ws = new WebSocket(",
-    '    "wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2",',
+    `    "wss://gen.pollinations.ai/v1/realtime?model=${DEFAULT_REALTIME_MODEL}",`,
     // biome-ignore lint/suspicious/noTemplateCurlyInString: literal JS snippet shown in docs
     "    { headers: { Authorization: `Bearer ${process.env.POLLINATIONS_API_KEY}` } },",
     ");",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -36,6 +36,10 @@ import {
     getModel3dModelIds,
 } from "@shared/registry/model3d.ts";
 import {
+    DEFAULT_REALTIME_MODEL,
+    REALTIME_MODEL_NAMES,
+} from "@shared/registry/realtime.ts";
+import {
     type CreateChatCompletionRequest,
     CreateChatCompletionRequestSchema,
     type CreateChatCompletionResponse,
@@ -559,10 +563,10 @@ export const proxyRoutes = new Hono<Env>()
             description: [
                 "OpenAI-compatible Realtime WebSocket proxy.",
                 "",
-                "Connect with `wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2` and send/receive Realtime JSON events over the socket.",
+                `Connect with \`wss://gen.pollinations.ai/v1/realtime?model=${DEFAULT_REALTIME_MODEL}\` and send/receive Realtime JSON events over the socket.`,
                 "Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.",
                 "",
-                "**Model:** `gpt-realtime-2`.",
+                `**Models:** ${REALTIME_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
                 "",
                 "**Billing:** requires a positive balance. Gen proxies the WebSocket, aggregates observed `response.done` usage, and deducts one session total when the socket closes. Input transcription sessions are not supported yet.",
             ].join("\n"),

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -11,7 +11,6 @@ import {
     truncateIpToSubnet,
 } from "@shared/client-ip.ts";
 import { sendToTinybird } from "@shared/events.ts";
-import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import {
     type CostDefinition,
     calculateCostWithDefinition,
@@ -38,15 +37,11 @@ import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
 
-// Azure OpenAI realtime endpoint. The gpt-realtime-2 deployment lives on the
-// Sweden Central myceli resource (same resource as the gpt-audio models). The
-// realtime WebSocket path mirrors OpenAI's: /openai/v1/realtime?model=<deployment>.
+// Azure OpenAI realtime endpoint. The deployments live on the Sweden Central
+// myceli resource (same resource as the gpt-audio models). The realtime
+// WebSocket path mirrors OpenAI's: /openai/v1/realtime?model=<deployment>.
 const AZURE_REALTIME_WEBSOCKET_URL =
-    "https://myceli-prod-swedencentral.cognitiveservices.azure.com/openai/v1/realtime";
-// Azure deployment name for the realtime model (set when deploying via the
-// Azure CLI). Matches DEFAULT_REALTIME_MODEL here, but kept separate because
-// Azure deployment names are independent of the public model id.
-const AZURE_REALTIME_DEPLOYMENT = "gpt-realtime-2";
+    "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime";
 const CREDENTIAL_QUERY_PARAMS = new Set([
     "access_token",
     "api_key",
@@ -110,17 +105,24 @@ async function createSafetyIdentifier(
     return bytesToHex(await crypto.subtle.digest("SHA-256", data));
 }
 
-function buildUpstreamUrl(): string {
+function buildUpstreamUrl(modelId: string): string {
     const upstreamUrl = new URL(AZURE_REALTIME_WEBSOCKET_URL);
-    upstreamUrl.searchParams.set("model", AZURE_REALTIME_DEPLOYMENT);
+    upstreamUrl.searchParams.set("model", modelId);
     return upstreamUrl.toString();
 }
 
 async function connectAzureRealtime(
     c: Context<Env>,
     userId: string,
+    modelId: string,
 ): Promise<WebSocket | Response> {
-    const response = (await fetch(buildUpstreamUrl(), {
+    if (!c.env.AZURE_MYCELI_PROD_SWEDEN_API_KEY) {
+        throw new HTTPException(503, {
+            message: "Azure realtime provider is not configured.",
+        });
+    }
+
+    const response = (await fetch(buildUpstreamUrl(modelId), {
         headers: {
             "api-key": c.env.AZURE_MYCELI_PROD_SWEDEN_API_KEY,
             "OpenAI-Safety-Identifier": await createSafetyIdentifier(
@@ -677,11 +679,6 @@ export async function handleRealtimeWebSocket(
     const user = c.var.auth.requireUser();
 
     const resolvedModel = c.var.model.resolved;
-    if (resolvedModel !== DEFAULT_REALTIME_MODEL) {
-        throw new HTTPException(400, {
-            message: `Only ${DEFAULT_REALTIME_MODEL} is currently supported for realtime sessions.`,
-        });
-    }
     requireAllowedModel(c, resolvedModel);
 
     // Same model-independent, estimated-price balance gate as every other
@@ -689,13 +686,11 @@ export async function handleRealtimeWebSocket(
     // model definition). checkBalance reads c.var.model.
     await checkBalance(c.var, c.env);
 
-    if (!c.env.AZURE_MYCELI_PROD_SWEDEN_API_KEY) {
-        throw new HTTPException(503, {
-            message: "Azure realtime provider is not configured.",
-        });
-    }
-
-    const upstream = await connectAzureRealtime(c, user.id);
+    const upstream = await connectAzureRealtime(
+        c,
+        user.id,
+        c.var.model.definition.modelId,
+    );
     if (upstream instanceof Response) return upstream;
 
     return proxyRealtimeWebSockets(

--- a/gen.pollinations.ai/src/schemas/realtime.ts
+++ b/gen.pollinations.ai/src/schemas/realtime.ts
@@ -1,15 +1,17 @@
-import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
+import {
+    DEFAULT_REALTIME_MODEL,
+    REALTIME_MODEL_NAMES,
+} from "@shared/registry/realtime.ts";
 import { z } from "zod";
 
 export const RealtimeRequestQueryParamsSchema = z
     .object({
         model: z
-            .literal(DEFAULT_REALTIME_MODEL)
+            .enum(REALTIME_MODEL_NAMES as [string, ...string[]])
             .optional()
             .default(DEFAULT_REALTIME_MODEL)
             .meta({
-                description:
-                    "Realtime model to use. Currently only gpt-realtime-2 is supported.",
+                description: `Realtime model to use. Supported models: ${REALTIME_MODEL_NAMES.join(", ")}.`,
             }),
         key: z.string().optional().meta({
             description:

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -179,26 +179,23 @@ test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
 }) => {
     const upstream = mockOpenAIRealtime();
 
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${paidApiKey}`,
-                Upgrade: "websocket",
-            },
+    const { response, ctx } = await fetchWorkerWithContext("/v1/realtime", {
+        headers: {
+            Authorization: `Bearer ${paidApiKey}`,
+            Upgrade: "websocket",
         },
-    );
+    });
 
     expect(response.status).toBe(101);
     expect(response.webSocket).toBeDefined();
     expect(upstream.request.url).toBe(
-        "https://myceli-prod-swedencentral.cognitiveservices.azure.com/openai/v1/realtime?model=gpt-realtime-2",
+        "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime?model=gpt-realtime-2-1",
     );
     expect(upstream.request.headers.get("Upgrade")).toBe("websocket");
-    // Azure auth uses the api-key header, never the caller's Pollinations key.
+    // Provider auth uses the Azure key, never the caller's Pollinations key.
     expect(upstream.request.headers.get("api-key")).toBeTruthy();
-    expect(upstream.request.headers.get("Authorization")).toBeNull();
     expect(upstream.request.headers.get("api-key")).not.toBe(paidApiKey);
+    expect(upstream.request.headers.get("Authorization")).toBeNull();
     expect(upstream.request.headers.get("OpenAI-Safety-Identifier")).toMatch(
         /^[a-f0-9]{64}$/,
     );
@@ -219,7 +216,7 @@ test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
     const downstreamMessage = nextMessage(client);
     const serverEvent = JSON.stringify({
         type: "session.created",
-        session: { model: "gpt-realtime-2" },
+        session: { model: "gpt-realtime-2-1" },
     });
     upstream.server.send(serverEvent);
     await expect(downstreamMessage).resolves.toBe(serverEvent);
@@ -717,10 +714,13 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     const publicBody = (await publicResponse.json()) as {
         data: { id: string; supported_endpoints?: string[] }[];
     };
-    const realtimeModel = publicBody.data.find(
-        (model) => model.id === "gpt-realtime-2",
+    const realtimeModels = publicBody.data.filter((model) =>
+        ["gpt-realtime-2", "gpt-realtime-2.1"].includes(model.id),
     );
-    expect(realtimeModel?.supported_endpoints).toContain("/v1/realtime");
+    expect(realtimeModels).toHaveLength(2);
+    for (const model of realtimeModels) {
+        expect(model.supported_endpoints).toContain("/v1/realtime");
+    }
 
     const restrictedResponse = await fetchWorker("/v1/models", {
         headers: { Authorization: `Bearer ${restrictedApiKey}` },
@@ -731,5 +731,8 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     };
     expect(restrictedBody.data.map((model) => model.id)).not.toContain(
         "gpt-realtime-2",
+    );
+    expect(restrictedBody.data.map((model) => model.id)).not.toContain(
+        "gpt-realtime-2.1",
     );
 });

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -1,6 +1,6 @@
 import type { ModelDefinition } from "./registry";
 
-export const DEFAULT_REALTIME_MODEL = "gpt-realtime-2" as const;
+export const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1" as const;
 export type RealtimeModelName = keyof typeof REALTIME_SERVICES;
 export type RealtimeModelId =
     (typeof REALTIME_SERVICES)[RealtimeModelName]["modelId"];
@@ -8,7 +8,32 @@ export type RealtimeModelId =
 export const REALTIME_SERVICES = {
     [DEFAULT_REALTIME_MODEL]: {
         aliases: [],
-        modelId: DEFAULT_REALTIME_MODEL,
+        modelId: "gpt-realtime-2-1",
+        provider: "azure",
+        brand: "OpenAI",
+        category: "realtime",
+        addedDate: new Date("2026-07-16").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            promptTextTokens: 0.000004,
+            promptCachedTokens: 0.0000004,
+            promptAudioTokens: 0.000032,
+            promptImageTokens: 0.000005,
+            completionTextTokens: 0.000024,
+            completionAudioTokens: 0.000064,
+        },
+        title: "GPT Realtime 2.1",
+        description:
+            "GPT Realtime 2.1 - realtime voice reasoning with improved silence and noise handling",
+        inputModalities: ["text", "audio", "image"],
+        outputModalities: ["text", "audio"],
+        tools: true,
+        reasoning: true,
+        contextLength: 32000,
+    },
+    "gpt-realtime-2": {
+        aliases: [],
+        modelId: "gpt-realtime-2",
         provider: "azure",
         brand: "OpenAI",
         category: "realtime",
@@ -31,3 +56,7 @@ export const REALTIME_SERVICES = {
         contextLength: 128000,
     },
 } satisfies Record<string, ModelDefinition<string>>;
+
+export const REALTIME_MODEL_NAMES = Object.keys(
+    REALTIME_SERVICES,
+) as RealtimeModelName[];


### PR DESCRIPTION
- Adds `gpt-realtime-2.1` as the default realtime model while keeping `gpt-realtime-2` available.
- Routes both models through the verified Azure Realtime endpoint and maps 2.1 to the `gpt-realtime-2-1` deployment.
- Updates realtime schema, model discovery, API docs, tests, and pricing snapshot.
- Validates Azure `session.created`, 17 realtime tests, 6 docs tests, typecheck, Biome, and pricing snapshot.