### PR TITLE
fix: terminate app validation output

### DIFF
--- a/.github/scripts/app-submission.test.js
+++ b/.github/scripts/app-submission.test.js
@@ -119,5 +119,6 @@ if (args[0] === "issue" && args[1] === "list") {
     fs.rmSync(fakeBin, { recursive: true, force: true });
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(result.stdout.endsWith("\n"));
     assert.equal(JSON.parse(result.stdout).submission.name, "Sunflower Studio");
 });

--- a/.github/scripts/app-validate-submission.js
+++ b/.github/scripts/app-validate-submission.js
@@ -104,7 +104,7 @@ function main() {
         metadata,
         row: errors.length === 0 ? buildRow(submission, metadata) : "",
     };
-    process.stdout.write(JSON.stringify(result));
+    process.stdout.write(`${JSON.stringify(result)}\n`);
     if (!result.valid) process.exitCode = 2;
 }
 
@@ -112,7 +112,7 @@ try {
     main();
 } catch (error) {
     process.stdout.write(
-        JSON.stringify({ valid: false, system_error: error.message }),
+        `${JSON.stringify({ valid: false, system_error: error.message })}\n`,
     );
     process.exitCode = 1;
 }


### PR DESCRIPTION
- Terminates validator JSON output with a newline on success and failure
- Prevents GitHub Actions output delimiters from joining the JSON payload
- Adds a regression assertion for newline-terminated output

Checks:
- npx biome check --write .github/scripts/app-validate-submission.js .github/scripts/app-submission.test.js
- node --test .github/scripts/app-submission.test.js