### PR TITLE
chore: promote main to production

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -437,7 +437,7 @@ curl "https://gen.pollinations.ai/text/Write%20a%20haiku%20about%20coding?model=
 
 Generate an image from a text prompt. Returns JPEG or PNG.
 
-**Available models:** `kontext`, `nanobanana`, `nanobanana-2`, `nanobanana-2-lite`, `nanobanana-pro`, `seedream5`, `seedream5-pro`, `seedream`, `seedream-pro`, `ideogram-v4-turbo`, `ideogram-v4-balanced`, `ideogram-v4-quality`, `gptimage`, `gptimage-large`, `gpt-image-2`, `flux`, `zimage`, `wan-image`, `wan-image-pro`, `qwen-image`, `grok-imagine`, `grok-imagine-pro`, `klein`, `p-image`, `p-image-edit`, `nova-canvas`. `zimage` is the default.
+**Available models:** `sana`, `kontext`, `nanobanana`, `nanobanana-2`, `nanobanana-2-lite`, `nanobanana-pro`, `seedream5`, `seedream5-pro`, `seedream`, `seedream-pro`, `ideogram-v4-turbo`, `ideogram-v4-balanced`, `ideogram-v4-quality`, `gptimage`, `gptimage-large`, `gpt-image-2`, `flux`, `zimage`, `wan-image`, `wan-image-pro`, `qwen-image`, `grok-imagine`, `grok-imagine-pro`, `klein`, `p-image`, `p-image-edit`, `nova-canvas`. `zimage` is the default.
 
 Browse all available models and their capabilities at [`/image/models`](https://gen.pollinations.ai/image/models).
 
@@ -730,10 +730,10 @@ curl "https://gen.pollinations.ai/audio/Hello%2C%20welcome%20to%20Pollinations!?
 
 OpenAI-compatible Realtime WebSocket proxy.
 
-Connect with `wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2` and send/receive Realtime JSON events over the socket.
+Connect with `wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2.1` and send/receive Realtime JSON events over the socket.
 Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.
 
-**Model:** `gpt-realtime-2`.
+**Models:** `gpt-realtime-2.1`, `gpt-realtime-2`.
 
 **Billing:** requires a positive balance. Gen proxies the WebSocket, aggregates observed `response.done` usage, and deducts one session total when the socket closes. Input transcription sessions are not supported yet.
 
@@ -741,7 +741,7 @@ Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebS
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `model` | `query` | `"gpt-realtime-2"` | Realtime model to use. Currently only gpt-realtime-2 is supported. · default: `"gpt-realtime-2"` |
+| `model` | `query` | `"gpt-realtime-2.1"` \| `"gpt-realtime-2"` | Realtime model to use. Supported models: gpt-realtime-2.1, gpt-realtime-2. · default: `"gpt-realtime-2.1"` |
 | `key` | `query` | `string` | Pollinations API key. Useful for browser WebSocket clients that cannot set custom Authorization headers. |
 
 <sub>`*` = required parameter</sub>
@@ -749,7 +749,7 @@ Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebS
 💻 **Example**
 
 ```bash
-curl "https://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2&key=:key" \
+curl "https://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2.1&key=:key" \
   -H "Authorization: Bearer $POLLINATIONS_KEY"
 ```
 

--- a/gen.pollinations.ai/src/model3d/models/inferenceportClient.ts
+++ b/gen.pollinations.ai/src/model3d/models/inferenceportClient.ts
@@ -11,7 +11,7 @@
 
 import { getModel3dEnv } from "../env.ts";
 
-const API_BASE = "https://sharktide-lightning.hf.space/v1";
+const API_BASE = "https://api.inferenceport.ai/v1";
 
 export class InferenceportError extends Error {
     constructor(

--- a/gen.pollinations.ai/test/model3d/createAndReturnModel3d.test.ts
+++ b/gen.pollinations.ai/test/model3d/createAndReturnModel3d.test.ts
@@ -28,9 +28,9 @@ function baseParams(model: string): Model3dParams {
 // upstream host is hit first for each model id.
 describe("createAndReturnModel3d dispatch", () => {
     it.each([
-        ["trellis-2-low", "sharktide-lightning"],
-        ["trellis-2-medium", "sharktide-lightning"],
-        ["trellis-2-high", "sharktide-lightning"],
+        ["trellis-2-low", "api.inferenceport.ai"],
+        ["trellis-2-medium", "api.inferenceport.ai"],
+        ["trellis-2-high", "api.inferenceport.ai"],
         ["hyper3d-rodin", "queue.fal.run"],
     ])("routes %s to the expected primary provider host", async (model, expectedHost) => {
         const fetchSpy = vi

--- a/gen.pollinations.ai/test/model3d/inferenceportClient.test.ts
+++ b/gen.pollinations.ai/test/model3d/inferenceportClient.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-const SUBMIT_URL = "https://sharktide-lightning.hf.space/v1/3d/generations";
+const SUBMIT_URL = "https://api.inferenceport.ai/v1/3d/generations";
 
 describe("runInferenceportSync", () => {
     it("POSTs to ?sync=true and returns GLB from data[0]", async () => {


### PR DESCRIPTION
- Promotes the latest `main` changes to production.
- Updates the InferencePort AI base URL for 3D generation.
- Includes the regenerated API docs update.