### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -782,6 +782,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000003,
     },
   },
+  "lyria-3-clip": {
+    "cost": {
+      "completionAudioTokens": 0.04,
+    },
+    "price": {
+      "completionAudioTokens": 0.04,
+    },
+  },
   "mercury": {
     "cost": {
       "completionTextTokens": 0.00000075,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -27,6 +27,7 @@ import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
 import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
+import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
@@ -53,12 +54,12 @@ const CreateSpeechRequestSchema = z
             .default("mp3")
             .meta({
                 description:
-                    "The audio format for the output. CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; eleven-sfx supports mp3 only.",
+                    "The audio format for the output. CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only.",
                 example: "mp3",
             }),
         duration: z.number().min(0.5).max(300).optional().meta({
             description:
-                "Output duration in seconds (elevenmusic 3-300; eleven-sfx 0.5-30)",
+                "Output duration in seconds (elevenmusic 3-300; lyria-3-clip fixed at 30; eleven-sfx 0.5-30)",
             example: 30,
         }),
         seconds: z.number().min(1).max(380).optional().meta({
@@ -822,6 +823,7 @@ const QWEN_TTS_ENDPOINT =
 
 const DEEPINFRA_TTS_ENDPOINT =
     "https://api.deepinfra.com/v1/openai/audio/speech";
+const LYRIA_3_CLIP_MODEL_ID = "lyria-3-clip-preview";
 const DEEPINFRA_CSM_MODEL_ID = "sesame/csm-1b";
 const CSM_AUDIO_FORMATS = ["mp3", "opus", "flac", "wav", "pcm"] as const;
 
@@ -831,6 +833,15 @@ const QWEN_TTS_MODEL_IDS = {
 } as const satisfies Partial<Record<AudioModelName, string>>;
 
 type QwenTtsModelName = keyof typeof QWEN_TTS_MODEL_IDS;
+
+type LyriaInteractionResponse = {
+    status?: string;
+    outputs?: Array<{
+        type?: string;
+        mime_type?: string;
+        data?: string;
+    }>;
+};
 
 const QWEN_TTS_OPENAI_VOICE_MAP: Record<string, string> = {
     alloy: "Chelsie",
@@ -848,6 +859,89 @@ const QWEN_TTS_OPENAI_VOICE_MAP: Record<string, string> = {
 
 function resolveQwenVoice(voice: string): string {
     return QWEN_TTS_OPENAI_VOICE_MAP[voice] ?? voice;
+}
+
+export async function generateLyria3Clip(opts: {
+    prompt: string;
+    durationSeconds?: number;
+    responseFormat: string;
+    projectId: string;
+    accessToken: string;
+    log: Logger;
+}): Promise<Response> {
+    const {
+        prompt,
+        durationSeconds,
+        responseFormat,
+        projectId,
+        accessToken,
+        log,
+    } = opts;
+
+    if (responseFormat !== "mp3") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `lyria-3-clip only supports mp3 output; response_format=${responseFormat} is not available.`,
+        });
+    }
+    if (durationSeconds !== undefined && durationSeconds !== 30) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "lyria-3-clip generates fixed 30-second clips; duration must be 30 or omitted.",
+        });
+    }
+    if (!projectId || !accessToken) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: "Lyria service is not configured",
+        });
+    }
+
+    const endpoint = `https://aiplatform.googleapis.com/v1beta1/projects/${projectId}/locations/global/interactions`;
+    const rawResponse = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({
+            model: LYRIA_3_CLIP_MODEL_ID,
+            input: [{ type: "text", text: prompt }],
+        }),
+    });
+    const response = await ensureUpstreamOk(rawResponse, endpoint);
+    const result = (await response.json()) as LyriaInteractionResponse;
+    const audio = result.outputs?.find(
+        (output) =>
+            output.type === "audio" &&
+            output.mime_type === "audio/mpeg" &&
+            typeof output.data === "string",
+    );
+
+    if (result.status !== "completed" || !audio?.data) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "Lyria returned no completed MP3 audio output",
+        });
+    }
+
+    const binary = atob(audio.data);
+    const audioBytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+        audioBytes[index] = binary.charCodeAt(index);
+    }
+
+    log.info("Lyria success: {bytes} bytes", {
+        bytes: audioBytes.byteLength,
+    });
+
+    return new Response(audioBytes, {
+        status: 200,
+        headers: {
+            "Content-Type": "audio/mpeg",
+            ...buildUsageHeaders("lyria-3-clip", {
+                // Vertex charges one fixed-price unit per generated clip.
+                completionAudioTokens: 1,
+            }),
+        },
+    });
 }
 
 function requireTextToAudioModel(
@@ -1588,6 +1682,31 @@ async function dispatchAudioGeneration(
         );
     }
 
+    if (c.var.model.resolved === "lyria-3-clip") {
+        const googleEnvKeys = [
+            "GOOGLE_PRIVATE_KEY",
+            "GOOGLE_PRIVATE_KEY_ID",
+            "GOOGLE_CLIENT_EMAIL",
+        ] as const;
+        for (const key of googleEnvKeys) {
+            const value = c.env[key];
+            if (typeof value === "string") process.env[key] = value;
+        }
+        const accessToken = await googleCloudAuth.getAccessToken();
+
+        return withSafetyHeaders(
+            c,
+            await generateLyria3Clip({
+                prompt: text,
+                durationSeconds: duration,
+                responseFormat,
+                projectId: c.env.GOOGLE_PROJECT_ID,
+                accessToken: accessToken ?? "",
+                log,
+            }),
+        );
+    }
+
     if (c.var.model.resolved === "stable-audio-3-medium") {
         return withSafetyHeaders(
             c,
@@ -1843,7 +1962,7 @@ export const audioRoutes = new Hono<Env>()
             description: [
                 "Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.",
                 "",
-                "Set `model` to `elevenmusic`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
+                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
                 "",
                 `**Available voices:** ${AUDIO_VOICES.join(", ")}`,
                 "",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -923,7 +923,7 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
                 "",
-                "**Music generation:** Set `model=elevenmusic`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.",
+                "**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.",
             ].join("\n"),
             responses: {
                 200: {
@@ -942,7 +942,7 @@ export const proxyRoutes = new Hono<Env>()
             z.object({
                 text: z.string().min(1).meta({
                     description:
-                        "Text to convert to speech, or a music description when model=elevenmusic",
+                        "Text to convert to speech, or a music description for a music-generation model",
                     example: "Hello, welcome to Pollinations!",
                 }),
             }),
@@ -963,12 +963,12 @@ export const proxyRoutes = new Hono<Env>()
                     .default("mp3")
                     .meta({
                         description:
-                            "Audio output format (TTS only). CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; eleven-sfx supports mp3 only.",
+                            "Audio output format. CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only.",
                         example: "mp3",
                     }),
                 model: z.string().optional().meta({
                     description:
-                        "Audio model: TTS (default) or elevenmusic for music generation",
+                        "Audio model: TTS (default) or a music-generation model such as lyria-3-clip",
                     example: "tts-1",
                 }),
                 duration: z
@@ -978,7 +978,7 @@ export const proxyRoutes = new Hono<Env>()
                     .pipe(z.number().min(0.5).max(300).optional())
                     .meta({
                         description:
-                            "Music duration in seconds, 3-300 (elevenmusic only)",
+                            "Music duration in seconds (elevenmusic 3-300; lyria-3-clip fixed at 30)",
                         example: "30",
                     }),
                 seconds: z.coerce.number().min(1).max(380).optional().meta({

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -7,6 +7,7 @@ import { getTextModelsInfo } from "@shared/registry/model-info.ts";
 import { test as fixtureTest } from "@shared/test/fixtures/index.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index.ts";
+import googleCloudAuth from "../src/text/auth/googleCloudAuth.ts";
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -721,6 +722,188 @@ fixtureTest(
         expect(calls).not.toContain(deepInfraEndpoint);
     },
 );
+
+fixtureTest(
+    "routes Lyria aliases through the Vertex interactions API",
+    async ({ paidApiKey }) => {
+        const endpoint =
+            "https://aiplatform.googleapis.com/v1beta1/projects/test-project/locations/global/interactions";
+        const calls: string[] = [];
+        vi.spyOn(googleCloudAuth, "getAccessToken").mockResolvedValue(
+            "test-google-token",
+        );
+
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+
+                if (request.url === endpoint) {
+                    expect(request.headers.get("authorization")).toBe(
+                        "Bearer test-google-token",
+                    );
+                    await expect(request.json()).resolves.toEqual({
+                        model: "lyria-3-clip-preview",
+                        input: [
+                            {
+                                type: "text",
+                                text: "bright French house with warm vocals",
+                            },
+                        ],
+                    });
+
+                    return Response.json({
+                        status: "completed",
+                        outputs: [
+                            { type: "text", text: "generated lyrics" },
+                            {
+                                type: "audio",
+                                mime_type: "audio/mpeg",
+                                data: "//uQZA==",
+                            },
+                        ],
+                    });
+                }
+
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/audio/bright%20French%20house%20with%20warm%20vocals?model=lyria&duration=30",
+                {
+                    headers: { Authorization: `Bearer ${paidApiKey}` },
+                },
+            ),
+            {
+                ...env,
+                GOOGLE_PROJECT_ID: "test-project",
+            } as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("audio/mpeg");
+        expect(response.headers.get("x-model-used")).toBe("lyria-3-clip");
+        expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
+            "1",
+        );
+        expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+            new Uint8Array([0xff, 0xfb, 0x90, 0x64]),
+        );
+
+        await waitOnExecutionContext(ctx);
+        expect(calls).toContain(endpoint);
+        expect(
+            calls.some((url) => new URL(url).hostname === "api.elevenlabs.io"),
+        ).toBe(false);
+    },
+);
+
+fixtureTest(
+    "rejects unsupported Lyria duration and output format",
+    async ({ paidApiKey }) => {
+        vi.spyOn(googleCloudAuth, "getAccessToken").mockResolvedValue(
+            "test-google-token",
+        );
+        const upstreamCalls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                upstreamCalls.push(request.url);
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const cases = [
+            {
+                body: {
+                    model: "lyria-3-clip",
+                    input: "slow ambient strings",
+                    duration: 20,
+                },
+                message: "fixed 30-second clips",
+            },
+            {
+                body: {
+                    model: "lyria-3",
+                    input: "slow ambient strings",
+                    response_format: "wav",
+                },
+                message: "only supports mp3",
+            },
+        ];
+
+        for (const testCase of cases) {
+            const ctx = createExecutionContext();
+            const response = await worker.fetch(
+                new Request(
+                    "https://staging.gen.pollinations.ai/v1/audio/speech",
+                    {
+                        method: "POST",
+                        headers: {
+                            Authorization: `Bearer ${paidApiKey}`,
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify(testCase.body),
+                    },
+                ),
+                {
+                    ...env,
+                    GOOGLE_PROJECT_ID: "test-project",
+                } as unknown as CloudflareBindings,
+                ctx,
+            );
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toMatchObject({
+                error: { message: expect.stringContaining(testCase.message) },
+            });
+            await waitOnExecutionContext(ctx);
+        }
+
+        expect(
+            upstreamCalls.some(
+                (url) => new URL(url).hostname === "aiplatform.googleapis.com",
+            ),
+        ).toBe(false);
+    },
+);
+
+it("lists Lyria with its aliases and text-to-audio modalities", async () => {
+    const response = await fetchWorker("/audio/models");
+
+    expect(response.status).toBe(200);
+    const models = (await response.json()) as {
+        name: string;
+        aliases?: string[];
+        input_modalities?: string[];
+        output_modalities?: string[];
+    }[];
+    const model = models.find((candidate) => candidate.name === "lyria-3-clip");
+    expect(model?.aliases).toEqual(["lyria", "lyria-3"]);
+    expect(model?.input_modalities).toEqual(["text"]);
+    expect(model?.output_modalities).toEqual(["audio"]);
+});
 
 fixtureTest(
     "routes stable-audio-3-medium requests through fal",

--- a/image.pollinations.ai/klein-runpod/handler.py
+++ b/image.pollinations.ai/klein-runpod/handler.py
@@ -14,16 +14,21 @@ import os
 import time
 from io import BytesIO
 
+# Reduce allocator fragmentation on long-running GPU workers. This must be set
+# before importing torch.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
 import torch
 import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException
 from PIL import Image, UnidentifiedImageError
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("klein")
 
 MODEL_ID = "black-forest-labs/FLUX.2-klein-4B"
+MAX_PIXELS = 1536 * 1536
 BACKEND_TOKEN = os.getenv("PLN_GPU_TOKEN")
 if not BACKEND_TOKEN:
     logger.critical("PLN_GPU_TOKEN not configured - refusing to start")
@@ -69,6 +74,17 @@ class ImageRequest(BaseModel):
     num_inference_steps: int = 4
     images: list[str] = Field(default=[], description="Base64-encoded reference images for editing")
 
+    @model_validator(mode="after")
+    def validate_total_pixels(self):
+        total_pixels = self.width * self.height
+        if total_pixels > MAX_PIXELS:
+            raise ValueError(
+                f"Requested {self.width}x{self.height} ({total_pixels:,} pixels) "
+                f"exceeds the {MAX_PIXELS:,}-pixel limit. "
+                "Maximum area is 1536x1536, 2048x1152, or equivalent."
+            )
+        return self
+
 
 @app.get("/health")
 async def health():
@@ -104,16 +120,38 @@ async def generate(request: ImageRequest, _=Depends(verify_backend_token)):
         if len(reference_images) == 1:
             reference_images = reference_images[0]
 
+    reference_count = min(len(request.images), 10)
+    logger.info(
+        "Generation started size=%dx%d reference_images=%d",
+        request.width,
+        request.height,
+        reference_count,
+    )
+
     t0 = time.time()
-    image = pipe(
-        image=reference_images,
-        prompt=prompt,
-        height=request.height,
-        width=request.width,
-        guidance_scale=request.guidance_scale,
-        num_inference_steps=request.num_inference_steps,
-        generator=generator,
-    ).images[0]
+    try:
+        image = pipe(
+            image=reference_images,
+            prompt=prompt,
+            height=request.height,
+            width=request.width,
+            guidance_scale=request.guidance_scale,
+            num_inference_steps=request.num_inference_steps,
+            generator=generator,
+        ).images[0]
+    except torch.OutOfMemoryError as error:
+        logger.error(
+            "CUDA OOM size=%dx%d reference_images=%d: %s",
+            request.width,
+            request.height,
+            reference_count,
+            error,
+        )
+        torch.cuda.empty_cache()
+        raise HTTPException(
+            status_code=503,
+            detail="GPU memory exhausted; use smaller dimensions or fewer reference images.",
+        ) from error
     elapsed = time.time() - t0
     logger.info(f"Generation took {elapsed:.2f}s ({request.width}x{request.height})")
 

--- a/image.pollinations.ai/klein-runpod/requirements.txt
+++ b/image.pollinations.ai/klein-runpod/requirements.txt
@@ -1,5 +1,5 @@
 torch>=2.5.0
-git+https://github.com/huggingface/diffusers.git
+git+https://github.com/huggingface/diffusers.git@01969142b55379991fee07608c9e7e8f80afced0
 transformers>=4.44.0
 huggingface-hub>=0.36.0
 accelerate>=0.33.0

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -140,6 +140,24 @@ export const AUDIO_SERVICES = {
         inputModalities: ["text", "audio"],
         outputModalities: ["audio"],
     },
+    "lyria-3-clip": {
+        aliases: ["lyria", "lyria-3"],
+        provider: "google",
+        brand: "Google",
+        category: "audio",
+        addedDate: new Date("2026-07-24").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        cost: {
+            // Vertex bills a fixed $0.04 for each 30-second generated clip.
+            completionAudioTokens: 0.04,
+        },
+        title: "Lyria 3 Clip",
+        description:
+            "30-second music with vocals, lyrics, or instrumental arrangements",
+        inputModalities: ["text"],
+        outputModalities: ["audio"],
+    },
     "eleven-sfx": {
         aliases: ["sfx", "sound-effects", "eleven-sound-effects"],
         provider: "elevenlabs",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -663,8 +663,7 @@ export const IMAGE_SERVICES = {
             completionImageTokens: 0.005,
         },
         title: "FLUX.2 Klein 4B",
-        description:
-            "Quick image generation and editing with solid quality per dollar",
+        description: "Fast image generation and editing up to 2.4 megapixels",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
         maxReferenceImages: 10, // Pollinations self-hosted route cap.


### PR DESCRIPTION
- Promotes the two commits merged through #12724 and #12725 from `main` to `production`.
- Adds paid-only Lyria 3 Clip music generation through Google Vertex with its validated fixed-price billing and aliases.
- Hardens Klein against GPU OOMs with an output-area cap, allocator tuning, controlled recovery, and diagnostic logging.
- Validation: both source PRs passed their focused tests, typechecks/compilation, formatting, linting, and CodeQL checks; the promotion diff contains no secret changes.