### PR TITLE
fix(mcp): simplify audio generation routing

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.25.1",
-                "play-sound": "^1.1.6",
                 "zod": "^3.24.3"
             },
             "bin": {
@@ -494,15 +493,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/find-exec": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/find-exec/-/find-exec-1.0.3.tgz",
-            "integrity": "sha512-gnG38zW90mS8hm5smNcrBnakPEt+cGJoiMkJwCU0IYnEb0H2NQk0NIljhNW+48oniCriFek/PH6QXbwsJo/qug==",
-            "license": "MIT",
-            "dependencies": {
-                "shell-quote": "^1.8.1"
-            }
-        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -854,15 +844,6 @@
                 "node": ">=16.20.0"
             }
         },
-        "node_modules/play-sound": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/play-sound/-/play-sound-1.1.6.tgz",
-            "integrity": "sha512-09eO4QiXNFXJffJaOW5P6x6F5RLihpLUkXttvUZeWml0fU6x6Zp7AjG9zaeMpgH2ZNvq4GR1ytB22ddYcqJIZA==",
-            "license": "MIT",
-            "dependencies": {
-                "find-exec": "1.0.3"
-            }
-        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1016,18 +997,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/shell-quote": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-            "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/side-channel": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,7 +43,6 @@
     "license": "MIT",
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "play-sound": "^1.1.6",
         "zod": "^3.24.3"
     },
     "repository": {

--- a/packages/mcp/src/index.js
+++ b/packages/mcp/src/index.js
@@ -8,7 +8,6 @@
 import { pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import player from "play-sound";
 import { accountTools } from "./services/accountService.js";
 import { audioTools } from "./services/audioService.js";
 import { authTools } from "./services/authService.js";
@@ -88,13 +87,6 @@ All requests go through: https://gen.pollinations.ai
  */
 export async function startMcpServer() {
     try {
-        // Initialize audio player (optional, for local playback)
-        try {
-            global.audioPlayer = player();
-        } catch (error) {
-            console.error("Audio player not available:", error.message);
-        }
-
         // Create the MCP server
         const server = new McpServer(
             {

--- a/packages/mcp/src/services/audioService.js
+++ b/packages/mcp/src/services/audioService.js
@@ -1,143 +1,78 @@
 import { z } from "zod";
 import { requireApiKey } from "../utils/authUtils.js";
 import {
+    API_BASE_URL,
     arrayBufferToBase64,
-    buildUrl,
     chatWithMedia,
     createAudioContent,
     createMCPResponse,
     createTextContent,
     fetchBinaryWithAuth,
+    postChatCompletion,
 } from "../utils/coreUtils.js";
-import { getAudioModels, validateVoice } from "../utils/models.js";
-
-const DEFAULT_AUDIO_MODEL = "openai-audio";
-
-async function resolveAudioModel(requested) {
-    if (requested) return requested;
-    try {
-        const models = await getAudioModels();
-        const tts = models.find((m) => m.output_modalities?.includes("audio"));
-        return tts?.name || DEFAULT_AUDIO_MODEL;
-    } catch {
-        return DEFAULT_AUDIO_MODEL;
-    }
-}
+import { getAudioModels } from "../utils/models.js";
 
 async function respondAudio(params) {
     requireApiKey();
 
-    const {
-        prompt,
-        voice = "alloy",
-        format = "mp3",
-        model,
-        voiceInstructions,
-    } = params;
+    const { prompt, voice = "alloy", format = "mp3" } = params;
 
     if (!prompt || typeof prompt !== "string") {
         throw new Error("Prompt is required and must be a string");
     }
 
-    const voiceCheck = await validateVoice(voice);
-    if (!voiceCheck.valid) {
-        throw new Error(
-            `${voiceCheck.error} Did you mean: ${voiceCheck.suggestions.join(", ")}? ` +
-                `Use listAudioVoices to see all ${voiceCheck.availableCount} available voices.`,
-        );
+    const response = await postChatCompletion({
+        model: "openai-audio",
+        messages: [{ role: "user", content: prompt }],
+        modalities: ["text", "audio"],
+        audio: { voice, format },
+    });
+    const result = await response.json();
+    const audio = result.choices?.[0]?.message?.audio;
+
+    if (!audio?.data) {
+        throw new Error("Audio response did not include audio data");
     }
 
-    let finalPrompt = prompt;
-    if (voiceInstructions) {
-        finalPrompt = `${voiceInstructions}\n\n${prompt}`;
+    const content = [
+        createAudioContent(
+            audio.data,
+            `audio/${format === "mp3" ? "mpeg" : format}`,
+        ),
+    ];
+    if (audio.transcript) {
+        content.push(createTextContent(audio.transcript));
     }
-
-    const queryParams = {
-        model: await resolveAudioModel(model),
-        voice,
-        format,
-    };
-
-    const url = buildUrl(
-        `/text/${encodeURIComponent(finalPrompt)}`,
-        queryParams,
-    );
-
-    try {
-        const { buffer, contentType } = await fetchBinaryWithAuth(url);
-        const base64Data = arrayBufferToBase64(buffer);
-
-        const mimeType =
-            contentType || `audio/${format === "mp3" ? "mpeg" : format}`;
-
-        return createMCPResponse([
-            createAudioContent(base64Data, mimeType),
-            createTextContent(
-                `Generated audio response for prompt: "${prompt}"\n\nVoice: ${voice}\nFormat: ${format}`,
-            ),
-        ]);
-    } catch (error) {
-        console.error("Error generating audio:", error);
-        throw error;
-    }
+    return createMCPResponse(content);
 }
 
 async function sayText(params) {
     requireApiKey();
 
-    const {
-        text,
-        voice = "alloy",
-        format = "mp3",
-        model,
-        voiceInstructions,
-    } = params;
+    const { text, voice = "alloy", format = "mp3", model } = params;
 
     if (!text || typeof text !== "string") {
         throw new Error("Text is required and must be a string");
     }
 
-    const voiceCheck = await validateVoice(voice);
-    if (!voiceCheck.valid) {
-        throw new Error(
-            `${voiceCheck.error} Did you mean: ${voiceCheck.suggestions.join(", ")}? ` +
-                `Use listAudioVoices to see all ${voiceCheck.availableCount} available voices.`,
-        );
-    }
+    const body = { input: text, voice, response_format: format };
+    if (model) body.model = model;
 
-    let finalPrompt = `Say verbatim: ${text}`;
-    if (voiceInstructions) {
-        finalPrompt = `${voiceInstructions}\n\n${finalPrompt}`;
-    }
-
-    const queryParams = {
-        model: await resolveAudioModel(model),
-        voice,
-        format,
-    };
-
-    const url = buildUrl(
-        `/text/${encodeURIComponent(finalPrompt)}`,
-        queryParams,
+    const { buffer, contentType } = await fetchBinaryWithAuth(
+        `${API_BASE_URL}/v1/audio/speech`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        },
     );
 
-    try {
-        const { buffer, contentType } = await fetchBinaryWithAuth(url);
-        const base64Data = arrayBufferToBase64(buffer);
-
-        const mimeType =
-            contentType || `audio/${format === "mp3" ? "mpeg" : format}`;
-
-        return createMCPResponse([
-            createAudioContent(base64Data, mimeType),
-            createTextContent(
-                `Generated speech for text: "${text}"\n\nVoice: ${voice}\nFormat: ${format}`,
-            ),
-        ]);
-    } catch (error) {
-        console.error("Error generating speech:", error);
-        throw error;
-    }
+    return createMCPResponse([
+        createAudioContent(arrayBufferToBase64(buffer), contentType),
+        createTextContent(
+            `Generated speech for text: "${text}"\n\nVoice: ${voice}\nFormat: ${format}`,
+        ),
+    ]);
 }
 
 async function listAudioVoices(_params) {
@@ -161,7 +96,7 @@ async function listAudioVoices(_params) {
             {
                 voices: allVoices,
                 byModel,
-                formats: ["wav", "mp3", "flac", "opus", "pcm16"],
+                formats: ["wav", "mp3", "flac", "opus", "aac", "pcm", "pcm16"],
                 total: allVoices.length,
             },
             true,
@@ -182,29 +117,24 @@ async function transcribeAudio(params) {
         throw new Error("audioUrl is required and must be a string");
     }
 
-    try {
-        const { content, model: respondedModel } = await chatWithMedia({
-            model,
-            prompt,
-            mediaType: "input_audio",
-            mediaUrl: audioUrl,
-        });
+    const { content, model: respondedModel } = await chatWithMedia({
+        model,
+        prompt,
+        mediaType: "input_audio",
+        mediaUrl: audioUrl,
+    });
 
-        return createMCPResponse([
-            createTextContent(
-                {
-                    transcription: content,
-                    audioUrl,
-                    model: respondedModel,
-                    prompt,
-                },
-                true,
-            ),
-        ]);
-    } catch (error) {
-        console.error("Error transcribing audio:", error);
-        throw error;
-    }
+    return createMCPResponse([
+        createTextContent(
+            {
+                transcription: content,
+                audioUrl,
+                model: respondedModel,
+                prompt,
+            },
+            true,
+        ),
+    ]);
 }
 
 const voiceSchema = z
@@ -214,14 +144,20 @@ const voiceSchema = z
             "Use listAudioVoices to see the full live list.",
     );
 
-const formatEnum = z.enum(["wav", "mp3", "flac", "opus", "pcm16"]);
+const responseAudioFormatSchema = z.enum([
+    "wav",
+    "mp3",
+    "flac",
+    "opus",
+    "pcm16",
+]);
+const speechFormatSchema = z.enum(["mp3", "opus", "aac", "flac", "wav", "pcm"]);
 
 const audioModelSchema = z
     .string()
     .optional()
     .describe(
-        "Audio model override (e.g. 'elevenlabs', 'openai-audio'). " +
-            "Defaults to the current primary TTS model from the registry.",
+        "Audio model override. Omit to use the current primary TTS model.",
     );
 
 export const audioTools = [
@@ -235,16 +171,9 @@ export const audioTools = [
             voice: voiceSchema
                 .optional()
                 .describe("Voice to use (default: alloy)"),
-            format: formatEnum
+            format: responseAudioFormatSchema
                 .optional()
                 .describe("Audio format (default: mp3)"),
-            model: audioModelSchema,
-            voiceInstructions: z
-                .string()
-                .optional()
-                .describe(
-                    "Additional instructions for voice style (e.g., 'Speak with enthusiasm')",
-                ),
         },
         respondAudio,
     ],
@@ -257,14 +186,10 @@ export const audioTools = [
             voice: voiceSchema
                 .optional()
                 .describe("Voice to use (default: alloy)"),
-            format: formatEnum
+            format: speechFormatSchema
                 .optional()
                 .describe("Audio format (default: mp3)"),
             model: audioModelSchema,
-            voiceInstructions: z
-                .string()
-                .optional()
-                .describe("Additional instructions for voice style"),
         },
         sayText,
     ],

--- a/packages/mcp/src/services/audioService.js
+++ b/packages/mcp/src/services/audioService.js
@@ -1,6 +1,3 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { z } from "zod";
 import { requireApiKey } from "../utils/authUtils.js";
 import {
@@ -12,11 +9,7 @@ import {
     createTextContent,
     fetchBinaryWithAuth,
 } from "../utils/coreUtils.js";
-import {
-    getAudioModels,
-    getAudioVoices,
-    validateVoice,
-} from "../utils/models.js";
+import { getAudioModels, validateVoice } from "../utils/models.js";
 
 const DEFAULT_AUDIO_MODEL = "openai-audio";
 
@@ -40,8 +33,6 @@ async function respondAudio(params) {
         format = "mp3",
         model,
         voiceInstructions,
-        audioPlayer,
-        tempDir,
     } = params;
 
     if (!prompt || typeof prompt !== "string") {
@@ -79,17 +70,6 @@ async function respondAudio(params) {
         const mimeType =
             contentType || `audio/${format === "mp3" ? "mpeg" : format}`;
 
-        if (audioPlayer) {
-            const tempDirPath = tempDir || os.tmpdir();
-            await playAudio(
-                base64Data,
-                mimeType,
-                "respond_audio",
-                audioPlayer,
-                tempDirPath,
-            );
-        }
-
         return createMCPResponse([
             createAudioContent(base64Data, mimeType),
             createTextContent(
@@ -111,8 +91,6 @@ async function sayText(params) {
         format = "mp3",
         model,
         voiceInstructions,
-        audioPlayer,
-        tempDir,
     } = params;
 
     if (!text || typeof text !== "string") {
@@ -150,17 +128,6 @@ async function sayText(params) {
         const mimeType =
             contentType || `audio/${format === "mp3" ? "mpeg" : format}`;
 
-        if (audioPlayer) {
-            const tempDirPath = tempDir || os.tmpdir();
-            await playAudio(
-                base64Data,
-                mimeType,
-                "say_text",
-                audioPlayer,
-                tempDirPath,
-            );
-        }
-
         return createMCPResponse([
             createAudioContent(base64Data, mimeType),
             createTextContent(
@@ -174,44 +141,32 @@ async function sayText(params) {
 }
 
 async function listAudioVoices(_params) {
-    try {
-        const audioModels = await getAudioModels();
-        const byModel = audioModels
-            .filter((m) => Array.isArray(m.voices) && m.voices.length > 0)
-            .map((m) => ({
-                model: m.name,
-                aliases: m.aliases || [],
-                description: m.description,
-                voices: m.voices,
-            }));
-        const allVoices = Array.from(new Set(byModel.flatMap((m) => m.voices)));
+    const audioModels = await getAudioModels();
+    const byModel = audioModels
+        .filter((m) => Array.isArray(m.voices) && m.voices.length > 0)
+        .map((m) => ({
+            model: m.name,
+            aliases: m.aliases || [],
+            description: m.description,
+            voices: m.voices,
+        }));
+    const allVoices = Array.from(new Set(byModel.flatMap((m) => m.voices)));
 
-        return createMCPResponse([
-            createTextContent(
-                {
-                    voices: allVoices,
-                    byModel,
-                    formats: ["wav", "mp3", "flac", "opus", "pcm16"],
-                    total: allVoices.length,
-                },
-                true,
-            ),
-        ]);
-    } catch (error) {
-        console.error("Error listing audio voices:", error);
-        const voices = await getAudioVoices();
-        return createMCPResponse([
-            createTextContent(
-                {
-                    voices,
-                    formats: ["wav", "mp3", "flac", "opus", "pcm16"],
-                    total: voices.length,
-                    note: "Using fallback voice list (registry unavailable)",
-                },
-                true,
-            ),
-        ]);
+    if (allVoices.length === 0) {
+        throw new Error("Audio model registry returned no voices");
     }
+
+    return createMCPResponse([
+        createTextContent(
+            {
+                voices: allVoices,
+                byModel,
+                formats: ["wav", "mp3", "flac", "opus", "pcm16"],
+                total: allVoices.length,
+            },
+            true,
+        ),
+    ]);
 }
 
 async function transcribeAudio(params) {
@@ -250,50 +205,6 @@ async function transcribeAudio(params) {
         console.error("Error transcribing audio:", error);
         throw error;
     }
-}
-
-function playAudio(audioData, mimeType, prefix, audioPlayer, tempDir) {
-    if (!audioPlayer || !tempDir) {
-        return Promise.resolve();
-    }
-
-    return new Promise((resolve, reject) => {
-        try {
-            const format = getFormatFromMimeType(mimeType);
-            const tempFile = path.join(
-                tempDir,
-                `${prefix}_${Date.now()}.${format}`,
-            );
-            fs.writeFileSync(tempFile, Buffer.from(audioData, "base64"));
-
-            audioPlayer.play(tempFile, (err) => {
-                try {
-                    fs.unlinkSync(tempFile);
-                } catch (e) {
-                    console.error("Error removing temp file:", e);
-                }
-
-                if (err) {
-                    console.error("Error playing audio:", err);
-                }
-                resolve();
-            });
-        } catch (error) {
-            console.error("Error playing audio:", error);
-            reject(error);
-        }
-    });
-}
-
-function getFormatFromMimeType(mimeType) {
-    const formats = {
-        "audio/mpeg": "mp3",
-        "audio/wav": "wav",
-        "audio/ogg": "ogg",
-        "audio/flac": "flac",
-        "audio/opus": "opus",
-    };
-    return formats[mimeType] || "mp3";
 }
 
 const voiceSchema = z

--- a/packages/mcp/src/utils/models.js
+++ b/packages/mcp/src/utils/models.js
@@ -34,33 +34,16 @@ export async function getVideoModels() {
 }
 
 export async function getAudioVoices() {
-    try {
-        const audioModels = await getAudioModels();
-        const voices = new Set();
-        for (const m of audioModels) {
-            if (Array.isArray(m.voices)) {
-                for (const v of m.voices) voices.add(v);
-            }
+    const voices = new Set();
+    for (const model of await getAudioModels()) {
+        if (Array.isArray(model.voices)) {
+            for (const voice of model.voices) voices.add(voice);
         }
-        if (voices.size > 0) return Array.from(voices);
-    } catch {}
-    // Last-resort fallback. Keep in sync with AUDIO_VOICES in
-    // shared/registry/text.ts (the canonical list the API serves).
-    return [
-        "alloy",
-        "echo",
-        "fable",
-        "onyx",
-        "nova",
-        "shimmer",
-        "coral",
-        "verse",
-        "ballad",
-        "ash",
-        "sage",
-        "amuch",
-        "dan",
-    ];
+    }
+    if (voices.size === 0) {
+        throw new Error("Audio model registry returned no voices");
+    }
+    return Array.from(voices);
 }
 
 async function validateAgainstRegistry(modelName, fetcher, kind) {


### PR DESCRIPTION
- Routes `respondAudio` through chat audio output and `sayText` through `/v1/audio/speech`
- Removes local playback, `play-sound`, model/voice fallbacks, and unused voice instructions
- Lets Gen validate audio models and voices, including custom ElevenLabs voice IDs
- Keeps audio results as MCP audio content blocks

Tests:
- `npx biome check --write src/services/audioService.js`
- `env -u POLLINATIONS_API_KEY npm test` (2/2)
- Focused mocked endpoint/body/response checks

PR #12495 only overlaps some MCP files; neither PR depends on the other, so whichever lands second should sync with main.