### PR TITLE
fix: hide retired models from API key permissions

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -11,6 +11,10 @@ import {
     user as userTable,
 } from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
+import {
+    filterPermissionsToVisibleModels,
+    getVisibleModelIdsForUser,
+} from "@shared/registry/visible-model-ids.ts";
 import { and, desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
@@ -1375,6 +1379,10 @@ export const accountRoutes = new Hono<Env>()
                 .from(apikeyTable)
                 .where(eq(apikeyTable.userId, user.id))
                 .all();
+            const visibleModelIds = await getVisibleModelIdsForUser(
+                c.env.DB,
+                user.id,
+            );
 
             c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
@@ -1389,7 +1397,10 @@ export const accountRoutes = new Hono<Env>()
                     permissions: key.permissions
                         ? (() => {
                               try {
-                                  return JSON.parse(key.permissions);
+                                  return filterPermissionsToVisibleModels(
+                                      JSON.parse(key.permissions),
+                                      visibleModelIds,
+                                  );
                               } catch {
                                   return null;
                               }
@@ -1652,9 +1663,17 @@ export const accountRoutes = new Hono<Env>()
             }
 
             // Format permissions for response
+            const visibleModelIds = await getVisibleModelIdsForUser(
+                c.env.DB,
+                c.var.auth.requireUser().id,
+            );
+            const effectivePermissions = filterPermissionsToVisibleModels(
+                apiKey.permissions ?? null,
+                visibleModelIds,
+            );
             const permissions = {
-                models: apiKey.permissions?.models || null,
-                account: apiKey.permissions?.account || null,
+                models: effectivePermissions?.models ?? null,
+                account: effectivePermissions?.account ?? null,
             };
 
             return c.json({

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1379,14 +1379,24 @@ export const accountRoutes = new Hono<Env>()
                 .from(apikeyTable)
                 .where(eq(apikeyTable.userId, user.id))
                 .all();
-            const visibleModelIds = await getVisibleModelIdsForUser(
-                c.env.DB,
-                user.id,
+            const parsedPermissions = keys.map((key) => {
+                if (!key.permissions) return null;
+                try {
+                    return JSON.parse(key.permissions);
+                } catch {
+                    return null;
+                }
+            });
+            const hasModelRestrictions = parsedPermissions.some((permissions) =>
+                Array.isArray(permissions?.models),
             );
+            const visibleModelIds = hasModelRestrictions
+                ? await getVisibleModelIdsForUser(c.env.DB, user.id)
+                : null;
 
             c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
-                data: keys.map((key) => ({
+                data: keys.map((key, index) => ({
                     id: key.id,
                     name: key.name,
                     start: key.start,
@@ -1394,18 +1404,12 @@ export const accountRoutes = new Hono<Env>()
                     createdAt: key.createdAt,
                     expiresAt: key.expiresAt,
                     lastRequest: key.lastRequest,
-                    permissions: key.permissions
-                        ? (() => {
-                              try {
-                                  return filterPermissionsToVisibleModels(
-                                      JSON.parse(key.permissions),
-                                      visibleModelIds,
-                                  );
-                              } catch {
-                                  return null;
-                              }
-                          })()
-                        : null,
+                    permissions: visibleModelIds
+                        ? filterPermissionsToVisibleModels(
+                              parsedPermissions[index],
+                              visibleModelIds,
+                          )
+                        : parsedPermissions[index],
                     metadata: parseMetadata(key.metadata),
                     pollenBalance: key.pollenBalance,
                     enabled: key.enabled,
@@ -1663,14 +1667,17 @@ export const accountRoutes = new Hono<Env>()
             }
 
             // Format permissions for response
-            const visibleModelIds = await getVisibleModelIdsForUser(
-                c.env.DB,
-                c.var.auth.requireUser().id,
-            );
-            const effectivePermissions = filterPermissionsToVisibleModels(
-                apiKey.permissions ?? null,
-                visibleModelIds,
-            );
+            const userId = c.var.auth.user?.id;
+            const visibleModelIds =
+                userId && Array.isArray(apiKey.permissions?.models)
+                    ? await getVisibleModelIdsForUser(c.env.DB, userId)
+                    : null;
+            const effectivePermissions = visibleModelIds
+                ? filterPermissionsToVisibleModels(
+                      apiKey.permissions ?? null,
+                      visibleModelIds,
+                  )
+                : (apiKey.permissions ?? null);
             const permissions = {
                 models: effectivePermissions?.models ?? null,
                 account: effectivePermissions?.account ?? null,

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -5,6 +5,10 @@ import {
 import { sanitizeAuthorizeAccountPermissions } from "@shared/auth/authorize-config.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
+import {
+    filterPermissionsToVisibleModels,
+    getVisibleModelIdsForUser,
+} from "@shared/registry/visible-model-ids.ts";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
@@ -269,6 +273,10 @@ export const apiKeysRoutes = new Hono<Env>()
                 where: eq(schema.apikey.userId, user.id),
                 orderBy: (apikey, { desc }) => [desc(apikey.createdAt)],
             });
+            const visibleModelIds = await getVisibleModelIdsForUser(
+                c.env.DB,
+                user.id,
+            );
 
             return c.json({
                 data: keys.map((key) => ({
@@ -279,7 +287,10 @@ export const apiKeysRoutes = new Hono<Env>()
                     lastRequest: key.lastRequest,
                     expiresAt: key.expiresAt,
                     permissions: key.permissions
-                        ? parsePermissions(key.permissions)
+                        ? filterPermissionsToVisibleModels(
+                              parsePermissions(key.permissions),
+                              visibleModelIds,
+                          )
                         : null,
                     metadata: key.metadata ? parseMetadata(key.metadata) : null,
                     pollenBalance: key.pollenBalance,

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -273,25 +273,30 @@ export const apiKeysRoutes = new Hono<Env>()
                 where: eq(schema.apikey.userId, user.id),
                 orderBy: (apikey, { desc }) => [desc(apikey.createdAt)],
             });
-            const visibleModelIds = await getVisibleModelIdsForUser(
-                c.env.DB,
-                user.id,
+            const parsedPermissions = keys.map((key) =>
+                key.permissions ? parsePermissions(key.permissions) : null,
             );
+            const hasModelRestrictions = parsedPermissions.some((permissions) =>
+                Array.isArray(permissions?.models),
+            );
+            const visibleModelIds = hasModelRestrictions
+                ? await getVisibleModelIdsForUser(c.env.DB, user.id)
+                : null;
 
             return c.json({
-                data: keys.map((key) => ({
+                data: keys.map((key, index) => ({
                     id: key.id,
                     name: key.name,
                     start: key.start,
                     createdAt: key.createdAt,
                     lastRequest: key.lastRequest,
                     expiresAt: key.expiresAt,
-                    permissions: key.permissions
+                    permissions: visibleModelIds
                         ? filterPermissionsToVisibleModels(
-                              parsePermissions(key.permissions),
+                              parsedPermissions[index],
                               visibleModelIds,
                           )
-                        : null,
+                        : parsedPermissions[index],
                     metadata: key.metadata ? parseMetadata(key.metadata) : null,
                     pollenBalance: key.pollenBalance,
                     byopClientKeyId: key.byopClientKeyId,
@@ -369,11 +374,25 @@ export const apiKeysRoutes = new Hono<Env>()
             const updated = await db.query.apikey.findFirst({
                 where: eq(schema.apikey.id, id),
             });
+            const permissions = updated?.permissions
+                ? parsePermissions(updated.permissions)
+                : null;
+            const visibleModelIds = Array.isArray(permissions?.models)
+                ? await getVisibleModelIdsForUser(c.env.DB, user.id)
+                : null;
+            const responsePermissions = visibleModelIds
+                ? JSON.stringify(
+                      filterPermissionsToVisibleModels(
+                          permissions,
+                          visibleModelIds,
+                      ),
+                  )
+                : updated?.permissions;
 
             return c.json({
                 id: updated?.id ?? id,
                 name: updated?.name,
-                permissions: updated?.permissions,
+                permissions: responsePermissions,
                 pollenBalance: updated?.pollenBalance ?? null,
                 expiresAt: updated?.expiresAt ?? null,
             });

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -95,7 +95,7 @@ test(
         await mocks.enable("tinybird");
         const created = await createApiKeyViaApi(sessionToken, {
             name: "current-key-with-retired-model",
-            allowedModels: ["retired-model"],
+            allowedModels: ["gpt-5-nano", "retired-model"],
         });
 
         const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
@@ -106,7 +106,7 @@ test(
 
         expect(response.status).toBe(200);
         const data = await response.json();
-        expect(data.permissions.models).toEqual([]);
+        expect(data.permissions.models).toEqual(["gpt-5-nano"]);
     },
 );
 

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -95,7 +95,7 @@ test(
         await mocks.enable("tinybird");
         const created = await createApiKeyViaApi(sessionToken, {
             name: "current-key-with-retired-model",
-            allowedModels: ["gpt-5-nano", "retired-model"],
+            allowedModels: ["openai-fast", "retired-model"],
         });
 
         const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
@@ -106,7 +106,7 @@ test(
 
         expect(response.status).toBe(200);
         const data = await response.json();
-        expect(data.permissions.models).toEqual(["gpt-5-nano"]);
+        expect(data.permissions.models).toEqual(["openai-fast"]);
     },
 );
 

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { expect } from "vitest";
-import { test } from "./fixtures.ts";
+import { createApiKeyViaApi, test } from "./fixtures.ts";
 
 const endpoint = "/api/account/key";
 
@@ -85,6 +85,28 @@ test(
         const data = await response.json();
         expect(data.permissions).toBeDefined();
         expect(data.permissions.models).toEqual(["openai-fast", "flux"]);
+    },
+);
+
+test(
+    "GET /api/account/key - omits retired models from permissions",
+    { timeout: 30000 },
+    async ({ sessionToken, mocks }) => {
+        await mocks.enable("tinybird");
+        const created = await createApiKeyViaApi(sessionToken, {
+            name: "current-key-with-retired-model",
+            allowedModels: ["retired-model"],
+        });
+
+        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+            headers: {
+                Authorization: `Bearer ${created.key}`,
+            },
+        });
+
+        expect(response.status).toBe(200);
+        const data = await response.json();
+        expect(data.permissions.models).toEqual([]);
     },
 );
 

--- a/enter.pollinations.ai/test/fixtures.ts
+++ b/enter.pollinations.ai/test/fixtures.ts
@@ -60,7 +60,11 @@ type SignupData = {
  */
 export const createApiKeyViaApi = async (
     sessionToken: string,
-    options: { name: string; type?: "secret" | "publishable" },
+    options: {
+        name: string;
+        type?: "secret" | "publishable";
+        allowedModels?: string[];
+    },
 ) => {
     const response = await SELF.fetch(
         "http://localhost:3000/api/account/keys",

--- a/enter.pollinations.ai/test/integration/account-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/account-keys.test.ts
@@ -336,6 +336,43 @@ describe("Account Key Management API", () => {
             }
         });
 
+        test("should omit retired models from listed permissions", async ({
+            sessionToken,
+        }) => {
+            const createResponse = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "account-key-with-retired-model",
+                        allowedModels: ["flux", "retired-model"],
+                    }),
+                },
+            );
+            expect(createResponse.status).toBe(200);
+            const created = await createResponse.json();
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/account/keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const body = await response.json();
+            const listed = body.data.find(
+                (key: { id: string }) => key.id === created.id,
+            );
+            expect(listed.permissions.models).toEqual(["flux"]);
+        });
+
         test("should reject API key without account:keys permission", async ({
             apiKey,
         }) => {

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -836,6 +836,38 @@ describe("API Key Management", () => {
             expect(response.headers.get("pragma")).toBe("no-cache");
         });
 
+        test("should omit retired models without rewriting stored permissions", async ({
+            sessionToken,
+        }) => {
+            const created = await createApiKeyViaApi(sessionToken, {
+                name: "key-with-retired-model",
+                allowedModels: ["flux", "retired-model"],
+            });
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const body = (await response.json()) as ApiKeyListResponse;
+            const listed = body.data.find((key) => key.id === created.id);
+            expect(listed?.permissions?.models).toEqual(["flux"]);
+
+            const db = drizzle(env.DB, { schema });
+            const stored = await db.query.apikey.findFirst({
+                where: (apikey, { eq }) => eq(apikey.id, created.id),
+            });
+            expect(JSON.parse(stored?.permissions ?? "{}").models).toEqual([
+                "flux",
+                "retired-model",
+            ]);
+        });
+
         test("should require authentication", async () => {
             const response = await SELF.fetch(
                 "http://localhost:3000/api/api-keys",

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -842,7 +842,7 @@ describe("API Key Management", () => {
         }) => {
             const created = await createApiKeyViaApi(sessionToken, {
                 name: "key-with-retired-model",
-                allowedModels: ["flux", "retired-model"],
+                allowedModels: ["flux", "nanobanana2", "retired-model"],
             });
 
             const response = await SELF.fetch(
@@ -865,6 +865,7 @@ describe("API Key Management", () => {
             });
             expect(JSON.parse(stored?.permissions ?? "{}").models).toEqual([
                 "flux",
+                "nanobanana2",
                 "retired-model",
             ]);
         });
@@ -876,7 +877,6 @@ describe("API Key Management", () => {
                 name: "key-with-private-community-models",
                 allowedModels: [
                     "model-owner/private-model",
-                    "community/model-owner/legacy-private-model",
                     "other-owner/private-model",
                 ],
             });
@@ -912,17 +912,6 @@ describe("API Key Management", () => {
                     completionTextPrice: 0,
                 },
                 {
-                    id: "owner-legacy-private-model",
-                    ownerUserId,
-                    name: "legacy-private-model",
-                    baseUrl: "https://owner.example.com/v1",
-                    upstreamModel: "legacy-private-model",
-                    bearerTokenCiphertext: "encrypted-token",
-                    visibility: "private",
-                    promptTextPrice: 0,
-                    completionTextPrice: 0,
-                },
-                {
                     id: "other-private-model",
                     ownerUserId: "other-model-owner-id",
                     name: "private-model",
@@ -949,7 +938,6 @@ describe("API Key Management", () => {
             const listed = body.data.find((item) => item.id === created.id);
             expect(listed?.permissions?.models).toEqual([
                 "model-owner/private-model",
-                "community/model-owner/legacy-private-model",
             ]);
         });
 

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -1,5 +1,6 @@
 import { env, SELF } from "cloudflare:test";
 import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect } from "vitest";
 import { createApiKeyViaApi, test } from "../fixtures.ts";
@@ -868,6 +869,90 @@ describe("API Key Management", () => {
             ]);
         });
 
+        test("should include only private community models owned by the user", async ({
+            sessionToken,
+        }) => {
+            const created = await createApiKeyViaApi(sessionToken, {
+                name: "key-with-private-community-models",
+                allowedModels: [
+                    "model-owner/private-model",
+                    "community/model-owner/legacy-private-model",
+                    "other-owner/private-model",
+                ],
+            });
+            const db = drizzle(env.DB, { schema });
+            const key = await db.query.apikey.findFirst({
+                where: (apikey, { eq }) => eq(apikey.id, created.id),
+            });
+            expect(key?.userId).toBeTruthy();
+            const ownerUserId = key?.userId as string;
+
+            await db
+                .update(schema.user)
+                .set({ githubUsername: "model-owner" })
+                .where(eq(schema.user.id, ownerUserId));
+            await db.insert(schema.user).values({
+                id: "other-model-owner-id",
+                name: "Other Model Owner",
+                email: "other-model-owner@example.com",
+                githubUsername: "other-owner",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+            await db.insert(schema.communityEndpoint).values([
+                {
+                    id: "owner-private-model",
+                    ownerUserId,
+                    name: "private-model",
+                    baseUrl: "https://owner.example.com/v1",
+                    upstreamModel: "private-model",
+                    bearerTokenCiphertext: "encrypted-token",
+                    visibility: "private",
+                    promptTextPrice: 0,
+                    completionTextPrice: 0,
+                },
+                {
+                    id: "owner-legacy-private-model",
+                    ownerUserId,
+                    name: "legacy-private-model",
+                    baseUrl: "https://owner.example.com/v1",
+                    upstreamModel: "legacy-private-model",
+                    bearerTokenCiphertext: "encrypted-token",
+                    visibility: "private",
+                    promptTextPrice: 0,
+                    completionTextPrice: 0,
+                },
+                {
+                    id: "other-private-model",
+                    ownerUserId: "other-model-owner-id",
+                    name: "private-model",
+                    baseUrl: "https://other.example.com/v1",
+                    upstreamModel: "private-model",
+                    bearerTokenCiphertext: "encrypted-token",
+                    visibility: "private",
+                    promptTextPrice: 0,
+                    completionTextPrice: 0,
+                },
+            ]);
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const body = (await response.json()) as ApiKeyListResponse;
+            const listed = body.data.find((item) => item.id === created.id);
+            expect(listed?.permissions?.models).toEqual([
+                "model-owner/private-model",
+                "community/model-owner/legacy-private-model",
+            ]);
+        });
+
         test("should require authentication", async () => {
             const response = await SELF.fetch(
                 "http://localhost:3000/api/api-keys",
@@ -1126,6 +1211,7 @@ describe("API Key Management", () => {
             // Create a new key
             const createdKey = await createApiKeyViaApi(sessionToken, {
                 name: "budget-test",
+                allowedModels: ["flux", "retired-model"],
             });
             const keyId = createdKey.id;
 
@@ -1147,6 +1233,7 @@ describe("API Key Management", () => {
             expect(updateResponse.status).toBe(200);
             const result = await updateResponse.json();
             expect(result.pollenBalance).toBe(50);
+            expect(JSON.parse(result.permissions).models).toEqual(["flux"]);
 
             // Verify in list
             const listResponse = await SELF.fetch(

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -211,8 +211,7 @@ function filterEntriesByPermissions(
     hasPaidBalance?: boolean,
 ): GenerationModelEntry[] {
     return entries.filter((entry) => {
-        if (allowedModels?.length && !allowedModels.includes(entry.id))
-            return false;
+        if (allowedModels && !allowedModels.includes(entry.id)) return false;
         if (entry.info.paid_only && hasPaidBalance === false) return false;
         return true;
     });

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -97,7 +97,7 @@ type RealtimeBillingContext = {
 
 function requireAllowedModel(c: Context<Env>, model: string): void {
     const allowedModels = c.var.auth.apiKey?.permissions?.models;
-    if (allowedModels?.length && !allowedModels.includes(model)) {
+    if (allowedModels && !allowedModels.includes(model)) {
         throw new HTTPException(403, {
             message: `Model '${model}' is not allowed for this API key`,
         });

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -1,6 +1,7 @@
 import { SELF } from "cloudflare:test";
 import { getAudioModelsInfo } from "@shared/registry/model-info.ts";
 import {
+    createTestApiKey,
     RESTRICTED_IMAGE_TEST_MODEL,
     RESTRICTED_TEST_MODELS,
     RESTRICTED_TEXT_TEST_MODEL,
@@ -48,6 +49,27 @@ test("filters image model list by API key permissions", async ({
         true,
     );
     expect(modelNames).toContain(RESTRICTED_IMAGE_TEST_MODEL);
+});
+
+test("empty model permissions deny access and return an empty catalog", async () => {
+    const { key } = await createTestApiKey({
+        allowedModels: [],
+        user: { tierBalance: 100 },
+    });
+    const headers = { Authorization: `Bearer ${key}` };
+
+    const modelsResponse = await fetchWorker("/v1/models", { headers });
+    expect(modelsResponse.status).toBe(200);
+    expect(await modelsResponse.json()).toEqual({
+        object: "list",
+        data: [],
+    });
+
+    const generationResponse = await fetchWorker(
+        `/text/test?model=${RESTRICTED_TEXT_TEST_MODEL}`,
+        { headers },
+    );
+    expect(generationResponse.status).toBe(403);
 });
 
 test("filters paid-only audio models by paid balance", async ({

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -736,3 +736,18 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
         "gpt-realtime-2.1",
     );
 });
+
+test("rejects realtime access for empty model permissions", async () => {
+    const { key } = await createTestApiKey({
+        allowedModels: [],
+        user: { packBalance: 1 },
+    });
+    const response = await fetchWorker("/v1/realtime?model=gpt-realtime-2", {
+        headers: {
+            Authorization: `Bearer ${key}`,
+            Upgrade: "websocket",
+        },
+    });
+
+    expect(response.status).toBe(403);
+});

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -283,7 +283,9 @@ function normalizePermissions(
         const safeScopes = scopes.filter(
             (scope): scope is string => typeof scope === "string",
         );
-        if (safeScopes.length) permissions[key] = safeScopes;
+        if (safeScopes.length || key === "models") {
+            permissions[key] = safeScopes;
+        }
     }
     return Object.keys(permissions).length ? permissions : undefined;
 }

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -305,14 +305,6 @@ export function resolveModelName(model: string): ModelName {
     );
 }
 
-export function resolveModelNameSafe(model: string): string {
-    try {
-        return resolveModelName(model);
-    } catch {
-        return model;
-    }
-}
-
 /**
  * Get all public model names
  */

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -305,6 +305,14 @@ export function resolveModelName(model: string): ModelName {
     );
 }
 
+export function resolveModelNameSafe(model: string): string {
+    try {
+        return resolveModelName(model);
+    } catch {
+        return model;
+    }
+}
+
 /**
  * Get all public model names
  */

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -1,0 +1,61 @@
+import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { communityModelId } from "../community-endpoints.ts";
+import * as schema from "../db/better-auth.ts";
+import { getModels, getRegistryModelDefinition } from "./registry.ts";
+
+export async function getVisibleModelIdsForUser(
+    dbBinding: D1Database,
+    userId: string,
+): Promise<Set<string>> {
+    const modelIds = new Set<string>(
+        getModels().filter(
+            (modelId) => !getRegistryModelDefinition(modelId).hidden,
+        ),
+    );
+    const db = drizzle(dbBinding, { schema });
+    const communityModels = await db
+        .select({
+            ownerGithubUsername: schema.user.githubUsername,
+            name: schema.communityEndpoint.name,
+        })
+        .from(schema.communityEndpoint)
+        .innerJoin(
+            schema.user,
+            eq(schema.communityEndpoint.ownerUserId, schema.user.id),
+        )
+        .where(
+            and(
+                isNull(schema.communityEndpoint.disabledAt),
+                isNotNull(schema.user.githubUsername),
+                or(
+                    eq(schema.communityEndpoint.visibility, "public"),
+                    eq(schema.communityEndpoint.ownerUserId, userId),
+                ),
+            ),
+        );
+
+    for (const model of communityModels) {
+        if (model.ownerGithubUsername) {
+            modelIds.add(
+                communityModelId(model.ownerGithubUsername, model.name),
+            );
+        }
+    }
+
+    return modelIds;
+}
+
+export function filterPermissionsToVisibleModels(
+    permissions: Record<string, string[]> | null,
+    visibleModelIds: ReadonlySet<string>,
+): Record<string, string[]> | null {
+    if (!Array.isArray(permissions?.models)) return permissions;
+
+    return {
+        ...permissions,
+        models: permissions.models.filter((modelId) =>
+            visibleModelIds.has(modelId),
+        ),
+    };
+}

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -1,18 +1,17 @@
 import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { communityModelId } from "../community-endpoints.ts";
+import {
+    communityModelId,
+    parseCommunityModelId,
+} from "../community-endpoints.ts";
 import * as schema from "../db/better-auth.ts";
-import { getModels, getRegistryModelDefinition } from "./registry.ts";
+import { getModels, resolveModelNameSafe } from "./registry.ts";
 
 export async function getVisibleModelIdsForUser(
     dbBinding: D1Database,
     userId: string,
 ): Promise<Set<string>> {
-    const modelIds = new Set<string>(
-        getModels().filter(
-            (modelId) => !getRegistryModelDefinition(modelId).hidden,
-        ),
-    );
+    const modelIds = new Set<string>(getModels());
     const db = drizzle(dbBinding, { schema });
     const communityModels = await db
         .select({
@@ -54,8 +53,19 @@ export function filterPermissionsToVisibleModels(
 
     return {
         ...permissions,
-        models: permissions.models.filter((modelId) =>
-            visibleModelIds.has(modelId),
-        ),
+        models: permissions.models.filter((modelId) => {
+            const resolvedModelId = resolveModelNameSafe(modelId);
+            if (visibleModelIds.has(resolvedModelId)) return true;
+
+            const communityModel = parseCommunityModelId(modelId);
+            return communityModel
+                ? visibleModelIds.has(
+                      communityModelId(
+                          communityModel.ownerGithubUsername,
+                          communityModel.modelName,
+                      ),
+                  )
+                : false;
+        }),
     };
 }

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -1,11 +1,8 @@
 import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import {
-    communityModelId,
-    parseCommunityModelId,
-} from "../community-endpoints.ts";
+import { communityModelId } from "../community-endpoints.ts";
 import * as schema from "../db/better-auth.ts";
-import { getModels, resolveModelNameSafe } from "./registry.ts";
+import { getModels } from "./registry.ts";
 
 export async function getVisibleModelIdsForUser(
     dbBinding: D1Database,
@@ -53,19 +50,8 @@ export function filterPermissionsToVisibleModels(
 
     return {
         ...permissions,
-        models: permissions.models.filter((modelId) => {
-            const resolvedModelId = resolveModelNameSafe(modelId);
-            if (visibleModelIds.has(resolvedModelId)) return true;
-
-            const communityModel = parseCommunityModelId(modelId);
-            return communityModel
-                ? visibleModelIds.has(
-                      communityModelId(
-                          communityModel.ownerGithubUsername,
-                          communityModel.modelName,
-                      ),
-                  )
-                : false;
-        }),
+        models: permissions.models.filter((modelId) =>
+            visibleModelIds.has(modelId),
+        ),
     };
 }


### PR DESCRIPTION
## Problem

API-key model restrictions are stored as JSON snapshots in D1. Removing a model from the catalog did not update those snapshots, so retired IDs remained visible even though they no longer granted usable access.

## Fix

- Intersects restricted model IDs with the current canonical callable catalog at read time; D1 remains unchanged.
- Applies the projection to dashboard/account lists, current-key status, and update responses.
- Includes built-in models, active public community models, and only the caller's active private community models.
- Preserves empty model allowlists as deny-all across authentication, generation, realtime, and model discovery.
- Skips catalog/D1 enrichment for unrestricted keys.

## Impact

Retired, aliased, and non-canonical IDs disappear from responses while canonical permissions remain visible. A filtered empty list cannot become unrestricted when round-tripped through an update.

## Validation

- Enter and Gen: `npx tsc --noEmit`
- Enter affected files: 55 pass; 4 existing failures use intentionally blocked native Better Auth routes
- Gen permission and realtime files: 22 pass
- Biome and GitHub CI