### PR TITLE
fix: stop counting fallback attempt rows as requests

### DIFF
--- a/.claude/skills/abuse-detection/SKILL.md
+++ b/.claude/skills/abuse-detection/SKILL.md
@@ -76,6 +76,7 @@ FROM (
         countIf(g.response_status >= 400) * 100.0 / count() as err_pct
     FROM generation_event_v2 g
     WHERE g.start_time >= now() - INTERVAL 7 DAY
+        AND g.is_attempt_row = 0
         AND g.user_id NOT IN ('undefined', '')
     GROUP BY g.user_id
     HAVING total_reqs >= 1000
@@ -130,11 +131,13 @@ FROM (
         SELECT ip_hash, count(DISTINCT user_id) as ip_cluster_size
         FROM generation_event_v2
         WHERE start_time >= now() - INTERVAL 7 DAY
+            AND is_attempt_row = 0
             AND ip_hash NOT IN ('undefined', '')
             AND user_id NOT IN ('undefined', '')
         GROUP BY ip_hash
     ) ips ON g.ip_hash = ips.ip_hash
     WHERE g.start_time >= now() - INTERVAL 7 DAY
+        AND g.is_attempt_row = 0
         AND g.user_id NOT IN ('undefined', '')
     GROUP BY g.user_id, u.github_username, u.email
     HAVING total_reqs >= 5
@@ -156,6 +159,7 @@ SELECT
     dateDiff('minute', min(start_time), max(start_time)) as span_min
 FROM generation_event_v2
 WHERE start_time >= now() - INTERVAL 7 DAY
+    AND is_attempt_row = 0
     AND ip_hash NOT IN ('undefined', '')
     AND user_id NOT IN ('undefined', '')
 GROUP BY ip_hash, ip_subnet
@@ -175,6 +179,7 @@ FROM generation_event_v2 g
 LEFT JOIN d1_user u ON g.user_id = u.id
     AND u.synced_at = (SELECT max(synced_at) FROM d1_user)
 WHERE g.start_time >= now() - INTERVAL 7 DAY
+    AND g.is_attempt_row = 0
     AND g.ip_hash = '<IP_HASH_HERE>'
     AND g.user_id NOT IN ('undefined', '')
 GROUP BY g.user_id, u.github_username, u.email

--- a/apps/operation/community-monitor/leaderboard/build-leaderboard.mjs
+++ b/apps/operation/community-monitor/leaderboard/build-leaderboard.mjs
@@ -49,7 +49,7 @@ async function fetchLeaderboardData() {
       round(medianIf((token_count_completion_text + token_count_completion_reasoning) / (response_time / 1000), response_status < 300 AND response_time > 0 AND token_count_completion_text + token_count_completion_reasoning >= 20), 1) AS median_tps,
       round(100 * countIf(response_status >= 200 AND response_status < 300) / greatest(countIf(response_status < 400 OR response_status >= 500), 1), 2) AS success
     FROM generation_event_v2
-    WHERE start_time > now() - INTERVAL 24 HOUR AND model_requested LIKE '%/%'
+    WHERE start_time > now() - INTERVAL 24 HOUR AND model_requested LIKE '%/%' AND is_attempt_row = 0
     GROUP BY model
     HAVING requests >= ${MIN_REQUESTS}
     ORDER BY total_tokens DESC
@@ -62,7 +62,7 @@ async function fetchLeaderboardData() {
            sum(token_count_prompt_text + token_count_prompt_cached + token_count_completion_text + token_count_completion_reasoning) AS total_tokens,
            uniq(model_requested) AS models
     FROM generation_event_v2
-    WHERE start_time > now() - INTERVAL 24 HOUR AND model_requested LIKE '%/%'
+    WHERE start_time > now() - INTERVAL 24 HOUR AND model_requested LIKE '%/%' AND is_attempt_row = 0
     FORMAT JSON
   `)
     )[0];

--- a/apps/operation/observability/provisioning/alerting/rules.yaml
+++ b/apps/operation/observability/provisioning/alerting/rules.yaml
@@ -25,7 +25,8 @@ groups:
                     count() AS server_errors
                   FROM generation_event_v2
                   WHERE
-                    start_time >= now() - INTERVAL 10 MINUTE
+                    is_attempt_row = 0
+                    AND start_time >= now() - INTERVAL 10 MINUTE
                     AND response_status >= 500
                     AND response_status < 600
                     AND resolved_model_requested != ''
@@ -39,7 +40,8 @@ groups:
                     count() AS total_requests
                   FROM generation_event_v2
                   WHERE
-                    start_time >= now() - INTERVAL 10 MINUTE
+                    is_attempt_row = 0
+                    AND start_time >= now() - INTERVAL 10 MINUTE
                     AND resolved_model_requested != ''
                     AND resolved_model_requested IS NOT NULL
                   GROUP BY model, provider
@@ -111,7 +113,8 @@ groups:
                     count() AS server_errors
                   FROM generation_event_v2
                   WHERE
-                    start_time >= now() - INTERVAL 10 MINUTE
+                    is_attempt_row = 0
+                    AND start_time >= now() - INTERVAL 10 MINUTE
                     AND response_status >= 500
                     AND response_status < 600
                     AND resolved_model_requested != ''
@@ -125,7 +128,8 @@ groups:
                     count() AS total_requests
                   FROM generation_event_v2
                   WHERE
-                    start_time >= now() - INTERVAL 10 MINUTE
+                    is_attempt_row = 0
+                    AND start_time >= now() - INTERVAL 10 MINUTE
                     AND resolved_model_requested != ''
                     AND resolved_model_requested IS NOT NULL
                   GROUP BY model, provider

--- a/enter.pollinations.ai/observability/datasources/generation_event_v2.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event_v2.datasource
@@ -54,6 +54,12 @@ SCHEMA >
 `model_used`                LowCardinality(String) `json:$.modelUsed` DEFAULT 'undefined',
 `model_provider_used`       LowCardinality(String) `json:$.modelProviderUsed` DEFAULT 'undefined',
 `fallback_used`             Bool                   `json:$.fallbackUsed` DEFAULT false,
+-- One upstream attempt rather than the request's outcome. A request that
+-- failed over emits one per model it called plus the settlement row, so count
+-- requests with `is_attempt_row = 0` and judge a model's own upstream with the
+-- attempt rows. Every row written before fallback existed is a settlement row,
+-- which is why the DEFAULT reads history correctly under both meanings.
+`is_attempt_row`            Bool                   `json:$.isAttemptRow` DEFAULT false,
 `is_billed_usage`           Bool                   `json:$.isBilledUsage`,
 
 -- Pricing

--- a/enter.pollinations.ai/observability/endpoints/app_byop_request_counts.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_byop_request_counts.pipe
@@ -23,6 +23,7 @@ SQL >
     LEFT JOIN latest_apps la
         ON ge.api_key_client_id = la.app_key_id
     WHERE ge.start_time > now() - INTERVAL 1 DAY
+    AND ge.is_attempt_row = 0  -- one row per request; attempts counted separately
       AND (
         ge.api_key_created_via = 'redirect-auth'
         OR (ge.api_key_type = 'secret' AND ge.api_key_name LIKE '%.%')

--- a/enter.pollinations.ai/observability/endpoints/app_request_counts.pipe
+++ b/enter.pollinations.ai/observability/endpoints/app_request_counts.pipe
@@ -12,6 +12,7 @@ SQL >
     FROM generation_event_v2 events
     INNER JOIN d1_user users ON events.user_id = users.id
     WHERE events.start_time > now() - INTERVAL 1 DAY
+    AND events.is_attempt_row = 0  -- one row per request; attempts counted separately
       AND users.synced_at = (SELECT max(synced_at) FROM d1_user)
       AND users.github_id IS NOT NULL
       AND events.user_id != 'undefined'

--- a/enter.pollinations.ai/observability/endpoints/model_health.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_health.pipe
@@ -57,6 +57,7 @@ SQL >
         ) as tokens_per_second
     FROM generation_event_v2
     WHERE start_time >= now() - interval {{Int32(minutes, 60)}} minute
+    AND is_attempt_row = 0  -- one row per request; attempts counted separately
     GROUP BY model, event_type
     ORDER BY total_requests DESC
 

--- a/enter.pollinations.ai/observability/endpoints/model_revenue.pipe
+++ b/enter.pollinations.ai/observability/endpoints/model_revenue.pipe
@@ -22,6 +22,7 @@ SQL >
         round(sumIf(total_price, selected_meter_slug = 'v1:meter:tier' AND response_status >= 200 AND response_status < 300), 4) as tier_value
     FROM generation_event_v2
     WHERE start_time >= now() - interval {{Int32(minutes, 60)}} minute
+    AND is_attempt_row = 0  -- one row per request; attempts counted separately
     GROUP BY model, event_type
     ORDER BY paid_revenue DESC
 

--- a/enter.pollinations.ai/observability/endpoints/public_model_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/public_model_stats.pipe
@@ -18,6 +18,7 @@ SQL >
         countIf(response_status >= 400) as error_count
     FROM generation_event_v2
     WHERE start_time >= now() - INTERVAL 7 DAY
+    AND is_attempt_row = 0  -- one row per request; attempts counted separately
     AND resolved_model_requested != 'undefined'
     GROUP BY model
     HAVING priced_success_count >= 3

--- a/enter.pollinations.ai/observability/endpoints/weekly_active_users.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_active_users.pipe
@@ -13,7 +13,7 @@ SQL >
         formatDateTime(toStartOfWeek(start_time, 1), '%Y-%m-%d') AS week,
         uniqExact(user_id) AS active_users,
         uniqExactIf(user_id, total_price > 0) AS paying_users,
-        count() AS total_requests,
+        countIf(is_attempt_row = 0) AS total_requests,  -- attempts are not requests
         sum(token_count_prompt_text + token_count_completion_text) AS total_tokens,
         sum(total_price) AS total_revenue
     FROM generation_event_v2

--- a/enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe
@@ -39,6 +39,7 @@ SQL >
         {% else %}
         start_time >= now() - INTERVAL {{Int32(weeks_back, 12)}} WEEK
         {% end %}
+        AND is_attempt_row = 0  -- one row per request; attempts counted separately
     GROUP BY week
     ORDER BY week ASC
 

--- a/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
@@ -30,6 +30,7 @@ SQL >
         {% else %}
         start_time >= now() - INTERVAL {{Int32(weeks_back, 12)}} WEEK
         {% end %}
+        AND is_attempt_row = 0  -- one row per request; attempts counted separately
     GROUP BY week
     ORDER BY week ASC
 

--- a/enter.pollinations.ai/observability/endpoints/weekly_user_segment.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_user_segment.pipe
@@ -15,7 +15,7 @@ SQL >
         ((api_key_type = 'secret' AND position(api_key_name, '.') > 0) OR api_key_created_via = 'redirect-auth') AS is_byop,
         uniq(user_id) AS users,
         sum(total_price) AS pollen,
-        count() AS requests
+        countIf(is_attempt_row = 0) AS requests  -- attempts are not requests
     FROM generation_event_v2
     WHERE
         {% if defined(start_date) %}

--- a/enter.pollinations.ai/observability/materializations/activity_earnings_model_rewards_mv.pipe
+++ b/enter.pollinations.ai/observability/materializations/activity_earnings_model_rewards_mv.pipe
@@ -8,8 +8,11 @@ SQL >
         start_time AS timestamp,
         event_id,
         'community_model' AS source,
-        resolved_model_requested AS entity_id,
-        resolved_model_requested AS entity_name,
+        -- The model that EARNED, which after a rescue is the fallback's,
+        -- not the one the caller asked for. Labelling by the requested
+        -- model put a rescuer's earnings under someone else's listing.
+        model_used AS entity_id,
+        model_used AS entity_name,
         model_used AS model,
         multiIf(
             selected_meter_slug = 'v1:meter:tier', 'tier',

--- a/enter.pollinations.ai/observability/materializations/byop_app_daily_mv.pipe
+++ b/enter.pollinations.ai/observability/materializations/byop_app_daily_mv.pipe
@@ -28,7 +28,7 @@ SQL >
             'quest',
             'unfunded'
         ) AS funding_source,
-        sumState(toUInt64(1)) AS all_calls,
+        sumState(toUInt64(is_attempt_row = 0)) AS all_calls,  -- attempts are not requests
         sumState(toUInt64(response_status >= 200 AND response_status < 300)) AS successful_calls,
         sumState(
             toUInt64(response_status >= 200 AND response_status < 300 AND is_billed_usage)

--- a/enter.pollinations.ai/observability/materializations/generation_usage_hourly_mv.pipe
+++ b/enter.pollinations.ai/observability/materializations/generation_usage_hourly_mv.pipe
@@ -25,7 +25,7 @@ SQL >
         api_key_client_id NOT IN ('', 'undefined') AS is_byop,
         model_provider_used = 'community' AS is_community,
         multiIf(is_byop, 'byop', is_community, 'community_direct', 'core') AS business_stream,
-        sumState(toUInt64(1)) AS all_calls,
+        sumState(toUInt64(is_attempt_row = 0)) AS all_calls,  -- attempts are not requests
         sumState(toUInt64(response_status >= 200 AND response_status < 300)) AS successful_calls,
         sumState(
             toUInt64(response_status >= 200 AND response_status < 300 AND is_billed_usage)


### PR DESCRIPTION
Prepares every consumer of `generation_event_v2` for the per-attempt rows that #12819 emits. **Deploy this before #12819 reaches production.**

- Adds `is_attempt_row Bool DEFAULT false` so each consumer picks its own reading: exclude attempts to count requests, or read exactly them to judge whether a model's own upstream works
- Filters the 11 pipes/materializations that count rows; four consumers act on that number unattended — the community monitor deactivates endpoints, Grafana pages, abuse-detection drives ban recommendations, the leaderboard has a request floor
- Fixes `activity_earnings_model_rewards_mv` labelling a rescuer's payout with the model the *caller* asked for, i.e. another owner's listing

Provably a no-op until the worker ships: nothing writes the column, and every existing row is a settlement row, so `DEFAULT false` keeps all history counting exactly as it does today.

Not deployed — Tinybird has no CI auto-deploy (#11127), so this needs `deployment create --check` on staging first, then both workspaces by hand. Grafana rules are a separate deploy path.

Addresses the telemetry defect found reviewing #12819.