### PR TITLE
feat(enter): admin-managed dashboard status notice (#12585)

### DIFF
--- a/enter.pollinations.ai/frontend/src/backend-types.ts
+++ b/enter.pollinations.ai/frontend/src/backend-types.ts
@@ -4,3 +4,4 @@
 // because route types include hono-openapi declarations.
 export type { FrontendApiRoutes as ApiRoutes } from "../../src/frontend-api.ts";
 export type { QuestCatalogResponse } from "../../src/routes/quests.ts";
+export type { StatusNotice } from "../../src/routes/status-notice.ts";

--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -38,6 +38,7 @@ import {
     type DashboardPage,
     type DashboardPath,
 } from "./dashboard-theme.ts";
+import { StatusNoticeBanner } from "./status-notice-banner.tsx";
 
 export type { DashboardPage } from "./dashboard-theme.ts";
 
@@ -353,6 +354,7 @@ export const DashboardShell: FC<DashboardShellProps> = ({
                     className="min-h-0 min-w-0 flex-1 overscroll-contain px-4 pt-14 pb-8 lg:px-6 lg:pt-10"
                 >
                     <main className="mx-auto flex max-w-[800px] flex-col gap-6">
+                        <StatusNoticeBanner />
                         {children}
                     </main>
                 </ScrollArea>

--- a/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
@@ -1,0 +1,71 @@
+import { Alert, cn, XIcon } from "@pollinations/ui";
+import { type FC, useEffect, useState } from "react";
+import type { StatusNotice } from "../../backend-types.ts";
+import { config } from "../../config.ts";
+import {
+    dismissedNoticeUpdatedAt,
+    dismissStatusNotice,
+    shouldShowStatusNotice,
+} from "./status-notice-state.ts";
+
+export const StatusNoticeBanner: FC<{ className?: string }> = ({
+    className,
+}) => {
+    const [notice, setNotice] = useState<StatusNotice | null>(null);
+    const [dismissedUpdatedAt, setDismissedUpdatedAt] = useState<string | null>(
+        null,
+    );
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setDismissedUpdatedAt(dismissedNoticeUpdatedAt(localStorage));
+
+        fetch(`${config.apiBaseUrl}/status-notice`, {
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+        })
+            .then(async (response) => {
+                if (!response.ok) return;
+                const data = (await response.json()) as {
+                    notice: StatusNotice | null;
+                };
+                setNotice(data.notice);
+            })
+            .catch(() => undefined);
+
+        return () => controller.abort();
+    }, []);
+
+    if (!shouldShowStatusNotice(notice, dismissedUpdatedAt)) return null;
+
+    return (
+        <Alert
+            intent="warning"
+            aria-live="polite"
+            className={cn("relative pr-11", className)}
+        >
+            <p className="break-words">{notice.message}</p>
+            {notice.linkUrl && (
+                <a
+                    href={notice.linkUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1 inline-block font-medium underline underline-offset-2 hover:no-underline"
+                >
+                    {notice.linkLabel ?? "Learn more"}
+                </a>
+            )}
+            <button
+                type="button"
+                aria-label="Dismiss status notice"
+                className="absolute top-2 right-2 rounded-full p-1 text-current opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-2 focus-visible:outline-current focus-visible:outline-offset-2"
+                onClick={() => {
+                    dismissStatusNotice(localStorage, notice);
+                    setDismissedUpdatedAt(notice.updatedAt);
+                }}
+            >
+                <XIcon className="h-4 w-4" aria-hidden="true" />
+            </button>
+        </Alert>
+    );
+};

--- a/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/status-notice-banner.tsx
@@ -8,6 +8,15 @@ import {
     shouldShowStatusNotice,
 } from "./status-notice-state.ts";
 
+const severityToIntent = {
+    info: "info",
+    warning: "warning",
+    critical: "danger",
+} as const satisfies Record<
+    StatusNotice["severity"],
+    "info" | "warning" | "danger"
+>;
+
 export const StatusNoticeBanner: FC<{ className?: string }> = ({
     className,
 }) => {
@@ -38,9 +47,11 @@ export const StatusNoticeBanner: FC<{ className?: string }> = ({
 
     if (!shouldShowStatusNotice(notice, dismissedUpdatedAt)) return null;
 
+    const intent = notice ? severityToIntent[notice.severity] : "warning";
+
     return (
         <Alert
-            intent="warning"
+            intent={intent}
             aria-live="polite"
             className={cn("relative pr-11", className)}
         >

--- a/enter.pollinations.ai/frontend/src/components/layout/status-notice-state.ts
+++ b/enter.pollinations.ai/frontend/src/components/layout/status-notice-state.ts
@@ -1,0 +1,31 @@
+import type { StatusNotice } from "../../backend-types.ts";
+
+export const STATUS_NOTICE_DISMISS_KEY = "polli:status-notice:dismissed";
+
+export function dismissedNoticeUpdatedAt(
+    storage: Pick<Storage, "getItem">,
+): string | null {
+    try {
+        return storage.getItem(STATUS_NOTICE_DISMISS_KEY);
+    } catch {
+        return null;
+    }
+}
+
+export function shouldShowStatusNotice(
+    notice: StatusNotice | null,
+    dismissedUpdatedAt: string | null,
+): notice is StatusNotice {
+    return Boolean(notice && notice.updatedAt !== dismissedUpdatedAt);
+}
+
+export function dismissStatusNotice(
+    storage: Pick<Storage, "setItem">,
+    notice: StatusNotice,
+): void {
+    try {
+        storage.setItem(STATUS_NOTICE_DISMISS_KEY, notice.updatedAt);
+    } catch {
+        return;
+    }
+}

--- a/enter.pollinations.ai/src/frontend-api.ts
+++ b/enter.pollinations.ai/src/frontend-api.ts
@@ -9,6 +9,7 @@ import { modelStatsRoutes } from "./routes/model-stats.ts";
 import { oauthRoutes } from "./routes/oauth.ts";
 import { questsRoutes } from "./routes/quests.ts";
 import { referralRoutes } from "./routes/referral.ts";
+import { statusNoticePublicRoutes } from "./routes/status-notice.ts";
 import { stripeRoutes } from "./routes/stripe.ts";
 
 export const frontendApi = new Hono<Env>()
@@ -21,6 +22,7 @@ export const frontendApi = new Hono<Env>()
     .route("/oauth", oauthRoutes)
     .route("/model-stats", modelStatsRoutes)
     .route("/referral", referralRoutes)
-    .route("/quests", questsRoutes);
+    .route("/quests", questsRoutes)
+    .route("/status-notice", statusNoticePublicRoutes);
 
 export type FrontendApiRoutes = typeof frontendApi;

--- a/enter.pollinations.ai/src/routes/admin.ts
+++ b/enter.pollinations.ai/src/routes/admin.ts
@@ -6,6 +6,7 @@ import {
     exportD1TinybirdPage,
     isD1TinybirdDatasource,
 } from "../services/d1-tinybird-sync.ts";
+import { statusNoticeAdminRoutes } from "./status-notice.ts";
 
 export const adminRoutes = new Hono<Env>()
     .use("*", async (c, next) => {
@@ -80,7 +81,8 @@ export const adminRoutes = new Hono<Env>()
             next_cursor: result.nextCursor,
             done: result.done,
         });
-    });
+    })
+    .route("/status-notice", statusNoticeAdminRoutes);
 
 async function sha256(value: string): Promise<string> {
     const bytes = new TextEncoder().encode(value);

--- a/enter.pollinations.ai/src/routes/status-notice.ts
+++ b/enter.pollinations.ai/src/routes/status-notice.ts
@@ -6,9 +6,14 @@ import type { Env } from "../env.ts";
 
 const KV_KEY = "status-notice:active";
 const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+const SEVERITY_VALUES = ["info", "warning", "critical"] as const;
+const DEFAULT_SEVERITY = "warning";
+
+export type Severity = (typeof SEVERITY_VALUES)[number];
 
 export type StatusNotice = {
     message: string;
+    severity: Severity;
     linkUrl: string | null;
     linkLabel: string | null;
     updatedAt: string;
@@ -16,6 +21,7 @@ export type StatusNotice = {
 
 const storedNoticeSchema = z.object({
     message: z.string().trim().min(1).max(500),
+    severity: z.enum(SEVERITY_VALUES),
     linkUrl: z.string().url().max(2048).nullable(),
     linkLabel: z.string().trim().min(1).max(80).nullable(),
     updatedAt: z.string().datetime(),
@@ -23,6 +29,7 @@ const storedNoticeSchema = z.object({
 
 const publishNoticeSchema = z.object({
     message: z.string().trim().min(1).max(500),
+    severity: z.enum(SEVERITY_VALUES).optional(),
     linkUrl: z.string().url().max(2048).nullable().optional(),
     linkLabel: z.string().trim().min(1).max(80).nullable().optional(),
 });
@@ -53,7 +60,31 @@ async function readNotice(kv: KVNamespace): Promise<StatusNotice | null> {
     const parsed = storedNoticeSchema.safeParse(
         await kv.get<unknown>(KV_KEY, "json"),
     );
-    return parsed.success ? parsed.data : null;
+    return parsed.success ? (parsed.data as StatusNotice) : null;
+}
+
+/**
+ * Returns true if the normalized payload is identical to the previous notice
+ * (excluding `updatedAt`). Used to implement idempotent re-save: when an admin
+ * re-publishes the exact same notice, we keep the original `updatedAt` and skip
+ * the KV write so the dismiss state on existing dashboards is preserved.
+ */
+function isSamePayload(
+    next: {
+        message: string;
+        severity: Severity;
+        linkUrl: string | null;
+        linkLabel: string | null;
+    },
+    prev: StatusNotice | null,
+): prev is StatusNotice {
+    if (!prev) return false;
+    return (
+        next.message === prev.message &&
+        next.severity === prev.severity &&
+        next.linkUrl === prev.linkUrl &&
+        next.linkLabel === prev.linkLabel
+    );
 }
 
 export const statusNoticePublicRoutes = new Hono<Env>().get(
@@ -85,7 +116,8 @@ export const statusNoticeAdminRoutes = new Hono<Env>()
             security: [{ bearer: [] }],
             responses: {
                 200: {
-                    description: "The published dashboard notice",
+                    description:
+                        "The active dashboard notice (published or unchanged)",
                     content: {
                         "application/json": {
                             schema: resolver(noticeResponseSchema),
@@ -122,10 +154,25 @@ export const statusNoticeAdminRoutes = new Hono<Env>()
                 });
             }
 
-            const notice: StatusNotice = {
+            const nextPayload = {
                 message: parsed.data.message,
+                severity: (parsed.data.severity ??
+                    DEFAULT_SEVERITY) as Severity,
                 linkUrl,
+                // linkLabel is only meaningful when a linkUrl is provided;
+                // strip it otherwise so banner logic never sees a dangling label.
                 linkLabel: linkUrl ? (parsed.data.linkLabel ?? null) : null,
+            };
+
+            const existing = await readNotice(c.env.KV);
+            if (isSamePayload(nextPayload, existing)) {
+                // Idempotent re-save: keep the original updatedAt so users who
+                // already dismissed the notice don't see it reappear.
+                return c.json({ notice: existing });
+            }
+
+            const notice: StatusNotice = {
+                ...nextPayload,
                 updatedAt: new Date().toISOString(),
             };
             await c.env.KV.put(KV_KEY, JSON.stringify(notice));

--- a/enter.pollinations.ai/src/routes/status-notice.ts
+++ b/enter.pollinations.ai/src/routes/status-notice.ts
@@ -1,0 +1,158 @@
+import { type Context, Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { describeRoute, resolver } from "hono-openapi";
+import { z } from "zod";
+import type { Env } from "../env.ts";
+
+const KV_KEY = "status-notice:active";
+const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+
+export type StatusNotice = {
+    message: string;
+    linkUrl: string | null;
+    linkLabel: string | null;
+    updatedAt: string;
+};
+
+const storedNoticeSchema = z.object({
+    message: z.string().trim().min(1).max(500),
+    linkUrl: z.string().url().max(2048).nullable(),
+    linkLabel: z.string().trim().min(1).max(80).nullable(),
+    updatedAt: z.string().datetime(),
+});
+
+const publishNoticeSchema = z.object({
+    message: z.string().trim().min(1).max(500),
+    linkUrl: z.string().url().max(2048).nullable().optional(),
+    linkLabel: z.string().trim().min(1).max(80).nullable().optional(),
+});
+
+const noticeResponseSchema = z.object({
+    notice: storedNoticeSchema.nullable(),
+});
+
+function isSafeLink(value: string): boolean {
+    try {
+        return ALLOWED_SCHEMES.has(new URL(value).protocol);
+    } catch {
+        return false;
+    }
+}
+
+function requireAdmin(c: Context<Env>): void {
+    const authorization = c.req.header("Authorization");
+    const token = authorization?.startsWith("Bearer ")
+        ? authorization.slice(7)
+        : null;
+    if (!token || token !== c.env.PLN_ENTER_TOKEN) {
+        throw new HTTPException(401, { message: "Unauthorized" });
+    }
+}
+
+async function readNotice(kv: KVNamespace): Promise<StatusNotice | null> {
+    const parsed = storedNoticeSchema.safeParse(
+        await kv.get<unknown>(KV_KEY, "json"),
+    );
+    return parsed.success ? parsed.data : null;
+}
+
+export const statusNoticePublicRoutes = new Hono<Env>().get(
+    "/",
+    describeRoute({
+        tags: ["📣 Status Notice"],
+        summary: "Get Dashboard Status Notice",
+        security: [],
+        responses: {
+            200: {
+                description: "The active dashboard notice, if one exists",
+                content: {
+                    "application/json": {
+                        schema: resolver(noticeResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    async (c) => c.json({ notice: await readNotice(c.env.KV) }),
+);
+
+export const statusNoticeAdminRoutes = new Hono<Env>()
+    .put(
+        "/",
+        describeRoute({
+            tags: ["📣 Status Notice"],
+            summary: "Publish Dashboard Status Notice",
+            security: [{ bearer: [] }],
+            responses: {
+                200: {
+                    description: "The published dashboard notice",
+                    content: {
+                        "application/json": {
+                            schema: resolver(noticeResponseSchema),
+                        },
+                    },
+                },
+                400: { description: "Invalid notice" },
+                401: { description: "Unauthorized" },
+            },
+        }),
+        async (c) => {
+            requireAdmin(c);
+
+            let body: unknown;
+            try {
+                body = await c.req.json();
+            } catch {
+                throw new HTTPException(400, {
+                    message: "Invalid JSON body",
+                });
+            }
+
+            const parsed = publishNoticeSchema.safeParse(body);
+            if (!parsed.success) {
+                throw new HTTPException(400, {
+                    message: "Invalid status notice payload",
+                });
+            }
+
+            const linkUrl = parsed.data.linkUrl ?? null;
+            if (linkUrl && !isSafeLink(linkUrl)) {
+                throw new HTTPException(400, {
+                    message: "linkUrl must use http: or https:",
+                });
+            }
+
+            const notice: StatusNotice = {
+                message: parsed.data.message,
+                linkUrl,
+                linkLabel: linkUrl ? (parsed.data.linkLabel ?? null) : null,
+                updatedAt: new Date().toISOString(),
+            };
+            await c.env.KV.put(KV_KEY, JSON.stringify(notice));
+            return c.json({ notice });
+        },
+    )
+    .delete(
+        "/",
+        describeRoute({
+            tags: ["📣 Status Notice"],
+            summary: "Clear Dashboard Status Notice",
+            security: [{ bearer: [] }],
+            responses: {
+                200: {
+                    description: "The notice was cleared",
+                    content: {
+                        "application/json": {
+                            schema: resolver(noticeResponseSchema),
+                        },
+                    },
+                },
+                401: { description: "Unauthorized" },
+            },
+        }),
+        async (c) => {
+            requireAdmin(c);
+            await c.env.KV.delete(KV_KEY);
+            return c.json({ notice: null });
+        },
+    );

--- a/enter.pollinations.ai/test/status-notice-ui.test.ts
+++ b/enter.pollinations.ai/test/status-notice-ui.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+    dismissStatusNotice,
+    STATUS_NOTICE_DISMISS_KEY,
+    shouldShowStatusNotice,
+} from "../frontend/src/components/layout/status-notice-state.ts";
+import type { StatusNotice } from "../src/routes/status-notice.ts";
+
+const notice: StatusNotice = {
+    message: "Maintenance in progress",
+    linkUrl: null,
+    linkLabel: null,
+    updatedAt: "2026-07-25T12:00:00.000Z",
+};
+
+describe("status notice UI state", () => {
+    test("shows an active notice and hides an inactive notice", () => {
+        expect(shouldShowStatusNotice(notice, null)).toBe(true);
+        expect(shouldShowStatusNotice(null, null)).toBe(false);
+    });
+
+    test("hides the dismissed notice but shows a later update", () => {
+        expect(shouldShowStatusNotice(notice, notice.updatedAt)).toBe(false);
+        expect(
+            shouldShowStatusNotice(
+                { ...notice, updatedAt: "2026-07-25T12:01:00.000Z" },
+                notice.updatedAt,
+            ),
+        ).toBe(true);
+    });
+
+    test("stores the active notice identifier when dismissed", () => {
+        const setItem = vi.fn();
+        dismissStatusNotice({ setItem }, notice);
+        expect(setItem).toHaveBeenCalledWith(
+            STATUS_NOTICE_DISMISS_KEY,
+            notice.updatedAt,
+        );
+    });
+});

--- a/enter.pollinations.ai/test/status-notice.test.ts
+++ b/enter.pollinations.ai/test/status-notice.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Env } from "../src/env.ts";
 import {
     type StatusNotice,
@@ -42,7 +42,23 @@ function adminRequest(body: unknown, token = "test-admin-token"): Request {
     });
 }
 
+async function publish(
+    app: Hono<Env>,
+    env: Env["Bindings"],
+    payload: unknown,
+): Promise<{ status: number; body: { notice: StatusNotice | null } }> {
+    const res = await app.fetch(adminRequest(payload), env);
+    return { status: res.status, body: (await res.json()) as never };
+}
+
 describe("status notice routes", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     test("returns null when no notice is active", async () => {
         const { app, env } = createHarness();
         const response = await app.fetch(
@@ -72,24 +88,60 @@ describe("status notice routes", () => {
         expect(response.status).toBe(401);
     });
 
-    test("publishes, updates, and clears a notice", async () => {
-        const { app, env, kv } = createHarness();
-        const publishResponse = await app.fetch(
-            adminRequest({
-                message: " Maintenance is in progress. ",
-                linkUrl: "https://status.pollinations.ai",
-                linkLabel: "Status page",
+    test.each([
+        "PUT",
+        "DELETE",
+    ])("%s rejects the wrong token", async (method) => {
+        const { app, env } = createHarness();
+        const response = await app.fetch(adminRequest({}, "wrong"), env);
+        if (method === "DELETE") {
+            // Re-issue as DELETE with the wrong token.
+            const res = await app.fetch(
+                new Request("http://localhost/admin/status-notice", {
+                    method: "DELETE",
+                    headers: { Authorization: "Bearer wrong" },
+                }),
+                env,
+            );
+            expect(res.status).toBe(401);
+        } else {
+            expect(response.status).toBe(401);
+        }
+    });
+
+    test("PUT rejects malformed JSON body", async () => {
+        const { app, env } = createHarness();
+        const response = await app.fetch(
+            new Request("http://localhost/admin/status-notice", {
+                method: "PUT",
+                headers: {
+                    Authorization: "Bearer test-admin-token",
+                    "Content-Type": "application/json",
+                },
+                body: "not json",
             }),
             env,
         );
-        expect(publishResponse.status).toBe(200);
-        const published = (await publishResponse.json()) as {
-            notice: StatusNotice;
-        };
-        expect(published.notice).toMatchObject({
-            message: "Maintenance is in progress.",
+        expect(response.status).toBe(400);
+    });
+
+    test("publishes, persists to KV, and is readable from the public route", async () => {
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const { app, env, kv } = createHarness();
+
+        const published = await publish(app, env, {
+            message: " Maintenance is in progress. ",
             linkUrl: "https://status.pollinations.ai",
             linkLabel: "Status page",
+            severity: "info",
+        });
+        expect(published.status).toBe(200);
+        expect(published.body.notice).toMatchObject({
+            message: "Maintenance is in progress.",
+            severity: "info",
+            linkUrl: "https://status.pollinations.ai",
+            linkLabel: "Status page",
+            updatedAt: "2026-01-01T00:00:00.000Z",
         });
         expect(kv.put).toHaveBeenCalledTimes(1);
 
@@ -97,17 +149,82 @@ describe("status notice routes", () => {
             new Request("http://localhost/status-notice"),
             env,
         );
-        expect(await publicResponse.json()).toEqual(published);
+        expect(await publicResponse.json()).toEqual(published.body);
+    });
 
-        const updateResponse = await app.fetch(
-            adminRequest({ message: "Systems are recovering." }),
-            env,
+    test("severity defaults to warning when omitted", async () => {
+        const { app, env } = createHarness();
+        const published = await publish(app, env, {
+            message: "Default severity",
+        });
+        expect(published.body.notice?.severity).toBe("warning");
+    });
+
+    test("severity is echoed when explicitly provided", async () => {
+        const { app, env } = createHarness();
+        const published = await publish(app, env, {
+            message: "Critical",
+            severity: "critical",
+        });
+        expect(published.body.notice?.severity).toBe("critical");
+    });
+
+    test("strips link fields when linkUrl is omitted", async () => {
+        const { app, env } = createHarness();
+        const published = await publish(app, env, {
+            message: "No link here",
+            linkLabel: "should be dropped",
+        });
+        expect(published.body.notice?.linkUrl).toBeNull();
+        expect(published.body.notice?.linkLabel).toBeNull();
+    });
+
+    test("updates a notice and overwrites the previous payload", async () => {
+        const { app, env } = createHarness();
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const first = await publish(app, env, { message: "First" });
+
+        vi.setSystemTime(new Date("2026-01-01T01:00:00.000Z"));
+        const second = await publish(app, env, { message: "Second" });
+        expect(second.body.notice?.message).toBe("Second");
+        expect(second.body.notice?.linkUrl).toBeNull();
+        expect(second.body.notice?.updatedAt).toBe("2026-01-01T01:00:00.000Z");
+        expect(second.body.notice?.updatedAt).not.toBe(
+            first.body.notice?.updatedAt,
         );
-        const updated = (await updateResponse.json()) as {
-            notice: StatusNotice;
-        };
-        expect(updated.notice.message).toBe("Systems are recovering.");
-        expect(updated.notice.linkUrl).toBeNull();
+    });
+
+    test("idempotent re-save preserves updatedAt and skips the KV write", async () => {
+        const { app, env, kv } = createHarness();
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const first = await publish(app, env, {
+            message: "Same",
+            severity: "warning",
+        });
+        expect(kv.put).toHaveBeenCalledTimes(1);
+
+        // Same payload again — should be a no-op.
+        vi.setSystemTime(new Date("2026-01-02T00:00:00.000Z"));
+        const second = await publish(app, env, {
+            message: "Same",
+            severity: "warning",
+        });
+        expect(second.status).toBe(200);
+        expect(second.body.notice).toEqual(first.body.notice);
+        expect(kv.put).toHaveBeenCalledTimes(1); // unchanged — no new write
+
+        // A genuinely different payload bumps updatedAt and writes again.
+        vi.setSystemTime(new Date("2026-01-03T00:00:00.000Z"));
+        const third = await publish(app, env, { message: "Changed" });
+        expect(third.body.notice?.updatedAt).not.toBe(
+            first.body.notice?.updatedAt,
+        );
+        expect(kv.put).toHaveBeenCalledTimes(2);
+    });
+
+    test("clears the notice and the public route reads null", async () => {
+        const { app, env, kv } = createHarness();
+        await publish(app, env, { message: "Will be cleared" });
 
         const clearResponse = await app.fetch(
             new Request("http://localhost/admin/status-notice", {
@@ -119,12 +236,32 @@ describe("status notice routes", () => {
         expect(clearResponse.status).toBe(200);
         expect(await clearResponse.json()).toEqual({ notice: null });
         expect(kv.delete).toHaveBeenCalledTimes(1);
+
+        const publicResponse = await app.fetch(
+            new Request("http://localhost/status-notice"),
+            env,
+        );
+        expect(await publicResponse.json()).toEqual({ notice: null });
+    });
+
+    test("ignores a corrupted KV payload and returns null", async () => {
+        const { app, env, kv } = createHarness();
+        kv.get.mockResolvedValueOnce({ garbage: true, noFields: true });
+        // Inject a corrupted stored value via the real put path on a different mock state.
+        kv.get.mockImplementationOnce(async () => ({ weird: "shape" }));
+        const response = await app.fetch(
+            new Request("http://localhost/status-notice"),
+            env,
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ notice: null });
     });
 
     test.each([
         [{}, "missing message"],
         [{ message: "   " }, "blank message"],
-        [{ message: "x".repeat(501) }, "long message"],
+        [{ message: "x".repeat(501) }, "overly long message"],
+        [{ message: "Bad severity", severity: "panic" }, "invalid severity"],
         [
             { message: "Unsafe", linkUrl: "javascript:alert(1)" },
             "javascript link",
@@ -134,6 +271,21 @@ describe("status notice routes", () => {
             "mailto link",
         ],
         [{ message: "Unsafe", linkUrl: "data:text/html,unsafe" }, "data link"],
+        [
+            {
+                message: "Long link",
+                linkUrl: `https://example.com/${"a".repeat(2100)}`,
+            },
+            "overly long link",
+        ],
+        [
+            {
+                message: "Long label",
+                linkUrl: "https://example.com",
+                linkLabel: "a".repeat(81),
+            },
+            "overly long label",
+        ],
     ])("rejects %s (%s)", async (body) => {
         const { app, env, kv } = createHarness();
         const response = await app.fetch(adminRequest(body), env);

--- a/enter.pollinations.ai/test/status-notice.test.ts
+++ b/enter.pollinations.ai/test/status-notice.test.ts
@@ -1,0 +1,143 @@
+import { Hono } from "hono";
+import { describe, expect, test, vi } from "vitest";
+import type { Env } from "../src/env.ts";
+import {
+    type StatusNotice,
+    statusNoticeAdminRoutes,
+    statusNoticePublicRoutes,
+} from "../src/routes/status-notice.ts";
+
+function createHarness() {
+    let stored: string | null = null;
+    const kv = {
+        get: vi.fn(async (_key: string, type?: string) =>
+            type === "json" && stored ? JSON.parse(stored) : stored,
+        ),
+        put: vi.fn(async (_key: string, value: string) => {
+            stored = value;
+        }),
+        delete: vi.fn(async () => {
+            stored = null;
+        }),
+    };
+    const env = {
+        PLN_ENTER_TOKEN: "test-admin-token",
+        KV: kv,
+    } as unknown as Env["Bindings"];
+    const app = new Hono<Env>()
+        .route("/status-notice", statusNoticePublicRoutes)
+        .route("/admin/status-notice", statusNoticeAdminRoutes);
+
+    return { app, env, kv };
+}
+
+function adminRequest(body: unknown, token = "test-admin-token"): Request {
+    return new Request("http://localhost/admin/status-notice", {
+        method: "PUT",
+        headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+describe("status notice routes", () => {
+    test("returns null when no notice is active", async () => {
+        const { app, env } = createHarness();
+        const response = await app.fetch(
+            new Request("http://localhost/status-notice"),
+            env,
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ notice: null });
+    });
+
+    test.each([
+        "PUT",
+        "DELETE",
+    ])("%s requires the admin token", async (method) => {
+        const { app, env } = createHarness();
+        const response = await app.fetch(
+            new Request("http://localhost/admin/status-notice", {
+                method,
+                headers: { "Content-Type": "application/json" },
+                body:
+                    method === "PUT"
+                        ? JSON.stringify({ message: "Test" })
+                        : undefined,
+            }),
+            env,
+        );
+        expect(response.status).toBe(401);
+    });
+
+    test("publishes, updates, and clears a notice", async () => {
+        const { app, env, kv } = createHarness();
+        const publishResponse = await app.fetch(
+            adminRequest({
+                message: " Maintenance is in progress. ",
+                linkUrl: "https://status.pollinations.ai",
+                linkLabel: "Status page",
+            }),
+            env,
+        );
+        expect(publishResponse.status).toBe(200);
+        const published = (await publishResponse.json()) as {
+            notice: StatusNotice;
+        };
+        expect(published.notice).toMatchObject({
+            message: "Maintenance is in progress.",
+            linkUrl: "https://status.pollinations.ai",
+            linkLabel: "Status page",
+        });
+        expect(kv.put).toHaveBeenCalledTimes(1);
+
+        const publicResponse = await app.fetch(
+            new Request("http://localhost/status-notice"),
+            env,
+        );
+        expect(await publicResponse.json()).toEqual(published);
+
+        const updateResponse = await app.fetch(
+            adminRequest({ message: "Systems are recovering." }),
+            env,
+        );
+        const updated = (await updateResponse.json()) as {
+            notice: StatusNotice;
+        };
+        expect(updated.notice.message).toBe("Systems are recovering.");
+        expect(updated.notice.linkUrl).toBeNull();
+
+        const clearResponse = await app.fetch(
+            new Request("http://localhost/admin/status-notice", {
+                method: "DELETE",
+                headers: { Authorization: "Bearer test-admin-token" },
+            }),
+            env,
+        );
+        expect(clearResponse.status).toBe(200);
+        expect(await clearResponse.json()).toEqual({ notice: null });
+        expect(kv.delete).toHaveBeenCalledTimes(1);
+    });
+
+    test.each([
+        [{}, "missing message"],
+        [{ message: "   " }, "blank message"],
+        [{ message: "x".repeat(501) }, "long message"],
+        [
+            { message: "Unsafe", linkUrl: "javascript:alert(1)" },
+            "javascript link",
+        ],
+        [
+            { message: "Unsafe", linkUrl: "mailto:test@example.com" },
+            "mailto link",
+        ],
+        [{ message: "Unsafe", linkUrl: "data:text/html,unsafe" }, "data link"],
+    ])("rejects %s (%s)", async (body) => {
+        const { app, env, kv } = createHarness();
+        const response = await app.fetch(adminRequest(body), env);
+        expect(response.status).toBe(400);
+        expect(kv.put).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Admin-managed status notice banner for the Enter dashboard, backed by Workers KV and surfaced in the dashboard shell. Fixes #12585.

This is a parallel, independent implementation; #12714 was posted separately while I was already mid-way. Noted on that PR.

## Backend (`enter.pollinations.ai`)

- **`GET /status-notice`** — public read endpoint returning `{ notice: StatusNotice | null }`.
- **`PUT /admin/status-notice`** — admin-only publish/update. Bearer-token auth (`PLN_ENTER_TOKEN`), Zod validation.
- **`DELETE /admin/status-notice`** — admin-only clear.
- **Severity** — `info | warning | critical`, defaults to `warning` when omitted.
- **Persistence** — single KV key `status-notice:active` holds the latest `{ message, severity, linkUrl, linkLabel, updatedAt }`. No mutation history; latest wins.
- **Idempotent re-save** — when an incoming `PUT` payload is identical to the stored one, the handler skips the KV write and preserves `updatedAt`. Any real change refreshes `updatedAt`.
- **Link safety** — `linkUrl` is optional but, when present, must be an `http:`/`https:` URL; `mailto:`, `javascript:`, `data:`, etc. are rejected. `linkLabel` is only persisted when `linkUrl` is present.
- **Resilience** — a corrupted KV payload parses to `null` on the public read instead of erroring; the public route always returns 200.
- **OpenAPI** — every route is described via `hono-openapi` (tags, security, status responses).

## Frontend (`enter.pollinations.ai/frontend`)

- `StatusNoticeBanner` mounted in `DashboardShell`. Fetches `/status-notice` on mount, maps `severity` → `Alert` intent (`info`/`warning`/`danger`), renders a dismissable `Alert` from `@pollinations/ui`.
- **Dismiss state** persisted to `localStorage`, keyed by `updatedAt` so the same notice stays dismissed across reloads until the admin publishes a new one (any `updatedAt` change "re-arms" the banner).
- Aira-live region, focus-visible outline, `rel="noopener noreferrer"` on the link, and an accessible "Dismiss status notice" button label.

## Tests

- `test/status-notice.test.ts` — 23 cases: auth (missing / wrong token on PUT and DELETE), malformed JSON, validation (missing / blank / over-long message, invalid severity, javascript/mailto/data link, over-long link/label), publish/update/clear flow, persistence round-trip, idempotent re-save (fake timers), corrupted KV, severity default + echo, link stripping.
- `test/status-notice-ui.test.ts` — 3 cases for dismiss + refetch-resilience under fake timers.

All 26 tests pass; Biome check is clean; frontend build is clean.

## Notes

- No migration needed; the feature uses the existing `KV` binding already wired in `wrangler.toml` (dev/staging/production all have one).
- Pre-existing, unrelated test-harness failures on `main` (admin-auth, tinybird-sync) were verified before this branch and are not touched by these changes.