### PR TITLE
fix: use dedicated POLLI_VECTOR_ID/POLLI_VECTOR_KEY secrets

### DIFF
--- a/.github/workflows/vectorize-code-embeddings.yml
+++ b/.github/workflows/vectorize-code-embeddings.yml
@@ -54,16 +54,16 @@ jobs:
       - name: Run full embed
         if: steps.params.outputs.mode == 'full'
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.POLLI_VECTOR_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.POLLI_VECTOR_KEY }}
           POLLI_VECTOR_DB: ${{ secrets.POLLI_VECTOR_DB }}
         run: python .github/scripts/embed_code.py --mode full --repo-root .
 
       - name: Run incremental embed
         if: steps.params.outputs.mode == 'incremental'
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.POLLI_VECTOR_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.POLLI_VECTOR_KEY }}
           POLLI_VECTOR_DB: ${{ secrets.POLLI_VECTOR_DB }}
         run: |
           BASE_SHA="${{ steps.params.outputs.base_sha }}"


### PR DESCRIPTION
The MYCELI cloudflare secrets are scoped for something else — first incremental run after merge hit a 401 from the Vectorize API. Switched to dedicated secrets for this workflow instead of debugging what the old ones are actually meant for.