### PR TITLE
fix: harden Klein against GPU OOMs

### DIFF
--- a/image.pollinations.ai/klein-runpod/handler.py
+++ b/image.pollinations.ai/klein-runpod/handler.py
@@ -14,16 +14,21 @@ import os
 import time
 from io import BytesIO
 
+# Reduce allocator fragmentation on long-running GPU workers. This must be set
+# before importing torch.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
 import torch
 import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException
 from PIL import Image, UnidentifiedImageError
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("klein")
 
 MODEL_ID = "black-forest-labs/FLUX.2-klein-4B"
+MAX_PIXELS = 1536 * 1536
 BACKEND_TOKEN = os.getenv("PLN_GPU_TOKEN")
 if not BACKEND_TOKEN:
     logger.critical("PLN_GPU_TOKEN not configured - refusing to start")
@@ -69,6 +74,17 @@ class ImageRequest(BaseModel):
     num_inference_steps: int = 4
     images: list[str] = Field(default=[], description="Base64-encoded reference images for editing")
 
+    @model_validator(mode="after")
+    def validate_total_pixels(self):
+        total_pixels = self.width * self.height
+        if total_pixels > MAX_PIXELS:
+            raise ValueError(
+                f"Requested {self.width}x{self.height} ({total_pixels:,} pixels) "
+                f"exceeds the {MAX_PIXELS:,}-pixel limit. "
+                "Maximum area is 1536x1536, 2048x1152, or equivalent."
+            )
+        return self
+
 
 @app.get("/health")
 async def health():
@@ -104,16 +120,38 @@ async def generate(request: ImageRequest, _=Depends(verify_backend_token)):
         if len(reference_images) == 1:
             reference_images = reference_images[0]
 
+    reference_count = min(len(request.images), 10)
+    logger.info(
+        "Generation started size=%dx%d reference_images=%d",
+        request.width,
+        request.height,
+        reference_count,
+    )
+
     t0 = time.time()
-    image = pipe(
-        image=reference_images,
-        prompt=prompt,
-        height=request.height,
-        width=request.width,
-        guidance_scale=request.guidance_scale,
-        num_inference_steps=request.num_inference_steps,
-        generator=generator,
-    ).images[0]
+    try:
+        image = pipe(
+            image=reference_images,
+            prompt=prompt,
+            height=request.height,
+            width=request.width,
+            guidance_scale=request.guidance_scale,
+            num_inference_steps=request.num_inference_steps,
+            generator=generator,
+        ).images[0]
+    except torch.OutOfMemoryError as error:
+        logger.error(
+            "CUDA OOM size=%dx%d reference_images=%d: %s",
+            request.width,
+            request.height,
+            reference_count,
+            error,
+        )
+        torch.cuda.empty_cache()
+        raise HTTPException(
+            status_code=503,
+            detail="GPU memory exhausted; use smaller dimensions or fewer reference images.",
+        ) from error
     elapsed = time.time() - t0
     logger.info(f"Generation took {elapsed:.2f}s ({request.width}x{request.height})")
 

--- a/image.pollinations.ai/klein-runpod/requirements.txt
+++ b/image.pollinations.ai/klein-runpod/requirements.txt
@@ -1,5 +1,5 @@
 torch>=2.5.0
-git+https://github.com/huggingface/diffusers.git
+git+https://github.com/huggingface/diffusers.git@01969142b55379991fee07608c9e7e8f80afced0
 transformers>=4.44.0
 huggingface-hub>=0.36.0
 accelerate>=0.33.0

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -663,8 +663,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.005,
         },
         title: "FLUX.2 Klein 4B",
-        description:
-            "Quick image generation and editing with solid quality per dollar",
+        description: "Fast image generation and editing up to 2.4 megapixels",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 10, // Pollinations self-hosted route cap.


### PR DESCRIPTION
## What changed

- Caps Klein output area at 2,359,296 pixels (1536×1536, 2048×1152, or equivalent); only 5 of 16,958 historical successes exceeded it.
- Enables expandable CUDA allocator segments, clears cached allocations after OOM, and returns a controlled 503.
- Logs only request dimensions and reference-image count before inference for safe incident diagnosis.
- Pins Diffusers to the exact commit running successfully in production and documents the 2.4 MP limit in the model description.

## Why

Twelve Klein requests failed in one burst because the RTX 3090 had 335 MiB free while PyTorch held 4.59 GiB reserved but unused. The worker recovered, but unrestricted image area allowed a single workload to repeatedly exhaust VRAM.

## Confirmed contract

`klein` / `flux-klein`; multiplier 1; not paid-only; Pollinations-operated Vast GPU; primary route Workers VPC → Vast Klein 4B; no fallback.

## Checks

- Klein boundary and synthetic OOM checks passed
- Image tests: 166 passed
- Registry/pricing tests: 285 passed
- Python compile, Biome, and diff checks passed