### PR TITLE
fix: mark Z-Image provider as Vast

### DIFF
--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -349,7 +349,7 @@ export const IMAGE_SERVICES = {
     "zimage": {
         aliases: ["z-image", "z-image-turbo"],
         modelId: "zimage",
-        provider: "runpod",
+        provider: "vast",
         brand: "Alibaba",
         category: "image",
         addedDate: new Date("2025-12-08").getTime(),


### PR DESCRIPTION
- Changes Z-Image's registry provider from `runpod` to `vast`
- Aligns model metadata with the production backend migrated in #12589
- Leaves pricing and routing behavior unchanged

Checks:
- `npx biome check --write shared/registry/image.ts`
- Registry import resolves `IMAGE_SERVICES.zimage.provider` as `vast`
- `git diff --check`
