### PR TITLE
chore: promote main to production

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -1157,6 +1157,7 @@ List private and public community models owned by the authenticated account. API
 | `data[].id` * | `string` | — |
 | `data[].modelId` * | `string` | — |
 | `data[].name` * | `string` | — |
+| `data[].title` * | `string` | — |
 | `data[].description` * | `string` \| `null` | — |
 | `data[].modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. |
 | `data[].imagePricing` * | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |
@@ -1198,7 +1199,8 @@ Register a private or public community text or image model. Private is the defau
 | Field | Type | Description |
 |---|---|---|
 | `name` * | `string` | length: `1…120` |
-| `description` | `string` | max length: `240` |
+| `title` * | `string` | Display name shown in the model catalog. · length: `1…42` |
+| `description` | `string` | max length: `160` |
 | `baseUrl` * | `string · uri` | OpenAI-compatible `/v1` base URL or full `/chat/completions` or `/images/generations` URL. |
 | `upstreamModel` | `string` | length: `1…253` |
 | `bearerToken` * | `string` | — |
@@ -1224,6 +1226,7 @@ Register a private or public community text or image model. Private is the defau
 | `id` * | `string` | — |
 | `modelId` * | `string` | — |
 | `name` * | `string` | — |
+| `title` * | `string` | — |
 | `description` * | `string` \| `null` | — |
 | `modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. |
 | `imagePricing` * | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |
@@ -1353,7 +1356,8 @@ Update a community model owned by the authenticated account. Changing visibility
 | Field | Type | Description |
 |---|---|---|
 | `name` | `string` | length: `1…120` |
-| `description` | `string` | max length: `240` |
+| `title` | `string` | Display name shown in the model catalog. · length: `1…42` |
+| `description` | `string` | max length: `160` |
 | `baseUrl` | `string · uri` | OpenAI-compatible `/v1` base URL or full `/chat/completions` or `/images/generations` URL. |
 | `upstreamModel` | `string` | length: `1…253` |
 | `bearerToken` | `string` | — |
@@ -1379,6 +1383,7 @@ Update a community model owned by the authenticated account. Changing visibility
 | `id` * | `string` | — |
 | `modelId` * | `string` | — |
 | `name` * | `string` | — |
+| `title` * | `string` | — |
 | `description` * | `string` \| `null` | — |
 | `modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. |
 | `imagePricing` * | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -29,6 +29,7 @@ const stripReasoning = createReasoningEffortTransform("strip");
 // 4.6+ use adaptive + output_config.effort.
 const claudeManualThinking = createClaudeThinkingTransform("budget");
 const claudeAdaptiveThinking = createClaudeThinkingTransform("adaptive");
+const claudeOpus5Thinking = createClaudeThinkingTransform("adaptive", true);
 
 interface ModelDefinition {
     name: string;
@@ -212,8 +213,8 @@ const models: ModelDefinition[] = [
     },
     {
         name: "claude-large",
-        config: portkeyConfig["claude-opus-4-8"],
-        transform: claudeAdaptiveThinking,
+        config: portkeyConfig["claude-opus-5"],
+        transform: claudeOpus5Thinking,
     },
     {
         name: "claude-fable-5",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -263,9 +263,9 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "us.anthropic.claude-opus-4-7",
             defaultOptions: { max_tokens: 128000 },
         }),
-    "claude-opus-4-8": () =>
+    "claude-opus-5": () =>
         createBedrockNativeConfig({
-            model: "us.anthropic.claude-opus-4-8",
+            model: "global.anthropic.claude-opus-5",
             defaultOptions: { max_tokens: 128000 },
         }),
     "claude-fable-5": () =>

--- a/gen.pollinations.ai/src/text/transforms/createClaudeThinkingTransform.ts
+++ b/gen.pollinations.ai/src/text/transforms/createClaudeThinkingTransform.ts
@@ -10,8 +10,8 @@ const log = debug("pollinations:transforms:claude-thinking");
  * - `"budget"`: Haiku 4.5 — classic `thinking:{type:"enabled",
  *   budget_tokens:N}`. (`adaptive` is rejected: "adaptive thinking is not
  *   supported on this model".)
- * - `"adaptive"`: Sonnet 4.6 and Opus 4.6/4.7/4.8 —
- *   `thinking:{type:"adaptive"}` + `output_config:{effort}`. On Opus 4.7/4.8,
+ * - `"adaptive"`: Sonnet 4.6 and Opus 4.6/4.7/4.8/5 —
+ *   `thinking:{type:"adaptive"}` + `output_config:{effort}`. On Opus 4.7+,
  *   `{type:"enabled",budget_tokens}` is rejected; on Sonnet/Opus 4.6 it still
  *   works but is deprecated.
  */
@@ -47,10 +47,13 @@ function normalizeEffort(value: unknown): string | undefined {
  * Creates a transform that maps the standard `reasoning_effort` onto Claude's
  * native extended-thinking request shape for Bedrock. Thinking is OFF by
  * default; it is only enabled when the caller asks for it.
- * `reasoning_effort:"none"` leaves thinking off.
+ * `reasoning_effort:"none"` leaves thinking off. Models that enable adaptive
+ * thinking upstream by default can set `disableAdaptiveByDefault` to preserve
+ * Pollinations' opt-in reasoning behavior.
  */
 export function createClaudeThinkingTransform(
     mode: ClaudeThinkingMode,
+    disableAdaptiveByDefault = false,
 ): TransformFn {
     return (messages, options) => {
         const updated: TransformOptions = { ...options };
@@ -63,7 +66,9 @@ export function createClaudeThinkingTransform(
         const wantsThinking = effort !== undefined && effort !== "none";
 
         if (!wantsThinking) {
-            // Off (default): emit no thinking block.
+            if (mode === "adaptive" && disableAdaptiveByDefault) {
+                updated.thinking = { type: "disabled" };
+            }
             return { messages, options: updated };
         }
 
@@ -90,7 +95,7 @@ export function createClaudeThinkingTransform(
 
         // Anthropic rejects non-default sampling params when thinking is on
         // ("`temperature` may only be set to 1 when thinking is enabled"). Strip
-        // them so an enabled toggle never 400s. (Opus 4.7/4.8 already get this in
+        // them so an enabled toggle never 400s. (Opus 4.7+ already get this in
         // parameterProcessor, but Sonnet/Haiku do not.)
         for (const param of ["temperature", "top_p", "top_k"] as const) {
             if (updated[param] !== undefined) {

--- a/gen.pollinations.ai/src/text/transforms/imageUrlToBase64Transform.ts
+++ b/gen.pollinations.ai/src/text/transforms/imageUrlToBase64Transform.ts
@@ -260,7 +260,7 @@ function needsConversion(url: string | undefined): boolean {
     if (!url) return false;
     if (url.startsWith("data:")) return false;
     if (url.startsWith("gs://")) return false;
-    return url.startsWith("http://") || url.startsWith("https://");
+    return true;
 }
 
 interface ContentPart {

--- a/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
+++ b/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
@@ -70,9 +70,9 @@ export function processParameters(
         updatedOptions.temperature = 1;
     }
 
-    // Claude Opus 4.7/4.8 and Fable 5 reject non-default sampling params.
+    // Claude Opus 4.7+, and Fable 5 reject non-default sampling params.
     // Strip them entirely.
-    if (/claude-(opus-4-[78]|fable-5)/i.test(model)) {
+    if (/claude-(opus-(4-[78]|5)|fable-5)/i.test(model)) {
         for (const param of ["temperature", "top_p", "top_k"] as const) {
             if (updatedOptions[param] !== undefined) {
                 log(`Stripping ${param} for ${model}`);

--- a/gen.pollinations.ai/test/text/transforms/createClaudeThinkingTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createClaudeThinkingTransform.test.ts
@@ -96,6 +96,32 @@ describe("createClaudeThinkingTransform — adaptive mode (Sonnet 4.6 and Opus 4
     });
 });
 
+describe("createClaudeThinkingTransform — adaptive mode with upstream default on", () => {
+    const adaptiveDefaultOff = createClaudeThinkingTransform("adaptive", true);
+
+    it("explicitly disables thinking by default", async () => {
+        const { options } = await adaptiveDefaultOff([], {});
+        expect(options.thinking).toEqual({ type: "disabled" });
+        expect(options.output_config).toBeUndefined();
+    });
+
+    it("explicitly disables thinking for reasoning_effort=none", async () => {
+        const { options } = await adaptiveDefaultOff([], {
+            reasoning_effort: "none",
+        });
+        expect(options.thinking).toEqual({ type: "disabled" });
+        expect(options.reasoning_effort).toBeUndefined();
+    });
+
+    it("enables adaptive thinking when requested", async () => {
+        const { options } = await adaptiveDefaultOff([], {
+            reasoning_effort: "high",
+        });
+        expect(options.thinking).toEqual({ type: "adaptive" });
+        expect(options.output_config).toEqual({ effort: "high" });
+    });
+});
+
 describe("Claude thinking model wiring", () => {
     it("wires budget thinking on claude-fast", async () => {
         const transform = findModelByName("claude-fast")?.transform;
@@ -123,5 +149,15 @@ describe("Claude thinking model wiring", () => {
         });
         expect(options.thinking).toEqual({ type: "adaptive" });
         expect(options.output_config).toEqual({ effort: "high" });
+    });
+
+    it("keeps claude-large reasoning opt-in", async () => {
+        const transform = findModelByName("claude-large")?.transform;
+        if (!transform) throw new Error("claude-large transform missing");
+        const { options } = await transform(
+            [{ role: "user", content: "hi" }],
+            {},
+        );
+        expect(options.thinking).toEqual({ type: "disabled" });
     });
 });

--- a/gen.pollinations.ai/test/text/transforms/imageUrlToBase64Transform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/imageUrlToBase64Transform.test.ts
@@ -21,6 +21,16 @@ function imageMessage(urls: string[]) {
 }
 
 describe("imageUrlToBase64Transform", () => {
+    it("rejects malformed image URLs before they reach the provider", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            transform(imageMessage(["not-a-url"]), bedrockOptions),
+        ).rejects.toMatchObject({ status: 400 });
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
     it("rejects localhost and literal IP image URLs before fetch", async () => {
         const fetchSpy = vi.spyOn(globalThis, "fetch");
 

--- a/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
@@ -80,6 +80,7 @@ describe("processParameters", () => {
     it.each([
         "us.anthropic.claude-opus-4-7",
         "global.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-opus-5",
         "global.anthropic.claude-fable-5",
     ])("strips temperature/top_p/top_k for %s", (model) => {
         const result = processParameters(messages, {

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -33,6 +33,14 @@ describe("resolveModelConfig", () => {
         expect(result.options.max_tokens).toBe(1024);
     });
 
+    it("routes claude-large to the global Opus 5 profile", () => {
+        const result = resolveModelConfig(messages, {
+            model: "claude-large",
+        });
+
+        expect(result.options.model).toBe("global.anthropic.claude-opus-5");
+    });
+
     it("does not set max_tokens for non-Anthropic models", () => {
         const result = resolveModelConfig(messages, { model: "openai" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -994,7 +994,7 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "claude-large": {
-        aliases: ["claude-opus-4.8", "claude-opus"],
+        aliases: ["claude-opus-5", "claude-opus-4.8", "claude-opus"],
         provider: "bedrock",
         brand: "Anthropic",
         category: "text",
@@ -1002,15 +1002,15 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // Bedrock global.anthropic.claude-opus-4-8 global standard rates.
+            // Bedrock global.anthropic.claude-opus-5 global standard rates.
             promptTextTokens: perMillion(5),
             promptCachedTokens: perMillion(0.5),
             promptCacheWriteTokens: perMillion(6.25),
             completionTextTokens: perMillion(25),
         },
-        title: "Claude Opus 4.8",
+        title: "Claude Opus 5",
         description:
-            "Top-shelf reasoning, writing and coding; premium price per token",
+            "Frontier reasoning for coding, complex analysis and long-running agents",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
         maxReferenceImages: 20, // Bedrock Converse image limit.


### PR DESCRIPTION
- Promotes #12751 and the generated API-reference refresh #12752 from `main` to `production`.
- Routes `claude-large` to AWS Bedrock Opus 5 while preserving aliases, pricing, paid-only access, and opt-in reasoning behavior.
- Adds the `claude-opus-5` model alias and clearer malformed-image validation.
- Validation: source PR #12751 passed the full Gen suite, Enter registry/pricing tests, typechecks, authenticated E2E coverage, burst testing, and CodeQL; #12752 passed formatting/linting and CodeQL. The updated promotion diff contains no secret changes.