### PR TITLE
chore: allow gggff123 community publishing

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -27,6 +27,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     113566110, // riofndev
     188266626, // solarnode-developement
     183505255, // timemachine-studio
+    228371309, // gggff123
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds GitHub user `gggff123` (`228371309`) to the community-model publisher allowlist.
- Keeps the change scoped to the existing static allowlist.
- Verified the branch is one commit ahead with a one-line diff.

Fixes #12634