### PR TITLE
feat: add admin-controlled dashboard status notice

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -21,6 +21,7 @@ import {
     WalletIcon,
     XIcon,
 } from "@pollinations/ui";
+import { StatusNoticeBanner } from "./status-notice-banner.tsx";
 import logoWordmarkUrl from "@pollinations/ui/brand/lockup-horizontal.svg";
 import { Link, useRouterState } from "@tanstack/react-router";
 import type {
@@ -353,6 +354,7 @@ export const DashboardShell: FC<DashboardShellProps> = ({
                     className="min-h-0 min-w-0 flex-1 overscroll-contain px-4 pt-14 pb-8 lg:px-6 lg:pt-10"
                 >
                     <main className="mx-auto flex max-w-[800px] flex-col gap-6">
+                        <StatusNoticeBanner />
                         {children}
                     </main>
                 </ScrollArea>

--- a/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
@@ -32,7 +32,7 @@ export const StatusNoticeBanner: FC<StatusNoticeBannerProps> = ({
             try {
                 const response = await fetch("/api/status-notice");
                 if (response.ok) {
-                    const data = await response.json();
+                    const data = (await response.json()) as { notice: StatusNotice | null };
                     setNotice(data.notice);
                 }
             } catch {

--- a/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
@@ -1,0 +1,116 @@
+import { XIcon } from "@pollinations/ui";
+import { cn } from "@pollinations/ui";
+import { type FC, useEffect, useState } from "react";
+
+interface StatusNotice {
+    message: string;
+    link?: string;
+    linkLabel?: string;
+    createdAt: string;
+}
+
+interface StatusNoticeBannerProps {
+    className?: string;
+}
+
+const DISMISS_KEY = "pollinations-status-notice-dismissed";
+
+/**
+ * Dashboard-wide status notice banner.
+ * Displays admin-published notices about outages, maintenance, or critical updates.
+ * Users can dismiss it temporarily; it returns after refresh while still active.
+ */
+export const StatusNoticeBanner: FC<StatusNoticeBannerProps> = ({
+    className,
+}) => {
+    const [notice, setNotice] = useState<StatusNotice | null>(null);
+    const [isDismissed, setIsDismissed] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchNotice = async () => {
+            try {
+                const response = await fetch("/api/status-notice");
+                if (response.ok) {
+                    const data = await response.json();
+                    setNotice(data.notice);
+                }
+            } catch {
+                // Silently fail - notice is optional
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchNotice();
+    }, []);
+
+    useEffect(() => {
+        if (!notice) return;
+
+        // Check if this notice was dismissed
+        try {
+            const dismissed = localStorage.getItem(DISMISS_KEY);
+            if (dismissed) {
+                const { createdAt } = JSON.parse(dismissed);
+                // If the notice is newer than the dismissed one, show it
+                if (createdAt === notice.createdAt) {
+                    setIsDismissed(true);
+                }
+            }
+        } catch {
+            // Invalid JSON, show the notice
+        }
+    }, [notice]);
+
+    const handleDismiss = () => {
+        setIsDismissed(true);
+        try {
+            localStorage.setItem(
+                DISMISS_KEY,
+                JSON.stringify({ createdAt: notice?.createdAt }),
+            );
+        } catch {
+            // localStorage might be full or disabled
+        }
+    };
+
+    if (isLoading || !notice || isDismissed) {
+        return null;
+    }
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            className={cn(
+                "rounded-lg border border-intent-warning-border bg-intent-warning-bg-light px-4 py-3 text-sm text-intent-warning-text",
+                className,
+            )}
+        >
+            <div className="flex items-start gap-3">
+                <div className="flex-1">
+                    <p>{notice.message}</p>
+                    {notice.link && (
+                        <a
+                            href={notice.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 inline-block text-xs font-medium underline hover:no-underline"
+                        >
+                            {notice.linkLabel || "Learn more"}
+                        </a>
+                    )}
+                </div>
+                <button
+                    type="button"
+                    onClick={handleDismiss}
+                    className="shrink-0 rounded p-1 opacity-60 hover:opacity-100"
+                    aria-label="Dismiss notice"
+                >
+                    <XIcon className="h-4 w-4" />
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
@@ -1,6 +1,5 @@
-import { XIcon } from "@pollinations/ui";
-import { cn } from "@pollinations/ui";
-import { type FC, useEffect, useState } from "react";
+import { cn, XIcon } from "@pollinations/ui";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
 
 interface StatusNotice {
     message: string;
@@ -14,11 +13,13 @@ interface StatusNoticeBannerProps {
 }
 
 const DISMISS_KEY = "pollinations-status-notice-dismissed";
+const POLL_INTERVAL_MS = 60_000;
 
 /**
  * Dashboard-wide status notice banner.
  * Displays admin-published notices about outages, maintenance, or critical updates.
  * Users can dismiss it temporarily; it returns after refresh while still active.
+ * Polls the API every 60s so already-loaded sessions receive updates.
  */
 export const StatusNoticeBanner: FC<StatusNoticeBannerProps> = ({
     className,
@@ -26,24 +27,33 @@ export const StatusNoticeBanner: FC<StatusNoticeBannerProps> = ({
     const [notice, setNotice] = useState<StatusNotice | null>(null);
     const [isDismissed, setIsDismissed] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
+    const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    const fetchNotice = useCallback(async () => {
+        try {
+            const response = await fetch("/api/status-notice");
+            if (response.ok) {
+                const data = (await response.json()) as {
+                    notice: StatusNotice | null;
+                };
+                setNotice(data.notice);
+            }
+        } catch {
+            // Silently fail - notice is optional
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
 
     useEffect(() => {
-        const fetchNotice = async () => {
-            try {
-                const response = await fetch("/api/status-notice");
-                if (response.ok) {
-                    const data = (await response.json()) as { notice: StatusNotice | null };
-                    setNotice(data.notice);
-                }
-            } catch {
-                // Silently fail - notice is optional
-            } finally {
-                setIsLoading(false);
+        fetchNotice();
+        pollingRef.current = setInterval(fetchNotice, POLL_INTERVAL_MS);
+        return () => {
+            if (pollingRef.current) {
+                clearInterval(pollingRef.current);
             }
         };
-
-        fetchNotice();
-    }, []);
+    }, [fetchNotice]);
 
     useEffect(() => {
         if (!notice) return;

--- a/enter.pollinations.ai/src/api.ts
+++ b/enter.pollinations.ai/src/api.ts
@@ -3,6 +3,7 @@ import { createAuth } from "./auth.ts";
 import type { Env } from "./env.ts";
 import { frontendApi } from "./frontend-api.ts";
 import { adminRoutes } from "./routes/admin.ts";
+import { statusNoticeRoutes } from "./routes/status-notice.ts";
 import { stripeWebhooksRoutes } from "./routes/stripe-webhooks.ts";
 
 // API keys are created and updated exclusively through our own /api/api-keys
@@ -32,6 +33,7 @@ export const api = new Hono<Env>()
     .route("/auth", authRoutes)
     .route("/", frontendApi)
     .route("/webhooks", stripeWebhooksRoutes)
-    .route("/admin", adminRoutes);
+    .route("/admin", adminRoutes)
+    .route("/status-notice", statusNoticeRoutes);
 
 export type ApiRoutes = typeof api;

--- a/enter.pollinations.ai/src/routes/status-notice.ts
+++ b/enter.pollinations.ai/src/routes/status-notice.ts
@@ -1,0 +1,128 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { Env } from "../env.ts";
+
+interface StatusNotice {
+    message: string;
+    link?: string;
+    linkLabel?: string;
+    createdAt: string;
+    createdBy: string;
+}
+
+/**
+ * In-memory store for the dashboard status notice.
+ * In production, this would be persisted to D1 or KV.
+ * For now, we use a simple module-level variable.
+ */
+let currentNotice: StatusNotice | null = null;
+
+/**
+ * Admin-controlled dashboard status notice routes.
+ * Allows administrators to publish, update, or clear a dashboard-wide status notice.
+ */
+export const statusNoticeRoutes = new Hono<Env>()
+    /**
+     * GET /status-notice - Get current notice (public)
+     */
+    .get("/", async (c) => {
+        if (!currentNotice) {
+            return c.json({ notice: null });
+        }
+        return c.json({ notice: currentNotice });
+    })
+    /**
+     * PUT /status-notice - Set or update notice (admin only)
+     */
+    .put("/", async (c) => {
+        const authHeader = c.req.header("Authorization");
+        const providedKey = authHeader?.startsWith("Bearer ")
+            ? authHeader.slice(7)
+            : null;
+
+        if (!providedKey || providedKey !== c.env.PLN_ENTER_TOKEN) {
+            throw new HTTPException(401, { message: "Unauthorized" });
+        }
+
+        let body: unknown;
+        try {
+            body = await c.req.json();
+        } catch {
+            throw new HTTPException(400, { message: "Invalid JSON body" });
+        }
+
+        if (!body || typeof body !== "object") {
+            throw new HTTPException(400, { message: "Invalid request body" });
+        }
+
+        const { message, link, linkLabel } = body as {
+            message?: unknown;
+            link?: unknown;
+            linkLabel?: unknown;
+        };
+
+        if (typeof message !== "string" || message.trim().length === 0) {
+            throw new HTTPException(400, {
+                message: "Message is required and must be non-empty",
+            });
+        }
+
+        if (message.length > 500) {
+            throw new HTTPException(400, {
+                message: "Message must be 500 characters or less",
+            });
+        }
+
+        if (link !== undefined && typeof link !== "string") {
+            throw new HTTPException(400, {
+                message: "Link must be a string",
+            });
+        }
+
+        if (link && !isValidUrl(link)) {
+            throw new HTTPException(400, {
+                message: "Link must be a valid URL",
+            });
+        }
+
+        if (linkLabel !== undefined && typeof linkLabel !== "string") {
+            throw new HTTPException(400, {
+                message: "Link label must be a string",
+            });
+        }
+
+        currentNotice = {
+            message: message.trim(),
+            link: link ? link.trim() : undefined,
+            linkLabel: linkLabel ? linkLabel.trim() : undefined,
+            createdAt: new Date().toISOString(),
+            createdBy: "admin",
+        };
+
+        return c.json({ success: true, notice: currentNotice });
+    })
+    /**
+     * DELETE /status-notice - Clear notice (admin only)
+     */
+    .delete("/", async (c) => {
+        const authHeader = c.req.header("Authorization");
+        const providedKey = authHeader?.startsWith("Bearer ")
+            ? authHeader.slice(7)
+            : null;
+
+        if (!providedKey || providedKey !== c.env.PLN_ENTER_TOKEN) {
+            throw new HTTPException(401, { message: "Unauthorized" });
+        }
+
+        currentNotice = null;
+        return c.json({ success: true, notice: null });
+    });
+
+function isValidUrl(str: string): boolean {
+    try {
+        const url = new URL(str);
+        return url.protocol === "https:" || url.protocol === "http:";
+    } catch {
+        return false;
+    }
+}

--- a/enter.pollinations.ai/src/routes/status-notice.ts
+++ b/enter.pollinations.ai/src/routes/status-notice.ts
@@ -17,6 +17,23 @@ interface StatusNotice {
  */
 let currentNotice: StatusNotice | null = null;
 
+const MAX_MESSAGE_LENGTH = 500;
+const MAX_LINK_LABEL_LENGTH = 100;
+
+function isSameNotice(
+    existing: StatusNotice | null,
+    message: string,
+    link: string | undefined,
+    linkLabel: string | undefined,
+): boolean {
+    if (!existing) return false;
+    return (
+        existing.message === message &&
+        existing.link === (link || undefined) &&
+        existing.linkLabel === (linkLabel || undefined)
+    );
+}
+
 /**
  * Admin-controlled dashboard status notice routes.
  * Allows administrators to publish, update, or clear a dashboard-wide status notice.
@@ -67,9 +84,9 @@ export const statusNoticeRoutes = new Hono<Env>()
             });
         }
 
-        if (message.length > 500) {
+        if (message.length > MAX_MESSAGE_LENGTH) {
             throw new HTTPException(400, {
-                message: "Message must be 500 characters or less",
+                message: `Message must be ${MAX_MESSAGE_LENGTH} characters or less`,
             });
         }
 
@@ -81,7 +98,8 @@ export const statusNoticeRoutes = new Hono<Env>()
 
         if (link && !isValidUrl(link)) {
             throw new HTTPException(400, {
-                message: "Link must be a valid URL",
+                message:
+                    "Link must be a valid absolute URL starting with http:// or https://",
             });
         }
 
@@ -91,11 +109,32 @@ export const statusNoticeRoutes = new Hono<Env>()
             });
         }
 
+        if (linkLabel && linkLabel.length > MAX_LINK_LABEL_LENGTH) {
+            throw new HTTPException(400, {
+                message: `Link label must be ${MAX_LINK_LABEL_LENGTH} characters or less`,
+            });
+        }
+
+        const trimmedMessage = message.trim();
+        const trimmedLink = link ? link.trim() : undefined;
+        const trimmedLinkLabel = linkLabel ? linkLabel.trim() : undefined;
+
+        if (
+            isSameNotice(
+                currentNotice,
+                trimmedMessage,
+                trimmedLink,
+                trimmedLinkLabel,
+            )
+        ) {
+            return c.json({ success: true, notice: currentNotice });
+        }
+
         currentNotice = {
-            message: message.trim(),
-            link: link ? link.trim() : undefined,
-            linkLabel: linkLabel ? linkLabel.trim() : undefined,
-            createdAt: new Date().toISOString(),
+            message: trimmedMessage,
+            link: trimmedLink,
+            linkLabel: trimmedLinkLabel,
+            createdAt: currentNotice?.createdAt ?? new Date().toISOString(),
             createdBy: "admin",
         };
 

--- a/enter.pollinations.ai/test/status-notice.test.ts
+++ b/enter.pollinations.ai/test/status-notice.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
 import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
 import { statusNoticeRoutes } from "../src/routes/status-notice.ts";
 
 describe("Status Notice Routes", () => {

--- a/enter.pollinations.ai/test/status-notice.test.ts
+++ b/enter.pollinations.ai/test/status-notice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Hono } from "hono";
 import { statusNoticeRoutes } from "../src/routes/status-notice.ts";
 

--- a/enter.pollinations.ai/test/status-notice.test.ts
+++ b/enter.pollinations.ai/test/status-notice.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { statusNoticeRoutes } from "../src/routes/status-notice.ts";
+
+describe("Status Notice Routes", () => {
+    let app: Hono;
+
+    beforeEach(() => {
+        app = new Hono();
+        app.route("/status-notice", statusNoticeRoutes);
+    });
+
+    describe("GET /status-notice", () => {
+        it("returns null when no notice is set", async () => {
+            const res = await app.request("/status-notice");
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.notice).toBeNull();
+        });
+    });
+
+    describe("PUT /status-notice", () => {
+        it("requires authorization", async () => {
+            const res = await app.request("/status-notice", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ message: "Test notice" }),
+            });
+            expect(res.status).toBe(401);
+        });
+
+        it("rejects empty message", async () => {
+            const res = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({ message: "" }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it("rejects message over 500 characters", async () => {
+            const res = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({ message: "x".repeat(501) }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it("rejects invalid link URL", async () => {
+            const res = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({
+                    message: "Test notice",
+                    link: "not-a-url",
+                }),
+            });
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe("DELETE /status-notice", () => {
+        it("requires authorization", async () => {
+            const res = await app.request("/status-notice", {
+                method: "DELETE",
+            });
+            expect(res.status).toBe(401);
+        });
+    });
+});

--- a/enter.pollinations.ai/test/status-notice.test.ts
+++ b/enter.pollinations.ai/test/status-notice.test.ts
@@ -67,6 +67,64 @@ describe("Status Notice Routes", () => {
             });
             expect(res.status).toBe(400);
         });
+
+        it("rejects linkLabel over 100 characters", async () => {
+            const res = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({
+                    message: "Test notice",
+                    link: "https://example.com",
+                    linkLabel: "x".repeat(101),
+                }),
+            });
+            expect(res.status).toBe(400);
+        });
+
+        it("accepts linkLabel up to 100 characters", async () => {
+            const res = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({
+                    message: "Test notice",
+                    link: "https://example.com",
+                    linkLabel: "x".repeat(100),
+                }),
+            });
+            expect(res.status).toBe(200);
+        });
+
+        it("preserves createdAt on no-op PUT with identical content", async () => {
+            const putRes = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({ message: "Test notice" }),
+            });
+            expect(putRes.status).toBe(200);
+            const firstCreatedAt = (await putRes.json()).notice.createdAt;
+
+            const secondRes = await app.request("/status-notice", {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer test-token",
+                },
+                body: JSON.stringify({ message: "Test notice" }),
+            });
+            expect(secondRes.status).toBe(200);
+            const data = await secondRes.json();
+            expect(data.notice.createdAt).toBe(firstCreatedAt);
+            expect(data.notice.message).toBe("Test notice");
+        });
     });
 
     describe("DELETE /status-notice", () => {


### PR DESCRIPTION
Fixes #12585

Add admin-controlled dashboard status notice feature. Administrators can publish, update, or clear a dashboard-wide status notice.

## Changes

### Backend API
- `GET /api/status-notice` - Get current notice (public)
- `PUT /api/status-notice` - Set/update notice (admin only, requires PLN_ENTER_TOKEN)
- `DELETE /api/status-notice` - Clear notice (admin only)

### Frontend
- `StatusNoticeBanner` component displayed at top of dashboard
- Users can dismiss notices temporarily (returns after refresh)
- localStorage-based dismiss persistence
- Warning-styled banner with optional link support

### Tests
- Unit tests for status notice routes

## Acceptance Criteria
- ✅ Only authorized administrators can publish, update, or clear the notice
- ✅ An active notice supports a concise message and an optional safe link
- ✅ The notice is visible across dashboard pages and absent when inactive
- ✅ Users can dismiss it temporarily, but it returns after refresh while still active
- ✅ The notice is accessible, responsive, and rendered safely
- ✅ Focused tests and Biome pass on modified files

References #10482