### PR TITLE
fix: improve embedding quality

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -102,9 +102,11 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "cohere-embed-v4": {
     "cost": {
+      "promptImageTokens": 0.00000047,
       "promptTextTokens": 0.00000012,
     },
     "price": {
+      "promptImageTokens": 0.0000003525,
       "promptTextTokens": 0.00000009,
     },
   },

--- a/gen.pollinations.ai/src/docs/embeddings.md
+++ b/gen.pollinations.ai/src/docs/embeddings.md
@@ -11,4 +11,8 @@ Generate vector embeddings with an OpenAI-compatible response format.
 
 String batch input supports up to 32 items. For retrieval, use `task_type` with Gemini text input (it is converted to the recommended prompt instruction) or `input_type` (`query` or `document`) with Cohere. Dimensions are model-specific: Cohere supports 256, 512, 1024, or 1536; `openai-3-small` supports up to 1536; `gemini-2` and `openai-3-large` support up to 3072; `qwen3-embedding-8b` supports up to 4096.
 
+Gemini task instructions count toward prompt token usage. Cohere requests containing an image expose one combined usage count, so any accompanying text is billed at the image-input rate.
+
+**Gemini GA migration:** `gemini-2` now uses the GA embedding space. Do not mix preview-era and GA vectors; re-embed stored `gemini-2` data before comparing it with new results.
+
 **Embedding models:** {{EMBEDDING_MODELS}}

--- a/gen.pollinations.ai/src/docs/embeddings.md
+++ b/gen.pollinations.ai/src/docs/embeddings.md
@@ -7,8 +7,8 @@ Generate vector embeddings with an OpenAI-compatible response format.
 | `POST /v1/embeddings` | OpenAI-compatible embeddings endpoint |
 | `GET /embeddings/models` | Embedding models with pricing and modalities |
 
-`gemini-2` supports text, image, audio, and video inputs. `openai-3-small` and `openai-3-large` are text-only models.
+`gemini-2` supports text, image, audio, and video inputs. `cohere-embed-v4` supports text and one image per input. The OpenAI and Qwen embedding models are text-only.
 
-String batch input supports up to 32 items. `task_type` is Gemini-only. Dimensions are model-specific: `openai-3-small` supports up to 1536; `gemini-2` and `openai-3-large` support up to 3072; `qwen3-embedding-8b` supports up to 4096.
+String batch input supports up to 32 items. For retrieval, use `task_type` with Gemini text input (it is converted to the recommended prompt instruction) or `input_type` (`query` or `document`) with Cohere. Dimensions are model-specific: Cohere supports 256, 512, 1024, or 1536; `openai-3-small` supports up to 1536; `gemini-2` and `openai-3-large` support up to 3072; `qwen3-embedding-8b` supports up to 4096.
 
 **Embedding models:** {{EMBEDDING_MODELS}}

--- a/gen.pollinations.ai/src/embeddings/cohereAzure.ts
+++ b/gen.pollinations.ai/src/embeddings/cohereAzure.ts
@@ -4,11 +4,22 @@ import type { OpenAIEmbeddingResponse } from "./openai.ts";
 
 const COHERE_AZURE_ENDPOINT =
     "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/v1/embeddings";
+const COHERE_AZURE_IMAGE_ENDPOINT =
+    "https://myceli-prod-eastus.cognitiveservices.azure.com/models/images/embeddings?api-version=2024-05-01-preview";
+
+type CohereAzureInputType = "document" | "query";
 
 type CohereAzureEmbeddingRequest = {
     model: string;
     input: string[];
-    input_type: "document" | "query" | "classification" | "clustering";
+    input_type: CohereAzureInputType;
+    dimensions?: number;
+};
+
+type CohereAzureImageEmbeddingRequest = {
+    model: string;
+    input: { image: string; text?: string }[];
+    input_type: CohereAzureInputType;
     dimensions?: number;
 };
 
@@ -19,12 +30,6 @@ export async function callCohereAzureEmbed(
     dimensions?: number,
     inputType: CohereAzureEmbeddingRequest["input_type"] = "document",
 ): Promise<OpenAIEmbeddingResponse> {
-    const apiKey = env.AZURE_MYCELI_PROD_API_KEY;
-
-    if (!apiKey) {
-        throw new Error("AZURE_MYCELI_PROD_API_KEY is not configured");
-    }
-
     const body: CohereAzureEmbeddingRequest = {
         model: modelId,
         input,
@@ -32,7 +37,37 @@ export async function callCohereAzureEmbed(
         ...(dimensions ? { dimensions } : {}),
     };
 
-    const response = await fetch(COHERE_AZURE_ENDPOINT, {
+    return callCohereAzure(env, COHERE_AZURE_ENDPOINT, body);
+}
+
+export async function callCohereAzureImageEmbed(
+    env: CloudflareBindings,
+    modelId: string,
+    input: CohereAzureImageEmbeddingRequest["input"],
+    dimensions?: number,
+    inputType: CohereAzureInputType = "document",
+): Promise<OpenAIEmbeddingResponse> {
+    const body: CohereAzureImageEmbeddingRequest = {
+        model: modelId,
+        input,
+        input_type: inputType,
+        ...(dimensions ? { dimensions } : {}),
+    };
+
+    return callCohereAzure(env, COHERE_AZURE_IMAGE_ENDPOINT, body);
+}
+
+async function callCohereAzure(
+    env: CloudflareBindings,
+    endpoint: string,
+    body: CohereAzureEmbeddingRequest | CohereAzureImageEmbeddingRequest,
+): Promise<OpenAIEmbeddingResponse> {
+    const apiKey = env.AZURE_MYCELI_PROD_API_KEY;
+    if (!apiKey) {
+        throw new Error("AZURE_MYCELI_PROD_API_KEY is not configured");
+    }
+
+    const response = await fetch(endpoint, {
         method: "POST",
         headers: {
             "content-type": "application/json",
@@ -41,20 +76,23 @@ export async function callCohereAzureEmbed(
         body: JSON.stringify(body),
     });
 
-    await ensureUpstreamOk(response, COHERE_AZURE_ENDPOINT);
+    await ensureUpstreamOk(response, endpoint);
     return response.json() as Promise<OpenAIEmbeddingResponse>;
 }
 
 export function extractCohereAzureUsage(
     response: OpenAIEmbeddingResponse,
+    modality: "text" | "image" = "text",
 ): Usage {
-    const promptTextTokens = response.usage?.prompt_tokens;
+    const promptTokens = response.usage?.prompt_tokens;
 
-    if (typeof promptTextTokens !== "number") {
+    if (typeof promptTokens !== "number") {
         throw new Error(
             "Cohere Azure embedding response is missing prompt_tokens",
         );
     }
 
-    return { promptTextTokens };
+    return modality === "image"
+        ? { promptImageTokens: promptTokens }
+        : { promptTextTokens: promptTokens };
 }

--- a/gen.pollinations.ai/src/embeddings/cohereAzure.ts
+++ b/gen.pollinations.ai/src/embeddings/cohereAzure.ts
@@ -4,6 +4,8 @@ import type { OpenAIEmbeddingResponse } from "./openai.ts";
 
 const COHERE_AZURE_ENDPOINT =
     "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/v1/embeddings";
+// This Cohere deployment exposes image embeddings only on this Azure preview
+// contract; the 2025-04-01 image route returns 404.
 const COHERE_AZURE_IMAGE_ENDPOINT =
     "https://myceli-prod-eastus.cognitiveservices.azure.com/models/images/embeddings?api-version=2024-05-01-preview";
 
@@ -92,6 +94,8 @@ export function extractCohereAzureUsage(
         );
     }
 
+    // Azure reports one aggregate count for image requests, including any
+    // accompanying text, so the complete request is billed at the image rate.
     return modality === "image"
         ? { promptImageTokens: promptTokens }
         : { promptTextTokens: promptTokens };

--- a/gen.pollinations.ai/src/embeddings/handler.ts
+++ b/gen.pollinations.ai/src/embeddings/handler.ts
@@ -3,11 +3,14 @@ import type { ModelDefinition, Usage } from "@shared/registry/registry.ts";
 import { buildUsageHeaders } from "@shared/registry/usage-headers.ts";
 import {
     callCohereAzureEmbed,
+    callCohereAzureImageEmbed,
     extractCohereAzureUsage,
 } from "./cohereAzure.ts";
 import { callFireworksEmbed, extractFireworksUsage } from "./fireworks.ts";
 import {
+    applyGeminiTaskInstruction,
     badRequest,
+    inputToCohereImage,
     inputToGeminiParts,
     inputToText,
     normalizeInputs,
@@ -29,7 +32,7 @@ type EmbeddingData = {
 // Provider-facing model IDs (what the upstream APIs expect), keyed by
 // registry model name. The registry only carries public names and pricing.
 const EMBEDDING_PROVIDER_MODEL_IDS: Record<EmbeddingServiceId, string> = {
-    "gemini-2": "gemini-embedding-2-preview",
+    "gemini-2": "gemini-embedding-2",
     "openai-3-small": "text-embedding-3-small",
     "openai-3-large": "text-embedding-3-large",
     "cohere-embed-v4": "embed-v-4-0",
@@ -47,9 +50,15 @@ export function getEmbeddingProviderModelId(modelName: string): string {
     return modelId;
 }
 
-const OPENAI_MAX_DIMENSIONS: Record<string, number> = {
-    "text-embedding-3-small": 1536,
-    "text-embedding-3-large": 3072,
+const EMBEDDING_DIMENSIONS: Record<
+    EmbeddingServiceId,
+    { max: number; allowed?: readonly number[] }
+> = {
+    "gemini-2": { max: 3072 },
+    "openai-3-small": { max: 1536 },
+    "openai-3-large": { max: 3072 },
+    "cohere-embed-v4": { max: 1536, allowed: [256, 512, 1024, 1536] },
+    "qwen3-embedding-8b": { max: 4096 },
 };
 
 export async function generateEmbeddings(
@@ -82,11 +91,31 @@ async function generateCohereAzureEmbeddings(
     request: EmbeddingRequest,
     responseModel: string,
 ): Promise<Response> {
+    validateDimensions(request.dimensions, responseModel);
     if (request.task_type) {
         badRequest("task_type is only supported by Gemini embedding models");
     }
 
     const inputs = normalizeInputs(request.input);
+    const imageInput =
+        inputs.length === 1 ? await inputToCohereImage(inputs[0]) : undefined;
+
+    if (imageInput) {
+        const result = await callCohereAzureImageEmbed(
+            env,
+            request.model,
+            [imageInput],
+            request.dimensions,
+            request.input_type,
+        );
+        return cohereEmbeddingsResponse(
+            result,
+            request,
+            responseModel,
+            "image",
+        );
+    }
+
     const textInputs = inputs.map(inputToText);
 
     if (textInputs.length === 0) {
@@ -98,18 +127,9 @@ async function generateCohereAzureEmbeddings(
         request.model,
         textInputs,
         request.dimensions,
+        request.input_type,
     );
-    const usage = extractCohereAzureUsage(result);
-
-    const data = [...result.data]
-        .sort((a, b) => a.index - b.index)
-        .map(({ embedding, index }) => ({
-            object: "embedding" as const,
-            embedding: encodeEmbedding(embedding, request.encoding_format),
-            index,
-        }));
-
-    return embeddingsResponse(responseModel, data, usage);
+    return cohereEmbeddingsResponse(result, request, responseModel, "text");
 }
 
 async function generateFireworksEmbeddings(
@@ -117,9 +137,11 @@ async function generateFireworksEmbeddings(
     request: EmbeddingRequest,
     responseModel: string,
 ): Promise<Response> {
+    validateDimensions(request.dimensions, responseModel);
     if (request.task_type) {
         badRequest("task_type is only supported by Gemini embedding models");
     }
+    rejectUnsupportedInputType(request);
 
     const inputs = normalizeInputs(request.input);
     const textInputs = inputs.map(inputToText);
@@ -152,17 +174,21 @@ async function generateGeminiEmbeddings(
     request: EmbeddingRequest,
     responseModel: string,
 ): Promise<Response> {
+    validateDimensions(request.dimensions, responseModel);
+    rejectUnsupportedInputType(request);
     syncGoogleEnvironment(env);
     const inputs = normalizeInputs(request.input);
     const aggregatedUsage: Usage = {};
 
     const data = await Promise.all(
         inputs.map(async (singleInput, index) => {
-            const parts = await inputToGeminiParts(singleInput);
+            const parts = applyGeminiTaskInstruction(
+                await inputToGeminiParts(singleInput),
+                request.task_type,
+            );
             const result = await callGeminiEmbed(
                 request.model,
                 parts,
-                request.task_type,
                 request.dimensions,
             );
             const usage = extractModalityUsage(result);
@@ -188,11 +214,11 @@ async function generateOpenAIEmbeddings(
     request: EmbeddingRequest,
     responseModel: string,
 ): Promise<Response> {
+    validateDimensions(request.dimensions, responseModel);
     if (request.task_type) {
         badRequest("task_type is only supported by Gemini embedding models");
     }
-
-    validateOpenAIDimensions(request, responseModel);
+    rejectUnsupportedInputType(request);
 
     const inputs = normalizeInputs(request.input);
     const textInputs = inputs.map(inputToText);
@@ -220,19 +246,53 @@ async function generateOpenAIEmbeddings(
     return embeddingsResponse(responseModel, data, usage);
 }
 
-function validateOpenAIDimensions(
-    request: EmbeddingRequest,
+function validateDimensions(
+    dimensions: number | undefined,
     responseModel: string,
 ) {
-    if (!request.dimensions) return;
+    if (!dimensions) return;
 
-    const maxDimensions = OPENAI_MAX_DIMENSIONS[request.model];
+    const constraints =
+        EMBEDDING_DIMENSIONS[responseModel as EmbeddingServiceId];
+    if (!constraints) return;
 
-    if (maxDimensions && request.dimensions > maxDimensions) {
+    if (dimensions > constraints.max) {
         badRequest(
-            `${responseModel} supports dimensions up to ${maxDimensions}`,
+            `${responseModel} supports dimensions up to ${constraints.max}`,
         );
     }
+
+    if (constraints.allowed && !constraints.allowed.includes(dimensions)) {
+        badRequest(
+            `${responseModel} supports dimensions ${constraints.allowed.join(
+                ", ",
+            )}`,
+        );
+    }
+}
+
+function rejectUnsupportedInputType(request: EmbeddingRequest) {
+    if (request.input_type) {
+        badRequest("input_type is only supported by Cohere embedding models");
+    }
+}
+
+function cohereEmbeddingsResponse(
+    result: Awaited<ReturnType<typeof callCohereAzureEmbed>>,
+    request: EmbeddingRequest,
+    responseModel: string,
+    modality: "text" | "image",
+): Response {
+    const usage = extractCohereAzureUsage(result, modality);
+    const data = [...result.data]
+        .sort((a, b) => a.index - b.index)
+        .map(({ embedding, index }) => ({
+            object: "embedding" as const,
+            embedding: encodeEmbedding(embedding, request.encoding_format),
+            index,
+        }));
+
+    return embeddingsResponse(responseModel, data, usage);
 }
 
 function encodeEmbedding(

--- a/gen.pollinations.ai/src/embeddings/handler.ts
+++ b/gen.pollinations.ai/src/embeddings/handler.ts
@@ -97,6 +97,7 @@ async function generateCohereAzureEmbeddings(
     }
 
     const inputs = normalizeInputs(request.input);
+    // ContentPart[] is one aggregate embedding; only string[] is batched.
     const imageInput =
         inputs.length === 1 ? await inputToCohereImage(inputs[0]) : undefined;
 

--- a/gen.pollinations.ai/src/embeddings/input.ts
+++ b/gen.pollinations.ai/src/embeddings/input.ts
@@ -2,7 +2,23 @@ import { HTTPException } from "hono/http-exception";
 import { HttpError } from "@/image/httpError.ts";
 import { downloadImageAsBase64 } from "@/image/utils/imageDownload.ts";
 import { MAX_EMBEDDING_BATCH_SIZE } from "./limits.ts";
-import type { ContentPart, EmbeddingRequest, GeminiPart } from "./types.ts";
+import type {
+    ContentPart,
+    EmbeddingRequest,
+    GeminiPart,
+    GeminiTaskType,
+} from "./types.ts";
+
+const GEMINI_TASK_PREFIXES: Record<GeminiTaskType, string> = {
+    SEMANTIC_SIMILARITY: "task: sentence similarity | query: ",
+    CLASSIFICATION: "task: classification | query: ",
+    CLUSTERING: "task: clustering | query: ",
+    RETRIEVAL_DOCUMENT: "title: none | text: ",
+    RETRIEVAL_QUERY: "task: search result | query: ",
+    CODE_RETRIEVAL_QUERY: "task: code retrieval | query: ",
+    QUESTION_ANSWERING: "task: question answering | query: ",
+    FACT_VERIFICATION: "task: fact checking | query: ",
+};
 
 export function badRequest(message: string): never {
     throw new HTTPException(400, { message });
@@ -111,6 +127,65 @@ export async function inputToGeminiParts(
         }
     }
     return parts;
+}
+
+export function applyGeminiTaskInstruction(
+    parts: GeminiPart[],
+    taskType?: GeminiTaskType,
+): GeminiPart[] {
+    if (!taskType) return parts;
+    if (parts.some((part) => part.inlineData)) {
+        badRequest("task_type is only supported for Gemini text input");
+    }
+
+    const prefix = GEMINI_TASK_PREFIXES[taskType];
+    const firstTextIndex = parts.findIndex((part) => part.text !== undefined);
+    if (firstTextIndex === -1) return [{ text: prefix.trimEnd() }, ...parts];
+
+    return parts.map((part, index) =>
+        index === firstTextIndex
+            ? { ...part, text: `${prefix}${part.text}` }
+            : part,
+    );
+}
+
+type CohereImageInput = {
+    image: string;
+    text?: string;
+};
+
+export async function inputToCohereImage(
+    input: string | ContentPart | ContentPart[],
+): Promise<CohereImageInput | undefined> {
+    if (typeof input === "string") return undefined;
+
+    const parts = Array.isArray(input) ? input : [input];
+    const textParts: string[] = [];
+    let image: string | undefined;
+
+    for (const part of parts) {
+        if (part.type === "text") {
+            textParts.push(part.text);
+            continue;
+        }
+        if (part.type !== "image_url") {
+            badRequest("Cohere Embed v4 supports text and image input only");
+        }
+        if (image) {
+            badRequest("Cohere Embed v4 supports one image per input");
+        }
+        const { inlineData } = await imageUrlToInlineData(part.image_url.url);
+        if (!inlineData) {
+            throw new Error("Image conversion did not produce inline data");
+        }
+        image = `data:${inlineData.mimeType};base64,${inlineData.data}`;
+    }
+
+    if (!image) return undefined;
+    return {
+        image,
+        ...(textParts.length > 0 ? { text: textParts.join("\n") } : {}),
+    };
 }
 
 export function inputToText(

--- a/gen.pollinations.ai/src/embeddings/input.ts
+++ b/gen.pollinations.ai/src/embeddings/input.ts
@@ -140,7 +140,9 @@ export function applyGeminiTaskInstruction(
 
     const prefix = GEMINI_TASK_PREFIXES[taskType];
     const firstTextIndex = parts.findIndex((part) => part.text !== undefined);
-    if (firstTextIndex === -1) return [{ text: prefix.trimEnd() }, ...parts];
+    if (firstTextIndex === -1) {
+        badRequest("task_type requires non-empty Gemini text input");
+    }
 
     return parts.map((part, index) =>
         index === firstTextIndex

--- a/gen.pollinations.ai/src/embeddings/vertex.ts
+++ b/gen.pollinations.ai/src/embeddings/vertex.ts
@@ -5,10 +5,10 @@ import type {
     GeminiEmbedResponse,
     GeminiModality,
     GeminiPart,
-    GeminiTaskType,
 } from "./types.ts";
 
-const VERTEX_REGION = "us-central1";
+const VERTEX_LOCATION = "us";
+const VERTEX_HOST = `aiplatform.${VERTEX_LOCATION}.rep.googleapis.com`;
 
 const MODALITY_TO_USAGE_KEY: Record<GeminiModality, keyof Usage> = {
     TEXT: "promptTextTokens",
@@ -48,7 +48,6 @@ export function extractModalityUsage(result: GeminiEmbedResponse): Usage {
 export async function callGeminiEmbed(
     modelId: string,
     parts: GeminiPart[],
-    taskType?: GeminiTaskType,
     outputDimensionality?: number,
 ): Promise<GeminiEmbedResponse> {
     const projectId = process.env.GOOGLE_PROJECT_ID;
@@ -58,7 +57,7 @@ export async function callGeminiEmbed(
         throw new Error("Google Cloud authentication failed");
     }
 
-    const url = `https://${VERTEX_REGION}-aiplatform.googleapis.com/v1beta1/projects/${projectId}/locations/${VERTEX_REGION}/publishers/google/models/${modelId}:embedContent`;
+    const url = `https://${VERTEX_HOST}/v1/projects/${projectId}/locations/${VERTEX_LOCATION}/publishers/google/models/${modelId}:embedContent`;
     const response = await fetch(url, {
         method: "POST",
         headers: {
@@ -68,7 +67,6 @@ export async function callGeminiEmbed(
         body: JSON.stringify({
             content: { parts },
             embedContentConfig: {
-                ...(taskType && { taskType }),
                 ...(outputDimensionality && { outputDimensionality }),
             },
         }),

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -627,13 +627,13 @@ export const proxyRoutes = new Hono<Env>()
             description: [
                 "Generate vector embeddings with an OpenAI-compatible response format.",
                 "",
-                "**Models:** `gemini-2` supports text, image, audio, and video inputs. `openai-3-small` and `openai-3-large` are text-only models.",
+                "**Models:** `gemini-2` supports text, image, audio, and video. `cohere-embed-v4` supports text and one image. OpenAI and Qwen embedding models are text-only.",
                 "",
-                "**Input:** Pass a string, an array of up to 32 strings, or Gemini multimodal content parts (`text`, `image_url`, `input_audio`, `video_url`) in the `input` field.",
+                "**Input:** Pass a string, an array of up to 32 strings, or supported multimodal content parts (`text`, `image_url`, `input_audio`, `video_url`) in the `input` field.",
                 "",
-                "**Task types:** `task_type` is Gemini-only. For example, use `RETRIEVAL_QUERY` or `CLASSIFICATION` with `gemini-2`.",
+                "**Retrieval roles:** Use `task_type` with Gemini text input; it is converted to the model's recommended prompt instruction. Use `input_type` (`query` or `document`) with Cohere.",
                 "",
-                "**Dimensions:** Defaults are model-specific. `qwen3-embedding-8b` supports up to 4096 dimensions; `gemini-2` and `openai-3-large` support up to 3072; `openai-3-small` supports up to 1536.",
+                "**Dimensions:** Defaults are model-specific. Qwen supports up to 4096; Gemini and OpenAI large up to 3072; OpenAI small up to 1536; Cohere supports 256, 512, 1024, or 1536.",
             ].join("\n"),
             responses: {
                 200: {

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -633,6 +633,10 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "**Retrieval roles:** Use `task_type` with Gemini text input; it is converted to the model's recommended prompt instruction. Use `input_type` (`query` or `document`) with Cohere.",
                 "",
+                "**Billing:** Gemini task instructions count toward prompt token usage. Cohere image requests expose one combined usage count, so text accompanying an image is billed at the image-input rate.",
+                "",
+                "**Gemini migration:** `gemini-2` uses the GA embedding space. Do not mix preview-era and GA vectors; re-embed stored `gemini-2` data before comparing it with new results.",
+                "",
                 "**Dimensions:** Defaults are model-specific. Qwen supports up to 4096; Gemini and OpenAI large up to 3072; OpenAI small up to 1536; Cohere supports 256, 512, 1024, or 1536.",
             ].join("\n"),
             responses: {

--- a/gen.pollinations.ai/src/schemas/embeddings.ts
+++ b/gen.pollinations.ai/src/schemas/embeddings.ts
@@ -69,12 +69,12 @@ export const CreateEmbeddingRequestSchema = z
                 z.array(ContentPartSchema),
             ])
             .meta({
-                description: `Input text or content parts to embed. Supports strings, arrays of strings (max ${MAX_EMBEDDING_BATCH_SIZE} inputs), or multimodal content parts (text, image_url, input_audio, video_url). Multimodal content parts are supported by Gemini embedding models only.`,
+                description: `Input text or content parts to embed. Supports strings, arrays of strings (max ${MAX_EMBEDDING_BATCH_SIZE} inputs), or multimodal content parts (text, image_url, input_audio, video_url). Gemini supports every listed modality; Cohere Embed v4 supports text and one image per input.`,
                 example: "Hello world",
             }),
         dimensions: z.number().int().min(128).max(4096).optional().meta({
             description:
-                "Output embedding dimensions (128-4096). Model-specific limits apply; openai-3-small supports up to 1536.",
+                "Output embedding dimensions (128-4096). Model-specific limits apply; Cohere supports 256, 512, 1024, or 1536.",
             example: 768,
         }),
         task_type: z
@@ -91,9 +91,14 @@ export const CreateEmbeddingRequestSchema = z
             .optional()
             .meta({
                 description:
-                    "Gemini-specific task type hint for optimized embeddings",
+                    "Gemini text-specific task hint, converted to the model's recommended prompt instruction",
                 example: "RETRIEVAL_QUERY",
             }),
+        input_type: z.enum(["query", "document"]).optional().meta({
+            description:
+                "Cohere-specific input role for retrieval. Use document when indexing and query when searching.",
+            example: "query",
+        }),
         encoding_format: z.enum(["float", "base64"]).default("float").meta({
             description:
                 "Output encoding for the embedding vector. `base64` packs Float32 little-endian like OpenAI.",

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -16,7 +16,7 @@ import worker from "../../src/index.ts";
 import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
 
 const TEST_EMBEDDING_MODEL = "gemini-2";
-const TEST_PROVIDER_MODEL = "gemini-embedding-2-preview";
+const TEST_PROVIDER_MODEL = "gemini-embedding-2";
 const TEST_OPENAI_SMALL_MODEL = "openai-3-small";
 const TEST_OPENAI_LARGE_MODEL = "openai-3-large";
 const TEST_OPENAI_SMALL_PROVIDER_MODEL = "text-embedding-3-small";
@@ -26,7 +26,7 @@ const TEST_COHERE_PROVIDER_MODEL = "embed-v-4-0";
 const TEST_QWEN_MODEL = "qwen3-embedding-8b";
 const TEST_QWEN_PROVIDER_MODEL = "accounts/fireworks/models/qwen3-embedding-8b";
 const TEST_EMBEDDING_INPUT = "Hello world";
-const VERTEX_HOST = "us-central1-aiplatform.googleapis.com";
+const VERTEX_HOST = "aiplatform.us.rep.googleapis.com";
 const OPENAI_HOST = "api.openai.com";
 const COHERE_AZURE_HOST = "myceli-prod-eastus.cognitiveservices.azure.com";
 const FIREWORKS_HOST = "api.fireworks.ai";
@@ -198,21 +198,23 @@ function createCohereAzureMock(): MockAPI<{
         handlerMap: {
             [COHERE_AZURE_HOST]: async (request) => {
                 const body = (await request.json()) as {
-                    input?: string[];
+                    input?: (string | { image: string; text?: string })[];
                     input_type?: string;
+                    dimensions?: number;
                     model?: string;
                 };
                 state.urls.push(request.url);
                 state.requests.push(body);
 
                 const inputs = body.input ?? [];
+                const dimensions = body.dimensions ?? 1536;
 
                 return Response.json({
                     object: "list",
                     data: inputs.map((_, index) => ({
                         object: "embedding",
                         embedding: Array.from(
-                            { length: 1536 },
+                            { length: dimensions },
                             (_, valueIndex) => index + valueIndex / 10,
                         ),
                         index,
@@ -370,7 +372,41 @@ describe("POST /v1/embeddings", () => {
         ).toBe(200);
         const data = JSON.parse(body) as { data: { embedding: number[] }[] };
         expect(data.data[0].embedding).toHaveLength(768);
-        expect(mocks.vertex.state.urls[0]).toContain(TEST_PROVIDER_MODEL);
+        expect(mocks.vertex.state.urls[0]).toBe(
+            `https://${VERTEX_HOST}/v1/projects/test-project/locations/us/publishers/google/models/${TEST_PROVIDER_MODEL}:embedContent`,
+        );
+        await wait();
+    });
+
+    test("converts Gemini task types to the GA prompt instruction", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "vertex");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({ task_type: "RETRIEVAL_QUERY" }),
+        });
+        const body = await response.text();
+
+        expect(
+            response.status,
+            `Expected 200 but got ${response.status}: ${body}`,
+        ).toBe(200);
+        expect(mocks.vertex.state.requests[0]).toEqual({
+            content: {
+                parts: [
+                    {
+                        text: "task: search result | query: Hello world",
+                    },
+                ],
+            },
+            embedContentConfig: {},
+        });
         await wait();
     });
 
@@ -449,7 +485,7 @@ describe("POST /v1/embeddings", () => {
         await wait();
     });
 
-    test("supports Azure OpenAI text-embedding-3-small", async ({
+    test("supports direct OpenAI text-embedding-3-small", async ({
         apiKey,
         mocks,
     }) => {
@@ -508,7 +544,7 @@ describe("POST /v1/embeddings", () => {
         });
     });
 
-    test("supports Azure OpenAI text-embedding-3-large", async ({
+    test("supports direct OpenAI text-embedding-3-large", async ({
         apiKey,
         mocks,
     }) => {
@@ -602,6 +638,92 @@ describe("POST /v1/embeddings", () => {
         });
     });
 
+    test("passes Cohere query input_type through Azure", async ({
+        apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "cohereAzure");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({
+                model: TEST_COHERE_MODEL,
+                input_type: "query",
+            }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(mocks.cohereAzure.state.requests).toEqual([
+            {
+                model: TEST_COHERE_PROVIDER_MODEL,
+                input: [TEST_EMBEDDING_INPUT],
+                input_type: "query",
+            },
+        ]);
+        await wait();
+    });
+
+    test("supports Cohere image embeddings through Azure", async ({
+        apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "cohereAzure");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({
+                model: TEST_COHERE_MODEL,
+                input: [
+                    {
+                        type: "image_url",
+                        image_url: {
+                            url: "data:image/png;base64,aGVsbG8=",
+                        },
+                    },
+                ],
+                dimensions: 256,
+            }),
+        });
+        const body = await response.text();
+
+        expect(
+            response.status,
+            `Expected 200 but got ${response.status}: ${body}`,
+        ).toBe(200);
+        expect(response.headers.get("x-usage-prompt-image-tokens")).toBe("4");
+        expect(response.headers.get("x-usage-prompt-text-tokens")).toBeNull();
+        expect(mocks.cohereAzure.state.urls[0]).toContain(
+            "/models/images/embeddings?api-version=2024-05-01-preview",
+        );
+        expect(mocks.cohereAzure.state.requests).toEqual([
+            {
+                model: TEST_COHERE_PROVIDER_MODEL,
+                input: [
+                    {
+                        image: "data:image/png;base64,aGVsbG8=",
+                    },
+                ],
+                input_type: "document",
+                dimensions: 256,
+            },
+        ]);
+        await wait();
+
+        expect(mocks.tinybird.state.events[0]).toMatchObject({
+            eventType: "generate.embedding",
+            modelUsed: TEST_COHERE_MODEL,
+            tokenCountPromptImage: 4,
+            tokenCountPromptText: 0,
+            isBilledUsage: true,
+        });
+    });
+
     test("supports Fireworks Qwen3 embeddings at 4096 dimensions", async ({
         apiKey,
         mocks,
@@ -680,7 +802,49 @@ describe("POST /v1/embeddings", () => {
         await wait();
     });
 
-    test("rejects multimodal input for Azure text embeddings", async ({
+    test("rejects Gemini dimensions above its model limit", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "vertex");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({ dimensions: 3073 }),
+        });
+        const body = await response.text();
+
+        expect(response.status).toBe(400);
+        expect(body).toContain("supports dimensions up to 3072");
+        expect(mocks.vertex.state.requests).toHaveLength(0);
+        await wait();
+    });
+
+    test("rejects unsupported Cohere dimensions", async ({ apiKey, mocks }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "cohereAzure");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({
+                model: TEST_COHERE_MODEL,
+                dimensions: 768,
+            }),
+        });
+        const body = await response.text();
+
+        expect(response.status).toBe(400);
+        expect(body).toContain("supports dimensions 256, 512, 1024, 1536");
+        expect(mocks.cohereAzure.state.requests).toHaveLength(0);
+        await wait();
+    });
+
+    test("rejects multimodal input for direct OpenAI embeddings", async ({
         apiKey,
         mocks,
     }) => {
@@ -711,7 +875,7 @@ describe("POST /v1/embeddings", () => {
         await wait();
     });
 
-    test("rejects Gemini task hints for Azure text embeddings", async ({
+    test("rejects Gemini task hints for direct OpenAI embeddings", async ({
         apiKey,
         mocks,
     }) => {
@@ -731,6 +895,30 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("task_type");
+        expect(mocks.openai.state.requests).toHaveLength(0);
+        await wait();
+    });
+
+    test("rejects Cohere input_type for other providers", async ({
+        apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({
+                model: TEST_OPENAI_SMALL_MODEL,
+                input_type: "query",
+            }),
+        });
+        const body = await response.text();
+
+        expect(response.status).toBe(400);
+        expect(body).toContain("input_type");
         expect(mocks.openai.state.requests).toHaveLength(0);
         await wait();
     });
@@ -776,6 +964,37 @@ describe("POST /v1/embeddings", () => {
             },
         });
         expect(response.headers.get("x-usage-prompt-image-tokens")).toBe("5");
+        await wait();
+    });
+
+    test("rejects Gemini task hints for multimodal input", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "vertex");
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({
+                input: [
+                    {
+                        type: "image_url",
+                        image_url: {
+                            url: "data:image/png;base64,aGVsbG8=",
+                        },
+                    },
+                ],
+                task_type: "RETRIEVAL_QUERY",
+            }),
+        });
+        const body = await response.text();
+
+        expect(response.status).toBe(400);
+        expect(body).toContain("Gemini text input");
+        expect(mocks.vertex.state.requests).toHaveLength(0);
         await wait();
     });
 
@@ -845,7 +1064,9 @@ describe("embedding models", () => {
         expect(response.status).toBe(200);
         const data = (await response.json()) as {
             name: string;
+            input_modalities?: string[];
             output_modalities?: string[];
+            context_length?: number;
         }[];
         expect(data).toEqual(
             expect.arrayContaining([
@@ -863,10 +1084,12 @@ describe("embedding models", () => {
                 }),
                 expect.objectContaining({
                     name: TEST_COHERE_MODEL,
+                    input_modalities: ["text", "image"],
                     output_modalities: ["embedding"],
                 }),
                 expect.objectContaining({
                     name: TEST_QWEN_MODEL,
+                    context_length: 40960,
                     output_modalities: ["embedding"],
                 }),
             ]),

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@shared/test/mocks/fetch.ts";
 import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
 import { afterEach, beforeEach, describe, expect, vi } from "vitest";
+import { applyGeminiTaskInstruction } from "../../src/embeddings/input.ts";
 import { MAX_EMBEDDING_BATCH_SIZE } from "../../src/embeddings/limits.ts";
 import worker from "../../src/index.ts";
 import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
@@ -296,6 +297,12 @@ async function fetchWorker(path: string, init: RequestInit = {}) {
 }
 
 describe("POST /v1/embeddings", () => {
+    test("rejects Gemini task hints without text content", () => {
+        expect(() => applyGeminiTaskInstruction([], "RETRIEVAL_QUERY")).toThrow(
+            "task_type requires non-empty Gemini text input",
+        );
+    });
+
     test("returns an OpenAI-compatible response and tracks billing", async ({
         paidApiKey: apiKey,
         mocks,
@@ -666,7 +673,7 @@ describe("POST /v1/embeddings", () => {
         await wait();
     });
 
-    test("supports Cohere image embeddings through Azure", async ({
+    test("supports Cohere combined text and image embeddings through Azure", async ({
         apiKey,
         mocks,
     }) => {
@@ -680,6 +687,10 @@ describe("POST /v1/embeddings", () => {
             body: buildEmbeddingsBody({
                 model: TEST_COHERE_MODEL,
                 input: [
+                    {
+                        type: "text",
+                        text: "Find visually similar items",
+                    },
                     {
                         type: "image_url",
                         image_url: {
@@ -707,6 +718,7 @@ describe("POST /v1/embeddings", () => {
                 input: [
                     {
                         image: "data:image/png;base64,aGVsbG8=",
+                        text: "Find visually similar items",
                     },
                 ],
                 input_type: "document",

--- a/gen.pollinations.ai/test/openapi-json.test.ts
+++ b/gen.pollinations.ai/test/openapi-json.test.ts
@@ -92,6 +92,26 @@ describe("/openapi.json", () => {
             expect(properties.thinking).toBeUndefined();
             expect(properties.thinking_budget).toBeUndefined();
         }
+
+        const embeddingRequestPropertySets = collectPropertySets(schema).filter(
+            (properties) =>
+                "input_type" in properties && "task_type" in properties,
+        );
+        expect(embeddingRequestPropertySets.length).toBeGreaterThan(0);
+        for (const properties of embeddingRequestPropertySets) {
+            const inputType = properties.input_type as {
+                enum?: string[];
+                description?: string;
+            };
+            const taskType = properties.task_type as {
+                description?: string;
+            };
+            expect(inputType.enum).toEqual(["query", "document"]);
+            expect(inputType.description).toContain("Cohere-specific");
+            expect(taskType.description).toContain(
+                "recommended prompt instruction",
+            );
+        }
     });
 
     it("returns the same spec as /docs/open-api/generate-schema", async () => {

--- a/gen.pollinations.ai/test/openapi-json.test.ts
+++ b/gen.pollinations.ai/test/openapi-json.test.ts
@@ -101,16 +101,8 @@ describe("/openapi.json", () => {
         for (const properties of embeddingRequestPropertySets) {
             const inputType = properties.input_type as {
                 enum?: string[];
-                description?: string;
-            };
-            const taskType = properties.task_type as {
-                description?: string;
             };
             expect(inputType.enum).toEqual(["query", "document"]);
-            expect(inputType.description).toContain("Cohere-specific");
-            expect(taskType.description).toContain(
-                "recommended prompt instruction",
-            );
         }
     });
 

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -68,15 +68,15 @@ export const EMBEDDING_SERVICES = {
         category: "embedding",
         addedDate: new Date("2026-05-26").getTime(),
         priceMultiplier: 0.75,
-        // Azure Cohere retail rates (Global). Image-token billing also available
-        // upstream ($0.47/1M Global text-img); we only expose text input for now.
+        // Azure Cohere retail rates (Global).
         cost: {
             promptTextTokens: perMillion(0.12),
+            promptImageTokens: perMillion(0.47),
         },
         title: "Cohere Embed v4",
         description:
-            "Cohere Embed v4 - Multilingual text embeddings. 1536 dimensions, 128K context.",
-        inputModalities: ["text"],
+            "Cohere Embed v4 - Multilingual text and image embeddings. 1536 dimensions, 128K context.",
+        inputModalities: ["text", "image"],
         outputModalities: ["embedding"],
         contextLength: 128000,
     },
@@ -92,9 +92,9 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Qwen3 Embedding 8B",
         description:
-            "Qwen3 Embedding 8B - Multilingual text embeddings. 4096 dimensions.",
+            "Qwen3 Embedding 8B - Multilingual text embeddings. 4096 dimensions, 40K context.",
         inputModalities: ["text"],
         outputModalities: ["embedding"],
-        contextLength: 32768,
+        contextLength: 40960,
     },
 } as const satisfies Record<string, ModelDefinition>;

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -92,9 +92,10 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Qwen3 Embedding 8B",
         description:
-            "Qwen3 Embedding 8B - Multilingual text embeddings. 4096 dimensions, 40K context.",
+            "Qwen3 Embedding 8B - Multilingual text embeddings. 4096 dimensions, 40,960-token Fireworks context.",
         inputModalities: ["text"],
         outputModalities: ["embedding"],
+        // Match the effective context advertised by the Fireworks deployment.
         contextLength: 40960,
     },
 } as const satisfies Record<string, ModelDefinition>;


### PR DESCRIPTION
- Migrates Gemini Embedding 2 from the preview contract to the GA v1 US multi-region endpoint and converts task hints to documented prompt instructions.
- Breaking vector-space change: existing `gemini-2` indexes must be re-embedded before mixing with GA vectors; inserted task instructions count toward billed prompt tokens.
- Adds model-specific dimension validation plus Cohere query/document roles and combined text-image coverage. Cohere mixed requests use aggregate image-rate billing; Azure currently exposes this deployment through its 2024-05-01-preview image route (the 2025-04-01 route returns 404).
- Keeps Qwen context at Fireworks effective 40,960-token deployment limit and documents the provider-specific value.
- Verified with 564 gen tests, 29 pricing tests, focused review regressions, typecheck, docs validation, live provider probes, formatting, and CodeQL.