### PR TITLE
Move Seedream 4.5 Pro to OpenRouter

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -18,6 +18,7 @@ import {
     callOpenRouterGeminiImageAPI,
     callOpenRouterGrokImagineProAPI,
     callOpenRouterRecraftVectorAPI,
+    callOpenRouterSeedreamProAPI,
 } from "./models/openRouterImageModel.ts";
 import {
     callPrunaImageAPI,
@@ -28,7 +29,6 @@ import { callSeedream5API } from "./models/seedream5ReplicateModel.ts";
 import {
     callSeedream5ProAPI,
     callSeedreamAPI,
-    callSeedreamProAPI,
 } from "./models/seedreamReplicateModel.ts";
 import { callWanImageAPI } from "./models/wanImageModel.ts";
 import { callXaiImageAPI } from "./models/xaiModel.ts";
@@ -813,7 +813,7 @@ const generateImage = async (
             return await callSeedreamAPI(prompt, safeParams);
 
         case "seedream-pro":
-            return await callSeedreamProAPI(prompt, safeParams);
+            return await callOpenRouterSeedreamProAPI(prompt, safeParams);
 
         case "ideogram-v4-turbo":
             return await callIdeogramTurboAPI(prompt, safeParams);

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -5,9 +5,18 @@ import type { ImageGenerationResult } from "../createAndReturnImages.ts";
 import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
-import { closestAspectRatio, closestByRatio } from "../utils/aspectRatio.ts";
+import {
+    closestAspectRatio,
+    closestByRatio,
+    closestRatioLogSpace,
+} from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
-import { base64ToBuffer, toDataUri } from "../utils/imageDownload.ts";
+import {
+    base64ToBuffer,
+    downloadUserImage,
+    readImageDimensions,
+    toDataUri,
+} from "../utils/imageDownload.ts";
 import { writeExifMetadata } from "../writeExifMetadata.ts";
 
 const logOps = debug("pollinations:openrouter-image:ops");
@@ -16,7 +25,32 @@ const logError = debug("pollinations:openrouter-image:error");
 const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
 const GROK_IMAGINE_QUALITY_MODEL = "x-ai/grok-imagine-image-quality";
 const RECRAFT_VECTOR_MODEL = "recraft/recraft-v4.1-vector";
+const SEEDREAM_PRO_MODEL = "bytedance-seed/seedream-4.5";
 const SVG_MEDIA_TYPE = "image/svg+xml";
+const SEEDREAM_PRO_ASPECT_RATIOS = [
+    "1:1",
+    "4:3",
+    "3:4",
+    "16:9",
+    "9:16",
+    "3:2",
+    "2:3",
+    "21:9",
+] as const;
+type SeedreamProAspectRatio = (typeof SEEDREAM_PRO_ASPECT_RATIOS)[number];
+// Seed rejects normalized 2K landscape/portrait dimensions below 3,686,400px.
+// These are its canonical 2K presets and preserve the previous route's output
+// ratios without silently promoting every non-square request to 4K.
+const SEEDREAM_PRO_2K_SIZES: Record<SeedreamProAspectRatio, string> = {
+    "1:1": "2048x2048",
+    "4:3": "2304x1728",
+    "3:4": "1728x2304",
+    "16:9": "2560x1440",
+    "9:16": "1440x2560",
+    "3:2": "2496x1664",
+    "2:3": "1664x2496",
+    "21:9": "3024x1296",
+};
 type GeminiImageConfig = {
     upstreamModel: string;
     provider: string;
@@ -140,7 +174,7 @@ function buildOpenRouterNoImageError(data: OpenRouterImageResponse): HttpError {
         providerMessage ||
             (isContentRejection
                 ? "Image generation rejected by content policy"
-                : "OpenRouter Gemini image API returned no image"),
+                : "OpenRouter image API returned no image"),
         isContentRejection ? 400 : 502,
         data,
         OPENROUTER_IMAGE_URL,
@@ -222,6 +256,138 @@ function resolveGeminiReasoningEffort(
         return undefined;
     }
     return safeParams.reasoning === "fast" ? "low" : "high";
+}
+
+function resolveSeedreamProAspectRatio(
+    safeParams: ImageParams,
+    referenceDimensions?: { width: number; height: number },
+): SeedreamProAspectRatio | "auto" {
+    const requested = safeParams.aspectRatio;
+    if (!requested) {
+        if (referenceDimensions) {
+            return closestRatioLogSpace(
+                referenceDimensions.width,
+                referenceDimensions.height,
+                SEEDREAM_PRO_ASPECT_RATIOS,
+            );
+        }
+        return closestRatioLogSpace(
+            safeParams.width,
+            safeParams.height,
+            SEEDREAM_PRO_ASPECT_RATIOS,
+        );
+    }
+    if (requested === "adaptive") {
+        if (!referenceDimensions) return "auto";
+        return closestRatioLogSpace(
+            referenceDimensions.width,
+            referenceDimensions.height,
+            SEEDREAM_PRO_ASPECT_RATIOS,
+        );
+    }
+    if (
+        requested === "9:21" ||
+        !(SEEDREAM_PRO_ASPECT_RATIOS as readonly string[]).includes(requested)
+    ) {
+        throw new HttpError(
+            `aspectRatio "${requested}" is not supported by Seedream 4.5 Pro. Supported: auto, ${SEEDREAM_PRO_ASPECT_RATIOS.join(", ")}.`,
+            400,
+        );
+    }
+    return requested as SeedreamProAspectRatio;
+}
+
+export async function callOpenRouterSeedreamProAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    if (safeParams.image.length > 14) {
+        throw new HttpError(
+            `Seedream 4.5 Pro supports at most 14 reference images (received ${safeParams.image.length}).`,
+            400,
+        );
+    }
+
+    const apiKey = getImageEnv("OPENROUTER_API_KEY");
+    if (!apiKey) {
+        throw new HttpError(
+            "OPENROUTER_API_KEY environment variable is required",
+            500,
+        );
+    }
+
+    const downloadedImages = await Promise.all(
+        safeParams.image.map((image) => downloadUserImage(image)),
+    );
+    const firstImage = downloadedImages[0];
+    // OpenRouter's "auto" currently defaults to square instead of matching a
+    // reference image, so derive the first reference's ratio as the old route did.
+    const referenceDimensions = firstImage
+        ? (readImageDimensions(firstImage.buffer, firstImage.mimeType) ??
+          undefined)
+        : undefined;
+    const inputReferences = downloadedImages.map((downloaded) => ({
+        type: "image_url",
+        image_url: {
+            url: `data:${downloaded.mimeType};base64,${downloaded.buffer.toString("base64")}`,
+        },
+    }));
+
+    const aspectRatio = resolveSeedreamProAspectRatio(
+        safeParams,
+        referenceDimensions,
+    );
+    const use4K = Math.max(safeParams.width, safeParams.height) > 2048;
+    const requestBody: Record<string, unknown> = {
+        model: SEEDREAM_PRO_MODEL,
+        prompt,
+        n: 1,
+        ...(use4K
+            ? { resolution: "4K", aspect_ratio: aspectRatio }
+            : aspectRatio === "auto"
+              ? { resolution: "2K", aspect_ratio: "auto" }
+              : { size: SEEDREAM_PRO_2K_SIZES[aspectRatio] }),
+        provider: {
+            only: ["seed"],
+            allow_fallbacks: false,
+        },
+    };
+    if (inputReferences.length > 0) {
+        requestBody.input_references = inputReferences;
+    }
+
+    const response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+        errorLabel: "OpenRouter Seedream image generation request failed",
+    });
+    const data = (await response.json()) as OpenRouterImageResponse;
+    const encodedImage = data.data?.[0]?.b64_json;
+    if (!encodedImage) {
+        throw buildOpenRouterNoImageError(data);
+    }
+
+    logOps("Seedream 4.5 Pro generation complete", {
+        referenceImages: safeParams.image.length,
+        providerUsage: data.usage,
+    });
+
+    return {
+        buffer: base64ToBuffer(encodedImage),
+        isMature: false,
+        isChild: false,
+        trackingData: {
+            actualModel: "seedream-pro",
+            usage: {
+                completionImageTokens: 1,
+                totalTokenCount: 1,
+            },
+        },
+    };
 }
 
 export async function callOpenRouterGrokImagineProAPI(

--- a/gen.pollinations.ai/src/image/models/seedreamReplicateModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedreamReplicateModel.ts
@@ -1,11 +1,10 @@
 /**
- * ByteDance Seedream 4.0, 4.5 Pro, 5.0 Lite, and 5.0 Pro image generation via Replicate.
+ * ByteDance Seedream 4.0, 5.0 Lite, and 5.0 Pro image generation via Replicate.
  *
  * Completes the BytePlus → Replicate migration started in PR #11073, which
  * moved seedream5 + seedance variants but left these legacy variants on the
  * BytePlus ARK endpoint. Replicate models:
  *   - seedream     → bytedance/seedream-4      ($0.03/img)
- *   - seedream-pro → bytedance/seedream-4.5    ($0.06/img)
  *   - seedream5    → bytedance/seedream-5-lite (flat per-image)
  *   - seedream5-pro → bytedance/seedream-5-pro ($0.09/img at 2K)
  *
@@ -49,25 +48,18 @@ const SEEDREAM_NUMERIC_RATIOS = SEEDREAM_ASPECT_RATIOS.filter(
 ) as readonly Exclude<SeedreamAspectRatio, "match_input_image">[];
 
 type Seedream4Size = "1K" | "2K" | "4K";
-type Seedream45Size = "2K" | "4K";
 type Seedream5Size = "2K" | "3K";
-type SeedreamVariantKey =
-    | "seedream"
-    | "seedream-pro"
-    | "seedream5"
-    | "seedream5-pro";
+type SeedreamVariantKey = "seedream" | "seedream5" | "seedream5-pro";
 
-// seedream-4 (4.0) supports two payload shapes; 4.5 and 5.0 do NOT support
-// custom.
+// seedream-4 (4.0) supports two payload shapes; 5.0 does NOT support custom.
 //   - preset: size: "1K"|"2K"|"4K"|"3K" + aspect_ratio
 //   - custom: size: "custom" + width + height (both 1024-4096)
 // Replicate's schema explicitly says aspect_ratio is ignored when
 // size === "custom", so they're mutually exclusive at the type level.
-// `output_format` is only sent for seedream5 variants — 4.5's schema strict-rejects
-// unknown fields, so it must stay opt-in.
+// `output_format` is only sent for seedream5 variants.
 type SeedreamPresetInput = {
     prompt: string;
-    size: Seedream4Size | Seedream45Size | Seedream5Size;
+    size: Seedream4Size | Seedream5Size;
     aspect_ratio: SeedreamAspectRatio;
     image_input: string[];
     output_format?: "png" | "jpeg";
@@ -97,14 +89,11 @@ interface SeedreamVariantConfig {
     /** Cap on reference images accepted by the upstream model. */
     maxReferenceImages: number;
     /** Pick the size bucket for a given longer-side pixel value. */
-    resolveSize(
-        longerSide: number,
-    ): Seedream4Size | Seedream45Size | Seedream5Size;
+    resolveSize(longerSide: number): Seedream4Size | Seedream5Size;
     /** Whether the upstream accepts size:"custom" + width/height. Only 4.0. */
     supportsCustom: boolean;
     /**
-     * Opt-in `output_format` field — only seedream5 accepts it. 4.5's schema
-     * strict-rejects unknown fields, so leave it unset for the others.
+     * Opt-in `output_format` field — only seedream5 accepts it.
      */
     outputFormat?: "png" | "jpeg";
 }
@@ -121,17 +110,6 @@ const SEEDREAM_VARIANTS: Record<SeedreamVariantKey, SeedreamVariantConfig> = {
             return "1K";
         },
         supportsCustom: true,
-    },
-    "seedream-pro": {
-        replicateModel: "bytedance/seedream-4.5",
-        displayName: "Seedream 4.5 Pro",
-        trackingLabel: "seedream-pro",
-        maxReferenceImages: 14,
-        resolveSize(longerSide) {
-            return longerSide > 2048 ? "4K" : "2K";
-        },
-        // 4.5's size enum is ["2K", "4K"] only — verified against live schema.
-        supportsCustom: false,
     },
     seedream5: {
         replicateModel: "bytedance/seedream-5-lite",
@@ -219,8 +197,7 @@ function buildPresetInput(
             variant.displayName,
         ),
         image_input: imageInput,
-        // Only seedream5 carries output_format — spread it conditionally so
-        // 4.5's strict schema never sees an unknown field.
+        // Only seedream5 variants carry output_format.
         ...(variant.outputFormat
             ? { output_format: variant.outputFormat }
             : {}),
@@ -276,14 +253,13 @@ async function callSeedreamReplicateAPI(
     const imageInput =
         images.length > 0 ? await Promise.all(images.map(toDataUri)) : [];
 
-    // Replicate's bytedance/seedream-4 and 4.5 schemas don't accept a `seed`
-    // field — 4.5 strict-rejects unknown fields, 4 silently drops them.
+    // Replicate's bytedance/seedream-4 schema does not accept a `seed` field.
     //
     // seedream-4 (4.0) supports a "custom" size mode that takes raw width and
     // height instead of a preset+aspect_ratio pair. When the caller actually
     // passed dimensions (OpenAI `size:"1792x1024"`, GET `?width=…&height=…`),
     // use that mode so we produce exact pixels instead of rounding to the
-    // nearest preset. 4.5 has no custom mode, so it stays on the preset path.
+    // nearest preset.
     const input: SeedreamReplicateInput =
         variant.supportsCustom && safeParams.dimensionsExplicit
             ? buildCustomInput(prompt, safeParams, imageInput, variant)
@@ -363,14 +339,6 @@ export function callSeedreamAPI(
     safeParams: ImageParams,
 ): Promise<ImageGenerationResult> {
     return callSeedreamReplicateAPI("seedream", prompt, safeParams);
-}
-
-/** Seedream 4.5 Pro via Replicate (bytedance/seedream-4.5). */
-export function callSeedreamProAPI(
-    prompt: string,
-    safeParams: ImageParams,
-): Promise<ImageGenerationResult> {
-    return callSeedreamReplicateAPI("seedream-pro", prompt, safeParams);
 }
 
 /** Seedream 5.0 Lite via Replicate (bytedance/seedream-5-lite). */

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -43,6 +43,87 @@ export function detectMimeType(buffer: Uint8Array): string {
     return detectImageMimeType(buffer) ?? "image/jpeg";
 }
 
+export function readImageDimensions(
+    buffer: Uint8Array,
+    mimeType: string,
+): { width: number; height: number } | null {
+    const view = new DataView(
+        buffer.buffer,
+        buffer.byteOffset,
+        buffer.byteLength,
+    );
+    const dimensions = (width: number, height: number) =>
+        width > 0 && height > 0 ? { width, height } : null;
+
+    if (mimeType === "image/png" && buffer.length >= 24) {
+        return dimensions(view.getUint32(16), view.getUint32(20));
+    }
+    if (mimeType === "image/gif" && buffer.length >= 10) {
+        return dimensions(view.getUint16(6, true), view.getUint16(8, true));
+    }
+    if (mimeType === "image/bmp" && buffer.length >= 26) {
+        return dimensions(
+            Math.abs(view.getInt32(18, true)),
+            Math.abs(view.getInt32(22, true)),
+        );
+    }
+    if (mimeType === "image/webp" && buffer.length >= 30) {
+        const chunk = String.fromCharCode(...buffer.subarray(12, 16));
+        if (chunk === "VP8X") {
+            const width =
+                1 + buffer[24] + (buffer[25] << 8) + (buffer[26] << 16);
+            const height =
+                1 + buffer[27] + (buffer[28] << 8) + (buffer[29] << 16);
+            return dimensions(width, height);
+        }
+        if (chunk === "VP8 " && buffer.length >= 30) {
+            return dimensions(
+                view.getUint16(26, true) & 0x3fff,
+                view.getUint16(28, true) & 0x3fff,
+            );
+        }
+        if (chunk === "VP8L" && buffer[20] === 0x2f) {
+            const bits = view.getUint32(21, true);
+            return dimensions((bits & 0x3fff) + 1, ((bits >> 14) & 0x3fff) + 1);
+        }
+    }
+    if (mimeType === "image/jpeg" && buffer.length >= 4) {
+        let offset = 2;
+        while (offset + 8 < buffer.length) {
+            if (buffer[offset] !== 0xff) {
+                offset++;
+                continue;
+            }
+            const marker = buffer[offset + 1];
+            if (marker === 0xd8 || marker === 0xd9 || marker === 0x01) {
+                offset += 2;
+                continue;
+            }
+            const segmentLength = view.getUint16(offset + 2);
+            if (
+                segmentLength < 2 ||
+                offset + 2 + segmentLength > buffer.length
+            ) {
+                return null;
+            }
+            if (
+                [
+                    0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb,
+                    0xcd, 0xce, 0xcf,
+                ].includes(marker) &&
+                segmentLength >= 7
+            ) {
+                return dimensions(
+                    view.getUint16(offset + 7),
+                    view.getUint16(offset + 5),
+                );
+            }
+            offset += 2 + segmentLength;
+        }
+    }
+    return null;
+}
+
 export async function downloadUserImage(
     imageUrl: string,
     signal?: AbortSignal,

--- a/gen.pollinations.ai/test/image/imageDownload.test.ts
+++ b/gen.pollinations.ai/test/image/imageDownload.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HttpError } from "../../src/image/httpError.ts";
-import { downloadUserImage } from "../../src/image/utils/imageDownload.ts";
+import {
+    downloadUserImage,
+    readImageDimensions,
+} from "../../src/image/utils/imageDownload.ts";
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -40,6 +43,60 @@ describe("downloadUserImage", () => {
             status: 400,
             details: { validation: true },
             message: `Unsupported image format from ${imageUrl}`,
+        });
+    });
+});
+
+describe("readImageDimensions", () => {
+    it("reads every accepted raster format", () => {
+        const png = Buffer.alloc(24);
+        png.set([0x89, 0x50, 0x4e, 0x47]);
+        png.writeUInt32BE(2560, 16);
+        png.writeUInt32BE(1440, 20);
+
+        const gif = Buffer.alloc(10);
+        gif.write("GIF89a", 0, "ascii");
+        gif.writeUInt16LE(640, 6);
+        gif.writeUInt16LE(480, 8);
+
+        const bmp = Buffer.alloc(26);
+        bmp.write("BM", 0, "ascii");
+        bmp.writeInt32LE(800, 18);
+        bmp.writeInt32LE(-600, 22);
+
+        const webp = Buffer.alloc(30);
+        webp.write("RIFF", 0, "ascii");
+        webp.write("WEBP", 8, "ascii");
+        webp.write("VP8X", 12, "ascii");
+        webp[24] = 0xff;
+        webp[25] = 0x03;
+        webp[27] = 0xff;
+        webp[28] = 0x01;
+
+        const jpeg = Buffer.from([
+            0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x02, 0xd0, 0x05, 0x00,
+            0x03, 0x01, 0x11, 0x00,
+        ]);
+
+        expect(readImageDimensions(png, "image/png")).toEqual({
+            width: 2560,
+            height: 1440,
+        });
+        expect(readImageDimensions(gif, "image/gif")).toEqual({
+            width: 640,
+            height: 480,
+        });
+        expect(readImageDimensions(bmp, "image/bmp")).toEqual({
+            width: 800,
+            height: 600,
+        });
+        expect(readImageDimensions(webp, "image/webp")).toEqual({
+            width: 1024,
+            height: 512,
+        });
+        expect(readImageDimensions(jpeg, "image/jpeg")).toEqual({
+            width: 1280,
+            height: 720,
         });
     });
 });

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -4,17 +4,24 @@ import {
     callOpenRouterGeminiImageAPI,
     callOpenRouterGrokImagineProAPI,
     callOpenRouterRecraftVectorAPI,
+    callOpenRouterSeedreamProAPI,
     mapOpenRouterGeminiImageUsage,
 } from "../../src/image/models/openRouterImageModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
 
 const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
 const REFERENCE_IMAGE_URL = "https://example.com/reference.png";
+const WIDE_REFERENCE_IMAGE_URL = "https://example.com/wide-reference.png";
 const PNG = Buffer.from(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
     "base64",
 );
 const PNG_DATA_URI = `data:image/png;base64,${PNG.toString("base64")}`;
+const WIDE_PNG = Buffer.alloc(24);
+WIDE_PNG.set([0x89, 0x50, 0x4e, 0x47]);
+WIDE_PNG.writeUInt32BE(2560, 16);
+WIDE_PNG.writeUInt32BE(1440, 20);
+const WIDE_PNG_DATA_URI = `data:image/png;base64,${WIDE_PNG.toString("base64")}`;
 
 const baseParams: ImageParams = {
     model: "grok-imagine-pro",
@@ -535,6 +542,161 @@ describe("OpenRouter Gemini image", () => {
             }),
         ).rejects.toMatchObject({ status: 400 });
         expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("OpenRouter Seedream 4.5 Pro", () => {
+    function mockSeedreamResponse(requests: Record<string, unknown>[]) {
+        return vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementation(async (url, init) => {
+                const href = typeof url === "string" ? url : url.toString();
+                if (
+                    href === REFERENCE_IMAGE_URL ||
+                    href === WIDE_REFERENCE_IMAGE_URL
+                ) {
+                    return new Response(
+                        href === WIDE_REFERENCE_IMAGE_URL ? WIDE_PNG : PNG,
+                        {
+                            headers: { "Content-Type": "image/png" },
+                        },
+                    );
+                }
+                if (href !== OPENROUTER_IMAGE_URL) {
+                    return new Response("unexpected URL", { status: 404 });
+                }
+                requests.push(
+                    JSON.parse(init?.body as string) as Record<string, unknown>,
+                );
+                return Response.json({
+                    data: [{ b64_json: PNG.toString("base64") }],
+                    usage: {
+                        completion_tokens: 16384,
+                        cost: 0.04,
+                        completion_tokens_details: { image_tokens: 16384 },
+                    },
+                });
+            });
+    }
+
+    it("pins the Seed provider without fallbacks and preserves flat billing", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        const fetchSpy = mockSeedreamResponse(requests);
+
+        const result = await callOpenRouterSeedreamProAPI("test prompt", {
+            ...baseParams,
+            model: "seedream-pro",
+            width: 2048,
+            height: 2048,
+        });
+
+        expect(fetchSpy).toHaveBeenCalledWith(
+            OPENROUTER_IMAGE_URL,
+            expect.objectContaining({
+                method: "POST",
+                headers: {
+                    Authorization: "Bearer openrouter-test-key",
+                    "Content-Type": "application/json",
+                },
+            }),
+        );
+        expect(requests[0]).toEqual({
+            model: "bytedance-seed/seedream-4.5",
+            prompt: "test prompt",
+            n: 1,
+            size: "2048x2048",
+            provider: {
+                only: ["seed"],
+                allow_fallbacks: false,
+            },
+        });
+        expect(result.buffer).toEqual(PNG);
+        expect(result.trackingData).toEqual({
+            actualModel: "seedream-pro",
+            usage: {
+                completionImageTokens: 1,
+                totalTokenCount: 1,
+            },
+        });
+    });
+
+    it("uses the 4K tier above 2048px and preserves explicit aspect ratios", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockSeedreamResponse(requests);
+
+        await callOpenRouterSeedreamProAPI("wide prompt", {
+            ...baseParams,
+            model: "seedream-pro",
+            width: 4096,
+            height: 2304,
+            aspectRatio: "16:9",
+        });
+
+        expect(requests[0]).toMatchObject({
+            resolution: "4K",
+            aspect_ratio: "16:9",
+        });
+    });
+
+    it("inlines all reference images and matches their aspect ratio automatically", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockSeedreamResponse(requests);
+
+        await callOpenRouterSeedreamProAPI("edit prompt", {
+            ...baseParams,
+            model: "seedream-pro",
+            image: [WIDE_REFERENCE_IMAGE_URL, REFERENCE_IMAGE_URL],
+        });
+
+        expect(requests[0]).toMatchObject({
+            size: "2560x1440",
+            input_references: [
+                {
+                    type: "image_url",
+                    image_url: { url: WIDE_PNG_DATA_URI },
+                },
+                {
+                    type: "image_url",
+                    image_url: { url: PNG_DATA_URI },
+                },
+            ],
+        });
+    });
+
+    it("rejects the unsupported 9:21 ratio and more than 14 references", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const params = {
+            ...baseParams,
+            model: "seedream-pro",
+        } satisfies ImageParams;
+
+        await expect(
+            callOpenRouterSeedreamProAPI("test", {
+                ...params,
+                aspectRatio: "9:21",
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        await expect(
+            callOpenRouterSeedreamProAPI("test", {
+                ...params,
+                image: Array(15).fill(REFERENCE_IMAGE_URL),
+            }),
+        ).rejects.toMatchObject({ status: 400 });
     });
 });
 

--- a/gen.pollinations.ai/test/image/seedreamModel.test.ts
+++ b/gen.pollinations.ai/test/image/seedreamModel.test.ts
@@ -13,7 +13,6 @@ import { callSeedream5API } from "../../src/image/models/seedream5ReplicateModel
 import {
     callSeedream5ProAPI,
     callSeedreamAPI,
-    callSeedreamProAPI,
 } from "../../src/image/models/seedreamReplicateModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
 
@@ -132,69 +131,6 @@ describe("seedreamReplicateModel - seedream 4.0", () => {
         await expect(callSeedreamAPI("test", params)).rejects.toMatchObject({
             status: 400,
         });
-    });
-});
-
-describe("seedreamReplicateModel - seedream-pro 4.5", () => {
-    it("posts to bytedance/seedream-4.5 with size resolved from dimensions", async () => {
-        const requests: ReplicateRequest[] = [];
-        mockReplicateFetch(requests);
-
-        const params: ImageParams = {
-            ...baseParams,
-            model: "seedream-pro",
-            width: 2048,
-            height: 2048,
-        };
-        await callSeedreamProAPI("test prompt", params);
-
-        expect(requests[0].url).toBe(
-            "https://api.replicate.com/v1/models/bytedance/seedream-4.5/predictions",
-        );
-        const input = (requests[0].body as { input: Record<string, unknown> })
-            .input;
-        // 2048px → "2K" bucket on seedream-4.5
-        expect(input.size).toBe("2K");
-        // 4.5 strict-rejects unknown fields — output_format must stay opt-in
-        // (seedream5 only).
-        expect(input.output_format).toBeUndefined();
-    });
-
-    it("routes reference images as data URIs in image_input", async () => {
-        const requests: ReplicateRequest[] = [];
-        mockReplicateFetch(requests);
-
-        const params: ImageParams = {
-            ...baseParams,
-            model: "seedream-pro",
-            image: [INPUT_IMAGE_URL],
-        };
-        await callSeedreamProAPI("test prompt", params);
-
-        // The Replicate POST is the request with a JSON body; example.com may
-        // be fetched first by downloadUserImage. Find the Replicate POST.
-        const post = requests.find((r) =>
-            r.url.includes(
-                "api.replicate.com/v1/models/bytedance/seedream-4.5",
-            ),
-        );
-        if (!post) throw new Error("Replicate POST not captured");
-        const input = (post.body as { input: Record<string, unknown> }).input;
-        expect(Array.isArray(input.image_input)).toBe(true);
-        expect((input.image_input as string[])[0]).toMatch(
-            /^data:image\/jpeg;base64,/,
-        );
-        // aspect_ratio defaults to match_input_image when an image is provided
-        expect(input.aspect_ratio).toBe("match_input_image");
-    });
-
-    it("returns seedream-pro as actualModel", async () => {
-        mockReplicateFetch([]);
-
-        const params: ImageParams = { ...baseParams, model: "seedream-pro" };
-        const result = await callSeedreamProAPI("test prompt", params);
-
-        expect(result.trackingData?.actualModel).toBe("seedream-pro");
     });
 });
 
@@ -362,30 +298,6 @@ describe("seedreamReplicateModel - seedream 4.0 custom-size mode", () => {
         await expect(callSeedreamAPI("test", params)).rejects.toMatchObject({
             status: 400,
         });
-    });
-
-    it("seedream-pro (4.5) ignores dimensionsExplicit — no custom mode", async () => {
-        const requests: ReplicateRequest[] = [];
-        mockReplicateFetch(requests);
-
-        const params: ImageParams = {
-            ...baseParams,
-            model: "seedream-pro",
-            width: 1792,
-            height: 1024,
-            dimensionsExplicit: true,
-        };
-        await callSeedreamProAPI("test", params);
-
-        const input = (requests[0].body as { input: Record<string, unknown> })
-            .input;
-        // 4.5's size enum is only ["2K","4K"] — must stay on preset path
-        // and derive aspect_ratio from the dimensions.
-        expect(input.size).not.toBe("custom");
-        expect(input.size).toBe("2K");
-        expect(input.aspect_ratio).toBe("16:9");
-        expect(input.width).toBeUndefined();
-        expect(input.height).toBeUndefined();
     });
 });
 

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -183,7 +183,7 @@ export const IMAGE_SERVICES = {
     },
     "seedream-pro": {
         aliases: [],
-        provider: "replicate",
+        provider: "openrouter",
         brand: "ByteDance",
         category: "image",
         addedDate: new Date("2025-12-04").getTime(),
@@ -196,7 +196,7 @@ export const IMAGE_SERVICES = {
         description: "Premium photorealism for lifelike scenes and portraits",
         inputModalities: ["text", "image"],
         outputModalities: ["image"],
-        maxReferenceImages: 14, // Pollinations route cap from Replicate schema.
+        maxReferenceImages: 14, // Pollinations route cap from OpenRouter schema.
     },
     // Ideogram 4.0 (turbo/balanced/quality) via Replicate. These are official
     // Replicate models (is_official=true) → billed a FLAT price per output


### PR DESCRIPTION
- Moves `seedream-pro` from Replicate to OpenRouter's exact `bytedance-seed/seedream-4.5` route, pinned to `seed` with fallback disabled.
- Preserves the public name, paid-only policy, multiplier 1, `$0.04` flat price, 2K/4K behavior, aspect ratios, image editing, and 14-reference limit.
- Uses verified explicit 2K presets because OpenRouter's normalized wide/tall 2K sizes fall below Seed's pixel minimum; reference dimensions preserve the previous match-input ratio behavior.
- Removes the dead Replicate 4.5 route. No secret or deployment changes.

Validation:
- Gen image/access/billing suites: 243 passed; Enter pricing/catalog suites: 32 passed; both workers type-check.
- Paid local E2E passed square, wide, tall, 4K, editing, 14 references, invalid ratio/count, exact `0.04` billing, and cache MISS→HIT. All successful media completed within 55 seconds.
- Repeated local 5-way burst passed 5/5 in 6.5–14.7 seconds. Direct pinned OpenRouter burst passed 15/15 in 12.4–16.9 seconds. An earlier local burst had one transient network disconnect; the immediate repeat and direct provider burst were clean.