### PR TITLE
fix: include low-volume model stats

### DIFF
--- a/shared/utils/model-stats.ts
+++ b/shared/utils/model-stats.ts
@@ -2,8 +2,8 @@ import type { Logger } from "@logtape/logtape";
 import { cached } from "../cache.ts";
 
 export const TINYBIRD_MODEL_STATS_URL =
-    "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json?token=p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8&limit=200";
-const CACHE_KEY = "model-stats";
+    "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json?token=p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8&limit=5000";
+const CACHE_KEY = "model-stats-v2";
 const CACHE_TTL = 3600; // 1 hour
 
 // Raw Tinybird response format - no transformation needed


### PR DESCRIPTION
- Raises the public model-stats fetch limit from 200 to 5,000.
- Keeps the existing three-success reliability threshold unchanged.
- Rotates the cache key so community image estimates refresh immediately after deployment.

Root cause: Enter truncated Tinybird results to the 200 highest-volume models, excluding every current community image model.

Checks: `npx biome check shared/utils/model-stats.ts`; `git diff --check`; live `limit=1000` query returned all 243 eligible models.