### PR TITLE
fix: strip whitespace from Vectorize/Pollinations secret env vars

### DIFF
--- a/.github/scripts/embed_code.py
+++ b/.github/scripts/embed_code.py
@@ -23,9 +23,9 @@ import requests
 import tiktoken
 import xxhash
 
-CF_ACCOUNT_ID = os.environ["CLOUDFLARE_ACCOUNT_ID"]
-CF_API_TOKEN = os.environ["CLOUDFLARE_API_TOKEN"]
-POLLINATIONS_TOKEN = os.environ["POLLI_VECTOR_DB"]
+CF_ACCOUNT_ID = os.environ["CLOUDFLARE_ACCOUNT_ID"].strip()
+CF_API_TOKEN = os.environ["CLOUDFLARE_API_TOKEN"].strip()
+POLLINATIONS_TOKEN = os.environ["POLLI_VECTOR_DB"].strip()
 INDEX_NAME = os.environ.get("VECTORIZE_INDEX", "polly-code-embeddings")
 EMBED_MODEL = "qwen3-embedding-8b"
 EMBED_DIMENSIONS = 1536

--- a/.github/scripts/embed_code.py
+++ b/.github/scripts/embed_code.py
@@ -208,9 +208,17 @@ def chunk_code(content: str, max_lines: int = 100) -> list[dict]:
 
 
 def chunk_id_for(file_path: str, chunk: dict) -> str:
+    """Vectorize caps vector IDs at 64 bytes — this repo has paths well past that on their
+    own (e.g. enter.pollinations.ai/frontend/src/components/...), so the raw
+    "path:start-end" id used during local dev doesn't survive contact with real paths.
+    Hash the full identifier instead: deterministic (same file+lines always hashes the
+    same, so incremental delete/re-insert by id still works), fixed-length, and the
+    human-readable path/lines are preserved in metadata for anyone reading query results.
+    """
     part = chunk.get("part")
     suffix = f"p{part}" if part is not None else ""
-    return f"{file_path}:{chunk['start_line']}-{chunk['end_line']}{suffix}"
+    raw = f"{file_path}:{chunk['start_line']}-{chunk['end_line']}{suffix}"
+    return xxhash.xxh3_64_hexdigest(raw.encode())
 
 
 def is_embeddable_path(rel_path: str) -> bool:


### PR DESCRIPTION
Two fixes surfaced by the first manual full-backfill run, both in the same script:

**1. Secret whitespace.** First run failed immediately with `requests.exceptions.InvalidHeader` — one of the CLOUDFLARE_ACCOUNT_ID/CLOUDFLARE_API_TOKEN/POLLI_VECTOR_DB secrets had trailing whitespace. `requests` rejects that outright as a header value. Now stripped defensively.

**2. Vector ID length.** After the whitespace fix, the run got to file 25/1852 then failed with `id too long; max is 64 bytes, got 75 bytes`. The `path:start-end` id scheme doesn't survive this repo's real path depth (paths under `enter.pollinations.ai/frontend/src/components/...` are already close to 64 bytes before line numbers). Now hashing the identifier instead — deterministic (incremental delete/re-insert by id still works), fixed-length, and `file_path`/`start_line`/`end_line` stay in metadata for readable query results.