### PR TITLE
fix: stop app review label reruns

### DIFF
--- a/.github/workflows/apps-review-submissions.yml
+++ b/.github/workflows/apps-review-submissions.yml
@@ -2,7 +2,7 @@ name: Apps / Pre-review submissions
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [opened, edited]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -19,7 +19,6 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.state == 'open' &&
-       (github.event.action != 'labeled' || github.event.label.name == 'APP-SUBMISSION') &&
        (contains(github.event.issue.labels.*.name, 'APP-SUBMISSION') ||
         startsWith(github.event.issue.title, '[App Submission]')) &&
        !contains(github.event.issue.labels.*.name, 'APP-APPROVED'))


### PR DESCRIPTION
- Stops the pre-review workflow from reacting to label changes
- Keeps automatic review on issue creation and edits, plus manual dispatch
- Prevents state labels from starting skipped runs that cancel successful reviews

Root cause:
The workflow-level concurrency rule was evaluated before the job-level label filter, so APP-SUBMISSION and APP-NEEDS-INFO events cancelled active runs.

Checks:
- YAML syntax validation
- Trigger-shape verification
- git diff --check