### PR TITLE
feat: add Sana image model

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -827,6 +827,9 @@ const generateImage = async (
         case "qwen-image":
             return await callQwenImageAPI(prompt, safeParams);
 
+        case "sana":
+            return await callSelfHostedServer(prompt, safeParams, "sana");
+
         case "flux":
             return await callFluxWithFallback(prompt, safeParams);
 

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -922,6 +922,49 @@ test("gpt-image-2 rejects transparent backgrounds with 400", async ({
     });
 });
 
+test("sana uses the registered backend pool and records its flat price", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    const existing = await env.KV.list({ prefix: "image:server:test:sana:" });
+    await Promise.all(existing.keys.map((key) => env.KV.delete(key.name)));
+
+    const { response: registerResponse } = await fetchWorker("/register", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${env.PLN_GPU_TOKEN}`,
+        },
+        body: JSON.stringify({
+            url: `https://${imageBackendHost}`,
+            type: "sana",
+        }),
+    });
+    expect(registerResponse.status).toBe(200);
+    await mocks.enable("tinybird", "imageBackend");
+
+    const { response, wait } = await fetchWorker(
+        "/image/fast%20flower?model=sana&width=512&height=512&seed=42",
+        {
+            headers: { authorization: `Bearer ${paidApiKey}` },
+        },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-model-used")).toBe("sana");
+    await wait();
+
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        eventType: "generate.image",
+        modelRequested: "sana",
+        modelUsed: "sana",
+        tokenCountCompletionImage: 1,
+        tokenPriceCompletionImage: 0.0002,
+        isBilledUsage: true,
+    });
+});
+
 test("image backend validation errors return client-facing 400", async ({
     paidApiKey,
     mocks,

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -960,7 +960,7 @@ test("sana uses the registered backend pool and records its flat price", async (
         modelRequested: "sana",
         modelUsed: "sana",
         tokenCountCompletionImage: 1,
-        tokenPriceCompletionImage: 0.0002,
+        tokenPriceCompletionImage: 0.00001,
         isBilledUsage: true,
     });
 });

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -960,7 +960,7 @@ test("sana uses the registered backend pool and records its flat price", async (
         modelRequested: "sana",
         modelUsed: "sana",
         tokenCountCompletionImage: 1,
-        tokenPriceCompletionImage: 0.00001,
+        tokenPriceCompletionImage: 0.0001,
         isBilledUsage: true,
     });
 });

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -271,6 +271,23 @@ describe("gen worker routing", () => {
         expect(models.every((m) => m.category === "video")).toBe(true);
     });
 
+    it("lists Sana with flat per-image pricing", async () => {
+        const response = await fetchWorker("/image/models", envWithEnter());
+
+        expect(response.status).toBe(200);
+        const models = (await response.json()) as {
+            name: string;
+            pricing: Record<string, string>;
+        }[];
+        expect(models.find((model) => model.name === "sana")).toMatchObject({
+            name: "sana",
+            pricing: {
+                completionImageTokens: "0.0002",
+                currency: "pollen",
+            },
+        });
+    });
+
     it("serves OpenAI-compatible models without auth", async () => {
         const response = await fetchWorker("/v1/models", envWithEnter());
 

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -282,7 +282,7 @@ describe("gen worker routing", () => {
         expect(models.find((model) => model.name === "sana")).toMatchObject({
             name: "sana",
             pricing: {
-                completionImageTokens: "0.00001",
+                completionImageTokens: "0.0001",
                 currency: "pollen",
             },
         });

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -282,7 +282,7 @@ describe("gen worker routing", () => {
         expect(models.find((model) => model.name === "sana")).toMatchObject({
             name: "sana",
             pricing: {
-                completionImageTokens: "0.0002",
+                completionImageTokens: "0.00001",
                 currency: "pollen",
             },
         });

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -16,7 +16,7 @@ export const IMAGE_SERVICES = {
         addedDate: new Date("2026-07-17").getTime(),
         priceMultiplier: 1,
         cost: {
-            completionImageTokens: 0.00001, // per image
+            completionImageTokens: 0.0001, // per image
         },
         title: "Sana Sprint 1.6B",
         description: "Sana Sprint 1.6B - Fast, low-cost image generation",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -16,7 +16,7 @@ export const IMAGE_SERVICES = {
         addedDate: new Date("2026-07-17").getTime(),
         priceMultiplier: 1,
         cost: {
-            completionImageTokens: 0.0002, // per image
+            completionImageTokens: 0.00001, // per image
         },
         title: "Sana Sprint 1.6B",
         description: "Sana Sprint 1.6B - Fast, low-cost image generation",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -7,6 +7,22 @@ export type ImageModelName = keyof typeof IMAGE_SERVICES;
 export type ImageModelId = (typeof IMAGE_SERVICES)[ImageModelName]["modelId"];
 
 export const IMAGE_SERVICES = {
+    "sana": {
+        aliases: [],
+        modelId: "sana",
+        provider: "lambda",
+        brand: "NVIDIA",
+        category: "image",
+        addedDate: new Date("2026-07-17").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            completionImageTokens: 0.0002, // per image
+        },
+        title: "Sana Sprint 1.6B",
+        description: "Sana Sprint 1.6B - Fast, low-cost image generation",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
     "kontext": {
         aliases: [],
         modelId: "kontext",


### PR DESCRIPTION
- Adds Sana Sprint 1.6B to the shared image registry at 0.0001 Pollen per image, close to the estimated 0.0000926 GPU cost at full utilization.
- Routes Sana requests through the existing authenticated self-hosted GPU pool.
- Adds model-list, backend registration, dispatch, and billing coverage.

Checks:
- `npm run typecheck` in `gen.pollinations.ai`
- 55 relevant Vitest tests passed; focused Sana pricing tests rerun after the final price change