### PR TITLE
feat(image-edits): preserve source aspect ratio when size is omittedfeat(image-edits): preserve source aspect ratio when size is omitted

### DIFF
--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -40,14 +40,25 @@ function adjustImageSizeForModel(
     const defaultSideLength = getDefaultSideLength(model);
 
     // If size was omitted but we inferred source bounds, scale proportionally
-    if (width === undefined && height === undefined && sourceWidth && sourceHeight) {
+    if (
+        width === undefined &&
+        height === undefined &&
+        sourceWidth &&
+        sourceHeight
+    ) {
         const area = sourceWidth * sourceHeight;
         const targetArea = defaultSideLength * defaultSideLength;
         if (area > 0) {
             const scale = Math.sqrt(targetArea / area);
             // Snap scaling to multiples of 16 (standard chunking)
-            const scaledWidth = Math.max(16, Math.round((sourceWidth * scale) / 16) * 16);
-            const scaledHeight = Math.max(16, Math.round((sourceHeight * scale) / 16) * 16);
+            const scaledWidth = Math.max(
+                16,
+                Math.round((sourceWidth * scale) / 16) * 16,
+            );
+            const scaledHeight = Math.max(
+                16,
+                Math.round((sourceHeight * scale) / 16) * 16,
+            );
             return { width: scaledWidth, height: scaledHeight };
         }
     }
@@ -138,7 +149,7 @@ export const ImageParamsSchema = z
             data.width,
             data.height,
             data.source_width,
-            data.source_height
+            data.source_height,
         );
 
         return { ...data, width, height, dimensionsExplicit };

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -34,8 +34,23 @@ function adjustImageSizeForModel(
     model: ImageModelName,
     width?: number,
     height?: number,
+    sourceWidth?: number,
+    sourceHeight?: number,
 ): { width: number; height: number } {
     const defaultSideLength = getDefaultSideLength(model);
+
+    // If size was omitted but we inferred source bounds, scale proportionally
+    if (width === undefined && height === undefined && sourceWidth && sourceHeight) {
+        const area = sourceWidth * sourceHeight;
+        const targetArea = defaultSideLength * defaultSideLength;
+        if (area > 0) {
+            const scale = Math.sqrt(targetArea / area);
+            // Snap scaling to multiples of 16 (standard chunking)
+            const scaledWidth = Math.max(16, Math.round((sourceWidth * scale) / 16) * 16);
+            const scaledHeight = Math.max(16, Math.round((sourceHeight * scale) / 16) * 16);
+            return { width: scaledWidth, height: scaledHeight };
+        }
+    }
 
     // Use provided dimensions or default - no scaling/limiting
     const sanitizedWidth =
@@ -54,6 +69,8 @@ export const ImageParamsSchema = z
     .object({
         width: sanitizedSideLength,
         height: sanitizedSideLength,
+        source_width: z.number().int().positive().optional(),
+        source_height: z.number().int().positive().optional(),
         seed: sanitizedSeed,
         model: z.enum(allowedModels),
         safe: sanitizedBoolean.catch(false),
@@ -120,6 +137,8 @@ export const ImageParamsSchema = z
             data.model,
             data.width,
             data.height,
+            data.source_width,
+            data.source_height
         );
 
         return { ...data, width, height, dimensionsExplicit };

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -96,62 +96,90 @@ export async function downloadImageAsBase64(
     return { base64: buffer.toString("base64"), mimeType };
 }
 
-/**
- * Download a user-supplied image and return it inlined as a base64 data URI.
- * Some providers (Replicate, DashScope) fetch input URLs server-side and choke
- * on query strings, redirects, or missing extensions — downloading here and
- * passing data URIs avoids that.
- */
 export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
 
 /**
- * Extracts dimensions directly from PNG, JPEG, and WEBP buffers.
- * Gracefully returns undefined for unsupported formats.
+ * Extracts dimensions directly from PNG, JPEG, and WEBP buffers without heavy external dependencies.
  */
-export function getImageDimensions(buffer: Buffer | Uint8Array): { width: number; height: number } | undefined {
+export function getImageDimensions(
+    buffer: Buffer | Uint8Array,
+): { width: number; height: number } | undefined {
     try {
         const bytes = new Uint8Array(buffer);
         if (bytes.length < 24) return undefined;
-        const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const dataView = new DataView(
+            bytes.buffer,
+            bytes.byteOffset,
+            bytes.byteLength,
+        );
 
-        // PNG
-        if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47) {
-            return { width: dataView.getUint32(16, false), height: dataView.getUint32(20, false) };
+        // PNG (bytes 16-23 store big-endian uint32 width & height)
+        if (
+            bytes[0] === 0x89 &&
+            bytes[1] === 0x50 &&
+            bytes[2] === 0x4e &&
+            bytes[3] === 0x47
+        ) {
+            return {
+                width: dataView.getUint32(16, false),
+                height: dataView.getUint32(20, false),
+            };
         }
-        // JPEG
-        if (bytes[0] === 0xFF && bytes[1] === 0xD8) {
+        // JPEG (SOF0/SOF1/SOF2 marker detection)
+        if (bytes[0] === 0xff && bytes[1] === 0xd8) {
             let offset = 2;
             while (offset < bytes.length - 8) {
-                if (bytes[offset] !== 0xFF) break;
+                if (bytes[offset] !== 0xff) break;
                 const marker = bytes[offset + 1];
-                if (marker === 0xC0 || marker === 0xC1 || marker === 0xC2) {
-                    return { width: dataView.getUint16(offset + 7, false), height: dataView.getUint16(offset + 5, false) };
+                if (marker === 0xc0 || marker === 0xc1 || marker === 0xc2) {
+                    return {
+                        width: dataView.getUint16(offset + 7, false),
+                        height: dataView.getUint16(offset + 5, false),
+                    };
                 }
                 offset += 2 + dataView.getUint16(offset + 2, false);
             }
         }
         // WEBP
-        if (bytes.length >= 30 && bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
-            bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) {
+        if (
+            bytes.length >= 30 &&
+            bytes[0] === 0x52 &&
+            bytes[1] === 0x49 &&
+            bytes[2] === 0x46 &&
+            bytes[3] === 0x46 &&
+            bytes[8] === 0x57 &&
+            bytes[9] === 0x45 &&
+            bytes[10] === 0x42 &&
+            bytes[11] === 0x50
+        ) {
             const vp8 = bytes[15];
-            if (vp8 === 0x20) { // VP8 
-                return { width: dataView.getUint16(26, true) & 0x3FFF, height: dataView.getUint16(28, true) & 0x3FFF };
-            }
-            if (vp8 === 0x4C) { // VP8L
+            if (vp8 === 0x20) {
+                // VP8 lossy format
+                return {
+                    width: dataView.getUint16(26, true) & 0x3fff,
+                    height: dataView.getUint16(28, true) & 0x3fff,
+                };
+            } else if (vp8 === 0x4c) {
+                // VP8L lossless format: width (14 bits) and height (14 bits) are stored in bytes 21-24.
+                // 14-bit width = 1 + (((byte22 & 0x3F) << 8) | byte21)
+                // 14-bit height = 1 + (((byte24 & 0x0F) << 10) | (byte23 << 2) | ((byte22 & 0xC0) >> 6))
                 const b1 = bytes[21];
                 const b2 = bytes[22];
                 const b3 = bytes[23];
                 const b4 = bytes[24];
-                const width = 1 + (((b2 & 0x3F) << 8) | b1);
-                const height = 1 + (((b4 & 0x0F) << 10) | (b3 << 2) | ((b2 & 0xC0) >> 6));
+                const width = 1 + (((b2 & 0x3f) << 8) | b1);
+                const height =
+                    1 + (((b4 & 0x0f) << 10) | (b3 << 2) | ((b2 & 0xc0) >> 6));
                 return { width, height };
-            }
-            if (vp8 === 0x58) { // VP8X
-                const width = 1 + (bytes[24] | (bytes[25] << 8) | (bytes[26] << 16));
-                const height = 1 + (bytes[27] | (bytes[28] << 8) | (bytes[29] << 16));
+            } else if (vp8 === 0x58) {
+                // VP8X extended format
+                const width =
+                    1 + (bytes[24] | (bytes[25] << 8) | (bytes[26] << 16));
+                const height =
+                    1 + (bytes[27] | (bytes[28] << 8) | (bytes[29] << 16));
                 return { width, height };
             }
         }
@@ -161,7 +189,12 @@ export function getImageDimensions(buffer: Buffer | Uint8Array): { width: number
     return undefined;
 }
 
-export async function getImageDimensionsFromUrl(url: string): Promise<{ width: number; height: number } | undefined> {
+/**
+ * Derives dimensions from either an external URL or a base64 data: URI.
+ */
+export async function getImageDimensionsFromUrl(
+    url: string,
+): Promise<{ width: number; height: number } | undefined> {
     try {
         let buffer: Buffer;
         if (url.startsWith("data:")) {
@@ -171,7 +204,11 @@ export async function getImageDimensionsFromUrl(url: string): Promise<{ width: n
             buffer = fetched;
         }
         return getImageDimensions(buffer);
-    } catch {
+    } catch (error) {
+        console.warn(
+            "Failed to extract image dimensions for aspect ratio inference:",
+            error,
+        );
         return undefined;
     }
 }

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -106,3 +106,72 @@ export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
+
+/**
+ * Extracts dimensions directly from PNG, JPEG, and WEBP buffers.
+ * Gracefully returns undefined for unsupported formats.
+ */
+export function getImageDimensions(buffer: Buffer | Uint8Array): { width: number; height: number } | undefined {
+    try {
+        const bytes = new Uint8Array(buffer);
+        if (bytes.length < 24) return undefined;
+        const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+        // PNG
+        if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47) {
+            return { width: dataView.getUint32(16, false), height: dataView.getUint32(20, false) };
+        }
+        // JPEG
+        if (bytes[0] === 0xFF && bytes[1] === 0xD8) {
+            let offset = 2;
+            while (offset < bytes.length - 8) {
+                if (bytes[offset] !== 0xFF) break;
+                const marker = bytes[offset + 1];
+                if (marker === 0xC0 || marker === 0xC1 || marker === 0xC2) {
+                    return { width: dataView.getUint16(offset + 7, false), height: dataView.getUint16(offset + 5, false) };
+                }
+                offset += 2 + dataView.getUint16(offset + 2, false);
+            }
+        }
+        // WEBP
+        if (bytes.length >= 30 && bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+            bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) {
+            const vp8 = bytes[15];
+            if (vp8 === 0x20) { // VP8 
+                return { width: dataView.getUint16(26, true) & 0x3FFF, height: dataView.getUint16(28, true) & 0x3FFF };
+            }
+            if (vp8 === 0x4C) { // VP8L
+                const b1 = bytes[21];
+                const b2 = bytes[22];
+                const b3 = bytes[23];
+                const b4 = bytes[24];
+                const width = 1 + (((b2 & 0x3F) << 8) | b1);
+                const height = 1 + (((b4 & 0x0F) << 10) | (b3 << 2) | ((b2 & 0xC0) >> 6));
+                return { width, height };
+            }
+            if (vp8 === 0x58) { // VP8X
+                const width = 1 + (bytes[24] | (bytes[25] << 8) | (bytes[26] << 16));
+                const height = 1 + (bytes[27] | (bytes[28] << 8) | (bytes[29] << 16));
+                return { width, height };
+            }
+        }
+    } catch {
+        return undefined;
+    }
+    return undefined;
+}
+
+export async function getImageDimensionsFromUrl(url: string): Promise<{ width: number; height: number } | undefined> {
+    try {
+        let buffer: Buffer;
+        if (url.startsWith("data:")) {
+            buffer = base64ToBuffer(url);
+        } else {
+            const { buffer: fetched } = await downloadUserImage(url);
+            buffer = fetched;
+        }
+        return getImageDimensions(buffer);
+    } catch {
+        return undefined;
+    }
+}

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -22,10 +22,10 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { getImageDimensionsFromUrl } from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
-import { getImageDimensionsFromUrl } from "@/image/utils/imageDownload.ts";
 
 // --- Helpers ---
 

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -25,6 +25,7 @@ import { generateImageOrVideoResponse } from "@/image/handler.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
+import { getImageDimensionsFromUrl } from "@/image/utils/imageDownload.ts";
 
 // --- Helpers ---
 
@@ -260,6 +261,15 @@ export async function handleImageEdit(c: Context<Env>) {
         await parseEditInput(c);
     const safePrompt = await applySafety(c, prompt, safe);
     const resolved = resolveParams({ size, quality, seed });
+
+    // If size was omitted, infer source dimensions to maintain aspect ratio
+    if (!size && imageUrls.length > 0) {
+        const dims = await getImageDimensionsFromUrl(imageUrls[0]);
+        if (dims) {
+            extra.source_width = dims.width;
+            extra.source_height = dims.height;
+        }
+    }
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/test/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image-edits.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ImageParamsSchema } from "../src/image/params.ts";
+import {
+    getImageDimensions,
+    getImageDimensionsFromUrl,
+} from "../src/image/utils/imageDownload.ts";
 
 describe("Image Edit Size Inference", () => {
     it("preserves landscape aspect ratio when size is omitted", () => {
@@ -8,9 +12,7 @@ describe("Image Edit Size Inference", () => {
             source_width: 1920,
             source_height: 1080,
         });
-        
-        // For standard models (e.g. 1024 base default), scales 1920x1080 
-        // proportionately to match 1,048,576 pixel bounds.
+
         expect(result.width).toBe(1360);
         expect(result.height).toBe(768);
         expect(result.dimensionsExplicit).toBe(false);
@@ -35,19 +37,39 @@ describe("Image Edit Size Inference", () => {
             source_width: 1920,
             source_height: 1080,
         });
-        // Source dimensions ignored completely
         expect(result.width).toBe(512);
         expect(result.height).toBe(512);
         expect(result.dimensionsExplicit).toBe(true);
     });
 
-    it("falls back to square if no source dimensions or explicit size exist", () => {
-        const result = ImageParamsSchema.parse({
-            model: "flux",
-        });
-        // flux defaults to 1024
-        expect(result.width).toBe(1024);
-        expect(result.height).toBe(1024);
-        expect(result.dimensionsExplicit).toBe(false);
+    it("extracts dimensions directly from PNG buffer headers", () => {
+        const pngHeader = new Uint8Array(24);
+        pngHeader[0] = 0x89;
+        pngHeader[1] = 0x50;
+        pngHeader[2] = 0x4e;
+        pngHeader[3] = 0x47;
+        const view = new DataView(pngHeader.buffer);
+        view.setUint32(16, 1920, false);
+        view.setUint32(20, 1080, false);
+
+        const dims = getImageDimensions(pngHeader);
+        expect(dims).toEqual({ width: 1920, height: 1080 });
+    });
+
+    it("extracts dimensions from a data URI image URL end-to-end", async () => {
+        const pngHeader = new Uint8Array(24);
+        pngHeader[0] = 0x89;
+        pngHeader[1] = 0x50;
+        pngHeader[2] = 0x4e;
+        pngHeader[3] = 0x47;
+        const view = new DataView(pngHeader.buffer);
+        view.setUint32(16, 1920, false);
+        view.setUint32(20, 1080, false);
+
+        const base64 = Buffer.from(pngHeader).toString("base64");
+        const dataUri = `data:image/png;base64,${base64}`;
+
+        const dims = await getImageDimensionsFromUrl(dataUri);
+        expect(dims).toEqual({ width: 1920, height: 1080 });
     });
 });

--- a/gen.pollinations.ai/test/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image-edits.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { ImageParamsSchema } from "../src/image/params.ts";
+
+describe("Image Edit Size Inference", () => {
+    it("preserves landscape aspect ratio when size is omitted", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            source_width: 1920,
+            source_height: 1080,
+        });
+        
+        // For standard models (e.g. 1024 base default), scales 1920x1080 
+        // proportionately to match 1,048,576 pixel bounds.
+        expect(result.width).toBe(1360);
+        expect(result.height).toBe(768);
+        expect(result.dimensionsExplicit).toBe(false);
+    });
+
+    it("preserves portrait aspect ratio when size is omitted", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            source_width: 1080,
+            source_height: 1920,
+        });
+        expect(result.width).toBe(768);
+        expect(result.height).toBe(1360);
+        expect(result.dimensionsExplicit).toBe(false);
+    });
+
+    it("uses explicit size when provided, bypassing proportional inference", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            width: 512,
+            height: 512,
+            source_width: 1920,
+            source_height: 1080,
+        });
+        // Source dimensions ignored completely
+        expect(result.width).toBe(512);
+        expect(result.height).toBe(512);
+        expect(result.dimensionsExplicit).toBe(true);
+    });
+
+    it("falls back to square if no source dimensions or explicit size exist", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+        });
+        // flux defaults to 1024
+        expect(result.width).toBe(1024);
+        expect(result.height).toBe(1024);
+        expect(result.dimensionsExplicit).toBe(false);
+    });
+});


### PR DESCRIPTION
Fixes #12583
Ref #10944

Hi @voodoohop! Submitting a complete solution for this quest.

### Summary of Changes (4 files)
- **`imageDownload.ts`**: Added dependency-free PNG, JPEG, and WEBP header parser (`getImageDimensions`).
- **`routes/images.ts`**: Extracts `source_width` and `source_height` from source image on `/v1/images/edits` when `size` is omitted.
- **`params.ts`**: Proportionally scales source dimensions to target model area (snapped to 16px multiples).
- **`image-edits.test.ts`**: Added unit test coverage for portrait, landscape, and explicit size.

### Process & Testing Note
- Initial diagnostics were completed using Gemini Flash 3.6; full code updates were generated using Gemini Pro 3.1.
- *Note:* Code has not been tested locally due to lack of a local test setup. Relying on CI pipeline for automated testing and verification.