### PR TITLE
fix: use direct Enter referral link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Primary: `https://gen.pollinations.ai` → routes to `enter.pollinations.ai` for
   connector prompt (`apps/operation/economics/ingest/agent.system.txt`).
 - Services: Text (Portkey, multi-provider), Image (gen Worker dispatch to providers/GPU backends), Video (Wan/Veo/LTX), Audio (ElevenLabs, TTM)
 - Wallet: Pollen is earned by completing Quests; balances live in the `tier_balance` (shown as Quest Pollen) and `pack_balance` (Paid) buckets. The legacy `tier` D1 column and `tier_balance` wire name are kept for compatibility; see `shared/db/better-auth.ts`.
+- Referral links must use the canonical landing page with a short `?ref=` value; record analytics behind the page instead of exposing a tracking API as the destination URL.
 
 ### Local Development
 

--- a/enter.pollinations.ai/frontend/src/main.tsx
+++ b/enter.pollinations.ai/frontend/src/main.tsx
@@ -1,7 +1,13 @@
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { type FC, type PropsWithChildren, StrictMode } from "react";
 import ReactDOM from "react-dom/client";
+import { config } from "./config";
 import { routeTree } from "./routeTree.gen";
+
+const ref = new URLSearchParams(window.location.search).get("ref");
+if (ref === "image") {
+    navigator.sendBeacon(`${config.apiBaseUrl}/referral?ref=${ref}`);
+}
 
 // Register the router instance for type safety
 declare module "@tanstack/react-router" {

--- a/enter.pollinations.ai/src/routes/referral.ts
+++ b/enter.pollinations.ai/src/routes/referral.ts
@@ -3,7 +3,7 @@ import { getTinybirdDatasourceIngestUrl } from "@shared/events.ts";
 import { Hono } from "hono";
 import type { Env } from "../env.ts";
 
-const LEGACY_IMAGE_REF = "legacy-image-error";
+const IMAGE_REF = "image";
 
 async function trackReferral(
     env: CloudflareBindings,
@@ -35,10 +35,10 @@ async function trackReferral(
     }
 }
 
-export const referralRoutes = new Hono<Env>().get("/", (c) => {
+export const referralRoutes = new Hono<Env>().post("/", (c) => {
     const ref = c.req.query("ref");
 
-    if (ref === LEGACY_IMAGE_REF) {
+    if (ref === IMAGE_REF) {
         c.executionCtx.waitUntil(
             trackReferral(c.env, ref, c.get("log")).catch((error) =>
                 c.get("log").warn("Referral event ingest failed: {error}", {
@@ -48,5 +48,5 @@ export const referralRoutes = new Hono<Env>().get("/", (c) => {
         );
     }
 
-    return c.redirect(new URL("/", c.req.url).toString());
+    return c.body(null, 204);
 });

--- a/enter.pollinations.ai/test/referral.test.ts
+++ b/enter.pollinations.ai/test/referral.test.ts
@@ -2,20 +2,17 @@ import { SELF } from "cloudflare:test";
 import { expect } from "vitest";
 import { test } from "./fixtures.ts";
 
-test("tracks the legacy image referral and redirects", async ({ mocks }) => {
+test("tracks the image referral", async ({ mocks }) => {
     await mocks.enable("tinybird");
 
     const response = await SELF.fetch(
-        "https://enter.pollinations.ai/api/referral?ref=legacy-image-error",
-        { redirect: "manual" },
+        "https://enter.pollinations.ai/api/referral?ref=image",
+        { method: "POST" },
     );
 
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toBe(
-        "https://enter.pollinations.ai/",
-    );
+    expect(response.status).toBe(204);
     expect(mocks.tinybird.state.referralEvents).toEqual([
-        expect.objectContaining({ ref: "legacy-image-error" }),
+        expect.objectContaining({ ref: "image" }),
     ]);
 });
 
@@ -24,9 +21,9 @@ test("does not track unknown referrals", async ({ mocks }) => {
 
     const response = await SELF.fetch(
         "https://enter.pollinations.ai/api/referral?ref=unknown",
-        { redirect: "manual" },
+        { method: "POST" },
     );
 
-    expect(response.status).toBe(302);
+    expect(response.status).toBe(204);
     expect(mocks.tinybird.state.referralEvents).toEqual([]);
 });


### PR DESCRIPTION
- Sends users directly to `https://enter.pollinations.ai/?ref=image`
- Records the allowlisted referral with a background beacon
- Removes the redirect behavior from the analytics endpoint
- Adds a regression test and referral URL guidance

Checks:
- `npx vitest run test/referral.test.ts`
- `npm run typecheck`
- legacy `createAndReturnImages` tests