### PR TITLE
feat: add LongCat 2.0

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -416,13 +416,13 @@ After every **MISS** call (cache HITs are explicitly NOT billed — see caveat b
 - For MISS: every non-zero header should have a matching registry cost entry.
 - For HIT: **text caches preserve `x-usage-*` headers** so the parsed usage matches the original MISS; **media (image/video/audio) caches drop `x-usage-*` headers** and only preserve selected safety metadata. Don't flag missing media usage headers on a HIT.
 
-### C. Tinybird `generation_event` row
+### C. Tinybird `generation_event_v2` row
 - Local gen / dev → staging workspace → `TINYBIRD_READ_STAGING`
 - Prod gen → prod workspace → `TINYBIRD_READ_PROD`
-- Confirm a row exists for your model with non-zero `token_count_*` and `token_price_*` columns matching the JSON/headers (column list: `enter.pollinations.ai/observability/datasources/generation_event.datasource`).
+- Confirm a row exists for your model with non-zero `token_count_*` and `token_price_*` columns matching the JSON/headers (column list: `enter.pollinations.ai/observability/datasources/generation_event_v2.datasource`).
 - **No row is written for cache HITs** (`isBilledUsage: false` at `gen.pollinations.ai/src/middleware/track.ts:395`). HIT-call verification stops at the `X-Cache: HIT` header.
 
-`model_health` returns counts/errors/latency only, no usage. Query `generation_event` directly to see token + price columns:
+`model_health` returns counts/errors/latency only, no usage. Query `generation_event_v2` directly to see token + price columns:
 ```bash
 TB="https://api.europe-west2.gcp.tinybird.co"
 SQL="SELECT resolved_model_requested AS model, start_time,
@@ -430,7 +430,7 @@ SQL="SELECT resolved_model_requested AS model, start_time,
   token_count_completion_text, token_count_completion_reasoning,
   token_count_completion_image, token_count_completion_video_seconds,
   total_cost, total_price, dev_price, markup_rate
- FROM generation_event
+ FROM generation_event_v2
  WHERE resolved_model_requested = '$MODEL'
    AND start_time >= now() - interval 10 minute
  ORDER BY start_time DESC
@@ -464,7 +464,7 @@ In a separate terminal during testing:
 1. Map to one of the **13 typed usage fields** in `shared/registry/usage-headers.ts` (`promptTextTokens`, `promptCachedTokens`, `promptAudioTokens`, `promptAudioSeconds`, `promptImageTokens`, `promptVideoTokens`, `completionTextTokens`, `completionReasoningTokens`, `completionAudioTokens`, `completionAudioSeconds`, `completionImageTokens`, `completionVideoSeconds`, `completionVideoTokens`),
 2. AND have a corresponding entry in the registry `cost` block (reasoning tokens are an exception — they're rewritten to `completionTextTokens` in `registry.ts:118` before rate lookup, so they don't need a separate cost line; but `completionTextTokens` itself must exist),
 3. AND surface in the response headers as `x-usage-<kebab-case-name>`,
-4. AND land in the Tinybird `generation_event` row via `track.ts`,
+4. AND land in the Tinybird `generation_event_v2` row via `track.ts`,
 5. AND appear in the worker logs (`wrangler tail`) so we can audit historical drift.
 
 If a field exists upstream that we don't map → either extend `usage-headers.ts` + the registry + the Tinybird schema, OR document explicitly in the PR why we're intentionally dropping it (rare; usually "provider bundles X into Y").
@@ -493,7 +493,7 @@ grep -iE "^x-usage-" /tmp/headers.txt
 # 4. Pull the actual billing row Tinybird wrote (wait ~5s for ingest)
 sleep 5
 TB="https://api.europe-west2.gcp.tinybird.co"
-SQL="SELECT * FROM generation_event
+SQL="SELECT * FROM generation_event_v2
  WHERE resolved_model_requested = '$MODEL'
    AND start_time >= now() - interval 2 minute
  ORDER BY start_time DESC LIMIT 1 FORMAT JSON"
@@ -543,8 +543,7 @@ This is acceptable. What's NOT acceptable is silently dropping a separately-bill
                                           test/media-cache.test.ts \
                                           test/text-cache.test.ts \
                                           test/billing-deduction.test.ts \
-                                          test/tracking-observability.test.ts \
-                                          test/openai-schema.test.ts)
+                                          test/tracking-observability.test.ts)
 
 # Modality-specific (run the relevant subset)
 (cd gen.pollinations.ai && npx vitest run test/image/)         # for image models

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -762,6 +762,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000001,
     },
   },
+  "longcat": {
+    "cost": {
+      "completionTextTokens": 0.0000012,
+      "promptCachedTokens": 0.000000006,
+      "promptTextTokens": 0.0000003,
+    },
+    "price": {
+      "completionTextTokens": 0.0000012,
+      "promptCachedTokens": 0.000000006,
+      "promptTextTokens": 0.0000003,
+    },
+  },
   "mercury": {
     "cost": {
       "completionTextTokens": 0.00000075,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -346,6 +346,14 @@ const models: ModelDefinition[] = [
         ),
     },
     {
+        name: "longcat",
+        config: portkeyConfig["meituan/longcat-2.0"],
+        transform: pipe(
+            sanitizeToolSchemas,
+            createReasoningEffortTransform("toggle"),
+        ),
+    },
+    {
         name: "mimo-v2.5",
         config: portkeyConfig["xiaomi/mimo-v2.5"],
         transform: stripCacheControl,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -170,6 +170,16 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
+    "meituan/longcat-2.0": () =>
+        createOpenRouterModelConfig({
+            model: "meituan/longcat-2.0",
+            defaultOptions: {
+                provider: {
+                    only: ["atlas-cloud/fp8"],
+                    allow_fallbacks: false,
+                },
+            },
+        }),
 
     // -- OpenRouter (Gemma) ---------------------------------------------------
     // Moved off DeepInfra: OpenRouter serves the same SKU ~cheaper ($0.06/$0.33

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -81,6 +81,7 @@ describe("reasoning_effort model wiring", () => {
         "kimi-code",
         "deepseek",
         "qwen-large",
+        "longcat",
         "minimax",
     ])("disables thinking via reasoning_effort=none on %s", async (modelName) => {
         const transform = findModelByName(modelName)?.transform;

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -45,6 +45,16 @@ describe("resolveModelConfig", () => {
         expect(result.options.model).toBe("us.amazon.nova-micro-v1:0");
     });
 
+    it("pins longcat to the exact OpenRouter endpoint without fallback", () => {
+        const result = resolveModelConfig(messages, { model: "longcat" });
+
+        expect(result.options.model).toBe("meituan/longcat-2.0");
+        expect(result.options.provider).toEqual({
+            only: ["atlas-cloud/fp8"],
+            allow_fallbacks: false,
+        });
+    });
+
     it.each([
         "perplexity-high",
         "perplexity-deep",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1229,6 +1229,30 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "longcat": {
+        aliases: ["longcat-2.0", "longcat-2"],
+        provider: "openrouter",
+        brand: "Meituan",
+        category: "text",
+        addedDate: new Date("2026-07-23").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter AtlasCloud FP8 route rates (2026-07-23).
+            promptTextTokens: perMillion(0.3),
+            promptCachedTokens: perMillion(0.006),
+            completionTextTokens: perMillion(1.2),
+        },
+        title: "LongCat 2.0",
+        description:
+            "Long-context reasoning for coding agents and repository-scale tasks",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "mimo-v2.5": {
         aliases: ["mimo", "mimo-2.5"],
         provider: "openrouter",


### PR DESCRIPTION
- Adds the paid-only `longcat` text service with `longcat-2.0` and `longcat-2` aliases, 1M context, reasoning, and function tools.
- Routes `meituan/longcat-2.0` through OpenRouter's exact `atlas-cloud/fp8` endpoint with `allow_fallbacks: false`; no Pollinations GPU and no fallback.
- Prices input at $0.30/M, cached input at $0.006/M, and output/reasoning at $1.20/M with multiplier `1`, matching the [live endpoint](https://openrouter.ai/api/v1/models/meituan/longcat-2.0/endpoints).
- Updates route/reasoning tests, aliases and effective-price snapshots; also fixes stale `generation_event_v2` and removed-test references in the model-management skill.
- Verified direct and local text, aliases, streaming, reasoning on/off, `max_tokens=1`, forced tools (9/9 valid), prompt caching, paid-only filtering, malformed requests, usage headers, Tinybird rows, and 5/15/30-request bursts. Both workers type-check; 418 focused tests pass. Local telemetry recorded 75 requests, zero 5xx, zero fallbacks, and P95 4.9s.

Contract: canonical `longcat`; aliases `longcat-2.0`, `longcat-2`; registry provider OpenRouter; primary OpenRouter → AtlasCloud FP8; paid-only yes; multiplier 1; Pollinations GPU no; fallback none.

Note: one exploratory automatic tool-selection response produced malformed tool output; exact forced tool selection passed every direct and local repetition.
