### PR TITLE
fix: use Luna for app pre-review

### DIFF
--- a/.github/scripts/app-review-agent.py
+++ b/.github/scripts/app-review-agent.py
@@ -21,7 +21,7 @@ POLLINATIONS_API_KEY = os.environ.get("POLLINATIONS_API_KEY", "")
 VALIDATION_RESULT = os.environ.get("VALIDATION_RESULT", "{}")
 
 REPO = "pollinations/pollinations"
-MODEL = "openai-large"
+MODEL = "gpt-5.6-luna"
 POLLINATIONS_API = "https://gen.pollinations.ai/v1/chat/completions"
 COMMENT_MARKER = "<!-- APP_PRE_REVIEW -->"
 POLLINATIONS_MARKERS = (


### PR DESCRIPTION
- Uses `gpt-5.6-luna` for app-submission AI pre-review.
- Avoids the 403 from `openai-large`, which is not allowed for `PLN_GITHUB_POLLY_KEY`.
- Keeps the evidence-gathering and human-review workflow unchanged.

Validation: `python3 -m py_compile .github/scripts/app-review-agent.py` and `git diff --check`.