### PR TITLE
fix: batch quest reward inserts safely

### DIFF
--- a/enter.pollinations.ai/test/integration/rewards.test.ts
+++ b/enter.pollinations.ai/test/integration/rewards.test.ts
@@ -80,6 +80,28 @@ describe("rewards", () => {
         });
     });
 
+    test("records more rewards than fit in one D1 insert", async () => {
+        const db = drizzle(env.DB, { schema });
+        const userId = "reward-user-batched";
+        await seedUser(db, userId);
+
+        const result = await recordRewards(
+            db,
+            Array.from({ length: 12 }, (_, index) => ({
+                idempotencyKey: `batched:${userId}:${index}`,
+                userId,
+                amount: 1,
+                bucket: "tier" as const,
+                questId: `batched-${index}`,
+                title: `Batched reward ${index}`,
+            })),
+        );
+
+        expect(result.recorded).toBe(12);
+        expect(result.rewardIds).toHaveLength(12);
+        expect(await listRewards(db, userId)).toHaveLength(12);
+    });
+
     test("recording is idempotent and claim credits once", async () => {
         const db = drizzle(env.DB, { schema });
         const userId = "reward-user-idem";

--- a/shared/billing/rewards.ts
+++ b/shared/billing/rewards.ts
@@ -56,11 +56,6 @@ function assertRewardAmount(amount: number): void {
     }
 }
 
-// D1 binds every value as a parameter and caps a statement at 100 bound
-// variables. Each reward row binds 8 columns, so 12 rows (96 params) is the
-// largest safe chunk.
-const REWARD_INSERT_CHUNK = 12;
-
 /**
  * Records earned rewards without moving pollen. The unique idempotency key
  * makes scanner retries safe; only claimReward() credits the user's balance.
@@ -89,16 +84,23 @@ export async function recordRewards(
         };
     });
 
-    const rewardIds: string[] = [];
-    for (let i = 0; i < rows.length; i += REWARD_INSERT_CHUNK) {
-        const chunk = rows.slice(i, i + REWARD_INSERT_CHUNK);
-        const inserted = await db
+    // Keep each insert as a separate statement so its bound parameter count is
+    // independent of the number of rewards. D1 executes the statements in one
+    // transactional batch, avoiding extra database round trips.
+    const statements = rows.map((row) =>
+        db
             .insert(rewards)
-            .values(chunk)
-            .onConflictDoNothing({ target: rewards.idempotencyKey })
-            .returning({ id: rewards.id });
-        rewardIds.push(...inserted.map((row) => row.id));
-    }
+            .values(row)
+            .onConflictDoNothing({ target: rewards.idempotencyKey }),
+    );
+    const [firstStatement, ...remainingStatements] = statements;
+    if (!firstStatement) return { recorded: 0, rewardIds: [] };
+
+    const results = await db.batch([firstStatement, ...remainingStatements]);
+    const rewardIds = rows.flatMap((row, index) => {
+        const result = results[index] as D1Result | undefined;
+        return result?.meta.changes ? [row.id] : [];
+    });
 
     return {
         recorded: rewardIds.length,


### PR DESCRIPTION
- Sends each pending reward as its own prepared insert inside one transactional D1 batch.
- Removes the schema-sensitive multi-row chunk size that exceeded D1's 100-bound-parameter limit.
- Preserves idempotency and returns only IDs for rows that were actually inserted.
- Adds coverage for a 12-reward scan, matching the production failure.

Validation:
- `npx biome check --write ../shared/billing/rewards.ts test/integration/rewards.test.ts`
- `npx tsc --noEmit --pretty false`
- Vitest Workers pool currently exits before loading any test file, including an unrelated existing test.