### PR TITLE
feat: add Cohere Command A+

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -110,6 +110,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000009,
     },
   },
+  "command-a-plus": {
+    "cost": {
+      "completionTextTokens": 0.0000032,
+      "promptTextTokens": 0.0000008,
+    },
+    "price": {
+      "completionTextTokens": 0.0000024,
+      "promptTextTokens": 0.0000006,
+    },
+  },
   "csm-1b": {
     "cost": {
       "completionAudioTokens": 0.000007,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -1,4 +1,5 @@
 import { resolveModelName } from "@shared/registry/registry.ts";
+import { validateCohereRequest } from "./cohereCommandAPlus.js";
 import { portkeyConfig } from "./configs/modelConfigs.js";
 import midijourneyPrompt from "./personas/midijourney.js";
 import { BASE_PROMPTS } from "./prompts/systemPrompts.js";
@@ -79,6 +80,12 @@ const models: ModelDefinition[] = [
         name: "mercury",
         config: portkeyConfig["mercury-2"],
         transform: stripReasoning,
+    },
+    {
+        name: "command-a-plus",
+        config: portkeyConfig["Cohere-command-a-plus-05-2026"],
+        // Azure runs automatic reasoning but rejects/ignores effort controls.
+        transform: pipe(validateCohereRequest, stripReasoning),
     },
     {
         name: "qwen-coder",

--- a/gen.pollinations.ai/src/text/cohereCommandAPlus.ts
+++ b/gen.pollinations.ai/src/text/cohereCommandAPlus.ts
@@ -1,31 +1,105 @@
 import type { ChatCompletion, ServiceError, TransformFn } from "./types.js";
 
 const COHERE_CONTROL_TOKENS = [
+    "<|START_THINKING|>",
+    "<|END_THINKING|>",
     "<|START_TEXT|>",
     "<|END_TEXT|>",
-    "<|END_THINKING|>",
+    "<|START_RESPONSE|>",
+    "<|END_RESPONSE|>",
 ] as const;
 
-function stripControlTokens(text: string): string {
+function stripLeadingControlTokens(text: string): string {
     let cleaned = text;
-    for (const token of COHERE_CONTROL_TOKENS) {
-        cleaned = cleaned.replaceAll(token, "");
+    while (true) {
+        const token = COHERE_CONTROL_TOKENS.find((value) =>
+            cleaned.startsWith(value),
+        );
+        if (!token) return cleaned;
+        cleaned = cleaned.slice(token.length);
     }
-    return cleaned;
 }
 
-function possibleTokenPrefixLength(text: string): number {
-    let length = 0;
-    for (const token of COHERE_CONTROL_TOKENS) {
-        const maxPrefixLength = Math.min(text.length, token.length - 1);
-        for (let index = maxPrefixLength; index > length; index -= 1) {
-            if (text.endsWith(token.slice(0, index))) {
-                length = index;
-                break;
-            }
+function stripTrailingControlTokens(text: string): string {
+    let cleaned = text;
+    while (true) {
+        const token = COHERE_CONTROL_TOKENS.find((value) =>
+            cleaned.endsWith(value),
+        );
+        if (!token) return cleaned;
+        cleaned = cleaned.slice(0, -token.length);
+    }
+}
+
+function isControlTokenSequenceOrPrefix(text: string): boolean {
+    let remaining = text;
+    while (remaining) {
+        const token = COHERE_CONTROL_TOKENS.find((value) =>
+            remaining.startsWith(value),
+        );
+        if (token) {
+            remaining = remaining.slice(token.length);
+            continue;
+        }
+        return COHERE_CONTROL_TOKENS.some((value) =>
+            value.startsWith(remaining),
+        );
+    }
+    return true;
+}
+
+function possibleTrailingControlLength(text: string): number {
+    for (let index = 0; index < text.length; index += 1) {
+        if (isControlTokenSequenceOrPrefix(text.slice(index))) {
+            return text.length - index;
         }
     }
-    return length;
+    return 0;
+}
+
+class CohereContentSanitizer {
+    private pending = "";
+    private atStart = true;
+
+    push(text: string): string {
+        this.pending += text;
+
+        if (this.atStart) {
+            this.pending = stripLeadingControlTokens(this.pending);
+            if (!this.pending) return "";
+            if (
+                COHERE_CONTROL_TOKENS.some((token) =>
+                    token.startsWith(this.pending),
+                )
+            ) {
+                return "";
+            }
+            this.atStart = false;
+        }
+
+        const retainedLength = possibleTrailingControlLength(this.pending);
+        const ready =
+            retainedLength > 0
+                ? this.pending.slice(0, -retainedLength)
+                : this.pending;
+        this.pending =
+            retainedLength > 0 ? this.pending.slice(-retainedLength) : "";
+        return ready;
+    }
+
+    finish(): string {
+        let ready = this.pending;
+        if (this.atStart) ready = stripLeadingControlTokens(ready);
+        ready = stripTrailingControlTokens(ready);
+        this.pending = "";
+        this.atStart = false;
+        return ready;
+    }
+}
+
+function sanitizeContent(text: string): string {
+    const sanitizer = new CohereContentSanitizer();
+    return sanitizer.push(text) + sanitizer.finish();
 }
 
 function sanitizeStream(
@@ -33,26 +107,129 @@ function sanitizeStream(
 ): ReadableStream<Uint8Array> {
     const decoder = new TextDecoder();
     const encoder = new TextEncoder();
-    let pending = "";
+    const contentSanitizers = new Map<number, CohereContentSanitizer>();
+    let pendingSse = "";
+    let lastChunkMetadata: Record<string, unknown> = {};
+
+    function sanitizerFor(index: number): CohereContentSanitizer {
+        const existing = contentSanitizers.get(index);
+        if (existing) return existing;
+        const sanitizer = new CohereContentSanitizer();
+        contentSanitizers.set(index, sanitizer);
+        return sanitizer;
+    }
+
+    function flushPendingContent(): string {
+        let output = "";
+        for (const [index, sanitizer] of contentSanitizers) {
+            const content = sanitizer.finish();
+            if (!content) continue;
+            output += `data: ${JSON.stringify({
+                ...lastChunkMetadata,
+                choices: [
+                    {
+                        index,
+                        delta: { content },
+                        finish_reason: null,
+                    },
+                ],
+            })}\n\n`;
+        }
+        contentSanitizers.clear();
+        return output;
+    }
+
+    function sanitizeEvent(event: string): string {
+        const lines = event.split(/\r?\n/);
+        const dataIndex = lines.findIndex((line) => line.startsWith("data:"));
+        if (dataIndex < 0) return `${event}\n\n`;
+
+        const data = lines[dataIndex].slice("data:".length).trimStart();
+        if (data === "[DONE]") {
+            return `${flushPendingContent()}${event}\n\n`;
+        }
+
+        let chunk: Record<string, unknown>;
+        try {
+            chunk = JSON.parse(data) as Record<string, unknown>;
+        } catch {
+            return `${event}\n\n`;
+        }
+
+        const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
+        const { choices: _choices, ...metadata } = chunk;
+        lastChunkMetadata = metadata;
+
+        for (const [choicePosition, choiceValue] of choices.entries()) {
+            if (!choiceValue || typeof choiceValue !== "object") continue;
+            const choice = choiceValue as Record<string, unknown>;
+            const index =
+                typeof choice.index === "number"
+                    ? choice.index
+                    : choicePosition;
+            const sanitizer = sanitizerFor(index);
+            const delta =
+                choice.delta && typeof choice.delta === "object"
+                    ? (choice.delta as Record<string, unknown>)
+                    : undefined;
+
+            if (delta && typeof delta.content === "string") {
+                delta.content = sanitizer.push(delta.content);
+            }
+
+            if (
+                choice.finish_reason !== undefined &&
+                choice.finish_reason !== null
+            ) {
+                const remaining = sanitizer.finish();
+                if (remaining) {
+                    choice.delta = {
+                        ...delta,
+                        content: `${
+                            typeof delta?.content === "string"
+                                ? delta.content
+                                : ""
+                        }${remaining}`,
+                    };
+                }
+                contentSanitizers.delete(index);
+            }
+        }
+
+        lines[dataIndex] = `data: ${JSON.stringify(chunk)}`;
+        return `${lines.join("\n")}\n\n`;
+    }
+
+    function emitReadyEvents(
+        controller: TransformStreamDefaultController<Uint8Array>,
+    ): void {
+        while (true) {
+            const boundary = pendingSse.match(/\r?\n\r?\n/);
+            if (!boundary || boundary.index === undefined) return;
+            const event = pendingSse.slice(0, boundary.index);
+            pendingSse = pendingSse.slice(boundary.index + boundary[0].length);
+            controller.enqueue(encoder.encode(sanitizeEvent(event)));
+        }
+    }
 
     return source.pipeThrough(
         new TransformStream<Uint8Array, Uint8Array>({
             transform(chunk, controller) {
-                pending += decoder.decode(chunk, { stream: true });
-                const retainedLength = possibleTokenPrefixLength(pending);
-                const ready =
-                    retainedLength > 0
-                        ? pending.slice(0, -retainedLength)
-                        : pending;
-                pending =
-                    retainedLength > 0 ? pending.slice(-retainedLength) : "";
-                const cleaned = stripControlTokens(ready);
-                if (cleaned) controller.enqueue(encoder.encode(cleaned));
+                pendingSse += decoder.decode(chunk, { stream: true });
+                emitReadyEvents(controller);
             },
             flush(controller) {
-                pending += decoder.decode();
-                const cleaned = stripControlTokens(pending);
-                if (cleaned) controller.enqueue(encoder.encode(cleaned));
+                pendingSse += decoder.decode();
+                emitReadyEvents(controller);
+                if (pendingSse) {
+                    controller.enqueue(
+                        encoder.encode(sanitizeEvent(pendingSse)),
+                    );
+                } else {
+                    const remaining = flushPendingContent();
+                    if (remaining)
+                        controller.enqueue(encoder.encode(remaining));
+                }
             },
         }),
     );
@@ -71,7 +248,7 @@ export function sanitizeCohereResponse(
     for (const choice of completion.choices ?? []) {
         const message = choice.message;
         if (message && typeof message.content === "string") {
-            message.content = stripControlTokens(message.content);
+            message.content = sanitizeContent(message.content);
         }
     }
     return completion;
@@ -96,13 +273,23 @@ export const validateCohereRequest: TransformFn = (messages, options) => {
         throw error;
     }
 
-    if (options.tool_choice !== undefined && options.tool_choice !== "auto") {
+    if (
+        options.tool_choice !== undefined &&
+        options.tool_choice !== "auto" &&
+        options.tool_choice !== "none"
+    ) {
         const error = new Error(
-            'Cohere Command A+ on Azure supports tool_choice "auto" only',
+            'Cohere Command A+ on Azure supports tool_choice "auto" or "none" only',
         ) as ServiceError;
         error.status = 400;
         throw error;
     }
 
-    return { messages, options: { ...options } };
+    const normalizedOptions = { ...options };
+    if (normalizedOptions.tool_choice === "none") {
+        delete normalizedOptions.tools;
+        delete normalizedOptions.tool_choice;
+    }
+
+    return { messages, options: normalizedOptions };
 };

--- a/gen.pollinations.ai/src/text/cohereCommandAPlus.ts
+++ b/gen.pollinations.ai/src/text/cohereCommandAPlus.ts
@@ -1,0 +1,108 @@
+import type { ChatCompletion, ServiceError, TransformFn } from "./types.js";
+
+const COHERE_CONTROL_TOKENS = [
+    "<|START_TEXT|>",
+    "<|END_TEXT|>",
+    "<|END_THINKING|>",
+] as const;
+
+function stripControlTokens(text: string): string {
+    let cleaned = text;
+    for (const token of COHERE_CONTROL_TOKENS) {
+        cleaned = cleaned.replaceAll(token, "");
+    }
+    return cleaned;
+}
+
+function possibleTokenPrefixLength(text: string): number {
+    let length = 0;
+    for (const token of COHERE_CONTROL_TOKENS) {
+        const maxPrefixLength = Math.min(text.length, token.length - 1);
+        for (let index = maxPrefixLength; index > length; index -= 1) {
+            if (text.endsWith(token.slice(0, index))) {
+                length = index;
+                break;
+            }
+        }
+    }
+    return length;
+}
+
+function sanitizeStream(
+    source: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+    const decoder = new TextDecoder();
+    const encoder = new TextEncoder();
+    let pending = "";
+
+    return source.pipeThrough(
+        new TransformStream<Uint8Array, Uint8Array>({
+            transform(chunk, controller) {
+                pending += decoder.decode(chunk, { stream: true });
+                const retainedLength = possibleTokenPrefixLength(pending);
+                const ready =
+                    retainedLength > 0
+                        ? pending.slice(0, -retainedLength)
+                        : pending;
+                pending =
+                    retainedLength > 0 ? pending.slice(-retainedLength) : "";
+                const cleaned = stripControlTokens(ready);
+                if (cleaned) controller.enqueue(encoder.encode(cleaned));
+            },
+            flush(controller) {
+                pending += decoder.decode();
+                const cleaned = stripControlTokens(pending);
+                if (cleaned) controller.enqueue(encoder.encode(cleaned));
+            },
+        }),
+    );
+}
+
+export function sanitizeCohereResponse(
+    completion: ChatCompletion,
+): ChatCompletion {
+    if (completion.stream && completion.responseStream) {
+        completion.responseStream = sanitizeStream(
+            completion.responseStream as ReadableStream<Uint8Array>,
+        );
+        return completion;
+    }
+
+    for (const choice of completion.choices ?? []) {
+        const message = choice.message;
+        if (message && typeof message.content === "string") {
+            message.content = stripControlTokens(message.content);
+        }
+    }
+    return completion;
+}
+
+export const validateCohereRequest: TransformFn = (messages, options) => {
+    const hasNonTextInput = messages.some(
+        (message) =>
+            Array.isArray(message.content) &&
+            message.content.some(
+                (part) =>
+                    !part ||
+                    typeof part !== "object" ||
+                    (part as { type?: unknown }).type !== "text",
+            ),
+    );
+    if (hasNonTextInput) {
+        const error = new Error(
+            "Cohere Command A+ on Azure supports text input only",
+        ) as ServiceError;
+        error.status = 400;
+        throw error;
+    }
+
+    if (options.tool_choice !== undefined && options.tool_choice !== "auto") {
+        const error = new Error(
+            'Cohere Command A+ on Azure supports tool_choice "auto" only',
+        ) as ServiceError;
+        error.status = 400;
+        throw error;
+    }
+
+    return { messages, options: { ...options } };
+};

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -144,6 +144,14 @@ export const portkeyConfig: PortkeyConfigMap = {
             "grok-4.3",
         ),
 
+    // -- Azure (Myceli Prod — eastus, Cohere) --------------------------------
+    "Cohere-command-a-plus-05-2026": () =>
+        createAzureModelConfig(
+            process.env.AZURE_MYCELI_PROD_API_KEY,
+            "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/deployments/Cohere-command-a-plus-05-2026/chat/completions?api-version=2024-12-01-preview",
+            "Cohere-command-a-plus-05-2026",
+        ),
+
     // -- OpenRouter (frontier models) ----------------------------------------
     "x-ai/grok-4.5": () =>
         createOpenRouterModelConfig({

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -1,5 +1,6 @@
 import debug from "debug";
 import { findModelByName } from "./availableModels.js";
+import { sanitizeCohereResponse } from "./cohereCommandAPlus.js";
 import { genericOpenAIClient } from "./genericOpenAIClient.js";
 import { generateHeaders } from "./transforms/headerGenerator.js";
 import { imageUrlToBase64Transform } from "./transforms/imageUrlToBase64Transform.js";
@@ -35,17 +36,17 @@ export async function generateTextPortkey(
     options: TransformOptions = {},
 ): Promise<ChatCompletion> {
     let state: TransformResult = { messages, options: { ...options } };
+    const modelDef = state.options.model
+        ? findModelByName(state.options.model)
+        : null;
 
-    if (state.options.model) {
-        const modelDef = findModelByName(state.options.model);
-        if (modelDef?.transform) {
-            // Transforms return the complete intended options (a copy of the
-            // input with mutations applied), so replace state wholesale — a
-            // spread-merge here would resurrect keys the transform deleted
-            // (e.g. reasoning_effort:"none" stripped for mandatory-reasoning
-            // models, which then 400 upstream).
-            state = await modelDef.transform(messages, state.options);
-        }
+    if (modelDef?.transform) {
+        // Transforms return the complete intended options (a copy of the
+        // input with mutations applied), so replace state wholesale — a
+        // spread-merge here would resurrect keys the transform deleted
+        // (e.g. reasoning_effort:"none" stripped for mandatory-reasoning
+        // models, which then 400 upstream).
+        state = await modelDef.transform(messages, state.options);
     }
 
     if (state.options.model) {
@@ -69,5 +70,12 @@ export async function generateTextPortkey(
     delete state.options.additionalHeaders;
     delete state.options.portkeyGatewayUrl;
 
-    return genericOpenAIClient(state.messages, state.options, requestConfig);
+    const completion = await genericOpenAIClient(
+        state.messages,
+        state.options,
+        requestConfig,
+    );
+    return modelDef?.name === "command-a-plus"
+        ? sanitizeCohereResponse(completion)
+        : completion;
 }

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -121,4 +121,15 @@ describe("reasoning_effort model wiring", () => {
         });
         expect(options.reasoning_effort).toBeUndefined();
     });
+
+    it("strips unsupported effort controls while Command A+ reasons automatically", async () => {
+        const transform = findModelByName("command-a-plus")?.transform;
+        if (!transform) throw new Error("command-a-plus transform missing");
+
+        const { options } = await transform([{ role: "user", content: "hi" }], {
+            reasoning_effort: "high",
+        });
+
+        expect(options.reasoning_effort).toBeUndefined();
+    });
 });

--- a/gen.pollinations.ai/test/text/transforms/sanitizeCohereResponse.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/sanitizeCohereResponse.test.ts
@@ -46,20 +46,85 @@ describe("sanitizeCohereResponse", () => {
         });
     });
 
-    it("removes framing split across streaming chunks", async () => {
+    it("removes every documented response framing token at boundaries", () => {
+        const completion: ChatCompletion = {
+            choices: [
+                {
+                    message: {
+                        role: "assistant",
+                        content:
+                            "<|START_THINKING|><|END_THINKING|>" +
+                            "<|START_RESPONSE|>Hello<|END_RESPONSE|>",
+                    },
+                },
+            ],
+        };
+
+        sanitizeCohereResponse(completion);
+
+        expect(completion.choices?.[0].message?.content).toBe("Hello");
+    });
+
+    it("preserves literal control tokens inside legitimate content", () => {
+        const completion: ChatCompletion = {
+            choices: [
+                {
+                    message: {
+                        role: "assistant",
+                        content:
+                            "<|START_TEXT|>Print <|END_TEXT|> literally." +
+                            "<|END_TEXT|>",
+                    },
+                },
+            ],
+        };
+
+        sanitizeCohereResponse(completion);
+
+        expect(completion.choices?.[0].message?.content).toBe(
+            "Print <|END_TEXT|> literally.",
+        );
+    });
+
+    it("removes framing split across network chunks and SSE events", async () => {
         const result = await streamText({ stream: true }, [
-            'data: {"choices":[{"delta":{"content":"<|STA',
-            'RT_TEXT|>Hello"}}]}\n\n',
-            'data: {"choices":[{"delta":{"content":" world<|END_',
+            'data: {"id":"one","choices":[{"index":0,"delta":{"content":"<|STA',
+            'RT_"},"finish_reason":null}]}\n\n',
+            'data: {"id":"one","choices":[{"index":0,"delta":{"content":"TEXT|>Hello"}}]}\n\n',
+            'data: {"id":"one","choices":[{"index":0,"delta":{"content":" world<|END_',
             'TEXT|>"}}]}\n\n',
+            'data: {"id":"one","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
             "data: [DONE]\n\n",
         ]);
 
         expect(result).toBe(
-            'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n' +
-                'data: {"choices":[{"delta":{"content":" world"}}]}\n\n' +
+            'data: {"id":"one","choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}\n\n' +
+                'data: {"id":"one","choices":[{"index":0,"delta":{"content":"Hello"}}]}\n\n' +
+                'data: {"id":"one","choices":[{"index":0,"delta":{"content":" world"}}]}\n\n' +
+                'data: {"id":"one","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n' +
                 "data: [DONE]\n\n",
         );
+    });
+
+    it("scrubs only content deltas, not reasoning or tool arguments", async () => {
+        const result = await streamText({ stream: true }, [
+            'data: {"choices":[{"index":0,"delta":{"reasoning_content":"<|START_THINKING|>reason","tool_calls":[{"function":{"arguments":"{\\"value\\":\\"<|END_TEXT|>\\"}"}}],"content":"<|START_TEXT|>answer<|END_TEXT|>"},"finish_reason":"stop"}]}\n\n',
+            "data: [DONE]\n\n",
+        ]);
+
+        const firstEvent = result.split("\n\n")[0].slice("data: ".length);
+        const firstChunk = JSON.parse(firstEvent);
+        expect(firstChunk.choices[0].delta).toEqual({
+            reasoning_content: "<|START_THINKING|>reason",
+            tool_calls: [
+                {
+                    function: {
+                        arguments: '{"value":"<|END_TEXT|>"}',
+                    },
+                },
+            ],
+            content: "answer",
+        });
     });
 });
 
@@ -72,6 +137,26 @@ describe("validateCohereRequest", () => {
         ).toEqual({
             messages: [{ role: "user", content: "hi" }],
             options: { tool_choice: "auto" },
+        });
+    });
+
+    it("honors tool_choice none by removing tools before Azure", () => {
+        expect(
+            validateCohereRequest([{ role: "user", content: "hi" }], {
+                tools: [
+                    {
+                        type: "function",
+                        function: {
+                            name: "lookup",
+                            parameters: { type: "object", properties: {} },
+                        },
+                    },
+                ],
+                tool_choice: "none",
+            }),
+        ).toEqual({
+            messages: [{ role: "user", content: "hi" }],
+            options: {},
         });
     });
 
@@ -109,7 +194,7 @@ describe("validateCohereRequest", () => {
             expect.objectContaining({
                 status: 400,
                 message:
-                    'Cohere Command A+ on Azure supports tool_choice "auto" only',
+                    'Cohere Command A+ on Azure supports tool_choice "auto" or "none" only',
             }),
         );
     });

--- a/gen.pollinations.ai/test/text/transforms/sanitizeCohereResponse.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/sanitizeCohereResponse.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+    sanitizeCohereResponse,
+    validateCohereRequest,
+} from "../../../src/text/cohereCommandAPlus.js";
+import type { ChatCompletion } from "../../../src/text/types.js";
+
+async function streamText(
+    completion: ChatCompletion,
+    chunks: string[],
+): Promise<string> {
+    const encoder = new TextEncoder();
+    completion.responseStream = new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks)
+                controller.enqueue(encoder.encode(chunk));
+            controller.close();
+        },
+    });
+
+    const sanitized = sanitizeCohereResponse(completion);
+    return new Response(sanitized.responseStream).text();
+}
+
+describe("sanitizeCohereResponse", () => {
+    it("removes Cohere framing from text while preserving reasoning", () => {
+        const completion: ChatCompletion = {
+            choices: [
+                {
+                    message: {
+                        role: "assistant",
+                        reasoning_content: "Checked the answer.",
+                        content:
+                            "<|END_THINKING|><|START_TEXT|>Hello<|END_TEXT|>",
+                    },
+                },
+            ],
+        };
+
+        sanitizeCohereResponse(completion);
+
+        expect(completion.choices?.[0].message).toEqual({
+            role: "assistant",
+            reasoning_content: "Checked the answer.",
+            content: "Hello",
+        });
+    });
+
+    it("removes framing split across streaming chunks", async () => {
+        const result = await streamText({ stream: true }, [
+            'data: {"choices":[{"delta":{"content":"<|STA',
+            'RT_TEXT|>Hello"}}]}\n\n',
+            'data: {"choices":[{"delta":{"content":" world<|END_',
+            'TEXT|>"}}]}\n\n',
+            "data: [DONE]\n\n",
+        ]);
+
+        expect(result).toBe(
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n' +
+                'data: {"choices":[{"delta":{"content":" world"}}]}\n\n' +
+                "data: [DONE]\n\n",
+        );
+    });
+});
+
+describe("validateCohereRequest", () => {
+    it("accepts text and automatic tool selection", () => {
+        expect(
+            validateCohereRequest([{ role: "user", content: "hi" }], {
+                tool_choice: "auto",
+            }),
+        ).toEqual({
+            messages: [{ role: "user", content: "hi" }],
+            options: { tool_choice: "auto" },
+        });
+    });
+
+    it("rejects unsupported image input before calling Azure", () => {
+        expect(() =>
+            validateCohereRequest(
+                [
+                    {
+                        role: "user",
+                        content: [
+                            { type: "text", text: "describe" },
+                            {
+                                type: "image_url",
+                                image_url: { url: "https://example.com/a.jpg" },
+                            },
+                        ],
+                    },
+                ],
+                {},
+            ),
+        ).toThrow(
+            expect.objectContaining({
+                status: 400,
+                message: "Cohere Command A+ on Azure supports text input only",
+            }),
+        );
+    });
+
+    it("rejects tool choices the Azure route does not honor", () => {
+        expect(() =>
+            validateCohereRequest([{ role: "user", content: "hi" }], {
+                tool_choice: "required",
+            }),
+        ).toThrow(
+            expect.objectContaining({
+                status: 400,
+                message:
+                    'Cohere Command A+ on Azure supports tool_choice "auto" only',
+            }),
+        );
+    });
+});

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -97,6 +97,21 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes Command A+ to the exact Azure deployment without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "command-a-plus",
+        });
+
+        expect(result.options.model).toBe("Cohere-command-a-plus-05-2026");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "azure-openai",
+            "azure-resource-name": "myceli-prod-eastus",
+            "azure-deployment-id": "Cohere-command-a-plus-05-2026",
+            "azure-model-name": "Cohere-command-a-plus-05-2026",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it.each([
         "perplexity-high",
         "perplexity-deep",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -259,6 +259,31 @@ export const TEXT_SERVICES = {
         contextLength: 128000,
         isSpecialized: false,
     },
+    "command-a-plus": {
+        aliases: [
+            "cohere-command-a-plus",
+            "command-a-plus-05-2026",
+            "cohere-command-a-plus-05-2026",
+        ],
+        provider: "azure",
+        brand: "Cohere",
+        category: "text",
+        addedDate: new Date("2026-07-30").getTime(),
+        priceMultiplier: 0.75,
+        cost: {
+            promptTextTokens: perMillion(0.8),
+            completionTextTokens: perMillion(3.2),
+        },
+        title: "Cohere Command A+",
+        description:
+            "Multilingual agentic reasoning with tools and long context",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 128000,
+        isSpecialized: false,
+    },
     "qwen-coder": {
         aliases: ["qwen3-coder", "qwen3-coder-30b-a3b-instruct"],
         provider: "ovhcloud",


### PR DESCRIPTION
- Adds `command-a-plus` on Azure East US Global Standard with version/provider aliases, Quest-Pollen access, and no fallback.
- Bills Azure's posted `$0.80/M` input and `$3.20/M` output at multiplier `0.75`.
- Preserves reasoning and automatic tools; supports `tool_choice: "none"` by removing tools before Azure while rejecting unsupported named/required selection.
- Removes documented Cohere framing only from assistant content boundaries, consistently across normal and SSE responses, including tokens split across separate events.

Contract: canonical `command-a-plus`; aliases `cohere-command-a-plus`, `command-a-plus-05-2026`, `cohere-command-a-plus-05-2026`; paid-only no; Pollinations GPU no; provider Azure; exact route `Cohere-command-a-plus-05-2026` v1; fallback none.

Validation:
- Live local E2E: text, JSON, automatic tools, `tool_choice: none`, streaming, aliases, cache, usage headers, wallet deduction, and Tinybird reconciliation.
- Streaming: 161 valid chunks, finish event, `[DONE]`, reasoning and content present, zero leaked control tokens.
- Burst: 5/15/30, 50/50 HTTP 200, 4.3s maximum.
- Gen: 746/746 local tests and typecheck. Enter: 311/311 focused tests and typecheck/build. All GitHub checks pass on the current main-synchronized head.
- Context: [Cohere](https://docs.cohere.com/docs/command-a-plus) and [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure) document 128K input / 64K output for this exact model; the live Azure route reports a 131,072-token technical maximum.

The exact version is Preview with a 2026-10-13 catalog deprecation date. Portkey masks Azure's correct over-context 400 as an opaque 500; this PR does not add an inaccurate tokenizer or character cap.
