### PR TITLE
Fix Polli GIF inputs and timeout retries

### DIFF
--- a/apps/polli/src/ai/client.py
+++ b/apps/polli/src/ai/client.py
@@ -263,25 +263,33 @@ class PollinationsClient:
         # Build current user message with media (images and videos)
         # NOTE: file_urls are NOT sent as media - they're mentioned in text for the AI to use web_scrape on
         file_urls = file_urls or []
-        file_notice = ""
+        notices = []
         if file_urls:
-            file_notice = (
-                f"\n\n[User attached {len(file_urls)} text/code file(s). Use web_scrape(action='fetch_file', file_url='...') to read them:\n"
+            notices.append(
+                f"[User attached {len(file_urls)} text/code file(s). "
+                "Use web_scrape(action='fetch_file', file_url='...') to read them:\n"
                 + "\n".join(f"- {url}" for url in file_urls[:5])
                 + "]"
             )
+        if video_urls:
+            notices.append(
+                f"[User attached or linked {len(video_urls)} video/GIF(s). "
+                "These URLs are context, not image inputs:\n"
+                + "\n".join(f"- {url}" for url in video_urls[:5])
+                + "]"
+            )
+        file_notice = "\n\n" + "\n\n".join(notices) if notices else ""
 
-        if image_urls or video_urls:
+        if image_urls:
             content = [
                 {
                     "type": "text",
                     "text": f"[{discord_username}]: {user_message}{file_notice}",
                 }
             ]
-            # Add images and videos as image_url (model handles both)
-            for url in (image_urls or [])[:10]:
-                content.append({"type": "image_url", "image_url": {"url": url}})
-            for url in (video_urls or [])[:10]:
+            # Only static images are valid OpenAI image_url inputs. Video/GIF URLs stay
+            # in the text notice above so unsupported media cannot poison the request.
+            for url in image_urls[:10]:
                 content.append({"type": "image_url", "image_url": {"url": url}})
             messages.append({"role": "user", "content": content})
         else:

--- a/apps/polli/src/bot.py
+++ b/apps/polli/src/bot.py
@@ -369,10 +369,13 @@ def extract_media_urls(
 
     # Process embeds
     for embed in message.embeds:
-        # YouTube and other video embeds - check embed.url first (the actual link)
-        if embed.url and is_video_url(embed.url):
+        # Discord's GIFV embeds expose an MP4 plus a static WebP thumbnail. OpenAI's
+        # image_url input cannot decode the MP4, so give vision the preview frame.
+        if embed.video and embed.thumbnail and embed.thumbnail.url:
+            image_urls.append(embed.thumbnail.url)
+        # YouTube and other video embeds - keep the actual link as text context.
+        elif embed.url and is_video_url(embed.url):
             video_urls.append(embed.url)
-        # Video embed URL (Tenor/Giphy GIFs, video players)
         elif embed.video and embed.video.url:
             video_urls.append(embed.video.url)
         # Regular embedded images
@@ -381,8 +384,7 @@ def extract_media_urls(
                 video_urls.append(embed.image.url)
             else:
                 image_urls.append(embed.image.url)
-        # Thumbnail as fallback (static preview) - only if not a video embed
-        elif embed.thumbnail and embed.thumbnail.url and not embed.video:
+        elif embed.thumbnail and embed.thumbnail.url:
             image_urls.append(embed.thumbnail.url)
 
     return image_urls, video_urls, file_urls

--- a/apps/polli/tests/test_media_inputs.py
+++ b/apps/polli/tests/test_media_inputs.py
@@ -1,0 +1,61 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from src.ai.client import PollinationsClient
+from src.bot import extract_media_urls
+
+
+class FakeMessage:
+    attachments = []
+
+    def __init__(self, embeds):
+        self.embeds = embeds
+
+
+class MediaExtractionTests(unittest.TestCase):
+    def test_gifv_embed_uses_static_thumbnail_for_vision(self):
+        embed = SimpleNamespace(
+            url="https://klipy.com/gifs/idiots-no-intelligent-life-vEn",
+            type="gifv",
+            image=None,
+            thumbnail=SimpleNamespace(url="https://static.klipy.com/preview.webp"),
+            video=SimpleNamespace(url="https://static.klipy.com/animation.mp4"),
+        )
+
+        images, videos, files = extract_media_urls(FakeMessage([embed]))  # type: ignore[arg-type]
+
+        self.assertEqual(images, ["https://static.klipy.com/preview.webp"])
+        self.assertEqual(videos, [])
+        self.assertEqual(files, [])
+
+
+class ClientMediaTests(unittest.IsolatedAsyncioTestCase):
+    async def test_video_urls_are_text_not_image_inputs(self):
+        client = PollinationsClient()
+        capture = AsyncMock(
+            return_value={
+                "response": "ok",
+                "tool_calls": [],
+                "tool_results": [],
+                "content_blocks": [],
+                "usage": {},
+            }
+        )
+
+        with patch.object(client, "_call_with_tools", capture):
+            await client.process_with_tools(
+                user_message="what is happening here?",
+                discord_username="tester",
+                video_urls=["https://static.klipy.com/animation.mp4"],
+            )
+
+        messages = capture.await_args.args[0]
+        current = messages[-1]["content"]
+        self.assertIsInstance(current, str)
+        self.assertIn("https://static.klipy.com/animation.mp4", current)
+        self.assertIn("video", current.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two live failures had different symptoms but shared the same bad retry behavior.

**GIF inputs:** Discord GIFV embeds expose a static thumbnail and an MP4. Polli picked the MP4, sent it as an OpenAI `image_url`, then retried the same undecodable payload three times. It now uses the static WebP preview for vision and keeps raw video/GIF URLs as text context.

**Long text replies:** a pathological GLM request timed out at 60s, then Polli retried GLM with the same hardcoded seed `42` despite the code claiming retries use a fresh seed and fallback model. This produced 109–193 second stalls. Timeouts and network errors now switch immediately to Kimi, with a fresh implicit seed per attempt. Explicit caller seeds remain stable.

Four regression tests cover both extraction/message-building seams and both seed/fallback behaviors. Replayed the original Klipy preview through Kimi: 200, correctly identified Buzz Lightyear.
