### PR TITLE
chore: promote community publisher allowlist

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -29,6 +29,8 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     183505255, // timemachine-studio
     228371309, // gggff123
     184364250, // Takax62
+    162339795, // meow18838
+    130518306, // Lorodn4x
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Promotes the community-model publisher allowlist additions from #12795.
- Adds `meow18838` and `Lorodn4x` to production.
- The production snapshot differs from main only in this two-line allowlist change.