### PR TITLE
fix(mcp): allow long-running video generation

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pollinations/mcp",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pollinations/mcp",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.25.1",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,7 +13,8 @@
         "LICENSE"
     ],
     "scripts": {
-        "test": "node test-mcp-client.js",
+        "test": "npm run test:unit && node test-mcp-client.js",
+        "test:unit": "node --test test/*.test.js",
         "start": "node src/index.js"
     },
     "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pollinations/mcp",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "Model Context Protocol (MCP) server for pollinations.ai - image, text, audio & video generation",
     "type": "module",
     "bin": {

--- a/packages/mcp/src/services/imageService.js
+++ b/packages/mcp/src/services/imageService.js
@@ -9,6 +9,7 @@ import {
     createMCPResponse,
     createTextContent,
     fetchBinaryWithAuth,
+    fetchWithAuth,
 } from "../utils/coreUtils.js";
 import {
     getImageModels,
@@ -16,6 +17,8 @@ import {
     validateImageModel,
     validateVideoModel,
 } from "../utils/models.js";
+
+const VIDEO_GENERATION_TIMEOUT_MS = 10 * 60 * 1000;
 
 function buildQueryParams(params) {
     const result = {};
@@ -347,7 +350,9 @@ async function generateVideo(params) {
     const url = buildUrl(`/image/${encodedPrompt}`, queryParams);
 
     try {
-        const { buffer, contentType } = await fetchBinaryWithAuth(url);
+        const { buffer, contentType } = await fetchBinaryWithAuth(url, {
+            timeoutMs: VIDEO_GENERATION_TIMEOUT_MS,
+        });
         const base64Data = arrayBufferToBase64(buffer);
 
         const metadata = {
@@ -396,9 +401,9 @@ async function generateVideoUrl(params) {
     const authUrl = buildUrl(`/image/${encodedPrompt}`, queryParams, true);
 
     try {
-        const headResponse = await fetch(authUrl, {
+        const headResponse = await fetchWithAuth(authUrl, {
             method: "HEAD",
-            headers: getAuthHeaders(),
+            timeoutMs: VIDEO_GENERATION_TIMEOUT_MS,
         });
         if (!headResponse.ok) {
             console.warn(

--- a/packages/mcp/test/video-timeout.test.js
+++ b/packages/mcp/test/video-timeout.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { imageTools } from "../src/services/imageService.js";
+import { clearApiKey, setApiKey } from "../src/utils/authUtils.js";
+
+const VIDEO_GENERATION_TIMEOUT_MS = 10 * 60 * 1000;
+
+test("video generation tools allow long-running requests", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const timeoutDelays = [];
+    const requests = [];
+
+    globalThis.setTimeout = (_callback, delay) => {
+        timeoutDelays.push(delay);
+        return 1;
+    };
+    globalThis.clearTimeout = () => {};
+    globalThis.fetch = async (url, init = {}) => {
+        requests.push({ url: String(url), init });
+        if (String(url).endsWith("/image/models")) {
+            return Response.json([
+                { name: "wan-fast", output_modalities: ["video"] },
+            ]);
+        }
+        return new Response(new Uint8Array([0, 1, 2]), {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+        });
+    };
+    setApiKey("sk_test");
+
+    try {
+        const generateVideo = imageTools.find(
+            ([name]) => name === "generateVideo",
+        )[3];
+        const generateVideoUrl = imageTools.find(
+            ([name]) => name === "generateVideoUrl",
+        )[3];
+
+        await generateVideo({ prompt: "test", model: "wan-fast" });
+        await generateVideoUrl({ prompt: "test", model: "wan-fast" });
+
+        assert.equal(
+            timeoutDelays.filter(
+                (delay) => delay === VIDEO_GENERATION_TIMEOUT_MS,
+            ).length,
+            2,
+        );
+        assert.equal(requests.at(-1).init.method, "HEAD");
+        assert.equal(
+            requests.at(-1).init.headers.Authorization,
+            "Bearer sk_test",
+        );
+    } finally {
+        clearApiKey();
+        globalThis.fetch = originalFetch;
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+    }
+});


### PR DESCRIPTION
- Gives MCP video generation a 10-minute ceiling instead of the generic 30-second timeout
- Uses the same bounded authenticated fetch for `generateVideoUrl` pre-generation
- Bumps `@pollinations/mcp` to publishable version `2.3.1`
- Adds a focused regression test for both video tools

Tests:
- `cd packages/mcp && npm run test` (unit: 1 passed; MCP smoke: 8/8 passed)

Addresses #12201. The refund request still requires a separate account/usage audit.