### PR TITLE
fix: enforce requested dimensions for self-hosted pool image results

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -50,6 +50,7 @@ import {
 } from "./utils/imageDownload.ts";
 import {
     resizeForGptImage,
+    transformImage,
     convertToJpeg as transformToJpeg,
 } from "./utils/imageTransform.ts";
 import type { TrackingData } from "./utils/trackingHeaders.ts";
@@ -902,14 +903,29 @@ const prepareMetadata = (
  * @param {Buffer} buffer - The raw image buffer
  * @param {Object} metadataObj - Metadata to embed in the image
  * @param {Object} maturity - Additional maturity information
+ * @param {Object} safeParams - Parameters the image was requested with
  * @returns {Promise<Buffer>} - The processed image buffer
  */
 const processImageBuffer = async (
     buffer: Buffer,
     metadataObj: object,
     maturity: object,
+    safeParams: ImageParams,
 ): Promise<Buffer> => {
-    const processedBuffer = await convertToJpeg(buffer);
+    // Backends only approximate the requested size: the GPU pool returns
+    // whatever resolution the worker produced, Replicate snaps to a preset
+    // aspect ratio, Azure to a fixed size. When the caller asked for exact
+    // dimensions, crop to them here — once, for every backend — instead of
+    // per model handler (issue #12225).
+    const processedBuffer = safeParams.dimensionsExplicit
+        ? await transformImage(buffer, {
+              width: safeParams.width,
+              height: safeParams.height,
+              fit: "cover",
+              format: "image/jpeg",
+              quality: 90,
+          })
+        : await convertToJpeg(buffer);
     return await writeExifMetadata(processedBuffer, metadataObj, maturity);
 };
 
@@ -956,6 +972,7 @@ export async function createAndReturnImageCached(
                       result.buffer,
                       metadataObj,
                       maturity,
+                      safeParams,
                   );
 
         return {

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -49,6 +49,7 @@ import {
 } from "./utils/imageDownload.ts";
 import {
     resizeForGptImage,
+    transformImage,
     convertToJpeg as transformToJpeg,
 } from "./utils/imageTransform.ts";
 import type { TrackingData } from "./utils/trackingHeaders.ts";
@@ -850,14 +851,29 @@ const prepareMetadata = (
  * @param {Buffer} buffer - The raw image buffer
  * @param {Object} metadataObj - Metadata to embed in the image
  * @param {Object} maturity - Additional maturity information
+ * @param {Object} safeParams - Parameters the image was requested with
  * @returns {Promise<Buffer>} - The processed image buffer
  */
 const processImageBuffer = async (
     buffer: Buffer,
     metadataObj: object,
     maturity: object,
+    safeParams: ImageParams,
 ): Promise<Buffer> => {
-    const processedBuffer = await convertToJpeg(buffer);
+    // Backends only approximate the requested size: the GPU pool returns
+    // whatever resolution the worker produced, Replicate snaps to a preset
+    // aspect ratio, Azure to a fixed size. When the caller asked for exact
+    // dimensions, crop to them here — once, for every backend — instead of
+    // per model handler (issue #12225).
+    const processedBuffer = safeParams.dimensionsExplicit
+        ? await transformImage(buffer, {
+              width: safeParams.width,
+              height: safeParams.height,
+              fit: "cover",
+              format: "image/jpeg",
+              quality: 90,
+          })
+        : await convertToJpeg(buffer);
     return await writeExifMetadata(processedBuffer, metadataObj, maturity);
 };
 
@@ -908,6 +924,7 @@ export async function createAndReturnImageCached(
                       result.buffer,
                       metadataObj,
                       maturity,
+                      safeParams,
                   );
 
         return {

--- a/gen.pollinations.ai/src/image/models/replicateFluxModel.ts
+++ b/gen.pollinations.ai/src/image/models/replicateFluxModel.ts
@@ -5,7 +5,6 @@ import type { ImageParams } from "../params.ts";
 import { sanitizeString } from "../util.ts";
 import { closestByRatio } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
-import { transformImage } from "../utils/imageTransform.ts";
 import {
     ReplicateError,
     runReplicatePrediction,
@@ -87,19 +86,11 @@ export async function callReplicateFluxSchnellAPI(
     const response = await fetchUpstream(outputUrls[0], {
         errorLabel: "Failed to download Replicate FLUX output image",
     });
-    let buffer: Buffer = Buffer.from(await response.arrayBuffer());
-    if (safeParams.dimensionsExplicit) {
-        buffer = await transformImage(buffer, {
-            width: safeParams.width,
-            height: safeParams.height,
-            fit: "cover",
-            format: "image/jpeg",
-            quality: 90,
-        });
-    }
 
     return {
-        buffer,
+        // Exact dimensions are enforced for every backend in
+        // createAndReturnImageCached, so the preset aspect ratio is fine here.
+        buffer: Buffer.from(await response.arrayBuffer()),
         isMature: false,
         isChild: false,
         trackingData: {

--- a/gen.pollinations.ai/test/image/fluxFallback.test.ts
+++ b/gen.pollinations.ai/test/image/fluxFallback.test.ts
@@ -5,8 +5,13 @@ import {
     registerServer,
     setServerRegistryBinding,
 } from "../../src/image/availableServers.ts";
-import { callSelfHostedServer } from "../../src/image/createAndReturnImages.ts";
+import {
+    type AuthResult,
+    callSelfHostedServer,
+    createAndReturnImageCached,
+} from "../../src/image/createAndReturnImages.ts";
 import type { ImageParams } from "../../src/image/params.ts";
+import { setImagesBinding } from "../../src/image/utils/imageTransform.ts";
 
 // Minimal in-memory KV stub matching the subset of KVNamespace we use
 // (same shape as availableServers.test.ts).
@@ -61,11 +66,11 @@ function mockFetch(respond: (url: string) => Response) {
     return calls;
 }
 
-const poolResponse = () =>
+const poolResponse = (bytes: Uint8Array = JPEG_BYTES) =>
     new Response(
         JSON.stringify([
             {
-                image: Buffer.from(JPEG_BYTES).toString("base64"),
+                image: Buffer.from(bytes).toString("base64"),
                 has_nsfw_concept: false,
                 concept: null,
                 width: 1024,
@@ -76,6 +81,57 @@ const poolResponse = () =>
         { status: 200 },
     );
 
+const userInfo: AuthResult = {
+    tokenAuth: false,
+    userId: null,
+};
+
+// A PNG header is enough to carry dimensions through the pipeline and read
+// them back off the final buffer.
+function pngWithDimensions(width: number, height: number): Buffer {
+    const png = Buffer.alloc(24);
+    png.write("\x89PNG\r\n\x1a\n", 0, "binary");
+    png.write("IHDR", 12, "binary");
+    png.writeUInt32BE(width, 16);
+    png.writeUInt32BE(height, 20);
+    return png;
+}
+
+function readPngDimensions(buffer: Buffer) {
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+// Stands in for the Cloudflare Images binding: outputs the size it was asked
+// to transform to, or the source size when no transform was requested.
+function fakeImagesBinding(): ImagesBinding {
+    return {
+        input(stream: ReadableStream<Uint8Array>) {
+            let target: { width: number; height: number } | null = null;
+            const pipeline = {
+                transform(options: { width: number; height: number }) {
+                    target = options;
+                    return pipeline;
+                },
+                async output() {
+                    const source = readPngDimensions(
+                        Buffer.from(await new Response(stream).arrayBuffer()),
+                    );
+                    const { width, height } = target || source;
+                    return {
+                        response: () =>
+                            new Response(
+                                Uint8Array.from(
+                                    pngWithDimensions(width, height),
+                                ),
+                            ),
+                    };
+                },
+            };
+            return pipeline;
+        },
+    } as unknown as ImagesBinding;
+}
+
 beforeEach(() => {
     setServerRegistryBinding(makeKv(), "test");
     __resetLatencyStateForTests();
@@ -83,6 +139,7 @@ beforeEach(() => {
 
 afterEach(() => {
     vi.restoreAllMocks();
+    setImagesBinding(undefined);
 });
 
 describe("Flux primary route", () => {
@@ -130,5 +187,52 @@ describe("Flux primary route", () => {
         expect(calls).toEqual(["https://gpu1.example/generate"]);
         expect(error).toMatchObject({ status: 500 });
         expect(isRetryableFallbackError(error)).toBe(true);
+    });
+});
+
+describe("createAndReturnImageCached dimensions", () => {
+    // The pool returns whatever resolution its worker produced, ignoring the
+    // requested width/height (issue #12225).
+    const poolAt1024x576 = () => poolResponse(pngWithDimensions(1024, 576));
+
+    it("resizes self-hosted pool output to the requested dimensions", async () => {
+        await registerServer("https://gpu1.example", "flux");
+        setImagesBinding(fakeImagesBinding());
+        mockFetch(poolAt1024x576);
+
+        const result = await createAndReturnImageCached(
+            "a red apple",
+            {
+                ...fluxParams,
+                width: 960,
+                height: 640,
+                dimensionsExplicit: true,
+            },
+            "a red apple",
+            userInfo,
+        );
+
+        expect(readPngDimensions(result.buffer)).toEqual({
+            width: 960,
+            height: 640,
+        });
+    });
+
+    it("keeps the backend resolution when no dimensions were requested", async () => {
+        await registerServer("https://gpu1.example", "flux");
+        setImagesBinding(fakeImagesBinding());
+        mockFetch(poolAt1024x576);
+
+        const result = await createAndReturnImageCached(
+            "a red apple",
+            { ...fluxParams, width: 960, height: 640 },
+            "a red apple",
+            userInfo,
+        );
+
+        expect(readPngDimensions(result.buffer)).toEqual({
+            width: 1024,
+            height: 576,
+        });
     });
 });

--- a/gen.pollinations.ai/test/image/fluxFallback.test.ts
+++ b/gen.pollinations.ai/test/image/fluxFallback.test.ts
@@ -4,9 +4,14 @@ import {
     registerServer,
     setServerRegistryBinding,
 } from "../../src/image/availableServers.ts";
-import { callFluxWithFallback } from "../../src/image/createAndReturnImages.ts";
+import {
+    type AuthResult,
+    callFluxWithFallback,
+    createAndReturnImageCached,
+} from "../../src/image/createAndReturnImages.ts";
 import { syncImageEnv } from "../../src/image/env.ts";
 import type { ImageParams } from "../../src/image/params.ts";
+import { setImagesBinding } from "../../src/image/utils/imageTransform.ts";
 
 // Minimal in-memory KV stub matching the subset of KVNamespace we use
 // (same shape as availableServers.test.ts).
@@ -61,11 +66,11 @@ function mockFetch(respond: (url: string) => Response) {
     return calls;
 }
 
-const poolResponse = () =>
+const poolResponse = (bytes: Uint8Array = JPEG_BYTES) =>
     new Response(
         JSON.stringify([
             {
-                image: Buffer.from(JPEG_BYTES).toString("base64"),
+                image: Buffer.from(bytes).toString("base64"),
                 has_nsfw_concept: false,
                 concept: null,
                 width: 1024,
@@ -75,6 +80,58 @@ const poolResponse = () =>
         ]),
         { status: 200 },
     );
+
+const userInfo: AuthResult = {
+    tokenAuth: false,
+    userId: null,
+    username: null,
+};
+
+// A PNG header is enough to carry dimensions through the pipeline and read
+// them back off the final buffer.
+function pngWithDimensions(width: number, height: number): Buffer {
+    const png = Buffer.alloc(24);
+    png.write("\x89PNG\r\n\x1a\n", 0, "binary");
+    png.write("IHDR", 12, "binary");
+    png.writeUInt32BE(width, 16);
+    png.writeUInt32BE(height, 20);
+    return png;
+}
+
+function readPngDimensions(buffer: Buffer) {
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+// Stands in for the Cloudflare Images binding: outputs the size it was asked
+// to transform to, or the source size when no transform was requested.
+function fakeImagesBinding(): ImagesBinding {
+    return {
+        input(stream: ReadableStream<Uint8Array>) {
+            let target: { width: number; height: number } | null = null;
+            const pipeline = {
+                transform(options: { width: number; height: number }) {
+                    target = options;
+                    return pipeline;
+                },
+                async output() {
+                    const source = readPngDimensions(
+                        Buffer.from(await new Response(stream).arrayBuffer()),
+                    );
+                    const { width, height } = target || source;
+                    return {
+                        response: () =>
+                            new Response(
+                                Uint8Array.from(
+                                    pngWithDimensions(width, height),
+                                ),
+                            ),
+                    };
+                },
+            };
+            return pipeline;
+        },
+    } as unknown as ImagesBinding;
+}
 
 beforeEach(() => {
     setServerRegistryBinding(makeKv(), "test");
@@ -89,6 +146,7 @@ beforeEach(() => {
 
 afterEach(() => {
     vi.restoreAllMocks();
+    setImagesBinding(undefined);
 });
 
 describe("callFluxWithFallback", () => {
@@ -162,5 +220,52 @@ describe("callFluxWithFallback", () => {
         expect(Buffer.from(result.buffer).equals(Buffer.from(JPEG_BYTES))).toBe(
             true,
         );
+    });
+});
+
+describe("createAndReturnImageCached dimensions", () => {
+    // The pool returns whatever resolution its worker produced, ignoring the
+    // requested width/height (issue #12225).
+    const poolAt1024x576 = () => poolResponse(pngWithDimensions(1024, 576));
+
+    it("resizes self-hosted pool output to the requested dimensions", async () => {
+        await registerServer("https://gpu1.example", "flux");
+        setImagesBinding(fakeImagesBinding());
+        mockFetch(poolAt1024x576);
+
+        const result = await createAndReturnImageCached(
+            "a red apple",
+            {
+                ...fluxParams,
+                width: 960,
+                height: 640,
+                dimensionsExplicit: true,
+            },
+            "a red apple",
+            userInfo,
+        );
+
+        expect(readPngDimensions(result.buffer)).toEqual({
+            width: 960,
+            height: 640,
+        });
+    });
+
+    it("keeps the backend resolution when no dimensions were requested", async () => {
+        await registerServer("https://gpu1.example", "flux");
+        setImagesBinding(fakeImagesBinding());
+        mockFetch(poolAt1024x576);
+
+        const result = await createAndReturnImageCached(
+            "a red apple",
+            { ...fluxParams, width: 960, height: 640 },
+            "a red apple",
+            userInfo,
+        );
+
+        expect(readPngDimensions(result.buffer)).toEqual({
+            width: 1024,
+            height: 576,
+        });
     });
 });


### PR DESCRIPTION
Explicit `width`/`height` only survived when a generation went through the Replicate flux fallback — that handler (`callReplicateFluxSchnellAPI`) crops its output to the requested size when `dimensionsExplicit` is set. Requests served by the self-hosted GPU pool (`callSelfHostedServer`, used by flux/zimage/sana) returned the worker's own resolution untouched, which is why the reporter's 960x640 request came back as 1024x576 with the aspect ratio distorted.

Rather than copy the crop into the pool path, I moved it up to `processImageBuffer` in `createAndReturnImageCached`, where results from every provider converge before EXIF and caching, and dropped the now-duplicate block from `replicateFluxModel.ts`. Same `transformImage` call and same `fit: "cover"` as before, just in one place, so Azure/OpenRouter handlers that snap to preset sizes get the same treatment. SVG results still skip it, and when no dimensions were requested nothing changes — the existing `convertToJpeg` path runs as before.

Extended `test/image/fluxFallback.test.ts` with two cases through `createAndReturnImageCached`: a pool response at 1024x576 with a 960x640 explicit request now comes back at 960x640, and the same response with no explicit dimensions is left at 1024x576. The Images binding is stubbed so the final buffer's dimensions can be read back. I checked the first test fails on main before the change. Full gen suite passes (720 passed, 6 skipped) along with typecheck.

Closes #12225
