### PR TITLE
fix(api): expose billing in /v1/models

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -316,7 +316,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                'Returns available models (text, community text, image, realtime, audio, embeddings) in the OpenAI-compatible format (`{object: "list", data: [...]}`). Entries include Pollinations billing extensions (`pricing` and `paid_only`) alongside capability metadata. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer descriptions and model-specific metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.',
+                'Returns available models (text, community text, image, realtime, audio, embeddings) in the OpenAI-compatible format (`{object: "list", data: [...]}`). Entries use the OpenRouter-compatible `pricing` field name plus the Pollinations `requires_paid_balance` extension alongside capability metadata. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer descriptions and model-specific metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and models requiring paid balance are hidden if the account has no paid balance.',
             responses: {
                 200: {
                     description: "Success",
@@ -354,7 +354,9 @@ export const proxyRoutes = new Hono<Env>()
                     context_length: entry.info.context_length,
                 }),
                 pricing: entry.info.pricing,
-                ...(entry.info.paid_only && { paid_only: true }),
+                ...(entry.info.paid_only && {
+                    requires_paid_balance: true,
+                }),
             });
 
             return c.json({

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -316,7 +316,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                "Returns available models (text, community text, image, realtime, audio, embeddings) in the OpenAI-compatible format (`{object: \"list\", data: [...]}`). Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                'Returns available models (text, community text, image, realtime, audio, embeddings) in the OpenAI-compatible format (`{object: "list", data: [...]}`). Entries include Pollinations billing extensions (`pricing` and `paid_only`) alongside capability metadata. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer descriptions and model-specific metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.',
             responses: {
                 200: {
                     description: "Success",
@@ -353,6 +353,8 @@ export const proxyRoutes = new Hono<Env>()
                 ...(entry.info.context_length && {
                     context_length: entry.info.context_length,
                 }),
+                pricing: entry.info.pricing,
+                ...(entry.info.paid_only && { paid_only: true }),
             });
 
             return c.json({

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -299,6 +299,7 @@ describe("gen worker routing", () => {
                 supported_endpoints?: string[];
                 input_modalities?: string[];
                 output_modalities?: string[];
+                pricing?: Record<string, string> & { currency: "pollen" };
             }[];
         };
         expect(models.object).toBe("list");
@@ -320,6 +321,7 @@ describe("gen worker routing", () => {
             input_modalities: expect.any(Array),
             output_modalities: expect.any(Array),
             supported_endpoints: expect.arrayContaining(["/text/{prompt}"]),
+            pricing: expect.objectContaining({ currency: "pollen" }),
         });
         expect(imageModel?.supported_endpoints).toContain("/image/{prompt}");
         expect(audioModel).toBeDefined();

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -43,14 +43,14 @@ test("includes billing metadata in the OpenAI-compatible model list", async ({
         data: {
             id: string;
             pricing?: Record<string, string> & { currency: "pollen" };
-            paid_only?: boolean;
+            requires_paid_balance?: boolean;
         }[];
     };
-    const paidModel = body.data.find((model) => model.paid_only);
+    const paidModel = body.data.find((model) => model.requires_paid_balance);
 
     expect(paidModel).toMatchObject({
         id: expect.any(String),
-        paid_only: true,
+        requires_paid_balance: true,
         pricing: expect.objectContaining({ currency: "pollen" }),
     });
 });

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -31,6 +31,30 @@ test("filters OpenAI-compatible model list by API key permissions", async ({
     expect(modelIds).toContain(RESTRICTED_TEXT_TEST_MODEL);
 });
 
+test("includes billing metadata in the OpenAI-compatible model list", async ({
+    paidApiKey,
+}) => {
+    const response = await fetchWorker("/v1/models", {
+        headers: { Authorization: `Bearer ${paidApiKey}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+        data: {
+            id: string;
+            pricing?: Record<string, string> & { currency: "pollen" };
+            paid_only?: boolean;
+        }[];
+    };
+    const paidModel = body.data.find((model) => model.paid_only);
+
+    expect(paidModel).toMatchObject({
+        id: expect.any(String),
+        paid_only: true,
+        pricing: expect.objectContaining({ currency: "pollen" }),
+    });
+});
+
 test("filters image model list by API key permissions", async ({
     restrictedApiKey,
 }) => {

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -517,9 +517,15 @@ const OpenAIModelSchema = z
         tools: z.boolean().optional(),
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
+        pricing: z
+            .record(z.string(), z.string())
+            .and(z.object({ currency: z.literal("pollen") }))
+            .optional(),
+        paid_only: z.boolean().optional(),
     })
     .meta({
-        description: "OpenAI-compatible model object with capability metadata",
+        description:
+            "OpenAI-compatible model object with capability and billing metadata",
     });
 
 export const GetModelsResponseSchema = z

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -521,7 +521,7 @@ const OpenAIModelSchema = z
             .record(z.string(), z.string())
             .and(z.object({ currency: z.literal("pollen") }))
             .optional(),
-        paid_only: z.boolean().optional(),
+        requires_paid_balance: z.boolean().optional(),
     })
     .meta({
         description:


### PR DESCRIPTION
- Adds the OpenRouter-compatible `pricing` field name to `/v1/models` entries.
- Adds `requires_paid_balance` for Pollinations' pack-balance restriction; OpenRouter and OpenAI define no equivalent per-model field.
- Updates the OpenAPI response schema and focused Worker assertions.

Verification:
- `npm run typecheck`
- Locked Biome 2.3.10 check

References:
- https://openrouter.ai/docs/api/api-reference/models/get-models
- https://platform.openai.com/docs/api-reference/models/object

Addresses #11203.