### PR TITLE
feat: tag SlidePainter images

### DIFF
--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -1,141 +1,171 @@
 // Pollinations API Service
 
-import type {
-  ImageGenerationResponse,
-  PollinationsRequest,
-} from './types';
+import type { ImageGenerationResponse, PollinationsRequest } from "./types";
 
-const POLLINATIONS_API_BASE = 'https://gen.pollinations.ai';
-const POLLINATIONS_MEDIA_API = 'https://media.pollinations.ai/upload';
+const POLLINATIONS_API_BASE = "https://gen.pollinations.ai";
+const POLLINATIONS_MEDIA_API = "https://media.pollinations.ai/upload";
 const DEFAULT_CONFIG = {
-  model: 'gptimage' as const,
-  enhance: true,
-  nologo: true,
+    model: "gptimage" as const,
+    enhance: true,
+    nologo: true,
 };
 
 export class PollinationsService {
-  private token: string | null = null;
+    private token: string | null = null;
 
-  setToken(token: string | null): void {
-    this.token = token;
-  }
+    setToken(token: string | null): void {
+        this.token = token;
+    }
 
-  async generateImageFromPrompt(
-    sectionPrompt: string,
-    projectPrompt?: string,
-    options?: Partial<PollinationsRequest>,
-    inputImageUrl?: string
-  ): Promise<ImageGenerationResponse> {
-    try {
-      const finalPrompt = projectPrompt
-        ? `${projectPrompt}\n\n${sectionPrompt}`
-        : sectionPrompt;
-
-      if (!options?.width || !options?.height) {
-        throw new Error('Width and height must be specified for image generation');
-      }
-
-      const payload: PollinationsRequest = {
-        prompt: finalPrompt,
-        model: options?.model || DEFAULT_CONFIG.model,
-        width: options.width,
-        height: options.height,
-        enhance: options?.enhance ?? DEFAULT_CONFIG.enhance,
-        nologo: options?.nologo ?? DEFAULT_CONFIG.nologo,
-        seed: options?.seed || Math.floor(Math.random() * 1000000),
-        ...(inputImageUrl && { imageUrl: inputImageUrl }),
-      };
-
-      // Build GET URL: https://gen.pollinations.ai/image/{prompt}
-      const encodedPrompt = encodeURIComponent(payload.prompt);
-      const url = new URL(`${POLLINATIONS_API_BASE}/image/${encodedPrompt}`);
-
-      url.searchParams.set('model', payload.model || DEFAULT_CONFIG.model);
-      url.searchParams.set('width', payload.width.toString());
-      url.searchParams.set('height', payload.height.toString());
-      url.searchParams.set('enhance', (payload.enhance ?? DEFAULT_CONFIG.enhance).toString());
-      url.searchParams.set('nologo', (payload.nologo ?? DEFAULT_CONFIG.nologo).toString());
-      url.searchParams.set('seed', payload.seed!.toString());
-
-      if (payload.imageUrl && this.isValidUrl(payload.imageUrl)) {
-        url.searchParams.set('imageUrl', payload.imageUrl);
-      }
-
-      const token = this.token || import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 || import.meta.env.VITE_POLLINATIONS_AI_TOKEN;
-
-      // Publishable keys (pk_) use query param, Secret keys (sk_) use Authorization header
-      const headers: HeadersInit = {};
-      if (token) {
-        if (token.startsWith('pk_')) {
-          url.searchParams.set('key', token);
-        } else {
-          headers['Authorization'] = `Bearer ${token}`;
-        }
-      }
-
-      const response = await fetch(url.toString(), {
-        method: 'GET',
-        headers,
-        signal: AbortSignal.timeout(300000), // 5 minute timeout
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error(`API error: ${response.status} ${response.statusText}`, errorText);
-
-        if (response.status === 500) {
-          throw new Error(`Backend overloaded (500) - Wait a few seconds and try again`);
-        } else if (response.status === 401) {
-          throw new Error(`Authentication failed (401) - Check your API key`);
-        } else if (response.status === 403) {
-          throw new Error(`Insufficient pollen balance (403) - Check https://enter.pollinations.ai`);
-        } else {
-          throw new Error(`Pollinations API error: ${response.status} ${response.statusText}`);
-        }
-      }
-
-      let resultUrl = url.toString();
-      if (token) {
+    async generateImageFromPrompt(
+        sectionPrompt: string,
+        projectPrompt?: string,
+        options?: Partial<PollinationsRequest>,
+        inputImageUrl?: string,
+    ): Promise<ImageGenerationResponse> {
         try {
-          const form = new FormData();
-          form.append('file', await response.blob(), 'slidepainter.png');
-          form.append('tags', 'slidepainter');
-          const upload = await fetch(POLLINATIONS_MEDIA_API, {
-            method: 'POST',
-            headers: { Authorization: `Bearer ${token}` },
-            body: form,
-            signal: AbortSignal.timeout(30000),
-          });
-          if (upload.ok) {
-            const published = await upload.json();
-            if (published.url) resultUrl = published.url;
-          }
+            const finalPrompt = projectPrompt
+                ? `${projectPrompt}\n\n${sectionPrompt}`
+                : sectionPrompt;
+
+            if (!options?.width || !options?.height) {
+                throw new Error(
+                    "Width and height must be specified for image generation",
+                );
+            }
+
+            const payload: PollinationsRequest = {
+                prompt: finalPrompt,
+                model: options?.model || DEFAULT_CONFIG.model,
+                width: options.width,
+                height: options.height,
+                enhance: options?.enhance ?? DEFAULT_CONFIG.enhance,
+                nologo: options?.nologo ?? DEFAULT_CONFIG.nologo,
+                seed: options?.seed || Math.floor(Math.random() * 1000000),
+                ...(inputImageUrl && { imageUrl: inputImageUrl }),
+            };
+
+            // Build GET URL: https://gen.pollinations.ai/image/{prompt}
+            const encodedPrompt = encodeURIComponent(payload.prompt);
+            const url = new URL(
+                `${POLLINATIONS_API_BASE}/image/${encodedPrompt}`,
+            );
+
+            url.searchParams.set(
+                "model",
+                payload.model || DEFAULT_CONFIG.model,
+            );
+            url.searchParams.set("width", payload.width.toString());
+            url.searchParams.set("height", payload.height.toString());
+            url.searchParams.set(
+                "enhance",
+                (payload.enhance ?? DEFAULT_CONFIG.enhance).toString(),
+            );
+            url.searchParams.set(
+                "nologo",
+                (payload.nologo ?? DEFAULT_CONFIG.nologo).toString(),
+            );
+            url.searchParams.set("seed", payload.seed!.toString());
+
+            if (payload.imageUrl && this.isValidUrl(payload.imageUrl)) {
+                url.searchParams.set("imageUrl", payload.imageUrl);
+            }
+
+            const token =
+                this.token ||
+                import.meta.env.VITE_POLLINATIONS_AI_TOKEN_2 ||
+                import.meta.env.VITE_POLLINATIONS_AI_TOKEN;
+
+            // Publishable keys (pk_) use query param, Secret keys (sk_) use Authorization header
+            const headers: HeadersInit = {};
+            if (token) {
+                if (token.startsWith("pk_")) {
+                    url.searchParams.set("key", token);
+                } else {
+                    headers["Authorization"] = `Bearer ${token}`;
+                }
+            }
+
+            const response = await fetch(url.toString(), {
+                method: "GET",
+                headers,
+                signal: AbortSignal.timeout(300000), // 5 minute timeout
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                console.error(
+                    `API error: ${response.status} ${response.statusText}`,
+                    errorText,
+                );
+
+                if (response.status === 500) {
+                    throw new Error(
+                        `Backend overloaded (500) - Wait a few seconds and try again`,
+                    );
+                } else if (response.status === 401) {
+                    throw new Error(
+                        `Authentication failed (401) - Check your API key`,
+                    );
+                } else if (response.status === 403) {
+                    throw new Error(
+                        `Insufficient pollen balance (403) - Check https://enter.pollinations.ai`,
+                    );
+                } else {
+                    throw new Error(
+                        `Pollinations API error: ${response.status} ${response.statusText}`,
+                    );
+                }
+            }
+
+            let resultUrl = url.toString();
+            if (token) {
+                try {
+                    const form = new FormData();
+                    form.append(
+                        "file",
+                        await response.blob(),
+                        "slidepainter.png",
+                    );
+                    form.append("tags", "slidepainter");
+                    const upload = await fetch(POLLINATIONS_MEDIA_API, {
+                        method: "POST",
+                        headers: { Authorization: `Bearer ${token}` },
+                        body: form,
+                        signal: AbortSignal.timeout(30000),
+                    });
+                    if (upload.ok) {
+                        const published = await upload.json();
+                        if (published.url) resultUrl = published.url;
+                    }
+                } catch (error) {
+                    console.warn(
+                        "Could not publish SlidePainter image:",
+                        error,
+                    );
+                }
+            }
+
+            const result: ImageGenerationResponse = {
+                url: resultUrl,
+                provider: "pollinations",
+                seed: payload.seed,
+                cached: false,
+            };
+
+            return result;
         } catch (error) {
-          console.warn('Could not publish SlidePainter image:', error);
+            console.error("Pollinations generation failed:", error);
+            throw error;
         }
-      }
-
-      const result: ImageGenerationResponse = {
-        url: resultUrl,
-        provider: 'pollinations',
-        seed: payload.seed,
-        cached: false,
-      };
-
-      return result;
-
-    } catch (error) {
-      console.error('Pollinations generation failed:', error);
-      throw error;
     }
-  }
 
-  private isValidUrl(urlString: string): boolean {
-    try {
-      const url = new URL(urlString);
-      return url.protocol === 'http:' || url.protocol === 'https:';
-    } catch {
-      return false;
+    private isValidUrl(urlString: string): boolean {
+        try {
+            const url = new URL(urlString);
+            return url.protocol === "http:" || url.protocol === "https:";
+        } catch {
+            return false;
+        }
     }
-  }
 }

--- a/apps/slidepainter/src/services/pollinations.ts
+++ b/apps/slidepainter/src/services/pollinations.ts
@@ -1,11 +1,12 @@
 // Pollinations API Service
 
-import {
+import type {
+  ImageGenerationResponse,
   PollinationsRequest,
-  ImageGenerationResponse
 } from './types';
 
 const POLLINATIONS_API_BASE = 'https://gen.pollinations.ai';
+const POLLINATIONS_MEDIA_API = 'https://media.pollinations.ai/upload';
 const DEFAULT_CONFIG = {
   model: 'gptimage' as const,
   enhance: true,
@@ -93,8 +94,29 @@ export class PollinationsService {
         }
       }
 
+      let resultUrl = url.toString();
+      if (token) {
+        try {
+          const form = new FormData();
+          form.append('file', await response.blob(), 'slidepainter.png');
+          form.append('tags', 'slidepainter');
+          const upload = await fetch(POLLINATIONS_MEDIA_API, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+            body: form,
+            signal: AbortSignal.timeout(30000),
+          });
+          if (upload.ok) {
+            const published = await upload.json();
+            if (published.url) resultUrl = published.url;
+          }
+        } catch (error) {
+          console.warn('Could not publish SlidePainter image:', error);
+        }
+      }
+
       const result: ImageGenerationResponse = {
-        url: url.toString(),
+        url: resultUrl,
         provider: 'pollinations',
         seed: payload.seed,
         cached: false,


### PR DESCRIPTION
- Publishes generated slide images with `slidepainter`
- Uses the media URL as the generated result when publishing succeeds
- Keeps media publishing non-blocking

Checks: Biome, esbuild, mocked multipart contract