### PR TITLE
test: verify delegated Polli run tokens

### DIFF
--- a/apps/polli-agent/README.md
+++ b/apps/polli-agent/README.md
@@ -27,7 +27,7 @@ docker build -t polli-agent .
 docker run -p 8000:8000 --env-file .env polli-agent
 ```
 
-The container needs no baked-in secrets — pass your Pollinations key per-request via `Authorization: Bearer <key>`, or set `OPENAI_API_KEY` for local/dev use.
+The container needs no baked-in secrets — pass your Pollinations credential per-request via `Authorization: Bearer <key>`, or set `OPENAI_API_KEY` for local/dev use. The credential is treated as opaque, so Pollinations can supply a short-lived `ag_` run token without exposing the user's original API key; the same token is used by the brain, tools, model registry, and media uploads for that request.
 
 ## Configuration
 

--- a/apps/polli-agent/tests/test_api_stream.py
+++ b/apps/polli-agent/tests/test_api_stream.py
@@ -163,3 +163,28 @@ def test_stream_false_returns_plain_json(monkeypatch):
     resp = client.post("/v1/chat/completions", json=_request_body(stream=False))
     assert resp.status_code == 200
     assert resp.json()["choices"][0]["message"]["content"] == "plain"
+
+
+def test_delegated_run_token_reaches_brain_and_tools(monkeypatch):
+    """Treat Pollinations run tokens as opaque per-request credentials."""
+    from polli_agent.config import _current_api_key
+    from polli_agent.tools import gen
+
+    delegated_token = "ag_test-delegated-run-token"
+
+    async def fake_run_agent(messages, **kwargs):
+        assert _current_api_key() == delegated_token
+        assert gen._key() == delegated_token
+        return {"text": "delegated", "artifacts": [], "iterations": 1}
+
+    monkeypatch.setattr(api_mod, "run_agent", fake_run_agent)
+
+    client = TestClient(api_mod.app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json=_request_body(stream=False),
+        headers={"Authorization": f"Bearer {delegated_token}"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "delegated"


### PR DESCRIPTION
Stacked on #12702; pairs with #12835.

- Confirms an opaque `ag_` bearer reaches Polli's per-request credential context.
- Covers the shared credential path used by the brain, registry, generation tools, and media uploads.
- Documents that the user's original API key is never required by Polli.
- Makes no runtime changes because #12702 already forwards arbitrary bearer credentials correctly.