### PR TITLE
fix: cap community model prices

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -14,6 +14,8 @@ import {
     type CommunityEndpointImagePricing,
     type CommunityEndpointModality,
     communityEndpointPriceFieldsForModality,
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
 } from "@shared/community-endpoints.ts";
 import { PRICE_ICON } from "../models/model-icons.tsx";
 import type { PriceKind } from "../models/types.ts";
@@ -181,6 +183,10 @@ function PriceInputCell({
     const inputId = `community-${field.key}`;
     const hasError = state.invalid;
     const unitLabel = field.priceUnit === "image" ? "/image" : "/1M";
+    const maximum =
+        field.priceUnit === "image"
+            ? MAX_COMMUNITY_PRICE_PER_IMAGE
+            : MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS;
 
     return (
         <TableCell align="right" className="w-40 align-top">
@@ -192,6 +198,7 @@ function PriceInputCell({
                         type="number"
                         step="any"
                         min="0"
+                        max={String(maximum)}
                         inputMode="decimal"
                         hideNumberSteppers
                         value={value}
@@ -210,7 +217,9 @@ function PriceInputCell({
                 </div>
                 {hasError && (
                     <p className="mt-1 text-right text-xs text-intent-danger-text">
-                        Enter 0 (free) or a valid positive price.
+                        {field.priceUnit === "image"
+                            ? `Enter 0–${maximum} ${unitLabel}.`
+                            : `Enter 0 or up to ${maximum} ${unitLabel}.`}
                     </p>
                 )}
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -7,6 +7,8 @@ import {
     type CommunityEndpointPrices,
     type CommunityEndpointVisibility,
     communityEndpointPriceFieldsForModality,
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
 } from "@shared/community-endpoints.ts";
 import type { Usage } from "@shared/registry/registry.ts";
@@ -144,9 +146,14 @@ export function isValidPriceInput(
     if (!trimmed) return true;
     if (trimmed.includes(",")) return false;
     const parsed = Number(trimmed);
+    const maximum =
+        priceUnit === "image"
+            ? MAX_COMMUNITY_PRICE_PER_IMAGE
+            : MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS;
     return (
         Number.isFinite(parsed) &&
         parsed >= 0 &&
+        parsed <= maximum &&
         (priceUnit === "image" ||
             parsed === 0 ||
             parsed >= MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS)
@@ -205,7 +212,7 @@ function formPricesToPayload(
                 const unit =
                     modalityField.priceUnit === "image" ? "image" : "1M units";
                 throw new Error(
-                    `Prices must be 0 (free) or a positive amount per ${unit}, using a dot decimal`,
+                    `Prices must be within the allowed range per ${unit}, using a dot decimal`,
                 );
             }
             return [

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -13,6 +13,9 @@ import {
     communityEndpointTitle,
     communityModelId,
     isCommunityEndpointOwnerAllowed,
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MAX_COMMUNITY_PRICE_PER_TOKEN,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityEndpointBaseUrl,
@@ -68,6 +71,32 @@ const UpdatePriceFieldsSchema = Object.fromEntries(
     CommunityEndpointPriceKey,
     z.ZodOptional<z.ZodType<number>>
 >;
+
+function enforceCommunityEndpointPriceLimits(
+    source: Partial<Record<CommunityEndpointPriceKey, number>>,
+    modality: (typeof COMMUNITY_ENDPOINT_MODALITIES)[number],
+    imagePricing: (typeof COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)[number],
+): void {
+    for (const field of communityEndpointPriceFieldsForModality(
+        modality,
+        imagePricing,
+    )) {
+        const price = source[field.key];
+        const maxPrice =
+            field.priceUnit === "image"
+                ? MAX_COMMUNITY_PRICE_PER_IMAGE
+                : MAX_COMMUNITY_PRICE_PER_TOKEN;
+        if (price === undefined || price <= maxPrice) continue;
+
+        const limit =
+            field.priceUnit === "image"
+                ? `${MAX_COMMUNITY_PRICE_PER_IMAGE} Pollen per image`
+                : `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`;
+        throw new HTTPException(400, {
+            message: `${field.label} price must not exceed ${limit}`,
+        });
+    }
+}
 
 const VisibilitySchema = z
     .enum(COMMUNITY_ENDPOINT_VISIBILITIES)
@@ -448,6 +477,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                           imagePricing,
                       )
                     : communityEndpointPrices({});
+            enforceCommunityEndpointPriceLimits(
+                prices,
+                input.modality,
+                imagePricing,
+            );
             await enforcePublishingAccess(db, user.id, input.visibility);
             const id = crypto.randomUUID();
             const [row] = await db
@@ -683,6 +717,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                           modality,
                           effectiveImagePricing,
                       );
+            enforceCommunityEndpointPriceLimits(
+                effectivePrices,
+                modality,
+                effectiveImagePricing,
+            );
             await enforcePublishingAccess(db, user.id, effectiveVisibility);
             // Persist visibility together with the complete effective price
             // set on every update, so concurrent partial updates cannot

--- a/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
@@ -1,4 +1,6 @@
 import {
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_TOKEN,
 } from "@shared/community-endpoints.ts";
@@ -44,5 +46,25 @@ describe("community endpoint price input", () => {
         expect(formPriceToStoredPrice("0.03", "image")).toBe(0.03);
         expect(storedPriceToFormValue(0.03, "image")).toBe("0.03");
         expect(isValidPriceInput("0.000000001", "image")).toBe(true);
+    });
+
+    it("rejects prices above the configured ceilings", () => {
+        expect(
+            isValidPriceInput(String(MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS)),
+        ).toBe(true);
+        expect(
+            isValidPriceInput(
+                String(MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS + 1),
+            ),
+        ).toBe(false);
+        expect(
+            isValidPriceInput(String(MAX_COMMUNITY_PRICE_PER_IMAGE), "image"),
+        ).toBe(true);
+        expect(
+            isValidPriceInput(
+                String(MAX_COMMUNITY_PRICE_PER_IMAGE + 0.01),
+                "image",
+            ),
+        ).toBe(false);
     });
 });

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -13,6 +13,9 @@ import {
     communityPriceDefinition,
     isCommunityEndpointOwnerAllowed,
     legacyCommunityModelId,
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MAX_COMMUNITY_PRICE_PER_TOKEN,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityAssetUrl,
@@ -1358,8 +1361,8 @@ fixtureTest(
                     upstreamModel: "gpt-4.1-mini",
                     bearerToken: "sk_saved_token",
                     visibility: "public",
-                    promptTextPrice: 0.1,
-                    completionTextPrice: 0.1,
+                    promptTextPrice: 0.00001,
+                    completionTextPrice: 0.00001,
                 }),
             }),
         );
@@ -1411,8 +1414,8 @@ fixtureTest(
                     },
                     body: JSON.stringify({
                         visibility: "public",
-                        promptTextPrice: 0.1,
-                        completionTextPrice: 0.1,
+                        promptTextPrice: 0.00001,
+                        completionTextPrice: 0.00001,
                     }),
                 },
             ),
@@ -1617,8 +1620,8 @@ fixtureTest(
                     upstreamModel: "openai",
                     bearerToken: "Bearer sk_pollinations_upstream",
                     visibility: "public",
-                    promptTextPrice: 0.1,
-                    completionTextPrice: 0.1,
+                    promptTextPrice: 0.00001,
+                    completionTextPrice: 0.00001,
                 }),
             }),
         );
@@ -1638,8 +1641,8 @@ fixtureTest(
             baseUrl: "https://gen.pollinations.ai/v1",
             upstreamModel: "openai",
             visibility: "public",
-            promptTextPrice: 0.1,
-            completionTextPrice: 0.1,
+            promptTextPrice: 0.00001,
+            completionTextPrice: 0.00001,
         });
 
         const testResponse = await fetchEnterApi(
@@ -2041,6 +2044,43 @@ fixtureTest(
                     new Request(input, init).url === TEST_COMMUNITY_IMAGE_URL,
             ),
         ).toHaveLength(3);
+
+        const maximumImagePriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${registered.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: await signedSessionCookie(sessionToken),
+                    },
+                    body: JSON.stringify({
+                        completionImagePrice: MAX_COMMUNITY_PRICE_PER_IMAGE,
+                    }),
+                },
+            ),
+        );
+        expect(maximumImagePriceResponse.status).toBe(200);
+
+        const excessiveImagePriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${registered.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: await signedSessionCookie(sessionToken),
+                    },
+                    body: JSON.stringify({
+                        completionImagePrice:
+                            MAX_COMMUNITY_PRICE_PER_IMAGE + 0.01,
+                    }),
+                },
+            ),
+        );
+        expect(excessiveImagePriceResponse.status).toBe(400);
     },
 );
 
@@ -2157,8 +2197,8 @@ fixtureTest(
                         title: "Updated Model Title",
                         description: "Updated description",
                         visibility: "public",
-                        promptTextPrice: 0.1,
-                        completionTextPrice: 0.2,
+                        promptTextPrice: 0.00001,
+                        completionTextPrice: 0.00002,
                     }),
                 },
             ),
@@ -2168,8 +2208,8 @@ fixtureTest(
             title: "Updated Model Title",
             description: "Updated description",
             visibility: "public",
-            promptTextPrice: 0.1,
-            completionTextPrice: 0.2,
+            promptTextPrice: 0.00001,
+            completionTextPrice: 0.00002,
             disabled: true,
             disabledReason: "was failing",
         });
@@ -2264,15 +2304,15 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ promptTextPrice: 0.3 }),
+                    body: JSON.stringify({ promptTextPrice: 0.00003 }),
                 },
             ),
         );
         expect(priceOnlyResponse.status).toBe(200);
         await expect(priceOnlyResponse.json()).resolves.toMatchObject({
             visibility: "public",
-            promptTextPrice: 0.3,
-            completionTextPrice: 0.2,
+            promptTextPrice: 0.00003,
+            completionTextPrice: 0.00002,
         });
 
         // Making the model private clears all owner-set prices.
@@ -2409,6 +2449,22 @@ fixtureTest(
         await expect(minimumResponse.json()).resolves.toMatchObject({
             promptTextPrice: MIN_COMMUNITY_PRICE_PER_TOKEN,
         });
+
+        const maximumResponse = await updatePrice(
+            MAX_COMMUNITY_PRICE_PER_TOKEN,
+        );
+        expect(maximumResponse.status).toBe(200);
+        await expect(maximumResponse.json()).resolves.toMatchObject({
+            promptTextPrice: MAX_COMMUNITY_PRICE_PER_TOKEN,
+        });
+
+        const aboveMaximumResponse = await updatePrice(
+            MAX_COMMUNITY_PRICE_PER_TOKEN * 1.01,
+        );
+        expect(aboveMaximumResponse.status).toBe(400);
+        expect(await aboveMaximumResponse.text()).toContain(
+            `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`,
+        );
 
         const belowMinimumResponse = await updatePrice(
             MIN_COMMUNITY_PRICE_PER_TOKEN / 10,

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -26,6 +26,12 @@ export const COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH = 160;
 export const MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS = 0.000001;
 export const MIN_COMMUNITY_PRICE_PER_TOKEN =
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
+// Keep typos and malicious configurations from exposing callers to extreme
+// charges.
+export const MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS = 50;
+export const MAX_COMMUNITY_PRICE_PER_TOKEN =
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
+export const MAX_COMMUNITY_PRICE_PER_IMAGE = 0.25;
 const BEARER_PREFIX = /^Bearer(?:\s+|$)/i;
 
 export type CommunityEndpointModality =


### PR DESCRIPTION
- Caps token-priced community models at 50 Pollen per 1M tokens.
- Caps fixed-price community image models at 0.25 Pollen per image.
- Enforces the limits in the API and dashboard price inputs.
- Adds boundary coverage for token and image pricing.

Checks:
- `biome check` on all changed files
- `git diff --check`

The focused local Worker test is currently blocked by an incomplete reused dependency tree (`stripe` missing); GitHub CI installs the locked dependencies.