### PR TITLE
feat: add Qwen3.7 Flash and move Step to DeepInfra

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1334,6 +1334,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000001,
     },
   },
+  "qwen3.7-flash": {
+    "cost": {
+      "completionTextTokens": 0.00000013,
+      "promptCacheWriteTokens": 0.000000038,
+      "promptCachedTokens": 0.000000006,
+      "promptTextTokens": 0.00000003,
+    },
+    "price": {
+      "completionTextTokens": 0.00000013,
+      "promptCacheWriteTokens": 0.000000038,
+      "promptCachedTokens": 0.000000006,
+      "promptTextTokens": 0.00000003,
+    },
+  },
   "qwen3.7-max": {
     "cost": {
       "completionTextTokens": 0.000004425,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -111,6 +111,11 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["qwen/qwen3.7-max"],
     },
     {
+        name: "qwen3.7-flash",
+        config: portkeyConfig["qwen/qwen3.7-flash"],
+        transform: createReasoningEffortTransform("toggle"),
+    },
+    {
         name: "qwen-vision",
         config: portkeyConfig["qwen/qwen3-vl-30b-a3b-instruct"],
         // Vision model, no reasoning mode.
@@ -129,7 +134,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "step-flash",
-        config: portkeyConfig["stepfun/step-3.7-flash"],
+        config: portkeyConfig["stepfun-ai/Step-3.7-Flash"],
         transform: mandatoryReasoning,
     },
     {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -178,6 +178,16 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "qwen/qwen3.7-max",
             defaultOptions: { provider: { sort: "price" } },
         }),
+    "qwen/qwen3.7-flash": () =>
+        createOpenRouterModelConfig({
+            model: "qwen/qwen3.7-flash",
+            defaultOptions: {
+                provider: {
+                    only: ["Alibaba"],
+                    allow_fallbacks: false,
+                },
+            },
+        }),
     "poolside/laguna-s-2.1": () =>
         createOpenRouterModelConfig({
             model: "poolside/laguna-s-2.1",
@@ -424,9 +434,11 @@ export const portkeyConfig: PortkeyConfigMap = {
         createOpenRouterModelConfig({
             model: "stepfun/step-3.5-flash",
         }),
-    "stepfun/step-3.7-flash": () =>
-        createOpenRouterModelConfig({
-            model: "stepfun/step-3.7-flash",
+
+    // -- DeepInfra (StepFun) --------------------------------------------------
+    "stepfun-ai/Step-3.7-Flash": () =>
+        createDeepInfraModelConfig({
+            model: "stepfun-ai/Step-3.7-Flash",
         }),
 
     // -- OVHcloud -------------------------------------------------------------

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -82,6 +82,7 @@ describe("reasoning_effort model wiring", () => {
         "kimi-k3",
         "deepseek",
         "qwen-large",
+        "qwen3.7-flash",
         "longcat",
         "nemotron",
         "minimax",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1708,6 +1708,34 @@ export const TEXT_SERVICES = {
         contextLength: 1000000,
         isSpecialized: false,
     },
+    "qwen3.7-flash": {
+        aliases: [],
+        provider: "openrouter",
+        brand: "Qwen",
+        category: "text",
+        addedDate: new Date("2026-07-30").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        // OpenRouter raises rates above 32K and 256K prompt tokens.
+        // Pollinations charges the base tier and absorbs the higher tiers.
+        cost: {
+            promptTextTokens: perMillion(0.03),
+            promptCachedTokens: perMillion(0.006),
+            promptCacheWriteTokens: perMillion(0.038),
+            completionTextTokens: perMillion(0.13),
+        },
+        title: "Qwen3.7 Flash",
+        description:
+            "Ultra-low-cost multimodal reasoning for agents and visual tasks",
+        inputModalities: ["text", "image", "video"],
+        outputModalities: ["text"],
+        maxReferenceImages: 10,
+        maxReferenceVideos: 10,
+        tools: true,
+        reasoning: true,
+        contextLength: 1000000,
+        isSpecialized: false,
+    },
     "qwen-vision": {
         aliases: [
             "qwen3-vl",
@@ -1767,14 +1795,14 @@ export const TEXT_SERVICES = {
     },
     "step-flash": {
         aliases: ["stepfun-flash", "step-3.7-flash", "step-flash-3.7"],
-        provider: "openrouter",
+        provider: "deepinfra",
         brand: "StepFun",
         category: "text",
         addedDate: new Date("2026-05-29").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // OpenRouter stepfun/step-3.7-flash posted rates (2026-05-29):
+            // DeepInfra stepfun-ai/Step-3.7-Flash posted rates (2026-07-30):
             // prompt $0.20/M, completion $1.15/M, cache read $0.04/M
             promptTextTokens: perMillion(0.2),
             promptCachedTokens: perMillion(0.04),


### PR DESCRIPTION
- Adds `qwen3.7-flash` through OpenRouter, pinned to Alibaba with fallbacks disabled; paid-only, multiplier 1.
- Moves the existing `step-flash` public model from OpenRouter to direct DeepInfra without changing aliases, capabilities, access, multiplier, or prices.
- Registers Qwen’s posted base rates ($0.03/M input, $0.006/M cache read, $0.038/M cache write, $0.13/M output); higher long-context tiers remain an explicitly documented absorbed cost.
- Live E2E covered text, image, video, tools, reasoning controls, streaming, cache writes/reads, usage headers, error handling, and five-way bursts for both routes.
- Validation: gen/enter typechecks; 29 reasoning-transform tests; 68 billing/permissions/cache/observability tests; 42 VCR/safety tests; 317 registry/alias/pricing tests.