### PR TITLE
fix: require approval for production secret changes

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -57,7 +57,7 @@ Model approval never authorizes a provider-secret mutation. If the work would cr
 1. Stop and present the exact secret name (never its value), environments, reason, impact, execution order, verification, and rollback.
 2. Wait for a separate approval in the current conversation using: `Yes, you can rotate <SECRET_NAME> in <ENVIRONMENTS> now.`
 3. Treat general approval such as “go ahead,” “deploy,” “continue,” or confirmation of the model contract as insufficient.
-4. Use a dedicated secret-only PR and follow the rotation order in the repository `AGENTS.md`.
+4. Do not edit the secret or open or push its PR before approval. After approval, use a dedicated secret-only PR and follow the rotation order in the repository `AGENTS.md`.
 
 If exposure is suspected, report it immediately but do not mutate the credential before receiving this approval.
 

--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -50,6 +50,17 @@ If a value is unknown, inferred, conflicting, or route-dependent:
 
 For batch work, use one table row per model with every field above. The user may approve the complete table in one response, but no blank or inherited cells are allowed.
 
+### Additional approval gate for provider secrets
+
+Model approval never authorizes a provider-secret mutation. If the work would create, replace, rotate, revoke, regenerate, synchronize, or deploy a provider credential or encrypted SOPS value:
+
+1. Stop and present the exact secret name (never its value), environments, reason, impact, execution order, verification, and rollback.
+2. Wait for a separate approval in the current conversation using: `Yes, you can rotate <SECRET_NAME> in <ENVIRONMENTS> now.`
+3. Treat general approval such as “go ahead,” “deploy,” “continue,” or confirmation of the model contract as insufficient.
+4. Use a dedicated secret-only PR and follow the rotation order in the repository `AGENTS.md`.
+
+If exposure is suspected, report it immediately but do not mutate the credential before receiving this approval.
+
 Keep these concepts separate:
 
 - **Configured** provider/GPU describes the registry's intended primary route.
@@ -572,6 +583,7 @@ This is acceptable. What's NOT acceptable is silently dropping a separately-bill
 - [ ] `priceMultiplier` is set to the explicitly confirmed value
 - [ ] No 5xx in [error-path matrix](#76-error-paths--every-malformed-request-must-return-4xx-never-opaque-5xx)
 - [ ] Burst test passed at expected production concurrency
+- [ ] Any required provider-secret mutation has its own dedicated PR and a separate, scoped approval using the exact format required by `AGENTS.md`
 - [ ] PR description notes any docs/upstream discrepancies found and any bundled-modality choices
 - [ ] `APIDOCS.md` is untouched. It is regenerated from the live OpenAPI schema after production deploy; update source schemas/routes instead.
 
@@ -581,12 +593,14 @@ This is acceptable. What's NOT acceptable is silently dropping a separately-bill
 
 ## 11.1 SOPS — provider secrets
 
+The [additional provider-secret approval gate](#additional-approval-gate-for-provider-secrets) is mandatory before any command that changes these files. Inspection must not print secret values. SOPS edits, GitHub secret updates, provider-side key regeneration/revocation, and production secret synchronization are all separate secret mutations and must remain within the explicitly approved scope.
+
 ```bash
 # Inspect keys in a vars file
 sops --decrypt gen.pollinations.ai/secrets/prod.vars.json \
   | python3 -c "import json,sys; [print(k) for k in json.load(sys.stdin)]"
 
-# Add or update a key
+# Add or update a key — only after the explicit approval gate
 sops set gen.pollinations.ai/secrets/prod.vars.json '["KEY_NAME"]' '"value"'
 
 # Decrypt to .dev.vars for local dev

--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -11,67 +11,14 @@ on:
       - 'package-lock.json'
       - '.github/workflows/deploy-gen-cloudflare.yml'
   workflow_dispatch:
-    inputs:
-      sync_production_secrets:
-        description: 'Synchronize encrypted production secrets (requires approval)'
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: pollinations-cloudflare-production
   cancel-in-progress: false
 
 jobs:
-  preflight:
-    runs-on: ubuntu-latest
-    outputs:
-      sync_production_secrets: ${{ steps.secret-changes.outputs.sync }}
-      deployment_environment: ${{ steps.secret-changes.outputs.environment }}
-    steps:
-      - name: Require the production branch
-        shell: bash
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/production" ]]; then
-            echo "::error::Production deployments must run from the production branch."
-            exit 1
-          fi
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect production secret synchronization
-        id: secret-changes
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
-          MANUAL_SECRET_SYNC: ${{ inputs.sync_production_secrets }}
-        run: |
-          sync=false
-
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            sync="$MANUAL_SECRET_SYNC"
-          elif ! git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- \
-            gen.pollinations.ai/secrets/prod.vars.json; then
-            sync=true
-          fi
-
-          echo "sync=$sync" >> "$GITHUB_OUTPUT"
-          if [[ "$sync" == "true" ]]; then
-            echo "environment=production-secrets" >> "$GITHUB_OUTPUT"
-          else
-            echo "environment=production" >> "$GITHUB_OUTPUT"
-          fi
-
   deploy:
-    needs: preflight
     runs-on: ubuntu-latest
-    # The production-secrets environment is restricted to the production branch
-    # and requires manual approval from its configured reviewer.
-    environment: ${{ needs.preflight.outputs.deployment_environment }}
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
     steps:
@@ -113,7 +60,6 @@ jobs:
         run: npm run deploy:production --workspace pollinations-gen
 
       - name: Push generation secrets
-        if: needs.preflight.outputs.sync_production_secrets == 'true'
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GEN }}

--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -11,14 +11,67 @@ on:
       - 'package-lock.json'
       - '.github/workflows/deploy-gen-cloudflare.yml'
   workflow_dispatch:
+    inputs:
+      sync_production_secrets:
+        description: 'Synchronize encrypted production secrets (requires approval)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: pollinations-cloudflare-production
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  preflight:
     runs-on: ubuntu-latest
+    outputs:
+      sync_production_secrets: ${{ steps.secret-changes.outputs.sync }}
+      deployment_environment: ${{ steps.secret-changes.outputs.environment }}
+    steps:
+      - name: Require the production branch
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/production" ]]; then
+            echo "::error::Production deployments must run from the production branch."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect production secret synchronization
+        id: secret-changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          MANUAL_SECRET_SYNC: ${{ inputs.sync_production_secrets }}
+        run: |
+          sync=false
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            sync="$MANUAL_SECRET_SYNC"
+          elif ! git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- \
+            gen.pollinations.ai/secrets/prod.vars.json; then
+            sync=true
+          fi
+
+          echo "sync=$sync" >> "$GITHUB_OUTPUT"
+          if [[ "$sync" == "true" ]]; then
+            echo "environment=production-secrets" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: preflight
+    runs-on: ubuntu-latest
+    # The production-secrets environment is restricted to the production branch
+    # and requires manual approval from its configured reviewer.
+    environment: ${{ needs.preflight.outputs.deployment_environment }}
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
     steps:
@@ -60,6 +113,7 @@ jobs:
         run: npm run deploy:production --workspace pollinations-gen
 
       - name: Push generation secrets
+        if: needs.preflight.outputs.sync_production_secrets == 'true'
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - Require a new approval in the current conversation after presenting that plan. General instructions such as “go ahead,” “fix it,” “deploy,” “continue,” or approval for the surrounding model/task work do not count.
 - Required approval format: `Yes, you can rotate <SECRET_NAME> in <ENVIRONMENTS> now.`
 - Approval is valid only for the named secret, environments, and one described operation. Never reuse or broaden it.
+- Do not edit a secret file, change provider/GitHub secret state, or open or push a secret-change PR before receiving that approval.
 - If exposure is suspected, report it immediately and stop. Do not revoke or rotate until the explicit approval is received.
 - Read-only inspection may continue, but never print, echo, log, or otherwise expose secret values.
 - Encrypted secret-file changes must use a dedicated PR. Never bundle them into a model, feature, pricing, or refactor PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,13 +76,29 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - No backward-compat fallbacks — clean breaks beat bloat. When changing tokens/headers/APIs, update all consumers at once.
 - When user says "keep it simple" — one function, one price, one config. Simplest thing that works.
 
+## Secret Mutation Safety
+
+**CRITICAL — never mutate a secret without the user's separate, explicit, scoped approval.**
+
+- A secret mutation includes creating, replacing, rotating, revoking, regenerating, synchronizing, or deploying a credential, token, API key, certificate, GitHub secret, provider secret, or encrypted SOPS value.
+- Before any mutation, stop and state the exact secret name (never its value), environments, reason, expected impact, execution order, verification, and rollback.
+- Require a new approval in the current conversation after presenting that plan. General instructions such as “go ahead,” “fix it,” “deploy,” “continue,” or approval for the surrounding model/task work do not count.
+- Required approval format: `Yes, you can rotate <SECRET_NAME> in <ENVIRONMENTS> now.`
+- Approval is valid only for the named secret, environments, and one described operation. Never reuse or broaden it.
+- If exposure is suspected, report it immediately and stop. Do not revoke or rotate until the explicit approval is received.
+- Read-only inspection may continue, but never print, echo, log, or otherwise expose secret values.
+- Encrypted secret-file changes must use a dedicated PR. Never bundle them into a model, feature, pricing, or refactor PR.
+- Never synchronize production secrets from an unmerged commit or a branch other than `production`.
+- For rotation, add and verify the replacement first, merge the encrypted update, deploy from `production`, run live tests for every affected service, and only then revoke the previous credential.
+
 ## Cloudflare Production Deployment Safety
 
 **CRITICAL — production Cloudflare deployments must always run through GitHub Actions:**
 
 - Use the service's production deployment workflow, such as `Deploy / gen.pollinations.ai`; use `workflow_dispatch` when path filters do not trigger it.
+- Dispatch production workflows only from the `production` branch. Select a secret-synchronization input only after the Secret Mutation Safety approval gate.
 - Never run `wrangler deploy --env production`, a production deployment npm script, or a direct production Worker upload from a local machine or agent session.
-- If CI credentials lack a required permission, update the scoped GitHub Actions secret and rerun the workflow. Never bypass CI with a local Cloudflare OAuth session.
+- If CI credentials lack a required permission, follow the Secret Mutation Safety approval gate before updating the scoped GitHub Actions secret and rerunning the workflow. Never bypass CI with a local Cloudflare OAuth session.
 - After the workflow succeeds, verify the active Worker version and required bindings before testing production traffic.
 
 ## Tinybird Deployment Safety


### PR DESCRIPTION
- Adds a mandatory, explicit, scoped approval gate before any secret edit or secret-change PR
- Defines the exact approval sentence and prevents general task approval from counting
- Adds the same checkpoint to the model-management skill and its SOPS procedure
- Requires secret changes to remain separate from model and feature PRs
- Does not modify workflows, environments, or credential values