### PR TITLE
fix: preserve source aspect ratio on image edits when size is omitted

### DIFF
--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -187,3 +187,48 @@ export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
+
+/**
+ * Extract image dimensions from a data URI without a network request.
+ * Returns null for unsupported formats or unreadable data.
+ */
+function getImageDimensionsFromDataUri(
+    dataUri: string,
+): { width: number; height: number } | null {
+    try {
+        const buf = base64ToBuffer(dataUri);
+        const mimeType = detectImageMimeType(buf);
+        if (!mimeType) return null;
+        return readImageDimensions(buf, mimeType);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Extract image dimensions from a remote URL by fetching the image.
+ * Returns null on fetch errors, unsupported formats, or unreadable data.
+ */
+export async function getImageDimensionsFromUrl(
+    url: string,
+): Promise<{ width: number; height: number } | null> {
+    try {
+        const { buffer, mimeType } = await downloadUserImage(url);
+        return readImageDimensions(buffer, mimeType);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Get image dimensions from either a data URI or a remote URL.
+ * Returns null if dimensions cannot be determined.
+ */
+export async function getSourceImageDimensions(
+    imageUrl: string,
+): Promise<{ width: number; height: number } | null> {
+    if (imageUrl.startsWith("data:")) {
+        return getImageDimensionsFromDataUri(imageUrl);
+    }
+    return getImageDimensionsFromUrl(imageUrl);
+}

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -25,6 +25,7 @@ import { generateImageOrVideoResponse } from "@/image/handler.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
+import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 
 // --- Helpers ---
 
@@ -266,13 +267,42 @@ export async function handleImageGeneration(c: Context<Env>) {
     );
 }
 
+function computeAspectRatioSize(
+    width: number,
+    height: number,
+    maxPixels: number = 1048576,
+): string {
+    const area = width * height;
+    let w: number;
+    let h: number;
+    if (area <= maxPixels) {
+        w = width;
+        h = height;
+    } else {
+        const scale = Math.sqrt(maxPixels / area);
+        w = Math.round(width * scale);
+        h = Math.round(height * scale);
+    }
+    const snap = (v: number) => Math.max(16, Math.round(v / 16) * 16);
+    return `${snap(w)}x${snap(h)}`;
+}
+
 export async function handleImageEdit(c: Context<Env>) {
     await requireGenerationAccess(c.var, c.env);
 
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
+
+    let effectiveSize = size;
+    if (!effectiveSize && imageUrls.length > 0) {
+        const dims = await getSourceImageDimensions(imageUrls[0]);
+        if (dims) {
+            effectiveSize = computeAspectRatioSize(dims.width, dims.height);
+        }
+    }
+
     const safePrompt = await applySafety(c, prompt, safe);
-    const resolved = resolveParams({ size, quality, seed });
+    const resolved = resolveParams({ size: effectiveSize, quality, seed });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -22,10 +22,10 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
-import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 
 // --- Helpers ---
 

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -267,7 +267,7 @@ export async function handleImageGeneration(c: Context<Env>) {
     );
 }
 
-function computeAspectRatioSize(
+export function computeAspectRatioSize(
     width: number,
     height: number,
     maxPixels: number = 1048576,

--- a/gen.pollinations.ai/test/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image-edits.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+    getSourceImageDimensions,
+} from "../src/image/utils/imageDownload.ts";
+
+describe("getSourceImageDimensions (data URI)", () => {
+    it("extracts PNG dimensions from a minimal data URI", async () => {
+        const png = new Uint8Array(24);
+        png[0] = 0x89;
+        png[1] = 0x50;
+        png[2] = 0x4e;
+        png[3] = 0x47;
+        new DataView(png.buffer).setUint32(16, 1920, false);
+        new DataView(png.buffer).setUint32(20, 1080, false);
+
+        const b64 = Buffer.from(png).toString("base64");
+        const dims = await getSourceImageDimensions(
+            `data:image/png;base64,${b64}`,
+        );
+        expect(dims).toEqual({ width: 1920, height: 1080 });
+    });
+
+    it("extracts JPEG dimensions from a data URI", async () => {
+        const jpeg = Uint8Array.from([
+            0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x02, 0xd0, 0x05, 0x00,
+            0x03, 0x01, 0x11, 0x00,
+        ]);
+        const b64 = Buffer.from(jpeg).toString("base64");
+        const dims = await getSourceImageDimensions(
+            `data:image/jpeg;base64,${b64}`,
+        );
+        expect(dims).toEqual({ width: 1280, height: 720 });
+    });
+
+    it("extracts WEBP VP8X dimensions from a data URI", async () => {
+        const webp = new Uint8Array(30);
+        webp.set([0x52, 0x49, 0x46, 0x46], 0);
+        webp.set([0x57, 0x45, 0x42, 0x50], 8);
+        webp.set([0x56, 0x50, 0x38, 0x58], 12);
+        webp[24] = 0xff;
+        webp[25] = 0x03;
+        webp[27] = 0xff;
+        webp[28] = 0x01;
+
+        const b64 = Buffer.from(webp).toString("base64");
+        const dims = await getSourceImageDimensions(
+            `data:image/webp;base64,${b64}`,
+        );
+        expect(dims).toEqual({ width: 1024, height: 512 });
+    });
+
+    it("returns null for unsupported input", async () => {
+        const dims = await getSourceImageDimensions(
+            "data:text/plain;base64,aGVsbG8=",
+        );
+        expect(dims).toBeNull();
+    });
+});

--- a/gen.pollinations.ai/test/image/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image/image-edits.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     getSourceImageDimensions,
-} from "../src/image/utils/imageDownload.ts";
+} from "../../src/image/utils/imageDownload.ts";
 
 describe("getSourceImageDimensions (data URI)", () => {
     it("extracts PNG dimensions from a minimal data URI", async () => {

--- a/gen.pollinations.ai/test/image/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image/image-edits.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getSourceImageDimensions } from "../../src/image/utils/imageDownload.ts";
+import { computeAspectRatioSize } from "../../src/routes/images.ts";
 
 describe("getSourceImageDimensions (data URI)", () => {
     it("extracts PNG dimensions from a minimal data URI", async () => {
@@ -52,5 +53,47 @@ describe("getSourceImageDimensions (data URI)", () => {
             "data:text/plain;base64,aGVsbG8=",
         );
         expect(dims).toBeNull();
+    });
+});
+
+describe("computeAspectRatioSize", () => {
+    it("preserves landscape aspect ratio when under maxPixels", () => {
+        expect(computeAspectRatioSize(1024, 576)).toBe("1024x576");
+    });
+
+    it("preserves portrait aspect ratio when under maxPixels", () => {
+        expect(computeAspectRatioSize(576, 1024)).toBe("576x1024");
+    });
+
+    it("scales down landscape proportionally when over maxPixels", () => {
+        const result = computeAspectRatioSize(3840, 2160);
+        const [w, h] = result.split("x").map(Number);
+        expect(w / h).toBeCloseTo(3840 / 2160, 1);
+    });
+
+    it("scales down portrait proportionally when over maxPixels", () => {
+        const result = computeAspectRatioSize(2160, 3840);
+        const [w, h] = result.split("x").map(Number);
+        expect(h / w).toBeCloseTo(3840 / 2160, 1);
+    });
+
+    it("snaps dimensions to 16px multiples", () => {
+        const result = computeAspectRatioSize(100, 100);
+        const [w, h] = result.split("x").map(Number);
+        expect(w % 16).toBe(0);
+        expect(h % 16).toBe(0);
+    });
+
+    it("never produces dimensions smaller than 16px", () => {
+        const result = computeAspectRatioSize(1, 1);
+        const [w, h] = result.split("x").map(Number);
+        expect(w).toBeGreaterThanOrEqual(16);
+        expect(h).toBeGreaterThanOrEqual(16);
+    });
+
+    it("uses custom maxPixels", () => {
+        const result = computeAspectRatioSize(2000, 1000, 500000);
+        const [w, h] = result.split("x").map(Number);
+        expect(w * h).toBeLessThanOrEqual(500000 + 256);
     });
 });

--- a/gen.pollinations.ai/test/image/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image/image-edits.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-    getSourceImageDimensions,
-} from "../../src/image/utils/imageDownload.ts";
+import { getSourceImageDimensions } from "../../src/image/utils/imageDownload.ts";
 
 describe("getSourceImageDimensions (data URI)", () => {
     it("extracts PNG dimensions from a minimal data URI", async () => {


### PR DESCRIPTION
Fixes #12583
Ref #10944

Preserves the source image aspect ratio when an image-edit request omits `size`. Keeps requests with an explicit `size` unchanged.

- Adds `getSourceImageDimensions()` - extracts dimensions from data URIs (multipart uploads) and remote URLs using existing `readImageDimensions`
- Adds `computeAspectRatioSize()` - proportionally scales dimensions to ~1MP with 16px snapping
- Modifies `handleImageEdit` - computes effective `size` from source image when omitted
- Zero new dependencies. Uses existing `base64ToBuffer`, `downloadUserImage`, `readImageDimensions`

Tested: portrait images, landscape images, and explicit size all handled correctly.