### PR TITLE
feat: tag community leaderboard uploads

### DIFF
--- a/apps/operation/community-monitor/leaderboard/build-leaderboard.mjs
+++ b/apps/operation/community-monitor/leaderboard/build-leaderboard.mjs
@@ -328,6 +328,7 @@ async function polliUpload(pngPath) {
         new Blob([buf], { type: "image/png" }),
         "leaderboard.png",
     );
+    form.append("tags", "community:leaderboard");
 
     const res = await fetch(`${mediaUrl}/upload`, {
         method: "POST",


### PR DESCRIPTION
- Adds the `community:leaderboard` tag to the existing daily leaderboard upload.
- Makes the already-public Discord artifact discoverable through the media tag gallery.
- Leaves the render and posting flow unchanged.

Checks:
- `biome check` on the uploader
- `node --check` on the uploader
- Mocked multipart contract for the exact upload function