### PR TITLE
feat: add Pollen gifting

### DIFF
--- a/enter.pollinations.ai/drizzle/0037_amazing_titania.sql
+++ b/enter.pollinations.ai/drizzle/0037_amazing_titania.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `stripe_gift_credits` (
+	`session_id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`event_type` text NOT NULL,
+	`sender_user_id` text NOT NULL,
+	`recipient_user_id` text NOT NULL,
+	`recipient_github_username` text NOT NULL,
+	`pack_key` text NOT NULL,
+	`pollen_credited` real NOT NULL,
+	`created_at` integer DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer)) NOT NULL,
+	FOREIGN KEY (`sender_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`recipient_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_stripe_gift_credits_sender_user_id` ON `stripe_gift_credits` (`sender_user_id`);--> statement-breakpoint
+CREATE INDEX `idx_stripe_gift_credits_recipient_user_id` ON `stripe_gift_credits` (`recipient_user_id`);--> statement-breakpoint
+CREATE INDEX `idx_user_github_username` ON `user` (`github_username`);

--- a/enter.pollinations.ai/drizzle/meta/0037_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,1766 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3cce679c-1f50-40c4-b9a7-9575b48bdb16",
+  "prevId": "adc29eb5-86d6-4428-b5e2-63f116bf22a3",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_gift_credits": {
+      "name": "stripe_gift_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_github_username": {
+          "name": "recipient_github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_key": {
+          "name": "pack_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_gift_credits_sender_user_id": {
+          "name": "idx_stripe_gift_credits_sender_user_id",
+          "columns": [
+            "sender_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_gift_credits_recipient_user_id": {
+          "name": "idx_stripe_gift_credits_recipient_user_id",
+          "columns": [
+            "recipient_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_gift_credits_sender_user_id_user_id_fk": {
+          "name": "stripe_gift_credits_sender_user_id_user_id_fk",
+          "tableFrom": "stripe_gift_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stripe_gift_credits_recipient_user_id_user_id_fk": {
+          "name": "stripe_gift_credits_recipient_user_id_user_id_fk",
+          "tableFrom": "stripe_gift_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_username": {
+          "name": "idx_user_github_username",
+          "columns": [
+            "github_username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_item": {
+          "name": "idx_media_tag_tag_item",
+          "columns": [
+            "tag",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1784063115626,
       "tag": "0036_community_endpoint_visibility",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1784143531230,
+      "tag": "0037_amazing_titania",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/components/pollen/gift-panel.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/gift-panel.tsx
@@ -1,0 +1,225 @@
+import { apiClient } from "@frontend/api.ts";
+import {
+    Alert,
+    Button,
+    ExternalLinkButton,
+    Field,
+    Input,
+    Surface,
+    Tooltip,
+    WalletIcon,
+} from "@pollinations/ui";
+import {
+    calculateServiceFeeCents,
+    formatUsdCentsCompact,
+    POLLEN_PACKS,
+} from "@shared/pollen-packs.ts";
+import { type FC, useEffect, useRef, useState } from "react";
+import { PaymentTrustBadge } from "./payment-trust-badge.tsx";
+import { PollenPackSlider } from "./pollen-pack-controls.tsx";
+
+type RecipientState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | {
+          status: "found";
+          name: string;
+          image: string | null;
+          githubUsername: string;
+      }
+    | { status: "error"; message: string };
+
+const LOOKUP_DEBOUNCE_MS = 400;
+
+export const GiftPanel: FC = () => {
+    const [selectedPackAmount, setSelectedPackAmount] = useState(
+        POLLEN_PACKS[1]?.amountUsd ?? 5,
+    );
+    const [githubUsername, setGithubUsername] = useState("");
+    const [recipient, setRecipient] = useState<RecipientState>({
+        status: "idle",
+    });
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        const trimmed = githubUsername.trim();
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+
+        if (!trimmed) {
+            setRecipient({ status: "idle" });
+            return;
+        }
+
+        setRecipient({ status: "loading" });
+        debounceRef.current = setTimeout(async () => {
+            try {
+                const response = await apiClient.gifts.lookup[
+                    ":githubUsername"
+                ].$get({
+                    param: { githubUsername: trimmed },
+                });
+                const payload: unknown = await response
+                    .json()
+                    .catch(() => ({}));
+                if (!response.ok) {
+                    const message =
+                        typeof payload === "object" &&
+                        payload &&
+                        "error" in payload &&
+                        typeof (payload as { error: unknown }).error ===
+                            "string"
+                            ? (payload as { error: string }).error
+                            : "Couldn't find that account.";
+                    setRecipient({ status: "error", message });
+                    return;
+                }
+                const data = payload as {
+                    name: string;
+                    image: string | null;
+                    githubUsername: string;
+                };
+                setRecipient({ status: "found", ...data });
+            } catch {
+                setRecipient({
+                    status: "error",
+                    message: "Couldn't look that up. Try again.",
+                });
+            }
+        }, LOOKUP_DEBOUNCE_MS);
+
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+        };
+    }, [githubUsername]);
+
+    const selectedPackIndex = Math.max(
+        0,
+        POLLEN_PACKS.findIndex((pack) => pack.amountUsd === selectedPackAmount),
+    );
+    const selectedPack = POLLEN_PACKS[selectedPackIndex] ?? POLLEN_PACKS[0];
+    const serviceFeeCents = selectedPack
+        ? calculateServiceFeeCents(selectedPack.amountUsd * 100)
+        : 0;
+    const subtotalBeforeTaxCents =
+        (selectedPack?.amountUsd ?? 0) * 100 + serviceFeeCents;
+    const chargeLabel = selectedPack
+        ? formatUsdCentsCompact(subtotalBeforeTaxCents)
+        : "$0";
+
+    const canSend = Boolean(selectedPack) && recipient.status === "found";
+
+    return (
+        <>
+            <Surface>
+                {selectedPack && (
+                    <div className="flex w-full flex-col gap-5">
+                        <Field.Root>
+                            <Field.Label className="mb-2 block text-sm font-semibold">
+                                Recipient's GitHub username
+                            </Field.Label>
+                            <Input
+                                value={githubUsername}
+                                onChange={(event) =>
+                                    setGithubUsername(event.target.value)
+                                }
+                                placeholder="octocat"
+                                className="w-full max-w-xs"
+                                autoComplete="off"
+                                spellCheck={false}
+                            />
+                        </Field.Root>
+
+                        {recipient.status === "loading" && (
+                            <p className="text-sm text-theme-text-muted">
+                                Looking up account…
+                            </p>
+                        )}
+                        {recipient.status === "error" && (
+                            <Alert intent="danger">{recipient.message}</Alert>
+                        )}
+                        {recipient.status === "found" && (
+                            <div className="flex items-center gap-3 rounded-xl bg-theme-bg-pale px-3 py-2">
+                                {recipient.image && (
+                                    <img
+                                        src={recipient.image}
+                                        alt={`${recipient.name} avatar`}
+                                        className="h-8 w-8 shrink-0 rounded-full"
+                                    />
+                                )}
+                                <div className="min-w-0">
+                                    <p className="truncate text-sm font-semibold text-theme-text-strong">
+                                        {recipient.name}
+                                    </p>
+                                    <p className="truncate text-xs text-theme-text-muted">
+                                        @{recipient.githubUsername}
+                                    </p>
+                                </div>
+                            </div>
+                        )}
+
+                        <div className="flex w-full flex-col items-start gap-4 pb-10 sm:flex-row sm:items-center sm:gap-4 sm:pb-20">
+                            <div className="w-full min-w-0 flex-1 pb-20 sm:pb-0">
+                                <PollenPackSlider
+                                    value={selectedPack.amountUsd}
+                                    onChange={setSelectedPackAmount}
+                                    selectedBadgeLabel={chargeLabel}
+                                    selectedBadgeDetail={`incl. ${formatUsdCentsCompact(serviceFeeCents)} fee`}
+                                />
+                            </div>
+                            <Tooltip
+                                content={
+                                    <span className="block">
+                                        Gift{" "}
+                                        <span className="font-semibold text-theme-text-strong">
+                                            {selectedPack.amountUsd} pollen
+                                        </span>{" "}
+                                        for{" "}
+                                        <span className="font-semibold text-theme-text-strong">
+                                            {chargeLabel}
+                                        </span>
+                                        <span className="mt-1 block text-theme-text-muted">
+                                            Tax calculated at checkout
+                                        </span>
+                                    </span>
+                                }
+                                displayContents
+                            >
+                                {canSend && recipient.status === "found" ? (
+                                    <ExternalLinkButton
+                                        href={`/api/gifts/checkout/${selectedPack.packKey}/${encodeURIComponent(recipient.githubUsername)}`}
+                                        target="_self"
+                                        className="w-28 min-w-0 gap-1.5 self-start text-center shadow-none sm:shrink-0 sm:self-center"
+                                    >
+                                        <span className="inline-flex items-center gap-1.5">
+                                            <WalletIcon className="h-4 w-4 shrink-0" />
+                                            Gift
+                                        </span>
+                                    </ExternalLinkButton>
+                                ) : (
+                                    <Button
+                                        as="button"
+                                        type="button"
+                                        disabled
+                                        className="w-28 min-w-0 gap-1.5 self-start text-center shadow-none sm:shrink-0 sm:self-center"
+                                    >
+                                        <span className="inline-flex items-center gap-1.5">
+                                            <WalletIcon className="h-4 w-4 shrink-0" />
+                                            Gift
+                                        </span>
+                                    </Button>
+                                )}
+                            </Tooltip>
+                        </div>
+                    </div>
+                )}
+            </Surface>
+            <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                <PaymentTrustBadge className="mt-0 pt-0" />
+                <p>
+                    Your recipient needs a Pollinations account already. We'll
+                    check as you type.
+                </p>
+            </div>
+        </>
+    );
+};

--- a/enter.pollinations.ai/frontend/src/components/pollen/index.ts
+++ b/enter.pollinations.ai/frontend/src/components/pollen/index.ts
@@ -1,3 +1,4 @@
+export { GiftPanel } from "./gift-panel.tsx";
 export { LastEventsPanel } from "./last-events-panel.tsx";
 export {
     BuyPollenPanel,

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
@@ -1,4 +1,4 @@
-import { Section } from "@pollinations/ui";
+import { Alert, Section, TabButton } from "@pollinations/ui";
 import {
     getPollenPackByAmount,
     getPollenPackByKey,
@@ -7,16 +7,29 @@ import {
     type PollenPackKey,
 } from "@shared/pollen-packs.ts";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { BuyPollenPanel, PollenBalance } from "../components/pollen";
+import { useState } from "react";
+import { BuyPollenPanel, GiftPanel, PollenBalance } from "../components/pollen";
 import { Route as DashboardRoute } from "./_dashboard.tsx";
 
 export const Route = createFileRoute("/_dashboard/pollen")({
     validateSearch: (
         search: Record<string, unknown>,
-    ): { pack?: PollenPackKey } => ({
+    ): {
+        pack?: PollenPackKey;
+        gift?: string;
+        recipient?: string;
+        stripe_success?: string;
+    } => ({
         pack:
             typeof search.pack === "string" && isPollenPackKey(search.pack)
                 ? search.pack
+                : undefined,
+        gift: typeof search.gift === "string" ? search.gift : undefined,
+        recipient:
+            typeof search.recipient === "string" ? search.recipient : undefined,
+        stripe_success:
+            typeof search.stripe_success === "string"
+                ? search.stripe_success
                 : undefined,
     }),
     beforeLoad: ({ context, location }) => {
@@ -31,11 +44,15 @@ export const Route = createFileRoute("/_dashboard/pollen")({
 });
 
 function PollenPage() {
-    const { pack } = Route.useSearch();
+    const { pack, gift, recipient, stripe_success } = Route.useSearch();
     const navigate = useNavigate({ from: "/pollen" });
     const { tierBalance, packBalance, paidWeek, tierWeek, billingState } =
         DashboardRoute.useLoaderData();
     const selectedPack = getPollenPackByKey(pack ?? "p5") ?? POLLEN_PACKS[0];
+    const [tab, setTab] = useState<"buy" | "gift">(
+        gift === "1" ? "gift" : "buy",
+    );
+    const giftConfirmed = gift === "1" && stripe_success === "true";
 
     function selectPack(amount: number): void {
         const selected = getPollenPackByAmount(amount);
@@ -52,12 +69,35 @@ function PollenPage() {
                     tierWeek={tierWeek}
                 />
             </Section>
+            {giftConfirmed && recipient && (
+                <Alert intent="info" title="Gift sent">
+                    You gifted Pollen to @{recipient}. 🎁
+                </Alert>
+            )}
             <Section title="Top-up" framed id="buy-pollen">
-                <BuyPollenPanel
-                    initialBillingState={billingState}
-                    selectedPackAmount={selectedPack?.amountUsd ?? 5}
-                    onSelectedPackAmountChange={selectPack}
-                />
+                <div className="mb-4 flex gap-2">
+                    <TabButton
+                        active={tab === "buy"}
+                        onClick={() => setTab("buy")}
+                    >
+                        Buy for me
+                    </TabButton>
+                    <TabButton
+                        active={tab === "gift"}
+                        onClick={() => setTab("gift")}
+                    >
+                        Gift to someone
+                    </TabButton>
+                </div>
+                {tab === "buy" ? (
+                    <BuyPollenPanel
+                        initialBillingState={billingState}
+                        selectedPackAmount={selectedPack?.amountUsd ?? 5}
+                        onSelectedPackAmountChange={selectPack}
+                    />
+                ) : (
+                    <GiftPanel />
+                )}
             </Section>
         </div>
     );

--- a/enter.pollinations.ai/src/frontend-api.ts
+++ b/enter.pollinations.ai/src/frontend-api.ts
@@ -5,6 +5,7 @@ import { apiKeysRoutes } from "./routes/api-keys.ts";
 import { appLookupRoutes } from "./routes/app-lookup.ts";
 import { customerRoutes } from "./routes/customer.ts";
 import { deviceRoutes } from "./routes/device.ts";
+import { giftsRoutes } from "./routes/gifts.ts";
 import { modelStatsRoutes } from "./routes/model-stats.ts";
 import { oauthRoutes } from "./routes/oauth.ts";
 import { questsRoutes } from "./routes/quests.ts";
@@ -17,6 +18,7 @@ export const frontendApi = new Hono<Env>()
     .route("/app-lookup", appLookupRoutes)
     .route("/account", accountRoutes)
     .route("/device", deviceRoutes)
+    .route("/gifts", giftsRoutes)
     .route("/oauth", oauthRoutes)
     .route("/model-stats", modelStatsRoutes)
     .route("/quests", questsRoutes);

--- a/enter.pollinations.ai/src/routes/gifts.ts
+++ b/enter.pollinations.ai/src/routes/gifts.ts
@@ -1,0 +1,223 @@
+import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    calculateServiceFeeCents,
+    formatPollenPackValue,
+    getPollenPackByKey,
+    SERVICE_FEE_NAME,
+    SERVICE_FEE_TAX_CODE,
+} from "@shared/pollen-packs.ts";
+import { PUBLIC_URLS } from "@shared/public-urls.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import type { Env } from "../env.ts";
+import { getCohortFromCountry } from "../utils/currency-router.ts";
+import { createStripeClient } from "../utils/stripe.ts";
+import { getOrCreateStripeCustomerId } from "../utils/stripe-billing.ts";
+import {
+    getStripeNewCardGateStatus,
+    stripeNewCardGateMetadata,
+} from "../utils/stripe-card-gate.ts";
+import { requireSessionUser } from "./stripe.ts";
+
+async function findRecipientByGithubUsername(
+    db: ReturnType<typeof drizzle>,
+    githubUsername: string,
+) {
+    const [recipient] = await db
+        .select({
+            id: userTable.id,
+            name: userTable.name,
+            image: userTable.image,
+            githubUsername: userTable.githubUsername,
+        })
+        .from(userTable)
+        .where(eq(userTable.githubUsername, githubUsername))
+        .limit(1);
+
+    return recipient;
+}
+
+export const giftsRoutes = new Hono<Env>()
+    /**
+     * GET /api/gifts/lookup/:githubUsername
+     * Resolve a GitHub username to a Pollinations account for gift checkout.
+     * Session-authenticated so the endpoint can't be used as a public
+     * GitHub-username-to-Pollinations-account enumeration oracle.
+     */
+    .get("/lookup/:githubUsername", async (c) => {
+        const sender = await requireSessionUser(c);
+        const githubUsername = c.req.param("githubUsername").trim();
+
+        if (!githubUsername) {
+            return c.json({ error: "GitHub username is required" }, 400);
+        }
+
+        const db = drizzle(c.env.DB);
+        const recipient = await findRecipientByGithubUsername(
+            db,
+            githubUsername,
+        );
+
+        if (!recipient) {
+            return c.json(
+                {
+                    error: "No Pollinations account found for that GitHub username",
+                },
+                404,
+            );
+        }
+        if (recipient.id === sender.id) {
+            return c.json({ error: "You can't gift Pollen to yourself" }, 400);
+        }
+
+        return c.json({
+            name: recipient.name,
+            image: recipient.image,
+            githubUsername: recipient.githubUsername,
+        });
+    })
+
+    /**
+     * GET /api/gifts/checkout/:packKey/:githubUsername
+     * Create a Stripe Checkout Session that credits the recipient's
+     * pack_balance instead of the payer's. Mirrors stripe.ts's
+     * /checkout/:packKey handler; the recipient is re-resolved and
+     * re-validated here (never trusted from client input) so a tampered
+     * request can't redirect funds to an arbitrary account.
+     */
+    .get("/checkout/:packKey/:githubUsername", async (c) => {
+        const pack = getPollenPackByKey(c.req.param("packKey"));
+        if (!pack) {
+            return c.json({ error: "Invalid pack" }, 400);
+        }
+
+        const sender = await requireSessionUser(c);
+        const githubUsername = c.req.param("githubUsername").trim();
+
+        const db = drizzle(c.env.DB);
+        const recipient = await findRecipientByGithubUsername(
+            db,
+            githubUsername,
+        );
+
+        if (!recipient) {
+            return c.json({ error: "Recipient not found" }, 404);
+        }
+        if (recipient.id === sender.id) {
+            return c.json({ error: "You can't gift Pollen to yourself" }, 400);
+        }
+
+        const pmcId = c.env.STRIPE_PMC;
+        if (!pmcId) {
+            console.error(
+                `Missing required env var STRIPE_PMC for gift checkout on ${c.env.ENVIRONMENT}`,
+            );
+            return c.json({ error: "Checkout configuration error" }, 500);
+        }
+
+        const stripe = createStripeClient(c.env);
+        const baseUrl =
+            c.env.STRIPE_SUCCESS_URL || PUBLIC_URLS.enter.production;
+        const pollenUrl = new URL("/pollen", baseUrl);
+        pollenUrl.searchParams.set("gift", "1");
+        pollenUrl.searchParams.set("recipient", githubUsername);
+        const pollenReturnUrl = pollenUrl.toString();
+
+        const cohort = getCohortFromCountry(c.req.header("cf-ipcountry"));
+
+        try {
+            const stripeCustomerId = await getOrCreateStripeCustomerId(
+                c.env,
+                sender.id,
+            );
+            const newCardGate = await getStripeNewCardGateStatus(
+                c.env.DB,
+                sender.id,
+            );
+
+            // userId identifies the payer for the existing new-card
+            // fingerprint gate (readUserIdFromMetadata / the failed-card
+            // ledger); senderUserId/recipientUserId identify who pays and
+            // who is credited for the gift-specific webhook branch.
+            const giftMetadata = {
+                type: "gift",
+                userId: sender.id,
+                senderUserId: sender.id,
+                recipientUserId: recipient.id,
+                recipientGithubUsername: githubUsername,
+                packKey: pack.packKey,
+                cohort,
+                ...stripeNewCardGateMetadata(newCardGate),
+            };
+            const serviceFeeCents = calculateServiceFeeCents(
+                pack.amountUsd * 100,
+            );
+
+            const checkoutSession = await stripe.checkout.sessions.create({
+                mode: "payment",
+                payment_method_configuration: pmcId,
+                line_items: [
+                    {
+                        price_data: {
+                            currency: "usd",
+                            unit_amount: pack.amountUsd * 100,
+                            tax_behavior: "exclusive",
+                            product_data: {
+                                name: `🎁 Gift: ${formatPollenPackValue(pack.amountUsd)} Pollen for @${githubUsername}`,
+                                description: pack.checkoutDescription,
+                                images: [pack.checkoutImageUrl],
+                                tax_code: pack.taxCode,
+                            },
+                        },
+                        quantity: 1,
+                    },
+                    {
+                        price_data: {
+                            currency: "usd",
+                            unit_amount: serviceFeeCents,
+                            tax_behavior: "exclusive",
+                            product_data: {
+                                name: SERVICE_FEE_NAME,
+                                tax_code: SERVICE_FEE_TAX_CODE,
+                            },
+                        },
+                        quantity: 1,
+                    },
+                ],
+                adaptive_pricing: { enabled: true },
+                allow_promotion_codes: true,
+                automatic_tax: { enabled: true },
+                billing_address_collection: "auto",
+                tax_id_collection: { enabled: true },
+                customer: stripeCustomerId,
+                customer_update: {
+                    address: "auto",
+                    name: "auto",
+                },
+                payment_intent_data: {
+                    metadata: giftMetadata,
+                },
+                invoice_creation: {
+                    enabled: true,
+                    invoice_data: {
+                        rendering_options: {
+                            amount_tax_display: "exclude_tax",
+                        },
+                    },
+                },
+                metadata: giftMetadata,
+                success_url: `${pollenReturnUrl}&stripe_success=true&session_id={CHECKOUT_SESSION_ID}`,
+                cancel_url: `${pollenReturnUrl}&stripe_canceled=true`,
+            });
+
+            if (checkoutSession.url) {
+                return c.redirect(checkoutSession.url);
+            }
+
+            return c.json({ error: "Failed to create checkout session" }, 500);
+        } catch (error) {
+            console.error("Stripe gift checkout error:", error);
+            return c.json({ error: "Failed to create checkout session" }, 500);
+        }
+    });

--- a/enter.pollinations.ai/src/routes/gifts.ts
+++ b/enter.pollinations.ai/src/routes/gifts.ts
@@ -7,7 +7,7 @@ import {
     SERVICE_FEE_TAX_CODE,
 } from "@shared/pollen-packs.ts";
 import { PUBLIC_URLS } from "@shared/public-urls.ts";
-import { eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import type { Env } from "../env.ts";
@@ -20,6 +20,10 @@ import {
 } from "../utils/stripe-card-gate.ts";
 import { requireSessionUser } from "./stripe.ts";
 
+// GitHub usernames are case-insensitive (github.com/OctoCat === /octocat),
+// but the stored value preserves whatever case the account was created
+// with. Compare case-insensitively so a differently-cased lookup still
+// resolves.
 async function findRecipientByGithubUsername(
     db: ReturnType<typeof drizzle>,
     githubUsername: string,
@@ -32,7 +36,9 @@ async function findRecipientByGithubUsername(
             githubUsername: userTable.githubUsername,
         })
         .from(userTable)
-        .where(eq(userTable.githubUsername, githubUsername))
+        .where(
+            sql`lower(${userTable.githubUsername}) = lower(${githubUsername})`,
+        )
         .limit(1);
 
     return recipient;

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -526,12 +526,17 @@ const handleGiftCheckoutSessionCompleted = async (
         return { success: false, message: "Missing required gift metadata" };
     }
 
-    const presentmentSubtotal = Math.round(
-        (session.amount_subtotal || 0) / 100,
-    );
-    if (presentmentSubtotal <= 0) {
-        console.error("Invalid payment amount:", session.amount_total);
-        return { success: false, message: "Invalid payment amount" };
+    // Belt-and-suspenders: the only current caller (checkout.session.completed)
+    // already gates on payment_status === "paid" before dispatching here, and
+    // async_payment_succeeded implies a paid session. Checking again here means
+    // a future dispatch-site change can't accidentally credit an unpaid gift.
+    if (session.payment_status !== "paid") {
+        console.error(
+            "Gift checkout session not paid:",
+            session.id,
+            session.payment_status,
+        );
+        return { success: false, message: "Payment not completed" };
     }
 
     const pack = getPollenPackByKey(packKey);
@@ -541,6 +546,31 @@ const handleGiftCheckoutSessionCompleted = async (
             packKey,
         });
         return { success: false, message: "Missing or invalid pack metadata" };
+    }
+
+    const presentmentSubtotal = Math.round(
+        (session.amount_subtotal || 0) / 100,
+    );
+    if (presentmentSubtotal <= 0) {
+        console.error("Invalid payment amount for gift:", {
+            sessionId: session.id,
+            presentmentSubtotal,
+        });
+        return { success: false, message: "Invalid payment amount" };
+    }
+    // amount_subtotal is localized by Adaptive Pricing to the buyer's
+    // presentment currency, so it isn't comparable to pack.amountUsd (USD)
+    // in general — that's why it's never used as a credit source. Only when
+    // the session settled in USD (no localization applied) can it double as
+    // a sanity floor catching a tampered/mismatched packKey.
+    if (session.currency === "usd" && presentmentSubtotal < pack.amountUsd) {
+        console.error("Gift payment amount below pack price:", {
+            sessionId: session.id,
+            packKey,
+            expectedAmountUsd: pack.amountUsd,
+            presentmentSubtotal,
+        });
+        return { success: false, message: "Invalid payment amount" };
     }
 
     const db = drizzle(env.DB);
@@ -580,7 +610,7 @@ const handleGiftCheckoutSessionCompleted = async (
     }
 
     console.log(
-        `Stripe: Credited ${pack.amountUsd} pollen gift from ${senderUserId} to ${recipientUserId} (pack: $${pack.amountUsd}, session: ${session.id})`,
+        `Stripe: Credited ${pack.amountUsd} pollen gift from ${senderUserId} to ${recipientUserId} (pack: $${pack.amountUsd}, presentment: ${presentment.presentmentAmount} ${presentment.presentmentCurrency}, session: ${session.id})`,
     );
 
     return {

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -256,6 +256,80 @@ async function creditCheckoutSessionOnce({
     }
 }
 
+/**
+ * Twin of creditCheckoutSessionOnce for gifts: writes to stripe_gift_credits
+ * (its own idempotency key space, so a gift session can never collide with a
+ * top-up session on stripe_checkout_credits' primary key) and credits
+ * recipientUserId's pack_balance instead of the payer's.
+ */
+async function creditGiftCheckoutOnce({
+    env,
+    event,
+    session,
+    senderUserId,
+    recipientUserId,
+    recipientGithubUsername,
+    packKey,
+    creditsToAdd,
+}: {
+    env: CloudflareBindings;
+    event: Stripe.Event;
+    session: Stripe.Checkout.Session;
+    senderUserId: string;
+    recipientUserId: string;
+    recipientGithubUsername: string;
+    packKey: string;
+    creditsToAdd: number;
+}): Promise<{ credited: boolean }> {
+    const createdAt = Date.now();
+
+    try {
+        const [, updateResult] = await env.DB.batch([
+            env.DB.prepare(
+                `INSERT INTO stripe_gift_credits (
+                    session_id,
+                    event_id,
+                    event_type,
+                    sender_user_id,
+                    recipient_user_id,
+                    recipient_github_username,
+                    pack_key,
+                    pollen_credited,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            ).bind(
+                session.id,
+                event.id,
+                event.type,
+                senderUserId,
+                recipientUserId,
+                recipientGithubUsername,
+                packKey,
+                creditsToAdd,
+                createdAt,
+            ),
+            env.DB.prepare(
+                `UPDATE user
+                SET pack_balance = COALESCE(pack_balance, 0) + ?
+                WHERE id = ?`,
+            ).bind(creditsToAdd, recipientUserId),
+        ]);
+
+        if ((updateResult.meta.changes ?? 0) !== 1) {
+            throw new Error(
+                `Gift credit failed to update recipient ${recipientUserId} for session ${session.id}`,
+            );
+        }
+
+        return { credited: true };
+    } catch (error) {
+        if (isUniqueConstraintError(error)) {
+            return { credited: false };
+        }
+        throw error;
+    }
+}
+
 async function sendStripeEventToTinybird(
     env: CloudflareBindings,
     data: StripeEventData,
@@ -427,6 +501,98 @@ function emitPaymentIntentAnalytics(
 }
 
 /**
+ * Handle a gift checkout session: credits recipientUserId's packBalance,
+ * not the payer's. Same shape as handleCheckoutSessionCompleted otherwise
+ * (presentment-based paid check, packKey lookup, idempotent D1 credit).
+ */
+const handleGiftCheckoutSessionCompleted = async (
+    event: Stripe.Event,
+    session: Stripe.Checkout.Session,
+    env: CloudflareBindings,
+): Promise<CheckoutSessionResult> => {
+    const metadata = session.metadata;
+    const senderUserId = metadata?.senderUserId;
+    const recipientUserId = metadata?.recipientUserId;
+    const recipientGithubUsername = metadata?.recipientGithubUsername;
+    const packKey = metadata?.packKey;
+
+    if (
+        !senderUserId ||
+        !recipientUserId ||
+        !recipientGithubUsername ||
+        !packKey
+    ) {
+        console.error("Missing gift metadata:", session.id);
+        return { success: false, message: "Missing required gift metadata" };
+    }
+
+    const presentmentSubtotal = Math.round(
+        (session.amount_subtotal || 0) / 100,
+    );
+    if (presentmentSubtotal <= 0) {
+        console.error("Invalid payment amount:", session.amount_total);
+        return { success: false, message: "Invalid payment amount" };
+    }
+
+    const pack = getPollenPackByKey(packKey);
+    if (!pack) {
+        console.error("Missing or invalid pack in gift checkout session:", {
+            sessionId: session.id,
+            packKey,
+        });
+        return { success: false, message: "Missing or invalid pack metadata" };
+    }
+
+    const db = drizzle(env.DB);
+    const [recipient] = await db
+        .select({ id: userTable.id })
+        .from(userTable)
+        .where(eq(userTable.id, recipientUserId))
+        .limit(1);
+
+    if (!recipient) {
+        console.error("Gift recipient not found:", recipientUserId);
+        return { success: false, message: "Recipient no longer exists" };
+    }
+
+    const presentment = readPresentment(session);
+
+    const { credited } = await creditGiftCheckoutOnce({
+        env,
+        event,
+        session,
+        senderUserId,
+        recipientUserId,
+        recipientGithubUsername,
+        packKey,
+        creditsToAdd: pack.amountUsd,
+    });
+
+    if (!credited) {
+        console.log(
+            `Stripe: Skipping duplicate gift credit for recipient ${recipientUserId} (session: ${session.id}, event: ${event.id})`,
+        );
+        return {
+            success: true,
+            message: `Skipped duplicate gift credit for session ${session.id}`,
+            duplicate: true,
+        };
+    }
+
+    console.log(
+        `Stripe: Credited ${pack.amountUsd} pollen gift from ${senderUserId} to ${recipientUserId} (pack: $${pack.amountUsd}, session: ${session.id})`,
+    );
+
+    return {
+        success: true,
+        message: `Credited ${pack.amountUsd} pollen from ${senderUserId} to ${recipientUserId}`,
+        pollenCredited: pack.amountUsd,
+        presentmentCurrency: presentment.presentmentCurrency,
+        presentmentAmount: presentment.presentmentAmount,
+    };
+};
+
+/**
  * Handle successful checkout session completion.
  * Credits pollen to user's packBalance and persists observability fields.
  * Pollen amount is derived from the selected pack metadata.
@@ -437,6 +603,13 @@ const handleCheckoutSessionCompleted = async (
     env: CloudflareBindings,
 ): Promise<CheckoutSessionResult> => {
     const metadata = session.metadata;
+
+    // Gift sessions also carry metadata.userId (the payer, for the new-card
+    // fingerprint gate below), so this dispatch must run before the userId
+    // check treats the payer as the credit target.
+    if (metadata?.type === "gift") {
+        return handleGiftCheckoutSessionCompleted(event, session, env);
+    }
 
     if (!metadata?.userId) {
         console.error("Missing userId in checkout session:", session.id);

--- a/enter.pollinations.ai/src/routes/stripe.ts
+++ b/enter.pollinations.ai/src/routes/stripe.ts
@@ -304,7 +304,7 @@ export const stripeRoutes = new Hono<Env>()
         return c.json(await processAutoTopUpForUser(c.env, body.userId));
     });
 
-async function requireSessionUser(c: Context<Env>) {
+export async function requireSessionUser(c: Context<Env>) {
     const auth = createAuth(c.env, c.executionCtx);
     const session = await auth.api.getSession({
         headers: c.req.raw.headers,

--- a/enter.pollinations.ai/test/integration/gifts.test.ts
+++ b/enter.pollinations.ai/test/integration/gifts.test.ts
@@ -75,15 +75,17 @@ function checkoutSessionEvent({
     sessionId,
     metadata,
     amountUsd,
+    type = "checkout.session.completed",
 }: {
     eventId: string;
     sessionId: string;
     metadata: Record<string, string>;
     amountUsd: number;
+    type?: string;
 }) {
     return {
         id: eventId,
-        type: "checkout.session.completed",
+        type,
         livemode: false,
         data: {
             object: {
@@ -163,6 +165,30 @@ test("GET /api/gifts/lookup/:githubUsername returns recipient profile without le
         name: "Octocat",
         image: "https://avatars.example/octocat.png",
         githubUsername: "octocat-gift",
+    });
+});
+
+test("GET /api/gifts/lookup/:githubUsername matches regardless of case", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    await insertRecipient({
+        id: "recipient-case",
+        githubUsername: "OctoCat-Case",
+        name: "Octocat",
+    });
+
+    const response = await SELF.fetch(`${base}/lookup/octocat-case`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual({
+        name: "Octocat",
+        image: null,
+        githubUsername: "OctoCat-Case",
     });
 });
 
@@ -370,6 +396,47 @@ test("POST /api/webhooks/stripe gift credit is idempotent on replay", async ({
         .select({ packBalance: userTable.packBalance })
         .from(userTable)
         .where(eq(userTable.id, "recipient-webhook-replay"))
+        .limit(1);
+    expect(recipient?.packBalance).toBe(5);
+});
+
+test("POST /api/webhooks/stripe credits a gift on checkout.session.async_payment_succeeded too", async ({
+    sessionToken,
+    mocks,
+}) => {
+    void sessionToken;
+    await mocks.enable("tinybird");
+
+    const senderId = await getSeededUserId();
+    await insertRecipient({
+        id: "recipient-webhook-async",
+        githubUsername: "recipient-webhook-async",
+        packBalance: 0,
+    });
+
+    const response = await postSignedStripeWebhook(
+        checkoutSessionEvent({
+            eventId: "evt_gift_async",
+            sessionId: "cs_gift_async",
+            amountUsd: 5,
+            type: "checkout.session.async_payment_succeeded",
+            metadata: {
+                type: "gift",
+                userId: senderId,
+                senderUserId: senderId,
+                recipientUserId: "recipient-webhook-async",
+                recipientGithubUsername: "recipient-webhook-async",
+                packKey: "p5",
+            },
+        }),
+    );
+    expect(response.status).toBe(200);
+
+    const db = drizzle(env.DB);
+    const [recipient] = await db
+        .select({ packBalance: userTable.packBalance })
+        .from(userTable)
+        .where(eq(userTable.id, "recipient-webhook-async"))
         .limit(1);
     expect(recipient?.packBalance).toBe(5);
 });

--- a/enter.pollinations.ai/test/integration/gifts.test.ts
+++ b/enter.pollinations.ai/test/integration/gifts.test.ts
@@ -1,0 +1,403 @@
+import { env, SELF } from "cloudflare:test";
+import { createHmac } from "node:crypto";
+import { user as userTable } from "@shared/db/better-auth.ts";
+import { getPollenPackByKey } from "@shared/pollen-packs.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "../fixtures.ts";
+
+const base = "http://localhost:3000/api/gifts";
+const stripeWebhookUrl = "http://localhost:3000/api/webhooks/stripe";
+
+function signStripeWebhookPayload(payload: string): string {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = createHmac("sha256", env.STRIPE_WEBHOOK_SECRET)
+        .update(`${timestamp}.${payload}`, "utf8")
+        .digest("hex");
+    return `t=${timestamp},v1=${signature}`;
+}
+
+async function postSignedStripeWebhook(
+    payloadObject: Record<string, unknown>,
+): Promise<Response> {
+    const payload = JSON.stringify(payloadObject);
+    return SELF.fetch(stripeWebhookUrl, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "stripe-signature": signStripeWebhookPayload(payload),
+        },
+        body: payload,
+    });
+}
+
+async function getSeededUserId(): Promise<string> {
+    const db = drizzle(env.DB);
+    const [user] = await db
+        .select({ id: userTable.id })
+        .from(userTable)
+        .limit(1);
+
+    expect(user).toBeTruthy();
+    if (!user) throw new Error("Expected seeded test user");
+    return user.id;
+}
+
+async function insertRecipient({
+    id,
+    githubUsername,
+    name = id,
+    image = null,
+    packBalance = 0,
+}: {
+    id: string;
+    githubUsername: string;
+    name?: string;
+    image?: string | null;
+    packBalance?: number;
+}) {
+    const db = drizzle(env.DB);
+    await db.insert(userTable).values({
+        id,
+        email: `${id}@test.com`,
+        name,
+        githubUsername,
+        image,
+        tier: "seed",
+        packBalance,
+        createdAt: new Date(),
+    });
+}
+
+function checkoutSessionEvent({
+    eventId,
+    sessionId,
+    metadata,
+    amountUsd,
+}: {
+    eventId: string;
+    sessionId: string;
+    metadata: Record<string, string>;
+    amountUsd: number;
+}) {
+    return {
+        id: eventId,
+        type: "checkout.session.completed",
+        livemode: false,
+        data: {
+            object: {
+                id: sessionId,
+                object: "checkout.session",
+                metadata,
+                payment_status: "paid",
+                amount_subtotal: amountUsd * 100,
+                amount_total: amountUsd * 100,
+                currency: "usd",
+                customer_email: "buyer@example.com",
+                payment_method_types: ["card"],
+            },
+        },
+    };
+}
+
+// --- Lookup endpoint ---
+
+test("GET /api/gifts/lookup/:githubUsername requires authentication", async () => {
+    const response = await SELF.fetch(`${base}/lookup/someone`, {
+        method: "GET",
+    });
+    expect(response.status).toBe(401);
+});
+
+test("GET /api/gifts/lookup/:githubUsername returns 404 for unknown username", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    const response = await SELF.fetch(`${base}/lookup/no-such-user`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+    });
+    expect(response.status).toBe(404);
+    const data = (await response.json()) as { error: string };
+    expect(data.error).toBe(
+        "No Pollinations account found for that GitHub username",
+    );
+});
+
+test("GET /api/gifts/lookup/:githubUsername returns 400 for self-lookup", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    // The seeded test user signs in via the GitHub mock with login "testuser".
+    const response = await SELF.fetch(`${base}/lookup/testuser`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+    });
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string };
+    expect(data.error).toBe("You can't gift Pollen to yourself");
+});
+
+test("GET /api/gifts/lookup/:githubUsername returns recipient profile without leaking userId", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    await insertRecipient({
+        id: "recipient-lookup",
+        githubUsername: "octocat-gift",
+        name: "Octocat",
+        image: "https://avatars.example/octocat.png",
+    });
+
+    const response = await SELF.fetch(`${base}/lookup/octocat-gift`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual({
+        name: "Octocat",
+        image: "https://avatars.example/octocat.png",
+        githubUsername: "octocat-gift",
+    });
+});
+
+// --- Checkout endpoint ---
+
+test("GET /api/gifts/checkout/:packKey/:githubUsername returns 400 for invalid pack", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    await insertRecipient({
+        id: "recipient-invalid-pack",
+        githubUsername: "recipient-invalid-pack",
+    });
+
+    const response = await SELF.fetch(
+        `${base}/checkout/invalid/recipient-invalid-pack`,
+        {
+            method: "GET",
+            headers: { cookie: `better-auth.session_token=${sessionToken}` },
+        },
+    );
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string };
+    expect(data.error).toBe("Invalid pack");
+});
+
+test("GET /api/gifts/checkout/:packKey/:githubUsername returns 404 for unknown recipient", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const response = await SELF.fetch(`${base}/checkout/p10/no-such-user`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+        redirect: "manual",
+    });
+    expect(response.status).toBe(404);
+    const data = (await response.json()) as { error: string };
+    expect(data.error).toBe("Recipient not found");
+});
+
+test("GET /api/gifts/checkout/:packKey/:githubUsername returns 400 for self-gift", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const response = await SELF.fetch(`${base}/checkout/p10/testuser`, {
+        method: "GET",
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+        redirect: "manual",
+    });
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { error: string };
+    expect(data.error).toBe("You can't gift Pollen to yourself");
+});
+
+test("GET /api/gifts/checkout/:packKey/:githubUsername creates a Stripe session with gift metadata", async ({
+    sessionToken,
+    mocks,
+}) => {
+    const pack = getPollenPackByKey("p10");
+    expect(pack).toBeDefined();
+    await mocks.enable("stripe", "tinybird");
+
+    const senderId = await getSeededUserId();
+    await insertRecipient({
+        id: "recipient-checkout",
+        githubUsername: "recipient-checkout",
+        name: "Recipient",
+    });
+
+    const response = await SELF.fetch(
+        `${base}/checkout/${pack?.packKey}/recipient-checkout`,
+        {
+            method: "GET",
+            headers: { cookie: `better-auth.session_token=${sessionToken}` },
+            redirect: "manual",
+        },
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain("checkout.stripe.test");
+
+    const body = mocks.stripe.state.requests.find(
+        (request) => request.path === "/v1/checkout/sessions",
+    )?.body;
+    expect(body).toBeTruthy();
+
+    expect(body?.["metadata[type]"]).toBe("gift");
+    expect(body?.["metadata[userId]"]).toBe(senderId);
+    expect(body?.["metadata[senderUserId]"]).toBe(senderId);
+    expect(body?.["metadata[recipientUserId]"]).toBe("recipient-checkout");
+    expect(body?.["metadata[recipientGithubUsername]"]).toBe(
+        "recipient-checkout",
+    );
+    expect(body?.["metadata[packKey]"]).toBe(pack?.packKey);
+    expect(body?.["line_items[0][price_data][product_data][name]"]).toContain(
+        "@recipient-checkout",
+    );
+    expect(body?.["customer_update[address]"]).toBe("auto");
+    expect(body?.["payment_intent_data[metadata][senderUserId]"]).toBe(
+        senderId,
+    );
+});
+
+// --- Webhook credit branch ---
+
+test("POST /api/webhooks/stripe credits the recipient's pack_balance on gift checkout, not the sender's", async ({
+    sessionToken,
+    mocks,
+}) => {
+    void sessionToken;
+    await mocks.enable("tinybird");
+
+    const senderId = await getSeededUserId();
+    await insertRecipient({
+        id: "recipient-webhook-credit",
+        githubUsername: "recipient-webhook-credit",
+        packBalance: 2,
+    });
+
+    const response = await postSignedStripeWebhook(
+        checkoutSessionEvent({
+            eventId: "evt_gift_credit",
+            sessionId: "cs_gift_credit",
+            amountUsd: 10,
+            metadata: {
+                type: "gift",
+                userId: senderId,
+                senderUserId: senderId,
+                recipientUserId: "recipient-webhook-credit",
+                recipientGithubUsername: "recipient-webhook-credit",
+                packKey: "p10",
+            },
+        }),
+    );
+    expect(response.status).toBe(200);
+
+    const db = drizzle(env.DB);
+    const [sender] = await db
+        .select({ packBalance: userTable.packBalance })
+        .from(userTable)
+        .where(eq(userTable.id, senderId))
+        .limit(1);
+    const [recipient] = await db
+        .select({ packBalance: userTable.packBalance })
+        .from(userTable)
+        .where(eq(userTable.id, "recipient-webhook-credit"))
+        .limit(1);
+
+    expect(recipient?.packBalance).toBe(12);
+    expect(sender?.packBalance ?? 0).toBe(0);
+
+    const giftCredit = await env.DB.prepare(
+        `SELECT sender_user_id AS senderUserId, recipient_user_id AS recipientUserId, pollen_credited AS pollenCredited
+        FROM stripe_gift_credits
+        WHERE session_id = 'cs_gift_credit'`,
+    ).first<{
+        senderUserId: string;
+        recipientUserId: string;
+        pollenCredited: number;
+    }>();
+    expect(giftCredit).toMatchObject({
+        senderUserId: senderId,
+        recipientUserId: "recipient-webhook-credit",
+        pollenCredited: 10,
+    });
+});
+
+test("POST /api/webhooks/stripe gift credit is idempotent on replay", async ({
+    sessionToken,
+    mocks,
+}) => {
+    void sessionToken;
+    await mocks.enable("tinybird");
+
+    const senderId = await getSeededUserId();
+    await insertRecipient({
+        id: "recipient-webhook-replay",
+        githubUsername: "recipient-webhook-replay",
+        packBalance: 0,
+    });
+
+    const event = checkoutSessionEvent({
+        eventId: "evt_gift_replay",
+        sessionId: "cs_gift_replay",
+        amountUsd: 5,
+        metadata: {
+            type: "gift",
+            userId: senderId,
+            senderUserId: senderId,
+            recipientUserId: "recipient-webhook-replay",
+            recipientGithubUsername: "recipient-webhook-replay",
+            packKey: "p5",
+        },
+    });
+
+    const first = await postSignedStripeWebhook(event);
+    expect(first.status).toBe(200);
+    const second = await postSignedStripeWebhook(event);
+    expect(second.status).toBe(200);
+
+    const db = drizzle(env.DB);
+    const [recipient] = await db
+        .select({ packBalance: userTable.packBalance })
+        .from(userTable)
+        .where(eq(userTable.id, "recipient-webhook-replay"))
+        .limit(1);
+    expect(recipient?.packBalance).toBe(5);
+});
+
+test("POST /api/webhooks/stripe non-gift checkout still credits the payer as before (regression)", async ({
+    sessionToken,
+    mocks,
+}) => {
+    void sessionToken;
+    await mocks.enable("tinybird");
+
+    const userId = await getSeededUserId();
+
+    const response = await postSignedStripeWebhook(
+        checkoutSessionEvent({
+            eventId: "evt_regular_topup",
+            sessionId: "cs_regular_topup",
+            amountUsd: 10,
+            metadata: { userId, packKey: "p10" },
+        }),
+    );
+    expect(response.status).toBe(200);
+
+    const db = drizzle(env.DB);
+    const [user] = await db
+        .select({ packBalance: userTable.packBalance })
+        .from(userTable)
+        .where(eq(userTable.id, userId))
+        .limit(1);
+    expect(user?.packBalance).toBe(10);
+});

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -50,6 +50,8 @@ export const user = sqliteTable("user", {
   index("idx_user_auto_top_up_enabled").on(table.autoTopUpEnabled),
   // GitHub profile lookup for quest checks and account display.
   index("idx_user_github_id").on(table.githubId),
+  // Gift-recipient lookup by GitHub username.
+  index("idx_user_github_username").on(table.githubUsername),
 ]);
 
 export const session = sqliteTable("session", {
@@ -321,6 +323,49 @@ export const stripeCheckoutCredits = sqliteTable("stripe_checkout_credits", {
 }, (table) => [
   index("idx_stripe_checkout_credits_user_id").on(table.userId),
 ]);
+
+// Mirrors stripe_checkout_credits, but the payer and the credited user
+// differ. Kept as its own table (rather than a nullable column on
+// stripe_checkout_credits) so gift-session idempotency never shares a
+// uniqueness key with regular top-up idempotency, and so "gifts I've
+// sent" / "gifts I've received" are simple indexed queries.
+export const stripeGiftCredits = sqliteTable("stripe_gift_credits", {
+  sessionId: text("session_id").primaryKey(),
+  eventId: text("event_id").notNull(),
+  eventType: text("event_type").notNull(),
+  senderUserId: text("sender_user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  recipientUserId: text("recipient_user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  // Snapshot of the GitHub username as resolved at checkout-creation time,
+  // so history/receipts still render correctly if the recipient later
+  // renames their GitHub account.
+  recipientGithubUsername: text("recipient_github_username").notNull(),
+  packKey: text("pack_key").notNull(),
+  pollenCredited: real("pollen_credited").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .defaultNow()
+    .notNull(),
+}, (table) => [
+  index("idx_stripe_gift_credits_sender_user_id").on(table.senderUserId),
+  index("idx_stripe_gift_credits_recipient_user_id").on(table.recipientUserId),
+]);
+
+export const stripeGiftCreditsRelations = relations(
+  stripeGiftCredits,
+  ({ one }) => ({
+    sender: one(user, {
+      fields: [stripeGiftCredits.senderUserId],
+      references: [user.id],
+    }),
+    recipient: one(user, {
+      fields: [stripeGiftCredits.recipientUserId],
+      references: [user.id],
+    }),
+  }),
+);
 
 export const polarCheckoutCredits = sqliteTable("polar_checkout_credits", {
   orderId: text("order_id").primaryKey(),


### PR DESCRIPTION
## Summary
- Adds GitHub-username recipient lookup and Stripe gift checkout endpoints
- Adds `stripe_gift_credits` table + idempotent webhook credit path (credits recipient, not payer)
- Adds gift panel UI on the Pollen dashboard with buy/gift tabs and a post-checkout confirmation banner

## Test plan
- [x] `drizzle-kit generate` migration applied cleanly
- [x] Biome check clean on all new/changed files
- [x] TypeScript typecheck clean (2 pre-existing unrelated errors on `main` untouched)
- [x] `gifts.test.ts`: 7/11 passing (lookup endpoint + all input-validation paths)
- [ ] 4/11 checkout/webhook tests blocked locally by missing `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` (same pre-existing `sops`-decryption gap that blocks the existing `stripe.test.ts` suite locally too — should run in CI where secrets are available)

🤖 Generated with [Tomdacat Code](https://www.youtube.com/watch?v=dQw4w9WgXcQ)