### PR TITLE
fix: route Sana through fixed tunnel

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -51,6 +51,8 @@ import type { TrackingData } from "./utils/trackingHeaders.ts";
 import { callVertexAIGemini } from "./vertexAIImageGenerator.js";
 import { writeExifMetadata } from "./writeExifMetadata.ts";
 
+const SANA_BACKEND_URL = "https://ltx2-backend.pollinations.ai/generate";
+
 // Loggers
 const logError = debug("pollinations:error");
 const logPerf = debug("pollinations:perf");
@@ -207,7 +209,7 @@ export const callSelfHostedServer = async (
 
         // Single attempt - no retry logic
         try {
-            response = await fetchFromWeightedServer(poolType, {
+            const requestInit = {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -216,7 +218,11 @@ export const callSelfHostedServer = async (
                     }),
                 },
                 body: JSON.stringify(body),
-            });
+            };
+            response =
+                poolType === "sana"
+                    ? await fetch(SANA_BACKEND_URL, requestInit)
+                    : await fetchFromWeightedServer(poolType, requestInit);
         } catch (error) {
             logError(`Fetch failed for ${safeParams.model}:`, error.message);
             logError("Request body:", JSON.stringify(body, null, 2));

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -17,6 +17,7 @@ const snapshotServerUrl = inject("snapshotServerUrl");
 const png1x1Base64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==";
 const imageBackendHost = "image-backend.test";
+const sanaBackendHost = "ltx2-backend.pollinations.ai";
 const fireworksHost = "api.fireworks.ai";
 
 afterEach(async () => {
@@ -56,6 +57,7 @@ function createGenerationMocks() {
             state: {},
             handlerMap: {
                 [imageBackendHost]: fakeImageBackendResponse,
+                [sanaBackendHost]: fakeImageBackendResponse,
             },
             reset: () => {},
         },
@@ -922,25 +924,10 @@ test("gpt-image-2 rejects transparent backgrounds with 400", async ({
     });
 });
 
-test("sana uses the registered backend pool and records its flat price", async ({
+test("sana uses its fixed backend and records its flat price", async ({
     paidApiKey,
     mocks,
 }) => {
-    const existing = await env.KV.list({ prefix: "image:server:test:sana:" });
-    await Promise.all(existing.keys.map((key) => env.KV.delete(key.name)));
-
-    const { response: registerResponse } = await fetchWorker("/register", {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            authorization: `Bearer ${env.PLN_GPU_TOKEN}`,
-        },
-        body: JSON.stringify({
-            url: `https://${imageBackendHost}`,
-            type: "sana",
-        }),
-    });
-    expect(registerResponse.status).toBe(200);
     await mocks.enable("tinybird", "imageBackend");
 
     const { response, wait } = await fetchWorker(


### PR DESCRIPTION
- Routes Sana directly through the existing Lambda media tunnel instead of requiring backend registration.
- Keeps Flux and Z-Image on the dynamic GPU registry.
- Updates the Sana generation test to prove the fixed endpoint path and billing.

The tunnel maps `ltx2-backend.pollinations.ai/generate` to Sana on localhost:8766; existing LTX2 routes are unchanged.

Checks:
- Focused Sana generation and billing test passed
- Gen typecheck passed
- Live tunnel generation returned HTTP 200