### PR TITLE
fix: normalize Nova provider to Bedrock

### DIFF
--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -132,6 +132,12 @@ test("Seedream 5 Pro uses Replicate and requires paid balance at provider cost",
     expect(definition.priceMultiplier).toBe(1);
 });
 
+test("Amazon Nova media models use the Bedrock registry provider", () => {
+    for (const model of ["nova-canvas", "nova-reel"] as const) {
+        expect(getRegistryModelDefinition(model).provider).toBe("bedrock");
+    }
+});
+
 test("DeepSeek V4 models are billed at provider cost", () => {
     const usage = {
         promptTextTokens: 1_000_000,

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -761,7 +761,7 @@ export const IMAGE_SERVICES = {
     },
     "nova-canvas": {
         aliases: ["amazon-nova-canvas"],
-        provider: "aws",
+        provider: "bedrock",
         brand: "Amazon",
         category: "image",
         addedDate: new Date("2026-03-23").getTime(),
@@ -777,7 +777,7 @@ export const IMAGE_SERVICES = {
     },
     "nova-reel": {
         aliases: ["amazon-nova-reel"],
-        provider: "aws",
+        provider: "bedrock",
         brand: "Amazon",
         category: "video",
         addedDate: new Date("2026-03-23").getTime(),


### PR DESCRIPTION
- Changes `nova-canvas` and `nova-reel` registry providers from `aws` to `bedrock`.
- Aligns Nova media attribution with the existing Claude and Nova text registry entries.
- Leaves Bedrock model IDs, runtime routing, pricing, and paid status unchanged.
- Adds a focused regression test for both media models.

Root cause: the Nova media entries retained the older `aws` label after the text registry standardized on `bedrock`.

Checks:
- `npx biome check --write shared/registry/image.ts enter.pollinations.ai/test/aliases.test.ts`
- `npx vitest run test/aliases.test.ts test/pricing-data.test.ts test/effective-prices.snapshot.test.ts` (298 passed)