### PR TITLE
feat: update AssemblyAI to Universal-3.5 Pro

### DIFF
--- a/apps/polli-agent/src/polli_agent/registry.py
+++ b/apps/polli-agent/src/polli_agent/registry.py
@@ -100,8 +100,24 @@ def _infer_meta(item: dict[str, Any]) -> dict[str, Any]:
         modalities.append("audio")
     if any(
         k in owned
-        for k in ["transcribe", "scrib", "whisper", "universal-2", "universal-3-pro"]
-    ) or any(k in mid for k in ["whisper", "scribe", "universal-2", "universal-3-pro"]):
+        for k in [
+            "transcribe",
+            "scrib",
+            "whisper",
+            "universal-2",
+            "universal-3.5-pro",
+            "universal-3-pro",
+        ]
+    ) or any(
+        k in mid
+        for k in [
+            "whisper",
+            "scribe",
+            "universal-2",
+            "universal-3.5-pro",
+            "universal-3-pro",
+        ]
+    ):
         modalities.append("transcript")
     if any(k in owned for k in ["image", "pollen"]) or any(
         k in mid

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1482,7 +1482,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptAudioSeconds": 0.0000416666666666667,
     },
   },
-  "universal-3-pro": {
+  "universal-3.5-pro": {
     "cost": {
       "promptAudioSeconds": 0.0000583333333333333,
     },

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -547,7 +547,7 @@ function parseFallbackUsed(response: Response): boolean {
 // caller skips the check entirely. Preserves the per-branch rules: image/video
 // uses startsWith; text-stream only guards when a stream was requested and uses
 // includes; audio allows audio/*, STT JSON, or explicitly marked timestamped
-// TTS JSON.
+// TTS JSON. STT also supports plain-text subtitle and transcript formats.
 function getContentTypeGuard(
     eventType: EventType,
     requestTracking: RequestTrackingData,
@@ -581,7 +581,10 @@ function getContentTypeGuard(
             kind: "audio",
             isExpected: (contentType) =>
                 contentType.startsWith("audio/") ||
-                ((isSTTModel || isTimestampedTts) &&
+                (isSTTModel &&
+                    (contentType.startsWith("application/json") ||
+                        contentType.startsWith("text/plain"))) ||
+                (isTimestampedTts &&
                     contentType.startsWith("application/json")),
         };
     }

--- a/gen.pollinations.ai/src/routes/assemblyai-transcription.ts
+++ b/gen.pollinations.ai/src/routes/assemblyai-transcription.ts
@@ -16,7 +16,7 @@ const ASSEMBLYAI_POLL_INTERVAL_MS = 2_000;
 const ASSEMBLYAI_TRANSCRIPTION_TIMEOUT_MS = 240_000;
 const ASSEMBLYAI_MODELS: Record<string, string[]> = {
     "universal-2": ["universal-2"],
-    "universal-3-pro": ["universal-3-pro", "universal-2"],
+    "universal-3.5-pro": ["universal-3-5-pro"],
 };
 
 interface AssemblyAiUploadResponse {
@@ -216,7 +216,7 @@ async function submitAssemblyAiTranscript(opts: {
     } else {
         transcriptRequest.language_detection = true;
     }
-    if (speechModels[0] === "universal-3-pro") {
+    if (speechModels[0] === "universal-3-5-pro") {
         if (prompt) transcriptRequest.prompt = prompt;
         if (temperature !== undefined)
             transcriptRequest.temperature = temperature;
@@ -356,7 +356,8 @@ function getAssemblyAiErrorStatus(message: string): 400 | 500 {
     const normalized = message.toLowerCase();
     if (
         normalized.includes("no spoken audio") ||
-        normalized.includes("does not appear to contain audio")
+        normalized.includes("does not appear to contain audio") ||
+        normalized.includes("transcoding failed")
     ) {
         return 400;
     }
@@ -368,7 +369,7 @@ function getAssemblyAiRegistryModel(
     fallbackModel: string,
 ): string {
     if (speechModelUsed === "universal-2") return "universal-2";
-    if (speechModelUsed === "universal-3-pro") return "universal-3-pro";
+    if (speechModelUsed === "universal-3-5-pro") return "universal-3.5-pro";
     return fallbackModel;
 }
 

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -2936,7 +2936,7 @@ export const audioRoutes = new Hono<Env>()
                 "- `whisper-1` — Alias for whisper-large-v3",
                 "- `scribe` — ElevenLabs Scribe (90+ languages, word-level timestamps)",
                 "- `universal-2` — AssemblyAI Universal-2 (99 languages)",
-                "- `universal-3-pro` — AssemblyAI Universal-3 Pro (highest accuracy, prompting)",
+                "- `universal-3.5-pro` — AssemblyAI Universal-3.5 Pro (18 languages, code switching, prompting)",
             ].join("\n"),
             requestBody: {
                 required: true,
@@ -2956,7 +2956,7 @@ export const audioRoutes = new Hono<Env>()
                                     type: "string",
                                     default: "whisper-large-v3",
                                     description:
-                                        "The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `universal-2`, `universal-3-pro`.",
+                                        "The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `universal-2`, `universal-3.5-pro`.",
                                 },
                                 language: {
                                     type: "string",
@@ -3109,7 +3109,7 @@ export const audioRoutes = new Hono<Env>()
 
             if (
                 c.var.model.resolved === "universal-2" ||
-                c.var.model.resolved === "universal-3-pro"
+                c.var.model.resolved === "universal-3.5-pro"
             ) {
                 const assemblyAiApiKey = (
                     c.env as unknown as { ASSEMBLYAI_API_KEY: string }

--- a/gen.pollinations.ai/test/assemblyai-transcription.test.ts
+++ b/gen.pollinations.ai/test/assemblyai-transcription.test.ts
@@ -17,7 +17,7 @@ describe("transcribeWithAssemblyAi", () => {
         vi.clearAllMocks();
     });
 
-    it("submits Universal-3 Pro with Universal-2 fallback and bills the model used", async () => {
+    it("submits only Universal-3.5 Pro and bills the canonical model", async () => {
         const fetchMock = vi
             .fn()
             .mockResolvedValueOnce(
@@ -33,7 +33,7 @@ describe("transcribeWithAssemblyAi", () => {
                     text: "hello world",
                     audio_duration: 12,
                     language_code: "en_us",
-                    speech_model_used: "universal-2",
+                    speech_model_used: "universal-3-5-pro",
                     words: [
                         { text: "hello", start: 0, end: 500 },
                         { text: "world", start: 600, end: 1200 },
@@ -44,7 +44,7 @@ describe("transcribeWithAssemblyAi", () => {
 
         const response = await transcribeWithAssemblyAi({
             file: new File(["audio"], "audio.mp3", { type: "audio/mpeg" }),
-            model: "universal-3-pro",
+            model: "universal-3.5-pro",
             apiKey: "test-key",
             responseFormat: "verbose_json",
             language: "en",
@@ -53,7 +53,7 @@ describe("transcribeWithAssemblyAi", () => {
             log,
         });
 
-        expect(response.headers.get("x-model-used")).toBe("universal-2");
+        expect(response.headers.get("x-model-used")).toBe("universal-3.5-pro");
         expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("12");
         await expect(response.json()).resolves.toMatchObject({
             text: "hello world",
@@ -70,7 +70,7 @@ describe("transcribeWithAssemblyAi", () => {
         );
         expect(submitBody).toMatchObject({
             audio_url: "https://cdn.assemblyai.com/upload/test-audio",
-            speech_models: ["universal-3-pro", "universal-2"],
+            speech_models: ["universal-3-5-pro"],
             language_code: "en_us",
             prompt: "Names include Pollinations.",
             temperature: 0,
@@ -92,7 +92,7 @@ describe("transcribeWithAssemblyAi", () => {
                     status: "completed",
                     text: "hello world",
                     audio_duration: 3,
-                    speech_model_used: "universal-3-pro",
+                    speech_model_used: "universal-3-5-pro",
                 }),
             )
             .mockResolvedValueOnce(new Response("WEBVTT\n\n00:00.000 -->"));
@@ -100,13 +100,13 @@ describe("transcribeWithAssemblyAi", () => {
 
         const response = await transcribeWithAssemblyAi({
             file: new File(["audio"], "audio.mp3", { type: "audio/mpeg" }),
-            model: "universal-3-pro",
+            model: "universal-3.5-pro",
             apiKey: "test-key",
             responseFormat: "vtt",
             log,
         });
 
-        expect(response.headers.get("x-model-used")).toBe("universal-3-pro");
+        expect(response.headers.get("x-model-used")).toBe("universal-3.5-pro");
         expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("3");
         await expect(response.text()).resolves.toContain("WEBVTT");
         expect(fetchMock.mock.calls[3][0]).toBe(
@@ -130,7 +130,7 @@ describe("transcribeWithAssemblyAi", () => {
                     text: "hello there general kenobi",
                     audio_duration: 8,
                     language_code: "en_us",
-                    speech_model_used: "universal-3-pro",
+                    speech_model_used: "universal-3-5-pro",
                     utterances: [
                         {
                             speaker: "A",
@@ -151,7 +151,7 @@ describe("transcribeWithAssemblyAi", () => {
 
         const response = await transcribeWithAssemblyAi({
             file: new File(["audio"], "audio.mp3", { type: "audio/mpeg" }),
-            model: "universal-3-pro",
+            model: "universal-3.5-pro",
             apiKey: "test-key",
             responseFormat: "diarized_json",
             speakersExpected: 2,
@@ -233,6 +233,7 @@ describe("transcribeWithAssemblyAi", () => {
         const clientErrorMessages = [
             "language_detection cannot be performed on files with no spoken audio.",
             "Transcoding failed. File does not appear to contain audio. File type is text/plain (ASCII text).",
+            "Transcoding failed. File type text/plain (ASCII text) may be unsupported or an unexpected error occurred.",
         ];
 
         for (const message of clientErrorMessages) {

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -159,6 +159,12 @@ test("filters paid-only audio models by paid balance", async ({
     );
     expect(freeModels.some((model) => model.paid_only)).toBe(false);
     expect(paidModels.some((model) => model.paid_only)).toBe(true);
+    expect(freeModels.some((model) => model.name === "universal-3.5-pro")).toBe(
+        false,
+    );
+    expect(
+        paidModels.find((model) => model.name === "universal-3.5-pro"),
+    ).toMatchObject({ paid_only: true });
 });
 
 test("requires paid balance for Recraft vector", async ({

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -160,11 +160,11 @@ test("filters paid-only audio models by paid balance", async ({
     expect(freeModels.some((model) => model.paid_only)).toBe(false);
     expect(paidModels.some((model) => model.paid_only)).toBe(true);
     expect(freeModels.some((model) => model.name === "universal-3.5-pro")).toBe(
-        false,
+        true,
     );
-    expect(
-        paidModels.find((model) => model.name === "universal-3.5-pro"),
-    ).toMatchObject({ paid_only: true });
+    expect(paidModels.some((model) => model.name === "universal-3.5-pro")).toBe(
+        true,
+    );
 });
 
 test("requires paid balance for Recraft vector", async ({

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -770,6 +770,62 @@ describe("tracking observability", () => {
         expect(consumePollen).toHaveBeenCalledWith(0.0002);
     });
 
+    it("bills plain-text speech-to-text responses from usage headers", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+        const upstream = new Response("hello world", {
+            headers: {
+                "content-type": "text/plain; charset=utf-8",
+                "x-model-used": "universal-3.5-pro",
+                "x-usage-prompt-audio-seconds": "6",
+            },
+        });
+
+        const ctx = createExecutionContext();
+        const response = await createWrongContentTypeApp(
+            consumePollen,
+            "generate.audio",
+            upstream,
+            "universal-3.5-pro",
+        ).fetch(
+            new Request("https://gen.pollinations.ai/upstream", {
+                method: "POST",
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(tinybirdRequests).toHaveLength(1);
+        await expect(tinybirdRequests[0].json()).resolves.toMatchObject({
+            eventType: "generate.audio",
+            isBilledUsage: true,
+            tokenCountPromptAudioSeconds: 6,
+            totalCost: 0.00035,
+            totalPrice: 0.00035,
+        });
+        expect(consumePollen).toHaveBeenCalledWith(0.00035);
+    });
+
     it("does not bill ordinary TTS when a provider returns JSON with HTTP 200", async () => {
         const tinybirdRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -127,7 +127,7 @@ Cheapest path: `--model wan-fast` at ~$0.01/sec, **fixed 5-second output** (any 
 ```bash
 polli gen transcribe recording.mp3 --language en
 ```
-Models: `whisper` (default), `scribe`, `universal-2`, `universal-3-pro`. Accepts common audio formats (mp3, wav, m4a, flac, ogg); non-audio input (e.g. a `.txt` file) returns a clear `400 invalid_request_error: extension "txt" not supported` — no need to pre-validate with `file`. Default output is the plain transcript on stdout as a single line (pipe-friendly). Use `--json` for structured output: **whisper** and **AssemblyAI** return timing data when requested through the API; **scribe** returns only `{text: "..."}` — use whisper or AssemblyAI if you need timing data. `--language <ISO-639-1>` (e.g. `en`, `fr`) is an optional hint that can improve accuracy for non-English or accented speech.
+Models: `whisper` (default), `scribe`, `universal-2`, `universal-3.5-pro`. Accepts common audio formats (mp3, wav, m4a, flac, ogg); non-audio input (e.g. a `.txt` file) returns a clear `400 invalid_request_error: extension "txt" not supported` — no need to pre-validate with `file`. Default output is the plain transcript on stdout as a single line (pipe-friendly). Use `--json` for structured output: **whisper** and **AssemblyAI** return timing data when requested through the API; **scribe** returns only `{text: "..."}` — use whisper or AssemblyAI if you need timing data. `--language <ISO-639-1>` (e.g. `en`, `fr`) is an optional hint that can improve accuracy for non-English or accented speech.
 
 ### Discover models
 ```bash

--- a/packages/polli-cli/src/commands/gen/transcribe.ts
+++ b/packages/polli-cli/src/commands/gen/transcribe.ts
@@ -17,7 +17,7 @@ export function createTranscribeCommand() {
         .argument("<file>", "Audio file path (mp3, wav, etc.)")
         .option(
             "--model <model>",
-            "STT model (whisper, scribe, universal-2, universal-3-pro)",
+            "STT model (whisper, scribe, universal-2, universal-3.5-pro)",
             "whisper",
         )
         .option("--language <lang>", "Language hint (ISO code)")

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -473,6 +473,7 @@ export type TranscriptionModel =
     | "whisper-1"
     | "scribe"
     | "universal-2"
+    | "universal-3.5-pro"
     | "universal-3-pro"
     | string;
 

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -315,7 +315,6 @@ export const AUDIO_SERVICES = {
         brand: "AssemblyAI",
         category: "audio",
         addedDate: new Date("2026-05-02").getTime(),
-        paidOnly: true,
         priceMultiplier: 1,
         cost: {
             // AssemblyAI Universal-3.5 Pro async: $0.21/hour

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -300,8 +300,13 @@ export const AUDIO_SERVICES = {
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },
-    "universal-3-pro": {
+    "universal-3.5-pro": {
         aliases: [
+            "universal-3-pro",
+            "universal-3-5-pro",
+            "assemblyai-universal-3.5-pro",
+            "assemblyai-universal-3-5-pro",
+            "assemblyai-u3.5-pro",
             "assemblyai-universal-3-pro",
             "assemblyai-u3-pro",
             "assemblyai-pro",
@@ -310,13 +315,15 @@ export const AUDIO_SERVICES = {
         brand: "AssemblyAI",
         category: "audio",
         addedDate: new Date("2026-05-02").getTime(),
+        paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // AssemblyAI Universal-3 Pro: $0.21/hour
+            // AssemblyAI Universal-3.5 Pro async: $0.21/hour
             promptAudioSeconds: 0.21 / 3600,
         },
-        title: "AssemblyAI Universal-3 Pro",
-        description: "Top-accuracy transcription you can steer with prompts",
+        title: "AssemblyAI Universal-3.5 Pro",
+        description:
+            "High-accuracy transcription with multilingual code switching and prompts",
         inputModalities: ["audio"],
         outputModalities: ["text"],
     },


### PR DESCRIPTION
- Replaces the canonical AssemblyAI service with `universal-3.5-pro` while preserving every Universal-3 Pro ID as an alias.
- Pins direct async inference to `universal-3-5-pro` with no fallback; keeps the $0.21/audio-hour base rate, multiplier 1, and existing Quest-Pollen access.
- Updates the public catalog, SDK/CLI/agent surfaces, returns bad-audio transcoding failures as client errors, and fixes pre-existing missing billing for plain-text/SRT/VTT speech-to-text responses.
- Live E2E passed MP3/WAV/M4A/WebM, all output formats, code switching, prompting, temperature, diarization, every alias, exact wallet deductions, errors, and 5/15/30-request bursts in about 3–4.5 seconds.
- Gen passed 735/735 plus build/typecheck; focused access/model tests pass 11/11; Enter focused tests passed 308/308; SDK passed 30/30 plus typecheck. The CLI JavaScript bundle succeeds, while its unchanged Commander help typings still fail the existing declaration build.

AssemblyAI separately prices prompting (+$0.05/audio-hour) and diarization (+$0.02/audio-hour), but completed responses expose duration without usage/cost or add-on fields. That pre-existing request-aware billing limitation is documented locally as BILL-012; this PR preserves the current base-duration calculation.