### PR TITLE
feat: allow timemachine-studio community models

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -169,6 +169,9 @@ describe("community endpoint helpers", () => {
         expect(isCommunityEndpointOwnerAllowed({ githubId: 101795137 })).toBe(
             true,
         );
+        expect(isCommunityEndpointOwnerAllowed({ githubId: 183505255 })).toBe(
+            true,
+        );
         expect(isCommunityEndpointOwnerAllowed({ githubId: 235942848 })).toBe(
             false,
         );

--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -26,6 +26,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     195966113, // JustScriptzz
     113566110, // riofndev
     188266626, // solarnode-developement
+    183505255, // timemachine-studio
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `timemachine-studio` (GitHub user ID `183505255`) to the community-model allowlist
- Adds a regression assertion for the immutable GitHub ID
- Validated with the focused community endpoint allowlist test