### PR TITLE
feat: pool identical community models

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -845,6 +845,103 @@ fixtureTest(
 );
 
 fixtureTest(
+    "retries an identical community model through its shared pool",
+    async ({ apiKey }) => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const modelName = `pooled-${suffix}`;
+        const firstOwner = `pool-a-${suffix}`;
+        const secondOwner = `pool-b-${suffix}`;
+        for (const [ownerGithubUsername, baseUrl] of [
+            [firstOwner, "https://pool-a.example.com/v1"],
+            [secondOwner, "https://pool-b.example.com/v1"],
+        ] as const) {
+            const ownerUserId = await createTestUser({
+                githubUsername: ownerGithubUsername,
+            });
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name: modelName,
+                baseUrl,
+                upstreamModel: "shared-model",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const upstreamHosts: string[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (isPortkeyChatCompletionsRequest(request)) {
+                    const host = request.headers.get("x-portkey-custom-host");
+                    if (host) upstreamHosts.push(host);
+                    if (host === "https://pool-a.example.com/v1") {
+                        return Response.json(
+                            { error: { message: "temporarily unavailable" } },
+                            { status: 503 },
+                        );
+                    }
+                    return Response.json({
+                        id: "chatcmpl_pool",
+                        object: "chat.completion",
+                        choices: [
+                            {
+                                index: 0,
+                                message: {
+                                    role: "assistant",
+                                    content: "ok",
+                                },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 2,
+                            completion_tokens: 3,
+                            total_tokens: 5,
+                        },
+                    });
+                }
+                if (isBillingFetch(request)) {
+                    return Response.json({ data: [] });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const modelId = communityModelId(firstOwner, modelName);
+        const response = await SELF.fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-model-used")).toBe(modelId);
+        expect(upstreamHosts).toEqual([
+            "https://pool-a.example.com/v1",
+            "https://pool-b.example.com/v1",
+        ]);
+    },
+);
+
+fixtureTest(
     "a private model is owner-only and a zero-priced public model is free",
     async ({ apiKey }) => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -1,4 +1,5 @@
 import {
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
     type CommunityEndpointRuntime,
     communityEndpointPrices,
     communityModelDefinition,
@@ -40,7 +41,30 @@ export type CommunityModelRegistryEntry = {
     info: ModelInfo;
     definition: ModelDefinition;
     communityEndpoint: CommunityEndpointRuntime;
+    communityPool?: CommunityEndpointRuntime[];
 };
+
+const poolCounters = new Map<string, number>();
+
+function communityPoolKey(endpoint: CommunityEndpointRuntime): string {
+    return JSON.stringify([
+        endpoint.name,
+        endpoint.modality,
+        endpoint.imagePricing,
+        endpoint.supportsImageEdits,
+        ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => endpoint[field.key]),
+    ]);
+}
+
+export function nextCommunityPoolOrder(
+    members: CommunityEndpointRuntime[],
+): CommunityEndpointRuntime[] {
+    if (members.length < 2) return members;
+    const key = members.map((member) => member.modelId).join("\n");
+    const start = (poolCounters.get(key) ?? 0) % members.length;
+    poolCounters.set(key, start + 1);
+    return [...members.slice(start), ...members.slice(0, start)];
+}
 
 export async function getCommunityModelRegistryEntries(
     dbBinding: CloudflareBindings["DB"] | undefined,
@@ -84,7 +108,7 @@ export async function getCommunityModelRegistryEntries(
         )
         .where(isNotNull(schema.user.githubUsername));
 
-    return rows.flatMap((row): CommunityModelRegistryEntry[] => {
+    const entries = rows.flatMap((row): CommunityModelRegistryEntry[] => {
         if (!row.ownerGithubUsername) return [];
         const modelId = communityModelId(row.ownerGithubUsername, row.name);
         const communityEndpoint: CommunityEndpointRuntime = {
@@ -120,4 +144,32 @@ export async function getCommunityModelRegistryEntries(
             },
         ];
     });
+
+    const pools = new Map<string, CommunityEndpointRuntime[]>();
+    for (const { communityEndpoint } of entries) {
+        if (
+            communityEndpoint.visibility !== "public" ||
+            communityEndpoint.disabledAt !== null
+        ) {
+            continue;
+        }
+        const key = communityPoolKey(communityEndpoint);
+        const members = pools.get(key) ?? [];
+        members.push(communityEndpoint);
+        pools.set(key, members);
+    }
+    for (const members of pools.values()) {
+        members.sort((a, b) => a.modelId.localeCompare(b.modelId));
+    }
+    for (const entry of entries) {
+        if (
+            entry.communityEndpoint.visibility !== "public" ||
+            entry.communityEndpoint.disabledAt !== null
+        ) {
+            continue;
+        }
+        const members = pools.get(communityPoolKey(entry.communityEndpoint));
+        if (members && members.length >= 2) entry.communityPool = members;
+    }
+    return entries;
 }

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -4,6 +4,7 @@ import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
+import { nextCommunityPoolOrder } from "../community-models.ts";
 import {
     getRegisteredServers,
     isValidType,
@@ -415,21 +416,40 @@ export async function generateImageOrVideoResponse(
     try {
         const communityEndpoint = c.var.model.communityEndpoint;
         if (communityEndpoint) {
-            const result = await callCommunityImageEndpoint(
-                communityEndpoint,
-                originalPrompt,
-                safeParams,
-                c.env.BETTER_AUTH_SECRET,
-            );
-            assertNonEmptyMedia(result.buffer, "Community image endpoint");
-            return new Response(bufferToUint8Array(result.buffer), {
-                headers: mediaHeaders(
-                    originalPrompt,
-                    safeParams,
-                    result,
-                    detectMimeType(result.buffer),
-                ),
-            });
+            const candidates = c.var.model.communityPool
+                ? nextCommunityPoolOrder(c.var.model.communityPool)
+                : [communityEndpoint];
+            for (const [index, candidate] of candidates.entries()) {
+                try {
+                    const result = await callCommunityImageEndpoint(
+                        candidate,
+                        originalPrompt,
+                        safeParams,
+                        c.env.BETTER_AUTH_SECRET,
+                    );
+                    c.var.model.communityEndpoint = candidate;
+                    assertNonEmptyMedia(
+                        result.buffer,
+                        "Community image endpoint",
+                    );
+                    return new Response(bufferToUint8Array(result.buffer), {
+                        headers: mediaHeaders(
+                            originalPrompt,
+                            safeParams,
+                            result,
+                            detectMimeType(result.buffer),
+                        ),
+                    });
+                } catch (error) {
+                    if (
+                        !(error instanceof HttpError) ||
+                        error.status < 500 ||
+                        index === candidates.length - 1
+                    ) {
+                        throw error;
+                    }
+                }
+            }
         }
 
         if (isVideoModel(safeParams.model)) {

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -28,6 +28,7 @@ export type ModelVariables = {
         /** Static registry definition, or a dynamic definition resolved from D1. */
         definition: ModelDefinition;
         communityEndpoint?: CommunityEndpointRuntime;
+        communityPool?: CommunityEndpointRuntime[];
     };
     formData?: FormData;
 };
@@ -107,6 +108,7 @@ export async function resolveModelDefinition(
         ...(entry.communityEndpoint && {
             communityEndpoint: entry.communityEndpoint,
         }),
+        ...(entry.communityPool && { communityPool: entry.communityPool }),
     };
 }
 

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -37,6 +37,7 @@ export type GenerationModelEntry = {
     definition: ModelDefinition;
     info: ModelInfo;
     communityEndpoint?: CommunityEndpointRuntime;
+    communityPool?: CommunityEndpointRuntime[];
     visible: boolean;
 };
 
@@ -110,6 +111,7 @@ function communityEntryToGenerationEntry(
         definition: entry.definition,
         info: entry.info,
         communityEndpoint: entry.communityEndpoint,
+        communityPool: entry.communityPool,
         // Public endpoints appear for everyone. Private endpoints are added
         // back for their owner by visibleEntries().
         visible:

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -9,6 +9,7 @@ import {
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
+import { nextCommunityPoolOrder } from "../community-models.ts";
 import { fixWavHeader } from "../routes/audio.js";
 import { communityEndpointGatewayContext } from "./communityEndpoint.ts";
 import { generateTextPortkey } from "./generateTextPortkey.js";
@@ -314,6 +315,18 @@ function throwTextError(error: ServiceError): never {
     });
 }
 
+function isRetryableCommunityError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const serviceError = error as ServiceError;
+    const status =
+        serviceError.upstreamStatus ?? serviceError.status ?? serviceError.code;
+    return (
+        (typeof status === "number" && status >= 500 && status < 600) ||
+        error.name === "TypeError" ||
+        error.name === "AbortError"
+    );
+}
+
 async function generateTextResponse(
     c: TextContext,
     requestData: RequestData,
@@ -323,20 +336,49 @@ async function generateTextResponse(
 
     try {
         const communityEndpoint = c.var.model?.communityEndpoint;
-        const gatewayContext = communityEndpoint
-            ? await communityEndpointGatewayContext(
-                  communityEndpoint,
-                  c.var.model.definition,
-                  requestData,
-                  c.env.BETTER_AUTH_SECRET,
-                  c.env.PORTKEY_GATEWAY_URL,
-                  c.var.auth?.apiKey?.rawKey || "",
-              )
-            : withGatewayContext(c, requestData);
-        const completion = await generateTextPortkey(
-            requestData.messages,
-            gatewayContext,
-        );
+        let completion: ChatCompletion | undefined;
+        if (communityEndpoint) {
+            const ordered = c.var.model.communityPool
+                ? nextCommunityPoolOrder(c.var.model.communityPool)
+                : [communityEndpoint];
+            let lastError: unknown;
+            for (const [index, candidate] of ordered.entries()) {
+                try {
+                    const gatewayContext =
+                        await communityEndpointGatewayContext(
+                            candidate,
+                            c.var.model.definition,
+                            requestData,
+                            c.env.BETTER_AUTH_SECRET,
+                            c.env.PORTKEY_GATEWAY_URL,
+                            c.var.auth?.apiKey?.rawKey || "",
+                        );
+                    completion = await generateTextPortkey(
+                        requestData.messages,
+                        gatewayContext,
+                    );
+                    c.var.model.communityEndpoint = candidate;
+                    lastError = undefined;
+                    break;
+                } catch (error) {
+                    lastError = error;
+                    if (
+                        !isRetryableCommunityError(error) ||
+                        index === ordered.length - 1
+                    ) {
+                        throw error;
+                    }
+                }
+            }
+            if (!completion) {
+                throw lastError ?? new Error("Community model pool is empty");
+            }
+        } else {
+            completion = await generateTextPortkey(
+                requestData.messages,
+                withGatewayContext(c, requestData),
+            );
+        }
         c.set("upstreamRequestUrl", completion.upstreamRequestUrl);
         completion.id = completion.id || generatePollinationsId();
 


### PR DESCRIPTION
- Automatically pools active public community models with the same name, modality, and pricing
- Round-robins requests across matching providers and retries 5xx/network failures
- Keeps existing model IDs and catalogs unchanged; no schema or labels
- Credits the provider that actually served the request

Tests:
- `npm run test -- src/community-endpoints.test.ts` (32 passed)
- `npm run typecheck`