### PR TITLE
feat: add Laguna S 2.1

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -617,6 +617,7 @@ If `-a "$USER"` doesn't match, try without `-a` (`security find-generic-password
 
 Format: `<what it does or what makes it distinct>`. ≤ ~70 chars when possible.
 
+- Write user-facing catalog copy for developers: make the model's practical use clear without exposing internal routing or implementation details.
 - Say what the model **does** or what makes it **different** ("Fast & affordable image generation", "Long-context MoE for retrieval"). Capability over branding.
 - **Do not repeat the model name/title** in the description. The model manager renders the display name separately, so descriptions like "Seedream 5.0 Pro - Premium image generation" are redundant.
 - **No provider/inference attribution** in the description — no "(OpenRouter)", "via DashScope", "OpenAI's", etc. `provider` and `brand` fields carry that.

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -720,6 +720,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.04,
     },
   },
+  "laguna": {
+    "cost": {
+      "completionTextTokens": 0.0000002,
+      "promptCachedTokens": 0.00000001,
+      "promptTextTokens": 0.0000001,
+    },
+    "price": {
+      "completionTextTokens": 0.0000002,
+      "promptCachedTokens": 0.00000001,
+      "promptTextTokens": 0.0000001,
+    },
+  },
   "llama": {
     "cost": {
       "completionTextTokens": 0.00000071,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -338,6 +338,14 @@ const models: ModelDefinition[] = [
         transform: stripCacheControl,
     },
     {
+        name: "laguna",
+        config: portkeyConfig["poolside/laguna-s-2.1"],
+        transform: pipe(
+            sanitizeToolSchemas,
+            createReasoningEffortTransform("toggle"),
+        ),
+    },
+    {
         name: "mimo-v2.5",
         config: portkeyConfig["xiaomi/mimo-v2.5"],
         transform: stripCacheControl,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -160,6 +160,16 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "qwen/qwen3.7-max",
             defaultOptions: { provider: { sort: "price" } },
         }),
+    "poolside/laguna-s-2.1": () =>
+        createOpenRouterModelConfig({
+            model: "poolside/laguna-s-2.1",
+            defaultOptions: {
+                provider: {
+                    only: ["Poolside"],
+                    allow_fallbacks: false,
+                },
+            },
+        }),
 
     // -- OpenRouter (Gemma) ---------------------------------------------------
     // Moved off DeepInfra: OpenRouter serves the same SKU ~cheaper ($0.06/$0.33

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1205,6 +1205,30 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "laguna": {
+        aliases: ["laguna-s-2.1", "laguna-s2.1", "poolside-laguna-s-2.1"],
+        provider: "openrouter",
+        brand: "Poolside",
+        category: "text",
+        addedDate: new Date("2026-07-22").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter Poolside route rates (2026-07-22).
+            promptTextTokens: perMillion(0.1),
+            promptCachedTokens: perMillion(0.01),
+            completionTextTokens: perMillion(0.2),
+        },
+        title: "Laguna S 2.1",
+        description:
+            "Long-context reasoning for coding agents and complex software tasks",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "mimo-v2.5": {
         aliases: ["mimo", "mimo-2.5"],
         provider: "openrouter",


### PR DESCRIPTION
- Adds the paid-only `laguna` service with `laguna-s-2.1`, `laguna-s2.1`, and `poolside-laguna-s-2.1` aliases.
- Pins OpenRouter to Poolside's `poolside/laguna-s-2.1` endpoint with provider fallbacks disabled.
- Registers text input/output, tools, optional reasoning, 1,048,576-token context, and exact $0.10/M input, $0.01/M cached-input, $0.20/M output rates.
- Clarifies that model descriptions are user-facing developer catalog copy and keeps unsupported image/JSON-schema capabilities unadvertised.

Tests:
- 279 focused Enter tests and 103 focused Gen tests
- Gen and Enter TypeScript checks
- Local E2E: canonical name + aliases, non-stream + stream, tools + continuation, reasoning, cache, paid-only gate, malformed inputs, usage headers, and Tinybird billing parity
