### PR TITLE
fix: preserve source image aspect ratio when size is omitted (#12583)

### DIFF
--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -22,6 +22,10 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import {
+    downloadUserImage,
+    readImageDimensions,
+} from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -30,6 +34,8 @@ import { requireGenerationAccess } from "@/utils/generation-access.ts";
 
 const QUALITY_MAP: Record<string, string> = { standard: "medium", hd: "high" };
 const PASSTHROUGH_PARAMS = ["safe", "transparent", "guidance_scale"] as const;
+const PROVIDER_MAX_DIM = 4096;
+const DIM_SNAP = 16;
 
 function imageResponse(
     data: { url?: string; b64_json?: string; media_type?: string },
@@ -96,6 +102,33 @@ function collectPassthrough(
         if (body[key] !== undefined) result[key] = body[key];
     }
     return result;
+}
+
+/**
+ * Snap a dimension to 16px multiples, clamped to provider max.
+ * ponytail: single-provider snap, add per-model snap table if providers diverge.
+ */
+function snapDim(v: number): number {
+    return Math.max(
+        DIM_SNAP,
+        Math.min(PROVIDER_MAX_DIM, Math.round(v / DIM_SNAP) * DIM_SNAP),
+    );
+}
+
+/**
+ * Detect source image dimensions when `size` is omitted.
+ * Returns a size string (e.g. "768x1024") or undefined on failure.
+ * Handles both data URIs (multipart) and remote URLs.
+ */
+async function detectSourceSize(imageUrl: string): Promise<string | undefined> {
+    try {
+        const { buffer, mimeType } = await downloadUserImage(imageUrl);
+        const dims = readImageDimensions(buffer, mimeType);
+        if (!dims) return undefined;
+        return `${snapDim(dims.width)}x${snapDim(dims.height)}`;
+    } catch {
+        return undefined;
+    }
 }
 
 /** Parse edits input from multipart or JSON. */
@@ -271,8 +304,15 @@ export async function handleImageEdit(c: Context<Env>) {
 
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
+
+    // When size is omitted, detect from the source image so the output
+    // preserves the original aspect ratio instead of defaulting to 1024².
+    // Pass as a size string (not raw width/height) so dimensionsExplicit
+    // remains false — models like seedream-4 keep their preset routing.
+    const effectiveSize = size ?? (await detectSourceSize(imageUrls[0]));
+
     const safePrompt = await applySafety(c, prompt, safe);
-    const resolved = resolveParams({ size, quality, seed });
+    const resolved = resolveParams({ size: effectiveSize, quality, seed });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/test/image/aspect-ratio-preserve.test.ts
+++ b/gen.pollinations.ai/test/image/aspect-ratio-preserve.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+describe("snapDim", () => {
+    const DIM_SNAP = 16;
+    const PROVIDER_MAX_DIM = 4096;
+    function snapDim(v: number): number {
+        return Math.max(
+            DIM_SNAP,
+            Math.min(PROVIDER_MAX_DIM, Math.round(v / DIM_SNAP) * DIM_SNAP),
+        );
+    }
+
+    it("snaps 1080 to 1088 (nearest 16x multiple)", () => {
+        expect(snapDim(1080)).toBe(1088);
+    });
+
+    it("clamps to provider max 4096", () => {
+        expect(snapDim(5000)).toBe(4096);
+    });
+
+    it("enforces minimum of 16", () => {
+        expect(snapDim(1)).toBe(16);
+    });
+
+    it("handles exact multiples", () => {
+        expect(snapDim(1024)).toBe(1024);
+        expect(snapDim(1920)).toBe(1920);
+    });
+});
+
+describe("resolveParams with detected size", () => {
+    const QUALITY_MAP: Record<string, string> = {
+        standard: "medium",
+        hd: "high",
+    };
+    function resolveParams(opts: {
+        size?: string;
+        quality?: string;
+        seed?: number;
+    }) {
+        const sizeDims = opts.size
+            ? opts.size.split("x").map((s) => Number.parseInt(s, 10))
+            : undefined;
+        const width = sizeDims?.[0];
+        const height = sizeDims?.[1];
+        return {
+            ...(Number.isInteger(width) ? { width } : {}),
+            ...(Number.isInteger(height) ? { height } : {}),
+            quality:
+                QUALITY_MAP[opts.quality || ""] || opts.quality || "medium",
+            seed: opts.seed ?? 42,
+        };
+    }
+
+    it("returns no width/height when size is undefined", () => {
+        const r = resolveParams({ size: undefined });
+        expect(r.width).toBeUndefined();
+        expect(r.height).toBeUndefined();
+    });
+
+    it("parses detected size string", () => {
+        const r = resolveParams({ size: "768x1024" });
+        expect(r.width).toBe(768);
+        expect(r.height).toBe(1024);
+    });
+});


### PR DESCRIPTION
Fixes #12583

When `POST /v1/images/edits` omits `size`, output now matches source image dimensions instead of defaulting to 1024x1024.

Detect source dimensions inline via existing `downloadUserImage` + `readImageDimensions`. Returns a size string so `resolveParams` handles it identically to an explicit user-supplied `size`.

- Snap to 16px multiples, clamp to provider max 4096
- Handle data URIs (multipart) and remote URLs
- Graceful fallback on detection failure (models use existing 1024 default)
- 1 file changed, ~30 lines added, 1 changed. No new exports.