### PR TITLE
docs: recognize repository maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Developer ecosystem and community contribution programs
+/apps/gsoc/ @Circuit-Overtime
+/packages/mcp/ @Circuit-Overtime
+/packages/polli-cli/ @Circuit-Overtime
+/packages/sdk/ @Circuit-Overtime
+
+# Repository and community automation
+/.github/ @Circuit-Overtime @Itachi-1824
+/apps/polly/ @Itachi-1824
+/social/ @Circuit-Overtime @Itachi-1824

--- a/README.md
+++ b/README.md
@@ -370,6 +370,19 @@ We believe in community-driven development. You can contribute to pollinations.a
 
 For any questions or support, please visit our [Discord channel](https://discord.gg/pollinations-ai-885844321461485618) or create an issue on our [GitHub repository](https://github.com/pollinations/pollinations).
 
+## 🛠️ Maintainers
+
+Pollinations is maintained by people with ongoing responsibility for reviewing contributions, triaging issues, and keeping the platform and its community tooling healthy.
+
+| Maintainer | Primary responsibilities |
+| --- | --- |
+| [@voodoohop](https://github.com/voodoohop) | Project direction and platform architecture |
+| [@ElliotEtag](https://github.com/ElliotEtag) | Platform engineering and operations |
+| [@Circuit-Overtime](https://github.com/Circuit-Overtime) | Developer ecosystem, community contribution programs, and SDK/MCP/CLI tooling |
+| [@Itachi-1824](https://github.com/Itachi-1824) | Polly, repository automation, and contributor operations |
+
+Area ownership is recorded in [CODEOWNERS](./.github/CODEOWNERS). Maintainers collaborate across the repository, and ownership does not limit who can contribute.
+
 ## 🗂️ Project Structure
 
 Our codebase is organized into several key folders, each serving a specific purpose in the pollinations.ai ecosystem:


### PR DESCRIPTION
- Documents the current repository maintainers and their primary responsibilities in the README.
- Adds CODEOWNERS for Circuit-Overtime’s developer ecosystem and community program areas.
- Adds CODEOWNERS for Itachi-1824’s Polly, repository automation, and contributor operations areas.
- Keeps ownership collaborative and does not limit community contributions.

Validation:
- `git diff --check`
- Confirmed every CODEOWNERS path exists.
- Confirmed both accounts have GitHub’s `maintain` role.