### PR TITLE
fix: include usage in OpenAI image responses

### DIFF
--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -7,6 +7,12 @@
 import { UpstreamError } from "@shared/error.ts";
 import { getPublicOrigin } from "@shared/public-origin.ts";
 import {
+    buildUsageHeaders,
+    type OpenAIImageUsage,
+    parseUsageHeaders,
+    usageToOpenAIImageUsage,
+} from "@shared/registry/usage-headers.ts";
+import {
     type CreateImageEditRequest,
     CreateImageEditRequestSchema,
     type CreateImageRequest,
@@ -28,11 +34,29 @@ const PASSTHROUGH_PARAMS = ["safe", "transparent", "guidance_scale"] as const;
 function imageResponse(
     data: { url?: string; b64_json?: string },
     prompt: string,
+    usage: OpenAIImageUsage,
 ) {
     return {
         created: Math.floor(Date.now() / 1000),
         data: [{ ...data, revised_prompt: prompt }],
+        usage,
     };
+}
+
+function responseImageUsage(
+    c: Context<Env>,
+    response: Response,
+): OpenAIImageUsage {
+    const usage = parseUsageHeaders(response.headers);
+    const modelUsed = response.headers.get("x-model-used");
+    if (!modelUsed) throw new Error("Image response is missing x-model-used");
+
+    for (const [name, value] of Object.entries(
+        buildUsageHeaders(modelUsed, usage),
+    )) {
+        c.header(name, value);
+    }
+    return usageToOpenAIImageUsage(usage);
 }
 
 /** Resolve OpenAI params to Pollinations equivalents. */
@@ -191,6 +215,7 @@ export async function handleImageGeneration(c: Context<Env>) {
         model,
     });
     c.var.track.overrideResponseTracking(response.clone());
+    const usage = responseImageUsage(c, response);
 
     if (body.response_format === "url") {
         const origin = getPublicOrigin(c);
@@ -209,14 +234,16 @@ export async function handleImageGeneration(c: Context<Env>) {
         await response.arrayBuffer();
         return withSafetyHeaders(
             c,
-            c.json(imageResponse({ url: imageUrl.toString() }, safePrompt)),
+            c.json(
+                imageResponse({ url: imageUrl.toString() }, safePrompt, usage),
+            ),
         );
     }
 
     const base64 = arrayBufferToBase64(await response.arrayBuffer());
     return withSafetyHeaders(
         c,
-        c.json(imageResponse({ b64_json: base64 }, safePrompt)),
+        c.json(imageResponse({ b64_json: base64 }, safePrompt, usage)),
     );
 }
 
@@ -236,10 +263,11 @@ export async function handleImageEdit(c: Context<Env>) {
         model: c.var.model.resolved,
     });
     c.var.track.overrideResponseTracking(response.clone());
+    const usage = responseImageUsage(c, response);
 
     const base64 = arrayBufferToBase64(await response.arrayBuffer());
     return withSafetyHeaders(
         c,
-        c.json(imageResponse({ b64_json: base64 }, safePrompt)),
+        c.json(imageResponse({ b64_json: base64 }, safePrompt, usage)),
     );
 }

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -886,6 +886,43 @@ test("flux image generation uses Fireworks serverless from gen", async ({
     });
 });
 
+test("OpenAI image generation returns token usage", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "fireworks");
+
+    const { response, wait } = await fetchWorker("/v1/images/generations", {
+        method: "POST",
+        headers: {
+            authorization: `Bearer ${paidApiKey}`,
+            "content-type": "application/json",
+        },
+        body: JSON.stringify({
+            model: "flux",
+            prompt: "vcr red square",
+            size: "1280x720",
+            seed: 42,
+            response_format: "b64_json",
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+        data: [{ b64_json: expect.any(String) }],
+        usage: {
+            input_tokens: 0,
+            output_tokens: 1,
+            total_tokens: 1,
+            input_tokens_details: {
+                text_tokens: 0,
+                image_tokens: 0,
+            },
+        },
+    });
+    await wait();
+});
+
 test("gpt-image-2 rejects transparent backgrounds with 400", async ({
     paidApiKey,
     mocks,

--- a/gen.pollinations.ai/test/image/trackingHeaders.test.ts
+++ b/gen.pollinations.ai/test/image/trackingHeaders.test.ts
@@ -1,3 +1,4 @@
+import { usageToOpenAIImageUsage } from "@shared/registry/usage-headers.ts";
 import { describe, expect, it } from "vitest";
 import { buildTrackingHeaders } from "../../src/image/utils/trackingHeaders.ts";
 
@@ -24,5 +25,25 @@ describe("buildTrackingHeaders", () => {
         expect(() => buildTrackingHeaders("flux", { usage: {} })).toThrow(
             "Missing billable usage for flux",
         );
+    });
+});
+
+describe("usageToOpenAIImageUsage", () => {
+    it("maps internal image billing buckets to the OpenAI response shape", () => {
+        expect(
+            usageToOpenAIImageUsage({
+                promptTextTokens: 12,
+                promptImageTokens: 40,
+                completionImageTokens: 1056,
+            }),
+        ).toEqual({
+            input_tokens: 52,
+            output_tokens: 1056,
+            total_tokens: 1108,
+            input_tokens_details: {
+                text_tokens: 12,
+                image_tokens: 40,
+            },
+        });
     });
 });

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -50,6 +50,36 @@ export const OPENAI_CHAT_USAGE_PATHS: Record<
     completionAudioTokens: ["completion_tokens_details.audio_tokens"],
 };
 
+export type OpenAIImageUsage = {
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    input_tokens_details: {
+        text_tokens: number;
+        image_tokens: number;
+    };
+};
+
+export function usageToOpenAIImageUsage(usage: Usage): OpenAIImageUsage {
+    const inputTextTokens =
+        (usage.promptTextTokens ?? 0) +
+        (usage.promptCachedTokens ?? 0) +
+        (usage.promptCacheWriteTokens ?? 0);
+    const inputImageTokens = usage.promptImageTokens ?? 0;
+    const inputTokens = inputTextTokens + inputImageTokens;
+    const outputTokens =
+        (usage.completionTextTokens ?? 0) + (usage.completionImageTokens ?? 0);
+    return {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        total_tokens: inputTokens + outputTokens,
+        input_tokens_details: {
+            text_tokens: inputTextTokens,
+            image_tokens: inputImageTokens,
+        },
+    };
+}
+
 /**
  * Internal worker header carrying Portkey's served fallback target (e.g.
  * "config.targets[1]"), re-emitted from x-portkey-last-used-option-index so

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -597,10 +597,21 @@ const ImageDataSchema = z.object({
     revised_prompt: z.string().optional(),
 });
 
+export const ImageUsageSchema = z.object({
+    input_tokens: z.number().int().nonnegative(),
+    output_tokens: z.number().int().nonnegative(),
+    total_tokens: z.number().int().nonnegative(),
+    input_tokens_details: z.object({
+        text_tokens: z.number().int().nonnegative(),
+        image_tokens: z.number().int().nonnegative(),
+    }),
+});
+
 export const CreateImageResponseSchema = z
     .object({
         created: z.number().int(),
         data: z.array(ImageDataSchema),
+        usage: ImageUsageSchema,
     })
     .meta({ $id: "CreateImageResponse" });
 


### PR DESCRIPTION
- Adds OpenAI-compatible token usage to image generation and edit responses.\n- Preserves internal image tracking headers when binary responses are wrapped as JSON.\n- Covers response mapping and billing behavior with focused tests.\n\nTests:\n- Focused image usage unit test\n- Focused OpenAI image generation integration test\n- Gen TypeScript typecheck