### PR TITLE
fix: restore Gemini Search to Vertex

### DIFF
--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -62,9 +62,13 @@ test("gemini-search applies grounding cost on top of shared token rates", () => 
     };
     const geminiFastCost = calculateCost("gemini-fast", usage);
     const geminiSearchCost = calculateCost("gemini-search", usage, {
-        usage: {
-            server_tool_use_details: { web_search_requests: 1 },
-        },
+        choices: [
+            {
+                groundingMetadata: {
+                    webSearchQueries: ["current news"],
+                },
+            },
+        ],
     });
 
     expect(geminiSearchCost.totalCost).toBeGreaterThan(

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -394,7 +394,7 @@ test("updated provider prices are reflected for xAI media and OpenRouter text", 
     ).toBeCloseTo(0.352, 8);
 });
 
-test("OpenRouter Gemini search cost is added from provider usage", () => {
+test("Gemini search cost follows each route's provider metadata", () => {
     const usage = {
         promptTextTokens: 1_000_000,
         completionTextTokens: 1_000_000,
@@ -404,16 +404,34 @@ test("OpenRouter Gemini search cost is added from provider usage", () => {
             server_tool_use_details: { web_search_requests: 2 },
         },
     };
+    const vertex25SearchOutput = {
+        choices: [
+            {
+                groundingMetadata: {
+                    webSearchQueries: ["query one", "query two"],
+                },
+            },
+        ],
+    };
+    const vertex3SearchOutput = {
+        choices: [
+            {
+                groundingMetadata: {
+                    webSearchQueries: ["query one", "query two"],
+                },
+            },
+        ],
+    };
 
     const geminiSearchCost = calculateCost(
         "gemini-search",
         usage,
-        openRouterSearchOutput,
+        vertex25SearchOutput,
     );
     const geminiSearchPrice = calculatePrice(
         "gemini-search",
         usage,
-        openRouterSearchOutput,
+        vertex25SearchOutput,
     );
     const gemini3FlashCost = calculateCost(
         "gemini-3-flash",
@@ -423,12 +441,12 @@ test("OpenRouter Gemini search cost is added from provider usage", () => {
     const geminiSearchFastCost = calculateCost(
         "gemini-search-fast",
         usage,
-        openRouterSearchOutput,
+        vertex3SearchOutput,
     );
     const geminiSearchLargeCost = calculateCost(
         "gemini-search-large",
         usage,
-        openRouterSearchOutput,
+        vertex3SearchOutput,
     );
     const ungroundedGeminiSearchFastCost = calculateCost(
         "gemini-search-fast",
@@ -436,12 +454,11 @@ test("OpenRouter Gemini search cost is added from provider usage", () => {
         { choices: [] },
     );
 
-    // OpenRouter reports each native search request. priceMultiplier is 1×,
-    // so price equals cost.
-    expect(geminiSearchCost.totalCost).toBeCloseTo(0.528, 8);
-    expect(geminiSearchPrice.totalPrice).toBeCloseTo(0.528, 8);
+    // Vertex 2.5 bills once per grounded prompt. priceMultiplier is 1×.
+    expect(geminiSearchCost.totalCost).toBeCloseTo(0.535, 8);
+    expect(geminiSearchPrice.totalPrice).toBeCloseTo(0.535, 8);
 
-    // Every pinned OpenRouter route uses the provider-reported request count.
+    // General Gemini remains on OpenRouter; Vertex Gemini 3 bills per query.
     expect(gemini3FlashCost.totalCost).toBeCloseTo(3.528, 8);
     expect(geminiSearchFastCost.totalCost).toBeCloseTo(2.828, 8);
     expect(geminiSearchLargeCost.totalCost).toBeCloseTo(9.028, 8);
@@ -564,32 +581,35 @@ test("Perplexity provider-reported request cost clamps-and-alerts, never throws"
     );
 });
 
-test("Gemini grounding is detected on streamed chunk output", () => {
+test("Vertex Gemini grounding is detected on streamed chunk output", () => {
     const usage = {
         promptTextTokens: 1_000_000,
         completionTextTokens: 1_000_000,
     };
-    const openRouterStreamOutput = {
+    const vertexStreamOutput = {
         streamEvents: [
             { choices: [{ delta: { content: "searching" } }] },
             {
-                usage: {
-                    server_tool_use_details: { web_search_requests: 2 },
-                },
+                choices: [
+                    {
+                        groundingMetadata: {
+                            webSearchQueries: ["query one", "query two"],
+                        },
+                    },
+                ],
             },
         ],
     };
 
-    // OpenRouter reports native search usage on the final stream event.
+    // Vertex reports grounding metadata on a streamed response event.
     expect(
-        calculateCost("gemini-search", usage, openRouterStreamOutput).totalCost,
-    ).toBeCloseTo(0.528, 8);
+        calculateCost("gemini-search", usage, vertexStreamOutput).totalCost,
+    ).toBeCloseTo(0.535, 8);
     expect(
-        calculatePrice("gemini-search", usage, openRouterStreamOutput)
-            .totalPrice,
-    ).toBeCloseTo(0.528, 8);
+        calculatePrice("gemini-search", usage, vertexStreamOutput).totalPrice,
+    ).toBeCloseTo(0.535, 8);
     expect(
-        calculateCost("gemini-search-fast", usage, openRouterStreamOutput)
+        calculateCost("gemini-search-fast", usage, vertexStreamOutput)
             .totalCost,
     ).toBeCloseTo(2.828, 8);
 });
@@ -658,7 +678,7 @@ test("Gemini models price cache writes at the standard input rate", () => {
     }
 });
 
-test("OpenRouter Gemini routes price separately reported media input tokens", () => {
+test("Gemini routes price separately reported media input tokens", () => {
     for (const model of [
         "gemini-3-flash",
         "gemini",
@@ -681,13 +701,15 @@ test("OpenRouter Gemini routes price separately reported media input tokens", ()
     }
 });
 
-test("Google text models use OpenRouter without advertising code execution", () => {
-    const googleModels = [
+test("Google text model providers match their configured routes", () => {
+    const openRouterModels = [
         "gemini-3-flash",
         "gemini",
         "gemini-flash-lite-3.5",
         "gemini-fast",
         "gemini-large",
+    ] as const;
+    const vertexModels = [
         "gemini-search",
         "gemini-search-fast",
         "gemini-search-large",
@@ -696,9 +718,19 @@ test("Google text models use OpenRouter without advertising code execution", () 
         getTextModelsInfo().map((model) => [model.name, model]),
     );
 
-    for (const model of googleModels) {
+    for (const model of openRouterModels) {
         const definition = getRegistryModelDefinition(model);
         expect(definition.provider, `${model} provider`).toBe("openrouter");
+        expect(definition.codeExecution, `${model} code execution`).toBeFalsy();
+        expect(
+            publicModels.get(model)?.capabilities,
+            `${model} public capabilities`,
+        ).not.toContain("code_execution");
+        expect(definition.paidOnly, `${model} paid-only status`).toBe(true);
+    }
+    for (const model of vertexModels) {
+        const definition = getRegistryModelDefinition(model);
+        expect(definition.provider, `${model} provider`).toBe("google");
         expect(definition.codeExecution, `${model} code execution`).toBeFalsy();
         expect(
             publicModels.get(model)?.capabilities,
@@ -761,9 +793,6 @@ test("OpenRouter Gemini adjustments use provider-reported cache and search usage
         "gemini-flash-lite-3.5",
         "gemini-fast",
         "gemini-large",
-        "gemini-search",
-        "gemini-search-fast",
-        "gemini-search-large",
     ] as const) {
         expect(
             calculateBillingAdjustments(
@@ -798,7 +827,7 @@ test("OpenRouter Gemini adjustments use provider-reported cache and search usage
     }
 
     const streamedSearch = calculateBillingAdjustments(
-        getRegistryModelDefinition("gemini-search"),
+        getRegistryModelDefinition("gemini"),
         {
             streamEvents: [
                 { choices: [{}] },
@@ -809,7 +838,7 @@ test("OpenRouter Gemini adjustments use provider-reported cache and search usage
                 },
             ],
         },
-        "gemini-search",
+        "gemini",
     );
     expect(streamedSearch).toEqual([
         {
@@ -826,7 +855,7 @@ test("OpenRouter Gemini adjustments use provider-reported cache and search usage
     for (const bad of [-5, "2", null, true, {}]) {
         expect(
             calculateBillingAdjustments(
-                getRegistryModelDefinition("gemini-search-fast"),
+                getRegistryModelDefinition("gemini-fast"),
                 {
                     usage: {
                         prompt_tokens_details: { cache_write_tokens: bad },
@@ -835,10 +864,100 @@ test("OpenRouter Gemini adjustments use provider-reported cache and search usage
                         },
                     },
                 },
-                "gemini-search-fast",
+                "gemini-fast",
             ),
         ).toEqual([]);
     }
+});
+
+test("Vertex Gemini Search adjustments use grounding metadata", () => {
+    const groundedPrompt = calculateBillingAdjustments(
+        getRegistryModelDefinition("gemini-search"),
+        {
+            choices: [
+                {
+                    groundingMetadata: {
+                        webSearchQueries: ["query one", "query two"],
+                    },
+                },
+            ],
+        },
+        "gemini-search",
+    );
+    expect(groundedPrompt).toEqual([
+        {
+            ruleId: "google.gemini_2.grounded_prompt.v1",
+            kind: "grounded_prompt",
+            unit: "prompt",
+            units: 1,
+            unitCost: 0.035,
+            cost: 0.035,
+            price: 0.035,
+        },
+    ]);
+
+    for (const model of [
+        "gemini-search-fast",
+        "gemini-search-large",
+    ] as const) {
+        expect(
+            calculateBillingAdjustments(
+                getRegistryModelDefinition(model),
+                {
+                    streamEvents: [
+                        {
+                            choices: [
+                                {
+                                    groundingMetadata: {
+                                        webSearchQueries: ["one", "two"],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            choices: [
+                                {
+                                    groundingMetadata: {
+                                        webSearchQueries: ["one", "two"],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                model,
+            ),
+        ).toEqual([
+            {
+                ruleId: "google.gemini_3.search_query.v1",
+                kind: "search_query",
+                unit: "query",
+                units: 2,
+                unitCost: 0.014,
+                cost: 0.028,
+                price: 0.028,
+            },
+        ]);
+    }
+
+    const cacheWrite = calculateBillingAdjustments(
+        getRegistryModelDefinition("gemini-search"),
+        {
+            usage: { cache_creation_input_tokens: 1_000_000 },
+        },
+        "gemini-search",
+    );
+    expect(cacheWrite).toEqual([
+        {
+            ruleId: "google.vertex.cache_storage.v1",
+            kind: "cache_storage",
+            unit: "token_hour",
+            units: 1_000_000,
+            unitCost: 0.000001,
+            cost: 1,
+            price: 1,
+        },
+    ]);
 });
 
 test("calculateBillingAdjustments returns per-rule breakdown entries", () => {
@@ -863,24 +982,28 @@ test("calculateBillingAdjustments returns per-rule breakdown entries", () => {
         },
     ]);
 
-    const openRouterGeminiSearch = calculateBillingAdjustments(
+    const vertexGeminiSearch = calculateBillingAdjustments(
         getRegistryModelDefinition("gemini-search"),
         {
-            usage: {
-                server_tool_use_details: { web_search_requests: 1 },
-            },
+            choices: [
+                {
+                    groundingMetadata: {
+                        webSearchQueries: ["current news"],
+                    },
+                },
+            ],
         },
         "gemini-search",
     );
-    expect(openRouterGeminiSearch).toEqual([
+    expect(vertexGeminiSearch).toEqual([
         {
-            ruleId: "openrouter.google.web_search.v1",
-            kind: "search_request",
-            unit: "request",
+            ruleId: "google.gemini_2.grounded_prompt.v1",
+            kind: "grounded_prompt",
+            unit: "prompt",
             units: 1,
-            unitCost: 0.014,
-            cost: 0.014,
-            price: 0.014,
+            unitCost: 0.035,
+            cost: 0.035,
+            price: 0.035,
         },
     ]);
 

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -6,7 +6,8 @@ import { createClaudeThinkingTransform } from "./transforms/createClaudeThinking
 import { createGeminiThinkingTransform } from "./transforms/createGeminiThinkingTransform.ts";
 import {
     adaptGoogleSearchToolForOpenRouter,
-    createOpenRouterNativeWebSearchTransform,
+    adaptGoogleSearchToolForVertex,
+    createGeminiToolsTransform,
     stripLogitBiasForNativeWebSearch,
 } from "./transforms/createGeminiToolsTransform.ts";
 import { createMessageTransform } from "./transforms/createMessageTransform.js";
@@ -263,32 +264,31 @@ const models: ModelDefinition[] = [
     },
     {
         name: "gemini-search",
-        config: portkeyConfig["google/gemini-2.5-flash-lite"],
+        config: portkeyConfig["vertex/gemini-2.5-flash-lite"],
         transform: pipe(
             sanitizeToolSchemas,
-            adaptGoogleSearchToolForOpenRouter,
-            createOpenRouterNativeWebSearchTransform(),
-            stripLogitBiasForNativeWebSearch,
+            adaptGoogleSearchToolForVertex,
+            createGeminiToolsTransform(["google_search"]),
             createGeminiThinkingTransform("v2.5"),
         ),
     },
     {
         name: "gemini-search-fast",
-        config: portkeyConfig["google/gemini-3.5-flash-lite"],
+        config: portkeyConfig["vertex/gemini-3.5-flash-lite"],
         transform: pipe(
             sanitizeToolSchemas,
-            adaptGoogleSearchToolForOpenRouter,
-            createOpenRouterNativeWebSearchTransform(),
+            adaptGoogleSearchToolForVertex,
+            createGeminiToolsTransform(["google_search"]),
             createGeminiThinkingTransform("v3-flash"),
         ),
     },
     {
         name: "gemini-search-large",
-        config: portkeyConfig["google/gemini-3.6-flash"],
+        config: portkeyConfig["vertex/gemini-3.6-flash"],
         transform: pipe(
             sanitizeToolSchemas,
-            adaptGoogleSearchToolForOpenRouter,
-            createOpenRouterNativeWebSearchTransform(),
+            adaptGoogleSearchToolForVertex,
+            createGeminiToolsTransform(["google_search"]),
             // Gemini 3.6 requires reasoning; map `none` to its lowest level.
             createGeminiThinkingTransform("v3-pro"),
         ),

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -1,3 +1,4 @@
+import googleCloudAuth from "../auth/googleCloudAuth.js";
 import {
     createAzureModelConfig,
     createBedrockNativeConfig,
@@ -16,6 +17,21 @@ import {
 
 type PortkeyConfigFactory = () => Record<string, unknown>;
 type PortkeyConfigMap = Record<string, PortkeyConfigFactory>;
+
+/** Creates a direct Vertex AI config for Gemini models. */
+function createVertexGeminiConfig(
+    modelId: string,
+    region: string,
+): PortkeyConfigFactory {
+    return () => ({
+        provider: "vertex-ai",
+        authKey: googleCloudAuth.getAccessToken,
+        "vertex-project-id": process.env.GOOGLE_PROJECT_ID,
+        "vertex-region": region,
+        "vertex-model-id": modelId,
+        "strict-openai-compliance": "false",
+    });
+}
 
 /** Creates a no-fallback OpenRouter route pinned to one Vertex deployment. */
 function createPinnedOpenRouterGeminiConfig(
@@ -320,6 +336,20 @@ export const portkeyConfig: PortkeyConfigMap = {
     "google/gemini-3.6-flash": createPinnedOpenRouterGeminiConfig(
         "gemini-3.6-flash",
         "google-vertex/global",
+    ),
+
+    // -- Google Vertex AI (dedicated Gemini Search services) -----------------
+    "vertex/gemini-2.5-flash-lite": createVertexGeminiConfig(
+        "gemini-2.5-flash-lite",
+        "global",
+    ),
+    "vertex/gemini-3.5-flash-lite": createVertexGeminiConfig(
+        "gemini-3.5-flash-lite",
+        "global",
+    ),
+    "vertex/gemini-3.6-flash": createVertexGeminiConfig(
+        "gemini-3.6-flash",
+        "global",
     ),
 
     // -- Perplexity -----------------------------------------------------------

--- a/gen.pollinations.ai/src/text/transforms/createGeminiToolsTransform.ts
+++ b/gen.pollinations.ai/src/text/transforms/createGeminiToolsTransform.ts
@@ -1,6 +1,43 @@
 import type { TransformFn } from "../types.ts";
 import { addDefaultTools } from "./pipe.ts";
 
+export type GeminiToolName = "code_execution" | "google_search";
+
+function toOpenAIFunctionFormat(name: GeminiToolName) {
+    return {
+        type: "function" as const,
+        function: { name },
+    };
+}
+
+/** Adds Gemini-native tools in the format expected by the Vertex adapter. */
+export function createGeminiToolsTransform(toolNames: GeminiToolName[]) {
+    return addDefaultTools(toolNames.map(toOpenAIFunctionFormat));
+}
+
+/** Converts the public Google Search tool shape for the Vertex adapter. */
+export const adaptGoogleSearchToolForVertex: TransformFn = (
+    messages,
+    options,
+) => ({
+    messages,
+    options: {
+        ...options,
+        ...(options.tools === undefined
+            ? {}
+            : {
+                  tools: options.tools.map((tool) =>
+                      typeof tool === "object" &&
+                      tool !== null &&
+                      "type" in tool &&
+                      tool.type === "google_search"
+                          ? toOpenAIFunctionFormat("google_search")
+                          : tool,
+                  ),
+              }),
+    },
+});
+
 function isGoogleSearchTool(tool: unknown): boolean {
     if (typeof tool !== "object" || tool === null || !("type" in tool)) {
         return false;
@@ -61,13 +98,3 @@ export const stripLogitBiasForNativeWebSearch: TransformFn = (
     delete supportedOptions.logit_bias;
     return { messages, options: supportedOptions };
 };
-
-/** Adds OpenRouter's provider-native Google Search tool without an Exa route. */
-export function createOpenRouterNativeWebSearchTransform() {
-    return addDefaultTools([
-        {
-            type: "openrouter:web_search",
-            parameters: { engine: "native" },
-        },
-    ]);
-}

--- a/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
@@ -15,18 +15,7 @@ describe("OpenRouter Gemini routing", () => {
             "google/gemini-3.5-flash-lite",
             "google-vertex/global",
         ],
-        ["gemini-search", "google/gemini-2.5-flash-lite", "google-vertex/eu"],
         ["gemini-fast", "google/gemini-2.5-flash-lite", "google-vertex/eu"],
-        [
-            "gemini-search-fast",
-            "google/gemini-3.5-flash-lite",
-            "google-vertex/global",
-        ],
-        [
-            "gemini-search-large",
-            "google/gemini-3.6-flash",
-            "google-vertex/global",
-        ],
         [
             "gemini-large",
             "google/gemini-3.1-pro-preview",
@@ -63,23 +52,6 @@ describe("OpenRouter Gemini routing", () => {
         const { options } = await transform([], {});
 
         expect(options.tools).toBeUndefined();
-    });
-
-    it.each([
-        "gemini-search",
-        "gemini-search-fast",
-        "gemini-search-large",
-    ])("injects search but not code execution for %s", async (model) => {
-        const transform = findModelByName(model)?.transform;
-        if (!transform) throw new Error(`${model} transform missing`);
-
-        const { options } = await transform([], {});
-
-        expect(options.tools).not.toContainEqual({ type: "code_execution" });
-        expect(options.tools).toContainEqual({
-            type: "openrouter:web_search",
-            parameters: { engine: "native" },
-        });
     });
 
     it.each(
@@ -119,12 +91,33 @@ describe("OpenRouter Gemini routing", () => {
     });
 });
 
-describe("OpenRouter Gemini native search", () => {
+describe("Vertex Gemini Search routing", () => {
+    const routes = [
+        ["gemini-search", "gemini-2.5-flash-lite"],
+        ["gemini-search-fast", "gemini-3.5-flash-lite"],
+        ["gemini-search-large", "gemini-3.6-flash"],
+    ] as const;
+
+    it.each(
+        routes,
+    )("routes %s directly to Vertex %s", (model, upstreamModel) => {
+        const { options } = resolveModelConfig([], { model });
+
+        expect(options.model).toBe(upstreamModel);
+        expect(options.modelConfig).toMatchObject({
+            provider: "vertex-ai",
+            "vertex-region": "global",
+            "vertex-model-id": upstreamModel,
+            "strict-openai-compliance": "false",
+        });
+        expect(options.provider).toBeUndefined();
+    });
+
     it.each([
         "gemini-search",
         "gemini-search-fast",
         "gemini-search-large",
-    ])("adds provider-native Google Search for %s", async (model) => {
+    ])("adds native Google Search without code execution for %s", async (model) => {
         const transform = findModelByName(model)?.transform;
         if (!transform) throw new Error(`${model} transform missing`);
 
@@ -135,8 +128,26 @@ describe("OpenRouter Gemini native search", () => {
 
         expect(options.tools).toEqual([
             {
-                type: "openrouter:web_search",
-                parameters: { engine: "native" },
+                type: "function",
+                function: { name: "google_search" },
+            },
+        ]);
+    });
+
+    it.each(
+        routes.map(([model]) => model),
+    )("adapts the public Google Search shape for %s", async (model) => {
+        const transform = findModelByName(model)?.transform;
+        if (!transform) throw new Error(`${model} transform missing`);
+
+        const { options } = await transform([], {
+            tools: [{ type: "google_search" }],
+        });
+
+        expect(options.tools).toEqual([
+            {
+                type: "function",
+                function: { name: "google_search" },
             },
         ]);
     });
@@ -153,7 +164,7 @@ describe("OpenRouter Gemini native search", () => {
         expect(options.tools).toEqual(tools);
     });
 
-    it("drops logit_bias from the 2.5 search route", async () => {
+    it("preserves logit_bias on the direct Vertex route", async () => {
         const transform = findModelByName("gemini-search")?.transform;
         if (!transform) throw new Error("gemini-search transform missing");
 
@@ -161,7 +172,7 @@ describe("OpenRouter Gemini native search", () => {
             logit_bias: { "1": -1 },
         });
 
-        expect(options.logit_bias).toBeUndefined();
+        expect(options.logit_bias).toEqual({ "1": -1 });
     });
 
     it("drops logit_bias from explicit search on the 2.5 general route", async () => {

--- a/shared/registry/gemini-billing.ts
+++ b/shared/registry/gemini-billing.ts
@@ -2,9 +2,13 @@ import type { BillingRules } from "./registry";
 
 const OPENROUTER_GOOGLE_SEARCH_COST_PER_REQUEST = 14 / 1000;
 const OPENROUTER_CACHE_TTL_HOURS = 5 / 60;
+const GEMINI_25_GROUNDING_COST_PER_PROMPT = 35 / 1000;
+const GEMINI_3_GROUNDING_COST_PER_QUERY = 14 / 1000;
+const VERTEX_CACHE_TTL_HOURS = 1;
 
 type CacheWriteOutput = {
     usage?: {
+        cache_creation_input_tokens?: unknown;
         prompt_tokens_details?: {
             cache_write_tokens?: unknown;
         };
@@ -15,9 +19,76 @@ type CacheWriteOutput = {
     streamEvents?: CacheWriteOutput[];
 };
 
+type GroundingMetadata = {
+    webSearchQueries?: string[];
+    groundingChunks?: { web?: { uri?: string } }[];
+};
+
+type GroundedOutput = {
+    choices?: { groundingMetadata?: GroundingMetadata }[];
+    streamEvents?: GroundedOutput[];
+};
+
 function outputEvents(output: unknown): CacheWriteOutput[] {
     const o = output as CacheWriteOutput | undefined;
     return Array.isArray(o?.streamEvents) ? o.streamEvents : o ? [o] : [];
+}
+
+function eachGroundingMetadata(output: unknown): GroundingMetadata[] {
+    const o = output as GroundedOutput | undefined;
+    const events = Array.isArray(o?.streamEvents)
+        ? o.streamEvents
+        : o
+          ? [o]
+          : [];
+    const metadata: GroundingMetadata[] = [];
+    for (const event of events) {
+        const choices = Array.isArray(event?.choices) ? event.choices : [];
+        for (const choice of choices) {
+            if (choice?.groundingMetadata)
+                metadata.push(choice.groundingMetadata);
+        }
+    }
+    return metadata;
+}
+
+function webSearchQueryStrings(metadata: GroundingMetadata): string[] {
+    if (!Array.isArray(metadata.webSearchQueries)) return [];
+    return metadata.webSearchQueries.filter(
+        (query): query is string =>
+            typeof query === "string" && query.trim() !== "",
+    );
+}
+
+function countGeminiGroundedPrompt(output: unknown): number {
+    for (const metadata of eachGroundingMetadata(output)) {
+        if (webSearchQueryStrings(metadata).length > 0) return 1;
+        const chunks = Array.isArray(metadata.groundingChunks)
+            ? metadata.groundingChunks
+            : [];
+        if (chunks.some((chunk) => chunk?.web?.uri)) return 1;
+    }
+    return 0;
+}
+
+function countGeminiWebSearchQueries(output: unknown): number {
+    const queries = new Set<string>();
+    for (const metadata of eachGroundingMetadata(output)) {
+        for (const query of webSearchQueryStrings(metadata)) {
+            queries.add(query.trim());
+        }
+    }
+    return queries.size;
+}
+
+function countVertexCacheWriteTokens(output: unknown): number {
+    for (const event of [...outputEvents(output)].reverse()) {
+        const value = event?.usage?.cache_creation_input_tokens;
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+            return value;
+        }
+    }
+    return 0;
 }
 
 // OpenRouter reports the complete cached prefix in cache_write_tokens. Its
@@ -77,6 +148,55 @@ export const OPENROUTER_GEMINI_SEARCH_BILLING: BillingRules = {
             unit: "request",
             unitCost: OPENROUTER_GOOGLE_SEARCH_COST_PER_REQUEST,
             countUnits: countOpenRouterWebSearchRequests,
+        },
+    ],
+};
+
+export function withVertexCacheStorage(
+    base: BillingRules,
+    storageCostPerMillionTokenHours: number,
+): BillingRules {
+    return {
+        adjustments: [
+            ...(base.adjustments ?? []),
+            {
+                id: "google.vertex.cache_storage.v1",
+                description: `Vertex explicit context caching storage: $${storageCostPerMillionTokenHours} / 1M tokens / hour, billed for the one-hour TTL on each cache create.`,
+                kind: "cache_storage",
+                unit: "token_hour",
+                unitCost:
+                    (storageCostPerMillionTokenHours / 1_000_000) *
+                    VERTEX_CACHE_TTL_HOURS,
+                countUnits: countVertexCacheWriteTokens,
+            },
+        ],
+    };
+}
+
+export const GEMINI_25_GROUNDING_BILLING: BillingRules = {
+    adjustments: [
+        {
+            id: "google.gemini_2.grounded_prompt.v1",
+            description:
+                "Google Search grounding adds $35 / 1K grounded prompts when grounding metadata is present.",
+            kind: "grounded_prompt",
+            unit: "prompt",
+            unitCost: GEMINI_25_GROUNDING_COST_PER_PROMPT,
+            countUnits: countGeminiGroundedPrompt,
+        },
+    ],
+};
+
+export const GEMINI_3_SEARCH_BILLING: BillingRules = {
+    adjustments: [
+        {
+            id: "google.gemini_3.search_query.v1",
+            description:
+                "Google Search grounding adds $14 / 1K search queries when grounding metadata is present.",
+            kind: "search_query",
+            unit: "query",
+            unitCost: GEMINI_3_GROUNDING_COST_PER_QUERY,
+            countUnits: countGeminiWebSearchQueries,
         },
     ],
 };

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,6 +1,9 @@
 import {
+    GEMINI_3_SEARCH_BILLING,
+    GEMINI_25_GROUNDING_BILLING,
     OPENROUTER_GEMINI_SEARCH_BILLING,
     withOpenRouterGeminiCacheStorage,
+    withVertexCacheStorage,
 } from "./gemini-billing";
 import {
     PERPLEXITY_FAST_BILLING,
@@ -728,13 +731,13 @@ export const TEXT_SERVICES = {
     },
     "gemini-search": {
         aliases: ["gemini-2.5-flash-search", "gemini-2.5-flash-lite-search"],
-        provider: "openrouter",
+        provider: "google",
         brand: "Google",
         category: "text",
         addedDate: new Date("2025-10-10").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // OpenRouter base rates for the pinned Google Vertex EU route.
+        // Vertex base rates for Gemini 2.5 Flash Lite.
         cost: {
             promptTextTokens: perMillion(0.1),
             promptCachedTokens: perMillion(0.01),
@@ -744,10 +747,7 @@ export const TEXT_SERVICES = {
             promptVideoTokens: perMillion(0.1),
             completionTextTokens: perMillion(0.4),
         },
-        billing: withOpenRouterGeminiCacheStorage(
-            OPENROUTER_GEMINI_SEARCH_BILLING,
-            1.0,
-        ),
+        billing: withVertexCacheStorage(GEMINI_25_GROUNDING_BILLING, 1.0),
         title: "Google Gemini 2.5 Flash Lite Search",
         description:
             "Answers grounded in live web search; fast and cheap, not a deep reasoner",
@@ -765,13 +765,13 @@ export const TEXT_SERVICES = {
             "gemini-3.1-flash-lite-search",
             "gemini-3.5-flash-lite-search",
         ],
-        provider: "openrouter",
+        provider: "google",
         brand: "Google",
         category: "text",
         addedDate: new Date("2026-05-26").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // OpenRouter base rates for the pinned Google Vertex global route.
+        // Vertex base rates for Gemini 3.5 Flash Lite.
         cost: {
             promptTextTokens: perMillion(0.3),
             promptCachedTokens: perMillion(0.03),
@@ -781,10 +781,7 @@ export const TEXT_SERVICES = {
             promptVideoTokens: perMillion(0.3),
             completionTextTokens: perMillion(2.5),
         },
-        billing: withOpenRouterGeminiCacheStorage(
-            OPENROUTER_GEMINI_SEARCH_BILLING,
-            1.0,
-        ),
+        billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.5 Flash Lite Search",
         description: "Fast multimodal answers grounded in live web results",
         inputModalities: ["text", "image", "audio", "video"],
@@ -798,13 +795,13 @@ export const TEXT_SERVICES = {
     },
     "gemini-search-large": {
         aliases: ["gemini-3.6-flash-search", "gemini-3.5-flash-search"],
-        provider: "openrouter",
+        provider: "google",
         brand: "Google",
         category: "text",
         addedDate: new Date("2026-05-26").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // OpenRouter base rates for the pinned Google Vertex global route.
+        // Vertex base rates for Gemini 3.6 Flash.
         cost: {
             promptTextTokens: perMillion(1.5),
             promptCachedTokens: perMillion(0.15),
@@ -814,10 +811,7 @@ export const TEXT_SERVICES = {
             promptVideoTokens: perMillion(1.5),
             completionTextTokens: perMillion(7.5),
         },
-        billing: withOpenRouterGeminiCacheStorage(
-            OPENROUTER_GEMINI_SEARCH_BILLING,
-            1.0,
-        ),
+        billing: withVertexCacheStorage(GEMINI_3_SEARCH_BILLING, 1.0),
         title: "Gemini 3.6 Flash Search",
         description: "Premium web research with grounded, up-to-date answers",
         inputModalities: ["text", "image", "audio", "video"],


### PR DESCRIPTION
- Routes `gemini-search`, `gemini-search-fast`, and `gemini-search-large` directly through Google Vertex again.
- Restores Vertex-native Google Search tool conversion, grounding billing, and cache-storage accounting.
- Keeps model names, aliases, pricing, paid-only access, multimodal support, and no-fallback behavior unchanged.
- Accepts that prompt caching is unavailable while Vertex Search tools are active; this reliability tradeoff was explicitly approved.
- Verified with typechecks, 451 focused tests, and live E2E covering search, image, multi-image, video, audio, streaming, aliases, billing, concurrency, and token limits.