### PR TITLE
fix: attribute Cloudflare Images transform failures

### DIFF
--- a/gen.pollinations.ai/src/image/utils/imageTransform.ts
+++ b/gen.pollinations.ai/src/image/utils/imageTransform.ts
@@ -1,3 +1,5 @@
+import { HttpError } from "../httpError.ts";
+
 type TransformOptions = {
     format?: "image/jpeg" | "image/png" | "image/webp";
     quality?: number;
@@ -7,6 +9,9 @@ type TransformOptions = {
     maxWidth?: number;
     maxHeight?: number;
 };
+
+// Synthetic URL used only to attribute Images binding failures in error telemetry.
+const CLOUDFLARE_IMAGES_UPSTREAM_URL = "https://images.cloudflare.com/binding";
 
 let imagesBinding: ImagesBinding | null = null;
 
@@ -54,22 +59,35 @@ export async function transformImage(
         },
     });
 
-    let pipeline = imagesBinding.input(stream);
-    if (width || height || maxWidth || maxHeight) {
-        pipeline = pipeline.transform({
-            width: width || maxWidth,
-            height: height || maxHeight,
-            fit,
-        });
-    }
+    let stage = "input";
+    try {
+        let pipeline = imagesBinding.input(stream);
+        if (width || height || maxWidth || maxHeight) {
+            pipeline = pipeline.transform({
+                width: width || maxWidth,
+                height: height || maxHeight,
+                fit,
+            });
+        }
 
-    const response = (
-        await pipeline.output({
-            format,
-            quality,
-        })
-    ).response();
-    return Buffer.from(await response.arrayBuffer());
+        stage = "output";
+        const response = (
+            await pipeline.output({
+                format,
+                quality,
+            })
+        ).response();
+        stage = "body read";
+        return Buffer.from(await response.arrayBuffer());
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new HttpError(
+            `Cloudflare Images ${stage} failed: ${message}`,
+            502,
+            { service: "cloudflare-images", stage },
+            CLOUDFLARE_IMAGES_UPSTREAM_URL,
+        );
+    }
 }
 
 export async function convertToJpeg(

--- a/gen.pollinations.ai/test/image/imageTransform.test.ts
+++ b/gen.pollinations.ai/test/image/imageTransform.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../../src/image/httpError.ts";
+import {
+    setImagesBinding,
+    transformImage,
+} from "../../src/image/utils/imageTransform.ts";
+
+afterEach(() => {
+    setImagesBinding(undefined);
+});
+
+function bindingWithPipeline(pipeline: object): ImagesBinding {
+    return {
+        input: vi.fn().mockReturnValue(pipeline),
+    } as unknown as ImagesBinding;
+}
+
+describe("transformImage", () => {
+    it("attributes Images binding output failures", async () => {
+        setImagesBinding(
+            bindingWithPipeline({
+                output: vi
+                    .fn()
+                    .mockRejectedValue(
+                        new TypeError("Network connection lost"),
+                    ),
+            }),
+        );
+
+        const error = await transformImage(Buffer.from("image")).catch(
+            (caught) => caught,
+        );
+
+        expect(error).toBeInstanceOf(HttpError);
+        expect(error).toMatchObject({
+            status: 502,
+            message: "Cloudflare Images output failed: Network connection lost",
+            details: { service: "cloudflare-images", stage: "output" },
+            upstreamUrl: "https://images.cloudflare.com/binding",
+        });
+    });
+
+    it("attributes Images binding response body failures", async () => {
+        setImagesBinding(
+            bindingWithPipeline({
+                output: vi.fn().mockResolvedValue({
+                    response: () => ({
+                        arrayBuffer: vi
+                            .fn()
+                            .mockRejectedValue(
+                                new TypeError("Network connection lost"),
+                            ),
+                    }),
+                }),
+            }),
+        );
+
+        await expect(
+            transformImage(Buffer.from("image")),
+        ).rejects.toMatchObject({
+            status: 502,
+            message:
+                "Cloudflare Images body read failed: Network connection lost",
+            details: {
+                service: "cloudflare-images",
+                stage: "body read",
+            },
+            upstreamUrl: "https://images.cloudflare.com/binding",
+        });
+    });
+});


### PR DESCRIPTION
- Wraps Cloudflare Images binding input/output/body-read failures as attributed `HttpError` responses.
- Records the transform stage and stable `images.cloudflare.com` upstream host in error telemetry.
- Preserves the original runtime error message, including `Network connection lost`.
- Adds focused coverage for output and response-body failures.

Root cause: `wan-image-pro` failures remained hostless after Replicate prediction and download boundaries were instrumented, leaving the subsequent PNG-to-JPEG Images binding transform ambiguous.

Checks:
- `npx biome check --write gen.pollinations.ai/src/image/utils/imageTransform.ts gen.pollinations.ai/test/image/imageTransform.test.ts`
- `npx vitest run test/image/imageTransform.test.ts --reporter=verbose`
- `npm run typecheck`