### PR TITLE
feat: pool identically-priced community models into groups

### DIFF
--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -941,6 +941,58 @@ describe("API Key Management", () => {
             ]);
         });
 
+        test("should keep a pooled group model in permissions", async ({
+            sessionToken,
+        }) => {
+            // A key scoped to `group/<name>` must read back unchanged: the
+            // dashboard seeds its edit form from this response and saves it,
+            // so dropping the id here silently locks the key out of every
+            // model.
+            const created = await createApiKeyViaApi(sessionToken, {
+                name: "key-with-group-model",
+                allowedModels: ["group/pooled-model", "flux"],
+            });
+            const db = drizzle(env.DB, { schema });
+            for (const owner of ["pool-alice", "pool-bob"]) {
+                await db.insert(schema.user).values({
+                    id: `${owner}-id`,
+                    name: owner,
+                    email: `${owner}@example.com`,
+                    githubUsername: owner,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                });
+                await db.insert(schema.communityEndpoint).values({
+                    id: `${owner}-pooled-model`,
+                    ownerUserId: `${owner}-id`,
+                    name: "pooled-model",
+                    baseUrl: `https://${owner}.example.com/v1`,
+                    upstreamModel: "pooled-model",
+                    bearerTokenCiphertext: "encrypted-token",
+                    visibility: "public",
+                    promptTextPrice: 0.1,
+                    completionTextPrice: 0.2,
+                });
+            }
+
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    headers: {
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const body = (await response.json()) as ApiKeyListResponse;
+            const listed = body.data.find((item) => item.id === created.id);
+            expect(listed?.permissions?.models).toEqual([
+                "group/pooled-model",
+                "flux",
+            ]);
+        });
+
         test("should require authentication", async () => {
             const response = await SELF.fetch(
                 "http://localhost:3000/api/api-keys",

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -2,11 +2,14 @@ import { createExecutionContext, env, SELF } from "cloudflare:test";
 import type { Logger } from "@logtape/logtape";
 import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
 import {
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
     type CommunityEndpointRuntime,
     communityChatCompletionsUrl,
     communityEndpointPriceFieldsForModality,
     communityEndpointPrices,
     communityEndpointTitle,
+    communityGroupKey,
+    communityGroupModelDefinition,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
     communityModelDefinition,
@@ -18,6 +21,7 @@ import {
     MAX_COMMUNITY_PRICE_PER_IMAGE,
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MIN_COMMUNITY_GROUP_MEMBERS,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityAssetUrl,
@@ -43,10 +47,16 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
-import { communityImageSupportedEndpoints } from "./community-models.ts";
+import {
+    communityGroupEntries,
+    communityImageSupportedEndpoints,
+} from "./community-models.ts";
 import { callCommunityImageEndpoint } from "./image/communityEndpoint.ts";
 import { resetGenerationModelRegistryCache } from "./model-registry.ts";
-import { communityEndpointGatewayContext } from "./text/communityEndpoint.ts";
+import {
+    communityEndpointGatewayContext,
+    communityGroupGatewayContext,
+} from "./text/communityEndpoint.ts";
 
 const db = drizzle(env.DB);
 const testLog = { getChild: () => testLog } as unknown as Logger;
@@ -805,6 +815,264 @@ describe("community endpoint helpers", () => {
             await expect(contextFor(endpoint, "parent-key-id")).rejects.toThrow(
                 "is not free",
             );
+    describe("community model groups", () => {
+        const secret = "test-secret";
+
+        async function groupMember(
+            overrides: Partial<CommunityEndpointRuntime> & { modelId: string },
+        ): Promise<CommunityEndpointRuntime> {
+            const owner = overrides.modelId.split("/")[0];
+            return {
+                id: `endpoint-${overrides.modelId}`,
+                ownerUserId: `${owner}-user`,
+                name: "laguna",
+                title: "Laguna",
+                description: null,
+                modality: "text",
+                imagePricing: "request",
+                supportsImageEdits: false,
+                baseUrl: `https://${owner}.example.com/v1`,
+                upstreamModel: `${owner}-upstream`,
+                visibility: "public",
+                disabledAt: null,
+                disabledReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    `sk_${owner}`,
+                    secret,
+                ),
+                ...communityEndpointPrices({
+                    promptTextPrice: 0.1,
+                    completionTextPrice: 0.2,
+                }),
+                ...overrides,
+            };
+        }
+
+        function groupGatewayContext(
+            members: CommunityEndpointRuntime[],
+            startIndex: number,
+        ) {
+            return communityGroupGatewayContext(
+                members,
+                communityGroupModelDefinition(members),
+                { messages: [{ role: "user", content: "hello" }] },
+                secret,
+                "https://portkey.test",
+                "sk_user_key",
+                startIndex,
+            );
+        }
+
+        it("pools identically priced endpoints sharing a model name", async () => {
+            const groups = communityGroupEntries([
+                await groupMember({ modelId: "bob/laguna" }),
+                await groupMember({ modelId: "alice/laguna" }),
+            ]);
+
+            expect(groups).toHaveLength(1);
+            expect(groups[0].id).toBe("group/laguna");
+            // Sorted by model id so the derived config is stable.
+            expect(groups[0].members.map((member) => member.modelId)).toEqual([
+                "alice/laguna",
+                "bob/laguna",
+            ]);
+            expect(groups[0].info).toMatchObject({
+                name: "group/laguna",
+                category: "text",
+                community: true,
+                pricing: {
+                    currency: "pollen",
+                    promptTextTokens: "0.1",
+                    completionTextTokens: "0.2",
+                },
+            });
+        });
+
+        it("does not pool endpoints whose prices differ at all", async () => {
+            const groups = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({
+                    modelId: "bob/laguna",
+                    completionTextPrice: 0.2 + MIN_COMMUNITY_PRICE_PER_TOKEN,
+                }),
+            ]);
+
+            expect(groups).toEqual([]);
+        });
+
+        it("does not pool across modalities or image billing modes", async () => {
+            const acrossModalities = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({
+                    modelId: "bob/laguna",
+                    modality: "image",
+                }),
+            ]);
+            const acrossImagePricing = communityGroupEntries([
+                await groupMember({
+                    modelId: "alice/laguna",
+                    modality: "image",
+                    imagePricing: "request",
+                }),
+                await groupMember({
+                    modelId: "bob/laguna",
+                    modality: "image",
+                    imagePricing: "tokens",
+                }),
+            ]);
+
+            expect(acrossModalities).toEqual([]);
+            expect(acrossImagePricing).toEqual([]);
+        });
+
+        it("needs at least MIN_COMMUNITY_GROUP_MEMBERS endpoints", async () => {
+            const members = await Promise.all(
+                Array.from(
+                    { length: MIN_COMMUNITY_GROUP_MEMBERS },
+                    (_unused, index) =>
+                        groupMember({ modelId: `owner${index}/laguna` }),
+                ),
+            );
+
+            expect(communityGroupEntries(members.slice(0, -1))).toEqual([]);
+            expect(communityGroupEntries(members)).toHaveLength(1);
+        });
+
+        it("excludes private and disabled endpoints from membership", async () => {
+            const alice = await groupMember({ modelId: "alice/laguna" });
+            const bob = await groupMember({ modelId: "bob/laguna" });
+            const carol = await groupMember({ modelId: "carol/laguna" });
+
+            const groups = communityGroupEntries([
+                alice,
+                bob,
+                { ...carol, visibility: "private" },
+            ]);
+            expect(groups).toHaveLength(1);
+            expect(groups[0].members.map((member) => member.modelId)).toEqual([
+                "alice/laguna",
+                "bob/laguna",
+            ]);
+
+            // Dropping below two eligible members removes the group entirely.
+            expect(
+                communityGroupEntries([
+                    alice,
+                    { ...bob, disabledAt: Date.now() },
+                    { ...carol, visibility: "private" },
+                ]),
+            ).toEqual([]);
+        });
+
+        it("keys the group on every stored price field", async () => {
+            const endpoint = await groupMember({ modelId: "alice/laguna" });
+            const key = communityGroupKey(endpoint);
+
+            for (const field of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
+                expect(
+                    communityGroupKey({
+                        ...endpoint,
+                        [field.key]: endpoint[field.key] + 0.5,
+                    }),
+                ).not.toBe(key);
+            }
+            expect(communityGroupKey({ ...endpoint, name: "other" })).not.toBe(
+                key,
+            );
+            // Owner-specific fields don't split an otherwise identical pool.
+            expect(
+                communityGroupKey({
+                    ...endpoint,
+                    modelId: "bob/laguna",
+                    baseUrl: "https://bob.example.com/v1",
+                    upstreamModel: "bob-upstream",
+                }),
+            ).toBe(key);
+        });
+
+        it("builds a Portkey fallback config across every member", async () => {
+            const members = [
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+            ];
+
+            const { options, targets } = await groupGatewayContext(members, 0);
+
+            expect(targets).toEqual(members);
+            expect(options).toMatchObject({
+                requestedModel: "group/laguna",
+                portkeyGatewayUrl: "https://portkey.test",
+                userApiKey: "sk_user_key",
+            });
+            expect(options).not.toHaveProperty("messages");
+
+            const modelConfig = options.modelConfig as {
+                model: string;
+                strategy: { mode: string; on_status_codes: number[] };
+                targets: Record<string, unknown>[];
+            };
+            // resolveModelConfig() derives the request-body model from
+            // config.model, so a strategy/targets config must still carry one.
+            expect(modelConfig.model).toBe("alice-upstream");
+            expect(modelConfig.strategy.mode).toBe("fallback");
+            expect(modelConfig.strategy.on_status_codes).toContain(429);
+            expect(modelConfig.strategy.on_status_codes).toContain(502);
+            // A malformed request fails on every member, so don't replay it.
+            expect(modelConfig.strategy.on_status_codes).not.toContain(400);
+            expect(modelConfig.targets).toEqual([
+                {
+                    provider: "openai",
+                    custom_host: "https://alice.example.com/v1",
+                    authKey: "sk_alice",
+                    override_params: { model: "alice-upstream" },
+                },
+                {
+                    provider: "openai",
+                    custom_host: "https://bob.example.com/v1",
+                    authKey: "sk_bob",
+                    override_params: { model: "bob-upstream" },
+                },
+            ]);
+        });
+
+        it("rotates the targets so any member can go first", async () => {
+            const members = [
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+                await groupMember({ modelId: "carol/laguna" }),
+            ];
+
+            const { options, targets } = await groupGatewayContext(members, 1);
+
+            expect(targets.map((target) => target.modelId)).toEqual([
+                "bob/laguna",
+                "carol/laguna",
+                "alice/laguna",
+            ]);
+            expect((options.modelConfig as { model: string }).model).toBe(
+                "bob-upstream",
+            );
+        });
+
+        it("describes the pool without repeating the model name", async () => {
+            const members = [
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+            ];
+
+            const definition = communityGroupModelDefinition(members);
+
+            expect(definition.aliases).toEqual([]);
+            expect(definition.title).toBe("laguna");
+            expect(definition.description).not.toContain("laguna");
+            expect(definition.description).toContain("2 community providers");
+            expect(definition).toMatchObject({
+                provider: "community",
+                category: "text",
+                priceMultiplier: 1,
+                alpha: true,
+                cost: { promptTextTokens: 0.1, completionTextTokens: 0.2 },
+            });
         });
     });
 });
@@ -2845,6 +3113,138 @@ fixtureTest(
         expect(testResponse.status).toBe(400);
         expect(await testResponse.text()).toContain("redirect");
         expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+);
+
+fixtureTest(
+    "pools two published endpoints into one group model and calls every member",
+    async ({ apiKey }) => {
+        const modelName = `pool-${crypto.randomUUID().slice(0, 8)}`;
+        const groupModelId = `group/${modelName}`;
+        for (const owner of ["alice", "bob"]) {
+            const ownerUserId = await createTestUser({
+                githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+                githubUsername: `${owner}-${crypto.randomUUID().slice(0, 8)}`,
+            });
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name: modelName,
+                description: `${owner} pooled endpoint`,
+                baseUrl: `https://${owner}.example.com/v1`,
+                upstreamModel: `${owner}-upstream`,
+                bearerTokenCiphertext: await encryptSecret(
+                    `sk_${owner}`,
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.2,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const portkeyConfigs: {
+            strategy: { mode: string; on_status_codes: number[] };
+            targets: {
+                custom_host: string;
+                api_key: string;
+                override_params: { model: string };
+            }[];
+        }[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+
+                if (isPortkeyChatCompletionsRequest(request)) {
+                    portkeyConfigs.push(
+                        JSON.parse(
+                            request.headers.get("x-portkey-config") || "null",
+                        ),
+                    );
+                    return Response.json({
+                        id: "chatcmpl_pooled",
+                        object: "chat.completion",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "ok" },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 2,
+                            completion_tokens: 3,
+                            total_tokens: 5,
+                        },
+                    });
+                }
+
+                if (isBillingFetch(request)) return Response.json({ data: [] });
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const modelsResponse = await SELF.fetch(
+            "https://gen.pollinations.ai/text/models",
+        );
+        expect(modelsResponse.status).toBe(200);
+        const models = (await modelsResponse.json()) as {
+            name: string;
+            title?: string;
+            aliases?: string[];
+            community?: boolean;
+        }[];
+        expect(
+            models.find((model) => model.name === groupModelId),
+        ).toMatchObject({
+            name: groupModelId,
+            title: modelName,
+            aliases: [],
+            community: true,
+        });
+
+        const response = await SELF.fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: groupModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-model-used")).toBe(groupModelId);
+        await expect(response.json()).resolves.toMatchObject({
+            choices: [{ message: { content: "ok" } }],
+        });
+
+        expect(portkeyConfigs).toHaveLength(1);
+        const config = portkeyConfigs[0];
+        expect(config.strategy.mode).toBe("fallback");
+        expect(config.strategy.on_status_codes).toContain(429);
+        // Both owners are reachable, each with their own credentials and
+        // upstream model name, in whichever rotation this request started at.
+        expect(
+            config.targets.map((target) => target.custom_host).sort(),
+        ).toEqual([
+            "https://alice.example.com/v1",
+            "https://bob.example.com/v1",
+        ]);
+        expect(config.targets.map((target) => target.api_key).sort()).toEqual([
+            "sk_alice",
+            "sk_bob",
+        ]);
+        expect(
+            config.targets.map((target) => target.override_params.model).sort(),
+        ).toEqual(["alice-upstream", "bob-upstream"]);
     },
 );
 

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1,8 +1,10 @@
 import { createExecutionContext, env, SELF } from "cloudflare:test";
 import type { Logger } from "@logtape/logtape";
 import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
+import { getUserBalance } from "@shared/billing/balance.ts";
 import {
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    COMMUNITY_MODEL_REWARD_RATE,
     type CommunityEndpointRuntime,
     communityChatCompletionsUrl,
     communityEndpointPriceFieldsForModality,
@@ -47,12 +49,16 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
+import { checkBalance } from "@/utils/generation-access.ts";
 import {
     communityGroupEntries,
     communityImageSupportedEndpoints,
 } from "./community-models.ts";
 import { callCommunityImageEndpoint } from "./image/communityEndpoint.ts";
-import { resetGenerationModelRegistryCache } from "./model-registry.ts";
+import {
+    getGenerationModelRegistry,
+    resetGenerationModelRegistryCache,
+} from "./model-registry.ts";
 import {
     communityEndpointGatewayContext,
     communityGroupGatewayContext,
@@ -206,6 +212,40 @@ function isBillingFetch(request: Request): boolean {
         request.url.startsWith("https://api.europe-west2.gcp.tinybird.co/") ||
         request.url.startsWith("http://localhost:7181/")
     );
+}
+
+// Model stats drive the estimated price; an empty set makes it 0, which is
+// exactly the case where only the free-model bypass can let a request through.
+function emptyStatsEnv(): CloudflareBindings {
+    return {
+        DB: env.DB,
+        KV: {
+            get: async () => ({ value: { data: [] }, ttl: 3600 }),
+            put: async () => undefined,
+        } as unknown as KVNamespace,
+    } as CloudflareBindings;
+}
+
+function emptyBalanceVars(
+    model: Record<string, unknown>,
+): Parameters<typeof checkBalance>[0] {
+    return {
+        auth: {
+            user: { id: `caller-${crypto.randomUUID()}` },
+            apiKey: { id: "sk-test", pollenBalance: 0 },
+        },
+        balance: {
+            getBalance: async () => ({ tierBalance: 0, packBalance: 0 }),
+        },
+        model,
+        log: {
+            trace: () => undefined,
+            debug: () => undefined,
+            info: () => undefined,
+            warn: () => undefined,
+            error: () => undefined,
+        },
+    } as unknown as Parameters<typeof checkBalance>[0];
 }
 
 describe("community endpoint helpers", () => {
@@ -980,14 +1020,13 @@ describe("community endpoint helpers", () => {
                 key,
             );
             // Owner-specific fields don't split an otherwise identical pool.
-            expect(
-                communityGroupKey({
-                    ...endpoint,
-                    modelId: "bob/laguna",
-                    baseUrl: "https://bob.example.com/v1",
-                    upstreamModel: "bob-upstream",
-                }),
-            ).toBe(key);
+            const otherOwner: CommunityEndpointRuntime = {
+                ...endpoint,
+                modelId: "bob/laguna",
+                baseUrl: "https://bob.example.com/v1",
+                upstreamModel: "bob-upstream",
+            };
+            expect(communityGroupKey(otherOwner)).toBe(key);
         });
 
         it("builds a Portkey fallback config across every member", async () => {
@@ -1073,6 +1112,109 @@ describe("community endpoint helpers", () => {
                 alpha: true,
                 cost: { promptTextTokens: 0.1, completionTextTokens: 0.2 },
             });
+        });
+
+        it("publishes no pool when two price cohorts share a name", async () => {
+            const groups = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+                await groupMember({
+                    modelId: "carol/laguna",
+                    promptTextPrice: 0.3,
+                    completionTextPrice: 0.4,
+                }),
+                await groupMember({
+                    modelId: "dave/laguna",
+                    promptTextPrice: 0.3,
+                    completionTextPrice: 0.4,
+                }),
+            ]);
+
+            // Both cohorts would claim `group/laguna`. Only one of the two
+            // could ever be routed to, and which one depends on D1 row order,
+            // so the catalog would advertise a price the caller isn't billed.
+            expect(groups).toEqual([]);
+        });
+
+        it("publishes no pool when cohorts of different modalities share a name", async () => {
+            const groups = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+                await groupMember({
+                    modelId: "carol/laguna",
+                    modality: "image",
+                }),
+                await groupMember({
+                    modelId: "dave/laguna",
+                    modality: "image",
+                }),
+            ]);
+
+            expect(groups).toEqual([]);
+        });
+
+        it("still pools unambiguous names alongside a contested one", async () => {
+            const groups = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+                await groupMember({
+                    modelId: "carol/laguna",
+                    completionTextPrice: 0.4,
+                }),
+                await groupMember({
+                    modelId: "dave/laguna",
+                    completionTextPrice: 0.4,
+                }),
+                await groupMember({ modelId: "alice/kimi", name: "kimi" }),
+                await groupMember({ modelId: "bob/kimi", name: "kimi" }),
+            ]);
+
+            expect(groups.map((group) => group.id)).toEqual(["group/kimi"]);
+        });
+
+        it("lets a caller with no balance use a free pool", async () => {
+            const freePrices = communityEndpointPrices({});
+            const [freeGroup] = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna", ...freePrices }),
+                await groupMember({ modelId: "bob/laguna", ...freePrices }),
+            ]);
+            const [pricedGroup] = communityGroupEntries([
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+            ]);
+
+            // A free pool must behave exactly like the free `owner/name`
+            // endpoints backing it, including for a drained key.
+            await checkBalance(
+                emptyBalanceVars({
+                    requested: freeGroup.id,
+                    resolved: freeGroup.id,
+                    definition: freeGroup.definition,
+                    communityGroupMembers: freeGroup.members,
+                }),
+                emptyStatsEnv(),
+            );
+            await checkBalance(
+                emptyBalanceVars({
+                    requested: freeGroup.members[0].modelId,
+                    resolved: freeGroup.members[0].modelId,
+                    definition: communityModelDefinition(freeGroup.members[0]),
+                    communityEndpoint: freeGroup.members[0],
+                }),
+                emptyStatsEnv(),
+            );
+
+            await expect(
+                checkBalance(
+                    emptyBalanceVars({
+                        requested: pricedGroup.id,
+                        resolved: pricedGroup.id,
+                        definition: pricedGroup.definition,
+                        communityGroupMembers: pricedGroup.members,
+                    }),
+                    emptyStatsEnv(),
+                ),
+            ).rejects.toMatchObject({ status: 402 });
         });
     });
 });
@@ -3245,6 +3387,190 @@ fixtureTest(
         expect(
             config.targets.map((target) => target.override_params.model).sort(),
         ).toEqual(["alice-upstream", "bob-upstream"]);
+    },
+);
+
+fixtureTest(
+    "serves an image pool from the next member when the first one fails",
+    async ({ apiKey }) => {
+        const modelName = `imgpool-${crypto.randomUUID().slice(0, 8)}`;
+        const groupModelId = `group/${modelName}`;
+        const ownerUserIds: Record<string, string> = {};
+        for (const owner of ["alice", "bob"]) {
+            const ownerUserId = await createTestUser({
+                githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+                githubUsername: `${owner}-${crypto.randomUUID().slice(0, 8)}`,
+            });
+            ownerUserIds[owner] = ownerUserId;
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name: modelName,
+                description: `${owner} pooled image endpoint`,
+                modality: "image",
+                baseUrl: `https://${owner}.example.com/v1/images/generations`,
+                upstreamModel: `${owner}-upstream`,
+                bearerTokenCiphertext: await encryptSecret(
+                    `sk_${owner}`,
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.03,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const attempted: string[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+
+                if (isCommunityImageGenerationsRequest(request)) {
+                    const owner = new URL(request.url).hostname.split(".")[0];
+                    attempted.push(owner);
+                    // Whichever member the random rotation picked first fails,
+                    // so a 200 can only come from the failover to the other.
+                    if (attempted.length === 1) {
+                        return new Response("upstream exploded", {
+                            status: 500,
+                        });
+                    }
+                    expect(request.headers.get("authorization")).toBe(
+                        `Bearer sk_${owner}`,
+                    );
+                    return Response.json({
+                        created: 1,
+                        data: [{ b64_json: TEST_PNG_BASE64 }],
+                    });
+                }
+
+                if (isBillingFetch(request)) return Response.json({ data: [] });
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const modelsResponse = await SELF.fetch(
+            "https://gen.pollinations.ai/image/models",
+        );
+        expect(modelsResponse.status).toBe(200);
+        const models = (await modelsResponse.json()) as { name: string }[];
+        expect(
+            models.find((model) => model.name === groupModelId),
+        ).toMatchObject({ name: groupModelId, community: true });
+
+        const response = await SELF.fetch(
+            new Request(
+                `https://gen.pollinations.ai/image/a%20cat?model=${encodeURIComponent(groupModelId)}`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("image/png");
+        expect(response.headers.get("x-model-used")).toBe(groupModelId);
+        expect(
+            Array.from(new Uint8Array(await response.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+        expect(attempted).toHaveLength(2);
+        expect([...attempted].sort()).toEqual(["alice", "bob"]);
+
+        // The reward follows the member that actually returned bytes, not the
+        // one the rotation happened to try first. Billing runs in the
+        // request's waitUntil, which SELF.fetch does not await, so poll the
+        // ledger instead of racing it.
+        await vi.waitFor(async () => {
+            expect(
+                (await getUserBalance(db, ownerUserIds[attempted[1]]))
+                    .tierBalance,
+            ).toBeCloseTo(0.03 * COMMUNITY_MODEL_REWARD_RATE, 10);
+        });
+        expect(
+            (await getUserBalance(db, ownerUserIds[attempted[0]])).tierBalance,
+        ).toBe(0);
+
+        // A pool is a community image model, so it rejects the URL response
+        // format for the same reason a single-owner one does — before any
+        // member is contacted.
+        const urlResponse = await SELF.fetch(
+            new Request("https://gen.pollinations.ai/v1/images/generations", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: groupModelId,
+                    prompt: "a cat",
+                    response_format: "url",
+                }),
+            }),
+        );
+        expect(urlResponse.status).toBe(400);
+        await expect(urlResponse.json()).resolves.toMatchObject({
+            error: {
+                message:
+                    'Community image models support response_format "b64_json" only',
+            },
+        });
+        expect(attempted).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "leaves a real `group` owner's model id alone instead of pooling over it",
+    async () => {
+        const modelName = `collide-${crypto.randomUUID().slice(0, 8)}`;
+        const collidingId = `group/${modelName}`;
+        // A GitHub user is literally named `group`, so their own model already
+        // owns the id a pool of the same name would want.
+        const ownerUserIds = await Promise.all(
+            ["group", "alice", "bob"].map((owner) =>
+                createTestUser({
+                    githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+                    githubUsername:
+                        owner === "group"
+                            ? "group"
+                            : `${owner}-${crypto.randomUUID().slice(0, 8)}`,
+                }),
+            ),
+        );
+        for (const ownerUserId of ownerUserIds) {
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name: modelName,
+                description: "colliding endpoint",
+                baseUrl: `https://${ownerUserId}.example.com/v1`,
+                upstreamModel: "upstream",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_upstream",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.2,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        resetGenerationModelRegistryCache();
+        const registry = await getGenerationModelRegistry(env);
+
+        // The pool is not created at all — not merely unroutable while still
+        // being advertised next to the real owner's model.
+        expect(
+            registry
+                .visibleEntries(undefined)
+                .filter((entry) => entry.id === collidingId),
+        ).toHaveLength(1);
+        expect(
+            registry.resolve(collidingId)?.communityEndpoint?.ownerUserId,
+        ).toBe(ownerUserIds[0]);
     },
 );
 

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -856,6 +856,9 @@ describe("community endpoint helpers", () => {
             await expect(contextFor(endpoint, "parent-key-id")).rejects.toThrow(
                 "is not free",
             );
+        });
+    });
+
     describe("community model groups", () => {
         const secret = "test-secret";
 
@@ -877,6 +880,7 @@ describe("community endpoint helpers", () => {
                 visibility: "public",
                 disabledAt: null,
                 disabledReason: null,
+                delegatesGeneration: false,
                 bearerTokenCiphertext: await encryptSecret(
                     `sk_${owner}`,
                     secret,
@@ -3577,6 +3581,80 @@ fixtureTest(
             },
         });
         expect(attempted).toHaveLength(2);
+    },
+);
+
+fixtureTest.for([
+    {
+        label: "caller errors",
+        status: 400,
+        message: "prompt is too long",
+        expectedStatus: 400,
+    },
+    {
+        label: "moderation refusals",
+        // A retryable status still must not be replayed when the body is a
+        // content refusal: a more permissive member would turn an unbilled
+        // rejection into a billed generation.
+        status: 500,
+        message: "Content policy violation: the prompt was rejected",
+        expectedStatus: 422,
+    },
+])(
+    "does not replay image pool $label on the next member",
+    async ({ status, message, expectedStatus }, { apiKey }) => {
+        const modelName = `imgpool-${crypto.randomUUID().slice(0, 8)}`;
+        const groupModelId = `group/${modelName}`;
+        for (const owner of ["alice", "bob"]) {
+            const ownerUserId = await createTestUser({
+                githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+                githubUsername: `${owner}-${crypto.randomUUID().slice(0, 8)}`,
+            });
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name: modelName,
+                description: `${owner} pooled image endpoint`,
+                modality: "image",
+                baseUrl: `https://${owner}.example.com/v1/images/generations`,
+                upstreamModel: `${owner}-upstream`,
+                bearerTokenCiphertext: await encryptSecret(
+                    `sk_${owner}`,
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.03,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const attempted: string[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (isCommunityImageGenerationsRequest(request)) {
+                    attempted.push(new URL(request.url).hostname.split(".")[0]);
+                    return Response.json({ error: { message } }, { status });
+                }
+                if (isBillingFetch(request)) return Response.json({ data: [] });
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const response = await SELF.fetch(
+            new Request(
+                `https://gen.pollinations.ai/image/a%20cat?model=${encodeURIComponent(groupModelId)}`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+
+        expect(response.status).toBe(expectedStatus);
+        // The whole point: one attempt, not one per member.
+        expect(attempted).toHaveLength(1);
     },
 );
 

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -51,6 +51,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
 import {
+    type CommunityGroupRegistryEntry,
     communityGroupEntries,
     communityImageSupportedEndpoints,
 } from "./community-models.ts";
@@ -1114,10 +1115,35 @@ describe("community endpoint helpers", () => {
             });
         });
 
-        it("publishes no pool when two price cohorts share a name", async () => {
+        it("publishes the biggest cohort when a name is contested", async () => {
             const groups = communityGroupEntries([
                 await groupMember({ modelId: "alice/laguna" }),
                 await groupMember({ modelId: "bob/laguna" }),
+                // Cheaper, but fewer people converged on it.
+                await groupMember({
+                    modelId: "carol/laguna",
+                    promptTextPrice: 0.01,
+                    completionTextPrice: 0.02,
+                }),
+                await groupMember({
+                    modelId: "dave/laguna",
+                    promptTextPrice: 0.01,
+                    completionTextPrice: 0.02,
+                }),
+                await groupMember({ modelId: "erin/laguna" }),
+            ]);
+
+            expect(groups).toHaveLength(1);
+            expect(groups[0].id).toBe("group/laguna");
+            expect(groups[0].members.map((member) => member.modelId)).toEqual([
+                "alice/laguna",
+                "bob/laguna",
+                "erin/laguna",
+            ]);
+        });
+
+        it("breaks an equal-sized contest by price", async () => {
+            const groups = communityGroupEntries([
                 await groupMember({
                     modelId: "carol/laguna",
                     promptTextPrice: 0.3,
@@ -1128,16 +1154,25 @@ describe("community endpoint helpers", () => {
                     promptTextPrice: 0.3,
                     completionTextPrice: 0.4,
                 }),
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
             ]);
 
-            // Both cohorts would claim `group/laguna`. Only one of the two
-            // could ever be routed to, and which one depends on D1 row order,
-            // so the catalog would advertise a price the caller isn't billed.
-            expect(groups).toEqual([]);
+            // Same size, so the cheaper cohort (0.1/0.2) takes the id even
+            // though the dearer one was seen first.
+            expect(groups).toHaveLength(1);
+            expect(groups[0].members.map((member) => member.modelId)).toEqual([
+                "alice/laguna",
+                "bob/laguna",
+            ]);
+            expect(groups[0].definition.cost).toMatchObject({
+                promptTextTokens: 0.1,
+                completionTextTokens: 0.2,
+            });
         });
 
-        it("publishes no pool when cohorts of different modalities share a name", async () => {
-            const groups = communityGroupEntries([
+        it("publishes one pool per name when modalities collide", async () => {
+            const textFirst = communityGroupEntries([
                 await groupMember({ modelId: "alice/laguna" }),
                 await groupMember({ modelId: "bob/laguna" }),
                 await groupMember({
@@ -1149,11 +1184,33 @@ describe("community endpoint helpers", () => {
                     modality: "image",
                 }),
             ]);
+            const imageFirst = communityGroupEntries([
+                await groupMember({
+                    modelId: "carol/laguna",
+                    modality: "image",
+                }),
+                await groupMember({
+                    modelId: "dave/laguna",
+                    modality: "image",
+                }),
+                await groupMember({ modelId: "alice/laguna" }),
+                await groupMember({ modelId: "bob/laguna" }),
+            ]);
 
-            expect(groups).toEqual([]);
+            // Same size and same prices, so only the modality tiebreaker
+            // decides — and it must decide the same way regardless of the
+            // order D1 happened to return the rows in. Compare ids, not whole
+            // members: each groupMember() call re-encrypts its bearer token
+            // with a fresh nonce, so the ciphertexts never match.
+            const memberIds = (groups: CommunityGroupRegistryEntry[]) =>
+                groups.map((group) =>
+                    group.members.map((member) => member.modelId),
+                );
+            expect(textFirst).toHaveLength(1);
+            expect(memberIds(imageFirst)).toEqual(memberIds(textFirst));
         });
 
-        it("still pools unambiguous names alongside a contested one", async () => {
+        it("pools a contested name alongside an uncontested one", async () => {
             const groups = communityGroupEntries([
                 await groupMember({ modelId: "alice/laguna" }),
                 await groupMember({ modelId: "bob/laguna" }),
@@ -1169,7 +1226,10 @@ describe("community endpoint helpers", () => {
                 await groupMember({ modelId: "bob/kimi", name: "kimi" }),
             ]);
 
-            expect(groups.map((group) => group.id)).toEqual(["group/kimi"]);
+            expect(groups.map((group) => group.id).sort()).toEqual([
+                "group/kimi",
+                "group/laguna",
+            ]);
         });
 
         it("lets a caller with no balance use a free pool", async () => {

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -1,12 +1,11 @@
 import {
     type CommunityEndpointRuntime,
     communityEndpointPrices,
-    communityGroupKey,
+    communityGroupBuckets,
     communityGroupModelDefinition,
     communityGroupModelId,
     communityModelDefinition,
     communityModelId,
-    MIN_COMMUNITY_GROUP_MEMBERS,
     normalizeCommunityEndpointImagePricing,
     normalizeCommunityEndpointModality,
 } from "@shared/community-endpoints.ts";
@@ -62,36 +61,21 @@ export type CommunityGroupRegistryEntry = {
 export function communityGroupEntries(
     endpoints: readonly CommunityEndpointRuntime[],
 ): CommunityGroupRegistryEntry[] {
-    const buckets = new Map<string, CommunityEndpointRuntime[]>();
-    for (const endpoint of endpoints) {
-        // A private endpoint is owner-only and a disabled one is broken, so
-        // neither can take its turn serving a pooled request.
-        if (endpoint.visibility !== "public" || endpoint.disabledAt !== null) {
-            continue;
-        }
-        const key = communityGroupKey(endpoint);
-        const bucket = buckets.get(key);
-        if (bucket) bucket.push(endpoint);
-        else buckets.set(key, [endpoint]);
-    }
-
-    return [...buckets.values()]
-        .filter((members) => members.length >= MIN_COMMUNITY_GROUP_MEMBERS)
-        .map((members) => {
-            // Deterministic member order keeps the derived config stable across
-            // registry rebuilds.
-            members.sort((a, b) => a.modelId.localeCompare(b.modelId));
-            const definition = communityGroupModelDefinition(members);
-            const id = communityGroupModelId(members[0].name);
-            return {
-                id,
-                info: modelInfoFromDefinition(id, definition, {
-                    community: true,
-                }),
-                definition,
-                members,
-            };
-        });
+    return communityGroupBuckets(endpoints).map((members) => {
+        // Deterministic member order keeps the derived config stable across
+        // registry rebuilds.
+        members.sort((a, b) => a.modelId.localeCompare(b.modelId));
+        const definition = communityGroupModelDefinition(members);
+        const id = communityGroupModelId(members[0].name);
+        return {
+            id,
+            info: modelInfoFromDefinition(id, definition, {
+                community: true,
+            }),
+            definition,
+            members,
+        };
+    });
 }
 
 export async function getCommunityModelRegistryEntries(

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -1,8 +1,12 @@
 import {
     type CommunityEndpointRuntime,
     communityEndpointPrices,
+    communityGroupKey,
+    communityGroupModelDefinition,
+    communityGroupModelId,
     communityModelDefinition,
     communityModelId,
+    MIN_COMMUNITY_GROUP_MEMBERS,
     normalizeCommunityEndpointImagePricing,
     normalizeCommunityEndpointModality,
 } from "@shared/community-endpoints.ts";
@@ -41,6 +45,54 @@ export type CommunityModelRegistryEntry = {
     definition: ModelDefinition;
     communityEndpoint: CommunityEndpointRuntime;
 };
+
+export type CommunityGroupRegistryEntry = {
+    id: string;
+    info: ModelInfo;
+    definition: ModelDefinition;
+    members: CommunityEndpointRuntime[];
+};
+
+/**
+ * Pools every set of two or more interchangeable endpoints (same callable name,
+ * same modality, identical prices) into one `group/<name>` model. Publishing
+ * under that name at those prices is the only way to join: no membership state
+ * is stored anywhere.
+ */
+export function communityGroupEntries(
+    endpoints: readonly CommunityEndpointRuntime[],
+): CommunityGroupRegistryEntry[] {
+    const buckets = new Map<string, CommunityEndpointRuntime[]>();
+    for (const endpoint of endpoints) {
+        // A private endpoint is owner-only and a disabled one is broken, so
+        // neither can take its turn serving a pooled request.
+        if (endpoint.visibility !== "public" || endpoint.disabledAt !== null) {
+            continue;
+        }
+        const key = communityGroupKey(endpoint);
+        const bucket = buckets.get(key);
+        if (bucket) bucket.push(endpoint);
+        else buckets.set(key, [endpoint]);
+    }
+
+    return [...buckets.values()]
+        .filter((members) => members.length >= MIN_COMMUNITY_GROUP_MEMBERS)
+        .map((members) => {
+            // Deterministic member order keeps the derived config stable across
+            // registry rebuilds.
+            members.sort((a, b) => a.modelId.localeCompare(b.modelId));
+            const definition = communityGroupModelDefinition(members);
+            const id = communityGroupModelId(members[0].name);
+            return {
+                id,
+                info: modelInfoFromDefinition(id, definition, {
+                    community: true,
+                }),
+                definition,
+                members,
+            };
+        });
+}
 
 export async function getCommunityModelRegistryEntries(
     dbBinding: CloudflareBindings["DB"] | undefined,

--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -1,0 +1,13 @@
+/**
+ * Upstream statuses that make a request move on to the next pool member.
+ * Portkey gets this as `strategy.on_status_codes` for text; the buffered image
+ * path applies the same list in-worker before retrying.
+ *
+ * 400 and 422 are left out on purpose: those are caller errors and replaying
+ * them cannot succeed. 401/402/403/404 are included because they mean this
+ * member's credentials or upstream model are broken, which another member may
+ * survive.
+ */
+export const FALLBACK_ON_STATUS_CODES = [
+    401, 402, 403, 404, 408, 429, 500, 502, 503, 504,
+];

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -6,9 +6,11 @@ import {
 import { remapUpstreamStatus, UpstreamError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
+import { FALLBACK_ON_STATUS_CODES } from "../fallback.ts";
 import {
     getRegisteredServers,
     isValidType,
@@ -412,6 +414,21 @@ async function generateVideoResult(
     );
 }
 
+// Only a broken member is worth replaying, so the image path gates on the same
+// statuses Portkey gets for text: caller errors (400/422) cannot succeed on a
+// retry. Content-policy refusals are excluded at any status — routing a
+// moderation rejection to a possibly more permissive member would turn an
+// unbilled 422 into a billed generation and bypass the first member's
+// moderation.
+function isRetryablePoolError(error: unknown): boolean {
+    if (!(error instanceof HttpError)) return false;
+    if (!FALLBACK_ON_STATUS_CODES.includes(error.status)) return false;
+    return !firstContentPolicyMessage([
+        parseUpstreamErrorBody(error).text,
+        error.message,
+    ]);
+}
+
 // The endpoints that may serve this request, in the order they are tried. A
 // pooled model starts at a random member: that is the load-spreading mechanism,
 // it needs no persisted counter, and a per-isolate counter would not distribute
@@ -427,6 +444,37 @@ function communityImageEndpoints(
     );
 }
 
+// The image response is fully buffered before anything reaches the client, so a
+// failed member can simply be retried on the next one. `index` is the position
+// of the member that served, so the caller can report a pool failover.
+async function callCommunityImagePool(
+    c: ImageContext,
+    endpoints: readonly CommunityEndpointRuntime[],
+    prompt: string,
+    safeParams: RuntimeImageParams,
+): Promise<{
+    result: ImageGenerationResult;
+    endpoint: CommunityEndpointRuntime;
+    index: number;
+}> {
+    for (const [index, endpoint] of endpoints.entries()) {
+        try {
+            const result = await callCommunityImageEndpoint(
+                endpoint,
+                prompt,
+                safeParams,
+                c.env.BETTER_AUTH_SECRET,
+            );
+            assertNonEmptyMedia(result.buffer, "Community image endpoint");
+            return { result, endpoint, index };
+        } catch (error) {
+            const isLast = index === endpoints.length - 1;
+            if (isLast || !isRetryablePoolError(error)) throw error;
+        }
+    }
+    throw new Error("Community image pool is empty");
+}
+
 export async function generateImageOrVideoResponse(
     c: ImageContext,
     prompt: string,
@@ -439,35 +487,25 @@ export async function generateImageOrVideoResponse(
     try {
         const communityEndpoints = communityImageEndpoints(c);
         if (communityEndpoints.length > 0) {
-            // The image response is fully buffered before anything reaches the
-            // client, so a failed member can simply be retried on the next one.
-            let lastError: unknown;
-            for (const endpoint of communityEndpoints) {
-                try {
-                    const result = await callCommunityImageEndpoint(
-                        endpoint,
-                        originalPrompt,
-                        safeParams,
-                        c.env.BETTER_AUTH_SECRET,
-                    );
-                    assertNonEmptyMedia(
-                        result.buffer,
-                        "Community image endpoint",
-                    );
-                    c.set("servedCommunityEndpoint", endpoint);
-                    return new Response(bufferToUint8Array(result.buffer), {
-                        headers: mediaHeaders(
-                            originalPrompt,
-                            safeParams,
-                            result,
-                            detectMimeType(result.buffer),
-                        ),
-                    });
-                } catch (error) {
-                    lastError = error;
-                }
+            const { result, endpoint, index } = await callCommunityImagePool(
+                c,
+                communityEndpoints,
+                originalPrompt,
+                safeParams,
+            );
+            c.set("servedCommunityEndpoint", endpoint);
+            const headers = mediaHeaders(
+                originalPrompt,
+                safeParams,
+                result,
+                detectMimeType(result.buffer),
+            );
+            if (index > 0) {
+                // Same "config.targets[N]" shape the Portkey text path emits,
+                // so tracking's fallback parsing covers both.
+                headers.set(FALLBACK_TARGET_HEADER, `config.targets[${index}]`);
             }
-            throw lastError;
+            return new Response(bufferToUint8Array(result.buffer), { headers });
         }
 
         if (isVideoModel(safeParams.model)) {

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -1,5 +1,6 @@
 import {
     type CommunityEndpointRuntime,
+    communityModelEndpoints,
     rotateCommunityGroupMembers,
 } from "@shared/community-endpoints.ts";
 import { remapUpstreamStatus, UpstreamError } from "@shared/error.ts";
@@ -115,9 +116,13 @@ function parseImageParams(
     const mergedParams = {
         ...queryParams,
         ...body,
-        model: c.var.model.communityEndpoint
-            ? DEFAULT_IMAGE_MODEL
-            : resolvedModel,
+        // ImageParamsSchema.model is an enum of the static image services, so a
+        // community id (`owner/name` or a pooled `group/name`) has to be
+        // validated under a placeholder. The real id is restored below.
+        model:
+            communityModelEndpoints(c.var.model).length > 0
+                ? DEFAULT_IMAGE_MODEL
+                : resolvedModel,
     };
     delete (mergedParams as Record<string, unknown>).prompt;
     delete (mergedParams as Record<string, unknown>).key;
@@ -413,16 +418,13 @@ async function generateVideoResult(
 // across Cloudflare isolates anyway.
 function communityImageEndpoints(
     c: ImageContext,
-): CommunityEndpointRuntime[] | null {
-    const members = c.var.model.communityGroupMembers;
-    if (members) {
-        return rotateCommunityGroupMembers(
-            members,
-            Math.floor(Math.random() * members.length),
-        );
-    }
-    const endpoint = c.var.model.communityEndpoint;
-    return endpoint ? [endpoint] : null;
+): readonly CommunityEndpointRuntime[] {
+    const endpoints = communityModelEndpoints(c.var.model);
+    if (endpoints.length === 0) return endpoints;
+    return rotateCommunityGroupMembers(
+        endpoints,
+        Math.floor(Math.random() * endpoints.length),
+    );
 }
 
 export async function generateImageOrVideoResponse(
@@ -436,7 +438,7 @@ export async function generateImageOrVideoResponse(
 
     try {
         const communityEndpoints = communityImageEndpoints(c);
-        if (communityEndpoints) {
+        if (communityEndpoints.length > 0) {
             // The image response is fully buffered before anything reaches the
             // client, so a failed member can simply be retried on the next one.
             let lastError: unknown;

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -1,3 +1,7 @@
+import {
+    type CommunityEndpointRuntime,
+    rotateCommunityGroupMembers,
+} from "@shared/community-endpoints.ts";
 import { remapUpstreamStatus, UpstreamError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
@@ -403,6 +407,24 @@ async function generateVideoResult(
     );
 }
 
+// The endpoints that may serve this request, in the order they are tried. A
+// pooled model starts at a random member: that is the load-spreading mechanism,
+// it needs no persisted counter, and a per-isolate counter would not distribute
+// across Cloudflare isolates anyway.
+function communityImageEndpoints(
+    c: ImageContext,
+): CommunityEndpointRuntime[] | null {
+    const members = c.var.model.communityGroupMembers;
+    if (members) {
+        return rotateCommunityGroupMembers(
+            members,
+            Math.floor(Math.random() * members.length),
+        );
+    }
+    const endpoint = c.var.model.communityEndpoint;
+    return endpoint ? [endpoint] : null;
+}
+
 export async function generateImageOrVideoResponse(
     c: ImageContext,
     prompt: string,
@@ -413,23 +435,37 @@ export async function generateImageOrVideoResponse(
     const safeParams = parseImageParams(c, body);
 
     try {
-        const communityEndpoint = c.var.model.communityEndpoint;
-        if (communityEndpoint) {
-            const result = await callCommunityImageEndpoint(
-                communityEndpoint,
-                originalPrompt,
-                safeParams,
-                c.env.BETTER_AUTH_SECRET,
-            );
-            assertNonEmptyMedia(result.buffer, "Community image endpoint");
-            return new Response(bufferToUint8Array(result.buffer), {
-                headers: mediaHeaders(
-                    originalPrompt,
-                    safeParams,
-                    result,
-                    detectMimeType(result.buffer),
-                ),
-            });
+        const communityEndpoints = communityImageEndpoints(c);
+        if (communityEndpoints) {
+            // The image response is fully buffered before anything reaches the
+            // client, so a failed member can simply be retried on the next one.
+            let lastError: unknown;
+            for (const endpoint of communityEndpoints) {
+                try {
+                    const result = await callCommunityImageEndpoint(
+                        endpoint,
+                        originalPrompt,
+                        safeParams,
+                        c.env.BETTER_AUTH_SECRET,
+                    );
+                    assertNonEmptyMedia(
+                        result.buffer,
+                        "Community image endpoint",
+                    );
+                    c.set("servedCommunityEndpoint", endpoint);
+                    return new Response(bufferToUint8Array(result.buffer), {
+                        headers: mediaHeaders(
+                            originalPrompt,
+                            safeParams,
+                            result,
+                            detectMimeType(result.buffer),
+                        ),
+                    });
+                } catch (error) {
+                    lastError = error;
+                }
+            }
+            throw lastError;
         }
 
         if (isVideoModel(safeParams.model)) {

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -429,24 +429,12 @@ function isRetryablePoolError(error: unknown): boolean {
     ]);
 }
 
-// The endpoints that may serve this request, in the order they are tried. A
-// pooled model starts at a random member: that is the load-spreading mechanism,
-// it needs no persisted counter, and a per-isolate counter would not distribute
-// across Cloudflare isolates anyway.
-function communityImageEndpoints(
-    c: ImageContext,
-): readonly CommunityEndpointRuntime[] {
-    const endpoints = communityModelEndpoints(c.var.model);
-    if (endpoints.length === 0) return endpoints;
-    return rotateCommunityGroupMembers(
-        endpoints,
-        Math.floor(Math.random() * endpoints.length),
-    );
-}
-
 // The image response is fully buffered before anything reaches the client, so a
-// failed member can simply be retried on the next one. `index` is the position
-// of the member that served, so the caller can report a pool failover.
+// failed member can simply be retried on the next one. A pooled model starts at
+// a random member: that is the load-spreading mechanism, it needs no persisted
+// counter, and a per-isolate counter would not distribute across Cloudflare
+// isolates anyway. `index` is the position of the member that served, so the
+// caller can report a pool failover.
 async function callCommunityImagePool(
     c: ImageContext,
     endpoints: readonly CommunityEndpointRuntime[],
@@ -457,7 +445,11 @@ async function callCommunityImagePool(
     endpoint: CommunityEndpointRuntime;
     index: number;
 }> {
-    for (const [index, endpoint] of endpoints.entries()) {
+    const members = rotateCommunityGroupMembers(
+        endpoints,
+        Math.floor(Math.random() * endpoints.length),
+    );
+    for (const [index, endpoint] of members.entries()) {
         try {
             const result = await callCommunityImageEndpoint(
                 endpoint,
@@ -468,7 +460,7 @@ async function callCommunityImagePool(
             assertNonEmptyMedia(result.buffer, "Community image endpoint");
             return { result, endpoint, index };
         } catch (error) {
-            const isLast = index === endpoints.length - 1;
+            const isLast = index === members.length - 1;
             if (isLast || !isRetryablePoolError(error)) throw error;
         }
     }
@@ -485,7 +477,7 @@ export async function generateImageOrVideoResponse(
     const safeParams = parseImageParams(c, body);
 
     try {
-        const communityEndpoints = communityImageEndpoints(c);
+        const communityEndpoints = communityModelEndpoints(c.var.model);
         if (communityEndpoints.length > 0) {
             const { result, endpoint, index } = await callCommunityImagePool(
                 c,

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -28,6 +28,8 @@ export type ModelVariables = {
         /** Static registry definition, or a dynamic definition resolved from D1. */
         definition: ModelDefinition;
         communityEndpoint?: CommunityEndpointRuntime;
+        /** Interchangeable endpoints backing a pooled `group/<name>` model. */
+        communityGroupMembers?: CommunityEndpointRuntime[];
     };
     formData?: FormData;
 };
@@ -106,6 +108,9 @@ export async function resolveModelDefinition(
         definition: entry.definition,
         ...(entry.communityEndpoint && {
             communityEndpoint: entry.communityEndpoint,
+        }),
+        ...(entry.communityGroupMembers && {
+            communityGroupMembers: entry.communityGroupMembers,
         }),
     };
 }

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -245,10 +245,9 @@ export const track = (eventType: EventType) =>
                 let shouldRunAutoTopUp = false;
                 try {
                     // Only the reward recipient varies for a pooled model:
-                    // every member of a group has identical prices by
-                    // construction (communityGroupKey), so the group
-                    // definition's cost already equals the serving member's
-                    // cost and price handling needs no group-specific branch.
+                    // members have identical prices by construction
+                    // (communityGroupKey), so the group definition's cost
+                    // already equals the serving member's.
                     const communityEndpoint =
                         c.var.servedCommunityEndpoint ??
                         c.var.model?.communityEndpoint;

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -122,6 +122,11 @@ export type TrackVariables = {
         streamRequested: boolean;
         overrideResponseTracking: (response: Response) => void;
     };
+    /**
+     * The pooled-model member that actually served the request, set by the text
+     * and image handlers so the reward follows the endpoint that did the work.
+     */
+    servedCommunityEndpoint?: CommunityEndpointRuntime;
 };
 
 export type TrackEnv = {
@@ -239,7 +244,14 @@ export const track = (eventType: EventType) =>
                 let billedPrice = 0;
                 let shouldRunAutoTopUp = false;
                 try {
-                    const communityEndpoint = c.var.model?.communityEndpoint;
+                    // Only the reward recipient varies for a pooled model:
+                    // every member of a group has identical prices by
+                    // construction (communityGroupKey), so the group
+                    // definition's cost already equals the serving member's
+                    // cost and price handling needs no group-specific branch.
+                    const communityEndpoint =
+                        c.var.servedCommunityEndpoint ??
+                        c.var.model?.communityEndpoint;
                     const deduction = await handleBalanceDeduction({
                         db: balanceDb,
                         isBilledUsage: responseTracking.isBilledUsage,

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -191,16 +191,24 @@ async function loadGenerationModelRegistry(
     dbBinding: CloudflareBindings["DB"] | undefined,
 ): Promise<GenerationModelRegistry> {
     const communityEntries = await getCommunityModelRegistryEntries(dbBinding);
+    const namedEntries = [
+        ...STATIC_ENTRIES,
+        ...communityEntries.map(communityEntryToGenerationEntry),
+    ];
+    const takenIds = new Set(namedEntries.map((entry) => entry.id));
     const groupEntries = communityGroupEntries(
         communityEntries.map((entry) => entry.communityEndpoint),
     );
     return buildRegistry([
-        ...STATIC_ENTRIES,
-        ...communityEntries.map(communityEntryToGenerationEntry),
-        // Groups come last because buildRegistry is first-wins: a real GitHub
-        // user named `group` who registers a colliding model keeps their id and
-        // the group is simply not created.
-        ...groupEntries.map(communityGroupEntryToGenerationEntry),
+        ...namedEntries,
+        // A pool never shadows a real id: a GitHub user literally named `group`
+        // who registers `group/<name>` keeps it and the pool is not created at
+        // all. Dropping it here rather than relying on buildRegistry being
+        // first-wins matters because visibleEntries() lists every entry, so an
+        // unroutable duplicate would still show up in /models.
+        ...groupEntries
+            .filter((entry) => !takenIds.has(entry.id))
+            .map(communityGroupEntryToGenerationEntry),
     ]);
 }
 

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -1,4 +1,7 @@
-import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
+import {
+    type CommunityEndpointRuntime,
+    communityGroupSupportsImageEdits,
+} from "@shared/community-endpoints.ts";
 import {
     type ModelInfo,
     modelInfoFromDefinition,
@@ -132,11 +135,7 @@ function communityGroupEntryToGenerationEntry(
         supportedEndpoints:
             eventType === "generate.image"
                 ? communityImageSupportedEndpoints(
-                      // Advertise edits only when every member can serve one:
-                      // an edit request may be taken by any member.
-                      entry.members.every(
-                          (member) => member.supportsImageEdits,
-                      ),
+                      communityGroupSupportsImageEdits(entry.members),
                   )
                 : communityTextSupportedEndpoints(),
         definition: entry.definition,
@@ -198,18 +197,15 @@ async function loadGenerationModelRegistry(
     const takenIds = new Set(namedEntries.map((entry) => entry.id));
     const groupEntries = communityGroupEntries(
         communityEntries.map((entry) => entry.communityEndpoint),
-    );
-    return buildRegistry([
-        ...namedEntries,
+    )
         // A pool never shadows a real id: a GitHub user literally named `group`
         // who registers `group/<name>` keeps it and the pool is not created at
         // all. Dropping it here rather than relying on buildRegistry being
         // first-wins matters because visibleEntries() lists every entry, so an
         // unroutable duplicate would still show up in /models.
-        ...groupEntries
-            .filter((entry) => !takenIds.has(entry.id))
-            .map(communityGroupEntryToGenerationEntry),
-    ]);
+        .filter((entry) => !takenIds.has(entry.id))
+        .map(communityGroupEntryToGenerationEntry);
+    return buildRegistry([...namedEntries, ...groupEntries]);
 }
 
 export async function getGenerationModelRegistry(

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -11,7 +11,9 @@ import {
 } from "@shared/registry/registry.ts";
 import type { EventType } from "@shared/schemas/generation-event.ts";
 import {
+    type CommunityGroupRegistryEntry,
     type CommunityModelRegistryEntry,
+    communityGroupEntries,
     communityImageSupportedEndpoints,
     communityTextSupportedEndpoints,
     getCommunityModelRegistryEntries,
@@ -37,6 +39,7 @@ export type GenerationModelEntry = {
     definition: ModelDefinition;
     info: ModelInfo;
     communityEndpoint?: CommunityEndpointRuntime;
+    communityGroupMembers?: CommunityEndpointRuntime[];
     visible: boolean;
 };
 
@@ -118,6 +121,32 @@ function communityEntryToGenerationEntry(
     };
 }
 
+function communityGroupEntryToGenerationEntry(
+    entry: CommunityGroupRegistryEntry,
+): GenerationModelEntry {
+    const eventType = eventTypeForCategory(entry.definition.category);
+    return {
+        id: entry.id,
+        aliases: [],
+        eventType,
+        supportedEndpoints:
+            eventType === "generate.image"
+                ? communityImageSupportedEndpoints(
+                      // Advertise edits only when every member can serve one:
+                      // an edit request may be taken by any member.
+                      entry.members.every(
+                          (member) => member.supportsImageEdits,
+                      ),
+                  )
+                : communityTextSupportedEndpoints(),
+        definition: entry.definition,
+        info: entry.info,
+        communityGroupMembers: entry.members,
+        // Every member is public and active by construction.
+        visible: true,
+    };
+}
+
 function buildRegistry(
     entries: GenerationModelEntry[],
 ): GenerationModelRegistry {
@@ -161,10 +190,18 @@ function buildRegistry(
 async function loadGenerationModelRegistry(
     dbBinding: CloudflareBindings["DB"] | undefined,
 ): Promise<GenerationModelRegistry> {
-    const communityEntries = (
-        await getCommunityModelRegistryEntries(dbBinding)
-    ).map(communityEntryToGenerationEntry);
-    return buildRegistry([...STATIC_ENTRIES, ...communityEntries]);
+    const communityEntries = await getCommunityModelRegistryEntries(dbBinding);
+    const groupEntries = communityGroupEntries(
+        communityEntries.map((entry) => entry.communityEndpoint),
+    );
+    return buildRegistry([
+        ...STATIC_ENTRIES,
+        ...communityEntries.map(communityEntryToGenerationEntry),
+        // Groups come last because buildRegistry is first-wins: a real GitHub
+        // user named `group` who registers a colliding model keeps their id and
+        // the group is simply not created.
+        ...groupEntries.map(communityGroupEntryToGenerationEntry),
+    ]);
 }
 
 export async function getGenerationModelRegistry(

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -4,6 +4,7 @@
  * POST /v1/images/edits — edit images with text prompts + source images
  */
 
+import { communityModelEndpoints } from "@shared/community-endpoints.ts";
 import { UpstreamError } from "@shared/error.ts";
 import { getPublicOrigin } from "@shared/public-origin.ts";
 import {
@@ -200,7 +201,10 @@ export async function handleImageGeneration(c: Context<Env>) {
     const body = c.req.valid("json" as never) as CreateImageRequest &
         Record<string, unknown>;
     const model = c.var.model.resolved;
-    if (body.response_format === "url" && c.var.model.communityEndpoint) {
+    if (
+        body.response_format === "url" &&
+        communityModelEndpoints(c.var.model).length > 0
+    ) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
             message:
                 'Community image models support response_format "b64_json" only',

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -26,6 +26,7 @@ import { handleImageEdit, handleImageGeneration } from "./images.ts";
 const resolver = <T extends Parameters<typeof baseResolver>[0]>(schema: T) =>
     baseResolver(schema, { reused: "ref" });
 
+import { communityModelEndpoints } from "@shared/community-endpoints.ts";
 import { UpstreamError } from "@shared/error.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { AUDIO_VOICES } from "@shared/registry/audio.ts";
@@ -292,11 +293,14 @@ async function getOrderedVisibleModelEntries(c: Context<Env>) {
     return [
         ...entries.filter(
             (entry) =>
-                entry.eventType === "generate.text" && !entry.communityEndpoint,
+                entry.eventType === "generate.text" &&
+                communityModelEndpoints(entry).length === 0,
         ),
+        // Community-backed text models last, pooled ones included.
         ...entries.filter(
             (entry) =>
-                entry.eventType === "generate.text" && entry.communityEndpoint,
+                entry.eventType === "generate.text" &&
+                communityModelEndpoints(entry).length > 0,
         ),
         ...entries.filter((entry) => entry.eventType === "generate.image"),
         ...entries.filter((entry) => entry.eventType === "generate.realtime"),

--- a/gen.pollinations.ai/src/text/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/text/communityEndpoint.ts
@@ -1,13 +1,24 @@
 import { signAgentRunToken } from "@shared/auth/agent-run-token.ts";
 import {
     type CommunityEndpointRuntime,
+    communityGroupModelId,
     communityOpenAIBaseUrl,
     isFreeCommunityEndpoint,
     normalizeCommunityEndpointBearerToken,
+    rotateCommunityGroupMembers,
 } from "@shared/community-endpoints.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { decryptSecret } from "@shared/secret-encryption.ts";
 import type { RequestData, TransformOptions } from "./types.js";
+
+// Statuses worth replaying against the next member. 400 and 422 are excluded on
+// purpose: they are malformed-request errors from the caller, so replaying them
+// against every member burns latency for a guaranteed failure. 401/402/403/404
+// are included because they mean this owner's upstream credentials or model are
+// broken — exactly when another member should take over.
+const COMMUNITY_GROUP_FALLBACK_STATUS_CODES = [
+    401, 402, 403, 404, 408, 429, 500, 502, 503, 504,
+];
 
 /**
  * The run token a delegating endpoint authenticates with, or undefined.
@@ -84,5 +95,59 @@ export async function communityEndpointGatewayContext(
         requestedModel: endpoint.modelId,
         portkeyGatewayUrl,
         userApiKey,
+    };
+}
+
+/**
+ * Portkey fallback config across the members of a pooled model. `targets` is
+ * returned so the caller can map Portkey's served-target index back to the
+ * member that did the work.
+ */
+export async function communityGroupGatewayContext(
+    members: readonly CommunityEndpointRuntime[],
+    modelDefinition: ModelDefinition,
+    requestData: RequestData,
+    secret: string,
+    portkeyGatewayUrl: string,
+    userApiKey: string,
+    startIndex: number,
+): Promise<{ options: TransformOptions; targets: CommunityEndpointRuntime[] }> {
+    const targets = rotateCommunityGroupMembers(members, startIndex);
+    const tokens = await Promise.all(
+        targets.map((member) =>
+            decryptSecret(member.bearerTokenCiphertext, secret),
+        ),
+    );
+    const { messages: _messages, ...requestDataWithoutMessages } = requestData;
+
+    return {
+        options: {
+            ...requestDataWithoutMessages,
+            modelConfig: {
+                // resolveModelConfig() derives the request-body model from
+                // config.model (utils/modelResolver.ts). A strategy/targets
+                // config has no provider-level model, so this must be set
+                // explicitly or the body ships model: undefined. Each target
+                // overrides it with its own upstream name anyway.
+                model: targets[0].upstreamModel,
+                strategy: {
+                    mode: "fallback",
+                    on_status_codes: COMMUNITY_GROUP_FALLBACK_STATUS_CODES,
+                },
+                targets: targets.map((member, index) => ({
+                    provider: "openai",
+                    custom_host: communityOpenAIBaseUrl(member.baseUrl),
+                    authKey: normalizeCommunityEndpointBearerToken(
+                        tokens[index],
+                    ),
+                    override_params: { model: member.upstreamModel },
+                })),
+            },
+            modelDef: modelDefinition,
+            requestedModel: communityGroupModelId(targets[0].name),
+            portkeyGatewayUrl,
+            userApiKey,
+        },
+        targets,
     };
 }

--- a/gen.pollinations.ai/src/text/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/text/communityEndpoint.ts
@@ -9,16 +9,8 @@ import {
 } from "@shared/community-endpoints.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { decryptSecret } from "@shared/secret-encryption.ts";
+import { FALLBACK_ON_STATUS_CODES } from "../fallback.ts";
 import type { RequestData, TransformOptions } from "./types.js";
-
-// Statuses worth replaying against the next member. 400 and 422 are excluded on
-// purpose: they are malformed-request errors from the caller, so replaying them
-// against every member burns latency for a guaranteed failure. 401/402/403/404
-// are included because they mean this owner's upstream credentials or model are
-// broken — exactly when another member should take over.
-const COMMUNITY_GROUP_FALLBACK_STATUS_CODES = [
-    401, 402, 403, 404, 408, 429, 500, 502, 503, 504,
-];
 
 /**
  * The run token a delegating endpoint authenticates with, or undefined.
@@ -132,7 +124,7 @@ export async function communityGroupGatewayContext(
                 model: targets[0].upstreamModel,
                 strategy: {
                     mode: "fallback",
-                    on_status_codes: COMMUNITY_GROUP_FALLBACK_STATUS_CODES,
+                    on_status_codes: FALLBACK_ON_STATUS_CODES,
                 },
                 targets: targets.map((member, index) => ({
                     provider: "openai",

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -17,7 +17,12 @@ import {
 } from "./communityEndpoint.ts";
 import { generateTextPortkey } from "./generateTextPortkey.js";
 import { type ExpressLikeRequest, getRequestData } from "./requestUtils.js";
-import type { ChatCompletion, RequestData, ServiceError } from "./types.js";
+import type {
+    ChatCompletion,
+    RequestData,
+    ServiceError,
+    TransformOptions,
+} from "./types.js";
 
 type TextContext = Context<Env>;
 
@@ -340,41 +345,44 @@ async function generateTextResponse(
     try {
         const groupMembers = c.var.model?.communityGroupMembers;
         const communityEndpoint = c.var.model?.communityEndpoint;
-        const group = groupMembers
-            ? await communityGroupGatewayContext(
-                  groupMembers,
-                  c.var.model.definition,
-                  requestData,
-                  c.env.BETTER_AUTH_SECRET,
-                  c.env.PORTKEY_GATEWAY_URL,
-                  c.var.auth?.apiKey?.rawKey || "",
-                  // A random start is the load-spreading mechanism: it needs no
-                  // persisted counter, and a per-isolate counter would not
-                  // distribute across Cloudflare isolates anyway.
-                  Math.floor(Math.random() * groupMembers.length),
-              )
-            : null;
-        const gatewayContext = group
-            ? group.options
-            : communityEndpoint
-              ? await communityEndpointGatewayContext(
-                    communityEndpoint,
-                    c.var.model.definition,
-                    requestData,
-                    c.env.BETTER_AUTH_SECRET,
-                    c.env.PORTKEY_GATEWAY_URL,
-                    c.var.auth?.apiKey?.rawKey || "",
-                    c.var.auth?.apiKey?.id,
-                )
-              : withGatewayContext(c, requestData);
+        let groupTargets: CommunityEndpointRuntime[] | null = null;
+        let gatewayContext: TransformOptions;
+        if (groupMembers) {
+            const group = await communityGroupGatewayContext(
+                groupMembers,
+                c.var.model.definition,
+                requestData,
+                c.env.BETTER_AUTH_SECRET,
+                c.env.PORTKEY_GATEWAY_URL,
+                c.var.auth?.apiKey?.rawKey || "",
+                // A random start is the load-spreading mechanism: it needs no
+                // persisted counter, and a per-isolate counter would not
+                // distribute across Cloudflare isolates anyway.
+                Math.floor(Math.random() * groupMembers.length),
+            );
+            gatewayContext = group.options;
+            groupTargets = group.targets;
+        } else if (communityEndpoint) {
+            gatewayContext = await communityEndpointGatewayContext(
+                communityEndpoint,
+                c.var.model.definition,
+                requestData,
+                c.env.BETTER_AUTH_SECRET,
+                c.env.PORTKEY_GATEWAY_URL,
+                c.var.auth?.apiKey?.rawKey || "",
+                c.var.auth?.apiKey?.id,
+            );
+        } else {
+            gatewayContext = withGatewayContext(c, requestData);
+        }
         const completion = await generateTextPortkey(
             requestData.messages,
             gatewayContext,
         );
-        if (group) {
+        if (groupTargets) {
             c.set(
                 "servedCommunityEndpoint",
-                servedGroupMember(group.targets, completion.fallbackTarget),
+                servedGroupMember(groupTargets, completion.fallbackTarget),
             );
         }
         c.set("upstreamRequestUrl", completion.upstreamRequestUrl);

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -1,3 +1,4 @@
+import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
 import { UpstreamError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
@@ -10,7 +11,10 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { fixWavHeader } from "../routes/audio.js";
-import { communityEndpointGatewayContext } from "./communityEndpoint.ts";
+import {
+    communityEndpointGatewayContext,
+    communityGroupGatewayContext,
+} from "./communityEndpoint.ts";
 import { generateTextPortkey } from "./generateTextPortkey.js";
 import { type ExpressLikeRequest, getRequestData } from "./requestUtils.js";
 import type { ChatCompletion, RequestData, ServiceError } from "./types.js";
@@ -314,6 +318,18 @@ function throwTextError(error: ServiceError): never {
     });
 }
 
+// Portkey reports the served target as "config.targets[N]" via
+// x-portkey-last-used-option-index, which genericOpenAIClient reads before
+// returning the body — so the serving member is known up front for streams too.
+// A missing or unparseable value means the primary target served.
+function servedGroupMember(
+    targets: CommunityEndpointRuntime[],
+    fallbackTarget: string | undefined,
+): CommunityEndpointRuntime {
+    const index = Number(fallbackTarget?.match(/\[(\d+)\]/)?.[1]);
+    return targets.at(index) ?? targets[0];
+}
+
 async function generateTextResponse(
     c: TextContext,
     requestData: RequestData,
@@ -322,22 +338,45 @@ async function generateTextResponse(
     syncTextEnvironment(c.env);
 
     try {
+        const groupMembers = c.var.model?.communityGroupMembers;
         const communityEndpoint = c.var.model?.communityEndpoint;
-        const gatewayContext = communityEndpoint
-            ? await communityEndpointGatewayContext(
-                  communityEndpoint,
+        const group = groupMembers
+            ? await communityGroupGatewayContext(
+                  groupMembers,
                   c.var.model.definition,
                   requestData,
                   c.env.BETTER_AUTH_SECRET,
                   c.env.PORTKEY_GATEWAY_URL,
                   c.var.auth?.apiKey?.rawKey || "",
-                  c.var.auth?.apiKey?.id,
+                  // A random start is the load-spreading mechanism: it needs no
+                  // persisted counter, and a per-isolate counter would not
+                  // distribute across Cloudflare isolates anyway.
+                  Math.floor(Math.random() * groupMembers.length),
               )
-            : withGatewayContext(c, requestData);
+            : null;
+        const gatewayContext = group
+            ? group.options
+            : communityEndpoint
+              ? await communityEndpointGatewayContext(
+                    communityEndpoint,
+                    c.var.model.definition,
+                    requestData,
+                    c.env.BETTER_AUTH_SECRET,
+                    c.env.PORTKEY_GATEWAY_URL,
+                    c.var.auth?.apiKey?.rawKey || "",
+                    c.var.auth?.apiKey?.id,
+                )
+              : withGatewayContext(c, requestData);
         const completion = await generateTextPortkey(
             requestData.messages,
             gatewayContext,
         );
+        if (group) {
+            c.set(
+                "servedCommunityEndpoint",
+                servedGroupMember(group.targets, completion.fallbackTarget),
+            );
+        }
         c.set("upstreamRequestUrl", completion.upstreamRequestUrl);
         completion.id = completion.id || generatePollinationsId();
 

--- a/gen.pollinations.ai/src/utils/generation-access.ts
+++ b/gen.pollinations.ai/src/utils/generation-access.ts
@@ -1,6 +1,9 @@
 import { createBalanceCheckResult } from "@shared/billing/balance.ts";
 import { canCoverEstimatedCharge } from "@shared/billing/bucket-selection.ts";
-import { isFreeCommunityEndpoint } from "@shared/community-endpoints.ts";
+import {
+    communityModelEndpoints,
+    isFreeCommunityEndpoint,
+} from "@shared/community-endpoints.ts";
 import { getModelStats } from "@shared/utils/model-stats.ts";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
@@ -32,10 +35,13 @@ export async function checkBalance(
         await getModelStats(env.KV, log),
         model.resolved,
     );
-    const communityEndpoint = model.communityEndpoint;
+    // A pooled `group/<name>` is backed by its members, so read the endpoints
+    // rather than `communityEndpoint`: otherwise a free pool is billed like a
+    // paid model and 402s the zero-balance users it exists to serve.
+    const communityEndpoints = communityModelEndpoints(model);
     const isFreeCommunityModel =
-        communityEndpoint !== undefined &&
-        isFreeCommunityEndpoint(communityEndpoint);
+        communityEndpoints.length > 0 &&
+        communityEndpoints.every(isFreeCommunityEndpoint);
 
     const apiKeyBudget = auth.apiKey?.pollenBalance;
     const requiredBudget = Math.max(0, estimatedCost);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3762,15 +3762,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workers-types": {
-      "version": "5.20260715.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260715.1.tgz",
-      "integrity": "sha512-saxo/nMqQJ1dKDUXp1a2y/+IjKENFVD9+QRefHg5EjJZY20OG3xcEge4PGljbqZiF3AiU4o5ZLS3Vm7cayQIxg==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
@@ -5660,7 +5651,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5677,7 +5667,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5694,7 +5683,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5711,7 +5699,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5728,7 +5715,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5745,7 +5731,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5762,7 +5747,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5779,7 +5763,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5796,7 +5779,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5813,7 +5795,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5830,7 +5811,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5847,7 +5827,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5864,7 +5843,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5881,7 +5859,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5898,7 +5875,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5915,7 +5891,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5932,7 +5907,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5949,7 +5923,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5966,7 +5939,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5983,7 +5955,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6000,7 +5971,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6017,7 +5987,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7091,7 +7060,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7102,7 +7071,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7144,7 +7113,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -7155,7 +7124,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7652,7 +7621,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7666,7 +7634,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7680,7 +7647,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7694,7 +7660,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7708,7 +7673,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7722,7 +7686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7736,7 +7699,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7750,7 +7712,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7764,7 +7725,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7778,7 +7738,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7792,7 +7751,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7806,7 +7764,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7820,7 +7777,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7834,7 +7790,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7848,7 +7803,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7862,7 +7816,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7876,7 +7829,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7890,7 +7842,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7904,7 +7855,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7918,7 +7868,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7932,7 +7881,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7946,7 +7894,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7960,7 +7907,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7974,7 +7920,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7988,7 +7933,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11717,7 +11661,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -13023,7 +12967,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13040,7 +12983,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13057,7 +12999,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13074,7 +13015,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13091,7 +13031,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13108,7 +13047,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13125,7 +13063,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13142,7 +13079,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13159,7 +13095,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13176,7 +13111,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13193,7 +13127,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13210,7 +13143,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13227,7 +13159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13244,7 +13175,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13261,7 +13191,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13278,7 +13207,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13295,7 +13223,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13312,7 +13239,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13329,7 +13255,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13346,7 +13271,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13363,7 +13287,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13380,7 +13303,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13397,7 +13319,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13414,7 +13335,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13431,7 +13351,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13448,7 +13367,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14976,7 +14894,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -15100,7 +15018,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -15133,7 +15051,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15154,7 +15071,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15175,7 +15091,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15196,7 +15111,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15217,7 +15131,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15238,7 +15151,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15259,7 +15171,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15280,7 +15191,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15301,7 +15211,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15322,7 +15231,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15343,7 +15251,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16795,8 +16702,7 @@
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
@@ -18540,7 +18446,7 @@
       "version": "5.46.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
       "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -18559,7 +18465,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -18929,7 +18835,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -7,8 +7,6 @@ import {
 } from "./registry/usage-headers.ts";
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
-// Pooled model id for every set of interchangeable community endpoints.
-export const COMMUNITY_GROUP_MODEL_PREFIX = "group/";
 export const MIN_COMMUNITY_GROUP_MEMBERS = 2;
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
 export const COMMUNITY_ENDPOINT_MODALITIES = ["text", "image"] as const;
@@ -290,8 +288,9 @@ export function legacyCommunityModelId(
     )}`;
 }
 
+/** Pooled model id for a set of interchangeable community endpoints. */
 export function communityGroupModelId(modelName: string): string {
-    return `${COMMUNITY_GROUP_MODEL_PREFIX}${modelName}`;
+    return `group/${modelName}`;
 }
 
 export function normalizeCommunityEndpointBearerToken(value: string): string {
@@ -464,8 +463,8 @@ export function communityModelDefinition(
 
 /**
  * Everything that decides whether two endpoints can serve the same pooled
- * request. Callers that only need the derived group ids (the API-key permission
- * catalog) can build this from a few columns instead of a full runtime.
+ * request — a subset of the runtime, so the API-key permission catalog can
+ * derive group ids from a few columns instead of loading full endpoints.
  */
 export type CommunityGroupCandidate = {
     name: string;
@@ -503,9 +502,9 @@ export function communityGroupKey(endpoint: CommunityGroupCandidate): string {
  * would otherwise compare equal and the winner would fall out of unordered D1
  * row order — the published pool has to be the same on every registry rebuild.
  */
-function compareCommunityGroupPools<T extends CommunityGroupCandidate>(
-    a: readonly T[],
-    b: readonly T[],
+function compareCommunityGroupPools(
+    a: readonly CommunityGroupCandidate[],
+    b: readonly CommunityGroupCandidate[],
 ): number {
     if (a.length !== b.length) return b.length - a.length;
     for (const field of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
@@ -519,9 +518,7 @@ function compareCommunityGroupPools<T extends CommunityGroupCandidate>(
 }
 
 /**
- * Buckets endpoints into pools of interchangeable members. A private endpoint
- * is owner-only and a disabled one is broken, so neither can take its turn
- * serving a pooled request.
+ * Buckets endpoints into pools of interchangeable members.
  *
  * One name publishes at most one pool, because every cohort under a name would
  * otherwise want the same `group/<name>` id. When a name is contested the
@@ -535,13 +532,14 @@ export function communityGroupBuckets<T extends CommunityGroupCandidate>(
 ): T[][] {
     const buckets = new Map<string, T[]>();
     for (const endpoint of endpoints) {
-        if (endpoint.visibility !== "public" || endpoint.disabledAt !== null) {
-            continue;
-        }
-        // A delegating endpoint must be sent a minted run token rather than its
-        // saved bearer (see mintDelegatedToken), which the pooled gateway
-        // context has no way to build. Keep them out of pools instead of
-        // silently moving the caller's cost onto the endpoint owner.
+        // A private endpoint is owner-only and a disabled one is broken, so
+        // neither can take its turn serving a pooled request. A delegating one
+        // must be sent a minted run token rather than its saved bearer (see
+        // mintDelegatedToken), which the pooled gateway context has no way to
+        // build — pooling it would silently move the caller's cost onto the
+        // endpoint owner.
+        if (endpoint.visibility !== "public") continue;
+        if (endpoint.disabledAt !== null) continue;
         if (endpoint.delegatesGeneration) continue;
         const key = communityGroupKey(endpoint);
         const bucket = buckets.get(key);
@@ -587,6 +585,16 @@ export function rotateCommunityGroupMembers(
 }
 
 /**
+ * Only advertise image edits when every member can serve one — any member may
+ * take the request after a failover.
+ */
+export function communityGroupSupportsImageEdits(
+    members: readonly CommunityEndpointRuntime[],
+): boolean {
+    return members.every((member) => member.supportsImageEdits);
+}
+
+/**
  * Pooled definition for a set of interchangeable endpoints. Prices are equal by
  * construction (communityGroupKey), so the first member carries every
  * price-bearing field. The legacy `community/...` alias is deliberately not
@@ -599,11 +607,7 @@ export function communityGroupModelDefinition(
     return {
         ...communityModelDefinition({
             ...first,
-            // Only advertise image edits when every member can serve one — any
-            // member may take the request after a failover.
-            supportsImageEdits: members.every(
-                (member) => member.supportsImageEdits,
-            ),
+            supportsImageEdits: communityGroupSupportsImageEdits(members),
         }),
         aliases: [],
         title: first.name,

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -7,6 +7,9 @@ import {
 } from "./registry/usage-headers.ts";
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
+// Pooled model id for every set of interchangeable community endpoints.
+export const COMMUNITY_GROUP_MODEL_PREFIX = "group/";
+export const MIN_COMMUNITY_GROUP_MEMBERS = 2;
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
 export const COMMUNITY_ENDPOINT_MODALITIES = ["text", "image"] as const;
 // How a community image endpoint is billed. "request" charges the fixed
@@ -287,6 +290,10 @@ export function legacyCommunityModelId(
     )}`;
 }
 
+export function communityGroupModelId(modelName: string): string {
+    return `${COMMUNITY_GROUP_MODEL_PREFIX}${modelName}`;
+}
+
 export function normalizeCommunityEndpointBearerToken(value: string): string {
     const token = value.trim().replace(BEARER_PREFIX, "").trim();
     if (!token) throw new Error("API bearer token is required");
@@ -452,6 +459,56 @@ export function communityModelDefinition(
         // catalog only renders per-1M prices when flat_rate === false or a
         // prompt token price is set.
         ...(isImage ? { flatRate: isFlatRateImage } : {}),
+    };
+}
+
+/**
+ * Endpoints group only when they are interchangeable: same callable name, same
+ * modality, same image billing mode, and every price field equal. Price
+ * equality is what makes the group's advertised price unambiguous and lets any
+ * member be billed identically, so the key is derived from
+ * COMMUNITY_ENDPOINT_PRICE_FIELDS rather than a hand-listed subset.
+ */
+export function communityGroupKey(endpoint: CommunityEndpointRuntime): string {
+    return JSON.stringify([
+        endpoint.name,
+        endpoint.modality,
+        endpoint.imagePricing,
+        ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => endpoint[field.key]),
+    ]);
+}
+
+/** Members rotated left so a request can start at any member of the group. */
+export function rotateCommunityGroupMembers(
+    members: readonly CommunityEndpointRuntime[],
+    startIndex: number,
+): CommunityEndpointRuntime[] {
+    const offset = startIndex % members.length;
+    return [...members.slice(offset), ...members.slice(0, offset)];
+}
+
+/**
+ * Pooled definition for a set of interchangeable endpoints. Prices are equal by
+ * construction (communityGroupKey), so the first member carries every
+ * price-bearing field. The legacy `community/...` alias is deliberately not
+ * emitted: it names one owner and means nothing for a pool.
+ */
+export function communityGroupModelDefinition(
+    members: readonly CommunityEndpointRuntime[],
+): ModelDefinition {
+    const first = members[0];
+    return {
+        ...communityModelDefinition({
+            ...first,
+            // Only advertise image edits when every member can serve one — any
+            // member may take the request after a failover.
+            supportsImageEdits: members.every(
+                (member) => member.supportsImageEdits,
+            ),
+        }),
+        aliases: [],
+        title: first.name,
+        description: `Pooled across ${members.length} community providers, with automatic failover between them.`,
     };
 }
 

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -492,16 +492,42 @@ export function communityGroupKey(endpoint: CommunityGroupCandidate): string {
 }
 
 /**
+ * Orders two cohorts competing for one `group/<name>` id: the one with more
+ * members wins, and an equal-sized tie goes to the cheaper one. Prices compare
+ * field by field in COMMUNITY_ENDPOINT_PRICE_FIELDS order, so a new price
+ * column joins the comparison automatically.
+ *
+ * Modality and image-pricing mode are the final tiebreakers. They never decide
+ * anything a human would notice, but cohorts differing only in those fields
+ * would otherwise compare equal and the winner would fall out of unordered D1
+ * row order — the published pool has to be the same on every registry rebuild.
+ */
+function compareCommunityGroupPools<T extends CommunityGroupCandidate>(
+    a: readonly T[],
+    b: readonly T[],
+): number {
+    if (a.length !== b.length) return b.length - a.length;
+    for (const field of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
+        const difference = a[0][field.key] - b[0][field.key];
+        if (difference !== 0) return difference;
+    }
+    return (
+        a[0].modality.localeCompare(b[0].modality) ||
+        a[0].imagePricing.localeCompare(b[0].imagePricing)
+    );
+}
+
+/**
  * Buckets endpoints into pools of interchangeable members. A private endpoint
  * is owner-only and a disabled one is broken, so neither can take its turn
  * serving a pooled request.
  *
- * A model name claimed by more than one pool is dropped entirely. Both pools
- * would want the same `group/<name>` id, only one of them could ever be routed
- * to, and which one that is depends on unordered D1 row order — so the price a
- * caller reads from the catalog would not be the price they are billed. That
- * ambiguity is exactly what the price-equality gate exists to prevent, so no
- * pool is published until the cohorts converge on one price.
+ * One name publishes at most one pool, because every cohort under a name would
+ * otherwise want the same `group/<name>` id. When a name is contested the
+ * biggest cohort wins — the pool people actually converged on — and an
+ * equal-sized tie goes to the cheaper one. Losing cohorts publish nothing;
+ * their members stay individually callable as `owner/name`, so nothing they
+ * already had breaks.
  */
 export function communityGroupBuckets<T extends CommunityGroupCandidate>(
     endpoints: readonly T[],
@@ -517,17 +543,16 @@ export function communityGroupBuckets<T extends CommunityGroupCandidate>(
         else buckets.set(key, [endpoint]);
     }
 
-    const pools = [...buckets.values()].filter(
-        (members) => members.length >= MIN_COMMUNITY_GROUP_MEMBERS,
-    );
-    const poolsPerName = new Map<string, number>();
-    for (const members of pools) {
-        poolsPerName.set(
-            members[0].name,
-            (poolsPerName.get(members[0].name) ?? 0) + 1,
-        );
+    const winnerByName = new Map<string, T[]>();
+    for (const members of buckets.values()) {
+        if (members.length < MIN_COMMUNITY_GROUP_MEMBERS) continue;
+        const name = members[0].name;
+        const incumbent = winnerByName.get(name);
+        if (!incumbent || compareCommunityGroupPools(members, incumbent) < 0) {
+            winnerByName.set(name, members);
+        }
     }
-    return pools.filter((members) => poolsPerName.get(members[0].name) === 1);
+    return [...winnerByName.values()];
 }
 
 /**

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -473,6 +473,7 @@ export type CommunityGroupCandidate = {
     imagePricing: CommunityEndpointImagePricing;
     visibility: CommunityEndpointVisibility;
     disabledAt: number | null;
+    delegatesGeneration: boolean;
 } & CommunityEndpointPrices;
 
 /**
@@ -537,6 +538,11 @@ export function communityGroupBuckets<T extends CommunityGroupCandidate>(
         if (endpoint.visibility !== "public" || endpoint.disabledAt !== null) {
             continue;
         }
+        // A delegating endpoint must be sent a minted run token rather than its
+        // saved bearer (see mintDelegatedToken), which the pooled gateway
+        // context has no way to build. Keep them out of pools instead of
+        // silently moving the caller's cost onto the endpoint owner.
+        if (endpoint.delegatesGeneration) continue;
         const key = communityGroupKey(endpoint);
         const bucket = buckets.get(key);
         if (bucket) bucket.push(endpoint);

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -463,19 +463,87 @@ export function communityModelDefinition(
 }
 
 /**
+ * Everything that decides whether two endpoints can serve the same pooled
+ * request. Callers that only need the derived group ids (the API-key permission
+ * catalog) can build this from a few columns instead of a full runtime.
+ */
+export type CommunityGroupCandidate = {
+    name: string;
+    modality: CommunityEndpointModality;
+    imagePricing: CommunityEndpointImagePricing;
+    visibility: CommunityEndpointVisibility;
+    disabledAt: number | null;
+} & CommunityEndpointPrices;
+
+/**
  * Endpoints group only when they are interchangeable: same callable name, same
  * modality, same image billing mode, and every price field equal. Price
  * equality is what makes the group's advertised price unambiguous and lets any
  * member be billed identically, so the key is derived from
  * COMMUNITY_ENDPOINT_PRICE_FIELDS rather than a hand-listed subset.
  */
-export function communityGroupKey(endpoint: CommunityEndpointRuntime): string {
+export function communityGroupKey(endpoint: CommunityGroupCandidate): string {
     return JSON.stringify([
         endpoint.name,
         endpoint.modality,
         endpoint.imagePricing,
         ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => endpoint[field.key]),
     ]);
+}
+
+/**
+ * Buckets endpoints into pools of interchangeable members. A private endpoint
+ * is owner-only and a disabled one is broken, so neither can take its turn
+ * serving a pooled request.
+ *
+ * A model name claimed by more than one pool is dropped entirely. Both pools
+ * would want the same `group/<name>` id, only one of them could ever be routed
+ * to, and which one that is depends on unordered D1 row order — so the price a
+ * caller reads from the catalog would not be the price they are billed. That
+ * ambiguity is exactly what the price-equality gate exists to prevent, so no
+ * pool is published until the cohorts converge on one price.
+ */
+export function communityGroupBuckets<T extends CommunityGroupCandidate>(
+    endpoints: readonly T[],
+): T[][] {
+    const buckets = new Map<string, T[]>();
+    for (const endpoint of endpoints) {
+        if (endpoint.visibility !== "public" || endpoint.disabledAt !== null) {
+            continue;
+        }
+        const key = communityGroupKey(endpoint);
+        const bucket = buckets.get(key);
+        if (bucket) bucket.push(endpoint);
+        else buckets.set(key, [endpoint]);
+    }
+
+    const pools = [...buckets.values()].filter(
+        (members) => members.length >= MIN_COMMUNITY_GROUP_MEMBERS,
+    );
+    const poolsPerName = new Map<string, number>();
+    for (const members of pools) {
+        poolsPerName.set(
+            members[0].name,
+            (poolsPerName.get(members[0].name) ?? 0) + 1,
+        );
+    }
+    return pools.filter((members) => poolsPerName.get(members[0].name) === 1);
+}
+
+/**
+ * The endpoints backing a model: one for `owner/name`, every member for a
+ * pooled `group/<name>`, none for a static model. Read this instead of
+ * `communityEndpoint` — that field alone is unset for a pool, so testing it
+ * silently treats a pooled model as a static one.
+ */
+export function communityModelEndpoints(model: {
+    communityEndpoint?: CommunityEndpointRuntime;
+    communityGroupMembers?: CommunityEndpointRuntime[];
+}): readonly CommunityEndpointRuntime[] {
+    return (
+        model.communityGroupMembers ??
+        (model.communityEndpoint ? [model.communityEndpoint] : [])
+    );
 }
 
 /** Members rotated left so a request can start at any member of the group. */

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -1,6 +1,13 @@
 import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { communityModelId } from "../community-endpoints.ts";
+import {
+    communityEndpointPrices,
+    communityGroupBuckets,
+    communityGroupModelId,
+    communityModelId,
+    normalizeCommunityEndpointImagePricing,
+    normalizeCommunityEndpointModality,
+} from "../community-endpoints.ts";
 import * as schema from "../db/better-auth.ts";
 import { getModels } from "./registry.ts";
 
@@ -14,6 +21,21 @@ export async function getVisibleModelIdsForUser(
         .select({
             ownerGithubUsername: schema.user.githubUsername,
             name: schema.communityEndpoint.name,
+            modality: schema.communityEndpoint.modality,
+            imagePricing: schema.communityEndpoint.imagePricing,
+            visibility: schema.communityEndpoint.visibility,
+            disabledAt: schema.communityEndpoint.disabledAt,
+            promptTextPrice: schema.communityEndpoint.promptTextPrice,
+            promptCachedPrice: schema.communityEndpoint.promptCachedPrice,
+            promptCacheWritePrice:
+                schema.communityEndpoint.promptCacheWritePrice,
+            promptAudioPrice: schema.communityEndpoint.promptAudioPrice,
+            promptImagePrice: schema.communityEndpoint.promptImagePrice,
+            completionTextPrice: schema.communityEndpoint.completionTextPrice,
+            completionReasoningPrice:
+                schema.communityEndpoint.completionReasoningPrice,
+            completionAudioPrice: schema.communityEndpoint.completionAudioPrice,
+            completionImagePrice: schema.communityEndpoint.completionImagePrice,
         })
         .from(schema.communityEndpoint)
         .innerJoin(
@@ -37,6 +59,26 @@ export async function getVisibleModelIdsForUser(
                 communityModelId(model.ownerGithubUsername, model.name),
             );
         }
+    }
+
+    // A pooled `group/<name>` is a real callable model, so a key restricted to
+    // one has to survive this filter. Otherwise the dashboard reads the key
+    // back with an empty model list and saves that empty list, locking the key
+    // out of every model.
+    const groups = communityGroupBuckets(
+        communityModels.map((model) => ({
+            name: model.name,
+            modality: normalizeCommunityEndpointModality(model.modality),
+            imagePricing: normalizeCommunityEndpointImagePricing(
+                model.imagePricing,
+            ),
+            visibility: model.visibility,
+            disabledAt: model.disabledAt ? model.disabledAt.getTime() : null,
+            ...communityEndpointPrices(model),
+        })),
+    );
+    for (const members of groups) {
+        modelIds.add(communityGroupModelId(members[0].name));
     }
 
     return modelIds;

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -68,14 +68,12 @@ export async function getVisibleModelIdsForUser(
     // out of every model.
     const groups = communityGroupBuckets(
         communityModels.map((model) => ({
-            name: model.name,
+            ...model,
             modality: normalizeCommunityEndpointModality(model.modality),
             imagePricing: normalizeCommunityEndpointImagePricing(
                 model.imagePricing,
             ),
-            visibility: model.visibility,
             disabledAt: model.disabledAt ? model.disabledAt.getTime() : null,
-            delegatesGeneration: model.delegatesGeneration,
             ...communityEndpointPrices(model),
         })),
     );

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -25,6 +25,7 @@ export async function getVisibleModelIdsForUser(
             imagePricing: schema.communityEndpoint.imagePricing,
             visibility: schema.communityEndpoint.visibility,
             disabledAt: schema.communityEndpoint.disabledAt,
+            delegatesGeneration: schema.communityEndpoint.delegatesGeneration,
             promptTextPrice: schema.communityEndpoint.promptTextPrice,
             promptCachedPrice: schema.communityEndpoint.promptCachedPrice,
             promptCacheWritePrice:
@@ -74,6 +75,7 @@ export async function getVisibleModelIdsForUser(
             ),
             visibility: model.visibility,
             disabledAt: model.disabledAt ? model.disabledAt.getTime() : null,
+            delegatesGeneration: model.delegatesGeneration,
             ...communityEndpointPrices(model),
         })),
     );


### PR DESCRIPTION
Pools community models that share a callable name **and** identical prices into one `group/<name>` model.

- **Zero schema.** Every input is already on the endpoint rows. Price equality is the opt-in: it is what makes the pool's advertised price unambiguous and lets any member be billed identically, so no invitation, membership, or admin table is needed.
- **Contested names** (two or more price cohorts under one name) publish exactly one group: the cohort with the most members, ties to the cheapest, then modality/image-pricing so the winner never depends on D1 row order.
- **Load spreading** is a random start index — no persisted counter, and a per-isolate counter would not distribute across Cloudflare isolates anyway.
- **Failover.** Text hands Portkey the rotated members as `strategy.targets`; image walks them in-worker. Both gate on the same status list (`src/fallback.ts`): 400/422 caller errors and content-policy refusals are never replayed, since a more permissive member would turn an unbilled refusal into a billed generation.
- **Billing.** Members are price-identical by construction, so only the reward recipient varies — it follows the member that returned bytes. Failed attempts are never billed.
- **Delegating endpoints are excluded** from pools: they need a minted run token that the pooled gateway context cannot build, and using their saved bearer would move the caller's cost onto the endpoint owner.

Compare with #12819 (owner-declared fallback list). Prior art: #12649 by @YoannDev90, and the #12615 discussion.
