### PR TITLE
fix: harden Z-Image Vast startup

### DIFF
--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,13 +1,13 @@
 # GPU Instances
 
-Last updated: 2026-07-22
+Last updated: 2026-07-27
 
 ## Capacity Summary
 
 | Model | Workers | GPUs | Provider | Cost/hr | Status |
 |-------|---------|------|----------|---------|--------|
 | Flux (FP4) | 1 | RTX 5090 | Vast.ai | $0.3744/hr | **ACTIVE — production** (Fireworks fallback) |
-| Z-Image | 3 | 4090 + 2x 3090 | RunPod | (see runpodctl) | **ACTIVE — production** |
+| Z-Image | 3 temporary | 3x RTX 5090 | Vast.ai | $1.195555/hr | **ACTIVE — two production + one validated canary** |
 | Klein 4B | 1 active + 1 rollback | RTX 3090 + A5000 | Vast.ai + RunPod | $0.1656 + $0.27 while rollback runs | **ACTIVE — Vast production; RunPod stop-ready** |
 | LTX-2 + ACE-Step + Sana | 1 | GH200 | Lambda Labs | — | **ACTIVE** |
 
@@ -74,6 +74,49 @@ POLLINATIONS_API_KEY=... bash image.pollinations.ai/nunchaku/verify-vast.sh  # r
 `QUEUE_LIMIT=3` allows one running request plus two waiting; additional load is
 shed with 503 so the gateway falls back to Fireworks instead of making users
 wait in a long queue.
+
+## Provider: Vast.ai — Z-Image Turbo (RTX 5090)
+
+Z-Image uses one remotely managed Cloudflare Tunnel shared by the Vast
+workers. Cloudflare balances requests across its connectors, while the registry
+sees one stable backend URL.
+
+| Worker | Vast instance | Region | Listed rate | Status |
+|--------|---------------|--------|-------------|--------|
+| zimage-vast-01 | 45311852 | South Korea | $0.422222/hr | ACTIVE — production |
+| zimage-vast-02 | 45313816 | South Korea | $0.422222/hr | ACTIVE — production |
+| zimage-vast-canary | 46003779 | California | $0.351111/hr | ACTIVE — validated production canary |
+
+The temporary three-worker fleet costs `$1.195555/hr`. Replacing one older
+worker with the canary leaves two workers at `$0.773333/hr`, saving
+`$0.071111/hr` or about `$51.20` per 30-day month versus the previous pair.
+Do not stop an older worker until the canary's production soak is accepted.
+
+**Canary validation (2026-07-27):**
+
+- Full reboot restored the model and four Cloudflare Tunnel connections.
+- Concurrency 4 for 120 seconds: 102/102 successful, 0.826 images/second,
+  4.69s p50, 5.73s p95, and 6.11s p99.
+- 512×512, 1024×1024, and 768×1152 outputs passed; fixed-seed output was
+  byte-identical.
+- Production soak added five successful requests with no 5xx, OOM, traceback,
+  or tunnel errors.
+- Requests above 2,359,296 pixels return HTTP 422.
+
+**Deployment behavior:**
+
+- `HEARTBEAT_ENABLED=false` disables registry registration, not traffic through
+  a shared named tunnel. Keep the `tunnel-enabled` marker absent for local-only
+  validation.
+- `/root/onstart.sh` starts the model first and waits for local `/health` before
+  joining the production tunnel.
+- Some Vast hosts drop Cloudflare's required SRV DNS responses. The setup
+  detects this and conditionally starts a local DNS-over-HTTPS resolver before
+  cloudflared; inspect `/root/tunnel-dns.log` on affected hosts.
+- Normal PyPI delivered the verified PyTorch 2.9.1 CUDA 12.8 Blackwell wheel
+  much faster than the dedicated PyTorch index on the canary.
+- See `z-image/README.md`, `z-image/setup-vast.sh`, and
+  `z-image/verify-vast.sh` for provisioning and verification.
 
 ## Provider: Vast.ai — FLUX.2 Klein 4B (RTX 3090)
 
@@ -176,13 +219,13 @@ still reports `provider=vast`, a successful request reaches instance `44766948`,
 and the production status window remains free of 5xx. To roll back, restart the
 pod, verify its health endpoint, remove `KLEIN_VPC`, and deploy gen through CI.
 
-### Z-Image pods
+### Historical Z-Image pods
 
 Flux left RunPod on 2026-07-02 (pod hsl3ksl31lvrcc terminated; flux now on
-Vast.ai, see above). Z-Image runs on dedicated pods — check current IDs with
-`runpodctl pod list` (as of 2026-07-02: `icagz5lxdzotdx` zimage-4090-secure,
-`ua39ysr9i86nil`/`owngt7t59jexy8` zimage-3090). Registered URLs use RunPod's
-https proxy (`https://<pod>-<port>.proxy.runpod.net`).
+Vast.ai, see above). Z-Image production moved to Vast in July 2026. Historical
+RunPod IDs were `icagz5lxdzotdx`, `ua39ysr9i86nil`, and `owngt7t59jexy8`.
+Confirm their current state with `runpodctl pod list` before any cleanup; these
+IDs are not the active Z-Image production route.
 
 **Registry check (all workers):**
 ```bash

--- a/image.pollinations.ai/z-image/README.md
+++ b/image.pollinations.ai/z-image/README.md
@@ -31,16 +31,26 @@ bash setup-vast.sh
 
 Using one remotely managed tunnel for the pool creates a Cloudflare replica per
 Vast worker. Cloudflare balances requests across those replicas, while the
-Pollinations registry sees one stable backend URL. Production currently uses
-two RTX 5090 replicas so either worker can be removed without changing routing.
+Pollinations registry sees one stable backend URL.
 
-The setup defaults to `HEARTBEAT_ENABLED=false`, so a new worker cannot join
-the production registry before validation. Run direct and tunnel verification,
-then benchmark the real Z-Image pipeline:
+The setup defaults to `HEARTBEAT_ENABLED=false`, which prevents registry
+registration but does not isolate a connector in the shared named tunnel.
+Validate local health and generation while cloudflared is stopped. The setup
+does not create `/root/.cloudflared/tunnel-enabled`, so reboots also remain
+local-only. Creating that marker and starting `/root/onstart.sh` is the
+production canary step: it waits for local `/health` and then joins the shared
+tunnel pool, where it may immediately receive live traffic.
+
+Run direct verification first, then start the tunnel and benchmark the real
+Z-Image pipeline:
 
 ```bash
-bash verify-vast.sh
 source .env.zimage
+curl -fsS "http://127.0.0.1:$PORT/health"
+# Run an authenticated local generation before starting the shared tunnel.
+touch /root/.cloudflared/tunnel-enabled
+/root/onstart.sh
+bash verify-vast.sh
 "$VENV/bin/python" benchmark-vast.py --duration 300 --concurrency 4
 ```
 
@@ -53,7 +63,27 @@ sed -i 's/export HEARTBEAT_ENABLED=false/export HEARTBEAT_ENABLED=true/' .env.zi
 ```
 
 Operational logs are `/root/zimage.log` and `/root/cloudflared.log`. Tokens are
-stored only in mode-0600 files on the rental host.
+stored only in mode-0600 files on the rental host. Some Vast hosts drop the SRV
+DNS responses required by cloudflared despite resolving ordinary A records.
+`setup-vast.sh` detects that condition and enables a reboot-safe local
+DNS-over-HTTPS fallback; its log is `/root/tunnel-dns.log`. Hosts with working
+SRV resolution retain the provider's resolver.
+
+### July 2026 RTX 5090 canary
+
+Instance `46003779` validated the hardened path on a California RTX 5090 at
+`$0.351111/hr`:
+
+- Full reboot restored the model, conditional DNS fallback, and all four
+  Cloudflare Tunnel connections automatically.
+- A 120-second concurrency-4 run completed 102 images with no errors:
+  0.826 images/second, 4.69s p50, and 5.73s p95.
+- 512×512, 1024×1024, and 768×1152 outputs were valid; a repeated fixed seed
+  was byte-identical.
+- The maximum accepted output area is 2,359,296 pixels (equivalent to
+  1536×1536); larger requests return HTTP 422.
+- A production soak observed successful requests and no model, tunnel, OOM, or
+  traceback errors.
 
 ## Working Mechanism
 

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -5,8 +5,9 @@
 # pinned Blackwell-capable PyTorch runtime and supervises the model server and a
 # remotely managed Cloudflare Tunnel in screen restart loops.
 #
-# Production registration is disabled by default. Run verify-vast.sh and the
-# benchmark first, then set HEARTBEAT_ENABLED=true in .env.zimage and restart.
+# Production registration is disabled by default. Keep the tunnel stopped for
+# local-only validation: starting a connector for the shared named tunnel can
+# receive production traffic even while registry heartbeats are disabled.
 #
 # Usage:
 #   PLN_GPU_TOKEN=... \
@@ -42,7 +43,7 @@ esac
 
 log "Installing system packages"
 $SUDO apt-get update -qq
-$SUDO apt-get install -y -qq curl git screen python3.12-venv python3.12-dev
+$SUDO apt-get install -y -qq curl dnsutils git screen python3.12-venv python3.12-dev
 
 # CUDA forward-compat libraries can fail on GeForce when the host driver is
 # older than the container toolkit. Use the host driver, as on the Flux Vast
@@ -64,10 +65,25 @@ if ! command -v cloudflared >/dev/null || \
 fi
 
 TUNNEL_TOKEN_FILE="$HOME/.cloudflared/tunnel-token"
+TUNNEL_ENABLED_FILE="$HOME/.cloudflared/tunnel-enabled"
+TUNNEL_DNS_FALLBACK_MARKER="$HOME/.cloudflared/use-local-doh"
+TUNNEL_RESOLV_BACKUP="/etc/resolv.conf.vast-original"
+TUNNEL_SRV_NAME="_v2-origintunneld._tcp.argotunnel.com"
 install -d -m 700 "$HOME/.cloudflared"
 printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
 chmod 600 "$TUNNEL_TOKEN_FILE"
 unset CLOUDFLARED_TUNNEL_TOKEN
+
+# A small subset of Vast hosts resolves A records but drops the SRV responses
+# cloudflared needs. Mark those hosts once so every reboot starts a local DoH
+# resolver before the tunnel. Hosts with working SRV DNS keep their resolver.
+if [ -f "$TUNNEL_DNS_FALLBACK_MARKER" ]; then
+    log "Reusing the local DoH fallback selected on this host"
+elif ! dig +time=3 +tries=1 +short SRV "$TUNNEL_SRV_NAME" | grep -q 'argotunnel.com'; then
+    log "Vast DNS does not return Cloudflare Tunnel SRV records; enabling local DoH"
+    [ -s "$TUNNEL_RESOLV_BACKUP" ] || cp /etc/resolv.conf "$TUNNEL_RESOLV_BACKUP"
+    touch "$TUNNEL_DNS_FALLBACK_MARKER"
+fi
 
 mkdir -p "$(dirname "$WORK_DIR")"
 if [ -n "${SKIP_CLONE:-}" ]; then
@@ -93,9 +109,10 @@ fi
 PIP_FLAGS="--resume-retries 20 --timeout 60 --retries 10"
 "$VENV/bin/pip" install --upgrade -q pip
 log "Installing PyTorch 2.9.1 cu128"
+# The normal PyPI wheels install the verified cu128 build on Linux and avoid
+# the much slower download.pytorch.org route seen on some Vast hosts.
 "$VENV/bin/pip" install -q $PIP_FLAGS \
-    torch==2.9.1 torchvision==0.24.1 \
-    --index-url https://download.pytorch.org/whl/cu128
+    torch==2.9.1 torchvision==0.24.1
 log "Installing Z-Image dependencies"
 "$VENV/bin/pip" install -q $PIP_FLAGS \
     -r "$ZIMAGE_DIR/requirements.txt" \
@@ -106,6 +123,7 @@ log "Verifying CUDA and Blackwell support"
 import torch
 
 assert torch.cuda.is_available(), "CUDA is not available"
+assert torch.version.cuda == "12.8", f"Expected CUDA 12.8, got {torch.version.cuda}"
 assert "sm_120" in torch.cuda.get_arch_list(), "PyTorch build lacks RTX 5090 support"
 print("CUDA OK:", torch.__version__, torch.version.cuda, torch.cuda.get_device_name(0))
 PY
@@ -158,10 +176,42 @@ chmod 700 /root/run-zimage.sh
 
 cat > /root/onstart.sh <<EOF
 #!/bin/bash
+set -euo pipefail
+
 screen -S zimage -X quit 2>/dev/null || true
 screen -S cloudflared -X quit 2>/dev/null || true
+screen -S tunnel-dns -X quit 2>/dev/null || true
+
 screen -dmS zimage bash -c 'while true; do /root/run-zimage.sh >> /root/zimage.log 2>&1; sleep 5; done'
-screen -dmS cloudflared bash -c 'while true; do cloudflared tunnel --no-autoupdate run --token-file "$TUNNEL_TOKEN_FILE" >> /root/cloudflared.log 2>&1; sleep 5; done'
+
+if [ ! -f "$TUNNEL_ENABLED_FILE" ]; then
+    echo "Production tunnel is disabled; create $TUNNEL_ENABLED_FILE after local validation"
+    exit 0
+fi
+
+if [ -f "$TUNNEL_DNS_FALLBACK_MARKER" ]; then
+    screen -dmS tunnel-dns bash -c 'while true; do cloudflared proxy-dns --address 127.0.0.1 --port 53 --upstream https://cloudflare-dns.com/dns-query --bootstrap https://162.159.36.1/dns-query --bootstrap https://162.159.46.1/dns-query >> /root/tunnel-dns.log 2>&1; sleep 5; done'
+
+    tunnel_dns_ready=false
+    for _ in \$(seq 1 20); do
+        if dig @127.0.0.1 +time=2 +tries=1 +short SRV "$TUNNEL_SRV_NAME" | grep -q 'argotunnel.com'; then
+            {
+                printf 'nameserver 127.0.0.1\n'
+                grep -v '^nameserver ' "$TUNNEL_RESOLV_BACKUP" || true
+            } > /etc/resolv.conf
+            tunnel_dns_ready=true
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "\$tunnel_dns_ready" != true ]; then
+        echo "Local DoH did not become ready; leaving the production tunnel stopped" >> /root/tunnel-dns.log
+        exit 1
+    fi
+fi
+
+screen -dmS cloudflared bash -c 'until curl -fsS --max-time 3 http://127.0.0.1:$PORT/health >/dev/null; do echo "Waiting for Z-Image health before joining the production tunnel" >> /root/cloudflared.log; sleep 5; done; while true; do cloudflared tunnel --no-autoupdate run --token-file "$TUNNEL_TOKEN_FILE" >> /root/cloudflared.log 2>&1; sleep 5; done'
 EOF
 chmod 700 /root/onstart.sh
 
@@ -169,5 +219,13 @@ chmod 700 /root/onstart.sh
 
 log "Z-Image is starting with production heartbeat=$HEARTBEAT_ENABLED"
 log "Model logs: tail -f /root/zimage.log"
-log "Tunnel logs: tail -f /root/cloudflared.log"
-log "Run verification before enabling production registration"
+if [ -f "$TUNNEL_ENABLED_FILE" ]; then
+    log "Tunnel logs: tail -f /root/cloudflared.log"
+    if [ -f "$TUNNEL_DNS_FALLBACK_MARKER" ]; then
+        log "Tunnel DNS logs: tail -f /root/tunnel-dns.log"
+    fi
+    log "The tunnel waits for local health, then joins the production connector pool"
+else
+    log "Production tunnel is disabled for local validation"
+    log "After validation: touch $TUNNEL_ENABLED_FILE && /root/onstart.sh"
+fi


### PR DESCRIPTION
- Keeps new workers local-only until an explicit persistent tunnel-enable marker is created.
- Waits for local Z-Image health before joining the shared production Cloudflare Tunnel.
- Adds a conditional, reboot-safe DNS-over-HTTPS fallback for Vast hosts that drop required SRV responses.
- Uses the empirically verified PyPI CUDA 12.8/Blackwell wheel path and documents the current Vast fleet, cost, limits, and canary results.
- Does not change credentials, encrypted secrets, registry pricing, or production routing.

Validation:
- `bash -n image.pollinations.ai/z-image/setup-vast.sh`
- Extracted generated `/root/onstart.sh` parses with `bash -n`
- `git diff --check`
- Live canary: 102/102 successful at concurrency 4 over 120s; 4.69s p50, 5.73s p95; reboot and production soak passed.