### PR TITLE
refactor: make TTS provider dispatch explicit

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -217,13 +217,8 @@ const ELEVENLABS_TTS_MODEL_IDS = {
 
 type ElevenLabsTtsModelName = keyof typeof ELEVENLABS_TTS_MODEL_IDS;
 
-function isElevenLabsTtsModel(model: string): model is ElevenLabsTtsModelName {
-    return model in ELEVENLABS_TTS_MODEL_IDS;
-}
-
-export async function generateSpeech(opts: {
-    modelName: string;
-    modelId: string;
+export async function generateElevenLabsSpeech(opts: {
+    modelName: ElevenLabsTtsModelName;
     text: string;
     voice: string;
     responseFormat: string;
@@ -231,8 +226,8 @@ export async function generateSpeech(opts: {
     apiKey: string;
     log: Logger;
 }): Promise<Response> {
-    const { modelName, modelId, text, voice, responseFormat, apiKey, log } =
-        opts;
+    const { modelName, text, voice, responseFormat, apiKey, log } = opts;
+    const modelId = ELEVENLABS_TTS_MODEL_IDS[modelName];
 
     if (!apiKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
@@ -849,10 +844,6 @@ function resolveQwenVoice(voice: string): string {
     return QWEN_TTS_OPENAI_VOICE_MAP[voice] ?? voice;
 }
 
-export function isQwenTtsModel(model: string): model is QwenTtsModelName {
-    return model in QWEN_TTS_MODEL_IDS;
-}
-
 function requireTextToAudioModel(
     model: string,
     definition: ModelDefinition,
@@ -1050,14 +1041,14 @@ async function parseSpeechRequest(c: AudioContext): Promise<
 
 export async function generateQwenTts(opts: {
     modelName: QwenTtsModelName;
-    modelId: string;
     text: string;
     voice: string;
     instruct?: string;
     apiKey: string;
     log: Logger;
 }): Promise<Response> {
-    const { modelName, modelId, text, voice, instruct, apiKey, log } = opts;
+    const { modelName, text, voice, instruct, apiKey, log } = opts;
+    const modelId = QWEN_TTS_MODEL_IDS[modelName];
 
     if (!apiKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
@@ -1558,40 +1549,40 @@ async function dispatchAudioGeneration(
         );
     }
 
-    if (isQwenTtsModel(c.var.model.resolved)) {
-        return withSafetyHeaders(
-            c,
-            await generateQwenTts({
-                modelName: c.var.model.resolved,
-                modelId: QWEN_TTS_MODEL_IDS[c.var.model.resolved],
-                text,
-                voice,
-                instruct,
-                apiKey: dashScopeApiKey,
-                log,
-            }),
-        );
+    switch (c.var.model.resolved) {
+        case "elevenlabs":
+        case "elevenflash":
+        case "eleven-multilingual-v2":
+            return withSafetyHeaders(
+                c,
+                await generateElevenLabsSpeech({
+                    modelName: c.var.model.resolved,
+                    text,
+                    voice,
+                    responseFormat,
+                    seed,
+                    apiKey,
+                    log,
+                }),
+            );
+        case "qwen-tts":
+        case "qwen-tts-instruct":
+            return withSafetyHeaders(
+                c,
+                await generateQwenTts({
+                    modelName: c.var.model.resolved,
+                    text,
+                    voice,
+                    instruct,
+                    apiKey: dashScopeApiKey,
+                    log,
+                }),
+            );
+        default:
+            throw new UpstreamError(500 as ContentfulStatusCode, {
+                message: `No audio provider route configured for model: ${c.var.model.resolved}`,
+            });
     }
-
-    if (!isElevenLabsTtsModel(c.var.model.resolved)) {
-        throw new UpstreamError(500 as ContentfulStatusCode, {
-            message: `No audio provider route configured for model: ${c.var.model.resolved}`,
-        });
-    }
-
-    return withSafetyHeaders(
-        c,
-        await generateSpeech({
-            modelName: c.var.model.resolved,
-            modelId: ELEVENLABS_TTS_MODEL_IDS[c.var.model.resolved],
-            text,
-            voice,
-            responseFormat,
-            seed,
-            apiKey,
-            log,
-        }),
-    );
 }
 
 export async function handleSimpleAudio(c: AudioContext): Promise<Response> {

--- a/gen.pollinations.ai/test/elevenlabs-tts.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-tts.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateElevenLabsSpeech } from "../src/routes/audio.ts";
+
+const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+} as never;
+
+describe("ElevenLabs TTS model routing", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it.each([
+        ["elevenlabs", "eleven_v3"],
+        ["elevenflash", "eleven_flash_v2_5"],
+        ["eleven-multilingual-v2", "eleven_multilingual_v2"],
+    ] as const)("maps %s to %s", async (modelName, expectedModelId) => {
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(new Uint8Array([1, 2, 3]), {
+                headers: { "content-type": "audio/mpeg" },
+            }),
+        );
+
+        await generateElevenLabsSpeech({
+            modelName,
+            text: "Hello",
+            voice: "nova",
+            responseFormat: "mp3",
+            apiKey: "test-eleven-key",
+            log,
+        });
+
+        const request = new Request(
+            fetchMock.mock.calls[0][0],
+            fetchMock.mock.calls[0][1],
+        );
+        await expect(request.json()).resolves.toMatchObject({
+            model_id: expectedModelId,
+        });
+    });
+});


### PR DESCRIPTION
- Renames `generateSpeech` to the provider-specific `generateElevenLabsSpeech`.
- Keeps ElevenLabs and Qwen upstream model-ID lookup inside their adapters.
- Replaces implicit TTS fallthrough and type guards with explicit provider dispatch.
- Adds focused coverage for all three ElevenLabs TTS mappings.

Follow-up to #12525.

Tests: `npm run typecheck`; 10 ElevenLabs audio tests; Qwen routing integration test.