### PR TITLE
fix: wrap long key model labels

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx
@@ -367,7 +367,10 @@ const ModelChip: FC<{
         <span className="min-w-0 whitespace-normal break-words">
             {officialName}
             {showApiName && (
-                <span className="font-mono opacity-70"> - {apiName}</span>
+                <span className="font-mono text-xs font-normal opacity-70">
+                    {" - "}
+                    {apiName}
+                </span>
             )}
         </span>
     </ModalityTab>

--- a/enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx
@@ -362,11 +362,13 @@ const ModelChip: FC<{
         onClick={onClick}
         disabled={disabled}
         size="sm"
-        className="polli:shrink-0"
+        className="polli:min-w-0 polli:max-w-full polli:justify-start polli:text-left"
     >
-        {officialName}
-        {showApiName && (
-            <span className="font-mono opacity-70"> - {apiName}</span>
-        )}
+        <span className="min-w-0 whitespace-normal break-words">
+            {officialName}
+            {showApiName && (
+                <span className="font-mono opacity-70"> - {apiName}</span>
+            )}
+        </span>
     </ModalityTab>
 );


### PR DESCRIPTION
- Fixes model chips overflowing the create/edit key dialogs when community model labels exceed the modal width.
- Replaces the chip’s fixed `shrink-0` sizing with bounded flex sizing and wraps the full display name and API model ID.
- Keeps the change local to the shared key-permissions model selector, so create, edit, and authorization flows all benefit.

Root cause: a single model chip could retain its intrinsic text width while the surrounding dialog hid horizontal overflow, producing a hard cutoff.

Checks:
- `npx biome check --write enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx`
- `npm run typecheck`
- `npm run build:frontend`
- Browser verification at 320px with long spaced and uninterrupted model identifiers; no horizontal overflow.