### PR TITLE
feat: allow Takax62 to publish community models

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -28,6 +28,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     188266626, // solarnode-developement
     183505255, // timemachine-studio
     228371309, // gggff123
+    184364250, // Takax62
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds GitHub user ID `184364250` (`Takax62`) to the community model publisher allowlist.
- Keeps the change limited to the shared allowlist.

Fixes #12684