### PR TITLE
feat: add GPT Realtime 2.1 Mini

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -522,6 +522,24 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000004,
     },
   },
+  "gpt-realtime-2.1-mini": {
+    "cost": {
+      "completionAudioTokens": 0.00002,
+      "completionTextTokens": 0.0000024,
+      "promptAudioTokens": 0.00001,
+      "promptCachedTokens": 0.00000006,
+      "promptImageTokens": 0.0000008,
+      "promptTextTokens": 0.0000006,
+    },
+    "price": {
+      "completionAudioTokens": 0.000015,
+      "completionTextTokens": 0.0000018,
+      "promptAudioTokens": 0.0000075,
+      "promptCachedTokens": 0.000000045,
+      "promptImageTokens": 0.0000006,
+      "promptTextTokens": 0.00000045,
+    },
+  },
   "gptimage": {
     "cost": {
       "completionImageTokens": 0.000008,

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -80,6 +80,10 @@ const UNSUPPORTED_TRANSCRIPTION_MESSAGE =
 type WebSocketResponse = Response & { webSocket?: WebSocket };
 type WebSocketResponseInit = ResponseInit & { webSocket?: WebSocket };
 type RealtimeDeduction = Awaited<ReturnType<typeof handleBalanceDeduction>>;
+type RealtimeCacheUsage = {
+    audioTokens: number;
+    imageTokens: number;
+};
 type RealtimeBillingContext = {
     userId: string;
     userTier?: string;
@@ -108,7 +112,8 @@ type RealtimeBillingContext = {
     ipHash?: string;
     sessionStartTime: Date;
     usage: Usage;
-    outputEvents: unknown[];
+    cacheUsage: RealtimeCacheUsage;
+    missingCacheDetailsWarned: boolean;
     settlementInFlight: boolean;
     settlementAttempts: number;
     settled: boolean;
@@ -258,9 +263,15 @@ function addUsage(target: Usage, delta: Usage): void {
     }
 }
 
-function realtimeUsageToUsage(rawUsage: unknown): Usage {
+type ParsedRealtimeUsage = {
+    usage: Usage;
+    cacheUsage: RealtimeCacheUsage;
+    cacheDetailsIncomplete: boolean;
+};
+
+function parseRealtimeUsage(rawUsage: unknown): ParsedRealtimeUsage | null {
     const parsed = RealtimeUsageSchema.safeParse(rawUsage);
-    if (!parsed.success) return {};
+    if (!parsed.success) return null;
     const usage = parsed.data;
     const inputDetails = usage.input_token_details ?? {};
     const outputDetails = usage.output_token_details ?? {};
@@ -269,9 +280,14 @@ function realtimeUsageToUsage(rawUsage: unknown): Usage {
     const cachedTextTokens = numeric(cachedDetails.text_tokens);
     const cachedAudioTokens = numeric(cachedDetails.audio_tokens);
     const cachedImageTokens = numeric(cachedDetails.image_tokens);
-    const cachedTokens =
-        numeric(inputDetails.cached_tokens) ||
+    const reportedCachedTokens = numeric(inputDetails.cached_tokens);
+    const detailedCachedTokens =
         cachedTextTokens + cachedAudioTokens + cachedImageTokens;
+    const cachedTokens = reportedCachedTokens || detailedCachedTokens;
+    const cacheDetailsIncomplete =
+        reportedCachedTokens > 0 &&
+        (inputDetails.cached_tokens_details == null ||
+            detailedCachedTokens !== reportedCachedTokens);
 
     const promptAudioTokens = Math.max(
         0,
@@ -300,22 +316,35 @@ function realtimeUsageToUsage(rawUsage: unknown): Usage {
         totalOutputTokens - completionAudioTokens,
     );
 
-    return positiveEntries({
-        promptTextTokens,
-        promptCachedTokens: cachedTokens,
-        promptAudioTokens,
-        promptImageTokens,
-        completionTextTokens,
-        completionAudioTokens,
-    });
+    return {
+        usage: positiveEntries({
+            promptTextTokens,
+            promptCachedTokens: cachedTokens,
+            promptAudioTokens,
+            promptImageTokens,
+            completionTextTokens,
+            completionAudioTokens,
+        }),
+        cacheUsage: {
+            audioTokens: cachedAudioTokens,
+            imageTokens: cachedImageTokens,
+        },
+        cacheDetailsIncomplete,
+    };
 }
 
-function extractResponseUsage(eventData: unknown): Usage | null {
+function realtimeUsageToUsage(rawUsage: unknown): Usage {
+    return parseRealtimeUsage(rawUsage)?.usage ?? {};
+}
+
+function extractResponseBilling(
+    eventData: unknown,
+): ParsedRealtimeUsage | null {
     const event = asRecord(eventData);
     if (event.type !== "response.done") return null;
     const response = asRecord(event.response);
-    const usage = realtimeUsageToUsage(response.usage);
-    return Object.keys(usage).length ? usage : null;
+    const parsed = parseRealtimeUsage(response.usage);
+    return parsed && Object.keys(parsed.usage).length ? parsed : null;
 }
 
 function parseEventData(data: unknown): unknown | null {
@@ -486,7 +515,7 @@ async function settleRealtimeSession(
         tracking.resolvedModelRequested,
         usage,
         tracking.modelDefinition,
-        { streamEvents: tracking.outputEvents },
+        { realtimeCache: tracking.cacheUsage },
     );
     if (price.totalPrice <= 0) {
         tracking.settled = true;
@@ -536,19 +565,36 @@ async function settleRealtimeSession(
 }
 
 function collectBillingEvents(
+    c: Context<Env>,
     upstream: WebSocket,
     billing: RealtimeBillingContext,
 ): void {
+    const log = c.get("log").getChild("realtime");
     upstream.addEventListener("message", (event) => {
         const eventData = parseEventData(event.data);
-        const usage =
-            extractResponseUsage(eventData) ??
-            extractUnsupportedInputTranscriptionUsage(eventData);
-        if (!usage) return;
-        if (asRecord(eventData).type === "response.done") {
-            billing.outputEvents.push(eventData);
+        const responseBilling = extractResponseBilling(eventData);
+        if (responseBilling) {
+            addUsage(billing.usage, responseBilling.usage);
+            billing.cacheUsage.audioTokens +=
+                responseBilling.cacheUsage.audioTokens;
+            billing.cacheUsage.imageTokens +=
+                responseBilling.cacheUsage.imageTokens;
+            if (
+                responseBilling.cacheDetailsIncomplete &&
+                !billing.missingCacheDetailsWarned
+            ) {
+                billing.missingCacheDetailsWarned = true;
+                log.warn(
+                    "Realtime cached token modality details are missing or incomplete; unmatched cached tokens use the cached-text rate: model={model}",
+                    { model: billing.resolvedModelRequested },
+                );
+            }
+            return;
         }
-        addUsage(billing.usage, usage);
+
+        const transcriptionUsage =
+            extractUnsupportedInputTranscriptionUsage(eventData);
+        if (transcriptionUsage) addUsage(billing.usage, transcriptionUsage);
     });
 }
 
@@ -626,7 +672,7 @@ function proxyRealtimeWebSockets(
     downstream.binaryType = "arraybuffer";
     downstream.accept({ allowHalfOpen: true });
 
-    collectBillingEvents(upstream, tracking);
+    collectBillingEvents(c, upstream, tracking);
     forwardMessage(downstream, upstream, validateClientRealtimeEvent, () =>
         scheduleRealtimeSettlement(c, tracking),
     );
@@ -691,7 +737,8 @@ async function createRealtimeBillingContext(
         ipHash: await hashIp(clientIp, c.env.BETTER_AUTH_SECRET),
         sessionStartTime: new Date(),
         usage: {},
-        outputEvents: [],
+        cacheUsage: { audioTokens: 0, imageTokens: 0 },
+        missingCacheDetailsWarned: false,
         settlementInFlight: false,
         settlementAttempts: 0,
         settled: false,

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -13,9 +13,9 @@ import {
 import { sendToTinybird } from "@shared/events.ts";
 import type { RealtimeModelName } from "@shared/registry/realtime.ts";
 import {
+    type BillingAdjustment,
     type CostDefinition,
-    calculateCostWithDefinition,
-    calculatePriceWithDefinition,
+    calculateUsageBilling,
     getPriceDefinitionForModel,
     type ModelDefinition,
     type PriceDefinition,
@@ -34,20 +34,40 @@ import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
+import { reduceAdjustmentsToEventFields } from "@/middleware/track.ts";
 import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
 
-// Azure OpenAI realtime endpoint. The deployments live on the Sweden Central
-// myceli resource (same resource as the gpt-audio models). The realtime
-// WebSocket path mirrors OpenAI's: /openai/v1/realtime?model=<deployment>.
-const AZURE_REALTIME_WEBSOCKET_URL =
-    "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime";
-// Azure deployment names, keyed by registry model name. Deployment names are
-// independent of the public model id; the registry only carries public names.
-const REALTIME_DEPLOYMENTS: Record<RealtimeModelName, string> = {
-    "gpt-realtime-2.1": "gpt-realtime-2-1",
-    "gpt-realtime-2": "gpt-realtime-2",
+type AzureRealtimeApiKey =
+    | "AZURE_MYCELI_PROD_EASTUS2_API_KEY"
+    | "AZURE_MYCELI_PROD_SWEDEN_API_KEY";
+
+// Deployment names are independent of the public model ids. Mini is in East
+// US 2 because Azure's Sweden Central control plane accepts the deployment but
+// its Realtime data plane currently rejects the exact model.
+const REALTIME_ROUTES: Record<
+    RealtimeModelName,
+    { endpoint: string; deployment: string; apiKeyEnv: AzureRealtimeApiKey }
+> = {
+    "gpt-realtime-2.1": {
+        endpoint:
+            "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime",
+        deployment: "gpt-realtime-2-1",
+        apiKeyEnv: "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
+    },
+    "gpt-realtime-2.1-mini": {
+        endpoint:
+            "https://myceli-prod-eastus2.openai.azure.com/openai/v1/realtime",
+        deployment: "gpt-realtime-2-1-mini",
+        apiKeyEnv: "AZURE_MYCELI_PROD_EASTUS2_API_KEY",
+    },
+    "gpt-realtime-2": {
+        endpoint:
+            "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime",
+        deployment: "gpt-realtime-2",
+        apiKeyEnv: "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
+    },
 };
 const CREDENTIAL_QUERY_PARAMS = new Set([
     "access_token",
@@ -88,6 +108,7 @@ type RealtimeBillingContext = {
     ipHash?: string;
     sessionStartTime: Date;
     usage: Usage;
+    outputEvents: unknown[];
     settlementInFlight: boolean;
     settlementAttempts: number;
     settled: boolean;
@@ -112,26 +133,29 @@ async function createSafetyIdentifier(
     return bytesToHex(await crypto.subtle.digest("SHA-256", data));
 }
 
-function buildUpstreamUrl(modelId: string): string {
-    const upstreamUrl = new URL(AZURE_REALTIME_WEBSOCKET_URL);
-    upstreamUrl.searchParams.set("model", modelId);
+function buildUpstreamUrl(model: RealtimeModelName): string {
+    const route = REALTIME_ROUTES[model];
+    const upstreamUrl = new URL(route.endpoint);
+    upstreamUrl.searchParams.set("model", route.deployment);
     return upstreamUrl.toString();
 }
 
 async function connectAzureRealtime(
     c: Context<Env>,
     userId: string,
-    modelId: string,
+    model: RealtimeModelName,
 ): Promise<WebSocket | Response> {
-    if (!c.env.AZURE_MYCELI_PROD_SWEDEN_API_KEY) {
+    const route = REALTIME_ROUTES[model];
+    const apiKey = c.env[route.apiKeyEnv];
+    if (!apiKey) {
         throw new HTTPException(503, {
             message: "Azure realtime provider is not configured.",
         });
     }
 
-    const response = (await fetch(buildUpstreamUrl(modelId), {
+    const response = (await fetch(buildUpstreamUrl(model), {
         headers: {
-            "api-key": c.env.AZURE_MYCELI_PROD_SWEDEN_API_KEY,
+            "api-key": apiKey,
             "OpenAI-Safety-Identifier": await createSafetyIdentifier(
                 userId,
                 c.env.BETTER_AUTH_SECRET,
@@ -399,6 +423,7 @@ function createRealtimeTrackingEvent(args: {
     usage: Usage;
     cost: UsageCost;
     price: UsagePrice;
+    adjustments: BillingAdjustment[];
     markup: MarkupResolution | null;
     payerBucket: "tier" | "pack" | null;
     balances: { tierBalance: number; packBalance: number };
@@ -436,6 +461,7 @@ function createRealtimeTrackingEvent(args: {
         ...getPostDeductionBalances(args.payerBucket, args.balances),
         ...priceToEventParams(args.tracking.modelPriceDefinition),
         ...usageToEventParams(args.usage),
+        ...reduceAdjustmentsToEventFields(args.adjustments),
         totalCost: args.cost.totalCost,
         totalPrice: args.price.totalPrice + (args.markup?.devCredit ?? 0),
         devPrice: args.price.totalPrice,
@@ -456,15 +482,11 @@ async function settleRealtimeSession(
         return;
     }
 
-    const cost = calculateCostWithDefinition(
+    const { cost, price, adjustments } = calculateUsageBilling(
         tracking.resolvedModelRequested,
         usage,
-        tracking.modelCostDefinition,
-    );
-    const price = calculatePriceWithDefinition(
-        tracking.resolvedModelRequested,
-        usage,
-        tracking.modelPriceDefinition,
+        tracking.modelDefinition,
+        { streamEvents: tracking.outputEvents },
     );
     if (price.totalPrice <= 0) {
         tracking.settled = true;
@@ -501,6 +523,7 @@ async function settleRealtimeSession(
             usage,
             cost,
             price,
+            adjustments,
             markup: tracking.deduction.markup,
             payerBucket: tracking.deduction.payerBucket,
             balances,
@@ -522,6 +545,9 @@ function collectBillingEvents(
             extractResponseUsage(eventData) ??
             extractUnsupportedInputTranscriptionUsage(eventData);
         if (!usage) return;
+        if (asRecord(eventData).type === "response.done") {
+            billing.outputEvents.push(eventData);
+        }
         addUsage(billing.usage, usage);
     });
 }
@@ -665,6 +691,7 @@ async function createRealtimeBillingContext(
         ipHash: await hashIp(clientIp, c.env.BETTER_AUTH_SECRET),
         sessionStartTime: new Date(),
         usage: {},
+        outputEvents: [],
         settlementInFlight: false,
         settlementAttempts: 0,
         settled: false,
@@ -696,7 +723,7 @@ export async function handleRealtimeWebSocket(
     const upstream = await connectAzureRealtime(
         c,
         user.id,
-        REALTIME_DEPLOYMENTS[c.var.model.resolved as RealtimeModelName],
+        c.var.model.resolved as RealtimeModelName,
     );
     if (upstream instanceof Response) return upstream;
 

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -546,28 +546,111 @@ test("bills mini cached audio and image tokens at their exact rates", async () =
     client.accept();
     upstream.server.accept();
 
+    const usageEvent = JSON.stringify({
+        type: "response.done",
+        response: {
+            output: [
+                {
+                    type: "message",
+                    content: [{ transcript: "content is never retained" }],
+                },
+            ],
+            usage: {
+                input_tokens: 100,
+                output_tokens: 30,
+                input_token_details: {
+                    text_tokens: 40,
+                    audio_tokens: 50,
+                    image_tokens: 10,
+                    cached_tokens: 30,
+                    cached_tokens_details: {
+                        text_tokens: 10,
+                        audio_tokens: 15,
+                        image_tokens: 5,
+                    },
+                },
+                output_token_details: {
+                    text_tokens: 20,
+                    audio_tokens: 10,
+                },
+            },
+        },
+    });
+
+    upstream.server.send(usageEvent);
+    upstream.server.send(usageEvent);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    client.close();
+    upstream.server.close();
+    await waitOnExecutionContext(ctx);
+
+    const expectedCost = 0.0006255 * 2;
+    const expectedCharge = 0.00093825;
+    const user = await waitForPackBalanceBelow(userId, 1);
+    expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
+    expect(upstream.tinybirdRequests).toHaveLength(1);
+
+    const telemetry = JSON.parse(
+        await upstream.tinybirdRequests[0].text(),
+    ) as Record<string, unknown>;
+    expect(telemetry.tokenCountPromptText).toBe(60);
+    expect(telemetry.tokenCountPromptCached).toBe(60);
+    expect(telemetry.tokenCountPromptAudio).toBe(70);
+    expect(telemetry.tokenCountPromptImage).toBe(10);
+    expect(telemetry.tokenCountCompletionText).toBe(40);
+    expect(telemetry.tokenCountCompletionAudio).toBe(20);
+    expect(telemetry.adjustmentUnits).toEqual({
+        "openai.realtime.cached_audio_delta.v1": 30,
+        "openai.realtime.cached_image_delta.v1": 10,
+    });
+    const adjustmentCosts = telemetry.adjustmentCosts as Record<string, number>;
+    expect(
+        adjustmentCosts["openai.realtime.cached_audio_delta.v1"],
+    ).toBeCloseTo(0.0000072, 12);
+    expect(
+        adjustmentCosts["openai.realtime.cached_image_delta.v1"],
+    ).toBeCloseTo(0.0000002, 12);
+    expect(telemetry.totalCost).toBeCloseTo(expectedCost, 10);
+    expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 10);
+});
+
+test("uses the cached-text rate when cache details are absent", async () => {
+    const { key, userId } = await createTestApiKey({
+        name: "mini-missing-cache-details-key",
+        pollenBudget: 1,
+        user: { tierBalance: 0, packBalance: 1 },
+    });
+    const upstream = mockOpenAIRealtime();
+
+    const { response, ctx } = await fetchWorkerWithContext(
+        "/v1/realtime?model=gpt-realtime-2.1-mini",
+        {
+            headers: {
+                Authorization: `Bearer ${key}`,
+                Upgrade: "websocket",
+            },
+        },
+    );
+
+    expect(response.status).toBe(101);
+    const client = response.webSocket;
+    if (!client) throw new Error("Expected downstream WebSocket");
+    client.accept();
+    upstream.server.accept();
+
     upstream.server.send(
         JSON.stringify({
             type: "response.done",
             response: {
                 usage: {
                     input_tokens: 100,
-                    output_tokens: 30,
+                    output_tokens: 10,
                     input_token_details: {
-                        text_tokens: 40,
-                        audio_tokens: 50,
-                        image_tokens: 10,
+                        text_tokens: 100,
                         cached_tokens: 30,
-                        cached_tokens_details: {
-                            text_tokens: 10,
-                            audio_tokens: 15,
-                            image_tokens: 5,
-                        },
                     },
-                    output_token_details: {
-                        text_tokens: 20,
-                        audio_tokens: 10,
-                    },
+                    output_token_details: { text_tokens: 10 },
                 },
             },
         }),
@@ -577,8 +660,8 @@ test("bills mini cached audio and image tokens at their exact rates", async () =
     upstream.server.close();
     await waitOnExecutionContext(ctx);
 
-    const expectedCost = 0.0006255;
-    const expectedCharge = 0.00046913;
+    const expectedCost = 0.0000678;
+    const expectedCharge = 0.00005085;
     const user = await waitForPackBalanceBelow(userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
     expect(upstream.tinybirdRequests).toHaveLength(1);
@@ -586,23 +669,10 @@ test("bills mini cached audio and image tokens at their exact rates", async () =
     const telemetry = JSON.parse(
         await upstream.tinybirdRequests[0].text(),
     ) as Record<string, unknown>;
-    expect(telemetry.tokenCountPromptText).toBe(30);
+    expect(telemetry.tokenCountPromptText).toBe(70);
     expect(telemetry.tokenCountPromptCached).toBe(30);
-    expect(telemetry.tokenCountPromptAudio).toBe(35);
-    expect(telemetry.tokenCountPromptImage).toBe(5);
-    expect(telemetry.tokenCountCompletionText).toBe(20);
-    expect(telemetry.tokenCountCompletionAudio).toBe(10);
-    expect(telemetry.adjustmentUnits).toEqual({
-        "openai.realtime.cached_audio_delta.v1": 15,
-        "openai.realtime.cached_image_delta.v1": 5,
-    });
-    const adjustmentCosts = telemetry.adjustmentCosts as Record<string, number>;
-    expect(
-        adjustmentCosts["openai.realtime.cached_audio_delta.v1"],
-    ).toBeCloseTo(0.0000036, 12);
-    expect(
-        adjustmentCosts["openai.realtime.cached_image_delta.v1"],
-    ).toBeCloseTo(0.0000001, 12);
+    expect(telemetry.tokenCountCompletionText).toBe(10);
+    expect(telemetry.adjustmentUnits).toBeUndefined();
     expect(telemetry.totalCost).toBeCloseTo(expectedCost, 10);
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 10);
 });

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -3,6 +3,7 @@ import {
     env,
     waitOnExecutionContext,
 } from "cloudflare:test";
+import { getLogger } from "@logtape/logtape";
 import { user as userTable } from "@shared/db/better-auth.ts";
 import { createTestApiKey, test } from "@shared/test/fixtures/index.ts";
 import { eq } from "drizzle-orm";
@@ -549,12 +550,6 @@ test("bills mini cached audio and image tokens at their exact rates", async () =
     const usageEvent = JSON.stringify({
         type: "response.done",
         response: {
-            output: [
-                {
-                    type: "message",
-                    content: [{ transcript: "content is never retained" }],
-                },
-            ],
             usage: {
                 input_tokens: 100,
                 output_tokens: 30,
@@ -577,9 +572,12 @@ test("bills mini cached audio and image tokens at their exact rates", async () =
         },
     });
 
+    const firstForwardedEvent = nextMessage(client);
     upstream.server.send(usageEvent);
+    await expect(firstForwardedEvent).resolves.toBe(usageEvent);
+    const secondForwardedEvent = nextMessage(client);
     upstream.server.send(usageEvent);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await expect(secondForwardedEvent).resolves.toBe(usageEvent);
 
     client.close();
     upstream.server.close();
@@ -639,29 +637,40 @@ test("uses the cached-text rate when cache details are absent", async () => {
     client.accept();
     upstream.server.accept();
 
-    upstream.server.send(
-        JSON.stringify({
-            type: "response.done",
-            response: {
-                usage: {
-                    input_tokens: 100,
-                    output_tokens: 10,
-                    input_token_details: {
-                        text_tokens: 100,
-                        cached_tokens: 30,
-                    },
-                    output_token_details: { text_tokens: 10 },
+    const warn = vi.spyOn(getLogger(["hono", "realtime"]), "warn");
+    const usageEvent = JSON.stringify({
+        type: "response.done",
+        response: {
+            usage: {
+                input_tokens: 100,
+                output_tokens: 10,
+                input_token_details: {
+                    text_tokens: 100,
+                    cached_tokens: 30,
                 },
+                output_token_details: { text_tokens: 10 },
             },
-        }),
+        },
+    });
+    const firstForwardedEvent = nextMessage(client);
+    upstream.server.send(usageEvent);
+    await expect(firstForwardedEvent).resolves.toBe(usageEvent);
+    const secondForwardedEvent = nextMessage(client);
+    upstream.server.send(usageEvent);
+    await expect(secondForwardedEvent).resolves.toBe(usageEvent);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+        "Realtime cached token modality details are missing or incomplete; unmatched cached tokens use the cached-text rate: model={model}",
+        { model: "gpt-realtime-2.1-mini" },
     );
 
     client.close();
     upstream.server.close();
     await waitOnExecutionContext(ctx);
 
-    const expectedCost = 0.0000678;
-    const expectedCharge = 0.00005085;
+    const expectedCost = 0.0000678 * 2;
+    const expectedCharge = 0.00005085 * 2;
     const user = await waitForPackBalanceBelow(userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
     expect(upstream.tinybirdRequests).toHaveLength(1);
@@ -669,9 +678,9 @@ test("uses the cached-text rate when cache details are absent", async () => {
     const telemetry = JSON.parse(
         await upstream.tinybirdRequests[0].text(),
     ) as Record<string, unknown>;
-    expect(telemetry.tokenCountPromptText).toBe(70);
-    expect(telemetry.tokenCountPromptCached).toBe(30);
-    expect(telemetry.tokenCountCompletionText).toBe(10);
+    expect(telemetry.tokenCountPromptText).toBe(140);
+    expect(telemetry.tokenCountPromptCached).toBe(60);
+    expect(telemetry.tokenCountCompletionText).toBe(20);
     expect(telemetry.adjustmentUnits).toBeUndefined();
     expect(telemetry.totalCost).toBeCloseTo(expectedCost, 10);
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 10);

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -226,6 +226,34 @@ test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
     await waitOnExecutionContext(ctx);
 });
 
+test("routes the mini model through the working East US 2 deployment", async ({
+    paidApiKey,
+}) => {
+    const upstream = mockOpenAIRealtime();
+
+    const { response, ctx } = await fetchWorkerWithContext(
+        "/v1/realtime?model=gpt-realtime-2.1-mini",
+        {
+            headers: {
+                Authorization: `Bearer ${paidApiKey}`,
+                Upgrade: "websocket",
+            },
+        },
+    );
+
+    expect(response.status).toBe(101);
+    expect(upstream.request.url).toBe(
+        "https://myceli-prod-eastus2.openai.azure.com/openai/v1/realtime?model=gpt-realtime-2-1-mini",
+    );
+    expect(upstream.request.headers.get("api-key")).toBeTruthy();
+
+    response.webSocket?.accept();
+    upstream.server.accept();
+    response.webSocket?.close();
+    upstream.server.close();
+    await waitOnExecutionContext(ctx);
+});
+
 test("accepts publishable keys through the query string for thin clients", async () => {
     const { key } = await createTestApiKey({
         name: "paid-publishable-realtime-key",
@@ -494,6 +522,91 @@ test("deducts aggregate session usage from paid pack balance on close", async ()
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 8);
 });
 
+test("bills mini cached audio and image tokens at their exact rates", async () => {
+    const { key, userId } = await createTestApiKey({
+        name: "mini-cache-realtime-key",
+        pollenBudget: 1,
+        user: { tierBalance: 0, packBalance: 1 },
+    });
+    const upstream = mockOpenAIRealtime();
+
+    const { response, ctx } = await fetchWorkerWithContext(
+        "/v1/realtime?model=gpt-realtime-2.1-mini",
+        {
+            headers: {
+                Authorization: `Bearer ${key}`,
+                Upgrade: "websocket",
+            },
+        },
+    );
+
+    expect(response.status).toBe(101);
+    const client = response.webSocket;
+    if (!client) throw new Error("Expected downstream WebSocket");
+    client.accept();
+    upstream.server.accept();
+
+    upstream.server.send(
+        JSON.stringify({
+            type: "response.done",
+            response: {
+                usage: {
+                    input_tokens: 100,
+                    output_tokens: 30,
+                    input_token_details: {
+                        text_tokens: 40,
+                        audio_tokens: 50,
+                        image_tokens: 10,
+                        cached_tokens: 30,
+                        cached_tokens_details: {
+                            text_tokens: 10,
+                            audio_tokens: 15,
+                            image_tokens: 5,
+                        },
+                    },
+                    output_token_details: {
+                        text_tokens: 20,
+                        audio_tokens: 10,
+                    },
+                },
+            },
+        }),
+    );
+
+    client.close();
+    upstream.server.close();
+    await waitOnExecutionContext(ctx);
+
+    const expectedCost = 0.0006255;
+    const expectedCharge = 0.00046913;
+    const user = await waitForPackBalanceBelow(userId, 1);
+    expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
+    expect(upstream.tinybirdRequests).toHaveLength(1);
+
+    const telemetry = JSON.parse(
+        await upstream.tinybirdRequests[0].text(),
+    ) as Record<string, unknown>;
+    expect(telemetry.tokenCountPromptText).toBe(30);
+    expect(telemetry.tokenCountPromptCached).toBe(30);
+    expect(telemetry.tokenCountPromptAudio).toBe(35);
+    expect(telemetry.tokenCountPromptImage).toBe(5);
+    expect(telemetry.tokenCountCompletionText).toBe(20);
+    expect(telemetry.tokenCountCompletionAudio).toBe(10);
+    expect(telemetry.adjustmentUnits).toEqual({
+        "openai.realtime.cached_audio_delta.v1": 15,
+        "openai.realtime.cached_image_delta.v1": 5,
+    });
+    const adjustmentCosts = telemetry.adjustmentCosts as Record<string, number>;
+    expect(
+        adjustmentCosts["openai.realtime.cached_audio_delta.v1"],
+    ).toBeCloseTo(0.0000036, 12);
+    expect(
+        adjustmentCosts["openai.realtime.cached_image_delta.v1"],
+    ).toBeCloseTo(0.0000001, 12);
+    expect(telemetry.totalCost).toBeCloseTo(expectedCost, 10);
+    expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 10);
+});
+
 test("falls back to aggregate realtime token totals when details are absent", async () => {
     const { key, userId } = await createTestApiKey({
         name: "aggregate-only-realtime-key",
@@ -715,9 +828,13 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
         data: { id: string; supported_endpoints?: string[] }[];
     };
     const realtimeModels = publicBody.data.filter((model) =>
-        ["gpt-realtime-2", "gpt-realtime-2.1"].includes(model.id),
+        [
+            "gpt-realtime-2",
+            "gpt-realtime-2.1",
+            "gpt-realtime-2.1-mini",
+        ].includes(model.id),
     );
-    expect(realtimeModels).toHaveLength(2);
+    expect(realtimeModels).toHaveLength(3);
     for (const model of realtimeModels) {
         expect(model.supported_endpoints).toContain("/v1/realtime");
     }
@@ -734,6 +851,9 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     );
     expect(restrictedBody.data.map((model) => model.id)).not.toContain(
         "gpt-realtime-2.1",
+    );
+    expect(restrictedBody.data.map((model) => model.id)).not.toContain(
+        "gpt-realtime-2.1-mini",
     );
 });
 

--- a/shared/registry/realtime-billing.ts
+++ b/shared/registry/realtime-billing.ts
@@ -1,0 +1,72 @@
+import type { BillingRules } from "./registry";
+
+const PER_MILLION = 1_000_000;
+
+type RealtimeBillingOutput = {
+    response?: {
+        usage?: {
+            input_token_details?: {
+                cached_tokens_details?: {
+                    audio_tokens?: unknown;
+                    image_tokens?: unknown;
+                };
+            };
+        };
+    };
+    streamEvents?: unknown[];
+};
+
+function outputEvents(output: unknown): unknown[] {
+    const value = output as RealtimeBillingOutput | undefined;
+    return Array.isArray(value?.streamEvents)
+        ? value.streamEvents
+        : value
+          ? [value]
+          : [];
+}
+
+function countCachedTokens(
+    output: unknown,
+    modality: "audio" | "image",
+): number {
+    return outputEvents(output).reduce<number>((total, event) => {
+        const details = (event as RealtimeBillingOutput | undefined)?.response
+            ?.usage?.input_token_details?.cached_tokens_details;
+        const value =
+            modality === "audio"
+                ? details?.audio_tokens
+                : details?.image_tokens;
+        return (
+            total +
+            (typeof value === "number" && Number.isFinite(value) && value > 0
+                ? value
+                : 0)
+        );
+    }, 0);
+}
+
+// Generic cached input is billed at the cached-text rate. The provider reports
+// cached audio and image tokens separately, so these rules add only the
+// modality-specific difference and keep both usage and totals exact.
+export const OPENAI_REALTIME_2_1_MINI_CACHE_BILLING: BillingRules = {
+    adjustments: [
+        {
+            id: "openai.realtime.cached_audio_delta.v1",
+            description:
+                "Cached audio input costs $0.30/M instead of the $0.06/M cached-text base rate.",
+            kind: "cached_audio_input",
+            unit: "token",
+            unitCost: (0.3 - 0.06) / PER_MILLION,
+            countUnits: (output) => countCachedTokens(output, "audio"),
+        },
+        {
+            id: "openai.realtime.cached_image_delta.v1",
+            description:
+                "Cached image input costs $0.08/M instead of the $0.06/M cached-text base rate.",
+            kind: "cached_image_input",
+            unit: "token",
+            unitCost: (0.08 - 0.06) / PER_MILLION,
+            countUnits: (output) => countCachedTokens(output, "image"),
+        },
+    ],
+};

--- a/shared/registry/realtime-billing.ts
+++ b/shared/registry/realtime-billing.ts
@@ -3,46 +3,24 @@ import type { BillingRules } from "./registry";
 const PER_MILLION = 1_000_000;
 
 type RealtimeBillingOutput = {
-    response?: {
-        usage?: {
-            input_token_details?: {
-                cached_tokens_details?: {
-                    audio_tokens?: unknown;
-                    image_tokens?: unknown;
-                };
-            };
-        };
+    realtimeCache?: {
+        audioTokens?: unknown;
+        imageTokens?: unknown;
     };
-    streamEvents?: unknown[];
 };
-
-function outputEvents(output: unknown): unknown[] {
-    const value = output as RealtimeBillingOutput | undefined;
-    return Array.isArray(value?.streamEvents)
-        ? value.streamEvents
-        : value
-          ? [value]
-          : [];
-}
 
 function countCachedTokens(
     output: unknown,
     modality: "audio" | "image",
 ): number {
-    return outputEvents(output).reduce<number>((total, event) => {
-        const details = (event as RealtimeBillingOutput | undefined)?.response
-            ?.usage?.input_token_details?.cached_tokens_details;
-        const value =
-            modality === "audio"
-                ? details?.audio_tokens
-                : details?.image_tokens;
-        return (
-            total +
-            (typeof value === "number" && Number.isFinite(value) && value > 0
-                ? value
-                : 0)
-        );
-    }, 0);
+    const value = output as RealtimeBillingOutput | undefined;
+    const tokens =
+        modality === "audio"
+            ? value?.realtimeCache?.audioTokens
+            : value?.realtimeCache?.imageTokens;
+    return typeof tokens === "number" && Number.isFinite(tokens) && tokens > 0
+        ? tokens
+        : 0;
 }
 
 // Generic cached input is billed at the cached-text rate. The provider reports

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -1,3 +1,4 @@
+import { OPENAI_REALTIME_2_1_MINI_CACHE_BILLING } from "./realtime-billing";
 import type { ModelDefinition } from "./registry";
 
 export const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1" as const;
@@ -27,6 +28,44 @@ export const REALTIME_SERVICES = {
         tools: true,
         reasoning: true,
         contextLength: 32000,
+    },
+    "gpt-realtime-2.1-mini": {
+        aliases: [],
+        provider: "azure",
+        brand: "OpenAI",
+        category: "realtime",
+        addedDate: new Date("2026-07-26").getTime(),
+        priceMultiplier: 0.75,
+        paidOnly: false,
+        cost: {
+            promptTextTokens: 0.0000006,
+            promptCachedTokens: 0.00000006,
+            promptAudioTokens: 0.00001,
+            promptImageTokens: 0.0000008,
+            completionTextTokens: 0.0000024,
+            completionAudioTokens: 0.00002,
+        },
+        billing: OPENAI_REALTIME_2_1_MINI_CACHE_BILLING,
+        title: "GPT Realtime 2.1 Mini",
+        description:
+            "Cost-efficient live voice conversations with fast, reasoned replies and tool use",
+        inputModalities: ["text", "audio", "image"],
+        outputModalities: ["text", "audio"],
+        tools: true,
+        reasoning: true,
+        contextLength: 128000,
+        voices: [
+            "alloy",
+            "ash",
+            "ballad",
+            "coral",
+            "echo",
+            "sage",
+            "shimmer",
+            "verse",
+            "marin",
+            "cedar",
+        ],
     },
     "gpt-realtime-2": {
         aliases: [],


### PR DESCRIPTION
- Adds `gpt-realtime-2.1-mini` through Azure East US 2 Global Standard at 300 RPM / 150,000 TPM.
- Bills text, audio, image, output, and cached modality tokens at exact published rates.
- Keeps session billing state bounded to aggregate usage plus two cache counters; missing/incomplete cache detail emits a warning.
- Adds routing, discovery, pricing, wallet, and Tinybird coverage. No secrets changed.

| Contract | Value |
|---|---|
| Canonical / aliases | `gpt-realtime-2.1-mini` / none |
| Multiplier / paid-only | `0.75` / no |
| Pollinations GPU | no |
| Registry provider | Azure |
| Primary route | `myceli-prod-eastus2` → `gpt-realtime-2-1-mini` |
| Fallback | none |

Validation: direct Azure E2E passed text, image, speech, all 10 voices, tools, reasoning, cancellation, audio formats, caching, 30 concurrent sessions, and a 100,025-input-token request. The exact model page specifies 128K context / 32K output; the 32K review claim referenced deprecated `gpt-realtime-mini`. Local Worker→Azure passed text, PCM audio, usage, and deduction. Gen passes 679/679, focused Enter passes 291/291, typecheck/build pass.