### PR TITLE
fix: require paid balance for OpenRouter models

### DIFF
--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -740,6 +740,15 @@ test("Google text model providers match their configured routes", () => {
     }
 });
 
+test("OpenRouter models require paid balance", () => {
+    for (const model of getModels()) {
+        const definition = getRegistryModelDefinition(model);
+        if (definition.provider === "openrouter") {
+            expect(definition.paidOnly, `${model} paid-only status`).toBe(true);
+        }
+    }
+});
+
 test("bedrock nova models price cache writes free and reads at 25% of input", () => {
     // AWS Price List API (verified 2026-07-05): Nova cache writes are a $0
     // SKU; cache reads bill at 25% of the standard input rate.

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -1,6 +1,10 @@
 import { SELF } from "cloudflare:test";
 import { getAudioModelsInfo } from "@shared/registry/model-info.ts";
 import {
+    getRegistryModelDefinition,
+    getVisibleTextModels,
+} from "@shared/registry/registry.ts";
+import {
     createTestApiKey,
     RESTRICTED_IMAGE_TEST_MODEL,
     RESTRICTED_TEST_MODELS,
@@ -72,7 +76,10 @@ test("empty model permissions deny access and return an empty catalog", async ()
     expect(generationResponse.status).toBe(403);
 });
 
-test("filters gemini-fast by paid balance", async ({ apiKey, paidApiKey }) => {
+test("filters OpenRouter text models by paid balance", async ({
+    apiKey,
+    paidApiKey,
+}) => {
     const freeResponse = await fetchWorker("/v1/models", {
         headers: { Authorization: `Bearer ${apiKey}` },
     });
@@ -89,13 +96,25 @@ test("filters gemini-fast by paid balance", async ({ apiKey, paidApiKey }) => {
     const paidModels = (await paidResponse.json()) as {
         data: { id: string }[];
     };
+    const openRouterModelNames = getVisibleTextModels().filter(
+        (model) => getRegistryModelDefinition(model).provider === "openrouter",
+    );
+    const freeModelNames = new Set(freeModels.data.map((model) => model.id));
+    const paidModelNames = new Set(paidModels.data.map((model) => model.id));
 
-    expect(freeModels.data.some((model) => model.id === "gemini-fast")).toBe(
-        false,
+    expect(openRouterModelNames.length).toBeGreaterThan(0);
+    expect(
+        openRouterModelNames.every((model) => !freeModelNames.has(model)),
+    ).toBe(true);
+    expect(
+        openRouterModelNames.every((model) => paidModelNames.has(model)),
+    ).toBe(true);
+
+    const generation = await fetchWorker(
+        "/text/paid-only-check?model=mistral",
+        { headers: { Authorization: `Bearer ${apiKey}` } },
     );
-    expect(paidModels.data.some((model) => model.id === "gemini-fast")).toBe(
-        true,
-    );
+    expect(generation.status).toBe(402);
 });
 
 test("filters paid-only audio models by paid balance", async ({

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -289,6 +289,7 @@ export const TEXT_SERVICES = {
         brand: "Mistral",
         category: "text",
         addedDate: new Date("2025-10-07").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.075),
@@ -315,6 +316,7 @@ export const TEXT_SERVICES = {
         brand: "Mistral",
         category: "text",
         addedDate: new Date("2026-05-15").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.15),
@@ -561,6 +563,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-05-08").getTime(),
         brand: "Google",
         category: "text",
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             // OpenRouter google/gemma-4-26b-a4b-it posted rates (2026-06-02):
@@ -585,7 +588,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-07-18").getTime(),
         brand: "Google",
         category: "text",
-        paidOnly: false,
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.12),
@@ -1287,7 +1290,7 @@ export const TEXT_SERVICES = {
         brand: "Xiaomi",
         category: "text",
         addedDate: new Date("2026-07-18").getTime(),
-        paidOnly: false,
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.14),
@@ -1310,7 +1313,7 @@ export const TEXT_SERVICES = {
         brand: "Xiaomi",
         category: "text",
         addedDate: new Date("2026-07-18").getTime(),
-        paidOnly: false,
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.435),
@@ -1489,6 +1492,7 @@ export const TEXT_SERVICES = {
         brand: "Meta",
         category: "text",
         addedDate: new Date("2026-05-04").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.1),
@@ -1633,7 +1637,7 @@ export const TEXT_SERVICES = {
         brand: "Qwen",
         category: "text",
         addedDate: new Date("2026-06-12").getTime(),
-        paidOnly: false,
+        paidOnly: true,
         priceMultiplier: 1,
         // OpenRouter triples token rates above 256K prompt tokens. Pollinations
         // keeps the full context window and absorbs that higher tier.
@@ -1690,6 +1694,7 @@ export const TEXT_SERVICES = {
         brand: "Qwen",
         category: "text",
         addedDate: new Date("2026-03-22").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.13),
@@ -1716,6 +1721,7 @@ export const TEXT_SERVICES = {
         provider: "openrouter",
         brand: "Qwen",
         addedDate: new Date("2026-05-15").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         category: "text",
         cost: {
@@ -1739,6 +1745,7 @@ export const TEXT_SERVICES = {
         brand: "StepFun",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             // OpenRouter stepfun/step-3.7-flash posted rates (2026-05-29):
@@ -1766,6 +1773,7 @@ export const TEXT_SERVICES = {
         brand: "StepFun",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             // OpenRouter stepfun/step-3.5-flash posted rates (2026-07-10):


### PR DESCRIPTION
- Marks the 12 remaining OpenRouter text models as paid-only: `mistral-small-3.2`, `mistral`, `gemma`, `gemma-4-31b`, `mimo-v2.5`, `mimo-v2.5-pro`, `llama-scout`, `qwen-large`, `qwen-vision`, `qwen-vision-pro`, `step-flash`, and `step-3.5-flash`.
- Leaves model IDs, providers, aliases, capabilities, pricing, multipliers, and routing unchanged.
- Adds a registry invariant requiring every OpenRouter model to be paid-only.
- Extends worker-level coverage to verify OpenRouter text models are hidden without pack balance, visible with pack balance, and rejected with HTTP 402 when called without paid balance.

Tests:
- Enter aliases: 274 passed
- Enter pricing and snapshot: 29 passed
- Gen permissions and billing: 12 passed
- Biome and `git diff --check` passed