### PR TITLE
feat: harden Z-Image deployment on Vast

### DIFF
--- a/image.pollinations.ai/z-image/.gitignore
+++ b/image.pollinations.ai/z-image/.gitignore
@@ -5,6 +5,7 @@ venv/
 .venv/
 testImages/
 env/
+.env.zimage
 model_cache/
 gfpgan/
 *.out

--- a/image.pollinations.ai/z-image/README.md
+++ b/image.pollinations.ai/z-image/README.md
@@ -13,7 +13,10 @@ FastAPI server for Z-Image-Turbo (6B parameter text-to-image model from Tongyi-M
 Production migration uses a verified single-GPU Vast instance with at least
 24GB VRAM and 80GB disk. RTX 5090 workers require the CUDA 12.8+ PyTorch
 runtime installed by `setup-vast.sh`; the older cu124 Dockerfile is not
-Blackwell-compatible.
+Blackwell-compatible. The setup also disables cuDNN's v8 API because its VAE
+decode path exits with signal 11 on the tested RTX 5090 / driver 570 stack;
+the legacy cuDNN API keeps the decode GPU-accelerated and stable. SPAN is run
+without cuDNN on that stack for the same reason while remaining GPU-backed.
 
 Create a remotely managed Cloudflare Tunnel whose public hostname routes to
 `http://localhost:10002`, then provision the worker:

--- a/image.pollinations.ai/z-image/README.md
+++ b/image.pollinations.ai/z-image/README.md
@@ -19,14 +19,20 @@ the legacy cuDNN API keeps the decode GPU-accelerated and stable. SPAN is run
 without cuDNN on that stack for the same reason while remaining GPU-backed.
 
 Create a remotely managed Cloudflare Tunnel whose public hostname routes to
-`http://localhost:10002`, then provision the worker:
+`http://localhost:10002`, then provision each worker with the same tunnel token
+and hostname:
 
 ```bash
 PLN_GPU_TOKEN=... \
 CLOUDFLARED_TUNNEL_TOKEN=... \
-PUBLIC_HOSTNAME=zimage-vast-NN.pollinations.ai \
+PUBLIC_HOSTNAME=zimage-vast.example.com \
 bash setup-vast.sh
 ```
+
+Using one remotely managed tunnel for the pool creates a Cloudflare replica per
+Vast worker. Cloudflare balances requests across those replicas, while the
+Pollinations registry sees one stable backend URL. Production currently uses
+two RTX 5090 replicas so either worker can be removed without changing routing.
 
 The setup defaults to `HEARTBEAT_ENABLED=false`, so a new worker cannot join
 the production registry before validation. Run direct and tunnel verification,

--- a/image.pollinations.ai/z-image/README.md
+++ b/image.pollinations.ai/z-image/README.md
@@ -8,6 +8,44 @@ FastAPI server for Z-Image-Turbo (6B parameter text-to-image model from Tongyi-M
 - **1024×1024**: ~3.5s
 - **VRAM**: ~20GB peak
 
+## Vast.ai deployment
+
+Production migration uses a verified single-GPU Vast instance with at least
+24GB VRAM and 80GB disk. RTX 5090 workers require the CUDA 12.8+ PyTorch
+runtime installed by `setup-vast.sh`; the older cu124 Dockerfile is not
+Blackwell-compatible.
+
+Create a remotely managed Cloudflare Tunnel whose public hostname routes to
+`http://localhost:10002`, then provision the worker:
+
+```bash
+PLN_GPU_TOKEN=... \
+CLOUDFLARED_TUNNEL_TOKEN=... \
+PUBLIC_HOSTNAME=zimage-vast-NN.pollinations.ai \
+bash setup-vast.sh
+```
+
+The setup defaults to `HEARTBEAT_ENABLED=false`, so a new worker cannot join
+the production registry before validation. Run direct and tunnel verification,
+then benchmark the real Z-Image pipeline:
+
+```bash
+bash verify-vast.sh
+source .env.zimage
+"$VENV/bin/python" benchmark-vast.py --duration 300 --concurrency 4
+```
+
+Enable production registration only after the worker passes verification and
+the fleet projects to at least 1.25 completed images/second:
+
+```bash
+sed -i 's/export HEARTBEAT_ENABLED=false/export HEARTBEAT_ENABLED=true/' .env.zimage
+/root/onstart.sh
+```
+
+Operational logs are `/root/zimage.log` and `/root/cloudflared.log`. Tokens are
+stored only in mode-0600 files on the rental host.
+
 ## Working Mechanism
 
 ```mermaid
@@ -37,4 +75,4 @@ flowchart TD
   "seed": 42
 }
 ```
-> Build with 💖 for Pollinations.ai 
+> Build with 💖 for Pollinations.ai

--- a/image.pollinations.ai/z-image/benchmark-vast.py
+++ b/image.pollinations.ai/z-image/benchmark-vast.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Bounded Z-Image throughput benchmark for a directly addressed Vast worker."""
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import time
+
+import aiohttp
+
+
+CASES = ((512, 512), (1024, 1024), (768, 1152))
+
+
+async def run(args: argparse.Namespace) -> int:
+    timeout = aiohttp.ClientTimeout(total=args.timeout)
+    headers = {
+        "Content-Type": "application/json",
+        "x-backend-token": args.token,
+    }
+    latencies: list[float] = []
+    errors: list[str] = []
+    counter = 0
+    counter_lock = asyncio.Lock()
+    started = time.perf_counter()
+
+    async def worker(session: aiohttp.ClientSession, worker_id: int) -> None:
+        nonlocal counter
+        while time.perf_counter() - started < args.duration:
+            async with counter_lock:
+                request_id = counter
+                counter += 1
+            width, height = CASES[request_id % len(CASES)]
+            payload = {
+                "prompts": [f"zimage vast benchmark {worker_id}-{request_id}"],
+                "width": width,
+                "height": height,
+                "seed": 100_000 + request_id,
+            }
+            request_started = time.perf_counter()
+            try:
+                async with session.post(
+                    f"{args.url.rstrip('/')}/generate",
+                    headers=headers,
+                    json=payload,
+                ) as response:
+                    await response.read()
+                    if response.status != 200:
+                        errors.append(f"HTTP {response.status}")
+                    else:
+                        latencies.append(time.perf_counter() - request_started)
+            except Exception as error:  # noqa: BLE001 - report all benchmark failures
+                errors.append(type(error).__name__)
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        await asyncio.gather(*(worker(session, i) for i in range(args.concurrency)))
+
+    elapsed = time.perf_counter() - started
+    ordered = sorted(latencies)
+
+    def percentile(p: float) -> float | None:
+        if not ordered:
+            return None
+        index = min(round((len(ordered) - 1) * p), len(ordered) - 1)
+        return ordered[index]
+
+    result = {
+        "completed": len(latencies),
+        "errors": len(errors),
+        "elapsed_seconds": round(elapsed, 3),
+        "images_per_second": round(len(latencies) / elapsed, 4),
+        "latency_p50_seconds": round(statistics.median(ordered), 3)
+        if ordered
+        else None,
+        "latency_p95_seconds": round(percentile(0.95), 3) if ordered else None,
+        "latency_p99_seconds": round(percentile(0.99), 3) if ordered else None,
+        "error_types": dict((name, errors.count(name)) for name in sorted(set(errors))),
+    }
+    print(json.dumps(result, indent=2))
+    return 0 if not errors and latencies else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://localhost:10002")
+    parser.add_argument("--token", default=os.getenv("PLN_GPU_TOKEN"))
+    parser.add_argument("--duration", type=int, default=300)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--timeout", type=int, default=180)
+    args = parser.parse_args()
+    if not args.token:
+        parser.error("set PLN_GPU_TOKEN or pass --token")
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/image.pollinations.ai/z-image/constraints-vast.txt
+++ b/image.pollinations.ai/z-image/constraints-vast.txt
@@ -1,0 +1,14 @@
+# Versions verified together on Vast RTX 5090 with PyTorch 2.9.1 cu128.
+accelerate==1.14.0
+aiohttp==3.14.1
+diffusers==0.39.0
+fastapi==0.139.2
+huggingface-hub==1.24.0
+numpy==2.4.4
+pillow==12.2.0
+pydantic==2.13.4
+requests==2.34.2
+safetensors==0.8.0
+spandrel==0.4.2
+transformers==5.14.1
+uvicorn==0.51.0

--- a/image.pollinations.ai/z-image/server.py
+++ b/image.pollinations.ai/z-image/server.py
@@ -84,8 +84,11 @@ async def periodic_heartbeat():
 
 
 MODEL_ID = "Tongyi-MAI/Z-Image-Turbo"
-MODEL_CACHE = "model_cache"
-SPAN_MODEL_PATH = "model_cache/span/2xNomosUni_span_multijpg.safetensors"
+MODEL_CACHE = os.getenv("MODEL_CACHE", "model_cache")
+SPAN_MODEL_PATH = os.getenv(
+    "SPAN_MODEL_PATH",
+    os.path.join(MODEL_CACHE, "span", "2xNomosUni_span_multijpg.safetensors"),
+)
 SAFETY_NSFW_MODEL = "CompVis/stable-diffusion-safety-checker"
 UPSCALE_FACTOR = 2
 MAX_GEN_PIXELS = 768 * 768  # Generate natively up to this size
@@ -243,8 +246,13 @@ async def lifespan(app: FastAPI):
         logger.error(f"Failed to load models: {e}")
         raise
     
-    # Start heartbeat task
-    heartbeat_task = asyncio.create_task(periodic_heartbeat())
+    # Fresh Vast workers stay out of production until direct verification and
+    # load testing pass. Existing deployments keep heartbeats enabled by
+    # default because they do not set HEARTBEAT_ENABLED.
+    if _truthy_env(os.getenv("HEARTBEAT_ENABLED", "true")):
+        heartbeat_task = asyncio.create_task(periodic_heartbeat())
+    else:
+        logger.warning("Production heartbeat disabled")
     
     yield
     

--- a/image.pollinations.ai/z-image/server.py
+++ b/image.pollinations.ai/z-image/server.py
@@ -186,7 +186,14 @@ def upscale_with_span(image_np: np.ndarray) -> np.ndarray:
     tensor = torch.from_numpy(img_float).permute(2, 0, 1).unsqueeze(0).cuda()
     
     with torch.no_grad():
-        output = upscaler(tensor)
+        if _truthy_env(os.getenv("SPAN_DISABLE_CUDNN")):
+            # The SPAN convolution path segfaults with cuDNN on the tested Vast
+            # RTX 5090 stack. Keep the workaround scoped to SPAN so diffusion
+            # and VAE inference still use accelerated cuDNN kernels.
+            with torch.backends.cudnn.flags(enabled=False):
+                output = upscaler(tensor)
+        else:
+            output = upscaler(tensor)
     
     # Convert back: NCHW -> CHW -> HWC uint8
     result = output.squeeze(0).permute(1, 2, 0).cpu().numpy()

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -69,6 +69,7 @@ printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
 chmod 600 "$TUNNEL_TOKEN_FILE"
 unset CLOUDFLARED_TUNNEL_TOKEN
 
+mkdir -p "$(dirname "$WORK_DIR")"
 if [ -n "${SKIP_CLONE:-}" ]; then
     log "Using existing files in $WORK_DIR"
 elif [ -d "$WORK_DIR/.git" ]; then

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -11,7 +11,7 @@
 # Usage:
 #   PLN_GPU_TOKEN=... \
 #   CLOUDFLARED_TUNNEL_TOKEN=... \
-#   PUBLIC_HOSTNAME=zimage-vast-NN.pollinations.ai \
+#   PUBLIC_HOSTNAME=zimage-vast.example.com \
 #   bash setup-vast.sh
 
 set -euo pipefail
@@ -29,7 +29,7 @@ SUDO=""
 log() { echo "[setup-vast] $1"; }
 
 if [ -z "${PLN_GPU_TOKEN:-}" ] || [ -z "${CLOUDFLARED_TUNNEL_TOKEN:-}" ] || [ -z "${PUBLIC_HOSTNAME:-}" ]; then
-    echo "Usage: PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... PUBLIC_HOSTNAME=zimage-vast-NN.pollinations.ai bash setup-vast.sh" >&2
+    echo "Usage: PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... PUBLIC_HOSTNAME=zimage-vast.example.com bash setup-vast.sh" >&2
     exit 1
 fi
 

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -47,10 +47,11 @@ $SUDO apt-get install -y -qq curl git screen python3.12-venv python3.12-dev
 # CUDA forward-compat libraries can fail on GeForce when the host driver is
 # older than the container toolkit. Use the host driver, as on the Flux Vast
 # deployment.
-if ls /usr/local/cuda*/compat/libcuda.so* >/dev/null 2>&1; then
+if find /usr/local -maxdepth 3 -path '/usr/local/cuda-*/compat/libcuda.so*' -print -quit 2>/dev/null | grep -q .; then
     log "Disabling CUDA forward-compat libraries"
     mkdir -p /root/cuda-compat-disabled
-    mv /usr/local/cuda*/compat/libcuda.so* /root/cuda-compat-disabled/
+    find /usr/local -maxdepth 3 -path '/usr/local/cuda-*/compat/libcuda.so*' \
+        -exec mv -t /root/cuda-compat-disabled/ {} +
     $SUDO ldconfig
 fi
 

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Provision Z-Image Turbo on a single-GPU Vast.ai SSH instance.
+#
+# Vast instances are root-owned containers without systemd. This script uses a
+# pinned Blackwell-capable PyTorch runtime and supervises the model server and a
+# remotely managed Cloudflare Tunnel in screen restart loops.
+#
+# Production registration is disabled by default. Run verify-vast.sh and the
+# benchmark first, then set HEARTBEAT_ENABLED=true in .env.zimage and restart.
+#
+# Usage:
+#   PLN_GPU_TOKEN=... \
+#   CLOUDFLARED_TUNNEL_TOKEN=... \
+#   PUBLIC_HOSTNAME=zimage-vast-NN.pollinations.ai \
+#   bash setup-vast.sh
+
+set -euo pipefail
+
+GIT_BRANCH="${GIT_BRANCH:-main}"
+WORK_DIR="${WORK_DIR:-/workspace/pollinations}"
+VENV="${VENV:-/workspace/zimage-venv}"
+MODEL_CACHE="${MODEL_CACHE:-/workspace/zimage-cache}"
+SERVICE_TYPE="${SERVICE_TYPE:-zimage}"
+PORT="${PORT:-10002}"
+HEARTBEAT_ENABLED="${HEARTBEAT_ENABLED:-false}"
+SUDO=""
+[ "$(id -u)" != "0" ] && SUDO="sudo"
+
+log() { echo "[setup-vast] $1"; }
+
+if [ -z "${PLN_GPU_TOKEN:-}" ] || [ -z "${CLOUDFLARED_TUNNEL_TOKEN:-}" ] || [ -z "${PUBLIC_HOSTNAME:-}" ]; then
+    echo "Usage: PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... PUBLIC_HOSTNAME=zimage-vast-NN.pollinations.ai bash setup-vast.sh" >&2
+    exit 1
+fi
+
+case "$PUBLIC_HOSTNAME" in
+    *[!A-Za-z0-9.-]*)
+        echo "PUBLIC_HOSTNAME must be a hostname without a scheme or path" >&2
+        exit 1
+        ;;
+esac
+
+log "Installing system packages"
+$SUDO apt-get update -qq
+$SUDO apt-get install -y -qq curl git screen python3.12-venv python3.12-dev
+
+# CUDA forward-compat libraries can fail on GeForce when the host driver is
+# older than the container toolkit. Use the host driver, as on the Flux Vast
+# deployment.
+if ls /usr/local/cuda*/compat/libcuda.so* >/dev/null 2>&1; then
+    log "Disabling CUDA forward-compat libraries"
+    mkdir -p /root/cuda-compat-disabled
+    mv /usr/local/cuda*/compat/libcuda.so* /root/cuda-compat-disabled/
+    $SUDO ldconfig
+fi
+
+if ! command -v cloudflared >/dev/null || \
+    ! cloudflared tunnel run --help 2>&1 | grep -q -- '--token-file'; then
+    log "Installing cloudflared"
+    curl -fsSL --retry 5 -o /tmp/cloudflared.deb \
+        https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+    $SUDO dpkg -i /tmp/cloudflared.deb >/dev/null
+fi
+
+TUNNEL_TOKEN_FILE="$HOME/.cloudflared/tunnel-token"
+install -d -m 700 "$HOME/.cloudflared"
+printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
+chmod 600 "$TUNNEL_TOKEN_FILE"
+unset CLOUDFLARED_TUNNEL_TOKEN
+
+if [ -n "${SKIP_CLONE:-}" ]; then
+    log "Using existing files in $WORK_DIR"
+elif [ -d "$WORK_DIR/.git" ]; then
+    log "Updating repository to $GIT_BRANCH"
+    git -C "$WORK_DIR" fetch --depth 1 origin "$GIT_BRANCH"
+    git -C "$WORK_DIR" checkout FETCH_HEAD
+else
+    log "Cloning repository branch $GIT_BRANCH"
+    git clone --depth 1 --branch "$GIT_BRANCH" \
+        https://github.com/pollinations/pollinations.git "$WORK_DIR"
+fi
+
+ZIMAGE_DIR="$WORK_DIR/image.pollinations.ai/z-image"
+mkdir -p "$MODEL_CACHE/span"
+
+if [ ! -d "$VENV" ]; then
+    log "Creating Python environment"
+    python3.12 -m venv "$VENV"
+fi
+
+PIP_FLAGS="--resume-retries 20 --timeout 60 --retries 10"
+"$VENV/bin/pip" install --upgrade -q pip
+log "Installing PyTorch 2.9.1 cu128"
+"$VENV/bin/pip" install -q $PIP_FLAGS \
+    torch==2.9.1 torchvision==0.24.1 \
+    --index-url https://download.pytorch.org/whl/cu128
+log "Installing Z-Image dependencies"
+"$VENV/bin/pip" install -q $PIP_FLAGS -r "$ZIMAGE_DIR/requirements.txt"
+
+log "Verifying CUDA and Blackwell support"
+"$VENV/bin/python" - <<'PY'
+import torch
+
+assert torch.cuda.is_available(), "CUDA is not available"
+assert "sm_120" in torch.cuda.get_arch_list(), "PyTorch build lacks RTX 5090 support"
+print("CUDA OK:", torch.__version__, torch.version.cuda, torch.cuda.get_device_name(0))
+PY
+
+log "Downloading SPAN upscaler"
+MODEL_CACHE="$MODEL_CACHE" "$VENV/bin/python" - <<'PY'
+import os
+from huggingface_hub import hf_hub_download
+
+hf_hub_download(
+    repo_id="Phips/2xNomosUni_span_multijpg",
+    filename="2xNomosUni_span_multijpg.safetensors",
+    local_dir=os.path.join(os.environ["MODEL_CACHE"], "span"),
+)
+PY
+
+ENV_FILE="$ZIMAGE_DIR/.env.zimage"
+log "Writing runtime environment to $ENV_FILE"
+{
+    printf 'export PLN_GPU_TOKEN=%q\n' "$PLN_GPU_TOKEN"
+    printf 'export PORT=%q\n' "$PORT"
+    printf 'export PUBLIC_PORT=443\n'
+    printf 'export PUBLIC_IP=%q\n' "$PUBLIC_HOSTNAME"
+    printf 'export SERVICE_TYPE=%q\n' "$SERVICE_TYPE"
+    printf 'export HEARTBEAT_ENABLED=%q\n' "$HEARTBEAT_ENABLED"
+    printf 'export VENV=%q\n' "$VENV"
+    printf 'export MODEL_CACHE=%q\n' "$MODEL_CACHE"
+    printf 'export SPAN_MODEL_PATH=%q\n' "$MODEL_CACHE/span/2xNomosUni_span_multijpg.safetensors"
+    printf 'export HF_HUB_CACHE=%q\n' "$MODEL_CACHE/hub"
+    printf 'export HF_XET_HIGH_PERFORMANCE=1\n'
+    printf 'export CUDA_VISIBLE_DEVICES=0\n'
+} > "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+unset PLN_GPU_TOKEN
+
+cat > /root/run-zimage.sh <<EOF
+#!/bin/bash
+set -a
+source "$ENV_FILE"
+set +a
+cd "$ZIMAGE_DIR"
+exec "$VENV/bin/python" -u server.py
+EOF
+chmod 700 /root/run-zimage.sh
+
+cat > /root/onstart.sh <<EOF
+#!/bin/bash
+screen -S zimage -X quit 2>/dev/null || true
+screen -S cloudflared -X quit 2>/dev/null || true
+screen -dmS zimage bash -c 'while true; do /root/run-zimage.sh >> /root/zimage.log 2>&1; sleep 5; done'
+screen -dmS cloudflared bash -c 'while true; do cloudflared tunnel --no-autoupdate run --token-file "$TUNNEL_TOKEN_FILE" >> /root/cloudflared.log 2>&1; sleep 5; done'
+EOF
+chmod 700 /root/onstart.sh
+
+/root/onstart.sh
+
+log "Z-Image is starting with production heartbeat=$HEARTBEAT_ENABLED"
+log "Model logs: tail -f /root/zimage.log"
+log "Tunnel logs: tail -f /root/cloudflared.log"
+log "Run verification before enabling production registration"

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -96,7 +96,9 @@ log "Installing PyTorch 2.9.1 cu128"
     torch==2.9.1 torchvision==0.24.1 \
     --index-url https://download.pytorch.org/whl/cu128
 log "Installing Z-Image dependencies"
-"$VENV/bin/pip" install -q $PIP_FLAGS -r "$ZIMAGE_DIR/requirements.txt"
+"$VENV/bin/pip" install -q $PIP_FLAGS \
+    -r "$ZIMAGE_DIR/requirements.txt" \
+    -c "$ZIMAGE_DIR/constraints-vast.txt"
 
 log "Verifying CUDA and Blackwell support"
 "$VENV/bin/python" - <<'PY'
@@ -134,6 +136,11 @@ log "Writing runtime environment to $ENV_FILE"
     printf 'export HF_HUB_CACHE=%q\n' "$MODEL_CACHE/hub"
     printf 'export HF_XET_HIGH_PERFORMANCE=1\n'
     printf 'export CUDA_VISIBLE_DEVICES=0\n'
+    # cuDNN v8's VAE convolution path segfaults with exit 139 on the tested
+    # RTX 5090 / driver 570 / cu128 stack. The legacy API remains GPU-backed
+    # and completes the same decode successfully.
+    printf 'export TORCH_CUDNN_V8_API_DISABLED=1\n'
+    printf 'export SPAN_DISABLE_CUDNN=1\n'
 } > "$ENV_FILE"
 chmod 600 "$ENV_FILE"
 unset PLN_GPU_TOKEN

--- a/image.pollinations.ai/z-image/verify-vast.sh
+++ b/image.pollinations.ai/z-image/verify-vast.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Verify the local Z-Image server and its stable Vast tunnel before production
+# registration. Both routes must return the same deterministic pixels.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env.zimage}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Missing $ENV_FILE; run setup-vast.sh first" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+: "${PLN_GPU_TOKEN:?PLN_GPU_TOKEN missing from $ENV_FILE}"
+: "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
+
+if [ "${HEARTBEAT_ENABLED:-true}" != "false" ]; then
+    echo "Refusing pre-production verification while HEARTBEAT_ENABLED is not false" >&2
+    exit 1
+fi
+
+VERIFY_DIR="$(mktemp -d)"
+trap 'rm -rf "$VERIFY_DIR"' EXIT
+
+wait_for_health() {
+    for _ in $(seq 1 180); do
+        if curl -fsS --max-time 5 "http://localhost:${PORT:-10002}/health" >/dev/null; then
+            return 0
+        fi
+        sleep 5
+    done
+    echo "Z-Image did not become healthy" >&2
+    return 1
+}
+
+generate() {
+    local base_url="$1"
+    local width="$2"
+    local height="$3"
+    local output="$4"
+    curl -fsS --max-time 180 "$base_url/generate" \
+        -H "Content-Type: application/json" \
+        -H "x-backend-token: $PLN_GPU_TOKEN" \
+        --data "{\"prompts\":[\"vast zimage deterministic canary\"],\"width\":$width,\"height\":$height,\"seed\":424242}" \
+        > "$output"
+}
+
+wait_for_health
+curl -fsS --max-time 10 "https://$PUBLIC_IP/health" >/dev/null
+
+for size in 512x512 1024x1024 768x1152; do
+    width="${size%x*}"
+    height="${size#*x}"
+    echo "Verifying $size"
+    generate "http://localhost:${PORT:-10002}" "$width" "$height" "$VERIFY_DIR/local-$size.json"
+    generate "https://$PUBLIC_IP" "$width" "$height" "$VERIFY_DIR/tunnel-$size.json"
+done
+
+"${VENV:-/workspace/zimage-venv}/bin/python" - "$VERIFY_DIR" <<'PY'
+import base64
+import io
+import json
+import pathlib
+import sys
+
+from PIL import Image, ImageChops, ImageStat
+
+root = pathlib.Path(sys.argv[1])
+for local_path in sorted(root.glob("local-*.json")):
+    suffix = local_path.name.removeprefix("local-")
+    tunnel_path = root / f"tunnel-{suffix}"
+    local = json.loads(local_path.read_text())[0]
+    tunnel = json.loads(tunnel_path.read_text())[0]
+    with Image.open(io.BytesIO(base64.b64decode(local["image"]))) as left, Image.open(
+        io.BytesIO(base64.b64decode(tunnel["image"]))
+    ) as right:
+        left_rgb = left.convert("RGB")
+        right_rgb = right.convert("RGB")
+        if left_rgb.size != right_rgb.size:
+            raise SystemExit(f"FAIL {suffix}: dimensions differ")
+        rms = sum(ImageStat.Stat(ImageChops.difference(left_rgb, right_rgb)).rms) / 3
+        if rms > 0.1:
+            raise SystemExit(f"FAIL {suffix}: RMS pixel difference {rms:.3f}")
+        print(f"PASS {suffix}: {left_rgb.size[0]}x{left_rgb.size[1]}, RMS={rms:.3f}")
+PY
+
+echo "Direct and tunnel verification passed; production heartbeat remains disabled"


### PR DESCRIPTION
- Adds guarded Vast setup with production heartbeat disabled by default
- Pins the verified RTX 5090 stack and works around cuDNN VAE/SPAN crashes while keeping GPU execution
- Adds deterministic tunnel checks, bounded benchmarks, persistent caches, and process supervision
- Documents a shared Cloudflare Tunnel hostname across two Vast replicas

Live checks:
- Both RTX 5090 hosts pass 512x512, 1024x1024, and 768x1152 generation
- Host 1: 332/332 in 5m, 1.095 images/s, p95 3.713s
- Host 2: 69/69 in 60s, 1.090 images/s, p95 3.748s
- Shared tunnel has two healthy replicas; unauthenticated generation returns 403
- Both hosts match direct and tunneled pixels at all three sizes (RMS 0.000)
- Production traffic is reaching both Vast replicas with no observed 5xx/runtime errors

Static checks:
- `bash -n image.pollinations.ai/z-image/setup-vast.sh image.pollinations.ai/z-image/verify-vast.sh`
- `python3 -m py_compile image.pollinations.ai/z-image/server.py image.pollinations.ai/z-image/benchmark-vast.py`
- `git diff --check`
