### PR TITLE
fix: rank free models first by pollen value

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/calculations.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/calculations.ts
@@ -38,7 +38,11 @@ function formatCount(num: number): string {
  * Returns undefined when no data is available.
  */
 export function calculatePerPollenValue(model: ModelPrice): number | undefined {
-    if (model.realAvgCost && model.realAvgCost > 0) {
+    if (model.free || model.realAvgCost === 0) {
+        return Number.POSITIVE_INFINITY;
+    }
+
+    if (model.realAvgCost !== undefined && model.realAvgCost > 0) {
         return 1 / model.realAvgCost;
     }
 
@@ -47,6 +51,10 @@ export function calculatePerPollenValue(model: ModelPrice): number | undefined {
 
 export function calculatePerPollen(model: ModelPrice): string {
     const unitsPerPollen = calculatePerPollenValue(model);
+    if (unitsPerPollen === Number.POSITIVE_INFINITY) {
+        return "∞";
+    }
+
     if (unitsPerPollen !== undefined) {
         return formatCount(unitsPerPollen);
     }

--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -173,6 +173,8 @@ export function getCatalogCategory(model: ApiModelInfo): ModelCategory {
 function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
     const name = getCatalogModelId(model);
     if (!name) return null;
+    const inputSortPrice = priceSum(model.pricing, INPUT_PRICE_FIELDS);
+    const outputSortPrice = priceSum(model.pricing, OUTPUT_PRICE_FIELDS);
 
     return {
         name,
@@ -185,10 +187,14 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         outputModalities: model.output_modalities,
         capabilities: model.capabilities ?? [],
         paidOnly: model.paid_only,
+        free:
+            model.pricing !== undefined &&
+            inputSortPrice === undefined &&
+            outputSortPrice === undefined,
         alpha: model.alpha,
         addedDate: model.added_date,
-        inputSortPrice: priceSum(model.pricing, INPUT_PRICE_FIELDS),
-        outputSortPrice: priceSum(model.pricing, OUTPUT_PRICE_FIELDS),
+        inputSortPrice,
+        outputSortPrice,
         prices: [],
     };
 }

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -51,6 +51,7 @@ export type ModelPrice = {
     outputModalities?: string[];
     capabilities: ModelCapability[];
     paidOnly?: boolean;
+    free?: boolean;
     alpha?: boolean;
     addedDate?: number;
     inputSortPrice?: number;

--- a/enter.pollinations.ai/test/model-calculations.test.ts
+++ b/enter.pollinations.ai/test/model-calculations.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+    calculatePerPollen,
+    calculatePerPollenValue,
+} from "../frontend/src/components/models/calculations.ts";
+import { getModelPricesFromCatalog } from "../frontend/src/components/models/model-catalog.ts";
+import type { ModelPrice } from "../frontend/src/components/models/types.ts";
+
+function model(overrides: Partial<ModelPrice> = {}): ModelPrice {
+    return {
+        name: "community/model",
+        type: "text",
+        community: true,
+        capabilities: [],
+        prices: [],
+        ...overrides,
+    };
+}
+
+describe("model per-pollen calculations", () => {
+    it("ranks a free model as unlimited generations per pollen", () => {
+        const freeModel = model({ free: true });
+        const freeValue = calculatePerPollenValue(freeModel);
+        const paidValue = calculatePerPollenValue(model({ realAvgCost: 0.25 }));
+
+        expect(freeValue).toBe(Number.POSITIVE_INFINITY);
+        expect(freeValue).toBeGreaterThan(paidValue ?? 0);
+        expect(calculatePerPollen(freeModel)).toBe("∞");
+    });
+
+    it("keeps missing usage data distinct from a free model", () => {
+        expect(calculatePerPollenValue(model())).toBeUndefined();
+        expect(calculatePerPollen(model())).toBe("—");
+    });
+
+    it("identifies a zero-priced catalog model as free", () => {
+        const [freeModel] = getModelPricesFromCatalog([
+            {
+                name: "community/free-model",
+                category: "text",
+                community: true,
+                pricing: { currency: "pollen" },
+            },
+        ]);
+
+        expect(freeModel?.free).toBe(true);
+        expect(calculatePerPollen(freeModel)).toBe("∞");
+    });
+});


### PR DESCRIPTION
- Marks catalog models with explicit zero pricing as free.
- Shows free models as `∞ gen/pollen` and sorts them above finite values in descending order.
- Keeps `—` for models that genuinely lack usage data.
- Adds regression coverage for catalog detection, display, and ranking.

Root cause: the usage statistics query excludes zero-price requests, so free models had no average-cost row and were treated as missing.

Checks:
- `npx biome check --write ...`
- `npx vitest run enter.pollinations.ai/test/model-calculations.test.ts`
- `npm run typecheck --workspace pollinations-enter`