### PR TITLE
fix(cache): honor no-cache for media generation

### DIFF
--- a/gen.pollinations.ai/src/docs/image-generation.md
+++ b/gen.pollinations.ai/src/docs/image-generation.md
@@ -6,4 +6,8 @@ Generate images from text prompts via a simple GET request. Returns JPEG or PNG.
 https://gen.pollinations.ai/image/a%20cat%20in%20space?model=flux
 ```
 
+Successful requests are cached by prompt and parameters. To regenerate and
+replace an existing entry after a backend correction, authenticated requests
+can add `no-cache=true`.
+
 **Available models:** {{IMAGE_MODELS}}

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -38,20 +38,25 @@ export function createMediaCache(config: MediaCacheConfig) {
     return createMiddleware<MediaCacheEnv>(async (c, next) => {
         const log = c.get("log").getChild(config.label);
 
-        const seedParam = new URL(c.req.url).searchParams.get("seed");
+        const url = new URL(c.req.url);
+        const seedParam = url.searchParams.get("seed");
         if (seedParam === "-1") {
             log.debug("seed=-1 detected, skipping cache");
             return next();
         }
 
+        const bypassRead = url.searchParams.get("no-cache") === "true";
+
         const cacheKey = generateCacheKey(
-            new URL(c.req.url),
+            url,
             c.req.header(SAFETY_HEADER_NAME),
         );
         log.debug("Cache key: {key}", { key: cacheKey });
 
         try {
-            const cached = await c.env.IMAGE_BUCKET.get(cacheKey);
+            const cached = bypassRead
+                ? null
+                : await c.env.IMAGE_BUCKET.get(cacheKey);
             if (cached) {
                 log.info("Cache HIT");
                 setHttpMetadataHeaders(
@@ -79,7 +84,11 @@ export function createMediaCache(config: MediaCacheConfig) {
                 );
             }
 
-            log.debug("Cache MISS");
+            log.debug(
+                bypassRead
+                    ? "no-cache=true detected, bypassing cache read"
+                    : "Cache MISS",
+            );
             c.header("X-Cache", "MISS");
         } catch (error) {
             log.error("Error retrieving cached response: {error}", { error });

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -55,6 +55,10 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
             description:
                 "Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter.",
         }),
+    "no-cache": z.literal("true").optional().meta({
+        description:
+            "Authenticated cache repair: regenerate the media and replace any existing cached response for the same prompt and parameters.",
+    }),
     safe: SafeSchema,
     quality: z
         .enum(QUALITIES as unknown as [string, ...string[]])

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -98,49 +98,49 @@ describe("media cache", () => {
     it.each([
         { label: "image", cache: imageCache, contentType: "image/png" },
         { label: "audio", cache: audioCache, contentType: "audio/mpeg" },
-    ])(
-        "serves cached $label responses before auth while misses still require auth",
-        async ({ cache, contentType }) => {
-            const media = createMediaCacheApp(cache, contentType);
-            const env = createMediaCacheEnv();
+    ])("serves cached $label responses before auth while misses still require auth", async ({
+        cache,
+        contentType,
+    }) => {
+        const media = createMediaCacheApp(cache, contentType);
+        const env = createMediaCacheEnv();
 
-            const warm = await dispatch(
-                media.app,
-                "/media/cached-hit",
-                {
-                    headers: { Authorization: "Bearer test-key" },
-                },
-                env,
-            );
-            expect(await consumeAndWait(warm)).toBe("origin:1");
+        const warm = await dispatch(
+            media.app,
+            "/media/cached-hit",
+            {
+                headers: { Authorization: "Bearer test-key" },
+            },
+            env,
+        );
+        expect(await consumeAndWait(warm)).toBe("origin:1");
 
-            const cachedNoAuth = await dispatch(
-                media.app,
-                "/media/cached-hit",
-                undefined,
-                env,
-            );
-            expect(await consumeAndWait(cachedNoAuth)).toBe("origin:1");
-            expect(cachedNoAuth.response.status).toBe(200);
-            expect(cachedNoAuth.response.headers.get("X-Cache")).toBe("HIT");
-            expect(cachedNoAuth.response.headers.get("Cache-Control")).toBe(
-                IMMUTABLE_CACHE_CONTROL,
-            );
-            expect(media.originHits).toBe(1);
+        const cachedNoAuth = await dispatch(
+            media.app,
+            "/media/cached-hit",
+            undefined,
+            env,
+        );
+        expect(await consumeAndWait(cachedNoAuth)).toBe("origin:1");
+        expect(cachedNoAuth.response.status).toBe(200);
+        expect(cachedNoAuth.response.headers.get("X-Cache")).toBe("HIT");
+        expect(cachedNoAuth.response.headers.get("Cache-Control")).toBe(
+            IMMUTABLE_CACHE_CONTROL,
+        );
+        expect(media.originHits).toBe(1);
 
-            const missNoAuth = await dispatch(
-                media.app,
-                "/media/uncached-miss",
-                undefined,
-                env,
-            );
-            expect(await consumeAndWait(missNoAuth)).toBe(
-                "Authentication required",
-            );
-            expect(missNoAuth.response.status).toBe(401);
-            expect(media.originHits).toBe(1);
-        },
-    );
+        const missNoAuth = await dispatch(
+            media.app,
+            "/media/uncached-miss",
+            undefined,
+            env,
+        );
+        expect(await consumeAndWait(missNoAuth)).toBe(
+            "Authentication required",
+        );
+        expect(missNoAuth.response.status).toBe(401);
+        expect(media.originHits).toBe(1);
+    });
 
     it("refreshes cached media TTL on aged cache hits", async () => {
         const media = createMediaCacheApp(imageCache, "image/png");

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -98,49 +98,49 @@ describe("media cache", () => {
     it.each([
         { label: "image", cache: imageCache, contentType: "image/png" },
         { label: "audio", cache: audioCache, contentType: "audio/mpeg" },
-    ])("serves cached $label responses before auth while misses still require auth", async ({
-        cache,
-        contentType,
-    }) => {
-        const media = createMediaCacheApp(cache, contentType);
-        const env = createMediaCacheEnv();
+    ])(
+        "serves cached $label responses before auth while misses still require auth",
+        async ({ cache, contentType }) => {
+            const media = createMediaCacheApp(cache, contentType);
+            const env = createMediaCacheEnv();
 
-        const warm = await dispatch(
-            media.app,
-            "/media/cached-hit",
-            {
-                headers: { Authorization: "Bearer test-key" },
-            },
-            env,
-        );
-        expect(await consumeAndWait(warm)).toBe("origin:1");
+            const warm = await dispatch(
+                media.app,
+                "/media/cached-hit",
+                {
+                    headers: { Authorization: "Bearer test-key" },
+                },
+                env,
+            );
+            expect(await consumeAndWait(warm)).toBe("origin:1");
 
-        const cachedNoAuth = await dispatch(
-            media.app,
-            "/media/cached-hit",
-            undefined,
-            env,
-        );
-        expect(await consumeAndWait(cachedNoAuth)).toBe("origin:1");
-        expect(cachedNoAuth.response.status).toBe(200);
-        expect(cachedNoAuth.response.headers.get("X-Cache")).toBe("HIT");
-        expect(cachedNoAuth.response.headers.get("Cache-Control")).toBe(
-            IMMUTABLE_CACHE_CONTROL,
-        );
-        expect(media.originHits).toBe(1);
+            const cachedNoAuth = await dispatch(
+                media.app,
+                "/media/cached-hit",
+                undefined,
+                env,
+            );
+            expect(await consumeAndWait(cachedNoAuth)).toBe("origin:1");
+            expect(cachedNoAuth.response.status).toBe(200);
+            expect(cachedNoAuth.response.headers.get("X-Cache")).toBe("HIT");
+            expect(cachedNoAuth.response.headers.get("Cache-Control")).toBe(
+                IMMUTABLE_CACHE_CONTROL,
+            );
+            expect(media.originHits).toBe(1);
 
-        const missNoAuth = await dispatch(
-            media.app,
-            "/media/uncached-miss",
-            undefined,
-            env,
-        );
-        expect(await consumeAndWait(missNoAuth)).toBe(
-            "Authentication required",
-        );
-        expect(missNoAuth.response.status).toBe(401);
-        expect(media.originHits).toBe(1);
-    });
+            const missNoAuth = await dispatch(
+                media.app,
+                "/media/uncached-miss",
+                undefined,
+                env,
+            );
+            expect(await consumeAndWait(missNoAuth)).toBe(
+                "Authentication required",
+            );
+            expect(missNoAuth.response.status).toBe(401);
+            expect(media.originHits).toBe(1);
+        },
+    );
 
     it("refreshes cached media TTL on aged cache hits", async () => {
         const media = createMediaCacheApp(imageCache, "image/png");
@@ -164,5 +164,45 @@ describe("media cache", () => {
         expect(cached.response.headers.get("X-Cache")).toBe("HIT");
         expect(media.originHits).toBe(1);
         expect(bucket.putCount).toBe(2);
+    });
+
+    it("regenerates and replaces cached media for authenticated no-cache requests", async () => {
+        const media = createMediaCacheApp(imageCache, "image/png");
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/regenerate";
+
+        const warm = await dispatch(
+            media.app,
+            path,
+            { headers: { Authorization: "Bearer test-key" } },
+            env,
+        );
+        expect(await consumeAndWait(warm)).toBe("origin:1");
+
+        const unauthenticated = await dispatch(
+            media.app,
+            `${path}?no-cache=true`,
+            undefined,
+            env,
+        );
+        expect(await consumeAndWait(unauthenticated)).toBe(
+            "Authentication required",
+        );
+        expect(unauthenticated.response.status).toBe(401);
+        expect(media.originHits).toBe(1);
+
+        const regenerate = await dispatch(
+            media.app,
+            `${path}?no-cache=true`,
+            { headers: { Authorization: "Bearer test-key" } },
+            env,
+        );
+        expect(await consumeAndWait(regenerate)).toBe("origin:2");
+
+        const replaced = await dispatch(media.app, path, undefined, env);
+        expect(await consumeAndWait(replaced)).toBe("origin:2");
+        expect(replaced.response.headers.get("X-Cache")).toBe("HIT");
+        expect(media.originHits).toBe(2);
     });
 });


### PR DESCRIPTION
- Makes authenticated `?no-cache=true` bypass an existing media-cache entry
- Regenerates and replaces the same cache key, so later requests receive the corrected asset
- Keeps unauthenticated bypass attempts behind the normal access check
- Documents the repair control in the source OpenAPI schema and image guide

Tests:
- `cd gen.pollinations.ai && npx vitest run test/media-cache.test.ts --reporter=verbose` (4 passed)
- `cd gen.pollinations.ai && npm run typecheck`

Addresses #12225. Fresh Flux requests already respect the requested dimensions; affected cached URLs can add `no-cache=true` once with authentication to replace stale immutable entries.