### PR TITLE
feat: track legacy image referrals

### DIFF
--- a/enter.pollinations.ai/observability/datasources/referral_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/referral_event.datasource
@@ -1,0 +1,13 @@
+TOKEN tinybird_ingest APPEND
+TOKEN tinybird_read READ
+
+DESCRIPTION >
+Visits to enter.pollinations.ai from tracked referral links.
+
+SCHEMA >
+`timestamp` DateTime               `json:$.timestamp`,
+`ref`       LowCardinality(String) `json:$.ref`
+
+ENGINE "MergeTree"
+ENGINE_SORTING_KEY "timestamp, ref"
+ENGINE_PRIMARY_KEY "timestamp"

--- a/enter.pollinations.ai/src/frontend-api.ts
+++ b/enter.pollinations.ai/src/frontend-api.ts
@@ -8,6 +8,7 @@ import { deviceRoutes } from "./routes/device.ts";
 import { modelStatsRoutes } from "./routes/model-stats.ts";
 import { oauthRoutes } from "./routes/oauth.ts";
 import { questsRoutes } from "./routes/quests.ts";
+import { referralRoutes } from "./routes/referral.ts";
 import { stripeRoutes } from "./routes/stripe.ts";
 
 export const frontendApi = new Hono<Env>()
@@ -19,6 +20,7 @@ export const frontendApi = new Hono<Env>()
     .route("/device", deviceRoutes)
     .route("/oauth", oauthRoutes)
     .route("/model-stats", modelStatsRoutes)
+    .route("/referral", referralRoutes)
     .route("/quests", questsRoutes);
 
 export type FrontendApiRoutes = typeof frontendApi;

--- a/enter.pollinations.ai/src/routes/referral.ts
+++ b/enter.pollinations.ai/src/routes/referral.ts
@@ -1,0 +1,52 @@
+import type { Logger } from "@logtape/logtape";
+import { getTinybirdDatasourceIngestUrl } from "@shared/events.ts";
+import { Hono } from "hono";
+import type { Env } from "../env.ts";
+
+const LEGACY_IMAGE_REF = "legacy-image-error";
+
+async function trackReferral(
+    env: CloudflareBindings,
+    ref: string,
+    log: Logger,
+): Promise<void> {
+    const response = await fetch(
+        getTinybirdDatasourceIngestUrl(
+            env.TINYBIRD_INGEST_URL,
+            "referral_event",
+        ),
+        {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${env.TINYBIRD_INGEST_TOKEN}`,
+                "Content-Type": "application/x-ndjson",
+            },
+            body: JSON.stringify({
+                timestamp: new Date().toISOString(),
+                ref,
+            }),
+        },
+    );
+
+    if (!response.ok) {
+        log.warn("Referral event ingest failed: status={status}", {
+            status: response.status,
+        });
+    }
+}
+
+export const referralRoutes = new Hono<Env>().get("/", (c) => {
+    const ref = c.req.query("ref");
+
+    if (ref === LEGACY_IMAGE_REF) {
+        c.executionCtx.waitUntil(
+            trackReferral(c.env, ref, c.get("log")).catch((error) =>
+                c.get("log").warn("Referral event ingest failed: {error}", {
+                    error,
+                }),
+            ),
+        );
+    }
+
+    return c.redirect(new URL("/", c.req.url).toString());
+});

--- a/enter.pollinations.ai/test/referral.test.ts
+++ b/enter.pollinations.ai/test/referral.test.ts
@@ -1,0 +1,32 @@
+import { SELF } from "cloudflare:test";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+test("tracks the legacy image referral and redirects", async ({ mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(
+        "https://enter.pollinations.ai/api/referral?ref=legacy-image-error",
+        { redirect: "manual" },
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+        "https://enter.pollinations.ai/",
+    );
+    expect(mocks.tinybird.state.referralEvents).toEqual([
+        expect.objectContaining({ ref: "legacy-image-error" }),
+    ]);
+});
+
+test("does not track unknown referrals", async ({ mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(
+        "https://enter.pollinations.ai/api/referral?ref=unknown",
+        { redirect: "manual" },
+    );
+
+    expect(response.status).toBe(302);
+    expect(mocks.tinybird.state.referralEvents).toEqual([]);
+});

--- a/shared/test/mocks/tinybird.ts
+++ b/shared/test/mocks/tinybird.ts
@@ -21,6 +21,7 @@ type PipeCall = {
 export type MockTinybirdState = {
     events: TinybirdGenerationEvent[];
     errorEvents: Record<string, unknown>[];
+    referralEvents: Record<string, unknown>[];
     stripeEvents: Record<string, unknown>[];
     dailyResponse: UsageRow[];
     usageResponse: UsageRow[];
@@ -36,6 +37,7 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
     const state: MockTinybirdState = {
         events: [],
         errorEvents: [],
+        referralEvents: [],
         stripeEvents: [],
         dailyResponse: [],
         usageResponse: [],
@@ -74,6 +76,8 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
 
             if (eventName === "error_event") {
                 state.errorEvents.push(...rows);
+            } else if (eventName === "referral_event") {
+                state.referralEvents.push(...rows);
             } else if (eventName === "stripe_event") {
                 state.stripeEvents.push(...rows);
             }
@@ -125,6 +129,7 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
     const reset = () => {
         state.events = [];
         state.errorEvents = [];
+        state.referralEvents = [];
         state.stripeEvents = [];
         state.dailyResponse = [];
         state.usageResponse = [];


### PR DESCRIPTION
- Adds a public `/api/referral` redirect with an allowlisted `legacy-image-error` ref.
- Records `timestamp` and `ref` in a minimal Tinybird datasource without client-side analytics.
- Redirects unknown refs without recording them.
- Adds focused Worker tests for tracking and redirect behavior.

Checks:
- `npx vitest run test/referral.test.ts`
- `npm run typecheck`
- `npx biome check --write ...`

Tinybird deployment validation is pending a token with `WORKSPACE:DEPLOY`; no Tinybird workspace changes were made.