### PR TITLE
infra: add Azure VM inventory and encrypted access

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,4 +1,10 @@
 creation_rules:
+    - path_regex: apps/operation/infrastructure/azure-vms/secrets/polli-prod\.vars\.json$
+      age: >-
+        age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd,age1e8fctjh7tttmrkukrshp9dvl50lqhx22p9wt907avc96pj9pfdzs92shdc,age1ry4pg28f38yrnd5nhdl2zrkh8f7vgfu0p6hdu8lwpvpa7vz8ag6qqxy4d6
+    - path_regex: apps/operation/infrastructure/azure-vms/secrets/lixsearch-prod\.vars\.json$
+      age: >-
+        age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd,age1ry4pg28f38yrnd5nhdl2zrkh8f7vgfu0p6hdu8lwpvpa7vz8ag6qqxy4d6
     - path_regex: apps/operation/economics/ingest/secrets/.*
       age: age1djc5mjmpvfaqzw5pgujfeqglrrqw05fmjmnnu4zcv2h7xkn2av2q67c7rt
     - path_regex: apps/operation/economics/secrets/.*

--- a/apps/operation/infrastructure/azure-vms/inventory.json
+++ b/apps/operation/infrastructure/azure-vms/inventory.json
@@ -1,0 +1,43 @@
+{
+  "resourceGroup": "rg-pollinations-bots-prod",
+  "location": "eastus",
+  "network": {
+    "vnet": "vnet-pollinations-bots-prod",
+    "subnet": "snet-workloads",
+    "addressPrefix": "10.42.0.0/16"
+  },
+  "adminUsername": "pollinations",
+  "image": "Canonical:ubuntu-24_04-lts:server:latest",
+  "vms": {
+    "polli": {
+      "name": "polli-prod",
+      "size": "Standard_D4als_v6",
+      "vcpus": 4,
+      "memoryGB": 8,
+      "osDiskGB": 128,
+      "storageSku": "StandardSSD_LRS",
+      "publicIp": "20.106.136.139",
+      "privateIp": "10.42.1.4",
+      "networkSecurityGroup": "nsg-polli-prod",
+      "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOHyFnKHmfdrlZrhPTxht2grp3yRutviLGnwy+5GvVJq pollinations-polli-prod-azure-2026",
+      "publicKeyFingerprint": "SHA256:d/BPmXx84+motnisbrS3qzI1twWsCGJ7QLUoerMu2ss",
+      "hostKeyFingerprint": "SHA256:RqwxyctpdlSwo8d8donROXW7149AcjUDYEX/lDWzcO4",
+      "secretFile": "secrets/polli-prod.vars.json"
+    },
+    "lixsearch": {
+      "name": "lixsearch-prod",
+      "size": "Standard_D4as_v6",
+      "vcpus": 4,
+      "memoryGB": 16,
+      "osDiskGB": 256,
+      "storageSku": "StandardSSD_LRS",
+      "publicIp": "172.174.39.180",
+      "privateIp": "10.42.1.5",
+      "networkSecurityGroup": "nsg-lixsearch-prod",
+      "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMZWYcdFsXF8kh1dWooIBwfUqO7DoljPfLgQ/RlXfIxN pollinations-lixsearch-prod-azure-2026",
+      "publicKeyFingerprint": "SHA256:pOtP1N/cZ8eNCFvrJpNgmW2rlwArtLhUcVFAmvodcDE",
+      "hostKeyFingerprint": "SHA256:2HkyEuXTIJxuAyiK3t/ij/D/dSsg+j2uO+TsVr3grAE",
+      "secretFile": "secrets/lixsearch-prod.vars.json"
+    }
+  }
+}

--- a/apps/operation/infrastructure/azure-vms/secrets/lixsearch-prod.vars.json
+++ b/apps/operation/infrastructure/azure-vms/secrets/lixsearch-prod.vars.json
@@ -1,0 +1,19 @@
+{
+	"SSH_PRIVATE_KEY": "ENC[AES256_GCM,data:Mt2pouB/JFi1OsRV7b1PjGp2CY1lWtjjfIeSPm7jrpN6SPcFCJ1Svdkosw2UfbRo08o5Lzy7/yzX1sTSNxy28ZP++gJAAj5pNev3+9OqBMhFLNZphzRzkXIxw9seqNlBFoZdbXjxlnh6j4n4w99ZdAS9yXO4PmtmyV51zcfTGwpx0t7c7lepdd/tcJ0vk9u1MdPc4xKAsA3iHsphvw3bxSBQadYHwW0XoS3MnsqtyPElM1y9iU4Gkvxxtk1vUnt4Ne4pkjGiv4dgpBTsP4ZalR+aMmz2xkDPmq3lf2mMeFpIURh0g5xHasoiJCUyM7BGxyI+0LezztxEd5l12P3RtpwhRWLZB7hj7oM+esBEKd/9g74NMWlbe9we+b7urFh69e76PxOndaL7+LOna8GQ28tofVjxCHj+OUDxdgFk+vDkOlOKIbCBFhDpKsfUC7wyjpzo8kuTZKNY5cQijxUUnUj1pVQ+j5v68QYwwBFnImyuS9DCo4ZzENfvMY+aF4+bI+lPwZkoLbw5RnDqMrUSlE4c3A62nAkrRSQIYkbGUPk8np8PWnIySdTW01U910GBz567g9y04+SHAjyx,iv:x37aGCwwd9BZoImRZdkEqjRvKdDseSam/ArpQOI/qrw=,tag:mTnPWsBvk4VI9JNa+XzdCA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPUUxUUnp3cUFEclViQlhz\nWlcxWSt6aVNJaDEyUzBWSkk3dmRUbXVoTGg0CndIdmhKUGZ0WVZseFVMRzRRUm5K\nekx5RGJ2T0E0TExpbUNyclZKcDJrU00KLS0tIFlIcjgyQk1jbngwNVJhOGpqak1I\nTmJKcVVVRmsvNXlMbHVJMjdoeWM0RmMKPr7lzWA5/ThtNsGqaE65RO73C+wYkl5f\nxk9nVf3Wl2DFii/HZlTm+w9aKmcCJoFkQwnGaTX53ecW6A4kgwnIaQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1ry4pg28f38yrnd5nhdl2zrkh8f7vgfu0p6hdu8lwpvpa7vz8ag6qqxy4d6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwa3lKSThDRmwwNTZtbzEx\nSnBlc001S1I3Q0lNRVYySFcybDFnMnFhUWhrCjRJS01tS1BpL1Q2Z2RFL2ZIb2FI\nNXVvN2FEdFBHcGpyaUdQMTI0SFBjYkUKLS0tIFlncUphWUhueHUwWkgwcVhGUEhR\ncEM3L0FvWTJWWU1QN1FHQ2dBb01IREkKDddpkehauCzcnTkhi/yss+i79iW3Yr0e\nf9Ag9jAwSVbinOYBCzu5Ylolka8aqukTh1RFyGTIcSAEQYbVlOsiAw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-07-21T13:00:19Z",
+		"mac": "ENC[AES256_GCM,data:X52CFqTBDBrsHu67FU393dJgemGJ9mBjEk1JNy/2kqNqruVGnUfBCWK0uwFTFp7srAZyErlwFMdfDG9uVwvPiHUwKlMsZZDfuLmj7NDTeyJGTjVgrWMrcpi4/W0tQYD7w3+yQglv3ExITpqXjA9s3SIt5hmYqJNDz7eaP4hE0tc=,iv:2ilflDsu3adCtVCVRfRNO2WqnxHxbJg67GdzCayk/O0=,tag:UK89oriNPLHHub0dJ0CVGg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}

--- a/apps/operation/infrastructure/azure-vms/secrets/polli-prod.vars.json
+++ b/apps/operation/infrastructure/azure-vms/secrets/polli-prod.vars.json
@@ -1,0 +1,23 @@
+{
+	"SSH_PRIVATE_KEY": "ENC[AES256_GCM,data:oKBauLKPcr2nPOZGNVeK9Cv+ARZFMGfG/R/J03Yqf43fy90rB6lybrbSsFaj5BFW8k1o1FHnjA9rdBloLZJKzly7Paej+JUGUXkiuQpFsbIsOQUVQGI24twFoHeyP1rfyH98cuprTqbuRSQyjDXKkzEWNXSOKERb00tDJTm2knw9lL+W1qeZ/hJW9Ii+Kgh1coyCgDIcsbf3s4XpdCh5/QhDoRqGNUdHWNdu0z5AYTWsxJTTUQYTljuSY+s8lu+9iZ2idKCDnfGzOhXZHqPPeOtSBdkiCMNe5t7E7kQ5xJmGJAt5b2iKfU7VcUd9IyOaMlFcjE7fje9jnTKyuD+6W5EGmsEb58UEmhbdCyE4MouchxxG2haK6Qdc0z/cyd8hpwBNxbqKu5law2eerdEp+ihu3akqRuNoBD+0jtu/es8twjm1ZwnhXWIyzdUYNDpATQ3zi7ZnNpevMRCatITGfKsbdRVlibHOX10XcbijAq36S0IRUOQQZtW80WAIF8AMlTP+fC8f9ut2Ax+HGMF+LfOi6KEJRQPJmWKc16aVaYrGlY1TohZ0Y8zEzETWGpaE,iv:95ASn32yeh/DytbA/pcAg/Q/NBwAx+8LkFGzaektZeE=,tag:x5aNI29U7w2cEHUGA3c9AA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUQTBtY1NpWkh3WnZoVXdZ\nLy9RV2FMeFJqN0JCNHVSVXRCcnNzZ0ZnZUFBCkMvL25YVGhYY013TFdxMTB5QVNB\nL2lYTzE3aW8yTWwwZTlaQjZrRHVSaDgKLS0tIG12bDMyZUlYaVhsd01ZaFFkRFE5\nbHZieEIrZHgxWmJHQm5PdHY0eWF1RTQKfLNUaTM4EdSG1d76ubATl2kJadyvvatQ\nuCid98Xve9TZlQk4sBO6vqdkBKV6fcNEGizaSdGjvvpGMLgrYkCLMw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1e8fctjh7tttmrkukrshp9dvl50lqhx22p9wt907avc96pj9pfdzs92shdc",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAweUF1MlhuWUFIQ3hGZzhj\nNFFBakgxZ2hLcWNBczF4YTA3dUZYTUlIQ1VFCjBRRTEwZ1dqVm95VUthNjFWdG4w\nZTNvZkRTdHFFZWZyT1V2N0R1QW1KWnMKLS0tIHUzMFB2ZStOdmhja0J1ejUvdGJ0\nbmZWaWl6emRXYS91b0pwYi9HcTdQb1kKDU70Pm9W5ZU9prhG7P/iyav4CS7WQY2p\nfbc5Y7q2EQFQiQT7MEvvJ63vofxrkAvpsmSUW76otsDbyjoprASB9g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1ry4pg28f38yrnd5nhdl2zrkh8f7vgfu0p6hdu8lwpvpa7vz8ag6qqxy4d6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhNDdpQmI2RENFc0tKUHlo\nOFdGR1RYcjRxdXdLbjIyVndUUUVIRWxpOHhvCmU0c0F2eThGUEZmM3Z1Rm9yNkFF\nN2d1NFdqQTBOVk5WbG1WNk9BbE50SFUKLS0tIEswa2xQSFhHMmRZQkM3TStldm04\nNm9HdTRoNDR3c1lqOWtmRzZmYllZTjQKxkRCrwVyhjsJtThVjK3j7Tf6/JPABpcG\nM6OFx+Plt3FAjmrJdxEnsAnZhgQYOScAJLygHIdIfY+2NDYh5V1qfA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-07-21T13:00:19Z",
+		"mac": "ENC[AES256_GCM,data:tvR7GmNB9Uk+wpW6Ohw+bQpvAwMnp3SL4+MP3hvOxNGica715AUyhaBhrcnwbFOVmrnjTai2k5WFyYEuOLO180yhIseWrcz+QhV8iSgCZjQ5InScCyL7b7i7Y5YHF1RQOKSKKWLcHwVZmIjQwZMRf8IeLZjvHXjL5MNXLQuGVAk=,iv:RtPR11pNy9DvuAfQqMnJxsARG7bsa+E+6Ky0nk1OpO8=,tag:Wit4SBo+NN1RLVxaRf1cPQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}


### PR DESCRIPTION
- Adds an operations-owned inventory for the new Polli and LixSearch production VMs on Azure.
- Stores one VM-specific SSH private key per host as committed SOPS ciphertext.
- Adds path-specific AGE recipients so Polli includes Itachi while LixSearch remains limited to core administrators and CI.
- Records static public/private IPs, VM sizing, SSH public-key fingerprints, and host-key fingerprints.

Validation:
- Confirmed both SOPS files are encrypted and locally decryptable.
- Confirmed no plaintext OpenSSH private key appears in the PR scope.
- Verified both Ubuntu 24.04 hosts over SSH, including CPU, memory, disk, cloud-init, and sudo access.