### PR TITLE
feat: serve the media agent from weaver.pollinations.ai

### DIFF
--- a/apps/apps.json
+++ b/apps/apps.json
@@ -113,10 +113,10 @@
     "description": "AI-powered slide image generator by Pollinations"
   },
   "polli-agent": {
-    "subdomain": "polli",
+    "subdomain": "weaver",
     "deployTarget": "worker",
     "workerEntrypoint": "worker.js",
-    "title": "Polli Agent | pollinations.ai",
-    "description": "OpenAI-compatible agent that chains image, video and audio generation"
+    "title": "Weaver | pollinations.ai",
+    "description": "Weaves image, video and audio generation into one result"
   }
 }

--- a/apps/polli-agent/wrangler.jsonc
+++ b/apps/polli-agent/wrangler.jsonc
@@ -18,12 +18,12 @@
   // origin serving before it verifies the public URL, so both are needed.
   "routes": [
     {
-      "pattern": "polli.myceli.ai",
+      "pattern": "weaver.myceli.ai",
       "zone_name": "myceli.ai",
       "custom_domain": true
     },
     {
-      "pattern": "polli.pollinations.ai",
+      "pattern": "weaver.pollinations.ai",
       "zone_name": "pollinations.ai",
       "custom_domain": true
     }


### PR DESCRIPTION
- `polli.pollinations.ai` is meant for exposing the Polli Discord bot as a model (per @Itachi-1824 in dev-polli); the media agent was squatting on it
- Rebinds to `weaver.myceli.ai` / `weaver.pollinations.ai` and points `apps.json` at the `weaver` subdomain
- Worker `name` deliberately stays `polli-agent`, so the running container is reused rather than orphaned
- Merging deploys: the `apps/**` push trigger on `main` runs `Apps / Deploy changed apps`

Follow-up after merge: repoint the `voodoohop/polli` community endpoint at the new host and drop the stale `polli.*` custom domains.