### PR TITLE
Move Mercury 2 to OpenRouter

### DIFF
--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -2,7 +2,6 @@ import {
     createAzureModelConfig,
     createBedrockNativeConfig,
     createFireworksModelConfig,
-    createInceptionModelConfig,
     createOpenRouterModelConfig,
     createOVHcloudModelConfig,
     createOVHcloudOAIConfig,
@@ -193,10 +192,16 @@ export const portkeyConfig: PortkeyConfigMap = {
             defaultOptions: { provider: { sort: "price" } },
         }),
 
-    // -- Inception Labs (Mercury) -------------------------------------------
+    // -- OpenRouter (Inception Labs) -----------------------------------------
     "mercury-2": () =>
-        createInceptionModelConfig({
-            model: "mercury-2",
+        createOpenRouterModelConfig({
+            model: "inception/mercury-2",
+            defaultOptions: {
+                provider: {
+                    only: ["Inception"],
+                    allow_fallbacks: false,
+                },
+            },
         }),
 
     // -- Fireworks AI (DeepSeek) ---------------------------------------------

--- a/gen.pollinations.ai/src/text/configs/providerConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/providerConfigs.ts
@@ -115,16 +115,6 @@ export function createVercelAIGatewayModelConfig(
     );
 }
 
-export function createInceptionModelConfig(
-    overrides: ModelOverride = {},
-): ProviderConfig {
-    return createOpenAICompatibleConfig(
-        "https://api.inceptionlabs.ai/v1",
-        process.env.INCEPTION_API_KEY,
-        overrides,
-    );
-}
-
 export function createPerplexityModelConfig(
     overrides: ModelOverride = {},
 ): ProviderConfig {

--- a/gen.pollinations.ai/src/text/genericOpenAIClient.ts
+++ b/gen.pollinations.ai/src/text/genericOpenAIClient.ts
@@ -18,6 +18,14 @@ const log = debug("pollinations:genericopenai");
 const errorLog = debug("pollinations:error");
 const DONE_EVENT_PATTERN = /data:\s*\[DONE\]/;
 
+function isUnsupportedInputError(details: unknown): boolean {
+    const serialized =
+        typeof details === "string" ? details : JSON.stringify(details);
+    return /no endpoints found that support (?:image|audio|video) input/i.test(
+        serialized,
+    );
+}
+
 function remapTextUpstreamStatus(status: number): number {
     return status === 429 ? 429 : remapUpstreamStatus(status);
 }
@@ -107,7 +115,9 @@ function createApiError(
     const error = new Error(
         detailMessage ? `${statusMessage}: ${detailMessage}` : statusMessage,
     ) as ServiceError;
-    error.status = remapTextUpstreamStatus(response.status);
+    error.status = isUnsupportedInputError(details)
+        ? 400
+        : remapTextUpstreamStatus(response.status);
     error.upstreamStatus = response.status;
     error.details = details;
     error.model = modelName;

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -311,6 +311,30 @@ describe("genericOpenAIClient", () => {
         ).rejects.toMatchObject({ status: 429, upstreamStatus: 429 });
     });
 
+    it("maps unsupported multimodal input errors to a client error", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json(
+                {
+                    error: {
+                        message: "Provider returned error",
+                        metadata: {
+                            raw: "No endpoints found that support image input",
+                        },
+                    },
+                },
+                { status: 404, statusText: "Not Found" },
+            ),
+        );
+
+        await expect(
+            genericOpenAIClient(
+                [{ role: "user", content: "hello" }],
+                { model: "provider-model" },
+                { endpoint: "https://portkey.test/chat" },
+            ),
+        ).rejects.toMatchObject({ status: 400, upstreamStatus: 404 });
+    });
+
     it("passes through 429 from an upstream error envelope", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
             Response.json({

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -63,6 +63,16 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("pins Mercury to Inception on OpenRouter without fallback", () => {
+        const result = resolveModelConfig(messages, { model: "mercury" });
+
+        expect(result.options.model).toBe("inception/mercury-2");
+        expect(result.options.provider).toEqual({
+            only: ["Inception"],
+            allow_fallbacks: false,
+        });
+    });
+
     it.each([
         "perplexity-high",
         "perplexity-deep",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -236,7 +236,7 @@ export const TEXT_SERVICES = {
     },
     "mercury": {
         aliases: ["mercury-2", "inception", "inception-mercury"],
-        provider: "inception",
+        provider: "openrouter",
         brand: "Inception",
         category: "text",
         addedDate: new Date("2026-06-23").getTime(),


### PR DESCRIPTION
- Routes `mercury` through OpenRouter's exact `inception/mercury-2` endpoint, pinned to Inception with fallback disabled.
- Keeps aliases, paid-only access, multiplier 1, capabilities, and token/cache prices unchanged.
- Preserves the existing 400 response for unsupported multimodal input instead of exposing an upstream 502.
- Removes the unused direct Inception config helper; existing secrets remain untouched.

Validation: Gen typecheck; 721/721 Gen tests; 298/298 focused Enter alias/pricing tests; direct and local E2E for all aliases, streaming, tools, structured output, cache, billing, errors, and 5/15/30-request bursts.