### PR TITLE
fix: clarify private model usage

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -286,7 +286,7 @@ export function CommunityEndpointDialog({
                     <div className="grid gap-4 sm:grid-cols-2">
                         <FieldStack
                             label="Model ID"
-                            helper="Public id: {username}/{model-id}."
+                            helper="Pollinations model ID: {username}/{model-id}."
                             alignLabelRow
                         >
                             <Input
@@ -326,8 +326,8 @@ export function CommunityEndpointDialog({
                             isShared
                                 ? "Public: listed in /models and callable by anyone. Set optional per-1M-token prices below, or leave them at 0 for free."
                                 : canPublish
-                                  ? "Private: callable only by you and shown only in model lists authenticated with your API key."
-                                  : "Private: callable only by you. Publishing publicly requires approval."
+                                  ? "Private: call it through the Pollinations API with your API key at no Pollen cost. Upstream charges may still apply."
+                                  : "Private: call it through the Pollinations API with your API key at no Pollen cost. Upstream charges may still apply; publishing publicly requires approval."
                         }
                         alignLabelRow
                     >

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -103,10 +103,11 @@ export function CommunityEndpoints({
 
     const privateModelGuidance = (
         <>
-            Your models are private — callable only by you and shown only when{" "}
-            <strong>/models</strong> is authenticated with your API key. Enter
-            the upstream model ID manually, then test the saved model by calling
-            its model ID. To request public publishing access, open a{" "}
+            Register your OpenAI-compatible endpoint as a private model, then
+            call its model ID through the Pollinations API with your API key.
+            Private models appear only in authenticated model lists and cost no
+            Pollen to call. Your upstream provider may still charge you. To
+            request public publishing access, open a{" "}
             <a
                 href="https://github.com/pollinations/pollinations/issues/new?title=Community%20model%20publishing%20request"
                 target="_blank"
@@ -169,7 +170,7 @@ export function CommunityEndpoints({
                             </p>
                             <p className="text-sm text-theme-text-muted">
                                 {canPublish
-                                    ? "Publish an OpenAI-compatible endpoint with your own per-1M-token pricing."
+                                    ? "Register an OpenAI-compatible endpoint as a private model, or publish it with your own per-1M-token pricing."
                                     : privateModelGuidance}
                             </p>
                         </Surface>
@@ -190,11 +191,12 @@ export function CommunityEndpoints({
                         <span>
                             {canPublish ? (
                                 <>
-                                    Private models are callable only by you and
-                                    shown only when model lists use your API
-                                    key. Make one public to list it for everyone
-                                    in <strong>/models</strong> and bill callers
-                                    at your per-1M-token pricing.
+                                    Call private models through the Pollinations
+                                    API with your API key at no Pollen cost. Your
+                                    upstream provider may still charge you. Make
+                                    one public to list it for everyone in{" "}
+                                    <strong>/models</strong> and bill callers at
+                                    your per-1M-token pricing.
                                 </>
                             ) : (
                                 privateModelGuidance


### PR DESCRIPTION
- Clarifies that owners call private models through the Pollinations API with their API key.
- States that private-model calls cost no Pollen while upstream-provider charges may still apply.
- Renames “Public id” to “Pollinations model ID.”

Validation:
- `npx biome check --write` on both changed files
- `npm run typecheck --workspace pollinations-enter`