### PR TITLE
feat: add model fallbacks

### DIFF
--- a/enter.pollinations.ai/drizzle/0040_old_taskmaster.sql
+++ b/enter.pollinations.ai/drizzle/0040_old_taskmaster.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `community_endpoint` ADD `fallback_model` text;

--- a/enter.pollinations.ai/drizzle/meta/0040_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,1689 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6102d74b-4a6c-42e6-a108-860889a3593e",
+  "prevId": "97c2bc54-b780-4e1a-99a4-8dc4afb8cb60",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "image_pricing": {
+          "name": "image_pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'request'"
+        },
+        "supports_image_edits": {
+          "name": "supports_image_edits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fallback_model": {
+          "name": "fallback_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_image_price": {
+          "name": "completion_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_item": {
+          "name": "idx_media_tag_tag_item",
+          "columns": [
+            "tag",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1785145497278,
       "tag": "0039_blushing_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1785244290883,
+      "tag": "0040_old_taskmaster",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -22,6 +22,11 @@ import type { FormEvent, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
 import {
+    type ApiModelInfo,
+    getCatalogDisplayName,
+    getCatalogModelId,
+} from "../models/model-catalog.ts";
+import {
     BASE_TEXT_PRICE_KEYS,
     formWithVisiblePrices,
     hasValidVisibleFormPrices,
@@ -51,6 +56,7 @@ type CommunityEndpointDialogProps = {
     // Allowlisted owners can choose Public. Everyone else sees the same
     // lifecycle control with Public disabled.
     canPublish: boolean;
+    catalogModels: ApiModelInfo[];
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onSubmit: (payload: EndpointPayload, bearerToken: string) => Promise<void>;
@@ -61,6 +67,7 @@ type CommunityEndpointDialogProps = {
 export function CommunityEndpointDialog({
     endpoint,
     canPublish,
+    catalogModels,
     open,
     onOpenChange,
     onSubmit,
@@ -283,6 +290,20 @@ export function CommunityEndpointDialog({
             : modelOptions.filter((model) =>
                   model.toLowerCase().includes(providerModelQuery),
               );
+    const fallbackOptions = catalogModels
+        .filter((model) => {
+            const id = getCatalogModelId(model);
+            return (
+                id !== "" &&
+                id !== endpoint?.modelId &&
+                model.category === form.modality
+            );
+        })
+        .sort((a, b) =>
+            getCatalogDisplayName(a, getCatalogModelId(a)).localeCompare(
+                getCatalogDisplayName(b, getCatalogModelId(b)),
+            ),
+        );
     const canSubmit =
         !isSubmitting &&
         form.name.trim() !== "" &&
@@ -394,6 +415,31 @@ export function CommunityEndpointDialog({
                             />
                         </FieldStack>
                     </div>
+
+                    <FieldStack
+                        label="Fallback model"
+                        helper="Optional. Retried once after a server error; must use the same modality and cost no more."
+                        alignLabelRow
+                    >
+                        <select
+                            name="community-fallback-model"
+                            value={form.fallbackModel}
+                            onChange={(event) =>
+                                updateForm("fallbackModel", event.target.value)
+                            }
+                            className="w-full rounded-md border border-divider bg-surface px-3 py-2 text-sm text-theme-text-strong"
+                        >
+                            <option value="">No fallback</option>
+                            {fallbackOptions.map((model) => {
+                                const id = getCatalogModelId(model);
+                                return (
+                                    <option key={id} value={id}>
+                                        {`${getCatalogDisplayName(model, id)} (${id})`}
+                                    </option>
+                                );
+                            })}
+                        </select>
+                    </FieldStack>
 
                     <FieldStack
                         label="Description"

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -8,6 +8,7 @@ import {
 } from "@pollinations/ui";
 import { useCallback, useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
+import type { ApiModelInfo } from "../models/model-catalog.ts";
 import { CommunityEndpointCard } from "./community-endpoint-card.tsx";
 import { CommunityEndpointDeleteConfirmation } from "./community-endpoint-delete-confirmation.tsx";
 import { CommunityEndpointDialog } from "./community-endpoint-dialog.tsx";
@@ -22,11 +23,13 @@ type CommunityEndpointsProps = {
     // Allowlisted owners can make models public (set prices, list in /models).
     // Everyone else can only create and edit private, owner-only models.
     canPublish: boolean;
+    catalogModels: ApiModelInfo[];
 };
 
 export function CommunityEndpoints({
     onChange,
     canPublish,
+    catalogModels,
 }: CommunityEndpointsProps) {
     const [endpoints, setEndpoints] = useState<CommunityEndpoint[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -167,6 +170,7 @@ export function CommunityEndpoints({
                 framed
                 action={
                     <CommunityEndpointDialog
+                        catalogModels={catalogModels}
                         open={createOpen}
                         onOpenChange={setCreateOpen}
                         onSubmit={handleCreate}
@@ -239,6 +243,7 @@ export function CommunityEndpoints({
             </Section>
 
             <CommunityEndpointDialog
+                catalogModels={catalogModels}
                 key={editing?.id ?? "edit-closed"}
                 endpoint={editing ?? undefined}
                 open={!!editing}

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -27,6 +27,7 @@ export type CommunityEndpoint = {
     supportsImageEdits: boolean;
     baseUrl: string;
     upstreamModel: string;
+    fallbackModel: string | null;
     // private → owner-only, shown only to the owner, no owner-set price;
     // public → globally listed + billed to callers.
     visibility: CommunityEndpointVisibility;
@@ -50,6 +51,7 @@ export type EndpointFormState = {
     visibility: CommunityEndpointVisibility;
     baseUrl: string;
     upstreamModel: string;
+    fallbackModel: string;
     bearerToken: string;
 } & EndpointFormPrices;
 
@@ -62,6 +64,7 @@ export type EndpointPayload = {
     description: string;
     baseUrl: string;
     upstreamModel: string;
+    fallbackModel: string | null;
     visibility: CommunityEndpointVisibility;
 } & CommunityEndpointPrices;
 
@@ -97,6 +100,7 @@ export const emptyForm: EndpointFormState = {
     visibility: "private",
     baseUrl: "",
     upstreamModel: "",
+    fallbackModel: "",
     bearerToken: "",
     ...emptyPriceForm,
 };
@@ -183,6 +187,7 @@ export function endpointToForm(endpoint: CommunityEndpoint): EndpointFormState {
         visibility: endpoint.visibility,
         baseUrl: endpoint.baseUrl,
         upstreamModel: endpoint.upstreamModel,
+        fallbackModel: endpoint.fallbackModel ?? "",
         bearerToken: "",
         ...(Object.fromEntries(
             COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => {
@@ -282,6 +287,7 @@ export function toEndpointPayload(form: EndpointFormState): EndpointPayload {
         visibility: form.visibility,
         baseUrl: form.baseUrl.trim(),
         upstreamModel: form.upstreamModel.trim() || modelName,
+        fallbackModel: form.fallbackModel.trim() || null,
         ...formPricesToPayload(form, form.modality, imagePricing),
     };
 }
@@ -298,6 +304,7 @@ export function nextFormState(
             ...current,
             modality: value === "image" ? "image" : "text",
             supportsImageEdits: false,
+            fallbackModel: "",
         };
     }
     const next = { ...current, [key]: value };

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -350,6 +350,7 @@ export const Models: FC<ModelsProps> = ({
             {showCommunityEndpoints && (
                 <CommunityEndpoints
                     canPublish={canPublish}
+                    catalogModels={catalogModels}
                     onChange={() => {
                         void loadModelCatalog({ refresh: true });
                     }}

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -11,6 +11,7 @@ import {
     communityEndpointPrices,
     communityEndpointPricesForModality,
     communityEndpointTitle,
+    communityModelDefinition,
     communityModelId,
     isCommunityEndpointOwnerAllowed,
     MAX_COMMUNITY_PRICE_PER_IMAGE,
@@ -22,11 +23,18 @@ import {
     normalizeCommunityEndpointBearerToken,
     normalizeCommunityEndpointImagePricing,
     normalizeCommunityEndpointModality,
+    parseCommunityModelId,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
+import {
+    getModels,
+    getRegistryModelDefinition,
+    isModelFallbackCompatible,
+    type ModelDefinition,
+} from "@shared/registry/registry.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -130,6 +138,7 @@ const EndpointFieldsSchema = {
             "OpenAI-compatible `/v1` base URL or full chat, image generation, or image edit URL.",
         ),
     upstreamModel: z.string().trim().min(1).max(253).optional(),
+    fallbackModel: z.string().trim().min(1).max(253).nullable().optional(),
     bearerToken: z.string().min(1),
 } as const;
 
@@ -147,6 +156,7 @@ const UpdateEndpointSchema = z.object({
     description: EndpointFieldsSchema.description,
     baseUrl: EndpointFieldsSchema.baseUrl.optional(),
     upstreamModel: EndpointFieldsSchema.upstreamModel,
+    fallbackModel: EndpointFieldsSchema.fallbackModel,
     bearerToken: EndpointFieldsSchema.bearerToken.optional(),
     visibility: VisibilitySchema.optional(),
     imagePricing: ImagePricingSchema.optional(),
@@ -178,6 +188,7 @@ const CommunityEndpointResponseSchema = z.object({
     supportsImageEdits: z.boolean(),
     baseUrl: z.string(),
     upstreamModel: z.string(),
+    fallbackModel: z.string().nullable(),
     visibility: VisibilitySchema,
     ...ResponsePriceFieldsSchema,
     disabled: z.boolean(),
@@ -299,6 +310,7 @@ function toResponse(row: CommunityEndpointRow, ownerGithubUsername: string) {
         supportsImageEdits: row.supportsImageEdits,
         baseUrl: row.baseUrl,
         upstreamModel: row.upstreamModel,
+        fallbackModel: row.fallbackModel,
         visibility: row.visibility,
         ...communityEndpointPrices(row),
         disabled: row.disabledAt !== null,
@@ -341,6 +353,84 @@ async function ensureModelNameAvailable(
     throw new HTTPException(400, {
         message: "Community model name is already registered",
     });
+}
+
+async function resolveFallbackModel(
+    db: Db,
+    model: string,
+    callerUserId: string,
+    allowPrivateCommunity: boolean,
+): Promise<{ id: string; definition: ModelDefinition } | null> {
+    for (const id of getModels()) {
+        const definition = getRegistryModelDefinition(id);
+        if (id === model || definition.aliases.includes(model)) {
+            return definition.hidden ? null : { id, definition };
+        }
+    }
+
+    const parsed = parseCommunityModelId(model);
+    if (!parsed) return null;
+    const owner = await db.query.user.findFirst({
+        columns: { id: true, githubUsername: true },
+        where: eq(schema.user.githubUsername, parsed.ownerGithubUsername),
+    });
+    if (!owner?.githubUsername) return null;
+    const row = await db.query.communityEndpoint.findFirst({
+        where: and(
+            eq(schema.communityEndpoint.ownerUserId, owner.id),
+            eq(schema.communityEndpoint.name, parsed.modelName),
+            isNull(schema.communityEndpoint.disabledAt),
+        ),
+    });
+    if (
+        !row ||
+        (row.visibility !== "public" &&
+            (!allowPrivateCommunity || row.ownerUserId !== callerUserId))
+    ) {
+        return null;
+    }
+    const id = communityModelId(owner.githubUsername, row.name);
+    return {
+        id,
+        definition: communityModelDefinition({
+            modelId: id,
+            title: row.title,
+            description: row.description,
+            modality: normalizeCommunityEndpointModality(row.modality),
+            imagePricing: normalizeCommunityEndpointImagePricing(
+                row.imagePricing,
+            ),
+            supportsImageEdits: row.supportsImageEdits,
+            ...communityEndpointPrices(row),
+        }),
+    };
+}
+
+async function validateFallbackModel(
+    db: Db,
+    callerUserId: string,
+    primaryId: string,
+    primary: ModelDefinition,
+    requestedFallback: string | null | undefined,
+    allowPrivateCommunity: boolean,
+): Promise<string | null> {
+    if (!requestedFallback) return null;
+    const fallback = await resolveFallbackModel(
+        db,
+        requestedFallback,
+        callerUserId,
+        allowPrivateCommunity,
+    );
+    if (!fallback || fallback.id === primaryId) {
+        throw new HTTPException(400, { message: "Invalid fallback model" });
+    }
+    if (!isModelFallbackCompatible(primary, fallback.definition)) {
+        throw new HTTPException(400, {
+            message:
+                "Fallback model must use the same modality and pricing mode, cost no more, and not require paid-only access",
+        });
+    }
+    return fallback.id;
 }
 
 function throwEndpointTestError(error: unknown): never {
@@ -494,6 +584,24 @@ export const communityEndpointsRoutes = new Hono<Env>()
             );
             await enforcePublishingAccess(db, user.id, input.visibility);
             const id = crypto.randomUUID();
+            const modelId = communityModelId(ownerGithubUsername, input.name);
+            const fallbackModel = await validateFallbackModel(
+                db,
+                user.id,
+                modelId,
+                communityModelDefinition({
+                    modelId,
+                    title: input.title,
+                    description: input.description || null,
+                    modality: input.modality,
+                    imagePricing,
+                    supportsImageEdits:
+                        input.modality === "image" && input.supportsImageEdits,
+                    ...prices,
+                }),
+                input.fallbackModel,
+                input.visibility === "private",
+            );
             const [row] = await db
                 .insert(schema.communityEndpoint)
                 .values({
@@ -508,6 +616,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         input.modality === "image" && input.supportsImageEdits,
                     baseUrl: normalizeInputBaseUrl(input.baseUrl),
                     upstreamModel: input.upstreamModel ?? input.name,
+                    fallbackModel,
                     bearerTokenCiphertext: await encryptSecret(
                         normalizeInputBearerToken(input.bearerToken),
                         c.env.BETTER_AUTH_SECRET,
@@ -741,6 +850,30 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 effectiveImagePricing,
             );
             await enforcePublishingAccess(db, user.id, effectiveVisibility);
+            const modelId = communityModelId(
+                ownerGithubUsername,
+                input.name ?? endpoint.name,
+            );
+            update.fallbackModel = await validateFallbackModel(
+                db,
+                user.id,
+                modelId,
+                communityModelDefinition({
+                    modelId,
+                    title: update.title ?? endpoint.title,
+                    description: update.description ?? endpoint.description,
+                    modality,
+                    imagePricing: effectiveImagePricing,
+                    supportsImageEdits:
+                        update.supportsImageEdits ??
+                        endpoint.supportsImageEdits,
+                    ...effectivePrices,
+                }),
+                input.fallbackModel !== undefined
+                    ? input.fallbackModel
+                    : endpoint.fallbackModel,
+                effectiveVisibility === "private",
+            );
             // Persist visibility together with the complete effective price
             // set on every update, so concurrent partial updates cannot
             // interleave into a public row with cleared prices.

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -30,7 +30,11 @@ import {
 } from "@shared/db/better-auth.ts";
 import { handleError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
-import { calculateUsageBilling } from "@shared/registry/registry.ts";
+import {
+    calculateUsageBilling,
+    isModelFallbackCompatible,
+} from "@shared/registry/registry.ts";
+import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
 import {
     createTestApiKey,
@@ -462,6 +466,34 @@ describe("community endpoint helpers", () => {
         );
     });
 
+    it("allows only same-modality fallbacks that cost no more", () => {
+        const model = (
+            id: string,
+            promptTextPrice: number,
+            modality: CommunityEndpointRuntime["modality"] = "text",
+        ) =>
+            communityModelDefinition({
+                modelId: id,
+                description: null,
+                modality,
+                ...communityEndpointPrices({ promptTextPrice }),
+            });
+
+        const primary = model("owner/primary", 0.1);
+        expect(
+            isModelFallbackCompatible(primary, model("owner/cheaper", 0.05)),
+        ).toBe(true);
+        expect(
+            isModelFallbackCompatible(primary, model("owner/expensive", 0.2)),
+        ).toBe(false);
+        expect(
+            isModelFallbackCompatible(
+                primary,
+                model("owner/image", 0.05, "image"),
+            ),
+        ).toBe(false);
+    });
+
     describe("community image endpoint billing", () => {
         afterEach(() => {
             vi.unstubAllGlobals();
@@ -841,6 +873,113 @@ fixtureTest(
             isPortkeyChatCompletionsRequest(new Request(input, init)),
         );
         expect(upstreamCalls).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "retries a failed model with its configured fallback",
+    async ({ apiKey }) => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const primaryOwner = `fallback-primary-${suffix}`;
+        const targetOwner = `fallback-target-${suffix}`;
+        const targetName = `target-${suffix}`;
+        const targetModel = communityModelId(targetOwner, targetName);
+        for (const [ownerGithubUsername, name, baseUrl, fallbackModel] of [
+            [
+                primaryOwner,
+                `primary-${suffix}`,
+                "https://primary.example.com/v1",
+                targetModel,
+            ],
+            [targetOwner, targetName, "https://fallback.example.com/v1", null],
+        ] as const) {
+            const ownerUserId = await createTestUser({
+                githubUsername: ownerGithubUsername,
+            });
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name,
+                baseUrl,
+                upstreamModel: "shared-model",
+                fallbackModel,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const upstreamHosts: string[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (isPortkeyChatCompletionsRequest(request)) {
+                    const host = request.headers.get("x-portkey-custom-host");
+                    if (host) upstreamHosts.push(host);
+                    if (host === "https://primary.example.com/v1") {
+                        return Response.json(
+                            { error: { message: "temporarily unavailable" } },
+                            { status: 503 },
+                        );
+                    }
+                    return Response.json({
+                        id: "chatcmpl_fallback",
+                        object: "chat.completion",
+                        choices: [
+                            {
+                                index: 0,
+                                message: {
+                                    role: "assistant",
+                                    content: "ok",
+                                },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 2,
+                            completion_tokens: 3,
+                            total_tokens: 5,
+                        },
+                    });
+                }
+                if (isBillingFetch(request)) {
+                    return Response.json({ data: [] });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const primaryModel = communityModelId(
+            primaryOwner,
+            `primary-${suffix}`,
+        );
+        const response = await SELF.fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: primaryModel,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(targetModel);
+        expect(upstreamHosts).toEqual([
+            "https://primary.example.com/v1",
+            "https://fallback.example.com/v1",
+        ]);
     },
 );
 

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -60,6 +60,7 @@ export async function getCommunityModelRegistryEntries(
             supportsImageEdits: schema.communityEndpoint.supportsImageEdits,
             baseUrl: schema.communityEndpoint.baseUrl,
             upstreamModel: schema.communityEndpoint.upstreamModel,
+            fallbackModel: schema.communityEndpoint.fallbackModel,
             bearerTokenCiphertext:
                 schema.communityEndpoint.bearerTokenCiphertext,
             visibility: schema.communityEndpoint.visibility,
@@ -101,6 +102,7 @@ export async function getCommunityModelRegistryEntries(
             supportsImageEdits: row.supportsImageEdits,
             baseUrl: row.baseUrl,
             upstreamModel: row.upstreamModel,
+            fallbackModel: row.fallbackModel,
             bearerTokenCiphertext: row.bearerTokenCiphertext,
             visibility: row.visibility,
             disabledAt: row.disabledAt ? row.disabledAt.getTime() : null,

--- a/gen.pollinations.ai/src/index.ts
+++ b/gen.pollinations.ai/src/index.ts
@@ -25,6 +25,7 @@ import { HTTPException } from "hono/http-exception";
 import { requestId } from "hono/request-id";
 import type { Env } from "@/env.ts";
 import { logger } from "@/middleware/logger.ts";
+import { modelFallback } from "./middleware/model-fallback.ts";
 import { audioRoutes } from "./routes/audio.ts";
 import { buildMergedOpenApiSpec, createDocsRoutes } from "./routes/docs.ts";
 import { modelStatusRoutes } from "./routes/model-status.ts";
@@ -107,6 +108,12 @@ function redirectLegacyDocs(c: Context<Env>): Response {
 app.use("*", cors(PERMISSIVE_CORS_OPTIONS))
     .use("*", requestId())
     .use("*", logger)
+    .use(
+        "*",
+        modelFallback((request, c) =>
+            app.fetch(request, c.env, c.executionCtx),
+        ),
+    )
     .get("/robots.txt", () => robotsTxt())
     .get("/manifest.webmanifest", () => manifestResponse())
     .get("/", (c) => c.html(docsLandingHtml(c)))

--- a/gen.pollinations.ai/src/middleware/model-fallback.ts
+++ b/gen.pollinations.ai/src/middleware/model-fallback.ts
@@ -1,0 +1,59 @@
+import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
+import type { Context } from "hono";
+import { createMiddleware } from "hono/factory";
+import type { Env } from "@/env.ts";
+
+type RetryRequest = (
+    request: Request,
+    context: Context<Env>,
+) => Response | Promise<Response>;
+
+function isRetryableError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const status = (error as { status?: unknown }).status;
+    return (
+        (typeof status === "number" && status >= 500 && status < 600) ||
+        error.name === "TypeError"
+    );
+}
+
+function withFallbackHeader(response: Response, model: string): Response {
+    const headers = new Headers(response.headers);
+    headers.set(FALLBACK_TARGET_HEADER, model);
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+}
+
+export function modelFallback(retryRequest: RetryRequest) {
+    return createMiddleware<Env>(async (c, next) => {
+        try {
+            await next();
+        } catch (error) {
+            const fallbackRequest = c.var.fallbackRequest;
+            const fallbackModel = c.var.model?.fallbackModel;
+            if (
+                !fallbackRequest ||
+                !fallbackModel ||
+                !isRetryableError(error)
+            ) {
+                throw error;
+            }
+            c.res = withFallbackHeader(
+                await retryRequest(fallbackRequest, c),
+                fallbackModel,
+            );
+            return;
+        }
+
+        const fallbackRequest = c.var.fallbackRequest;
+        const fallbackModel = c.var.model?.fallbackModel;
+        if (c.res.status < 500 || !fallbackRequest || !fallbackModel) return;
+        c.res = withFallbackHeader(
+            await retryRequest(fallbackRequest, c),
+            fallbackModel,
+        );
+    });
+}

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -3,7 +3,10 @@ import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
 import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import {
+    isModelFallbackCompatible,
+    type ModelDefinition,
+} from "@shared/registry/registry.ts";
 import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
 import type { EventType } from "@shared/schemas/generation-event.ts";
 import { createMiddleware } from "hono/factory";
@@ -28,9 +31,17 @@ export type ModelVariables = {
         /** Static registry definition, or a dynamic definition resolved from D1. */
         definition: ModelDefinition;
         communityEndpoint?: CommunityEndpointRuntime;
+        fallbackModel?: string;
     };
+    fallbackRequest?: Request;
     formData?: FormData;
 };
+
+const fallbackSources = new WeakMap<Request, string>();
+
+export function getModelFallbackSource(request: Request): string | undefined {
+    return fallbackSources.get(request);
+}
 
 type ResolveModelOptions = {
     defaultModel?: string;
@@ -49,6 +60,63 @@ function getValidatedJsonBody<T>(req: {
     } catch {
         return undefined;
     }
+}
+
+async function createFallbackRequest(
+    request: Request,
+    fallbackModel: string,
+    fallbackFrom: string,
+    validatedJson?: Record<string, unknown>,
+    formData?: FormData,
+): Promise<Request | undefined> {
+    const url = new URL(request.url);
+    const headers = new Headers(request.headers);
+    headers.delete("content-length");
+
+    if (request.method === "GET" || request.method === "HEAD") {
+        url.searchParams.set("model", fallbackModel);
+        const fallbackRequest = new Request(url, {
+            method: request.method,
+            headers,
+        });
+        fallbackSources.set(fallbackRequest, fallbackFrom);
+        return fallbackRequest;
+    }
+
+    if (formData) {
+        const fallbackForm = new FormData();
+        for (const [key, value] of formData.entries()) {
+            fallbackForm.append(key, value);
+        }
+        fallbackForm.set("model", fallbackModel);
+        headers.delete("content-type");
+        const fallbackRequest = new Request(url, {
+            method: request.method,
+            headers,
+            body: fallbackForm,
+        });
+        fallbackSources.set(fallbackRequest, fallbackFrom);
+        return fallbackRequest;
+    }
+
+    if (!hasJsonContentType(request.headers.get("content-type") || "")) {
+        return undefined;
+    }
+    let body = validatedJson;
+    if (!body) {
+        try {
+            body = (await request.clone().json()) as Record<string, unknown>;
+        } catch {
+            return undefined;
+        }
+    }
+    const fallbackRequest = new Request(url, {
+        method: request.method,
+        headers,
+        body: JSON.stringify({ ...body, model: fallbackModel }),
+    });
+    fallbackSources.set(fallbackRequest, fallbackFrom);
+    return fallbackRequest;
 }
 
 export async function resolveModelDefinition(
@@ -100,6 +168,22 @@ export async function resolveModelDefinition(
         });
     }
 
+    const configuredFallback = entry.definition.fallbackModel;
+    const fallback = configuredFallback
+        ? registry.resolve(configuredFallback)
+        : null;
+    const fallbackCommunity = fallback?.communityEndpoint;
+    const fallbackAllowed =
+        fallback &&
+        fallback.id !== entry.id &&
+        fallback.eventType === entry.eventType &&
+        (!supportedEndpoint ||
+            fallback.supportedEndpoints.includes(supportedEndpoint)) &&
+        (!fallbackCommunity ||
+            fallbackCommunity.visibility === "public" ||
+            fallbackCommunity.ownerUserId === callerUserId) &&
+        isModelFallbackCompatible(entry.definition, fallback.definition);
+
     return {
         requested: model,
         resolved: entry.id,
@@ -107,6 +191,7 @@ export async function resolveModelDefinition(
         ...(entry.communityEndpoint && {
             communityEndpoint: entry.communityEndpoint,
         }),
+        ...(fallbackAllowed && { fallbackModel: fallback.id }),
     };
 }
 
@@ -171,16 +256,27 @@ export function resolveModel(
         // routes, so the caller identity is available to gate private
         // endpoints. If it isn't (unauthenticated path), callerUserId is
         // undefined and a private endpoint fails closed — never exposed.
-        c.set(
-            "model",
-            await resolveModelDefinition(
-                model,
-                eventType,
-                c.env,
-                c.var.auth?.user?.id,
-                options?.supportedEndpoint,
-            ),
+        const resolvedModel = await resolveModelDefinition(
+            model,
+            eventType,
+            c.env,
+            c.var.auth?.user?.id,
+            options?.supportedEndpoint,
         );
+        c.set("model", resolvedModel);
+        if (resolvedModel.fallbackModel && !getModelFallbackSource(c.req.raw)) {
+            const validatedJson = getValidatedJsonBody<Record<string, unknown>>(
+                c.req,
+            );
+            const fallbackRequest = await createFallbackRequest(
+                c.req.raw,
+                resolvedModel.fallbackModel,
+                resolvedModel.resolved,
+                validatedJson,
+                c.var.formData,
+            );
+            if (fallbackRequest) c.set("fallbackRequest", fallbackRequest);
+        }
         await next();
     });
 }

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -71,6 +71,7 @@ import { mergeContentFilterResults } from "@/content-filter.ts";
 import type { AuthVariables } from "@/middleware/auth.ts";
 import type { BalanceVariables } from "@/middleware/balance.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
+import { getModelFallbackSource } from "@/middleware/model.ts";
 import type { FrontendKeyRateLimitVariables } from "@/middleware/rate-limit-durable.ts";
 import { generateRandomId, parseBooleanLike } from "@/util.ts";
 
@@ -81,6 +82,7 @@ type ModelVariables = {
         definition: ModelDefinition;
         communityEndpoint?: CommunityEndpointRuntime;
     };
+    fallbackRequest?: Request;
 };
 
 export type ModelUsage = {
@@ -92,6 +94,8 @@ export type ModelUsage = {
 type RequestTrackingData = {
     modelRequested: string | null;
     resolvedModelRequested: string;
+    billingModel: string;
+    fallbackTarget?: string;
     modelProvider?: string;
     modelDefinition: ModelDefinition;
     modelCostDefinition: CostDefinition;
@@ -185,6 +189,10 @@ export const track = (eventType: EventType) =>
         });
 
         await next();
+
+        // The fallback middleware records the retry as the one logical
+        // generation event. Avoid emitting a second failed primary attempt.
+        if (c.var.fallbackRequest && c.res.status >= 500) return;
 
         c.executionCtx.waitUntil(
             (async () => {
@@ -407,8 +415,9 @@ async function trackRequest(
     request: HonoRequest,
 ): Promise<RequestTrackingData> {
     // Model is already resolved by the resolveModel middleware
-    const modelRequested = modelInfo.requested;
-    const resolvedModelRequested = modelInfo.resolved;
+    const fallbackFrom = getModelFallbackSource(request.raw);
+    const modelRequested = fallbackFrom || modelInfo.requested;
+    const resolvedModelRequested = fallbackFrom || modelInfo.resolved;
 
     const modelDefinition = modelInfo.definition;
     const modelProvider = modelDefinition.provider;
@@ -425,6 +434,8 @@ async function trackRequest(
     return {
         modelRequested,
         resolvedModelRequested,
+        billingModel: modelInfo.resolved,
+        fallbackTarget: fallbackFrom ? modelInfo.resolved : undefined,
         modelProvider,
         modelDefinition,
         modelCostDefinition,
@@ -460,7 +471,9 @@ async function trackResponse(
     const log = getLogger(["hono", "track", "response"]);
     const { resolvedModelRequested } = requestTracking;
     const cacheHit = response.headers.get("x-cache") === "HIT";
-    const fallbackUsed = parseFallbackUsed(response);
+    const fallbackUsed =
+        requestTracking.fallbackTarget !== undefined ||
+        parseFallbackUsed(response);
     const notBilled = (
         extra?: Partial<ResponseTrackingData>,
     ): ResponseTrackingData => ({
@@ -513,7 +526,7 @@ async function trackResponse(
     // one walk over the billing rules, so the event's adjustment maps always
     // match the billed totals and clamp warnings log once per request.
     const { cost, price, adjustments } = calculateUsageBilling(
-        resolvedModelRequested,
+        requestTracking.billingModel,
         modelUsage.usage,
         requestTracking.modelDefinition,
         modelUsage.output,

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -232,6 +232,7 @@ export type CommunityEndpointRuntime = {
     supportsImageEdits: boolean;
     baseUrl: string;
     upstreamModel: string;
+    fallbackModel?: string | null;
     bearerTokenCiphertext: string;
     visibility: CommunityEndpointVisibility;
     disabledAt: number | null;
@@ -245,6 +246,7 @@ export type CommunityModelDefinitionInput = {
     modality?: CommunityEndpointModality;
     imagePricing?: CommunityEndpointImagePricing;
     supportsImageEdits?: boolean;
+    fallbackModel?: string | null;
 } & CommunityEndpointPrices;
 
 export type CommunityModelParts = {
@@ -420,6 +422,9 @@ export function communityModelDefinition(
     return {
         aliases,
         provider: "community",
+        ...(endpoint.fallbackModel
+            ? { fallbackModel: endpoint.fallbackModel }
+            : {}),
         brand: "Community",
         category: isImage ? "image" : "text",
         cost: communityPriceDefinition(endpoint, modality, imagePricing),

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -216,6 +216,7 @@ export const communityEndpoint = sqliteTable("community_endpoint", {
     .notNull(),
   baseUrl: text("base_url").notNull(),
   upstreamModel: text("upstream_model").notNull(),
+  fallbackModel: text("fallback_model"),
   bearerTokenCiphertext: text("bearer_token_ciphertext").notNull(),
   // Models default to private (owner-only and free). Public visibility is
   // allowlist-gated and may be free or owner-priced.

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -102,6 +102,8 @@ export type BillingAdjustment = {
 export type ModelDefinition = {
     aliases: string[];
     provider: string;
+    /** One model to retry after a server-side failure. Fallbacks never chain. */
+    fallbackModel?: string;
     // Optional secondary provider for binary-asset models with provider-level
     // fallback (3D only, as of this field). Purely descriptive metadata for
     // /models transparency — does not drive fallback logic, which lives in
@@ -143,6 +145,27 @@ export type ModelDefinition = {
     maxReferenceImages?: number; // Models with image input: effective accepted reference images
     maxReferenceVideos?: number; // Models with video input: effective accepted reference videos
 };
+
+export function isModelFallbackCompatible(
+    primary: ModelDefinition,
+    fallback: ModelDefinition,
+): boolean {
+    if (
+        primary.category !== fallback.category ||
+        primary.flatRate !== fallback.flatRate ||
+        (!primary.paidOnly && fallback.paidOnly)
+    ) {
+        return false;
+    }
+
+    const primaryPrice = getPriceDefinitionForModel(primary);
+    const fallbackPrice = getPriceDefinitionForModel(fallback);
+    return Object.entries(fallbackPrice).every(
+        ([key, price]) =>
+            typeof price !== "number" ||
+            price <= (primaryPrice[key as keyof PriceDefinition] ?? 0),
+    );
+}
 
 // Helper: Convert usage counts to rated USD-equivalent cost or Pollen charge.
 // When a usage type is reported by upstream but the registry has no rate for it,


### PR DESCRIPTION
- Adds one optional fallback target to the shared model definition and community model editor
- Retries once on network or server failures across generation routes; fallback chains are disabled
- Requires the fallback to match modality and pricing mode, cost no more, and remain accessible to the caller
- Records and bills the successful target as one logical generation event
- Tests: community endpoint suite (33/33), Enter typecheck, Gen typecheck, Biome