### PR TITLE
fix: harden Vast Flux deployment and cap queue

### DIFF
--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -71,7 +71,9 @@ POLLINATIONS_API_KEY=... bash image.pollinations.ai/nunchaku/verify-vast.sh  # r
 ```
 
 **Key behavior:** FP4 nunchaku, 4 steps, full 1024x1024 (`MAX_PIXELS=1048576`);
-`QUEUE_LIMIT=10` sheds load with 503 → gateway falls back to Fireworks.
+`QUEUE_LIMIT=3` allows one running request plus two waiting; additional load is
+shed with 503 so the gateway falls back to Fireworks instead of making users
+wait in a long queue.
 
 ## Provider: Vast.ai — FLUX.2 Klein 4B (RTX 3090)
 

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,6 +1,6 @@
 # GPU Instances
 
-Last updated: 2026-07-14
+Last updated: 2026-07-22
 
 ## Capacity Summary
 
@@ -19,7 +19,7 @@ with automatic Fireworks fallback
 
 | Worker | Vast instance | GPU | Listed rate | Status |
 |--------|---------------|-----|-------------|--------|
-| flux-vast-03 | 44731147 | RTX 5090 | $0.374444/hr | OUT OF ROTATION (2026-07-14) — host network degraded; needs reprovision. All Flux traffic is on the Fireworks fallback (~$70/day) |
+| flux-vast-03 | 44731147 | RTX 5090 | $0.374444/hr | ACTIVE (reactivated 2026-07-22) — named tunnel `flux-vast-04.pollinations.ai` |
 
 > Instance IDs/IPs/ports change on recreate — check `vastai show instances`.
 > CRITICAL: workers MUST be behind a named Cloudflare tunnel created in the
@@ -36,9 +36,10 @@ hangs, not errors — and the worker kept heartbeating green the whole time.
 Never point production at a quick tunnel; use a named tunnel.
 
 When reprovisioning, check the host's HuggingFace throughput before committing
-to it (`curl -r 0-5000000 -L <hf-model-url>`): this host managed 384 KB/s, so
-the worker could never finish loading its weights and stalled indefinitely
-mid-download.
+to it (`curl -r 0-5000000 -L <hf-model-url>`): this host previously managed
+384 KB/s and stalled during its cold download. It was reactivated only after
+its 17 GB model cache was complete, so a cold rebuild on this host remains a
+risk.
 
 **Provision a new instance** (see `nunchaku/setup-vast.sh` header for all env):
 ```bash
@@ -65,6 +66,7 @@ instances and destroying the loser is cheap (~$0.40/hr each).
 curl -s https://<named-tunnel-hostname>/docs -o /dev/null -w "%{http_code}\n"   # control-plane only
 curl -s https://gen.pollinations.ai/register -H "Authorization: Bearer $PLN_GPU_TOKEN"  # registry
 # on the instance: screen -r flux / screen -r cloudflared; logs /tmp/flux.log /tmp/cloudflared.log
+# Vast runs /root/onstart.sh after a container restart to restore both services
 POLLINATIONS_API_KEY=... bash image.pollinations.ai/nunchaku/verify-vast.sh  # required before cutover
 ```
 

--- a/image.pollinations.ai/nunchaku/README.md
+++ b/image.pollinations.ai/nunchaku/README.md
@@ -62,6 +62,11 @@ screen -r cloudflared
 /root/onstart.sh
 ```
 
-The setup defaults are `QUEUE_LIMIT=10`, `MAX_PIXELS=1048576`, and
+The setup defaults are `QUEUE_LIMIT=3`, `MAX_PIXELS=1048576`, and
 `mit-han-lab/svdq-fp4-flux.1-schnell`. Override them only through the documented
 environment variables in `setup-vast.sh`.
+
+`QUEUE_LIMIT=3` means one request can run while two wait. Additional requests
+receive 503 immediately so the gateway can use Fireworks rather than building a
+long user-facing queue. Keep Fireworks enabled as burst capacity; add a second
+Vast GPU only when its measured avoided fallback cost exceeds its hourly cost.

--- a/image.pollinations.ai/nunchaku/README.md
+++ b/image.pollinations.ai/nunchaku/README.md
@@ -33,7 +33,8 @@ bash setup-vast.sh
 
 The tunnel token is written to a mode `0600` token file and is not included in
 the `cloudflared` process arguments. Model and server settings are persisted in
-the ignored `.env.flux` file.
+the ignored `.env.flux` file. The setup also installs `/root/onstart.sh`, which
+Vast runs after a container restart to restore both supervised services.
 
 ## Verify before traffic cutover
 
@@ -58,6 +59,7 @@ tail -f /tmp/flux.log
 tail -f /tmp/cloudflared.log
 screen -r flux
 screen -r cloudflared
+/root/onstart.sh
 ```
 
 The setup defaults are `QUEUE_LIMIT=10`, `MAX_PIXELS=1048576`, and

--- a/image.pollinations.ai/nunchaku/server.py
+++ b/image.pollinations.ai/nunchaku/server.py
@@ -47,7 +47,7 @@ gpu_semaphore = asyncio.Semaphore(1)  # Serialize GPU inference to prevent CUDA 
 BACKEND_TOKEN = os.getenv("PLN_GPU_TOKEN")
 # Shed load instead of building unbounded backlog: beyond this many in-flight
 # requests, reply 503 so the gateway falls back to its secondary provider.
-QUEUE_LIMIT = int(os.getenv("QUEUE_LIMIT", "10"))
+QUEUE_LIMIT = int(os.getenv("QUEUE_LIMIT", "3"))
 pending_requests = 0
 
 # Function to get public IP address

--- a/image.pollinations.ai/nunchaku/setup-vast.sh
+++ b/image.pollinations.ai/nunchaku/setup-vast.sh
@@ -157,11 +157,25 @@ log "Writing run environment to $NUNCHAKU_DIR/.env.flux..."
 } > "$NUNCHAKU_DIR/.env.flux"
 chmod 600 "$NUNCHAKU_DIR/.env.flux"
 
-log "Starting server in screen session 'flux' (restart loop, log: /tmp/flux.log)..."
+cat > /root/run-flux.sh <<EOF
+#!/bin/bash
+cd "$NUNCHAKU_DIR"
+source venv/bin/activate
+source .env.flux
+exec python server.py
+EOF
+
+cat > /root/onstart.sh <<EOF
+#!/bin/bash
 screen -S flux -X quit 2>/dev/null || true
-screen -dmS flux bash -c "cd $NUNCHAKU_DIR && source venv/bin/activate && source .env.flux && \
-    while true; do python server.py 2>&1 | tee -a /tmp/flux.log; \
-    echo \"[setup-vast] server exited, restarting in 5s\" | tee -a /tmp/flux.log; sleep 5; done"
+screen -S cloudflared -X quit 2>/dev/null || true
+screen -dmS flux bash -c 'while true; do /root/run-flux.sh 2>&1 | tee -a /tmp/flux.log; echo "[setup-vast] server exited, restarting in 5s" | tee -a /tmp/flux.log; sleep 5; done'
+screen -dmS cloudflared bash -c 'while true; do cloudflared tunnel run --token-file "$TUNNEL_TOKEN_FILE" 2>&1 | tee -a /tmp/cloudflared.log; sleep 5; done'
+EOF
+chmod 700 /root/run-flux.sh /root/onstart.sh
+
+log "Starting durable Flux and tunnel services (logs: /tmp/flux.log, /tmp/cloudflared.log)..."
+/root/onstart.sh
 
 log "Done. Model load takes 2-3 min on first start."
 log "  Logs:       tail -f /tmp/flux.log"

--- a/image.pollinations.ai/nunchaku/setup-vast.sh
+++ b/image.pollinations.ai/nunchaku/setup-vast.sh
@@ -32,8 +32,9 @@
 #                     use mit-han-lab/svdq-int4-flux.1-schnell on Ada GPUs
 #   MAX_PIXELS        default 1048576 (1024x1024, matches FP4/5090);
 #                     use 810000 on RTX 4090
-#   QUEUE_LIMIT       default 10 (server.py sheds load with 503 beyond this;
-#                     gateway then falls back to Fireworks)
+#   QUEUE_LIMIT       default 3 (one running plus two waiting; server.py sheds
+#                     additional load with 503 so the gateway falls back to
+#                     Fireworks instead of building a long user-facing queue)
 #   SERVICE_TYPE      default flux
 #   GIT_BRANCH        default main
 #   SKIP_CLONE        use files already in $WORK_DIR (hosts w/ broken GitHub egress)
@@ -151,7 +152,7 @@ log "Writing run environment to $NUNCHAKU_DIR/.env.flux..."
     printf 'export SERVICE_TYPE=%q\n' "$SERVICE_TYPE"
     printf 'export QUANT_MODEL_PATH=%q\n' "$QUANT_MODEL_PATH"
     printf 'export MAX_PIXELS=%q\n' "$MAX_PIXELS"
-    printf 'export QUEUE_LIMIT=%q\n' "${QUEUE_LIMIT:-10}"
+    printf 'export QUEUE_LIMIT=%q\n' "${QUEUE_LIMIT:-3}"
     printf 'export CUDA_VISIBLE_DEVICES=%q\n' "${CUDA_VISIBLE_DEVICES:-0}"
     printf 'export HF_XET_HIGH_PERFORMANCE=1\n'
 } > "$NUNCHAKU_DIR/.env.flux"

--- a/image.pollinations.ai/nunchaku/verify-vast.sh
+++ b/image.pollinations.ai/nunchaku/verify-vast.sh
@@ -21,6 +21,12 @@ source "$ENV_FILE"
 : "${PLN_GPU_TOKEN:?PLN_GPU_TOKEN missing from $ENV_FILE}"
 : "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
 
+PYTHON="$SCRIPT_DIR/venv/bin/python"
+if [ ! -x "$PYTHON" ]; then
+    echo "Missing $PYTHON; run setup-vast.sh first" >&2
+    exit 1
+fi
+
 CANARY_DIR=$(mktemp -d)
 trap 'rm -rf "$CANARY_DIR"' EXIT
 
@@ -42,7 +48,7 @@ curl -fsS --max-time 180 "https://$PUBLIC_IP/generate" \
     --data "{\"prompts\":[\"$PROMPT\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
     > "$CANARY_DIR/direct.json"
 
-python - "$CANARY_DIR/direct.json" "$CANARY_DIR/direct.jpg" <<'PY'
+"$PYTHON" - "$CANARY_DIR/direct.json" "$CANARY_DIR/direct.jpg" <<'PY'
 import base64
 import json
 import sys
@@ -58,7 +64,7 @@ curl -fsS --max-time 180 "$PUBLIC_URL" \
     -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
     > "$CANARY_DIR/public.jpg"
 
-python - "$CANARY_DIR/direct.jpg" "$CANARY_DIR/public.jpg" <<'PY'
+"$PYTHON" - "$CANARY_DIR/direct.jpg" "$CANARY_DIR/public.jpg" <<'PY'
 import sys
 from PIL import Image, ImageChops, ImageStat
 


### PR DESCRIPTION
- Restores Flux and its named Cloudflare tunnel automatically after Vast container restarts.
- Pins the production queue limit to three: one request running, two waiting, then Fireworks fallback.
- Fixes the end-to-end verifier to use the deployment virtualenv.
- Documents provisioning, restart, canary, and burst-capacity behavior.

Live verification:
- Production worker is registered and serving requests through the named tunnel.
- Concurrency probe returned `200, 200, 200, 503`, confirming Q3 load shedding.
- Production requests resumed with successful 200 responses after restart.

Checks: `bash -n`, `python3 -m py_compile`, and `git diff --check`.