### PR TITLE
chore: promote main to production

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -1336,6 +1336,7 @@ Update a community text model owned by the authenticated account. Changing visib
 | `upstreamModel` | `string` | length: `1…253` |
 | `bearerToken` | `string` | — |
 | `visibility` | `"private"` \| `"public"` | "private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account. |
+| `active` | `boolean` | — |
 | `promptTextPrice` | `number` | — |
 | `promptCachedPrice` | `number` | — |
 | `promptCacheWritePrice` | `number` | — |

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -38,7 +38,7 @@ export function base64ToBuffer(base64: string): Buffer {
     return buffer;
 }
 
-export function detectMimeType(buffer: Uint8Array): string {
+function detectKnownMimeType(buffer: Uint8Array): string | undefined {
     if (
         buffer[0] === 0x89 &&
         buffer[1] === 0x50 &&
@@ -66,7 +66,11 @@ export function detectMimeType(buffer: Uint8Array): string {
         return "image/gif";
     }
     if (buffer[0] === 0x42 && buffer[1] === 0x4d) return "image/bmp";
-    return "image/jpeg";
+    return undefined;
+}
+
+export function detectMimeType(buffer: Uint8Array): string {
+    return detectKnownMimeType(buffer) ?? "image/jpeg";
 }
 
 export async function downloadUserImage(
@@ -93,8 +97,25 @@ export async function downloadUserImage(
         );
     }
 
-    const buffer = Buffer.from(await imageResponse.arrayBuffer());
-    return { buffer, mimeType: detectMimeType(buffer) };
+    let buffer: Buffer;
+    try {
+        buffer = Buffer.from(await imageResponse.arrayBuffer());
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new HttpError(
+            `Failed to read image ${imageUrl}: ${message}`,
+            400,
+            { validation: true },
+        );
+    }
+
+    const mimeType = detectKnownMimeType(buffer);
+    if (!mimeType) {
+        throw new HttpError(`Unsupported image format from ${imageUrl}`, 400, {
+            validation: true,
+        });
+    }
+    return { buffer, mimeType };
 }
 
 export async function downloadImageAsBase64(

--- a/gen.pollinations.ai/src/image/utils/imageTransform.ts
+++ b/gen.pollinations.ai/src/image/utils/imageTransform.ts
@@ -1,3 +1,5 @@
+import { HttpError } from "../httpError.ts";
+
 type TransformOptions = {
     format?: "image/jpeg" | "image/png" | "image/webp";
     quality?: number;
@@ -7,6 +9,9 @@ type TransformOptions = {
     maxWidth?: number;
     maxHeight?: number;
 };
+
+// Synthetic URL used only to attribute Images binding failures in error telemetry.
+const CLOUDFLARE_IMAGES_UPSTREAM_URL = "https://images.cloudflare.com/binding";
 
 let imagesBinding: ImagesBinding | null = null;
 
@@ -54,22 +59,35 @@ export async function transformImage(
         },
     });
 
-    let pipeline = imagesBinding.input(stream);
-    if (width || height || maxWidth || maxHeight) {
-        pipeline = pipeline.transform({
-            width: width || maxWidth,
-            height: height || maxHeight,
-            fit,
-        });
-    }
+    let stage = "input";
+    try {
+        let pipeline = imagesBinding.input(stream);
+        if (width || height || maxWidth || maxHeight) {
+            pipeline = pipeline.transform({
+                width: width || maxWidth,
+                height: height || maxHeight,
+                fit,
+            });
+        }
 
-    const response = (
-        await pipeline.output({
-            format,
-            quality,
-        })
-    ).response();
-    return Buffer.from(await response.arrayBuffer());
+        stage = "output";
+        const response = (
+            await pipeline.output({
+                format,
+                quality,
+            })
+        ).response();
+        stage = "body read";
+        return Buffer.from(await response.arrayBuffer());
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new HttpError(
+            `Cloudflare Images ${stage} failed: ${message}`,
+            502,
+            { service: "cloudflare-images", stage },
+            CLOUDFLARE_IMAGES_UPSTREAM_URL,
+        );
+    }
 }
 
 export async function convertToJpeg(

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -207,6 +207,7 @@ export function classifyReplicateHttpStatus(httpStatus: number): number {
  * structured code field. Patterns observed in our prod logs:
  * - E005 / "flagged as sensitive" — Seedance content filter (400)
  * - "Input validation error:" — Replicate's input URL fetcher (400)
+ * - "cannot identify image file" — malformed image input (400)
  * - E003 / "unavailable due to high demand" — Alibaba capacity for WAN
  *   models (503, so monitoring separates provider capacity from our bugs)
  * Default 500 keeps new failure modes loud.
@@ -214,6 +215,7 @@ export function classifyReplicateHttpStatus(httpStatus: number): number {
 export function classifyReplicatePredictionError(message: string): number {
     if (/\bE005\b|flagged as sensitive/i.test(message)) return 400;
     if (/^Input validation error:/i.test(message)) return 400;
+    if (/cannot identify image file/i.test(message)) return 400;
     if (/\bE003\b|unavailable due to high demand/i.test(message)) return 503;
     return 500;
 }

--- a/gen.pollinations.ai/test/image/imageDownload.test.ts
+++ b/gen.pollinations.ai/test/image/imageDownload.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../../src/image/httpError.ts";
+import { downloadUserImage } from "../../src/image/utils/imageDownload.ts";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("downloadUserImage", () => {
+    it("returns a validation error when the response body disconnects", async () => {
+        const imageUrl = "https://example.com/input.png";
+        const body = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new Uint8Array([137, 80, 78, 71]));
+                controller.error(new TypeError("Network connection lost"));
+            },
+        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(body, { status: 200 }),
+        );
+
+        const error = await downloadUserImage(imageUrl).catch((cause) => cause);
+
+        expect(error).toBeInstanceOf(HttpError);
+        expect(error).toMatchObject({
+            status: 400,
+            details: { validation: true },
+            message: `Failed to read image ${imageUrl}: Network connection lost`,
+        });
+    });
+
+    it("rejects a successful response whose body is not an image", async () => {
+        const imageUrl = "https://example.com/input.jpg";
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response("<html>not an image</html>", { status: 200 }),
+        );
+
+        await expect(downloadUserImage(imageUrl)).rejects.toMatchObject({
+            name: "HttpError",
+            status: 400,
+            details: { validation: true },
+            message: `Unsupported image format from ${imageUrl}`,
+        });
+    });
+});

--- a/gen.pollinations.ai/test/image/imageTransform.test.ts
+++ b/gen.pollinations.ai/test/image/imageTransform.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../../src/image/httpError.ts";
+import {
+    setImagesBinding,
+    transformImage,
+} from "../../src/image/utils/imageTransform.ts";
+
+afterEach(() => {
+    setImagesBinding(undefined);
+});
+
+function bindingWithPipeline(pipeline: object): ImagesBinding {
+    return {
+        input: vi.fn().mockReturnValue(pipeline),
+    } as unknown as ImagesBinding;
+}
+
+describe("transformImage", () => {
+    it("attributes Images binding output failures", async () => {
+        setImagesBinding(
+            bindingWithPipeline({
+                output: vi
+                    .fn()
+                    .mockRejectedValue(
+                        new TypeError("Network connection lost"),
+                    ),
+            }),
+        );
+
+        const error = await transformImage(Buffer.from("image")).catch(
+            (caught) => caught,
+        );
+
+        expect(error).toBeInstanceOf(HttpError);
+        expect(error).toMatchObject({
+            status: 502,
+            message: "Cloudflare Images output failed: Network connection lost",
+            details: { service: "cloudflare-images", stage: "output" },
+            upstreamUrl: "https://images.cloudflare.com/binding",
+        });
+    });
+
+    it("attributes Images binding response body failures", async () => {
+        setImagesBinding(
+            bindingWithPipeline({
+                output: vi.fn().mockResolvedValue({
+                    response: () => ({
+                        arrayBuffer: vi
+                            .fn()
+                            .mockRejectedValue(
+                                new TypeError("Network connection lost"),
+                            ),
+                    }),
+                }),
+            }),
+        );
+
+        await expect(
+            transformImage(Buffer.from("image")),
+        ).rejects.toMatchObject({
+            status: 502,
+            message:
+                "Cloudflare Images body read failed: Network connection lost",
+            details: {
+                service: "cloudflare-images",
+                stage: "body read",
+            },
+            upstreamUrl: "https://images.cloudflare.com/binding",
+        });
+    });
+});

--- a/gen.pollinations.ai/test/image/replicateClient.test.ts
+++ b/gen.pollinations.ai/test/image/replicateClient.test.ts
@@ -114,6 +114,10 @@ describe("runReplicatePrediction", () => {
             "input validation error (e.g. expired image URL)",
             "Input validation error: 403 Client Error: Forbidden for url: https://example.com/img.jpg",
         ],
+        [
+            "malformed image input",
+            "cannot identify image file '/tmp/tmpuv5xc__efile.jpg'",
+        ],
     ])("classifies %s as 400 (user input error)", async (_, errorMessage) => {
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
             new Response(

--- a/gen.pollinations.ai/test/image/seedreamModel.test.ts
+++ b/gen.pollinations.ai/test/image/seedreamModel.test.ts
@@ -23,6 +23,8 @@ interface ReplicateRequest {
 }
 
 const REPLICATE_IMAGE_URL = "https://replicate.delivery/x/seedream-output.png";
+const INPUT_IMAGE_URL = "https://example.com/ref.jpg";
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xdb]);
 
 function mockReplicateFetch(requests: ReplicateRequest[]) {
     return vi
@@ -34,6 +36,9 @@ function mockReplicateFetch(requests: ReplicateRequest[]) {
                     new TextEncoder().encode("png-bytes").buffer,
                     { status: 200 },
                 );
+            }
+            if (href === INPUT_IMAGE_URL) {
+                return new Response(JPEG_BYTES, { status: 200 });
             }
             const body = init?.body
                 ? (JSON.parse(init.body as string) as Record<string, unknown>)
@@ -162,7 +167,7 @@ describe("seedreamReplicateModel - seedream-pro 4.5", () => {
         const params: ImageParams = {
             ...baseParams,
             model: "seedream-pro",
-            image: ["https://example.com/ref.jpg"],
+            image: [INPUT_IMAGE_URL],
         };
         await callSeedreamProAPI("test prompt", params);
 
@@ -310,7 +315,7 @@ describe("seedreamReplicateModel - seedream 4.0 custom-size mode", () => {
             width: 1792,
             height: 1024,
             dimensionsExplicit: true,
-            image: ["https://example.com/ref.jpg"],
+            image: [INPUT_IMAGE_URL],
         };
         await callSeedreamAPI("test", params);
 
@@ -330,7 +335,7 @@ describe("seedreamReplicateModel - seedream 4.0 custom-size mode", () => {
 
         const params: ImageParams = {
             ...baseParams,
-            image: ["https://example.com/ref.jpg"],
+            image: [INPUT_IMAGE_URL],
             // dimensionsExplicit defaults to false in baseParams
         };
         await callSeedreamAPI("test", params);


### PR DESCRIPTION
- Promotes `main` to `production`.
- Includes Cloudflare Images transform error attribution (#12654).
- Includes reference-image download validation (#12655).
- Includes the latest generated API reference update (#12646).

The production push triggers `Deploy / gen.pollinations.ai` through GitHub Actions.