### PR TITLE
fix: remap image provider errors

### DIFF
--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -239,6 +239,9 @@ type ParsedUpstreamBody = {
     text: string | null;
 };
 
+const OPERATIONAL_PROVIDER_ERROR_PATTERN =
+    /rate[ -]?limit|too many requests|quota|capacity|insufficient (?:credit|balance)|invalid api key|unauthori[sz]ed|forbidden/i;
+
 /**
  * Build the responseBody to thread through UpstreamError so clients see a real
  * error message instead of `"{}"`. Prefer the upstream provider's raw body
@@ -261,11 +264,22 @@ function classifyImageHttpError(error: HttpError): {
     message: string;
 } {
     const parsed = parseUpstreamErrorBody(error);
+    const providerText = [
+        parsed.text,
+        error.message,
+        typeof error.details?.body === "string" ? error.details.body : null,
+    ]
+        .filter(Boolean)
+        .join(" ");
+    const isOperationalProviderError =
+        Boolean(error.upstreamUrl) &&
+        OPERATIONAL_PROVIDER_ERROR_PATTERN.test(providerText);
     const isValidation =
-        error.status === 422 ||
-        (error.status === 400 &&
-            (error.details?.validation === true ||
-                parsed.kind === "validation"));
+        !isOperationalProviderError &&
+        (error.status === 422 ||
+            (error.status === 400 &&
+                (error.details?.validation === true ||
+                    parsed.kind === "validation")));
 
     if (isValidation) {
         const text = parsed.text || error.message;
@@ -287,7 +301,10 @@ function classifyImageHttpError(error: HttpError): {
     if (error.status >= 400 && error.status < 500) {
         const text = parsed.text || error.message;
         return {
-            status: remapUpstreamStatus(error.status),
+            // Any provider rejection that was not identified above as input
+            // validation is an operational model failure. Surface it as 502
+            // so health monitoring does not discard it as client noise.
+            status: 502,
             message: text
                 ? `Image provider error: ${text}`
                 : "Image provider error",

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -140,6 +140,9 @@ async function fakeImageBackendResponse(request: Request) {
             { status: 400 },
         );
     }
+    if (prompt.includes("rate limit 400")) {
+        return Response.json({ detail: "Rate limit exceeded" }, { status: 400 });
+    }
     if (prompt.includes("empty body 400")) {
         return new Response("", { status: 400 });
     }
@@ -1004,7 +1007,7 @@ test("sana uses its fixed backend and records its flat price", async ({
     });
 });
 
-test("image backend validation errors return client-facing 400", async ({
+test("image backend separates validation errors from provider failures", async ({
     paidApiKey,
     mocks,
 }) => {
@@ -1081,11 +1084,11 @@ test("image backend validation errors return client-facing 400", async ({
             },
         );
 
-    expect(provider400Response.status).toBe(400);
+    expect(provider400Response.status).toBe(502);
     await expect(provider400Response.json()).resolves.toMatchObject({
         success: false,
         error: {
-            code: "BAD_REQUEST",
+            code: "BAD_GATEWAY",
             message: "Image provider error: missing provider key",
         },
     });
@@ -1095,7 +1098,32 @@ test("image backend validation errors return client-facing 400", async ({
     expect(mocks.tinybird.state.events[2]).toMatchObject({
         eventType: "generate.image",
         modelRequested: "zimage",
-        responseStatus: 400,
+        responseStatus: 502,
+    });
+
+    const { response: rateLimit400Response, wait: waitRateLimit400 } =
+        await fetchWorker(
+            "/image/rate%20limit%20400?model=zimage&width=280&height=280&seed=42",
+            {
+                headers: { authorization: `Bearer ${paidApiKey}` },
+            },
+        );
+
+    expect(rateLimit400Response.status).toBe(502);
+    await expect(rateLimit400Response.json()).resolves.toMatchObject({
+        success: false,
+        error: {
+            code: "BAD_GATEWAY",
+            message: "Image provider error: Rate limit exceeded",
+        },
+    });
+    await waitRateLimit400();
+
+    expect(mocks.tinybird.state.events).toHaveLength(4);
+    expect(mocks.tinybird.state.events[3]).toMatchObject({
+        eventType: "generate.image",
+        modelRequested: "zimage",
+        responseStatus: 502,
     });
 
     // Upstream 400 with empty body must still surface a useful message via
@@ -1108,11 +1136,11 @@ test("image backend validation errors return client-facing 400", async ({
             },
         );
 
-    expect(emptyBody400Response.status).toBe(400);
+    expect(emptyBody400Response.status).toBe(502);
     await expect(emptyBody400Response.json()).resolves.toMatchObject({
         success: false,
         error: {
-            code: "BAD_REQUEST",
+            code: "BAD_GATEWAY",
             message:
                 "Image provider error: Image backend rejected request with status 400",
         },


### PR DESCRIPTION
- Keeps recognized image validation and moderation failures as client-facing 4xx.
- Maps other provider-origin image 4xx responses to 502, including quota, rate-limit, and provider-auth failures returned as HTTP 400.
- Ensures model-health analytics count those responses as provider failures.
- Adds regression coverage for plain, empty-body, and rate-limit provider 400 responses.

Checks:
- `npx biome check --write gen.pollinations.ai/src/image/handler.ts gen.pollinations.ai/test/generation-vcr.test.ts`
- Pure image moderation suite: 38/38 passed
- Full Workers integration collection is deferred to CI because the local Workers harness exits before collecting tests on unchanged baseline code too.