### PR TITLE
fix: keep model access label near title

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -153,7 +153,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             copiedTooltip="Copied model id"
                             aria-label={`Copy model id ${model.name}`}
                             tooltipAlign="start"
-                            tooltipClassName="min-w-0 flex-1"
+                            tooltipClassName="min-w-0"
                             className={(copied) =>
                                 cn(
                                     "flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left text-base font-medium leading-none transition-colors",

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -191,7 +191,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 copiedTooltip="Copied model id"
                                 aria-label={`Copy model id ${model.name}`}
                                 tooltipAlign="start"
-                                tooltipClassName="min-w-0 flex-1"
+                                tooltipClassName="min-w-0"
                                 className={(copied) =>
                                     cn(
                                         "pointer-events-auto flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left text-sm font-medium leading-none transition-colors",


### PR DESCRIPTION
- Keeps the `Quest` / `Paid` label directly after the model title.
- Preserves title truncation when the model column is narrow.