### PR TITLE
fix: use dedicated Vectorize API token

### DIFF
--- a/.github/workflows/vectorize-code-embeddings.yml
+++ b/.github/workflows/vectorize-code-embeddings.yml
@@ -55,7 +55,7 @@ jobs:
         if: steps.params.outputs.mode == 'full'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_VECTORIZE }}
           POLLI_VECTOR_DB: ${{ secrets.POLLI_VECTOR_DB }}
         run: python .github/scripts/embed_code.py --mode full --repo-root .
 
@@ -63,7 +63,7 @@ jobs:
         if: steps.params.outputs.mode == 'incremental'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_VECTORIZE }}
           POLLI_VECTOR_DB: ${{ secrets.POLLI_VECTOR_DB }}
         run: |
           BASE_SHA="${{ steps.params.outputs.base_sha }}"


### PR DESCRIPTION
- Uses `CLOUDFLARE_API_TOKEN_VECTORIZE` for full and incremental code-embedding runs.
- Fixes the Cloudflare Vectorize 401 caused by the shared Myceli token credential.
- Keeps Vectorize access least-privilege: `Vectorize:Edit` on the Myceli account only.
- Verified with [workflow run 29765418431](https://github.com/pollinations/pollinations/actions/runs/29765418431): incremental query and upsert completed successfully.