### PR TITLE
chore: promote main to production

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -609,7 +609,7 @@ curl -X POST "https://gen.pollinations.ai/v1/audio/music/upload" \
 
 Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.
 
-Set `model` to `elevenmusic`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.
+Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.
 
 **Available voices:** alloy, echo, fable, onyx, nova, shimmer, ash, ballad, coral, sage, verse, rachel, domi, bella, elli, charlotte, dorothy, sarah, emily, lily, matilda, adam, antoni, arnold, josh, sam, daniel, charlie, james, fin, callum, liam, george, brian, bill, conversational_a, conversational_b, read_speech_a, read_speech_b, read_speech_c, read_speech_d
 
@@ -691,17 +691,17 @@ Generate speech or music from text via a simple GET request.
 
 **Output formats:** mp3 (default), opus, aac, flac, wav, pcm
 
-**Music generation:** Set `model=elevenmusic`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.
+**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.
 
 ⚙️ **Parameters**
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `text` * | `path` | `string` | Text to convert to speech, or a music description when model=elevenmusic |
+| `text` * | `path` | `string` | Text to convert to speech, or a music description for a music-generation model |
 | `voice` | `query` | `string` | Voice to use for speech generation (TTS only) · default: `"alloy"` |
-| `response_format` | `query` | enum (6) — `"mp3"`, `"opus"`, `"aac"`, … | Audio output format (TTS only). CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; eleven-sfx supports mp3 only. · default: `"mp3"` |
-| `model` | `query` | `string` | Audio model: TTS (default) or elevenmusic for music generation |
-| `duration` | `query` | `string` | Music duration in seconds, 3-300 (elevenmusic only) |
+| `response_format` | `query` | enum (6) — `"mp3"`, `"opus"`, `"aac"`, … | Audio output format. CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only. · default: `"mp3"` |
+| `model` | `query` | `string` | Audio model: TTS (default) or a music-generation model such as lyria-3-clip |
+| `duration` | `query` | `string` | Music duration in seconds (elevenmusic 3-300; lyria-3-clip fixed at 30) |
 | `seconds` | `query` | `number` | Audio duration in seconds for stable-audio-3-medium/large, 1-380 · range: `1…380` |
 | `steps` | `query` | `integer` | Sampling steps (stable-audio-3-medium 1-100, stable-audio-3-large 4-8) · range: `1…100` |
 | `negative_prompt` | `query` | `string` | Negative prompt for stable-audio-3-large |

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -704,9 +704,7 @@ test("Google text models use OpenRouter without advertising code execution", () 
             publicModels.get(model)?.capabilities,
             `${model} public capabilities`,
         ).not.toContain("code_execution");
-        expect(definition.paidOnly, `${model} paid-only status`).toBe(
-            model !== "gemini-fast",
-        );
+        expect(definition.paidOnly, `${model} paid-only status`).toBe(true);
     }
 });
 

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -743,7 +743,8 @@ const generateImage = async (
             }
         }
 
-        case "nanobanana": {
+        case "nanobanana":
+        case "nanobanana-2": {
             logError(
                 "Nano Banana authentication check:",
                 formatAuthInfo(userInfo),
@@ -765,7 +766,6 @@ const generateImage = async (
             }
         }
 
-        case "nanobanana-2":
         case "nanobanana-2-lite":
         case "nanobanana-pro": {
             logError(

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -14,7 +14,10 @@ import {
     callIdeogramTurboAPI,
 } from "./models/ideogramReplicateModel.ts";
 import { callNovaCanvasAPI } from "./models/novaCanvasModel.ts";
-import { callOpenRouterGrokImagineProAPI } from "./models/openRouterImageModel.ts";
+import {
+    callOpenRouterGeminiImageAPI,
+    callOpenRouterGrokImagineProAPI,
+} from "./models/openRouterImageModel.ts";
 import {
     callPrunaImageAPI,
     callPrunaImageEditAPI,
@@ -740,7 +743,28 @@ const generateImage = async (
             }
         }
 
-        case "nanobanana":
+        case "nanobanana": {
+            logError(
+                "Nano Banana authentication check:",
+                formatAuthInfo(userInfo),
+            );
+
+            try {
+                if (safeParams.safe) {
+                    await requireSafePrompt(prompt, safeParams, userInfo);
+                }
+
+                return await callOpenRouterGeminiImageAPI(prompt, safeParams);
+            } catch (error) {
+                logError(
+                    "OpenRouter Gemini image generation or safety check failed:",
+                    error.message,
+                );
+                await logGptImageError(prompt, safeParams, userInfo, error);
+                throw error;
+            }
+        }
+
         case "nanobanana-2":
         case "nanobanana-2-lite":
         case "nanobanana-pro": {

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -744,7 +744,8 @@ const generateImage = async (
         }
 
         case "nanobanana":
-        case "nanobanana-2": {
+        case "nanobanana-2":
+        case "nanobanana-2-lite": {
             logError(
                 "Nano Banana authentication check:",
                 formatAuthInfo(userInfo),
@@ -766,7 +767,6 @@ const generateImage = async (
             }
         }
 
-        case "nanobanana-2-lite":
         case "nanobanana-pro": {
             logError(
                 "Nano Banana authentication check:",

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -52,7 +52,6 @@ import {
     convertToJpeg as transformToJpeg,
 } from "./utils/imageTransform.ts";
 import type { TrackingData } from "./utils/trackingHeaders.ts";
-import { callVertexAIGemini } from "./vertexAIImageGenerator.js";
 import { writeExifMetadata } from "./writeExifMetadata.ts";
 
 const SANA_BACKEND_URL = "https://ltx2-backend.pollinations.ai/generate";
@@ -778,10 +777,10 @@ const generateImage = async (
                     await requireSafePrompt(prompt, safeParams, userInfo);
                 }
 
-                return await callVertexAIGemini(prompt, safeParams);
+                return await callOpenRouterGeminiImageAPI(prompt, safeParams);
             } catch (error) {
                 logError(
-                    "Vertex AI Gemini image generation or safety check failed:",
+                    "OpenRouter Gemini image generation or safety check failed:",
                     error.message,
                 );
                 await logGptImageError(prompt, safeParams, userInfo, error);

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -1,20 +1,159 @@
+import type { Usage } from "@shared/registry/registry.ts";
 import debug from "debug";
 import type { ImageGenerationResult } from "../createAndReturnImages.ts";
 import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
-import { closestAspectRatio } from "../utils/aspectRatio.ts";
+import { closestAspectRatio, closestByRatio } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
-import { base64ToBuffer } from "../utils/imageDownload.ts";
+import { base64ToBuffer, toDataUri } from "../utils/imageDownload.ts";
+import { writeExifMetadata } from "../writeExifMetadata.ts";
 
 const logOps = debug("pollinations:openrouter-image:ops");
+const logError = debug("pollinations:openrouter-image:error");
 
 const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
 const GROK_IMAGINE_QUALITY_MODEL = "x-ai/grok-imagine-image-quality";
+const GEMINI_IMAGE_CONFIGS = {
+    nanobanana: {
+        upstreamModel: "google/gemini-2.5-flash-image",
+        provider: "google-vertex/global",
+        maxReferenceImages: 3,
+        generator: "Vertex AI Gemini 2.5 Flash Image",
+    },
+} as const;
+const GEMINI_ASPECT_RATIOS = [
+    { ratio: 1, label: "1:1" },
+    { ratio: 16 / 9, label: "16:9" },
+    { ratio: 9 / 16, label: "9:16" },
+    { ratio: 4 / 3, label: "4:3" },
+    { ratio: 3 / 4, label: "3:4" },
+    { ratio: 3 / 2, label: "3:2" },
+    { ratio: 2 / 3, label: "2:3" },
+    { ratio: 21 / 9, label: "21:9" },
+    { ratio: 4 / 5, label: "4:5" },
+    { ratio: 5 / 4, label: "5:4" },
+] as const;
 
 interface OpenRouterImageResponse {
-    data?: Array<{ b64_json?: string }>;
-    usage?: { cost?: number | null };
+    data?: Array<{ b64_json?: string; media_type?: string }>;
+    usage?: OpenRouterImageUsage;
+    error?:
+        | string
+        | {
+              message?: string;
+              type?: string;
+              metadata?: { error_type?: string };
+          };
+    message?: string;
+}
+
+interface OpenRouterImageUsage {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    cost?: number | null;
+    is_byok?: boolean;
+    prompt_tokens_details?: {
+        image_tokens?: number;
+    };
+    completion_tokens_details?: {
+        reasoning_tokens?: number;
+        image_tokens?: number;
+    };
+}
+
+function isTokenCount(value: unknown): value is number {
+    return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function invalidOpenRouterImageUsage(
+    usage: OpenRouterImageUsage | undefined,
+): never {
+    logError(
+        "OpenRouter returned invalid image billing usage:",
+        JSON.stringify(usage),
+    );
+    throw new HttpError(
+        "OpenRouter returned invalid image billing usage",
+        502,
+        usage,
+        OPENROUTER_IMAGE_URL,
+    );
+}
+
+function addUsage(usage: Usage, key: keyof Usage, amount: number) {
+    if (amount > 0) usage[key] = amount;
+}
+
+function buildOpenRouterNoImageError(data: OpenRouterImageResponse): HttpError {
+    const providerMessage =
+        typeof data.error === "string"
+            ? data.error
+            : data.error?.message || data.message;
+    const errorType =
+        typeof data.error === "object"
+            ? data.error.metadata?.error_type || data.error.type
+            : undefined;
+    const errorText = `${errorType ?? ""} ${providerMessage ?? ""}`;
+    const isContentRejection =
+        /content.?policy|prohibited|refusal|refused|safety/i.test(errorText);
+
+    return new HttpError(
+        providerMessage ||
+            (isContentRejection
+                ? "Image generation rejected by content policy"
+                : "OpenRouter Gemini image API returned no image"),
+        isContentRejection ? 400 : 502,
+        data,
+        OPENROUTER_IMAGE_URL,
+    );
+}
+
+export function mapOpenRouterGeminiImageUsage(
+    usage: OpenRouterImageUsage | undefined,
+): Usage {
+    if (
+        !usage ||
+        !isTokenCount(usage.prompt_tokens) ||
+        !isTokenCount(usage.completion_tokens) ||
+        !isTokenCount(usage.total_tokens) ||
+        !isTokenCount(usage.completion_tokens_details?.image_tokens)
+    ) {
+        invalidOpenRouterImageUsage(usage);
+    }
+
+    const promptTokens = usage.prompt_tokens;
+    const promptImageTokens = usage.prompt_tokens_details?.image_tokens ?? 0;
+    if (!isTokenCount(promptImageTokens) || promptImageTokens > promptTokens) {
+        invalidOpenRouterImageUsage(usage);
+    }
+
+    const completionTokens = usage.completion_tokens;
+    const completionImageTokens = usage.completion_tokens_details.image_tokens;
+    const completionReasoningTokens =
+        usage.completion_tokens_details.reasoning_tokens ?? 0;
+    const completionTextTokens =
+        completionTokens - completionImageTokens - completionReasoningTokens;
+    if (
+        !isTokenCount(completionReasoningTokens) ||
+        completionTextTokens < 0 ||
+        usage.total_tokens !== promptTokens + completionTokens
+    ) {
+        invalidOpenRouterImageUsage(usage);
+    }
+
+    const mapped: Usage = {};
+    addUsage(mapped, "promptImageTokens", promptImageTokens);
+    // The dedicated OpenRouter image API currently returns combined
+    // prompt_tokens without an input-image split. Gemini prices text and image
+    // input identically, so assigning the unsplit remainder to text preserves
+    // exact billing while retaining image tokens if OpenRouter adds the field.
+    addUsage(mapped, "promptTextTokens", promptTokens - promptImageTokens);
+    addUsage(mapped, "completionTextTokens", completionTextTokens);
+    addUsage(mapped, "completionReasoningTokens", completionReasoningTokens);
+    addUsage(mapped, "completionImageTokens", completionImageTokens);
+    return mapped;
 }
 
 export async function callOpenRouterGrokImagineProAPI(
@@ -84,6 +223,115 @@ export async function callOpenRouterGrokImagineProAPI(
                 ...(referenceImage ? { promptImageTokens: 1 } : {}),
                 completionImageTokens: 1,
             },
+        },
+    };
+}
+
+export async function callOpenRouterGeminiImageAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    const config =
+        GEMINI_IMAGE_CONFIGS[
+            safeParams.model as keyof typeof GEMINI_IMAGE_CONFIGS
+        ];
+    if (!config) {
+        throw new HttpError(
+            `Unsupported OpenRouter Gemini image model: ${safeParams.model}`,
+            400,
+        );
+    }
+    if (safeParams.image.length > config.maxReferenceImages) {
+        throw new HttpError(
+            `${safeParams.model} supports at most ${config.maxReferenceImages} reference images`,
+            400,
+        );
+    }
+
+    const apiKey = getImageEnv("OPENROUTER_API_KEY");
+    if (!apiKey) {
+        throw new HttpError(
+            "OPENROUTER_API_KEY environment variable is required",
+            500,
+        );
+    }
+
+    const requestBody: Record<string, unknown> = {
+        model: config.upstreamModel,
+        prompt,
+        n: 1,
+        aspect_ratio: closestByRatio(
+            safeParams.width,
+            safeParams.height,
+            GEMINI_ASPECT_RATIOS,
+        ).label,
+        seed: safeParams.seed,
+        provider: {
+            only: [config.provider],
+            allow_fallbacks: false,
+        },
+    };
+
+    if (safeParams.image.length > 0) {
+        const inputReferences = [];
+        for (const image of safeParams.image) {
+            inputReferences.push({
+                type: "image_url",
+                image_url: { url: await toDataUri(image) },
+            });
+        }
+        requestBody.input_references = inputReferences;
+    }
+
+    const response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+        errorLabel: "OpenRouter Gemini image generation request failed",
+    });
+    const data = (await response.json()) as OpenRouterImageResponse;
+    const encodedImage = data.data?.[0]?.b64_json;
+    if (!encodedImage) {
+        throw buildOpenRouterNoImageError(data);
+    }
+    const usage = mapOpenRouterGeminiImageUsage(data.usage);
+    const imageBuffer = base64ToBuffer(encodedImage);
+
+    let finalImageBuffer = imageBuffer;
+    try {
+        finalImageBuffer = await writeExifMetadata(
+            imageBuffer,
+            {
+                prompt,
+                model: safeParams.model,
+                width: safeParams.width,
+                height: safeParams.height,
+            },
+            {
+                generator: config.generator,
+                usage,
+            },
+        );
+    } catch (error) {
+        logError("Failed to add Gemini image EXIF metadata:", error);
+    }
+
+    logOps("Gemini image generation complete", {
+        actualModel: safeParams.model,
+        referenceImages: safeParams.image.length,
+        providerCost: data.usage?.cost,
+    });
+
+    return {
+        buffer: finalImageBuffer,
+        isMature: false,
+        isChild: false,
+        trackingData: {
+            actualModel: safeParams.model,
+            usage,
         },
     };
 }

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -39,6 +39,14 @@ const GEMINI_IMAGE_CONFIGS = {
         resolution: "tiered",
         reasoning: true,
     },
+    "nanobanana-2-lite": {
+        upstreamModel: "google/gemini-3.1-flash-lite-image",
+        provider: "google-vertex/global",
+        maxReferenceImages: 14,
+        generator: "Vertex AI Gemini 3.1 Flash-Lite Image",
+        resolution: "1K",
+        reasoning: true,
+    },
 } as const satisfies Record<string, GeminiImageConfig>;
 const GEMINI_ASPECT_RATIOS = [
     { ratio: 1, label: "1:1" },

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -47,6 +47,14 @@ const GEMINI_IMAGE_CONFIGS = {
         resolution: "1K",
         reasoning: true,
     },
+    "nanobanana-pro": {
+        upstreamModel: "google/gemini-3-pro-image",
+        provider: "google-ai-studio/global",
+        maxReferenceImages: 14,
+        generator: "Google AI Studio Gemini 3 Pro Image",
+        resolution: "tiered",
+        reasoning: false,
+    },
 } as const satisfies Record<string, GeminiImageConfig>;
 const GEMINI_ASPECT_RATIOS = [
     { ratio: 1, label: "1:1" },

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -14,14 +14,32 @@ const logError = debug("pollinations:openrouter-image:error");
 
 const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
 const GROK_IMAGINE_QUALITY_MODEL = "x-ai/grok-imagine-image-quality";
+type GeminiImageConfig = {
+    upstreamModel: string;
+    provider: string;
+    maxReferenceImages: number;
+    generator: string;
+    resolution: "none" | "tiered" | "1K";
+    reasoning: boolean;
+};
 const GEMINI_IMAGE_CONFIGS = {
     nanobanana: {
         upstreamModel: "google/gemini-2.5-flash-image",
         provider: "google-vertex/global",
         maxReferenceImages: 3,
         generator: "Vertex AI Gemini 2.5 Flash Image",
+        resolution: "none",
+        reasoning: false,
     },
-} as const;
+    "nanobanana-2": {
+        upstreamModel: "google/gemini-3.1-flash-image",
+        provider: "google-vertex/global",
+        maxReferenceImages: 14,
+        generator: "Vertex AI Gemini 3.1 Flash Image",
+        resolution: "tiered",
+        reasoning: true,
+    },
+} as const satisfies Record<string, GeminiImageConfig>;
 const GEMINI_ASPECT_RATIOS = [
     { ratio: 1, label: "1:1" },
     { ratio: 16 / 9, label: "16:9" },
@@ -156,6 +174,37 @@ export function mapOpenRouterGeminiImageUsage(
     return mapped;
 }
 
+function resolveGeminiImageResolution(
+    config: GeminiImageConfig,
+    safeParams: ImageParams,
+): "1K" | "2K" | "4K" | undefined {
+    if (config.resolution === "none") return undefined;
+    if (config.resolution === "1K") return "1K";
+
+    const totalPixels = safeParams.width * safeParams.height;
+    const tiers = [
+        { name: "1K" as const, pixels: 1024 * 1024 },
+        { name: "2K" as const, pixels: 1920 * 1080 },
+        { name: "4K" as const, pixels: 3840 * 2160 },
+    ];
+    return tiers.reduce((closest, tier) =>
+        Math.abs(tier.pixels - totalPixels) <
+        Math.abs(closest.pixels - totalPixels)
+            ? tier
+            : closest,
+    ).name;
+}
+
+function resolveGeminiReasoningEffort(
+    config: GeminiImageConfig,
+    safeParams: ImageParams,
+): "low" | "high" | undefined {
+    if (!config.reasoning || safeParams.reasoning === "balanced") {
+        return undefined;
+    }
+    return safeParams.reasoning === "fast" ? "low" : "high";
+}
+
 export async function callOpenRouterGrokImagineProAPI(
     prompt: string,
     safeParams: ImageParams,
@@ -271,6 +320,10 @@ export async function callOpenRouterGeminiImageAPI(
             allow_fallbacks: false,
         },
     };
+    const resolution = resolveGeminiImageResolution(config, safeParams);
+    if (resolution) requestBody.resolution = resolution;
+    const reasoningEffort = resolveGeminiReasoningEffort(config, safeParams);
+    if (reasoningEffort) requestBody.reasoning_effort = reasoningEffort;
 
     if (safeParams.image.length > 0) {
         const inputReferences = [];

--- a/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
@@ -184,3 +184,62 @@ test("nanobanana rejects usage that does not sum to its total", async ({
     expect(response.status, await response.clone().text()).toBe(502);
     await wait();
 });
+
+test("nanobanana-2 preserves 4K routing, reasoning, and exact billing", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "openrouter");
+    mocks.openrouter.state.usage = {
+        prompt_tokens: 12,
+        completion_tokens: 2524,
+        total_tokens: 2536,
+        cost: 0.151254,
+        prompt_tokens_details: {},
+        completion_tokens_details: {
+            reasoning_tokens: 4,
+            image_tokens: 2520,
+        },
+    };
+
+    const { response, wait } = await fetchWorker(
+        "/image/black%20circle?model=nanobanana-2&width=3840&height=2160&seed=42&reasoning=pro",
+        { headers: { authorization: `Bearer ${paidApiKey}` } },
+    );
+
+    expect(response.status, await response.clone().text()).toBe(200);
+    expect(response.headers.get("x-model-used")).toBe("nanobanana-2");
+    expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("12");
+    expect(response.headers.get("x-usage-completion-reasoning-tokens")).toBe(
+        "4",
+    );
+    expect(response.headers.get("x-usage-completion-image-tokens")).toBe(
+        "2520",
+    );
+    await response.arrayBuffer();
+    await wait();
+
+    expect(mocks.openrouter.state.requests).toHaveLength(1);
+    expect(mocks.openrouter.state.requests[0]).toMatchObject({
+        body: {
+            model: "google/gemini-3.1-flash-image",
+            resolution: "4K",
+            reasoning_effort: "high",
+            provider: {
+                only: ["google-vertex/global"],
+                allow_fallbacks: false,
+            },
+        },
+    });
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    const event = mocks.tinybird.state.events[0];
+    expect(event).toMatchObject({
+        modelRequested: "nanobanana-2",
+        tokenCountPromptText: 12,
+        tokenCountCompletionReasoning: 4,
+        tokenCountCompletionImage: 2520,
+    });
+    const expectedCost = (12 * 0.5 + 4 * 3 + 2520 * 60) / 1_000_000;
+    expect(event.totalCost).toBeCloseTo(expectedCost, 10);
+    expect(event.totalPrice).toBeCloseTo(expectedCost, 10);
+});

--- a/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
@@ -9,69 +9,51 @@ import {
     teardownFetchMock,
 } from "@shared/test/mocks/fetch.ts";
 import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
-import { afterEach, beforeEach, expect, vi } from "vitest";
+import { afterEach, expect } from "vitest";
+import { syncImageEnv } from "../../src/image/env.ts";
 import worker from "../../src/index.ts";
-import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
 
 const png1x1Base64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==";
-
-// The test env has no real service account key, so stub token minting.
-// beforeEach: the config's mock restoration would undo a beforeAll spy
-// after the first test.
-beforeEach(() => {
-    vi.spyOn(googleCloudAuth, "getAccessToken").mockResolvedValue(
-        "test-access-token",
-    );
-});
 
 afterEach(async () => {
     await teardownFetchMock();
 });
 
-type VertexState = {
+type OpenRouterState = {
     requests: Array<{ url: string; body: Record<string, unknown> }>;
-    usageMetadata: Record<string, unknown> | undefined;
+    usage: Record<string, unknown> | undefined;
 };
 
 function createNanobananaMocks() {
-    const vertexState: VertexState = {
+    const openRouterState: OpenRouterState = {
         requests: [],
-        usageMetadata: undefined,
+        usage: undefined,
     };
     return createFetchMock({
         tinybird: createMockTinybird(),
-        vertex: {
-            state: vertexState,
+        openrouter: {
+            state: openRouterState,
             handlerMap: {
-                "aiplatform.googleapis.com": async (request: Request) => {
-                    vertexState.requests.push({
+                "openrouter.ai": async (request: Request) => {
+                    openRouterState.requests.push({
                         url: request.url,
                         body: (await request.json()) as Record<string, unknown>,
                     });
                     return Response.json({
-                        candidates: [
+                        data: [
                             {
-                                content: {
-                                    parts: [
-                                        {
-                                            inlineData: {
-                                                mimeType: "image/png",
-                                                data: png1x1Base64,
-                                            },
-                                        },
-                                    ],
-                                },
-                                finishReason: "STOP",
+                                b64_json: png1x1Base64,
+                                media_type: "image/png",
                             },
                         ],
-                        usageMetadata: vertexState.usageMetadata,
+                        usage: openRouterState.usage,
                     });
                 },
             },
             reset: () => {
-                vertexState.requests = [];
-                vertexState.usageMetadata = undefined;
+                openRouterState.requests = [];
+                openRouterState.usage = undefined;
             },
         },
     });
@@ -82,6 +64,10 @@ const test = baseTest.extend<{
 }>({
     // biome-ignore lint/correctness/noEmptyPattern: vitest fixture pattern requires object destructuring
     mocks: async ({}, use) => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
         const mocks = createNanobananaMocks();
         await use(mocks);
     },
@@ -97,17 +83,21 @@ async function fetchWorker(path: string, init: RequestInit) {
     return { response, wait: () => waitOnExecutionContext(ctx) };
 }
 
-test("nanobanana bills exact Vertex usage end-to-end", async ({
+test("nanobanana bills exact OpenRouter usage end-to-end", async ({
     paidApiKey,
     mocks,
 }) => {
-    await mocks.enable("tinybird", "vertex");
-    mocks.vertex.state.usageMetadata = {
-        promptTokenCount: 11,
-        candidatesTokenCount: 1290,
-        totalTokenCount: 1301,
-        promptTokensDetails: [{ modality: "TEXT", tokenCount: 11 }],
-        candidatesTokensDetails: [{ modality: "IMAGE", tokenCount: 1290 }],
+    await mocks.enable("tinybird", "openrouter");
+    mocks.openrouter.state.usage = {
+        prompt_tokens: 11,
+        completion_tokens: 1290,
+        total_tokens: 1301,
+        cost: 0.0387033,
+        prompt_tokens_details: {},
+        completion_tokens_details: {
+            reasoning_tokens: 0,
+            image_tokens: 1290,
+        },
     };
 
     const { response, wait } = await fetchWorker(
@@ -127,10 +117,17 @@ test("nanobanana bills exact Vertex usage end-to-end", async ({
     );
     await wait();
 
-    expect(mocks.vertex.state.requests).toHaveLength(1);
-    expect(mocks.vertex.state.requests[0].url).toContain(
-        "models/gemini-2.5-flash-image:generateContent",
-    );
+    expect(mocks.openrouter.state.requests).toHaveLength(1);
+    expect(mocks.openrouter.state.requests[0]).toMatchObject({
+        url: "https://openrouter.ai/api/v1/images",
+        body: {
+            model: "google/gemini-2.5-flash-image",
+            provider: {
+                only: ["google-vertex/global"],
+                allow_fallbacks: false,
+            },
+        },
+    });
     expect(mocks.tinybird.state.events).toHaveLength(1);
     const event = mocks.tinybird.state.events[0];
     expect(event).toMatchObject({
@@ -149,8 +146,8 @@ test("nanobanana rejects a response without usage metadata", async ({
     paidApiKey,
     mocks,
 }) => {
-    await mocks.enable("tinybird", "vertex");
-    mocks.vertex.state.usageMetadata = undefined;
+    await mocks.enable("tinybird", "openrouter");
+    mocks.openrouter.state.usage = undefined;
 
     const { response, wait } = await fetchWorker(
         "/image/red%20square?model=nanobanana&width=1024&height=1024&seed=42",
@@ -159,7 +156,7 @@ test("nanobanana rejects a response without usage metadata", async ({
 
     expect(response.status).toBe(502);
     await expect(response.text()).resolves.toContain(
-        "invalid billing usage metadata",
+        "invalid image billing usage",
     );
     await wait();
 });
@@ -168,13 +165,15 @@ test("nanobanana rejects usage that does not sum to its total", async ({
     paidApiKey,
     mocks,
 }) => {
-    await mocks.enable("tinybird", "vertex");
-    mocks.vertex.state.usageMetadata = {
-        promptTokenCount: 11,
-        candidatesTokenCount: 1290,
-        totalTokenCount: 9999,
-        promptTokensDetails: [{ modality: "TEXT", tokenCount: 11 }],
-        candidatesTokensDetails: [{ modality: "IMAGE", tokenCount: 1290 }],
+    await mocks.enable("tinybird", "openrouter");
+    mocks.openrouter.state.usage = {
+        prompt_tokens: 11,
+        completion_tokens: 1290,
+        total_tokens: 9999,
+        completion_tokens_details: {
+            reasoning_tokens: 0,
+            image_tokens: 1290,
+        },
     };
 
     const { response, wait } = await fetchWorker(

--- a/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
@@ -302,3 +302,64 @@ test("nanobanana-2-lite preserves fixed 1K routing and exact billing", async ({
     expect(event.totalCost).toBeCloseTo(expectedCost, 10);
     expect(event.totalPrice).toBeCloseTo(expectedCost, 10);
 });
+
+test("nanobanana-pro preserves 4K AI Studio routing and exact billing", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "openrouter");
+    mocks.openrouter.state.usage = {
+        prompt_tokens: 14,
+        completion_tokens: 2008,
+        total_tokens: 2022,
+        cost: 0.240124,
+        prompt_tokens_details: {},
+        completion_tokens_details: {
+            reasoning_tokens: 8,
+            image_tokens: 2000,
+        },
+    };
+
+    const { response, wait } = await fetchWorker(
+        "/image/purple%20hexagon?model=nanobanana-pro&width=3840&height=2160&seed=42&reasoning=pro",
+        { headers: { authorization: `Bearer ${paidApiKey}` } },
+    );
+
+    expect(response.status, await response.clone().text()).toBe(200);
+    expect(response.headers.get("x-model-used")).toBe("nanobanana-pro");
+    expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("14");
+    expect(response.headers.get("x-usage-completion-reasoning-tokens")).toBe(
+        "8",
+    );
+    expect(response.headers.get("x-usage-completion-image-tokens")).toBe(
+        "2000",
+    );
+    await response.arrayBuffer();
+    await wait();
+
+    expect(mocks.openrouter.state.requests).toHaveLength(1);
+    expect(mocks.openrouter.state.requests[0]).toMatchObject({
+        body: {
+            model: "google/gemini-3-pro-image",
+            resolution: "4K",
+            provider: {
+                only: ["google-ai-studio/global"],
+                allow_fallbacks: false,
+            },
+        },
+    });
+    expect(mocks.openrouter.state.requests[0].body).not.toHaveProperty(
+        "reasoning_effort",
+    );
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    const event = mocks.tinybird.state.events[0];
+    expect(event).toMatchObject({
+        modelRequested: "nanobanana-pro",
+        tokenCountPromptText: 14,
+        tokenCountCompletionReasoning: 8,
+        tokenCountCompletionImage: 2000,
+    });
+    const expectedCost = (14 * 2 + 8 * 12 + 2000 * 120) / 1_000_000;
+    expect(event.totalCost).toBeCloseTo(expectedCost, 10);
+    expect(event.totalPrice).toBeCloseTo(expectedCost, 10);
+});

--- a/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
@@ -243,3 +243,62 @@ test("nanobanana-2 preserves 4K routing, reasoning, and exact billing", async ({
     expect(event.totalCost).toBeCloseTo(expectedCost, 10);
     expect(event.totalPrice).toBeCloseTo(expectedCost, 10);
 });
+
+test("nanobanana-2-lite preserves fixed 1K routing and exact billing", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "openrouter");
+    mocks.openrouter.state.usage = {
+        prompt_tokens: 10,
+        completion_tokens: 1124,
+        total_tokens: 1134,
+        cost: 0.0336135,
+        prompt_tokens_details: {},
+        completion_tokens_details: {
+            reasoning_tokens: 4,
+            image_tokens: 1120,
+        },
+    };
+
+    const { response, wait } = await fetchWorker(
+        "/image/white%20triangle?model=nanobanana-lite&width=1920&height=1080&seed=42&reasoning=pro",
+        { headers: { authorization: `Bearer ${paidApiKey}` } },
+    );
+
+    expect(response.status, await response.clone().text()).toBe(200);
+    expect(response.headers.get("x-model-used")).toBe("nanobanana-2-lite");
+    expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("10");
+    expect(response.headers.get("x-usage-completion-reasoning-tokens")).toBe(
+        "4",
+    );
+    expect(response.headers.get("x-usage-completion-image-tokens")).toBe(
+        "1120",
+    );
+    await response.arrayBuffer();
+    await wait();
+
+    expect(mocks.openrouter.state.requests).toHaveLength(1);
+    expect(mocks.openrouter.state.requests[0]).toMatchObject({
+        body: {
+            model: "google/gemini-3.1-flash-lite-image",
+            resolution: "1K",
+            reasoning_effort: "high",
+            provider: {
+                only: ["google-vertex/global"],
+                allow_fallbacks: false,
+            },
+        },
+    });
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    const event = mocks.tinybird.state.events[0];
+    expect(event).toMatchObject({
+        modelRequested: "nanobanana-lite",
+        tokenCountPromptText: 10,
+        tokenCountCompletionReasoning: 4,
+        tokenCountCompletionImage: 1120,
+    });
+    const expectedCost = (10 * 0.25 + 4 * 1.5 + 1120 * 30) / 1_000_000;
+    expect(event.totalCost).toBeCloseTo(expectedCost, 10);
+    expect(event.totalPrice).toBeCloseTo(expectedCost, 10);
+});

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -1,9 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
-import { callOpenRouterGrokImagineProAPI } from "../../src/image/models/openRouterImageModel.ts";
+import {
+    callOpenRouterGeminiImageAPI,
+    callOpenRouterGrokImagineProAPI,
+    mapOpenRouterGeminiImageUsage,
+} from "../../src/image/models/openRouterImageModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
 
 const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
+const REFERENCE_IMAGE_URL = "https://example.com/reference.png";
+const PNG = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+);
+const PNG_DATA_URI = `data:image/png;base64,${PNG.toString("base64")}`;
 
 const baseParams: ImageParams = {
     model: "grok-imagine-pro",
@@ -133,5 +143,217 @@ describe("OpenRouter Grok Imagine Pro", () => {
             status: 502,
             upstreamUrl: OPENROUTER_IMAGE_URL,
         });
+    });
+});
+
+const geminiUsage = {
+    prompt_tokens: 9,
+    completion_tokens: 1290,
+    total_tokens: 1299,
+    cost: 0.0387027,
+    is_byok: false,
+    prompt_tokens_details: {},
+    completion_tokens_details: {
+        reasoning_tokens: 0,
+        image_tokens: 1290,
+    },
+};
+
+function mockGeminiFetch(
+    requests: Record<string, unknown>[],
+    usage: Record<string, unknown> = geminiUsage,
+) {
+    return vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (url, init) => {
+            const href = typeof url === "string" ? url : url.toString();
+            if (href === REFERENCE_IMAGE_URL) {
+                return new Response(PNG, {
+                    status: 200,
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+            if (href !== OPENROUTER_IMAGE_URL) {
+                return new Response("unexpected URL", { status: 404 });
+            }
+
+            requests.push(
+                JSON.parse(init?.body as string) as Record<string, unknown>,
+            );
+            return Response.json({
+                data: [
+                    {
+                        b64_json: PNG.toString("base64"),
+                        media_type: "image/png",
+                    },
+                ],
+                usage,
+            });
+        });
+}
+
+describe("OpenRouter Gemini image", () => {
+    it("pins NanoBanana to Google Vertex with no fallback", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests);
+
+        const result = await callOpenRouterGeminiImageAPI("test prompt", {
+            ...baseParams,
+            model: "nanobanana",
+            width: 1024,
+            height: 1024,
+        });
+
+        expect(requests).toEqual([
+            {
+                model: "google/gemini-2.5-flash-image",
+                prompt: "test prompt",
+                n: 1,
+                aspect_ratio: "1:1",
+                seed: 42,
+                provider: {
+                    only: ["google-vertex/global"],
+                    allow_fallbacks: false,
+                },
+            },
+        ]);
+        expect(result.trackingData).toEqual({
+            actualModel: "nanobanana",
+            usage: {
+                promptTextTokens: 9,
+                completionImageTokens: 1290,
+            },
+        });
+    });
+
+    it("validates and inlines edit images while preserving exact combined input billing", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests, {
+            ...geminiUsage,
+            prompt_tokens: 1302,
+            total_tokens: 2592,
+            cost: 0.0390906,
+        });
+
+        const result = await callOpenRouterGeminiImageAPI("edit prompt", {
+            ...baseParams,
+            model: "nanobanana",
+            width: 1280,
+            height: 720,
+            image: [REFERENCE_IMAGE_URL],
+        });
+
+        expect(requests[0]).toEqual({
+            model: "google/gemini-2.5-flash-image",
+            prompt: "edit prompt",
+            n: 1,
+            aspect_ratio: "16:9",
+            seed: 42,
+            provider: {
+                only: ["google-vertex/global"],
+                allow_fallbacks: false,
+            },
+            input_references: [
+                {
+                    type: "image_url",
+                    image_url: { url: PNG_DATA_URI },
+                },
+            ],
+        });
+        expect(result.trackingData.usage).toEqual({
+            promptTextTokens: 1302,
+            completionImageTokens: 1290,
+        });
+    });
+
+    it("maps input-image tokens when OpenRouter supplies the split", () => {
+        expect(
+            mapOpenRouterGeminiImageUsage({
+                ...geminiUsage,
+                prompt_tokens: 1302,
+                total_tokens: 2592,
+                prompt_tokens_details: { image_tokens: 1290 },
+            }),
+        ).toEqual({
+            promptTextTokens: 12,
+            promptImageTokens: 1290,
+            completionImageTokens: 1290,
+        });
+    });
+
+    it("rejects invalid usage instead of underbilling", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        mockGeminiFetch([], {
+            prompt_tokens: 9,
+            completion_tokens: 1290,
+            total_tokens: 9999,
+            completion_tokens_details: { image_tokens: 1290 },
+        });
+
+        await expect(
+            callOpenRouterGeminiImageAPI("test prompt", {
+                ...baseParams,
+                model: "nanobanana",
+            }),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it("preserves content-policy rejections as client errors", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json({
+                data: [],
+                error: {
+                    message: "Image rejected by provider content policy",
+                    metadata: { error_type: "content_policy_violation" },
+                },
+            }),
+        );
+
+        await expect(
+            callOpenRouterGeminiImageAPI("test prompt", {
+                ...baseParams,
+                model: "nanobanana",
+            }),
+        ).rejects.toMatchObject({
+            status: 400,
+            message: "Image rejected by provider content policy",
+        });
+    });
+
+    it("rejects more than three reference images before fetching", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callOpenRouterGeminiImageAPI("edit prompt", {
+                ...baseParams,
+                model: "nanobanana",
+                image: [
+                    REFERENCE_IMAGE_URL,
+                    REFERENCE_IMAGE_URL,
+                    REFERENCE_IMAGE_URL,
+                    REFERENCE_IMAGE_URL,
+                ],
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
     });
 });

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -230,6 +230,84 @@ describe("OpenRouter Gemini image", () => {
         });
     });
 
+    it("routes NanoBanana 2 at the matching resolution and reasoning tier", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests, {
+            prompt_tokens: 12,
+            completion_tokens: 2536,
+            total_tokens: 2548,
+            cost: 0.151254,
+            prompt_tokens_details: {},
+            completion_tokens_details: {
+                reasoning_tokens: 4,
+                image_tokens: 2520,
+            },
+        });
+
+        const result = await callOpenRouterGeminiImageAPI("test prompt", {
+            ...baseParams,
+            model: "nanobanana-2",
+            width: 1920,
+            height: 1080,
+            reasoning: "pro",
+        });
+
+        expect(requests).toEqual([
+            {
+                model: "google/gemini-3.1-flash-image",
+                prompt: "test prompt",
+                n: 1,
+                aspect_ratio: "16:9",
+                seed: 42,
+                provider: {
+                    only: ["google-vertex/global"],
+                    allow_fallbacks: false,
+                },
+                resolution: "2K",
+                reasoning_effort: "high",
+            },
+        ]);
+        expect(result.trackingData).toEqual({
+            actualModel: "nanobanana-2",
+            usage: {
+                promptTextTokens: 12,
+                completionTextTokens: 12,
+                completionReasoningTokens: 4,
+                completionImageTokens: 2520,
+            },
+        });
+    });
+
+    it.each([
+        [1024, 1024, "1K"],
+        [1920, 1080, "2K"],
+        [3840, 2160, "4K"],
+    ] as const)("maps %sx%s NanoBanana 2 requests to %s", async (width, height, expectedResolution) => {
+        syncImageEnv(
+            {
+                OPENROUTER_API_KEY: "openrouter-test-key",
+            } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests);
+
+        await callOpenRouterGeminiImageAPI("test prompt", {
+            ...baseParams,
+            model: "nanobanana-2",
+            width,
+            height,
+            reasoning: "fast",
+        });
+
+        expect(requests[0].resolution).toBe(expectedResolution);
+        expect(requests[0].reasoning_effort).toBe("low");
+    });
+
     it("validates and inlines edit images while preserving exact combined input billing", async () => {
         syncImageEnv(
             { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -308,6 +308,57 @@ describe("OpenRouter Gemini image", () => {
         expect(requests[0].reasoning_effort).toBe("low");
     });
 
+    it("pins NanoBanana 2 Lite to 1K Vertex with no fallback", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests, {
+            prompt_tokens: 10,
+            completion_tokens: 1124,
+            total_tokens: 1134,
+            cost: 0.0336135,
+            prompt_tokens_details: {},
+            completion_tokens_details: {
+                reasoning_tokens: 4,
+                image_tokens: 1120,
+            },
+        });
+
+        const result = await callOpenRouterGeminiImageAPI("test prompt", {
+            ...baseParams,
+            model: "nanobanana-2-lite",
+            width: 1920,
+            height: 1080,
+            reasoning: "pro",
+        });
+
+        expect(requests).toEqual([
+            {
+                model: "google/gemini-3.1-flash-lite-image",
+                prompt: "test prompt",
+                n: 1,
+                aspect_ratio: "16:9",
+                seed: 42,
+                provider: {
+                    only: ["google-vertex/global"],
+                    allow_fallbacks: false,
+                },
+                resolution: "1K",
+                reasoning_effort: "high",
+            },
+        ]);
+        expect(result.trackingData).toEqual({
+            actualModel: "nanobanana-2-lite",
+            usage: {
+                promptTextTokens: 10,
+                completionReasoningTokens: 4,
+                completionImageTokens: 1120,
+            },
+        });
+    });
+
     it("validates and inlines edit images while preserving exact combined input billing", async () => {
         syncImageEnv(
             { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -359,6 +359,56 @@ describe("OpenRouter Gemini image", () => {
         });
     });
 
+    it("pins NanoBanana Pro to 4K AI Studio with default reasoning", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests, {
+            prompt_tokens: 14,
+            completion_tokens: 2008,
+            total_tokens: 2022,
+            cost: 0.240124,
+            prompt_tokens_details: {},
+            completion_tokens_details: {
+                reasoning_tokens: 8,
+                image_tokens: 2000,
+            },
+        });
+
+        const result = await callOpenRouterGeminiImageAPI("test prompt", {
+            ...baseParams,
+            model: "nanobanana-pro",
+            width: 3840,
+            height: 2160,
+            reasoning: "pro",
+        });
+
+        expect(requests).toEqual([
+            {
+                model: "google/gemini-3-pro-image",
+                prompt: "test prompt",
+                n: 1,
+                aspect_ratio: "16:9",
+                seed: 42,
+                provider: {
+                    only: ["google-ai-studio/global"],
+                    allow_fallbacks: false,
+                },
+                resolution: "4K",
+            },
+        ]);
+        expect(result.trackingData).toEqual({
+            actualModel: "nanobanana-pro",
+            usage: {
+                promptTextTokens: 14,
+                completionReasoningTokens: 8,
+                completionImageTokens: 2000,
+            },
+        });
+    });
+
     it("validates and inlines edit images while preserving exact combined input billing", async () => {
         syncImageEnv(
             { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -72,6 +72,32 @@ test("empty model permissions deny access and return an empty catalog", async ()
     expect(generationResponse.status).toBe(403);
 });
 
+test("filters gemini-fast by paid balance", async ({ apiKey, paidApiKey }) => {
+    const freeResponse = await fetchWorker("/v1/models", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const paidResponse = await fetchWorker("/v1/models", {
+        headers: { Authorization: `Bearer ${paidApiKey}` },
+    });
+
+    expect(freeResponse.status).toBe(200);
+    expect(paidResponse.status).toBe(200);
+
+    const freeModels = (await freeResponse.json()) as {
+        data: { id: string }[];
+    };
+    const paidModels = (await paidResponse.json()) as {
+        data: { id: string }[];
+    };
+
+    expect(freeModels.data.some((model) => model.id === "gemini-fast")).toBe(
+        false,
+    );
+    expect(paidModels.data.some((model) => model.id === "gemini-fast")).toBe(
+        true,
+    );
+});
+
 test("filters paid-only audio models by paid balance", async ({
     apiKey,
     paidApiKey,

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -107,7 +107,7 @@ export const IMAGE_SERVICES = {
     },
     "nanobanana-pro": {
         aliases: [],
-        provider: "google",
+        provider: "openrouter",
         brand: "Google",
         category: "image",
         addedDate: new Date("2025-12-01").getTime(),

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -85,7 +85,7 @@ export const IMAGE_SERVICES = {
     },
     "nanobanana-2-lite": {
         aliases: ["nanobanana2lite", "nanobanana-lite"],
-        provider: "google",
+        provider: "openrouter",
         brand: "Google",
         category: "image",
         addedDate: new Date("2026-06-30").getTime(),

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -41,7 +41,7 @@ export const IMAGE_SERVICES = {
     },
     "nanobanana": {
         aliases: [],
-        provider: "google",
+        provider: "openrouter",
         brand: "Google",
         category: "image",
         addedDate: new Date("2025-10-07").getTime(),

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -63,7 +63,7 @@ export const IMAGE_SERVICES = {
     },
     "nanobanana-2": {
         aliases: ["nanobanana2"],
-        provider: "google",
+        provider: "openrouter",
         brand: "Google",
         category: "image",
         addedDate: new Date("2026-02-27").getTime(),

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -494,7 +494,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2025-12-18").getTime(),
         priceMultiplier: 1,
-        paidOnly: false,
+        paidOnly: true,
         cost: {
             promptTextTokens: perMillion(0.1), // per 1M tokens
             promptCachedTokens: perMillion(0.01), // per 1M tokens


### PR DESCRIPTION
- Promotes five commits from `main` to `production`, covering #12708, #12709, #12710, #12712, and #12728.
- Routes NanoBanana, NanoBanana 2, NanoBanana 2 Lite, and NanoBanana Pro through pinned OpenRouter providers with fallback disabled while preserving their public contracts and billing.
- Includes the generated API-reference refresh from the successful prior production deployment.
- Validation: all source PR checks passed, including focused generation/access/pricing tests, typechecks, formatting/linting, and CodeQL; the promotion diff contains no secret changes.