### PR TITLE
feat: rewrite model registry descriptions for end users

### DIFF
--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -65,7 +65,7 @@ export const AUDIO_SERVICES = {
         },
         title: "ElevenLabs v3 TTS",
         description:
-            "ElevenLabs v3 TTS - Expressive voices with emotions & audio tags",
+            "Expressive speech with emotion control and audio tags",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
@@ -86,7 +86,7 @@ export const AUDIO_SERVICES = {
         },
         title: "ElevenLabs Flash v2.5",
         description:
-            "ElevenLabs Flash v2.5 - Fast, low-latency TTS (~75ms, 32 languages)",
+            "Snappy low-latency speech in 32 languages; leaner than the premium voices",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
@@ -107,7 +107,7 @@ export const AUDIO_SERVICES = {
         },
         title: "ElevenLabs Multilingual v2",
         description:
-            "ElevenLabs Multilingual v2 - Lifelike, emotionally rich TTS (29 languages)",
+            "Lifelike, emotionally rich speech in 29 languages",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
@@ -128,7 +128,7 @@ export const AUDIO_SERVICES = {
         },
         title: "ElevenLabs Music",
         description:
-            "ElevenLabs Music - Generate studio-grade music from text prompts and reference audio",
+            "Studio-grade music from a text prompt or reference track",
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
     },
@@ -145,8 +145,7 @@ export const AUDIO_SERVICES = {
             completionAudioSeconds: 0.002,
         },
         title: "ElevenLabs Sound Effects",
-        description:
-            "ElevenLabs Sound Effects - Generate sound effects from text prompts",
+        description: "Sound effects from a text description",
         inputModalities: ["text"],
         outputModalities: ["audio"],
     },
@@ -162,7 +161,7 @@ export const AUDIO_SERVICES = {
             promptAudioSeconds: 0.0000445,
         },
         title: "Whisper Large V3",
-        description: "Whisper Large V3 - Speech to text transcription",
+        description: "Accurate, affordable speech-to-text transcription",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
@@ -179,7 +178,8 @@ export const AUDIO_SERVICES = {
             promptAudioSeconds: 0.22 / 3600,
         },
         title: "Scribe v2",
-        description: "Scribe v2 - Speech to text (90+ languages, diarization)",
+        description:
+            "Transcription in 90+ languages with speaker labels",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
@@ -195,8 +195,7 @@ export const AUDIO_SERVICES = {
             promptAudioSeconds: 0.15 / 3600,
         },
         title: "AssemblyAI Universal-2",
-        description:
-            "AssemblyAI Universal-2 - Fast speech to text with 99-language support",
+        description: "Fast transcription with support for 99 languages",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
@@ -217,7 +216,7 @@ export const AUDIO_SERVICES = {
         },
         title: "AssemblyAI Universal-3 Pro",
         description:
-            "AssemblyAI Universal-3 Pro - High-accuracy speech to text with prompting",
+            "Top-accuracy transcription you can steer with prompts",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
@@ -241,7 +240,7 @@ export const AUDIO_SERVICES = {
         },
         title: "Stable Audio 3 Medium",
         description:
-            "Stable Audio 3 Medium - Long-form 44.1 kHz stereo music and sound generation",
+            "Long-form stereo music and soundscapes in studio quality",
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
     },
@@ -266,7 +265,7 @@ export const AUDIO_SERVICES = {
         },
         title: "Stable Audio 3 Large",
         description:
-            "Stable Audio 3 Large - Long-form 44.1 kHz stereo music via Stability's direct API",
+            "Highest-quality long-form stereo music generation; priced per generation",
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
     },
@@ -283,7 +282,7 @@ export const AUDIO_SERVICES = {
             completionAudioTokens: 0.01 / 1000,
         },
         title: "Qwen3-TTS Flash",
-        description: "Qwen3-TTS Flash - Fast multilingual text-to-speech",
+        description: "Fast multilingual text-to-speech at low cost",
         inputModalities: ["text"],
         outputModalities: ["audio"],
     },
@@ -300,7 +299,8 @@ export const AUDIO_SERVICES = {
             completionAudioTokens: 0.0115 / 1000,
         },
         title: "Qwen3-TTS Instruct",
-        description: "Qwen3-TTS Instruct - TTS with emotion & style control",
+        description:
+            "Text-to-speech you can direct with emotion and style instructions",
         inputModalities: ["text"],
         outputModalities: ["audio"],
     },

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -64,8 +64,7 @@ export const AUDIO_SERVICES = {
             completionAudioTokens: 0.1 / 1000,
         },
         title: "ElevenLabs v3 TTS",
-        description:
-            "Expressive speech with emotion control and audio tags",
+        description: "Expressive speech with emotion control and audio tags",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
@@ -106,8 +105,7 @@ export const AUDIO_SERVICES = {
             completionAudioTokens: 0.1 / 1000,
         },
         title: "ElevenLabs Multilingual v2",
-        description:
-            "Lifelike, emotionally rich speech in 29 languages",
+        description: "Lifelike, emotionally rich speech in 29 languages",
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
@@ -127,8 +125,7 @@ export const AUDIO_SERVICES = {
             completionAudioSeconds: 0.0025,
         },
         title: "ElevenLabs Music",
-        description:
-            "Studio-grade music from a text prompt or reference track",
+        description: "Studio-grade music from a text prompt or reference track",
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
     },
@@ -178,8 +175,7 @@ export const AUDIO_SERVICES = {
             promptAudioSeconds: 0.22 / 3600,
         },
         title: "Scribe v2",
-        description:
-            "Transcription in 90+ languages with speaker labels",
+        description: "Transcription in 90+ languages with speaker labels",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
@@ -215,8 +211,7 @@ export const AUDIO_SERVICES = {
             promptAudioSeconds: 0.21 / 3600,
         },
         title: "AssemblyAI Universal-3 Pro",
-        description:
-            "Top-accuracy transcription you can steer with prompts",
+        description: "Top-accuracy transcription you can steer with prompts",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
@@ -239,8 +234,7 @@ export const AUDIO_SERVICES = {
             completionAudioTokens: 0.0376,
         },
         title: "Stable Audio 3 Medium",
-        description:
-            "Long-form stereo music and soundscapes in studio quality",
+        description: "Long-form stereo music and soundscapes in studio quality",
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
     },

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -22,7 +22,7 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Gemini Embedding 2",
         description:
-            "Gemini Embedding 2 - Multimodal Embeddings for Text, Images, Audio, and Video. 3072 dimensions, 8192 token limit.",
+            "Turns text, images, audio and video into vectors for semantic search. 3072 dimensions, 8192 token limit.",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["embedding"],
         contextLength: 8192,
@@ -39,7 +39,7 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Text Embedding 3 Small",
         description:
-            "Text Embedding 3 Small - Low-Cost Text Embeddings. 1536 dimensions, 8192 token limit.",
+            "Low-cost text vectors for search and similarity. 1536 dimensions, 8192 token limit.",
         inputModalities: ["text"],
         outputModalities: ["embedding"],
         contextLength: 8192,
@@ -56,7 +56,7 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Text Embedding 3 Large",
         description:
-            "Text Embedding 3 Large - High-Quality Text Embeddings. 3072 dimensions, 8192 token limit.",
+            "High-quality text vectors for demanding search. 3072 dimensions, 8192 token limit.",
         inputModalities: ["text"],
         outputModalities: ["embedding"],
         contextLength: 8192,
@@ -75,7 +75,7 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Cohere Embed v4",
         description:
-            "Cohere Embed v4 - Multilingual text and image embeddings. 1536 dimensions, 128K context.",
+            "Multilingual text and image vectors. 1536 dimensions, 128K context.",
         inputModalities: ["text", "image"],
         outputModalities: ["embedding"],
         contextLength: 128000,
@@ -92,7 +92,7 @@ export const EMBEDDING_SERVICES = {
         },
         title: "Qwen3 Embedding 8B",
         description:
-            "Qwen3 Embedding 8B - Multilingual text embeddings. 4096 dimensions, 40,960-token Fireworks context.",
+            "Multilingual text vectors. 4096 dimensions, 40,960-token context.",
         inputModalities: ["text"],
         outputModalities: ["embedding"],
         // Match the effective context advertised by the Fireworks deployment.

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -17,7 +17,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.0001, // per image
         },
         title: "Sana Sprint 1.6B",
-        description: "Sana Sprint 1.6B - Fast, low-cost image generation",
+        description:
+            "Near-instant images at rock-bottom cost; simpler detail than premium models",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -32,7 +33,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.04, // per image
         },
         title: "FLUX.1 Kontext",
-        description: "FLUX.1 Kontext - In-context editing & generation",
+        description:
+            "Edits an existing image from plain instructions — swap, restyle, refine",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 1, // Azure FLUX.1 Kontext edit route forwards one input image.
@@ -53,7 +55,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: perMillion(30), // per 1M tokens, 1290 tokens/image
         },
         title: "NanoBanana",
-        description: "NanoBanana - Fast image generation & editing",
+        description:
+            "Quick image generation and editing that follows instructions well",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 3, // Pollinations cap for Gemini 2.5 Flash Image route.
@@ -75,7 +78,7 @@ export const IMAGE_SERVICES = {
         },
         title: "NanoBanana 2",
         description:
-            "NanoBanana 2 - Image generation & editing with sharper detail",
+            "Sharper detail and better text rendering in generated and edited images",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations cap for Gemini 3.1 Flash Image route.
@@ -97,7 +100,7 @@ export const IMAGE_SERVICES = {
         },
         title: "NanoBanana 2 Lite",
         description:
-            "NanoBanana 2 Lite - Fast, low-cost image generation & editing",
+            "Speedy, affordable image generation and editing for everyday use",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations cap for Gemini 3.1 Flash-Lite Image route.
@@ -120,7 +123,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: perMillion(120), // per 1M tokens, 1120 tokens per 1K image
         },
         title: "NanoBanana Pro",
-        description: "NanoBanana Pro - Gemini 3 Pro Image (4K, Thinking)",
+        description:
+            "Studio-quality images up to 4K, with reasoning for tricky prompts",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 14, // Gemini 3 Pro Image provider limit.
@@ -138,7 +142,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Seedream 5.0 Lite",
         description:
-            "Seedream 5.0 Lite - Image generation with web search & reasoning",
+            "Image generation that can search the web and reason about your prompt",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations route cap from Replicate schema.
@@ -172,7 +176,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.03, // per image
         },
         title: "Seedream 4.0",
-        description: "Seedream 4.0 - Photorealistic image generation",
+        description: "Photorealistic images with strong prompt adherence",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 10, // Pollinations route cap from Replicate schema.
@@ -190,7 +194,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Seedream 4.5 Pro",
         description:
-            "Seedream 4.5 Pro - Premium photorealistic image generation",
+            "Premium photorealism for lifelike scenes and portraits",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations route cap from Replicate schema.
@@ -214,7 +218,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Ideogram 4.0 Turbo",
         description:
-            "Ideogram 4.0 Turbo - Fast text-to-image with accurate typography",
+            "Fast images with crisp, accurate text and typography",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -231,7 +235,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Ideogram 4.0 Balanced",
         description:
-            "Ideogram 4.0 Balanced - Text-to-image with accurate typography",
+            "Balanced speed and quality with accurate text rendering",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -248,7 +252,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Ideogram 4.0 Quality",
         description:
-            "Ideogram 4.0 Quality - High-fidelity text-to-image with typography",
+            "Highest-fidelity images with spot-on typography; slower to generate",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -266,7 +270,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: perMillion(8), // per 1M tokens
         },
         title: "GPT Image 1 Mini",
-        description: "GPT Image 1 Mini - Fast & affordable image generation",
+        description:
+            "Affordable image creation and editing for everyday use",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 16, // GPT Image edit endpoint accepts up to 16 input images.
@@ -287,7 +292,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: perMillion(32), // per 1M tokens
         },
         title: "GPT Image 1.5",
-        description: "GPT Image 1.5 - High-fidelity image generation & editing",
+        description:
+            "High-fidelity image generation and editing with fine detail",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 16, // GPT Image edit endpoint accepts up to 16 input images.
@@ -308,7 +314,7 @@ export const IMAGE_SERVICES = {
         },
         title: "GPT Image 2",
         description:
-            "GPT Image 2 - Premium high-resolution image generation & editing",
+            "Premium high-resolution images with excellent prompt following",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 16, // GPT Image edit endpoint accepts up to 16 input images.
@@ -324,7 +330,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.0014, // per image
         },
         title: "Flux Schnell",
-        description: "Flux Schnell - Fast high-quality image generation",
+        description: "Fast, high-quality images at a tiny cost",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -339,7 +345,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.002, // per image
         },
         title: "Z-Image Turbo",
-        description: "Z-Image Turbo - Alibaba S3-DiT 6B with 2x SPAN upscaling",
+        description:
+            "Instant, budget-friendly images with crisp upscaled output",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -397,7 +404,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Seedance Pro-Fast",
         description:
-            "Seedance Pro-Fast - Text/image-to-video (720p, better prompt adherence)",
+            "720p video from text or a start image, with strong prompt adherence",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame"],
@@ -417,7 +424,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Seedance 2.0",
         description:
-            "Seedance 2.0 - ByteDance multimodal video gen (720p, native audio)",
+            "720p video with natively synced sound, from text or images",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
@@ -438,7 +445,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Wan 2.6",
         description:
-            "Wan 2.6 - text/image-to-video with audio (720p, 5/10/15s)",
+            "Video with sound from text or an image (720p, 5/10/15s clips)",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame", "audio_output"],
@@ -458,7 +465,8 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.01, // per sec (480p, silent)
         },
         title: "Wan 2.2",
-        description: "Wan 2.2 - Fast & cheap text/image-to-video (5s, 480p)",
+        description:
+            "Cheap 5-second silent clips at 480p — great for quick drafts",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame", "end_frame"],
@@ -479,7 +487,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Wan 2.7",
         description:
-            "Wan 2.7 - text/image-to-video with bundled audio (720p, keyframes)",
+            "Keyframe-controlled video with sound at 720p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
@@ -501,7 +509,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Wan 2.7 1080p",
         description:
-            "Wan 2.7 1080p - text/image-to-video with bundled audio (1080p, keyframes)",
+            "Keyframe-controlled video with sound in full 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
@@ -521,7 +529,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Wan 2.7 Image",
         description:
-            "Wan 2.7 Image - Alibaba text-to-image and image editing (up to 2K)",
+            "Text-to-image and instruction-based editing up to 2K resolution",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 9, // Pollinations route cap.
@@ -541,7 +549,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Wan 2.7 Image Pro",
         description:
-            "Wan 2.7 Image Pro - Alibaba text-to-image and editing (4K, thinking mode)",
+            "Detailed 4K image generation and editing with a thinking mode",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 9, // Pollinations route cap.
@@ -566,7 +574,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Qwen Image Plus",
         description:
-            "Qwen Image Plus - Alibaba text-to-image and image editing",
+            "Versatile image creation and editing, strong at text inside images",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 3, // DashScope Qwen Image Edit route cap.
@@ -584,7 +592,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.02, // per image
         },
         title: "Grok Imagine",
-        description: "Grok Imagine - Photorealistic image generation",
+        description: "Photorealistic image generation and quick edits",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 1, // xAI image edit route forwards one input image.
@@ -608,7 +616,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Grok Imagine Pro",
         description:
-            "Grok Imagine Pro - xAI official pro image generation (Aurora)",
+            "Higher-fidelity photorealistic images for polished results",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 1, // xAI image edit route forwards one input image.
@@ -627,7 +635,7 @@ export const IMAGE_SERVICES = {
         },
         title: "Grok Video Pro",
         description:
-            "Grok Video Pro - xAI official video generation (720p, 1-15s)",
+            "Short videos from text or an image (720p, 1-15s)",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame"],
@@ -662,7 +670,8 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.01,
         },
         title: "FLUX.2 Klein 4B",
-        description: "FLUX.2 Klein 4B - Fast image generation and editing",
+        description:
+            "Quick image generation and editing with solid quality per dollar",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 10, // Pollinations self-hosted route cap.
@@ -679,7 +688,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.005, // per image
         },
         title: "Pruna p-image",
-        description: "Pruna p-image - Fast text-to-image generation",
+        description: "Cheap, speedy text-to-image for rapid iteration",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -695,7 +704,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.01, // per image
         },
         title: "Pruna p-image-edit",
-        description: "Pruna p-image-edit - Image-to-image editing",
+        description: "Fast instruction-based photo editing",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 5, // Pollinations route cap.
@@ -716,7 +725,7 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.02, // Replicate 720p per sec
         },
         title: "Pruna p-video 720p",
-        description: "Pruna p-video - Text/image-to-video generation (720p)",
+        description: "Affordable video from text or an image at 720p",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame"],
@@ -734,7 +743,7 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.04, // Replicate 1080p per sec
         },
         title: "Pruna p-video 1080p",
-        description: "Pruna p-video - Text/image-to-video generation (1080p)",
+        description: "Affordable video from text or an image at 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame"],
@@ -751,7 +760,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.04, // per image
         },
         title: "Nova Canvas",
-        description: "Nova Canvas - Image generation, editing & inpainting",
+        description: "Image generation with editing and inpainting tools",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 1, // Nova Canvas route forwards one input image.
@@ -767,7 +776,8 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.08, // per sec
         },
         title: "Nova Reel",
-        description: "Nova Reel - Video Generation (6-120s, 720p)",
+        description:
+            "Long-form video — clips from 6 seconds up to 2 minutes at 720p",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame"],

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -193,8 +193,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.04, // per image
         },
         title: "Seedream 4.5 Pro",
-        description:
-            "Premium photorealism for lifelike scenes and portraits",
+        description: "Premium photorealism for lifelike scenes and portraits",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 14, // Pollinations route cap from Replicate schema.
@@ -217,8 +216,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.03, // flat per image — ideogram-ai/ideogram-v4-turbo
         },
         title: "Ideogram 4.0 Turbo",
-        description:
-            "Fast images with crisp, accurate text and typography",
+        description: "Fast images with crisp, accurate text and typography",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -234,8 +232,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.06, // flat per image — ideogram-ai/ideogram-v4-balanced
         },
         title: "Ideogram 4.0 Balanced",
-        description:
-            "Balanced speed and quality with accurate text rendering",
+        description: "Balanced speed and quality with accurate text rendering",
         inputModalities: ["text"],
         outputModalities: ["image"],
     },
@@ -270,8 +267,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: perMillion(8), // per 1M tokens
         },
         title: "GPT Image 1 Mini",
-        description:
-            "Affordable image creation and editing for everyday use",
+        description: "Affordable image creation and editing for everyday use",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 16, // GPT Image edit endpoint accepts up to 16 input images.
@@ -486,8 +482,7 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.1, // per sec (720p, includes audio)
         },
         title: "Wan 2.7",
-        description:
-            "Keyframe-controlled video with sound at 720p",
+        description: "Keyframe-controlled video with sound at 720p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
@@ -508,8 +503,7 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.15, // per sec (1080p, includes audio)
         },
         title: "Wan 2.7 1080p",
-        description:
-            "Keyframe-controlled video with sound in full 1080p",
+        description: "Keyframe-controlled video with sound in full 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
@@ -634,8 +628,7 @@ export const IMAGE_SERVICES = {
             completionVideoSeconds: 0.07, // per sec at 720p
         },
         title: "Grok Video Pro",
-        description:
-            "Short videos from text or an image (720p, 1-15s)",
+        description: "Short videos from text or an image (720p, 1-15s)",
         inputModalities: ["text", "image"],
         outputModalities: ["video"],
         videoCapabilities: ["start_frame"],

--- a/shared/registry/model3d.ts
+++ b/shared/registry/model3d.ts
@@ -22,7 +22,8 @@ export const MODEL3D_SERVICES = {
             completionImageTokens: 0.24, // per generation, "low" resolution
         },
         title: "Trellis 2 (Low)",
-        description: "Trellis 2 - High-quality image-to-3D, low resolution",
+        description:
+            "Turns a photo into a 3D model — fastest option, lowest detail",
         inputModalities: ["image"],
         outputModalities: ["3d"],
         maxReferenceImages: 1,
@@ -40,7 +41,8 @@ export const MODEL3D_SERVICES = {
             completionImageTokens: 0.29, // per generation, "medium" resolution
         },
         title: "Trellis 2 (Medium)",
-        description: "Trellis 2 - High-quality image-to-3D, medium resolution",
+        description:
+            "Turns a photo into a 3D model with balanced detail and cost",
         inputModalities: ["image"],
         outputModalities: ["3d"],
         maxReferenceImages: 1,
@@ -58,7 +60,8 @@ export const MODEL3D_SERVICES = {
             completionImageTokens: 0.35, // per generation, "high" resolution
         },
         title: "Trellis 2 (High)",
-        description: "Trellis 2 - High-quality image-to-3D, high resolution",
+        description:
+            "Turns a photo into a 3D model at maximum detail; the priciest tier",
         inputModalities: ["image"],
         outputModalities: ["3d"],
         maxReferenceImages: 1,
@@ -77,7 +80,8 @@ export const MODEL3D_SERVICES = {
             completionImageTokens: 0.1, // per generation
         },
         title: "Hyper3D Rodin 2.5",
-        description: "Hyper3D Rodin 2.5 - Image/text-to-3D with textures",
+        description:
+            "Textured 3D models from an image or a text prompt",
         inputModalities: ["text", "image"],
         outputModalities: ["3d"],
         maxReferenceImages: 1,

--- a/shared/registry/model3d.ts
+++ b/shared/registry/model3d.ts
@@ -80,8 +80,7 @@ export const MODEL3D_SERVICES = {
             completionImageTokens: 0.1, // per generation
         },
         title: "Hyper3D Rodin 2.5",
-        description:
-            "Textured 3D models from an image or a text prompt",
+        description: "Textured 3D models from an image or a text prompt",
         inputModalities: ["text", "image"],
         outputModalities: ["3d"],
         maxReferenceImages: 1,

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -21,7 +21,7 @@ export const REALTIME_SERVICES = {
         },
         title: "GPT Realtime 2.1",
         description:
-            "GPT Realtime 2.1 - realtime voice reasoning with improved silence and noise handling",
+            "Live voice conversations with instant replies and solid noise handling",
         inputModalities: ["text", "audio", "image"],
         outputModalities: ["text", "audio"],
         tools: true,
@@ -44,7 +44,8 @@ export const REALTIME_SERVICES = {
             completionAudioTokens: 0.000064,
         },
         title: "GPT Realtime 2",
-        description: "GPT Realtime 2 - realtime voice reasoning",
+        description:
+            "Live voice conversations with instant, reasoned replies",
         inputModalities: ["text", "audio", "image"],
         outputModalities: ["text", "audio"],
         tools: true,

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -44,8 +44,7 @@ export const REALTIME_SERVICES = {
             completionAudioTokens: 0.000064,
         },
         title: "GPT Realtime 2",
-        description:
-            "Live voice conversations with instant, reasoned replies",
+        description: "Live voice conversations with instant, reasoned replies",
         inputModalities: ["text", "audio", "image"],
         outputModalities: ["text", "audio"],
         tools: true,

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -761,8 +761,7 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.1 Flash Lite Search",
-        description:
-            "Low-cost answers grounded in live web search results",
+        description: "Low-cost answers grounded in live web search results",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -792,8 +791,7 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.5 Flash Search",
-        description:
-            "Premium web research with grounded, up-to-date answers",
+        description: "Premium web research with grounded, up-to-date answers",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -1419,8 +1417,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.2),
         },
         title: "MiniMax M2.7",
-        description:
-            "Multilingual coding and agent tasks at a friendly price",
+        description: "Multilingual coding and agent tasks at a friendly price",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -46,7 +46,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.25),
         },
         title: "GPT-5.4 Nano",
-        description: "GPT-5.4 Nano - Fast & Balanced",
+        description:
+            "Fast, affordable all-rounder for everyday chat and image questions",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure OpenAI vision limit: 10 images/chat request (provider cap).
@@ -67,7 +68,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.4),
         },
         title: "GPT-5 Nano",
-        description: "GPT-5 Nano - Ultra Fast & Affordable",
+        description:
+            "Ultra-fast and ultra-cheap for simple tasks; not built for hard problems",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure OpenAI vision limit: 10 images/chat request (provider cap).
@@ -87,7 +89,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.18),
         },
         title: "GPT-OSS 20B",
-        description: "Open-weight reasoning model with tool support",
+        description:
+            "Compact open-weight reasoner; solid logic on a budget, limited world knowledge",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -108,7 +111,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(15.0),
         },
         title: "GPT-5.4",
-        description: "GPT-5.4 - Most Powerful & Intelligent",
+        description:
+            "Deep reasoning for the hardest questions; slower and pricier than lighter tiers",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure OpenAI vision limit: 10 images/chat request (provider cap).
@@ -130,7 +134,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(4.5),
         },
         title: "GPT-5.4 Mini",
-        description: "GPT-5.4 Mini - Balanced Speed & Cost",
+        description:
+            "Strong all-round quality at mid cost; a good default when speed matters",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure OpenAI vision limit: 10 images/chat request (provider cap).
@@ -151,7 +156,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(30.0),
         },
         title: "GPT-5.5",
-        description: "GPT-5.5 - Frontier Reasoning",
+        description:
+            "Frontier reasoning for complex, multi-step problems; takes its time thinking",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure OpenAI vision limit: 10 images/chat request (provider cap).
@@ -243,7 +249,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.75),
         },
         title: "Mercury 2",
-        description: "Mercury 2 - Fast diffusion LLM for real-time agents",
+        description:
+            "Near-instant responses for real-time apps; skip it for heavy reasoning",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -262,7 +269,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.22),
         },
         title: "Qwen3 Coder 30B",
-        description: "Qwen3 Coder 30B - Specialized for Code Generation",
+        description:
+            "Writes and fixes code quickly at low cost; best for programming, not chat",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -286,7 +294,7 @@ export const TEXT_SERVICES = {
         },
         title: "Mistral Small 3.2",
         description:
-            "Mistral Small 3.2 - Improved Instruction Following & Function Calling",
+            "Follows instructions reliably and calls functions well, at low cost",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // OpenRouter/Mistral image count varies by provider/model; Pollinations cap.
@@ -312,7 +320,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.6),
         },
         title: "Mistral Small 4",
-        description: "Mistral Small 4 - Unified Reasoning & Multimodal",
+        description:
+            "Compact all-rounder that combines reasoning with image understanding",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Mistral image count varies by model/token budget; Pollinations cap.
@@ -340,7 +349,8 @@ export const TEXT_SERVICES = {
             completionAudioTokens: perMillion(20.0),
         },
         title: "GPT Audio Mini",
-        description: "GPT Audio Mini - Voice Input & Output",
+        description:
+            "Talks and listens — voice conversations with spoken or text replies",
         voices: [...AUDIO_VOICES],
         inputModalities: ["text", "audio"],
         outputModalities: ["audio", "text"],
@@ -362,7 +372,8 @@ export const TEXT_SERVICES = {
             completionAudioTokens: perMillion(80.0),
         },
         title: "GPT Audio 1.5",
-        description: "GPT Audio 1.5 - Premium Voice Input & Output",
+        description:
+            "Rich, natural voice conversations; premium quality at a higher price",
         voices: [...AUDIO_VOICES],
         inputModalities: ["text", "audio"],
         outputModalities: ["audio", "text"],
@@ -387,7 +398,8 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3 Flash",
-        description: "Gemini 3 Flash - Pro-Grade Reasoning at Flash Speed",
+        description:
+            "Pro-grade reasoning at high speed, with web search and a huge context window",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -417,7 +429,8 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.5 Flash",
-        description: "Gemini 3.5 Flash - Next-Gen Reasoning at Flash Speed",
+        description:
+            "Sharp, fast reasoning over text, images, audio and video, plus web search",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -449,7 +462,8 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.1 Flash Lite",
-        description: "Gemini 3.1 Flash Lite - Fast & Cost-Effective",
+        description:
+            "Quick, low-cost answers across text, images, audio and video",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -477,7 +491,8 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_25_GROUNDING_BILLING, 1.0),
         title: "Gemini 2.5 Flash Lite",
-        description: "Gemini 2.5 Flash Lite - Ultra Fast & Cost-Effective",
+        description:
+            "Cheapest way to handle everyday multimodal tasks; trades depth for speed",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -507,7 +522,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.28),
         },
         title: "DeepSeek V4 Flash (Lite)",
-        description: "DeepSeek V4 Flash (Lite) - Fast Reasoning & Coding",
+        description: "Fast reasoning and coding at bargain prices",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -535,7 +550,7 @@ export const TEXT_SERVICES = {
         },
         title: "Gemma 4 26B A4B",
         description:
-            "Gemma 4 26B A4B - Open-source multimodal MoE for fast inference",
+            "Efficient open-source chat with image understanding; modest on hard problems",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
@@ -579,7 +594,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(3.48),
         },
         title: "DeepSeek V4 Pro",
-        description: "DeepSeek V4 Pro - Advanced Reasoning & Coding",
+        description: "Deep reasoning and strong coding for demanding problems",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -610,7 +625,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(6.0),
         },
         title: "Grok 4.20 Non-Reasoning",
-        description: "Grok 4.20 Non-Reasoning - Fast multimodal tool-calling",
+        description:
+            "Snappy multimodal chat with tool calling; skips step-by-step reasoning",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 100, // xAI publishes no hard image-count limit; Pollinations cap.
@@ -633,7 +649,7 @@ export const TEXT_SERVICES = {
         },
         title: "Grok 4.20 Reasoning",
         description:
-            "Grok 4.20 Reasoning - Multimodal reasoning and agentic tasks",
+            "Step-by-step multimodal reasoning for agentic tasks; slower than the non-thinking variant",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 100, // xAI publishes no hard image-count limit; Pollinations cap.
@@ -658,7 +674,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(2.5),
         },
         title: "Grok 4.3",
-        description: "Grok 4.3 - Newer & cheaper multimodal reasoning",
+        description:
+            "Strong multimodal reasoning with a huge context window at a friendly price",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 100, // xAI publishes no hard image-count limit; Pollinations cap.
@@ -712,7 +729,7 @@ export const TEXT_SERVICES = {
         billing: withVertexCacheStorage(GEMINI_25_GROUNDING_BILLING, 1.0),
         title: "Google Gemini 2.5 Flash Lite Search",
         description:
-            "Google Gemini 2.5 Flash Lite Search - Web-grounded answers via Google Search",
+            "Answers grounded in live web search; fast and cheap, not a deep reasoner",
         inputModalities: ["text", "image", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -745,7 +762,7 @@ export const TEXT_SERVICES = {
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.1 Flash Lite Search",
         description:
-            "Gemini 3.1 Flash Lite Search - Cheap grounded web answers",
+            "Low-cost answers grounded in live web search results",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -775,7 +792,8 @@ export const TEXT_SERVICES = {
         },
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.5 Flash Search",
-        description: "Gemini 3.5 Flash Search - Premium grounded web research",
+        description:
+            "Premium web research with grounded, up-to-date answers",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -799,7 +817,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(4.5),
         },
         title: "MIDIjourney",
-        description: "MIDIjourney - AI Music Composition Assistant",
+        description: "Turns your musical ideas into playable MIDI notation",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -818,7 +836,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(30.0),
         },
         title: "MIDIjourney Large",
-        description: "MIDIjourney Large - Premium AI Music Composition",
+        description:
+            "Composes richer, more detailed MIDI arrangements; costs more per piece",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -840,7 +859,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(5),
         },
         title: "Claude Haiku 4.5",
-        description: "Claude Haiku 4.5 - Fast & Intelligent",
+        description:
+            "Quick, capable chat and coding at low cost; great for high-volume tasks",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -864,7 +884,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(15),
         },
         title: "Claude Sonnet 4.6",
-        description: "Claude Sonnet 4.6 - Most Capable & Balanced",
+        description:
+            "Excellent writing, coding and analysis with balanced speed and cost",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -888,7 +909,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(10),
         },
         title: "Claude Sonnet 5",
-        description: "Claude Sonnet 5 - Best balance of speed & intelligence",
+        description:
+            "Sharp reasoning with fast responses — a strong default for most work",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -912,7 +934,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(25),
         },
         title: "Claude Opus 4.6",
-        description: "Claude Opus 4.6 - Most Intelligent Model",
+        description:
+            "Deep analysis and careful reasoning for tough problems; slower and premium-priced",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -936,7 +959,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(25),
         },
         title: "Claude Opus 4.7",
-        description: "Claude Opus 4.7 - Most Intelligent Model",
+        description:
+            "Heavyweight reasoning and analysis; built for hard problems, not quick replies",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -960,7 +984,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(25),
         },
         title: "Claude Opus 4.8",
-        description: "Claude Opus 4.8 - Most Intelligent Model",
+        description:
+            "Top-shelf reasoning, writing and coding; premium price per token",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -984,7 +1009,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(50),
         },
         title: "Claude Fable 5",
-        description: "Claude Fable 5 - Frontier reasoning & agentic work",
+        description:
+            "Frontier intelligence for complex reasoning and long agentic work; the priciest tier",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -1005,7 +1031,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.0),
         },
         title: "Perplexity Sonar",
-        description: "Perplexity Sonar - Fast & affordable web search",
+        description: "Quick web searches with cited answers; keeps it brief",
         // Sonar is text-only — verified empirically (image input is ignored,
         // no image tokens billed). Do not add "image".
         inputModalities: ["text"],
@@ -1028,7 +1054,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.0),
         },
         title: "Perplexity Sonar",
-        description: "Perplexity Sonar - Deep web search with broad grounding",
+        description:
+            "Digs through many sources for thorough, cited research answers",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: false,
@@ -1049,7 +1076,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(15.0),
         },
         title: "Perplexity Sonar Pro",
-        description: "Perplexity Sonar Pro - Advanced multi-source web search",
+        description:
+            "Advanced web search that synthesizes multiple sources with citations",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: false,
@@ -1071,7 +1099,7 @@ export const TEXT_SERVICES = {
         },
         title: "Perplexity Sonar Reasoning",
         description:
-            "Perplexity Sonar Reasoning - Step-by-step reasoning with web search",
+            "Thinks step by step while searching the web; slower but more rigorous",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: false,
@@ -1100,7 +1128,7 @@ export const TEXT_SERVICES = {
         },
         title: "Moonshot Kimi K2.6",
         description:
-            "Moonshot Kimi K2.6 - Flagship Agentic Model with CoT Reasoning",
+            "Agentic all-rounder that shows its chain-of-thought reasoning",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 30, // Fireworks vision hard limit.
@@ -1125,7 +1153,7 @@ export const TEXT_SERVICES = {
         },
         title: "Moonshot Kimi K2.7 Code",
         description:
-            "Moonshot Kimi K2.7 Code - Agentic coding model with CoT reasoning",
+            "Built for agentic coding — plans, reasons and edits code step by step",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 30, // Fireworks vision hard limit.
@@ -1222,7 +1250,7 @@ export const TEXT_SERVICES = {
         billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 4.5),
         title: "Gemini 3.1 Pro",
         description:
-            "Gemini 3.1 Pro - Most Intelligent Model with 1M Context (Preview)",
+            "Top-tier multimodal reasoning over huge documents, images and video",
         inputModalities: ["text", "image", "audio", "video"],
         outputModalities: ["text"],
         maxReferenceImages: 3600, // Gemini API image-understanding file limit.
@@ -1250,7 +1278,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.14),
         },
         title: "Nova Micro",
-        description: "Nova Micro - Ultra Fast & Ultra Cheap",
+        description:
+            "Instant, ultra-cheap replies for simple tasks; not a deep thinker",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -1273,7 +1302,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(2.75),
         },
         title: "Nova 2 Lite",
-        description: "Nova 2 Lite - 1M Context with Reasoning",
+        description:
+            "Budget-friendly reasoning with room for very long documents",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.
@@ -1296,7 +1326,7 @@ export const TEXT_SERVICES = {
         },
         title: "Z.ai GLM-5.2",
         description:
-            "Z.ai GLM-5.2 - 743B MoE, Long Context Reasoning & Agentic Workflows",
+            "Massive open-weight model for long-context reasoning and agent workflows",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -1317,7 +1347,7 @@ export const TEXT_SERVICES = {
         },
         title: "Meta Llama 3.3 70B",
         description:
-            "Meta Llama 3.3 70B - Open-source dense model for general chat",
+            "Open-source workhorse for general chat and summarization; text only",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -1342,7 +1372,7 @@ export const TEXT_SERVICES = {
         },
         title: "Meta Llama 4 Maverick",
         description:
-            "Meta Llama 4 Maverick - Open-source multimodal MoE with vision",
+            "Open-source chat that understands images, with a huge context window",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure-hosted Llama vision route has no public fixed image count; Pollinations cap.
@@ -1368,7 +1398,7 @@ export const TEXT_SERVICES = {
         },
         title: "Meta Llama 4 Scout",
         description:
-            "Meta Llama 4 Scout - Open-source MoE for long context & retrieval",
+            "Open-source long-context specialist for digging through big documents",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
@@ -1389,7 +1419,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.2),
         },
         title: "MiniMax M2.7",
-        description: "MiniMax M2.7 - Coding, Agentic & Multi-Language",
+        description:
+            "Multilingual coding and agent tasks at a friendly price",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -1412,7 +1443,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.2),
         },
         title: "MiniMax M3",
-        description: "MiniMax M3 - Coding, agentic & 512K-context reasoning",
+        description:
+            "Strong coding and agent skills with a very long memory for big projects",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 30, // Fireworks vision hard limit.
@@ -1457,7 +1489,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.5),
         },
         title: "Mistral Large 3",
-        description: "Mistral Large 3 - Premium Multilingual & Reasoning",
+        description:
+            "Polished multilingual writing and reasoning with image understanding",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // Mistral image count varies by model/token budget; Pollinations cap.
@@ -1479,7 +1512,7 @@ export const TEXT_SERVICES = {
         },
         title: "Polly by @Itachi-1824",
         description:
-            "Polly by @Itachi-1824 - Pollinations AI Assistant with GitHub, Code Search & Web Tools (Alpha)",
+            "Community-built assistant with GitHub, code search and web tools (alpha)",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 3, // Pollinations community model cap.
@@ -1505,7 +1538,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.8), // per 1M tokens
         },
         title: "Qwen3 Coder Next",
-        description: "Qwen3 Coder Next - Advanced Code Generation",
+        description:
+            "Advanced code generation for demanding projects; code-focused, text only",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -1588,7 +1622,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.52),
         },
         title: "Qwen3 VL 30B A3B Instruct",
-        description: "Qwen3 VL 30B A3B Instruct - Fast vision-language model",
+        description:
+            "Fast image understanding — describes, reads and analyzes what it sees",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
@@ -1614,7 +1649,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(2.6),
         },
         title: "Qwen3 VL 235B A22B Thinking",
-        description: "Qwen3 VL 235B A22B Thinking - Vision-Language Reasoning",
+        description:
+            "Careful visual reasoning for charts, documents and complex scenes",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
@@ -1638,7 +1674,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.15),
         },
         title: "StepFun Step 3.7 Flash",
-        description: "StepFun Step 3.7 Flash - Fast multimodal reasoning model",
+        description:
+            "Speedy reasoning over text and images for everyday questions",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
@@ -1663,7 +1700,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.3),
         },
         title: "StepFun Step 3.5 Flash",
-        description: "StepFun Step 3.5 Flash - Fast text reasoning model",
+        description: "Fast, low-cost text reasoning for everyday tasks",
         inputModalities: ["text"],
         outputModalities: ["text"],
         tools: true,
@@ -1683,7 +1720,8 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(0.01),
         },
         title: "Qwen3Guard 8B",
-        description: "Qwen3Guard 8B - Content Safety & Moderation",
+        description:
+            "Flags unsafe content — a moderation filter, not a chat companion",
         inputModalities: ["text"],
         outputModalities: ["text"],
         isSpecialized: true,


### PR DESCRIPTION
- Rewrites all 132 model descriptions across `shared/registry/` (text, image, video, audio, embeddings, 3D, realtime)
- Removes model title/name duplication from every description — the display name is rendered separately, so `"GPT-5.4 Nano - Fast & Balanced"` becomes `"Fast, affordable all-rounder for everyday chat and image questions"`
- Removes brand/provider attribution from description copy (`brand`/`provider` fields carry that)
- Reframes descriptions for end users: what each model does, what it's good at, and trade-offs (speed vs depth, cost vs quality) so apps can show the list directly to their users
- Description-only change: titles, aliases, pricing, modalities, and `addedDate` untouched; verified by script that no description contains its title or a brand name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocSzpGECCMHq8XovmUZbK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KocSzpGECCMHq8XovmUZbK)_