### PR TITLE
feat: add Robot DJ app

### DIFF
--- a/apps/apps.json
+++ b/apps/apps.json
@@ -111,5 +111,12 @@
         "outputDir": "dist",
         "title": "SlidePainter",
         "description": "AI-powered slide image generator by Pollinations"
+    },
+    "robot-dj": {
+        "subdomain": "robot-dj",
+        "buildCommand": null,
+        "outputDir": ".",
+        "title": "Robot DJ",
+        "description": "A camera-aware AI DJ for your local music library"
     }
 }

--- a/apps/robot-dj/app.js
+++ b/apps/robot-dj/app.js
@@ -1,0 +1,1276 @@
+const API_URL = "https://gen.pollinations.ai/v1/chat/completions";
+const AUTH_ISSUER = "https://enter.pollinations.ai";
+const AUTH_AUTHORIZE_URL = `${AUTH_ISSUER}/authorize`;
+const AUTH_STORAGE_KEY = "robot-dj-pollinations-session";
+const AUTH_PENDING_KEY = "robot-dj-oauth-pending";
+const DEFAULT_MODEL = "gemini-fast";
+const AUTH_MODELS = [DEFAULT_MODEL];
+const AUTH_BUDGET = 5;
+const AUTH_EXPIRY_DAYS = 7;
+const DB_NAME = "pollinations-robot-dj";
+const DB_STORE = "settings";
+const LIBRARY_KEY = "music-library";
+const CAMERA_STORAGE_KEY = "robot-dj-camera";
+const SNAPSHOT_DELAY_MS = 8_000;
+const RESCAN_INTERVAL_MS = 30_000;
+const MODEL_REQUEST_TIMEOUT_MS = 75_000;
+const CROSSFADE_SECONDS = 8;
+const EXCERPT_SECONDS = 120;
+const MAX_CANDIDATES = 80;
+const RECENT_TRACK_COUNT = 8;
+
+const $ = (id) => document.getElementById(id);
+
+const elements = {
+    authStatus: $("authStatus"),
+    connectButton: $("connectButton"),
+    disconnectButton: $("disconnectButton"),
+    chooseFolderButton: $("chooseFolderButton"),
+    folderFallback: $("folderFallback"),
+    dropZone: $("dropZone"),
+    reconnectButton: $("reconnectButton"),
+    startButton: $("startButton"),
+    fullscreenButton: $("fullscreenButton"),
+    pauseButton: $("pauseButton"),
+    skipButton: $("skipButton"),
+    scanButton: $("scanButton"),
+    volumeInput: $("volumeInput"),
+    libraryStatus: $("libraryStatus"),
+    cameraStatus: $("cameraStatus"),
+    aiStatus: $("aiStatus"),
+    libraryCount: $("libraryCount"),
+    libraryName: $("libraryName"),
+    nowPlaying: $("nowPlaying"),
+    nextPanel: $("nextPanel"),
+    nextTrack: $("nextTrack"),
+    nextStatus: $("nextStatus"),
+    roomRead: $("roomRead"),
+    thinkingLine: $("thinkingLine"),
+    progressBar: $("progressBar"),
+    elapsedTime: $("elapsedTime"),
+    durationTime: $("durationTime"),
+    cameraPlaceholder: $("cameraPlaceholder"),
+    cameraVideo: $("cameraVideo"),
+    cameraLive: $("cameraLive"),
+    cameraPicker: $("cameraPicker"),
+    cameraSelect: $("cameraSelect"),
+    snapshotCanvas: $("snapshotCanvas"),
+    errorMessage: $("errorMessage"),
+};
+
+let tracks = [];
+let rememberedSource = null;
+let cameraStream = null;
+let selectedCameraId = localStorage.getItem(CAMERA_STORAGE_KEY) || "";
+let latestSnapshot = null;
+let audioContext = null;
+let masterGain = null;
+let decks = [];
+let activeDeckIndex = 0;
+let currentTrack = null;
+let queuedTrack = null;
+let history = [];
+let scanTimer = null;
+let selectionInFlight = false;
+let isCrossfading = false;
+let fallbackLoading = false;
+let djStarted = false;
+let textFitFrame = null;
+let authSession = loadAuthSession();
+
+sessionStorage.removeItem("robot-dj-api-key");
+$("fadeSeconds").textContent = CROSSFADE_SECONDS;
+
+function showError(message) {
+    elements.errorMessage.textContent = message;
+    elements.errorMessage.hidden = false;
+}
+
+function clearError() {
+    elements.errorMessage.hidden = true;
+    elements.errorMessage.textContent = "";
+}
+
+function loadAuthSession() {
+    try {
+        const session = JSON.parse(localStorage.getItem(AUTH_STORAGE_KEY));
+        if (!session?.accessToken?.startsWith("sk_")) return null;
+        if (!AUTH_MODELS.every((model) => session.models?.includes(model))) {
+            localStorage.removeItem(AUTH_STORAGE_KEY);
+            return null;
+        }
+        if (session.expiresAt && session.expiresAt <= Date.now()) {
+            localStorage.removeItem(AUTH_STORAGE_KEY);
+            return null;
+        }
+        return session;
+    } catch {
+        localStorage.removeItem(AUTH_STORAGE_KEY);
+        return null;
+    }
+}
+
+function saveAuthSession(session) {
+    authSession = session;
+    if (session)
+        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session));
+    else localStorage.removeItem(AUTH_STORAGE_KEY);
+    updateAuthUi();
+}
+
+function updateStartButtonState() {
+    elements.startButton.disabled =
+        tracks.length === 0 || !authSession || djStarted;
+}
+
+function updateAuthUi() {
+    const connected = Boolean(authSession);
+    elements.authStatus.textContent = connected ? "CONNECTED" : "NOT CONNECTED";
+    elements.connectButton.hidden = connected;
+    elements.disconnectButton.hidden = !connected;
+    updateStartButtonState();
+}
+
+function base64Url(bytes) {
+    return btoa(String.fromCharCode(...bytes))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+}
+
+function randomBase64Url(length) {
+    return base64Url(crypto.getRandomValues(new Uint8Array(length)));
+}
+
+function oauthRedirectUri() {
+    const url = new URL(window.location.href);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+}
+
+function cleanOauthCallbackUrl() {
+    const url = new URL(window.location.href);
+    url.hash = "";
+    window.history.replaceState({}, "", `${url.pathname}${url.search}`);
+}
+
+function connectPollinations() {
+    clearError();
+    elements.connectButton.disabled = true;
+    elements.connectButton.textContent = "CONNECTING…";
+    try {
+        const state = randomBase64Url(24);
+        const redirectUri = oauthRedirectUri();
+        sessionStorage.setItem(
+            AUTH_PENDING_KEY,
+            JSON.stringify({ state, createdAt: Date.now() }),
+        );
+
+        const authorizeUrl = new URL(AUTH_AUTHORIZE_URL);
+        authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+        authorizeUrl.searchParams.set("state", state);
+        authorizeUrl.searchParams.set("models", AUTH_MODELS.join(","));
+        authorizeUrl.searchParams.set("budget", String(AUTH_BUDGET));
+        authorizeUrl.searchParams.set("expiry", String(AUTH_EXPIRY_DAYS));
+        window.location.assign(authorizeUrl);
+    } catch (error) {
+        elements.connectButton.disabled = false;
+        elements.connectButton.textContent = "CONNECT POLLINATIONS";
+        showError(error.message);
+    }
+}
+
+async function handleOauthCallback() {
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const accessToken = params.get("api_key");
+    const error = params.get("error");
+    if (!accessToken && !error) return;
+
+    let pending;
+    try {
+        pending = JSON.parse(sessionStorage.getItem(AUTH_PENDING_KEY));
+    } catch {
+        pending = null;
+    }
+    const receivedState = params.get("state");
+    if (!pending || !receivedState || receivedState !== pending.state) {
+        cleanOauthCallbackUrl();
+        throw new Error(
+            "Pollinations login was rejected because its security state did not match.",
+        );
+    }
+
+    sessionStorage.removeItem(AUTH_PENDING_KEY);
+    cleanOauthCallbackUrl();
+    if (Date.now() - pending.createdAt > 10 * 60 * 1000) {
+        throw new Error("Pollinations login expired. Please connect again.");
+    }
+    if (error) {
+        throw new Error(
+            params.get("error_description") ||
+                `Pollinations login failed: ${error}`,
+        );
+    }
+
+    if (!accessToken.startsWith("sk_")) {
+        throw new Error("Pollinations returned an invalid delegated key.");
+    }
+
+    saveAuthSession({
+        accessToken,
+        expiresAt: Date.now() + AUTH_EXPIRY_DAYS * 86400 * 1000,
+        models: AUTH_MODELS,
+    });
+}
+
+function disconnectPollinations() {
+    saveAuthSession(null);
+    elements.aiStatus.textContent = "ROBOT IDLE";
+}
+
+function openDatabase() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = () => {
+            request.result.createObjectStore(DB_STORE);
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+async function databaseGet(key) {
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(DB_STORE, "readonly");
+        const request = transaction.objectStore(DB_STORE).get(key);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        transaction.oncomplete = () => db.close();
+    });
+}
+
+async function databasePut(key, value) {
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(DB_STORE, "readwrite");
+        transaction.objectStore(DB_STORE).put(value, key);
+        transaction.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        transaction.onerror = () => reject(transaction.error);
+    });
+}
+
+async function hasReadPermission(handle, request = false) {
+    if (!handle.queryPermission) return true;
+    const options = { mode: "read" };
+    if ((await handle.queryPermission(options)) === "granted") return true;
+    return request && (await handle.requestPermission(options)) === "granted";
+}
+
+function updateLibraryUi(label = "No folder selected") {
+    elements.libraryCount.textContent = `${tracks.length} TRACK${tracks.length === 1 ? "" : "S"} READY`;
+    elements.libraryName.textContent = label;
+    elements.libraryStatus.textContent = tracks.length
+        ? `${tracks.length} TRACKS LOADED`
+        : "NO LIBRARY";
+    updateStartButtonState();
+}
+
+function syncSafeInteger(bytes) {
+    return (
+        ((bytes[0] & 0x7f) << 21) |
+        ((bytes[1] & 0x7f) << 14) |
+        ((bytes[2] & 0x7f) << 7) |
+        (bytes[3] & 0x7f)
+    );
+}
+
+function decodeId3Text(bytes) {
+    if (bytes.length < 2) return "";
+    const encoding = bytes[0];
+    let content = bytes.slice(1);
+    let decoder;
+
+    if (encoding === 0) decoder = new TextDecoder("windows-1252");
+    else if (encoding === 3) decoder = new TextDecoder("utf-8");
+    else if (encoding === 2) decoder = new TextDecoder("utf-16be");
+    else {
+        const bigEndian = content[0] === 0xfe && content[1] === 0xff;
+        decoder = new TextDecoder(bigEndian ? "utf-16be" : "utf-16le");
+        if (
+            (content[0] === 0xff && content[1] === 0xfe) ||
+            (content[0] === 0xfe && content[1] === 0xff)
+        ) {
+            content = content.slice(2);
+        }
+    }
+
+    return decoder.decode(content).replaceAll("\u0000", "").trim();
+}
+
+function metadataFromFilename(filename) {
+    const base = filename.replace(/\.mp3$/i, "");
+    const parts = base.split(/\s[-–—]\s/, 2);
+    if (parts.length === 2)
+        return { artist: parts[0].trim(), title: parts[1].trim() };
+    return { artist: "", title: base.trim() };
+}
+
+async function readTrackMetadata(file) {
+    const fallback = metadataFromFilename(file.name);
+    const bytes = new Uint8Array(await file.slice(0, 512 * 1024).arrayBuffer());
+    if (
+        bytes.length < 20 ||
+        String.fromCharCode(...bytes.slice(0, 3)) !== "ID3"
+    ) {
+        return fallback;
+    }
+
+    const version = bytes[3];
+    const tagEnd = Math.min(
+        bytes.length,
+        10 + syncSafeInteger(bytes.slice(6, 10)),
+    );
+    let offset = 10;
+    let artist = "";
+    let title = "";
+
+    while (offset + 10 <= tagEnd) {
+        const id = String.fromCharCode(...bytes.slice(offset, offset + 4));
+        if (!/^[A-Z0-9]{4}$/.test(id)) break;
+        const sizeBytes = bytes.slice(offset + 4, offset + 8);
+        const size =
+            version === 4
+                ? syncSafeInteger(sizeBytes)
+                : new DataView(
+                      sizeBytes.buffer,
+                      sizeBytes.byteOffset,
+                      4,
+                  ).getUint32(0);
+        if (!size || offset + 10 + size > tagEnd) break;
+        const value = bytes.slice(offset + 10, offset + 10 + size);
+        if (id === "TIT2") title = decodeId3Text(value);
+        if (id === "TPE1") artist = decodeId3Text(value);
+        if (artist && title) break;
+        offset += 10 + size;
+    }
+
+    return {
+        artist: artist || fallback.artist,
+        title: title || fallback.title,
+    };
+}
+
+async function collectMp3Handles(handle, path = "") {
+    if (handle.kind === "file") {
+        return handle.name.toLowerCase().endsWith(".mp3")
+            ? [{ handle, path: path || handle.name }]
+            : [];
+    }
+
+    const found = [];
+    for await (const [name, child] of handle.entries()) {
+        found.push(
+            ...(await collectMp3Handles(
+                child,
+                path ? `${path}/${name}` : name,
+            )),
+        );
+    }
+    return found;
+}
+
+async function indexHandles(handles, label) {
+    clearError();
+    elements.libraryStatus.textContent = "READING MP3s…";
+    elements.libraryName.textContent = `Indexing ${label}`;
+
+    const collected = [];
+    for (const handle of handles)
+        collected.push(...(await collectMp3Handles(handle)));
+
+    const indexed = [];
+    for (let i = 0; i < collected.length; i += 16) {
+        const batch = collected.slice(i, i + 16);
+        indexed.push(
+            ...(await Promise.all(
+                batch.map(async ({ handle, path }) => {
+                    const file = await handle.getFile();
+                    const metadata = await readTrackMetadata(file);
+                    return {
+                        id: path,
+                        path,
+                        handle,
+                        file: null,
+                        artist: metadata.artist,
+                        title: metadata.title,
+                        label: metadata.artist
+                            ? `${metadata.artist} — ${metadata.title}`
+                            : metadata.title,
+                    };
+                }),
+            )),
+        );
+        elements.libraryCount.textContent = `${indexed.length} TRACKS INDEXED…`;
+    }
+
+    tracks = indexed.sort((a, b) => a.label.localeCompare(b.label));
+    updateLibraryUi(label);
+    if (!tracks.length) showError("That folder contains no MP3 files.");
+}
+
+async function indexFallbackFiles(files) {
+    const mp3Files = [...files].filter(
+        (file) =>
+            file.type === "audio/mpeg" ||
+            file.name.toLowerCase().endsWith(".mp3"),
+    );
+    const indexed = await Promise.all(
+        mp3Files.map(async (file) => {
+            const metadata = await readTrackMetadata(file);
+            const path = file.webkitRelativePath || file.name;
+            return {
+                id: path,
+                path,
+                handle: null,
+                file,
+                artist: metadata.artist,
+                title: metadata.title,
+                label: metadata.artist
+                    ? `${metadata.artist} — ${metadata.title}`
+                    : metadata.title,
+            };
+        }),
+    );
+    tracks = indexed.sort((a, b) => a.label.localeCompare(b.label));
+    updateLibraryUi("Temporary folder (choose with Chrome to remember it)");
+    if (!tracks.length) showError("That folder contains no MP3 files.");
+}
+
+async function saveAndIndexHandles(handles, label) {
+    rememberedSource = { handles, label };
+    try {
+        await databasePut(LIBRARY_KEY, rememberedSource);
+    } catch (error) {
+        console.warn("Could not remember the music handles", error);
+    }
+    await indexHandles(handles, label);
+    elements.reconnectButton.hidden = true;
+}
+
+async function chooseFolder() {
+    clearError();
+    if (!window.showDirectoryPicker) {
+        elements.folderFallback.click();
+        return;
+    }
+
+    try {
+        const handle = await window.showDirectoryPicker({
+            id: "robot-dj-library",
+            mode: "read",
+        });
+        await saveAndIndexHandles([handle], handle.name);
+    } catch (error) {
+        if (error.name !== "AbortError")
+            showError(`Could not open that folder: ${error.message}`);
+    }
+}
+
+async function restoreRememberedLibrary() {
+    try {
+        rememberedSource = await databaseGet(LIBRARY_KEY);
+        if (!rememberedSource?.handles?.length) return;
+        const permissions = await Promise.all(
+            rememberedSource.handles.map((handle) => hasReadPermission(handle)),
+        );
+        if (permissions.every(Boolean)) {
+            await indexHandles(
+                rememberedSource.handles,
+                rememberedSource.label,
+            );
+        } else {
+            elements.libraryName.textContent = `${rememberedSource.label} is remembered — reconnect to use it`;
+            elements.reconnectButton.hidden = false;
+        }
+    } catch (error) {
+        console.warn("Could not restore the remembered library", error);
+    }
+}
+
+async function reconnectLibrary() {
+    if (!rememberedSource?.handles?.length) return;
+    const permissions = await Promise.all(
+        rememberedSource.handles.map((handle) =>
+            hasReadPermission(handle, true),
+        ),
+    );
+    if (!permissions.every(Boolean)) {
+        showError(
+            "Chrome still needs permission to read the remembered music folder.",
+        );
+        return;
+    }
+    await indexHandles(rememberedSource.handles, rememberedSource.label);
+    elements.reconnectButton.hidden = true;
+}
+
+async function handlesFromDrop(event) {
+    const handlePromises = [...event.dataTransfer.items]
+        .filter((item) => item.kind === "file" && item.getAsFileSystemHandle)
+        .map((item) => item.getAsFileSystemHandle());
+    return (await Promise.all(handlePromises)).filter(Boolean);
+}
+
+function cameraConstraints(cameraId = selectedCameraId) {
+    return {
+        width: { ideal: 1280 },
+        height: { ideal: 720 },
+        ...(cameraId ? { deviceId: { exact: cameraId } } : {}),
+    };
+}
+
+function stopCamera() {
+    for (const track of cameraStream?.getTracks() || []) track.stop();
+    cameraStream = null;
+    elements.cameraVideo.srcObject = null;
+}
+
+async function populateCameraPicker() {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const cameras = devices.filter((device) => device.kind === "videoinput");
+    if (cameras.length < 2) {
+        elements.cameraPicker.hidden = true;
+        return;
+    }
+
+    const activeCameraId = cameraStream
+        ?.getVideoTracks()[0]
+        ?.getSettings().deviceId;
+    elements.cameraSelect.replaceChildren(
+        ...cameras.map((camera, index) => {
+            const option = document.createElement("option");
+            option.value = camera.deviceId;
+            option.textContent = camera.label || `CAMERA ${index + 1}`;
+            return option;
+        }),
+    );
+    elements.cameraSelect.value = activeCameraId || selectedCameraId;
+    elements.cameraPicker.hidden = false;
+}
+
+async function startCamera() {
+    if (cameraStream) return;
+    if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error(
+            "This browser does not expose a camera API. Use a current Chrome over HTTPS or localhost.",
+        );
+    }
+
+    try {
+        cameraStream = await navigator.mediaDevices.getUserMedia({
+            audio: false,
+            video: cameraConstraints(),
+        });
+    } catch (error) {
+        if (!selectedCameraId) throw error;
+        localStorage.removeItem(CAMERA_STORAGE_KEY);
+        selectedCameraId = "";
+        cameraStream = await navigator.mediaDevices.getUserMedia({
+            audio: false,
+            video: cameraConstraints(),
+        });
+    }
+    elements.cameraVideo.srcObject = cameraStream;
+    await elements.cameraVideo.play();
+    selectedCameraId =
+        cameraStream.getVideoTracks()[0]?.getSettings().deviceId || "";
+    if (selectedCameraId)
+        localStorage.setItem(CAMERA_STORAGE_KEY, selectedCameraId);
+    await populateCameraPicker();
+    elements.cameraPlaceholder.hidden = true;
+    elements.cameraVideo.classList.add("visible");
+    elements.cameraLive.classList.add("visible");
+    elements.cameraStatus.textContent = "CAMERA LIVE";
+}
+
+async function changeCamera() {
+    const nextCameraId = elements.cameraSelect.value;
+    if (!nextCameraId || nextCameraId === selectedCameraId) return;
+    selectedCameraId = nextCameraId;
+    localStorage.setItem(CAMERA_STORAGE_KEY, selectedCameraId);
+    stopCamera();
+    try {
+        await startCamera();
+    } catch (error) {
+        showError(`Could not switch camera: ${error.message}`);
+    }
+}
+
+async function captureSnapshot() {
+    await startCamera();
+    if (!elements.cameraVideo.videoWidth) {
+        await new Promise((resolve) =>
+            elements.cameraVideo.addEventListener("loadedmetadata", resolve, {
+                once: true,
+            }),
+        );
+    }
+
+    const maxWidth = 1024;
+    const scale = Math.min(1, maxWidth / elements.cameraVideo.videoWidth);
+    const width = Math.round(elements.cameraVideo.videoWidth * scale);
+    const height = Math.round(elements.cameraVideo.videoHeight * scale);
+    elements.snapshotCanvas.width = width;
+    elements.snapshotCanvas.height = height;
+    elements.snapshotCanvas
+        .getContext("2d")
+        .drawImage(elements.cameraVideo, 0, 0, width, height);
+    latestSnapshot = elements.snapshotCanvas.toDataURL("image/jpeg", 0.72);
+    return latestSnapshot;
+}
+
+function initializeAudio() {
+    if (audioContext) return;
+    audioContext = new AudioContext();
+    masterGain = audioContext.createGain();
+    masterGain.gain.value = Number(elements.volumeInput.value);
+    masterGain.connect(audioContext.destination);
+
+    decks = [0, 1].map((index) => {
+        const element = new Audio();
+        element.preload = "auto";
+        const source = audioContext.createMediaElementSource(element);
+        const gain = audioContext.createGain();
+        gain.gain.value = index === 0 ? 1 : 0;
+        source.connect(gain).connect(masterGain);
+        element.addEventListener("timeupdate", () => handleTimeUpdate(index));
+        element.addEventListener("ended", () => handleTrackEnded(index));
+        return {
+            element,
+            gain,
+            track: null,
+            objectUrl: null,
+            excerptStart: 0,
+            excerptEnd: 0,
+        };
+    });
+}
+
+async function fileForTrack(track) {
+    return track.handle ? track.handle.getFile() : track.file;
+}
+
+async function loadDeck(deck, track) {
+    const file = await fileForTrack(track);
+    if (!file) throw new Error(`Could not open ${track.label}`);
+    if (deck.objectUrl) URL.revokeObjectURL(deck.objectUrl);
+    deck.objectUrl = URL.createObjectURL(file);
+    deck.track = track;
+    deck.element.src = deck.objectUrl;
+    deck.element.load();
+
+    await new Promise((resolve, reject) => {
+        const timeout = setTimeout(
+            () => reject(new Error(`Timed out loading ${track.label}`)),
+            10_000,
+        );
+        const done = () => {
+            clearTimeout(timeout);
+            resolve();
+        };
+        const failed = () => {
+            clearTimeout(timeout);
+            reject(new Error(`Chrome could not decode ${track.label}`));
+        };
+        deck.element.addEventListener("loadedmetadata", done, { once: true });
+        deck.element.addEventListener("error", failed, { once: true });
+    });
+    deck.excerptStart = deck.element.duration / 3;
+    deck.excerptEnd = Math.min(
+        deck.element.duration,
+        deck.excerptStart + EXCERPT_SECONDS,
+    );
+    deck.element.currentTime = deck.excerptStart;
+}
+
+function randomItem(items) {
+    return items[Math.floor(Math.random() * items.length)];
+}
+
+function recentTrackIds() {
+    return new Set(
+        history.slice(-RECENT_TRACK_COUNT).map((entry) => entry.track.id),
+    );
+}
+
+function randomUnplayedTrack() {
+    const recent = recentTrackIds();
+    const eligible = tracks.filter(
+        (track) => track.id !== currentTrack?.id && !recent.has(track.id),
+    );
+    return randomItem(
+        eligible.length
+            ? eligible
+            : tracks.filter((track) => track.id !== currentTrack?.id),
+    );
+}
+
+function formatTime(seconds) {
+    if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}:${String(Math.floor(seconds % 60)).padStart(2, "0")}`;
+}
+
+function updateProgress() {
+    if (audioContext && decks.length) {
+        const deck = decks[activeDeckIndex];
+        const { element } = deck;
+        const excerptDuration = deck.excerptEnd - deck.excerptStart;
+        const ratio = excerptDuration
+            ? (element.currentTime - deck.excerptStart) / excerptDuration
+            : 0;
+        elements.progressBar.style.width = `${Math.min(100, ratio * 100)}%`;
+        elements.elapsedTime.textContent = formatTime(
+            element.currentTime - deck.excerptStart,
+        );
+        elements.durationTime.textContent = formatTime(excerptDuration);
+    }
+    requestAnimationFrame(updateProgress);
+}
+
+function scheduleRoomScan(delay = SNAPSHOT_DELAY_MS) {
+    clearTimeout(scanTimer);
+    scanTimer = setTimeout(() => scanAndSelect(), delay);
+}
+
+function onTrackStarted(track) {
+    currentTrack = track;
+    history.push({ track, startedAt: new Date().toISOString() });
+    history = history.slice(-40);
+    elements.nowPlaying.textContent = track.label;
+    elements.nextTrack.textContent = "WATCHING THE ROOM…";
+    elements.nextStatus.textContent = "NEXT SELECTION IN 8 SECONDS";
+    elements.nextPanel.classList.remove("is-selected");
+    elements.aiStatus.textContent = "NEXT SCAN IN 8 SECONDS";
+    elements.pauseButton.textContent = "PAUSE";
+    elements.pauseButton.disabled = false;
+    elements.skipButton.disabled = false;
+    elements.scanButton.disabled = false;
+    scheduleTextFit();
+    scheduleRoomScan();
+}
+
+function fitTextToBox(element, minimumFontSize) {
+    element.style.removeProperty("font-size");
+    if (!document.body.classList.contains("installation-mode")) return;
+
+    const maximumFontSize = Number.parseFloat(
+        getComputedStyle(element).fontSize,
+    );
+    if (!maximumFontSize || !element.clientHeight || !element.clientWidth)
+        return;
+
+    const fits = () =>
+        element.scrollHeight <= element.clientHeight + 1 &&
+        element.scrollWidth <= element.clientWidth + 1;
+    if (fits()) return;
+
+    let smallestFit = minimumFontSize;
+    let largestFit = maximumFontSize;
+    element.style.fontSize = `${smallestFit}px`;
+    if (!fits()) return;
+
+    while (largestFit - smallestFit > 0.5) {
+        const candidate = (smallestFit + largestFit) / 2;
+        element.style.fontSize = `${candidate}px`;
+        if (fits()) smallestFit = candidate;
+        else largestFit = candidate;
+    }
+    element.style.fontSize = `${smallestFit.toFixed(1)}px`;
+}
+
+function fitInstallationText() {
+    fitTextToBox(elements.nowPlaying, 12);
+    fitTextToBox(elements.roomRead, 20);
+    fitTextToBox(elements.nextTrack, 16);
+}
+
+function scheduleTextFit() {
+    cancelAnimationFrame(textFitFrame);
+    textFitFrame = requestAnimationFrame(fitInstallationText);
+}
+
+function shortSentence(text, fallback) {
+    const clean = String(text || fallback)
+        .replace(/\s+/g, " ")
+        .trim();
+    const firstSentence =
+        clean.match(/^[^.!?]+[.!?]?/)?.[0]?.trim() || fallback;
+    const words = firstSentence.replace(/[.!?]+$/, "").split(" ");
+    const shortened =
+        words.length > 18
+            ? `${words.slice(0, 18).join(" ")}…`
+            : words.join(" ");
+    return /[.!?…]$/.test(shortened) ? shortened : `${shortened}.`;
+}
+
+function formatRobotRead(observation, reason) {
+    const visibleRead = shortSentence(
+        observation,
+        "The camera caught a room keeping its secrets.",
+    );
+    const songRead = shortSentence(
+        reason,
+        "The next track follows that visible energy.",
+    );
+    return `${visibleRead} ${songRead}`;
+}
+
+function shuffled(items) {
+    const result = [...items];
+    for (let i = result.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+}
+
+function selectionCandidates() {
+    const recent = recentTrackIds();
+    let eligible = tracks.filter(
+        (track) => track.id !== currentTrack?.id && !recent.has(track.id),
+    );
+    if (!eligible.length)
+        eligible = tracks.filter((track) => track.id !== currentTrack?.id);
+    return shuffled(eligible).slice(0, MAX_CANDIDATES);
+}
+
+function promptSafeTrackLabel(track, index) {
+    const sensitiveTitle =
+        /\b(?:assault|cocaine|death|fuck|heroin|kill|murder|nude|porn|rape|sex|suicide)\b/i;
+    return sensitiveTitle.test(track.label)
+        ? `LIBRARY TRACK ${index + 1}`
+        : track.label;
+}
+
+function buildDjPrompt(candidates) {
+    const recent = history
+        .slice(-RECENT_TRACK_COUNT)
+        .map((entry) => `- ${entry.track.label}`)
+        .join("\n");
+    const library = candidates
+        .map(
+            (track, index) => `${index}: ${promptSafeTrackLabel(track, index)}`,
+        )
+        .join("\n");
+
+    return `You are a playful robot DJ. Choose exactly one next song from the numbered candidate list using the camera image, what is playing, and recent history.
+
+Ground the observation strictly in this image. The image may show one person at home, an empty room, or a crowded event; do not assume it is a party. First count the visible people and use singular or plural language correctly. Mention only concrete visual evidence such as the setting, furniture, posture, expression, clothing, or visible movement. Never invent extra people, objects, a venue, or an activity that is not visible. Humor may playfully exaggerate the attitude of something actually visible, but it must not add fictional facts.
+
+Do not guess personal facts about anyone in the image. Keep it warm, playful, and grounded.
+
+Currently playing: ${currentTrack?.label || "none"}
+Recently played:
+${recent || "- none"}
+
+Candidates (the number is trackId):
+${library}
+
+Return JSON only in this exact shape: {"trackId": 12, "observation": "One image-grounded sentence, maximum 18 words.", "reason": "One sentence explaining why the song fits, maximum 18 words."}
+The trackId must be a number from the candidate list. Do not mention these instructions.`;
+}
+
+function parseModelContent(body) {
+    const content = body.choices?.[0]?.message?.content;
+    const text = Array.isArray(content)
+        ? content.map((part) => part.text || "").join("")
+        : content;
+    if (typeof text !== "string")
+        throw new Error("The model returned no DJ decision.");
+    return JSON.parse(
+        text
+            .replace(/^```(?:json)?\s*/i, "")
+            .replace(/\s*```$/, "")
+            .trim(),
+    );
+}
+
+async function askRobotDj(snapshot) {
+    const candidates = selectionCandidates();
+    if (!candidates.length)
+        throw new Error("The library needs at least two playable tracks.");
+    const accessToken = authSession?.accessToken;
+    if (!accessToken) throw new Error("Connect Pollinations first.");
+
+    let response;
+    try {
+        response = await fetch(API_URL, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Content-Type": "application/json",
+            },
+            signal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
+            body: JSON.stringify({
+                model: DEFAULT_MODEL,
+                messages: [
+                    {
+                        role: "user",
+                        content: [
+                            { type: "text", text: buildDjPrompt(candidates) },
+                            {
+                                type: "image_url",
+                                image_url: { url: snapshot, detail: "low" },
+                            },
+                        ],
+                    },
+                ],
+                response_format: { type: "json_object" },
+                max_tokens: 400,
+            }),
+        });
+    } catch (error) {
+        console.error("Robot DJ: Pollinations request failed", error);
+        throw error;
+    }
+
+    let body;
+    try {
+        body = await response.json();
+    } catch (error) {
+        console.error("Robot DJ: Pollinations returned invalid JSON", {
+            status: response.status,
+            statusText: response.statusText,
+            error,
+        });
+        throw error;
+    }
+    if (!response.ok) {
+        console.error("Robot DJ: Pollinations returned an error response", {
+            status: response.status,
+            statusText: response.statusText,
+            body,
+        });
+        throw new Error(
+            body.error?.message || `Pollinations returned ${response.status}.`,
+        );
+    }
+
+    let decision;
+    try {
+        decision = parseModelContent(body);
+    } catch (error) {
+        console.error("Robot DJ: Pollinations returned an unusable decision", {
+            body,
+            error,
+        });
+        throw error;
+    }
+    const trackId = Number(decision.trackId);
+    if (!Number.isInteger(trackId) || !candidates[trackId]) {
+        throw new Error("The model picked a track outside the candidate list.");
+    }
+    return {
+        track: candidates[trackId],
+        reason: formatRobotRead(decision.observation, decision.reason),
+    };
+}
+
+async function prepareNextTrack(track, reason) {
+    const nextDeck = decks[1 - activeDeckIndex];
+    await loadDeck(nextDeck, track);
+    nextDeck.gain.gain.setValueAtTime(0, audioContext.currentTime);
+    queuedTrack = { track, reason };
+    elements.nextTrack.textContent = track.label;
+    elements.nextStatus.textContent = "ROBOT SELECTED · LOCKED FOR TRANSITION";
+    elements.nextPanel.classList.add("is-selected");
+    elements.roomRead.textContent = reason;
+    scheduleTextFit();
+    elements.aiStatus.textContent = "NEXT TRACK READY";
+}
+
+async function scanAndSelect() {
+    if (!djStarted || selectionInFlight || isCrossfading) return;
+    clearTimeout(scanTimer);
+    selectionInFlight = true;
+    clearError();
+    elements.thinkingLine.hidden = false;
+    elements.aiStatus.textContent = "READING THE ROOM…";
+    const trackAtStart = currentTrack;
+    let selected = false;
+
+    try {
+        const snapshot = await captureSnapshot();
+        const decision = await askRobotDj(snapshot);
+        if (currentTrack?.id !== trackAtStart?.id) return;
+        await prepareNextTrack(decision.track, decision.reason);
+        selected = true;
+    } catch (error) {
+        console.error("Robot DJ: selection attempt failed", {
+            currentTrack: trackAtStart?.label,
+            error,
+        });
+        if (currentTrack?.id !== trackAtStart?.id) return;
+        elements.nextTrack.textContent = "RETRYING THE ROOM…";
+        elements.nextStatus.textContent =
+            "NO PICK YET · RETRYING IN 30 SECONDS";
+        elements.nextPanel.classList.remove("is-selected");
+    } finally {
+        selectionInFlight = false;
+        elements.thinkingLine.hidden = true;
+        if (currentTrack?.id === trackAtStart?.id && !isCrossfading) {
+            scheduleRoomScan(RESCAN_INTERVAL_MS);
+            elements.aiStatus.textContent = selected
+                ? "NEXT READY · READING AGAIN IN 30 SECONDS"
+                : "ROOM READ WILL RETRY IN 30 SECONDS";
+        }
+    }
+}
+
+async function startCrossfade(seconds = CROSSFADE_SECONDS) {
+    if (isCrossfading || !queuedTrack) return;
+    isCrossfading = true;
+    clearTimeout(scanTimer);
+    elements.pauseButton.disabled = true;
+    elements.aiStatus.textContent = "CROSSFADING…";
+
+    const oldIndex = activeDeckIndex;
+    const oldDeck = decks[oldIndex];
+    const nextDeck = decks[1 - oldIndex];
+    const now = audioContext.currentTime;
+    const duration = Math.max(0.15, seconds);
+
+    nextDeck.element.currentTime = nextDeck.excerptStart;
+    try {
+        await nextDeck.element.play();
+    } catch (error) {
+        isCrossfading = false;
+        elements.pauseButton.disabled = false;
+        elements.aiStatus.textContent = "CROSSFADE FAILED";
+        showError(
+            `Could not play ${queuedTrack.track.label}: ${error.message}`,
+        );
+        return;
+    }
+    oldDeck.gain.gain.cancelScheduledValues(now);
+    nextDeck.gain.gain.cancelScheduledValues(now);
+    oldDeck.gain.gain.setValueAtTime(oldDeck.gain.gain.value, now);
+    nextDeck.gain.gain.setValueAtTime(0, now);
+    oldDeck.gain.gain.linearRampToValueAtTime(0, now + duration);
+    nextDeck.gain.gain.linearRampToValueAtTime(1, now + duration);
+
+    setTimeout(() => finishCrossfade(oldIndex), duration * 1000 + 80);
+}
+
+function finishCrossfade(oldIndex) {
+    if (!isCrossfading || activeDeckIndex !== oldIndex || !queuedTrack) return;
+    const oldDeck = decks[oldIndex];
+    const newIndex = 1 - oldIndex;
+    const newDeck = decks[newIndex];
+    const selected = queuedTrack;
+
+    oldDeck.element.pause();
+    oldDeck.element.currentTime = 0;
+    oldDeck.gain.gain.setValueAtTime(0, audioContext.currentTime);
+    newDeck.gain.gain.setValueAtTime(1, audioContext.currentTime);
+    activeDeckIndex = newIndex;
+    queuedTrack = null;
+    isCrossfading = false;
+    elements.roomRead.textContent = selected.reason;
+    onTrackStarted(selected.track);
+}
+
+async function loadRandomBackupAndFade(seconds) {
+    if (fallbackLoading || queuedTrack) return;
+    fallbackLoading = true;
+    try {
+        const fallback = randomUnplayedTrack();
+        if (!fallback) return;
+        await prepareNextTrack(
+            fallback,
+            "Emergency shuffle engaged: the room gets mystery meat, but make it musical.",
+        );
+        await startCrossfade(seconds);
+    } catch (error) {
+        showError(error.message);
+    } finally {
+        fallbackLoading = false;
+    }
+}
+
+function handleTimeUpdate(index) {
+    if (index !== activeDeckIndex || isCrossfading) return;
+    const element = decks[index].element;
+    if (!Number.isFinite(element.duration)) return;
+    const remaining = decks[index].excerptEnd - element.currentTime;
+    if (queuedTrack && remaining <= CROSSFADE_SECONDS) {
+        startCrossfade(Math.min(CROSSFADE_SECONDS, Math.max(0.2, remaining)));
+    } else if (!queuedTrack && remaining <= 1.5) {
+        loadRandomBackupAndFade(0.3);
+    }
+}
+
+function handleTrackEnded(index) {
+    if (index !== activeDeckIndex) return;
+    if (isCrossfading) finishCrossfade(index);
+    else if (queuedTrack) startCrossfade(0.15);
+    else loadRandomBackupAndFade(0.15);
+}
+
+async function skipTrack() {
+    if (!djStarted || isCrossfading) return;
+    if (!queuedTrack) {
+        const fallback = randomUnplayedTrack();
+        if (!fallback) return;
+        await prepareNextTrack(
+            fallback,
+            "A human touched the controls. Democracy is terrifying.",
+        );
+    }
+    await startCrossfade(2);
+}
+
+async function togglePause() {
+    if (!djStarted || isCrossfading) return;
+    const element = decks[activeDeckIndex].element;
+    if (element.paused) {
+        await element.play();
+        elements.pauseButton.textContent = "PAUSE";
+    } else {
+        element.pause();
+        elements.pauseButton.textContent = "PLAY";
+    }
+}
+
+async function startDj() {
+    clearError();
+    if (tracks.length < 2) {
+        showError("Choose a folder with at least two MP3 files.");
+        return;
+    }
+    if (!authSession) {
+        showError(
+            "Connect Pollinations so the robot can spend your approved Pollen budget.",
+        );
+        elements.connectButton.focus();
+        return;
+    }
+
+    elements.startButton.disabled = true;
+    elements.startButton.textContent = "WAKING THE ROBOT…";
+
+    try {
+        await startCamera();
+        initializeAudio();
+        await audioContext.resume();
+        const openingTrack = randomItem(tracks);
+        await loadDeck(decks[0], openingTrack);
+        decks[0].gain.gain.setValueAtTime(0, audioContext.currentTime);
+        await decks[0].element.play();
+        decks[0].gain.gain.linearRampToValueAtTime(
+            1,
+            audioContext.currentTime + 1.2,
+        );
+        djStarted = true;
+        document.body.classList.add("installation-mode");
+        elements.startButton.textContent = "ROBOT DJ IS RUNNING";
+        elements.roomRead.textContent =
+            "The opening track is a blind draw. Eight seconds in, then every thirty seconds, the robot opens one digital eye and updates its read.";
+        onTrackStarted(openingTrack);
+    } catch (error) {
+        updateStartButtonState();
+        elements.startButton.textContent = "START ROBOT DJ";
+        showError(`Could not start: ${error.message}`);
+    }
+}
+
+elements.chooseFolderButton.addEventListener("click", (event) => {
+    event.stopPropagation();
+    chooseFolder();
+});
+elements.dropZone.addEventListener("click", (event) => {
+    if (event.target === elements.dropZone || event.target.closest("div"))
+        chooseFolder();
+});
+elements.dropZone.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        chooseFolder();
+    }
+});
+elements.folderFallback.addEventListener("change", () =>
+    indexFallbackFiles(elements.folderFallback.files),
+);
+elements.reconnectButton.addEventListener("click", reconnectLibrary);
+elements.dropZone.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    elements.dropZone.classList.add("dragging");
+});
+elements.dropZone.addEventListener("dragleave", () =>
+    elements.dropZone.classList.remove("dragging"),
+);
+elements.dropZone.addEventListener("drop", async (event) => {
+    event.preventDefault();
+    elements.dropZone.classList.remove("dragging");
+    try {
+        const handles = await handlesFromDrop(event);
+        if (handles.length) {
+            const label =
+                handles.length === 1
+                    ? handles[0].name
+                    : `${handles.length} dropped items`;
+            await saveAndIndexHandles(handles, label);
+        } else {
+            await indexFallbackFiles(event.dataTransfer.files);
+        }
+    } catch (error) {
+        showError(`Could not read the dropped music: ${error.message}`);
+    }
+});
+
+elements.startButton.addEventListener("click", startDj);
+elements.connectButton.addEventListener("click", connectPollinations);
+elements.disconnectButton.addEventListener("click", disconnectPollinations);
+elements.scanButton.addEventListener("click", scanAndSelect);
+elements.cameraSelect.addEventListener("change", changeCamera);
+elements.skipButton.addEventListener("click", skipTrack);
+elements.pauseButton.addEventListener("click", togglePause);
+elements.volumeInput.addEventListener("input", () => {
+    if (masterGain) masterGain.gain.value = Number(elements.volumeInput.value);
+});
+elements.fullscreenButton.addEventListener("click", () => {
+    if (document.fullscreenElement) document.exitFullscreen();
+    else document.documentElement.requestFullscreen();
+});
+
+window.addEventListener("beforeunload", () => {
+    clearTimeout(scanTimer);
+    for (const deck of decks) {
+        deck.element.pause();
+        if (deck.objectUrl) URL.revokeObjectURL(deck.objectUrl);
+    }
+    stopCamera();
+});
+window.addEventListener("resize", scheduleTextFit);
+
+updateProgress();
+updateAuthUi();
+
+async function initialize() {
+    try {
+        await handleOauthCallback();
+    } catch (error) {
+        showError(error.message);
+    }
+    updateAuthUi();
+    await restoreRememberedLibrary();
+    scheduleTextFit();
+}
+
+initialize();

--- a/apps/robot-dj/index.html
+++ b/apps/robot-dj/index.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="A camera-aware AI DJ for your local music library, powered by Pollinations"
+        />
+        <title>Robot DJ · Pollinations</title>
+        <link rel="stylesheet" href="./style.css?v=17" />
+    </head>
+    <body>
+        <header class="masthead">
+            <div class="masthead-copy">
+                <p class="eyebrow">POLLINATIONS AI NIGHT</p>
+                <h1>ROBOT DJ</h1>
+                <p class="subtitle">YOUR MUSIC. THE ROOM. ONE ROBOT.</p>
+            </div>
+        </header>
+
+        <main>
+            <section class="performance-grid">
+                <article class="panel now-panel">
+                    <div class="now-content">
+                        <div class="panel-heading">
+                            <span class="number yellow-bg">1</span>
+                            <h2>NOW PLAYING</h2>
+                        </div>
+                        <div class="track-display">
+                            <p class="micro-label">CURRENT TRANSMISSION</p>
+                            <h3 id="nowPlaying">WAITING FOR MUSIC</h3>
+                            <div class="progress-track" aria-label="Track progress">
+                                <div id="progressBar"></div>
+                            </div>
+                            <div class="time-row">
+                                <span id="elapsedTime">0:00</span>
+                                <span id="durationTime">0:00</span>
+                            </div>
+                        </div>
+                        <div class="transport">
+                            <button id="pauseButton" class="button black" disabled>PAUSE</button>
+                            <button id="skipButton" class="button red-button" disabled>SKIP →</button>
+                            <label class="volume-control">
+                                VOLUME
+                                <input id="volumeInput" type="range" min="0" max="1" value="0.85" step="0.01" />
+                            </label>
+                        </div>
+                    </div>
+                    <section class="next-panel" id="nextPanel" aria-live="polite">
+                        <div class="panel-heading">
+                            <span class="number yellow-bg">4</span>
+                            <h2>NEXT UP</h2>
+                        </div>
+                        <p class="micro-label" id="nextStatus">AWAITING A ROOM READ</p>
+                        <h3 id="nextTrack">THE ROBOT HAS NOT DECIDED</h3>
+                        <p class="fade-copy"><span id="fadeSeconds">8</span> SECOND CROSSFADE</p>
+                    </section>
+                </article>
+
+                <article class="panel camera-panel">
+                    <div class="panel-heading">
+                        <span class="number red-bg">2</span>
+                        <h2>ROOM SCAN</h2>
+                    </div>
+                    <div class="camera-frame" id="cameraFrame">
+                        <div class="camera-placeholder" id="cameraPlaceholder" aria-hidden="true">
+                            <div class="placeholder-circle"></div>
+                            <div class="placeholder-block"></div>
+                            <p>THE ROBOT<br />HAS NOT LOOKED YET</p>
+                        </div>
+                        <video id="cameraVideo" muted playsinline></video>
+                        <label id="cameraPicker" class="camera-picker" hidden>
+                            CAMERA
+                            <select id="cameraSelect" aria-label="Choose camera"></select>
+                        </label>
+                        <span id="cameraLive" class="camera-live">● CAMERA LIVE</span>
+                    </div>
+                    <button id="scanButton" class="button blue-button full" disabled>
+                        TAKE A NEW LOOK
+                    </button>
+                </article>
+
+                <article class="panel thought-panel">
+                    <div class="panel-heading">
+                        <span class="number blue-bg">3</span>
+                        <h2>ROBOT'S READ</h2>
+                    </div>
+                    <blockquote id="roomRead">
+                        Add a music folder and start the DJ. Eight seconds in, then every thirty
+                        seconds, the robot reads the room and plans what comes next.
+                    </blockquote>
+                    <div class="thinking-line" id="thinkingLine" hidden>
+                        <span></span><span></span><span></span>
+                        CONSULTING THE VIBES
+                    </div>
+                </article>
+
+            </section>
+
+            <section class="setup-panel panel" id="setupPanel">
+                <p class="setup-kicker">THREE THINGS. THEN MUSIC.</p>
+
+                <div class="setup-actions">
+                    <div class="setup-action">
+                        <div class="setup-action-copy">
+                            <span class="number red-bg">1</span>
+                            <div>
+                                <b>CONNECT POLLINATIONS</b>
+                                <span id="authStatus">NOT CONNECTED</span>
+                            </div>
+                        </div>
+                        <button id="connectButton" class="button yellow-button" type="button">
+                            CONNECT
+                        </button>
+                        <button id="disconnectButton" class="text-button" type="button" hidden>
+                            DISCONNECT
+                        </button>
+                    </div>
+
+                    <div id="dropZone" class="setup-action drop-zone" tabindex="0" role="button">
+                        <div class="setup-action-copy">
+                            <span class="number blue-bg">2</span>
+                            <div>
+                                <b>MUSIC FOLDER</b>
+                                <span><strong id="libraryCount">0 TRACKS READY</strong> · <span id="libraryName">DROP A FOLDER OR CHOOSE ONE</span></span>
+                            </div>
+                        </div>
+                        <button id="chooseFolderButton" class="button blue-button" type="button">
+                            CHOOSE FOLDER
+                        </button>
+                        <input id="folderFallback" type="file" accept="audio/mpeg,.mp3" webkitdirectory multiple hidden />
+                    </div>
+                </div>
+
+                <button id="reconnectButton" class="text-button reconnect-button" hidden>RECONNECT REMEMBERED FOLDER</button>
+
+                <div id="errorMessage" class="error-message" role="alert" hidden></div>
+
+                <div class="launch-row">
+                    <button id="startButton" class="launch-button" disabled>3 · START ROBOT DJ</button>
+                    <button id="fullscreenButton" class="text-button" type="button">FULL SCREEN</button>
+                </div>
+                <p class="privacy-note">Your MP3s and live camera stay here. One still frame per read goes to Pollinations.</p>
+            </section>
+        </main>
+
+        <div hidden>
+            <span id="libraryStatus">NO LIBRARY</span>
+            <span id="cameraStatus">CAMERA OFF</span>
+            <span id="aiStatus">ROBOT IDLE</span>
+        </div>
+
+        <canvas id="snapshotCanvas" hidden></canvas>
+        <script type="module" src="./app.js?v=17"></script>
+    </body>
+</html>

--- a/apps/robot-dj/style.css
+++ b/apps/robot-dj/style.css
@@ -1,0 +1,1081 @@
+:root {
+    color-scheme: light;
+    --paper: #f3efe6;
+    --ink: #050505;
+    --yellow: #ffb900;
+    --red: #f21c0c;
+    --blue: #0758be;
+    --line: 3px solid var(--ink);
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    background: var(--paper);
+}
+
+body {
+    min-width: 320px;
+    margin: 0;
+    color: var(--ink);
+    background:
+        radial-gradient(circle at 10% 4%, rgb(255 255 255 / 70%), transparent 24rem),
+        var(--paper);
+}
+
+button,
+input,
+select {
+    font: inherit;
+}
+
+button {
+    color: inherit;
+}
+
+.masthead,
+main {
+    width: min(1420px, calc(100% - 48px));
+    margin-inline: auto;
+}
+
+.masthead {
+    min-height: 0;
+    padding: 48px 0 28px;
+    border-bottom: var(--line);
+}
+
+.masthead-copy {
+    position: relative;
+    z-index: 2;
+}
+
+.eyebrow,
+.subtitle,
+.panel-heading h2,
+.micro-label,
+.field-group label,
+.button,
+.launch-button,
+.drop-zone b,
+.library-row b,
+footer {
+    font-weight: 900;
+    letter-spacing: -0.025em;
+}
+
+.eyebrow {
+    margin: 0 0 14px;
+    font-size: clamp(0.9rem, 1.4vw, 1.3rem);
+}
+
+h1 {
+    max-width: none;
+    margin: 0;
+    font-family: Impact, Haettenschweiler, "Arial Black", sans-serif;
+    font-size: clamp(5.2rem, 12vw, 10rem);
+    font-stretch: condensed;
+    font-weight: 950;
+    letter-spacing: -0.055em;
+    line-height: 0.78;
+}
+
+.subtitle {
+    margin: 18px 0 0;
+    font-size: clamp(1rem, 1.8vw, 1.5rem);
+    line-height: 1.05;
+}
+
+.masthead-art {
+    position: relative;
+    min-height: 360px;
+    overflow: hidden;
+    border-left: var(--line);
+}
+
+.shape {
+    position: absolute;
+    box-shadow: inset 0 0 32px rgb(0 0 0 / 10%);
+}
+
+.shape-blue {
+    z-index: 2;
+    top: 0;
+    right: 4%;
+    width: min(28vw, 350px);
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: var(--blue);
+}
+
+.shape-red {
+    bottom: 0;
+    left: 4%;
+    width: 56%;
+    height: 51%;
+    border-radius: 100% 0 0;
+    background: var(--red);
+}
+
+.shape-yellow {
+    right: 4%;
+    bottom: 0;
+    width: 33%;
+    height: 60%;
+    background: var(--yellow);
+}
+
+.robot-face {
+    position: absolute;
+    z-index: 4;
+    right: 14%;
+    bottom: 13%;
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    width: 120px;
+    height: 105px;
+    padding-top: 31px;
+    border: 13px solid var(--yellow);
+    background: var(--ink);
+}
+
+.robot-face::before,
+.robot-face::after {
+    position: absolute;
+    left: 50%;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--blue);
+    content: "";
+    transform: translateX(-50%);
+}
+
+.robot-face::before {
+    top: -63px;
+}
+
+.robot-face::after {
+    bottom: -63px;
+}
+
+.robot-face span {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--paper);
+}
+
+.status-strip {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    border-bottom: var(--line);
+}
+
+.status-strip > div {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 20px 4px;
+    font-size: clamp(0.82rem, 1.2vw, 1.05rem);
+}
+
+.status-strip > div:not(:last-child) {
+    border-right: var(--line);
+}
+
+.dot {
+    display: inline-block;
+    width: 28px;
+    height: 28px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+}
+
+.yellow,
+.yellow-bg {
+    background: var(--yellow);
+}
+
+.red,
+.red-bg {
+    background: var(--red);
+}
+
+.blue,
+.blue-bg {
+    background: var(--blue);
+}
+
+.performance-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+}
+
+body:not(.installation-mode) .performance-grid {
+    display: none;
+}
+
+.panel {
+    min-width: 0;
+    border-bottom: var(--line);
+}
+
+.performance-grid > .panel:nth-child(odd) {
+    padding-right: 42px;
+    border-right: var(--line);
+}
+
+.performance-grid > .panel:nth-child(even) {
+    padding-left: 42px;
+}
+
+.panel-heading {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    min-height: 102px;
+}
+
+.panel-heading h2 {
+    margin: 0;
+    font-family: Impact, Haettenschweiler, "Arial Black", sans-serif;
+    font-size: clamp(2rem, 4vw, 4.6rem);
+    letter-spacing: -0.035em;
+    line-height: 0.9;
+}
+
+.number {
+    display: grid;
+    width: 62px;
+    height: 62px;
+    flex: 0 0 auto;
+    place-items: center;
+    border-radius: 50%;
+    font-size: 2.25rem;
+    font-weight: 950;
+}
+
+.track-display {
+    display: flex;
+    min-height: 238px;
+    flex-direction: column;
+    justify-content: center;
+    padding: 30px 0;
+}
+
+.micro-label {
+    margin: 0 0 12px;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+}
+
+.track-display h3,
+.next-panel h3 {
+    overflow-wrap: anywhere;
+    margin: 0;
+    font-size: clamp(2rem, 4.5vw, 5rem);
+    letter-spacing: -0.06em;
+    line-height: 0.88;
+}
+
+.progress-track {
+    height: 17px;
+    margin-top: 36px;
+    border: 2px solid var(--ink);
+    background: transparent;
+}
+
+.progress-track > div {
+    width: 0;
+    height: 100%;
+    background: var(--blue);
+}
+
+.time-row {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 7px;
+    font-weight: 800;
+}
+
+.transport {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 0 34px;
+}
+
+.button,
+.launch-button {
+    min-height: 48px;
+    padding: 12px 18px;
+    border: 2px solid var(--ink);
+    border-radius: 0;
+    box-shadow: 4px 4px 0 var(--ink);
+    cursor: pointer;
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.button:hover:not(:disabled),
+.launch-button:hover:not(:disabled) {
+    box-shadow: 2px 2px 0 var(--ink);
+    transform: translate(2px, 2px);
+}
+
+.button:disabled,
+.launch-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
+}
+
+.black {
+    color: var(--paper);
+    background: var(--ink);
+}
+
+.red-button {
+    background: var(--red);
+}
+
+.blue-button {
+    color: white;
+    background: var(--blue);
+}
+
+.yellow-button {
+    background: var(--yellow);
+}
+
+.full {
+    width: calc(100% - 4px);
+    margin: 17px 0 30px;
+}
+
+.volume-control {
+    display: grid;
+    flex: 1;
+    gap: 4px;
+    margin-left: 14px;
+    font-size: 0.72rem;
+    font-weight: 900;
+}
+
+input[type="range"] {
+    width: 100%;
+    accent-color: var(--blue);
+}
+
+.camera-frame {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border: var(--line);
+    background: var(--yellow);
+}
+
+.camera-frame video {
+    position: absolute;
+    inset: 0;
+    display: none;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.camera-frame video.visible {
+    display: block;
+}
+
+.camera-picker {
+    position: absolute;
+    z-index: 6;
+    top: 12px;
+    left: 12px;
+    display: grid;
+    gap: 3px;
+    max-width: min(52%, 260px);
+    padding: 6px 8px;
+    color: white;
+    background: var(--ink);
+    font-size: 0.62rem;
+    font-weight: 900;
+}
+
+.camera-picker[hidden] {
+    display: none;
+}
+
+.camera-picker select {
+    min-width: 0;
+    border: 0;
+    border-radius: 0;
+    padding: 3px 5px;
+    color: var(--ink);
+    background: var(--paper);
+    font: inherit;
+    font-size: 0.72rem;
+    font-weight: 800;
+}
+
+.camera-placeholder {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+
+.camera-placeholder p {
+    position: absolute;
+    z-index: 3;
+    bottom: 18px;
+    left: 22px;
+    margin: 0;
+    font-weight: 950;
+    line-height: 0.95;
+}
+
+.placeholder-circle {
+    position: absolute;
+    z-index: 2;
+    top: -14%;
+    right: -2%;
+    width: 55%;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: var(--blue);
+}
+
+.placeholder-block {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 38%;
+    height: 52%;
+    background: var(--red);
+}
+
+.camera-live {
+    position: absolute;
+    z-index: 5;
+    top: 12px;
+    right: 12px;
+    display: none;
+    padding: 7px 9px;
+    color: white;
+    background: var(--red);
+    font-size: 0.7rem;
+    font-weight: 900;
+}
+
+.camera-live.visible {
+    display: block;
+}
+
+.thought-panel,
+.next-panel {
+    min-height: 315px;
+}
+
+.thought-panel blockquote {
+    max-width: 850px;
+    margin: 10px 0 40px;
+    font-size: clamp(1.35rem, 2.6vw, 2.8rem);
+    font-weight: 800;
+    letter-spacing: -0.035em;
+    line-height: 1.04;
+}
+
+.thinking-line {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin-bottom: 30px;
+    font-size: 0.8rem;
+    font-weight: 900;
+}
+
+.thinking-line[hidden],
+.error-message[hidden] {
+    display: none;
+}
+
+.thinking-line span {
+    width: 9px;
+    height: 30px;
+    background: var(--ink);
+    animation: meter 0.8s ease-in-out infinite alternate;
+}
+
+.thinking-line span:nth-child(2) {
+    animation-delay: -0.3s;
+}
+
+.thinking-line span:nth-child(3) {
+    animation-delay: -0.55s;
+}
+
+@keyframes meter {
+    to {
+        height: 9px;
+    }
+}
+
+.next-panel {
+    padding-bottom: 35px;
+}
+
+.fade-copy {
+    display: inline-block;
+    margin: 25px 0 0;
+    padding: 7px 10px;
+    color: white;
+    background: var(--blue);
+    font-weight: 900;
+}
+
+.setup-panel {
+    width: min(780px, 100%);
+    margin-inline: auto;
+    padding: 34px 0 54px;
+    border-bottom: 0;
+}
+
+.setup-kicker {
+    margin: 0 0 14px;
+    font-size: 0.8rem;
+    font-weight: 900;
+    letter-spacing: 0.1em;
+}
+
+.setup-actions {
+    display: grid;
+    gap: 12px;
+}
+
+.setup-action,
+.launch-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+}
+
+.setup-action {
+    min-height: 94px;
+    padding: 16px 18px;
+    border: var(--line);
+    background: rgb(255 255 255 / 36%);
+}
+
+.setup-action-copy {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 14px;
+}
+
+.setup-action-copy .number {
+    width: 48px;
+    height: 48px;
+    font-size: 1.75rem;
+}
+
+.setup-action-copy b,
+.setup-action-copy span {
+    display: block;
+}
+
+.setup-action-copy b {
+    font-size: clamp(1.15rem, 2.2vw, 1.6rem);
+    font-weight: 950;
+}
+
+.setup-action-copy span {
+    margin-top: 4px;
+    overflow: hidden;
+    font-size: 0.78rem;
+    font-weight: 750;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.setup-action-copy strong {
+    font-weight: 950;
+}
+
+.drop-zone {
+    cursor: pointer;
+}
+
+.drop-zone.dragging {
+    background: var(--yellow);
+}
+
+.text-button {
+    padding: 0;
+    border: 0;
+    border-bottom: 2px solid var(--ink);
+    background: transparent;
+    font-weight: 900;
+    cursor: pointer;
+}
+
+.error-message {
+    margin-top: 18px;
+    padding: 13px 15px;
+    border: 2px solid var(--ink);
+    color: white;
+    background: var(--red);
+    font-weight: 800;
+}
+
+.launch-row {
+    margin-top: 16px;
+}
+
+.launch-button {
+    min-height: 74px;
+    flex: 1;
+    background: var(--yellow);
+    font-size: clamp(1.3rem, 2.7vw, 2.4rem);
+}
+
+.reconnect-button {
+    margin-top: 12px;
+}
+
+.privacy-note {
+    margin: 14px 0 0;
+    color: rgb(0 0 0 / 70%);
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+/* Running installation: one screen, three essential signals. */
+.installation-mode {
+    overflow: hidden;
+}
+
+.installation-mode .masthead,
+.installation-mode .setup-panel {
+    display: none;
+}
+
+.installation-mode main {
+    width: 100%;
+    height: 100dvh;
+}
+
+.installation-mode .performance-grid {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    grid-template-columns: minmax(0, 1.25fr) minmax(430px, 0.75fr);
+    grid-template-rows: minmax(0, 1fr);
+}
+
+.installation-mode .performance-grid > .panel {
+    padding: 20px 24px !important;
+    border-right: 0 !important;
+    border-bottom: 0;
+}
+
+.installation-mode .camera-panel {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    grid-column: 1;
+    grid-row: 1;
+    border-right: var(--line) !important;
+}
+
+.installation-mode .now-panel {
+    display: grid;
+    width: min(630px, calc(100% - 48px));
+    height: min(205px, calc(100dvh - 48px));
+    min-height: 0;
+    grid-template-columns: minmax(0, 1.5fr) minmax(210px, 0.5fr);
+    align-self: end;
+    justify-self: end;
+    z-index: 6;
+    grid-column: 1 / -1;
+    grid-row: 1;
+    margin: 0 24px 24px 0;
+    padding: 0 !important;
+    border: 2px solid var(--ink) !important;
+    background: var(--paper);
+    box-shadow: 6px 6px 0 var(--ink);
+}
+
+.installation-mode .now-content {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    padding: 9px 12px;
+}
+
+.installation-mode .thought-panel {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    grid-column: 2;
+    grid-row: 1;
+}
+
+.installation-mode .next-panel {
+    display: flex;
+    width: auto;
+    height: auto;
+    min-height: 0;
+    flex-direction: column;
+    align-self: stretch;
+    margin: 0;
+    padding: 10px 12px !important;
+    border: 0 !important;
+    border-left: 2px solid var(--ink) !important;
+    background: var(--yellow);
+    box-shadow: none;
+}
+
+.installation-mode .next-panel.is-selected {
+    background: var(--red);
+    animation: selected-track 180ms ease-out;
+}
+
+.installation-mode .next-panel .panel-heading {
+    min-height: 28px;
+    gap: 7px;
+}
+
+.installation-mode .next-panel .number {
+    width: 24px;
+    height: 24px;
+    font-size: 0.95rem;
+}
+
+.installation-mode .next-panel .panel-heading h2 {
+    font-size: clamp(1.35rem, 2vw, 2rem);
+}
+
+.installation-mode .next-panel .micro-label {
+    margin: 7px 0 4px;
+    font-size: 0.55rem;
+    line-height: 1.05;
+}
+
+.installation-mode .next-panel h3 {
+    min-height: 0;
+    flex: 1;
+    overflow: hidden;
+    font-size: clamp(1.05rem, 1.7vw, 1.7rem);
+    line-height: 0.9;
+    text-wrap: balance;
+}
+
+.installation-mode .next-panel .fade-copy {
+    align-self: flex-start;
+    margin: 6px 0 0;
+    padding: 3px 5px;
+    color: var(--paper);
+    background: var(--ink);
+    font-size: 0.6rem;
+}
+
+@keyframes selected-track {
+    from {
+        transform: translate(10px, 10px);
+    }
+}
+
+.installation-mode .panel-heading {
+    min-height: 68px;
+    flex: 0 0 auto;
+    gap: 14px;
+}
+
+.installation-mode .now-content .panel-heading {
+    min-height: 36px;
+    gap: 9px;
+}
+
+.installation-mode .now-content .number {
+    width: 30px;
+    height: 30px;
+    font-size: 1.1rem;
+}
+
+.installation-mode .now-content .panel-heading h2 {
+    font-size: clamp(1.5rem, 2.1vw, 2.2rem);
+}
+
+.installation-mode .now-content .micro-label {
+    margin-bottom: 5px;
+    font-size: 0.58rem;
+}
+
+.installation-mode .now-content .track-display {
+    padding: 2px 0 4px;
+}
+
+.installation-mode .now-content #nowPlaying {
+    min-height: 44px;
+    overflow-wrap: anywhere;
+}
+
+.installation-mode .now-content .transport {
+    gap: 6px;
+}
+
+.installation-mode .now-content .transport .button {
+    min-height: 36px;
+    padding: 8px 10px;
+    font-size: 0.72rem;
+}
+
+.installation-mode .now-content .volume-control {
+    margin-left: 6px;
+    font-size: 0.58rem;
+}
+
+.installation-mode .panel-heading h2 {
+    font-size: clamp(2rem, 3.2vw, 4rem);
+}
+
+.installation-mode .number {
+    width: 48px;
+    height: 48px;
+    font-size: 1.75rem;
+}
+
+.installation-mode .camera-frame {
+    min-height: 0;
+    flex: 1;
+    aspect-ratio: auto;
+}
+
+.installation-mode .camera-panel .full {
+    min-height: 42px;
+    margin: 14px 4px 4px 0;
+    padding-block: 8px;
+}
+
+.installation-mode .track-display {
+    min-height: 0;
+    flex: 1;
+    padding: 4px 0 12px;
+}
+
+.installation-mode .track-display h3 {
+    font-size: clamp(1rem, 1.65vw, 1.85rem);
+}
+
+.installation-mode #nowPlaying {
+    overflow: hidden;
+    min-height: 0;
+    flex: 1;
+    text-wrap: balance;
+}
+
+.installation-mode .progress-track {
+    height: 12px;
+    margin-top: auto;
+}
+
+.installation-mode .transport {
+    flex: 0 0 auto;
+    padding-bottom: 0;
+}
+
+.installation-mode .thought-panel blockquote {
+    overflow: hidden;
+    min-height: 0;
+    flex: 1;
+    max-width: none;
+    margin: 6px 0 20px;
+    overflow-wrap: anywhere;
+    font-size: clamp(2rem, 3.3vw, 4.3rem);
+    line-height: 1.02;
+    text-wrap: balance;
+}
+
+@media (max-width: 840px) {
+    .masthead,
+    main,
+    footer {
+        width: min(100% - 24px, 680px);
+    }
+
+    .masthead {
+        grid-template-columns: 1fr;
+        min-height: 0;
+        padding-top: 28px;
+    }
+
+    h1 {
+        font-size: clamp(5.2rem, 28vw, 10rem);
+    }
+
+    .subtitle {
+        margin-top: 25px;
+    }
+
+    .masthead-art {
+        min-height: 280px;
+        margin-top: 28px;
+        border-top: var(--line);
+        border-left: 0;
+    }
+
+    .shape-blue {
+        width: 260px;
+    }
+
+    .status-strip {
+        grid-template-columns: 1fr;
+    }
+
+    .status-strip > div {
+        border-right: 0 !important;
+        border-bottom: 2px solid var(--ink);
+    }
+
+    .performance-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .performance-grid > .panel {
+        padding-inline: 0 !important;
+        border-right: 0 !important;
+    }
+
+    .setup-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .drop-zone,
+    .launch-row {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .library-row {
+        align-items: flex-start;
+        flex-direction: column;
+        padding: 14px 0;
+    }
+
+    footer {
+        grid-template-columns: 1fr;
+        gap: 8px;
+        padding: 25px 0;
+    }
+
+    .installation-mode {
+        overflow: auto;
+    }
+
+    .installation-mode main {
+        height: auto;
+        min-height: 100dvh;
+    }
+
+    .installation-mode .performance-grid {
+        height: auto;
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+    }
+
+    .installation-mode .performance-grid > .panel {
+        grid-column: 1;
+        grid-row: auto;
+        border-right: 0 !important;
+        border-bottom: var(--line);
+    }
+
+    .installation-mode .camera-panel {
+        min-height: 72dvh;
+    }
+
+    .installation-mode .now-panel {
+        grid-row: 2;
+        width: auto;
+        height: auto;
+        grid-template-columns: 1fr;
+        margin: 0;
+        box-shadow: none;
+    }
+
+    .installation-mode .thought-panel {
+        grid-row: 3;
+    }
+
+    .installation-mode .next-panel {
+        width: auto;
+        height: 160px;
+        margin: 0;
+        border-top: 2px solid var(--ink) !important;
+        border-left: 0 !important;
+        box-shadow: none;
+    }
+}
+
+@media (max-width: 520px) {
+    .masthead-art {
+        min-height: 220px;
+    }
+
+    .shape-blue {
+        width: 190px;
+    }
+
+    .robot-face {
+        right: 10%;
+        transform: scale(0.75);
+    }
+
+    .panel-heading {
+        min-height: 84px;
+    }
+
+    .number {
+        width: 50px;
+        height: 50px;
+        font-size: 1.75rem;
+    }
+
+    .transport {
+        align-items: stretch;
+        flex-wrap: wrap;
+    }
+
+    .volume-control {
+        min-width: 100%;
+        margin: 10px 0 0;
+    }
+
+    .auth-control {
+        align-items: stretch;
+        flex-direction: column;
+        padding: 12px;
+    }
+
+    .auth-control .button {
+        width: 100%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}


### PR DESCRIPTION
- Adds a browser-based Robot DJ for local MP3 libraries
- Uses camera snapshots and `gemini-fast` to read the room and select tracks
- Adds delegated Pollinations login; no API key or secret is embedded in the source
- Registers the static app as `robot-dj` in `apps/apps.json`
- Validated with Biome, `node --check`, staged secret scanning, whitespace checks, and HTML ID consistency