### PR TITLE
fix: restore product path charts

### DIFF
--- a/apps/operation/observability/provisioning/dashboards/platform-usage-rebuild.json
+++ b/apps/operation/observability/provisioning/dashboards/platform-usage-rebuild.json
@@ -559,7 +559,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "time|paid_pollen"
+              "pattern": "/^(time.*|paid_pollen.*)$/"
             }
           }
         },
@@ -746,7 +746,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "time|quest_pollen"
+              "pattern": "/^(time.*|quest_pollen.*)$/"
             }
           }
         },
@@ -932,7 +932,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "time|requests"
+              "pattern": "/^(time.*|requests.*)$/"
             }
           }
         },


### PR DESCRIPTION
- Keeps the partitioned `time` fields and the selected numeric series in all three product-path charts.
- Fixes “Data is missing a number field” for Paid Pollen, Quest Pollen, and Requests.
- Leaves Tinybird queries and every other dashboard unchanged.

Root cause: Grafana labels fields after `partitionByValues`, while the exact field filter discarded the labeled numeric fields.

Validation:
- Rendered all three panels locally with four representative product paths.
- `npx biome check --write provisioning/dashboards/platform-usage-rebuild.json`
- `npm run check` (Wrangler dry run)
- `git diff --check`