### PR TITLE
feat: move Kimi K3 to Fireworks

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -335,8 +335,8 @@ const models: ModelDefinition[] = [
     },
     {
         name: "kimi-k3",
-        config: portkeyConfig["moonshotai/kimi-k3"],
-        transform: stripCacheControl,
+        config: portkeyConfig["accounts/fireworks/models/kimi-k3"],
+        transform: pipe(stripCacheControl, fireworksThinking),
     },
     {
         name: "laguna",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -145,11 +145,6 @@ export const portkeyConfig: PortkeyConfigMap = {
         ),
 
     // -- OpenRouter (frontier models) ----------------------------------------
-    "moonshotai/kimi-k3": () =>
-        createOpenRouterModelConfig({
-            model: "moonshotai/kimi-k3",
-            defaultOptions: { provider: { sort: "price" } },
-        }),
     "x-ai/grok-4.5": () =>
         createOpenRouterModelConfig({
             model: "x-ai/grok-4.5",
@@ -248,6 +243,10 @@ export const portkeyConfig: PortkeyConfigMap = {
     "accounts/fireworks/models/kimi-k2p7-code": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/kimi-k2p7-code",
+        }),
+    "accounts/fireworks/models/kimi-k3": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/kimi-k3",
         }),
 
     // -- OpenRouter (Mistral Small 3.2, Mistral Small 4) ---------------------

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -79,6 +79,7 @@ describe("reasoning_effort model wiring", () => {
         "glm",
         "kimi",
         "kimi-code",
+        "kimi-k3",
         "deepseek",
         "qwen-large",
         "longcat",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -86,6 +86,17 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes Kimi K3 directly to Fireworks without fallback", () => {
+        const result = resolveModelConfig(messages, { model: "kimi-k3" });
+
+        expect(result.options.model).toBe("accounts/fireworks/models/kimi-k3");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it.each([
         "perplexity-high",
         "perplexity-deep",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1183,12 +1183,13 @@ export const TEXT_SERVICES = {
     },
     "kimi-k3": {
         aliases: [],
-        provider: "openrouter",
+        provider: "fireworks",
         brand: "Moonshot AI",
         category: "text",
         addedDate: new Date("2026-07-18").getTime(),
-        paidOnly: true,
+        paidOnly: false,
         priceMultiplier: 1,
+        // Fireworks standard serverless rates (2026-07-30).
         cost: {
             promptTextTokens: perMillion(3),
             promptCachedTokens: perMillion(0.3),


### PR DESCRIPTION
- Routes `kimi-k3` to Fireworks standard serverless with no fallback.
- Keeps the existing model contract and $3/M input, $0.30/M cached-input, and $15/M output pricing.
- Opens the model to Quest Pollen while retaining multiplier 1.
- Verifies text, vision (1/10 images), reasoning, tools, JSON, streaming, prompt cache, billing, errors, and 5/15/30-request bursts end to end.
- Passes Gen tests/typecheck and focused Enter registry, access, and effective-price tests (302/302).