### PR TITLE
docs: point generation-event references at v2

### DIFF
--- a/.claude/skills/abuse-detection/SKILL.md
+++ b/.claude/skills/abuse-detection/SKILL.md
@@ -12,7 +12,7 @@ description: Detect and analyze abusive accounts on Pollinations. IP clustering,
 **Tinybird query pattern:**
 ```bash
 cd enter.pollinations.ai/observability
-tb --cloud sql "SELECT ... FROM generation_event ..."
+tb --cloud sql "SELECT ... FROM generation_event_v2 ..."
 ```
 
 > **Workspace**: This skill is **prod-only**. The `.tinyb` in `observability/` points to the `pollinations_enter` workspace (prod traffic). Staging traffic lives in `pollinations_enter_staging` and has no real abuse signal — don't waste time analyzing it. To pin a query to staging anyway (e.g. testing a new scoring query), set `TB_TOKEN=<staging_admin_token>` for that one command.
@@ -74,7 +74,7 @@ FROM (
         count() as total_reqs,
         round(sumIf(g.total_price, g.selected_meter_slug IN ('v1:meter:pack', 'local:pack')), 4) as pack_spend,
         countIf(g.response_status >= 400) * 100.0 / count() as err_pct
-    FROM generation_event g
+    FROM generation_event_v2 g
     WHERE g.start_time >= now() - INTERVAL 7 DAY
         AND g.user_id NOT IN ('undefined', '')
     GROUP BY g.user_id
@@ -123,12 +123,12 @@ FROM (
                if(countIf(g.moderation_prompt_sexual_severity NOT IN ('safe', '')) * 100.0 / count() >= 50, 8, 0)) +
             if(countDistinct(g.ip_hash) >= 50, 10, if(countDistinct(g.ip_hash) >= 20, 5, 0))
         , 0) as abuse_score
-    FROM generation_event g
+    FROM generation_event_v2 g
     LEFT JOIN d1_user u ON g.user_id = u.id
         AND u.synced_at = (SELECT max(synced_at) FROM d1_user)
     LEFT JOIN (
         SELECT ip_hash, count(DISTINCT user_id) as ip_cluster_size
-        FROM generation_event
+        FROM generation_event_v2
         WHERE start_time >= now() - INTERVAL 7 DAY
             AND ip_hash NOT IN ('undefined', '')
             AND user_id NOT IN ('undefined', '')
@@ -154,7 +154,7 @@ SELECT
     count(DISTINCT user_id) as unique_users,
     count() as total_requests,
     dateDiff('minute', min(start_time), max(start_time)) as span_min
-FROM generation_event
+FROM generation_event_v2
 WHERE start_time >= now() - INTERVAL 7 DAY
     AND ip_hash NOT IN ('undefined', '')
     AND user_id NOT IN ('undefined', '')
@@ -171,7 +171,7 @@ SELECT DISTINCT
     g.user_id, u.github_username, u.email,
     sumIf(g.total_price, g.selected_meter_slug IN ('v1:meter:pack', 'local:pack')) as pack_spend,
     sum(g.total_price) as total_spend
-FROM generation_event g
+FROM generation_event_v2 g
 LEFT JOIN d1_user u ON g.user_id = u.id
     AND u.synced_at = (SELECT max(synced_at) FROM d1_user)
 WHERE g.start_time >= now() - INTERVAL 7 DAY
@@ -301,7 +301,7 @@ npx wrangler d1 execute production-pollinations-enter-db --remote \
 
 | Table | Key columns for abuse |
 |-------|----------------------|
-| `generation_event` | `user_id`, `ip_hash`, `ip_subnet`, `response_status`, `total_price`, `selected_meter_slug`, `moderation_prompt_*`, `event_type` |
+| `generation_event_v2` | `user_id`, `ip_hash`, `ip_subnet`, `response_status`, `total_price`, `selected_meter_slug`, `moderation_prompt_*`, `event_type` |
 | `d1_user` | `id`, `email`, `github_username`, `banned`, `banReason`, `created_at` |
 
 **IP implementation** (`src/middleware/track.ts`):

--- a/.claude/skills/model-debugging/SKILL.md
+++ b/.claude/skills/model-debugging/SKILL.md
@@ -529,13 +529,13 @@ curl -s "https://api.europe-west2.gcp.tinybird.co/v0/pipes/model_health.json?tok
 
 ### Raw SQL Queries
 
-The prod `TINYBIRD_READ_TOKEN` above can query the raw `generation_event` datasource directly via `/v0/sql` (verified). Reuse `$TB`:
+The prod `TINYBIRD_READ_TOKEN` above can query the raw `generation_event_v2` datasource directly via `/v0/sql` (verified). Reuse `$TB`:
 
 ```bash
 # Find users with frequent 403 errors (last 24 hours)
 curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TB" \
   --data-urlencode "q=SELECT user_id, user_github_username, user_tier, count() as error_403_count
-FROM generation_event
+FROM generation_event_v2
 WHERE response_status = 403
   AND start_time > now() - interval 24 hour
   AND user_id != ''
@@ -547,7 +547,7 @@ LIMIT 20"
 # Find users with 500 errors (actual backend issues)
 curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TB" \
   --data-urlencode "q=SELECT user_github_username, model_requested, error_message, count() as error_count 
-FROM generation_event 
+FROM generation_event_v2 
 WHERE response_status >= 500 
   AND start_time > now() - interval 24 hour 
 GROUP BY user_github_username, model_requested, error_message 
@@ -557,7 +557,7 @@ LIMIT 20"
 # Check specific user's recent errors
 curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TB" \
   --data-urlencode "q=SELECT start_time, response_status, model_requested, error_message 
-FROM generation_event 
+FROM generation_event_v2 
 WHERE user_github_username = 'USERNAME_HERE' 
   AND start_time > now() - interval 24 hour 
 ORDER BY start_time DESC 
@@ -566,7 +566,7 @@ LIMIT 50"
 
 ### Datasource Schema
 
-The `generation_event` datasource is defined in `enter.pollinations.ai/observability/datasources/generation_event.datasource` and includes:
+The `generation_event_v2` datasource is defined in `enter.pollinations.ai/observability/datasources/generation_event_v2.datasource` and includes:
 - `user_id`, `user_github_username`, `user_tier`
 - `response_status`, `error_message`, `error_response_code`
 - `model_requested`, `model_used`

--- a/.claude/skills/model-debugging/scripts/check-user-errors.sh
+++ b/.claude/skills/model-debugging/scripts/check-user-errors.sh
@@ -22,7 +22,7 @@ if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
 fi
 
 QUERY="SELECT start_time, response_status, model_requested, error_message 
-FROM generation_event 
+FROM generation_event_v2 
 WHERE user_github_username = '$USERNAME' 
   AND start_time > now() - interval $HOURS hour 
 ORDER BY start_time DESC 

--- a/.claude/skills/model-debugging/scripts/find-402-users.sh
+++ b/.claude/skills/model-debugging/scripts/find-402-users.sh
@@ -17,7 +17,7 @@ if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
 fi
 
 QUERY="SELECT user_github_username, count() as error_count
-FROM generation_event 
+FROM generation_event_v2 
 WHERE response_status = 402 
   AND start_time > now() - interval $HOURS hour 
   AND user_github_username != '' 

--- a/.claude/skills/model-debugging/scripts/find-403-users.sh
+++ b/.claude/skills/model-debugging/scripts/find-403-users.sh
@@ -17,7 +17,7 @@ if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
 fi
 
 QUERY="SELECT user_github_username, count() as error_count
-FROM generation_event 
+FROM generation_event_v2 
 WHERE response_status = 403 
   AND start_time > now() - interval $HOURS hour 
   AND user_github_username != '' 

--- a/.claude/skills/model-debugging/scripts/find-500-errors.sh
+++ b/.claude/skills/model-debugging/scripts/find-500-errors.sh
@@ -16,7 +16,7 @@ if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
 fi
 
 QUERY="SELECT user_github_username, model_requested, error_message, count() as error_count 
-FROM generation_event 
+FROM generation_event_v2 
 WHERE response_status >= 500 
   AND start_time > now() - interval $HOURS hour 
 GROUP BY user_github_username, model_requested, error_message 

--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -90,7 +90,7 @@ client → gen.pollinations.ai → upstream provider
          enter.pollinations.ai (dashboard, auth, Stripe surfaces)
 ```
 
-**Generation does not go through Enter, and neither does billing tracking.** Gen reads the shared D1/KV bindings directly to validate tokens, check balances, and apply model permissions. Gen also sends the `generation_event` directly to Tinybird (`gen.pollinations.ai/src/middleware/track.ts:290`). The `ENTER` service binding is invoked in only three places:
+**Generation does not go through Enter, and neither does billing tracking.** Gen reads the shared D1/KV bindings directly to validate tokens, check balances, and apply model permissions. Gen also sends the `generation_event_v2` directly to Tinybird (`gen.pollinations.ai/src/middleware/track.ts:290`). The `ENTER` service binding is invoked in only three places:
 
 | File:line | Call site purpose |
 |---|---|
@@ -225,7 +225,7 @@ Provider/runtime secrets (Azure, OpenAI, OpenRouter API keys, etc.) belong in `g
 | `shared/registry/registry.ts` | `convertUsage()` — where missing cost keys log `[registry] Missing conversion rate`. `completionReasoningTokens` is rewritten to `completionTextTokens` **before** the rate lookup (line 118), so it never produces this warning. If you see the warning for reasoning, it actually means `completionTextTokens` is missing. |
 | `shared/registry/usage-headers.ts` | `x-usage-*` header builder/parser; defines every typed usage field (13 total) |
 | `shared/registry/price-helpers.ts` | `perMillion()`, `priceMultiplier` math (`price = usage × cost × priceMultiplier`, rounded to 8 decimals) |
-| `gen.pollinations.ai/src/middleware/track.ts` | Builds the `generation_event` row sent to Tinybird; cache HITs are flagged `isBilledUsage: false` (line 395) |
+| `gen.pollinations.ai/src/middleware/track.ts` | Builds the `generation_event_v2` row sent to Tinybird; cache HITs are flagged `isBilledUsage: false` (line 395) |
 | `enter.pollinations.ai/frontend/src/components/models/model-info.ts` + `frontend/public/brand-logos/*.svg` | Catalog brand-to-logo mapping and monochrome SVG assets |
 
 ### `priceMultiplier`

--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -235,7 +235,7 @@ TOKEN=$(grep ENTER_API_TOKEN_REMOTE enter.pollinations.ai/.testingtokens | cut -
 for i in 1 2 3 4 5; do curl -s -o /dev/null -w "HTTP %{http_code}\n" --max-time 60 \
   "https://gen.pollinations.ai/image/verify_${i}_$(date +%s%N)?model=zimage&width=512&height=512&seed=$i" \
   -H "Authorization: Bearer $TOKEN"; done
-# Then confirm the 524 trend dropped in Tinybird (model_health / generation_event, model_requested='zimage').
+# Then confirm the 524 trend dropped in Tinybird (model_health / generation_event_v2, model_requested='zimage').
 ```
 
 The registry is Cloudflare KV-backed (`image:server:<env>:<type>:<hash>`, 240s TTL); workers heartbeat to `gen.pollinations.ai/register`.

--- a/.claude/skills/spending-analysis/SKILL.md
+++ b/.claude/skills/spending-analysis/SKILL.md
@@ -50,14 +50,14 @@ curl -sS "https://api.europe-west2.gcp.tinybird.co/v0/sql" \
 ```bash
 curl -sS "https://api.europe-west2.gcp.tinybird.co/v0/sql" \
   -H "Authorization: Bearer $TINYBIRD_TOKEN" \
-  --data-urlencode "q=SELECT toStartOfWeek(start_time) AS week, splitByChar(':', selected_meter_slug)[-1] AS meter_source, sum(total_price) AS total_spend, count() AS requests FROM generation_event WHERE start_time >= now() - INTERVAL 60 DAY AND environment = 'production' GROUP BY week, meter_source ORDER BY week DESC FORMAT JSON" \
+  --data-urlencode "q=SELECT toStartOfWeek(start_time) AS week, splitByChar(':', selected_meter_slug)[-1] AS meter_source, sum(total_price) AS total_spend, count() AS requests FROM generation_event_v2 WHERE start_time >= now() - INTERVAL 60 DAY AND environment = 'production' GROUP BY week, meter_source ORDER BY week DESC FORMAT JSON" \
   | jq '.data'
 ```
 
 # Notes
 
 - `stripe_event` is the source of truth for pack-purchase revenue analytics.
-- `generation_event` records Pollen consumption, not cash revenue.
+- `generation_event_v2` records Pollen consumption, not cash revenue.
 - Both datasets use `user_id`, so revenue and usage can be joined directly.
 - The dashboard's `daily_stripe_revenue` pipe applies the same paid-event filter.
 - For pre-migration revenue history, note that Polar was the pre-Stripe merchant

--- a/.claude/skills/tinybird-deploy/SKILL.md
+++ b/.claude/skills/tinybird-deploy/SKILL.md
@@ -44,7 +44,8 @@ Always sanity-check which workspace a token targets before deploying: `tb --clou
 ```
 enter.pollinations.ai/observability/
 ├── datasources/       # Data source definitions (.datasource)
-│   ├── generation_event.datasource
+│   ├── generation_event_v2.datasource   # current ingest + analytics
+│   ├── generation_event.datasource      # archived (read-only, pre-v2)
 │   ├── polar_event.datasource
 │   ├── stripe_event.datasource
 │   └── ...

--- a/apps/operation/economics/ingest/connectors/bytedance.md
+++ b/apps/operation/economics/ingest/connectors/bytedance.md
@@ -19,7 +19,7 @@ Use when:
 Primary evidence sources:
 
 - Historical usage: Tinybird `op_pollen` rows where `vendor = 'bytedance'`.
-- Historical detail: bounded `generation_event` rows for old direct BytePlus models.
+- Historical detail: bounded `generation_event` (pre-v2 archive) rows for old direct BytePlus models.
 - Current Seedance/Seedream provider activity: use `replicate.md`.
 - Balance/expiry: BytePlus Console → Cost Center screenshot or export.
 - Cash: invoice, receipt, Wise, or `op_transactions`.
@@ -40,7 +40,8 @@ Collection steps:
    ORDER BY month
    ```
 
-2. If model detail is needed, query `generation_event` for the bounded period
+2. If model detail is needed, query `generation_event_v2` (or the archived
+   `generation_event` for periods before the v2 cutover) for the bounded period
    and the relevant `seedance*` / `seedream*` model names.
 3. Ask the operator for a current Cost Center screenshot when balance or expiry
    matters. The international Model Ark API exposes models and generation, not

--- a/apps/operation/economics/ingest/connectors/replicate.md
+++ b/apps/operation/economics/ingest/connectors/replicate.md
@@ -23,7 +23,7 @@ Primary evidence sources:
 - API recent predictions: `GET https://api.replicate.com/v1/predictions`
 - API model schema: `GET https://api.replicate.com/v1/models/{owner}/{name}`
 - Pricing evidence: public Replicate model pages. Pricing is not exposed in the model API.
-- Internal usage context: Tinybird `generation_event` rows where `model_provider = 'replicate'`.
+- Internal usage context: Tinybird `generation_event_v2` rows where `model_provider = 'replicate'`.
 
 Required credential:
 
@@ -95,7 +95,7 @@ Known traps:
 Reconciliation notes:
 
 - The invoice or Wise/card charge explains `op_transactions`.
-- Tinybird `generation_event.total_cost` explains internal per-model `op_cloud` attribution.
+- Tinybird `generation_event_v2.total_cost` explains internal per-model `op_cloud` attribution.
 - Replicate prediction exports can help find untracked model IDs, web-created predictions, status mix, and output metrics for video pricing.
 - If invoice total exceeds metered model cost, keep the raw model price unchanged unless independent model-level pricing evidence shows the model itself is underpriced.
 

--- a/apps/operation/economics/web/src/views/GpuTab.tsx
+++ b/apps/operation/economics/web/src/views/GpuTab.tsx
@@ -104,7 +104,7 @@ function computeBreakEven(
 }
 
 // GPU rent is attributed at vendor+month grain, not per-pod or per-model:
-// generation_event's provider field is real per-request ground truth, but a
+// generation_event_v2's provider field is real per-request ground truth, but a
 // pod's manually-entered "model" label isn't (one host can run several
 // models at once), so splitting rent across models would just be a guess
 // dressed up as precision. This is still biased when a vendor's Pollen

--- a/apps/operation/kpi/src/components/KPITrendTable.jsx
+++ b/apps/operation/kpi/src/components/KPITrendTable.jsx
@@ -94,7 +94,7 @@ export function KPITrendTable({ weeklyData, title }) {
             category: "Acquisition",
             format: "number",
             tooltip:
-                "Users who made at least one API request within 7 days of registration. Source: D1 + Tinybird (generation_event)",
+                "Users who made at least one API request within 7 days of registration. Source: D1 + Tinybird (generation_event_v2)",
         },
         {
             key: "activationRate",
@@ -111,7 +111,7 @@ export function KPITrendTable({ weeklyData, title }) {
             category: "Usage",
             format: "number",
             tooltip:
-                "Weekly Active Users: Unique users with at least one API request this week. Source: Tinybird (uniqExact(user_id) from generation_event)",
+                "Weekly Active Users: Unique users with at least one API request this week. Source: Tinybird (uniqExact(user_id) from generation_event_v2)",
         },
         {
             key: "tokens",
@@ -165,7 +165,7 @@ export function KPITrendTable({ weeklyData, title }) {
                     ? ((w.revenue - (w.costUsd || 0)) / w.revenue) * 100
                     : null,
             tooltip:
-                "Formula: (Revenue - COGS) / Revenue × 100. Higher is better. COGS = compute costs from generation_event.total_cost (GPU, tokens, providers).",
+                "Formula: (Revenue - COGS) / Revenue × 100. Higher is better. COGS = compute costs from generation_event_v2.total_cost (GPU, tokens, providers).",
         },
         {
             key: "revenuePerMTokens",

--- a/apps/operation/kpi/src/worker/index.ts
+++ b/apps/operation/kpi/src/worker/index.ts
@@ -205,7 +205,7 @@ app.get("/api/kpi/total-users", async (c) => {
 });
 
 // D7 Activations: users who made their first API request within 7 days of registration
-// Fully computed in Tinybird by joining d1_user with generation_event
+// Fully computed in Tinybird by joining d1_user with generation_event_v2
 app.get("/api/kpi/activations", async (c) => {
     const result = await fetchTinybird(c.env, "kpi_activations", {
         min_created_at: DATA_START_TIMESTAMP_SEC,


### PR DESCRIPTION
Follow-up to the v2 cutover (#12640/#12641). Complements #12674, which covers the Grafana dashboards and Tinybird pipes — no file overlap with that PR.

- Fixes 4 `model-debugging` scripts that still queried the frozen `generation_event`. These returned zero rows for any window after 2026-07-22 22:28 UTC — the only functional bug here.
- Updates skill queries and prose: `abuse-detection`, `spending-analysis`, `model-debugging`, `model-management`, `monitor-services`.
- Fixes KPI tooltips and economics connector docs that named the old datasource.

Kept the archived table where it is still correct: pre-v2 historical BytePlus lookups in `bytedance.md`, and the `tinybird-deploy` tree listing (both files exist, now labelled).

Verified: `abuse-detection` already excludes anonymous users in every query, so v2 is a safe swap. Ran the updated `find-500-errors` query against live v2 — returns current rows. Left `enter.pollinations.ai/wrangler.toml` alone: it only reads `.origin` off that URL, so the datasource name there is inert.