### PR TITLE
chore: allow community model publishers

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -29,6 +29,8 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     183505255, // timemachine-studio
     228371309, // gggff123
     184364250, // Takax62
+    162339795, // meow18838
+    130518306, // Lorodn4x
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `meow18838` (GitHub ID `162339795`) to the community-model publisher allowlist.
- Adds `Lorodn4x` (GitHub ID `130518306`) from #12789.
- Changes only the immutable GitHub ID allowlist.

Checks:
- `biome check shared/auth/github-id-list.ts`
- `git diff --check`

Fixes #12789