### PR TITLE
fix: show model slug on mobile

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -232,7 +232,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                             brandLogoPath ? "pl-[42px]" : "pl-0",
                         )}
                     >
-                        <div className="min-w-0 rounded-lg bg-theme-bg-subtle px-3 py-2">
+                        <div className="min-w-0 w-fit max-w-full rounded-lg bg-theme-bg-subtle px-3 py-2">
                             <ModelId name={model.name} />
                         </div>
                         {modelDescription && (

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -14,7 +14,7 @@ import {
     isNewModel,
     isPaidOnly,
 } from "./model-info.ts";
-import { ModelRow } from "./model-row.tsx";
+import { ModelId, ModelRow } from "./model-row.tsx";
 import type {
     ModelCategory,
     ModelSortDirection,
@@ -232,6 +232,9 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                             brandLogoPath ? "pl-[42px]" : "pl-0",
                         )}
                     >
+                        <div className="min-w-0 rounded-lg bg-theme-bg-subtle px-3 py-2">
+                            <ModelId name={model.name} />
+                        </div>
                         {modelDescription && (
                             <p className="mb-2 text-sm leading-relaxed text-theme-text-muted">
                                 {modelDescription}


### PR DESCRIPTION
## What changed

- Adds the copyable model slug to expanded mobile model cards.
- Places the slug above the description in a subtle monospace code-style surface.
- Reuses the desktop `ModelId` component for consistent copy behavior and accessibility.

## Why

The mobile card showed the display name but hid the exact model identifier users need in API requests. This makes the slug available without adding noise to the collapsed card.

## Checks

- `biome check --write`
- `tsc --noEmit`
- Local frontend/worker build
- Browser verification at 390 × 844