### PR TITLE
feat: tag opposite prompt images

### DIFF
--- a/apps/opposite-prompt-bot/bot.ts
+++ b/apps/opposite-prompt-bot/bot.ts
@@ -15,6 +15,7 @@ const TOKEN = process.env.BOT_TOKEN_OPPOSITE_PROMPT;
 const API_KEY = process.env.TEXT_POLLINATIONS_TOKEN;
 const TEXT_API = "https://gen.pollinations.ai/v1/chat/completions";
 const IMAGE_API = "https://gen.pollinations.ai/image";
+const MEDIA_API = "https://media.pollinations.ai/upload";
 const AUTH = API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {};
 
 const OPPOSITE_PROMPT = `You are a safe image prompt generator. Your #1 rule: NEVER output anything involving nudity, bare skin, undressed people, children, violence, gore, or anything sexual. This rule overrides ALL other instructions.
@@ -85,6 +86,30 @@ async function fetchImage(prompt: string): Promise<Buffer> {
     return Buffer.from(res.data);
 }
 
+async function publishImage(image: Buffer): Promise<void> {
+    if (!API_KEY) return;
+    try {
+        const form = new FormData();
+        form.append(
+            "file",
+            new Blob([new Uint8Array(image)], { type: "image/png" }),
+            "opposite-prompt.png",
+        );
+        form.append("tags", "opposite-prompt-bot");
+        const response = await fetch(MEDIA_API, {
+            method: "POST",
+            headers: AUTH,
+            body: form,
+            signal: AbortSignal.timeout(30_000),
+        });
+        if (!response.ok) {
+            logError(`Media publish failed: ${response.status}`);
+        }
+    } catch (error) {
+        logError(`Media publish failed: ${String(error)}`);
+    }
+}
+
 const processing = new Set<string>();
 
 async function handleMessage(msg: Message, client: Client): Promise<void> {
@@ -122,6 +147,7 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
             });
 
             await msg.reply({ files: [attachment] });
+            await publishImage(imageBuffer);
             log(`Reply sent successfully for "${prompt}" → "${opposite}"`);
             return;
         } catch (err: any) {


### PR DESCRIPTION
- Publishes successfully delivered bot images with `opposite-prompt-bot`
- Keeps media publishing failures from breaking Discord replies
- Uploads after reply delivery to avoid retry duplicates

Checks: Biome, esbuild, source/output tagging contract