### PR TITLE
fix: align model alpha label

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-status-chips.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-status-chips.tsx
@@ -7,7 +7,6 @@ export type BalanceAccess = "quest" | "paid";
 type ModelStatusChipsProps = {
     showNew: boolean;
     showAlpha: boolean;
-    alphaTooltip?: boolean;
 };
 
 type BalanceAccessChipProps = {
@@ -18,7 +17,6 @@ type BalanceAccessChipProps = {
 export const ModelStatusChips: FC<ModelStatusChipsProps> = ({
     showNew,
     showAlpha,
-    alphaTooltip = true,
 }) => {
     if (!showNew && !showAlpha) {
         return null;
@@ -31,21 +29,17 @@ export const ModelStatusChips: FC<ModelStatusChipsProps> = ({
                     NEW
                 </Chip>
             )}
-            {showAlpha &&
-                (alphaTooltip ? (
-                    <Tooltip
-                        triggerAs="span"
-                        content="Alpha model — experimental, may be unstable"
-                    >
-                        <Chip intent="alpha" size="sm">
-                            ALPHA
-                        </Chip>
-                    </Tooltip>
-                ) : (
+            {showAlpha && (
+                <Tooltip
+                    triggerAs="span"
+                    content="Alpha model — experimental, may be unstable"
+                    className="pointer-events-auto shrink-0"
+                >
                     <Chip intent="alpha" size="sm">
-                        ALPHA
+                        Alpha
                     </Chip>
-                ))}
+                </Tooltip>
+            )}
         </span>
     );
 };

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -184,7 +184,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                         />
                     )}
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
-                        <div className="flex min-w-0 items-center gap-2">
+                        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
                             <CopyButton
                                 value={model.name}
                                 tooltip={modelNameTooltip}
@@ -209,6 +209,10 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 access={balanceAccess}
                                 className="whitespace-nowrap"
                             />
+                            <ModelStatusChips
+                                showNew={showNew}
+                                showAlpha={showAlpha}
+                            />
                         </div>
                         <div className="flex min-w-0 flex-wrap items-center gap-2">
                             <ModelId name={model.name} />
@@ -219,15 +223,6 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 <MobileMetadataBadges
                                     inputModalities={inputModalities}
                                     capabilities={capabilities}
-                                />
-                            </div>
-                        )}
-                        {(showNew || showAlpha) && (
-                            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                                <ModelStatusChips
-                                    showNew={showNew}
-                                    showAlpha={showAlpha}
-                                    alphaTooltip={false}
                                 />
                             </div>
                         )}


### PR DESCRIPTION
- Uses the same tooltip wrapper for Alpha as Quest and Paid.
- Places Alpha with the title-row labels on mobile.
- Renames `ALPHA` to `Alpha`.