### PR TITLE
chore: prune agent scaffolding written for older models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,25 +190,13 @@ npx vitest run test/file.test.ts
 ## Workflow Orchestration
 
 - Plan mode for any non-trivial task (3+ steps or architectural). If things go sideways, STOP and re-plan. Write specs upfront.
-- Use subagents liberally for research, exploration, parallel analysis — one task per subagent.
+- Delegate to a subagent only for large, genuinely independent tracks of work (e.g. a wide multi-file investigation). Don't delegate what you can finish in a handful of tool calls, and don't use subagents to verify your own work.
 - After user correction: propose an AGENTS.md update capturing the pattern; iterate until mistake rate drops.
-- Never mark complete without proving it works — run tests, check logs, diff vs main when relevant.
-- Non-trivial changes: ask "is there a more elegant way?" If fix feels hacky, redo elegantly. Skip for obvious fixes.
 - Bug reports: just fix them — point at logs/errors/failing tests and resolve. Fix failing CI without being asked how.
-
-## Task Management
-
-1. Plan first (todos or plan mode). 2. Verify plan before implementing. 3. Track progress. 4. Summarize changes. 5. Capture lessons in AGENTS.md.
 
 ## Compact Instructions
 
 Preserve during compaction: modified files + line numbers, all code/diffs/impl details, test output + errors + command results, full plan + progress + pending, user preferences/corrections this session, architectural decisions + rationale.
-
-## Core Principles
-
-- Simplicity first — minimal code impact.
-- No laziness — find root causes, no temp fixes, senior standards.
-- Minimal impact — touch only what's necessary.
 
 ## Git Workflow
 


### PR DESCRIPTION
Trims `AGENTS.md` instructions that Anthropic's current Opus 5 / Fable 5 prompting guides identify as counterproductive.

- Replaces "use subagents liberally" with explicit delegation limits — Opus 5 delegates more readily than prior models, and the docs recommend capping it
- Drops "never mark complete without proving it works" and the "is there a more elegant way?" self-critique prompt — [the Opus 5 guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) says explicit verification instructions cause over-verification with no quality gain
- Drops **Task Management** and **Core Principles** — both duplicate instructions the built-in system prompt already carries
- No behavioural/code change; instructions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)