### PR TITLE
feat: add presigned media upload support

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -510,6 +510,29 @@ const media = await upload(imageBuffer, {
 console.log(media.url);
 ```
 
+To exercise the AWS presigned upload flow against the development media
+service without changing production behavior:
+
+```javascript
+import { Pollinations } from '@pollinations/sdk';
+
+const client = new Pollinations({
+  apiKey: process.env.POLLINATIONS_API_KEY,
+  mediaBaseUrl: 'https://media.dev.pollinations.ai',
+  mediaUploadMode: 'presigned',
+});
+
+const media = await client.upload(imageBuffer, {
+  name: 'cat.png',
+  contentType: 'image/png',
+  tags: ['cats'],
+});
+```
+
+In presigned mode, the SDK initializes the upload with the media service,
+uploads the file directly to S3, and confirms completion before returning the
+same public media response.
+
 ## Error Handling
 
 ```javascript

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -190,6 +190,122 @@ describe("Pollinations media upload", () => {
         expect(formData.get("tags")).toBe("cats,gallery");
         expect(result.tags).toEqual(["cats", "gallery"]);
     });
+
+    it("completes a presigned upload without sending the API key to S3", async () => {
+        const client = new Pollinations({
+            apiKey: "sk_test",
+            mediaBaseUrl: "https://media.dev.pollinations.ai/",
+            mediaUploadMode: "presigned",
+        });
+        const finalResponse = {
+            id: "3dcf2ce3-3c68-46d8-bbc5-fad08b70aa23",
+            url: "https://media.dev.pollinations.ai/3dcf2ce3-3c68-46d8-bbc5-fad08b70aa23",
+            contentType: "image/png",
+            size: 8,
+            tags: ["cats", "gallery"],
+        };
+
+        fetchMock
+            .mockResolvedValueOnce(
+                makeResponse({
+                    id: finalResponse.id,
+                    uploadUrl: "https://s3.example.test/upload",
+                    fields: {
+                        key: finalResponse.id,
+                        policy: "signed-policy",
+                        "x-amz-signature": "signature",
+                    },
+                }),
+            )
+            .mockResolvedValueOnce(makeResponse(null, { status: 204 }))
+            .mockResolvedValueOnce(makeResponse(finalResponse));
+
+        const result = await client.upload(new ArrayBuffer(8), {
+            contentType: "image/png",
+            name: "cat.png",
+            tags: ["cats", "gallery"],
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
+        const [initUrl, initRequest] = fetchMock.mock.calls[0] as [
+            string,
+            RequestInit,
+        ];
+        expect(initUrl).toBe("https://media.dev.pollinations.ai/upload");
+        expect(initRequest.headers).toMatchObject({
+            "Authorization": "Bearer sk_test",
+            "Content-Type": "application/json",
+        });
+        expect(JSON.parse(initRequest.body as string)).toEqual({
+            contentType: "image/png",
+            name: "cat.png",
+            tags: ["cats", "gallery"],
+            size: 8,
+        });
+
+        const [s3Url, s3Request] = fetchMock.mock.calls[1] as [
+            string,
+            RequestInit,
+        ];
+        expect(s3Url).toBe("https://s3.example.test/upload");
+        expect(s3Request.headers).toBeUndefined();
+        const s3FormData = s3Request.body as FormData;
+        const s3FieldOrder: string[] = [];
+        s3FormData.forEach((_value, field) => {
+            s3FieldOrder.push(field);
+        });
+        expect(s3FieldOrder).toEqual([
+            "key",
+            "policy",
+            "x-amz-signature",
+            "file",
+        ]);
+        expect(s3FormData.get("file")).toBeInstanceOf(Blob);
+
+        const [completeUrl, completeRequest] = fetchMock.mock.calls[2] as [
+            string,
+            RequestInit,
+        ];
+        expect(completeUrl).toBe(
+            `https://media.dev.pollinations.ai/upload/${finalResponse.id}/complete`,
+        );
+        expect(completeRequest).toMatchObject({
+            method: "POST",
+            headers: { Authorization: "Bearer sk_test" },
+        });
+        expect(result).toEqual(finalResponse);
+    });
+
+    it("does not confirm a presigned upload when S3 rejects the file", async () => {
+        const client = new Pollinations({
+            apiKey: "sk_test",
+            mediaBaseUrl: "https://media.dev.pollinations.ai",
+            mediaUploadMode: "presigned",
+        });
+
+        fetchMock
+            .mockResolvedValueOnce(
+                makeResponse({
+                    id: "3dcf2ce3-3c68-46d8-bbc5-fad08b70aa23",
+                    uploadUrl: "https://s3.example.test/upload",
+                    fields: { policy: "signed-policy" },
+                }),
+            )
+            .mockResolvedValueOnce(
+                makeResponse(null, { ok: false, status: 403 }),
+            );
+
+        await expect(
+            client.upload(new ArrayBuffer(8), {
+                contentType: "image/png",
+                name: "cat.png",
+            }),
+        ).rejects.toMatchObject({
+            status: 403,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe("Pollinations seed handling", () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -42,6 +42,7 @@ import type {
 import { PollinationsError } from "./types.js";
 
 const DEFAULT_BASE_URL = "https://gen.pollinations.ai";
+const DEFAULT_MEDIA_BASE_URL = "https://media.pollinations.ai";
 export const AUTH_BASE_URL = "https://enter.pollinations.ai";
 const DEVICE_FLOW_CLIENT_ID = "pk_NgBAArhUeGvSRFba";
 const DEVICE_FLOW_DEFAULT_SCOPE = "generate keys usage";
@@ -186,6 +187,8 @@ function parseSSEBuffer<T>(
 export class Pollinations {
     private apiKey: string;
     private baseUrl: string;
+    private mediaBaseUrl: string;
+    private mediaUploadMode: "direct" | "presigned";
     private textTimeout: number;
     private imageTimeout: number;
     private videoTimeout: number;
@@ -204,6 +207,9 @@ export class Pollinations {
 
         this.apiKey = apiKey;
         this.baseUrl = config.baseUrl?.replace(/\/$/, "") || DEFAULT_BASE_URL;
+        this.mediaBaseUrl =
+            config.mediaBaseUrl?.replace(/\/$/, "") || DEFAULT_MEDIA_BASE_URL;
+        this.mediaUploadMode = config.mediaUploadMode || "direct";
 
         // Allow timeout to be a default fallback for all types
         const defaultTimeout = config.timeout ?? DEFAULT_TIMEOUT;
@@ -1238,15 +1244,92 @@ export class Pollinations {
         data: ArrayBuffer | Blob,
         options: UploadOptions = {},
     ): Promise<UploadResponse> {
-        const formData = new FormData();
-
         const blob =
             data instanceof Blob
                 ? data
                 : new Blob([data], {
                       type: options.contentType || "application/octet-stream",
                   });
+        const contentType =
+            options.contentType || blob.type || "application/octet-stream";
+        const name = options.name || "upload";
 
+        if (this.mediaUploadMode === "presigned") {
+            const initResponse = await fetchWithTimeout(
+                `${this.mediaBaseUrl}/upload`,
+                {
+                    method: "POST",
+                    headers: this.getHeaders("application/json"),
+                    body: JSON.stringify({
+                        contentType,
+                        name,
+                        tags: options.tags,
+                        size: blob.size,
+                    }),
+                },
+                this.imageTimeout,
+                options.signal,
+            );
+
+            if (!initResponse.ok) {
+                await this.handleErrorResponse(initResponse);
+            }
+
+            const uploadTarget = (await initResponse.json()) as {
+                id: string;
+                uploadUrl: string;
+                fields: Record<string, string>;
+            };
+            if (
+                !uploadTarget.id ||
+                !uploadTarget.uploadUrl ||
+                !uploadTarget.fields
+            ) {
+                throw new PollinationsError(
+                    "Invalid media upload initialization response",
+                    "INVALID_RESPONSE",
+                    502,
+                );
+            }
+
+            const s3FormData = new FormData();
+            for (const [field, value] of Object.entries(uploadTarget.fields)) {
+                s3FormData.append(field, value);
+            }
+            s3FormData.append("file", blob, name);
+
+            const s3Response = await fetchWithTimeout(
+                uploadTarget.uploadUrl,
+                {
+                    method: "POST",
+                    body: s3FormData,
+                },
+                this.imageTimeout,
+                options.signal,
+            );
+
+            if (!s3Response.ok) {
+                await this.handleErrorResponse(s3Response);
+            }
+
+            const completeResponse = await fetchWithTimeout(
+                `${this.mediaBaseUrl}/upload/${encodeURIComponent(uploadTarget.id)}/complete`,
+                {
+                    method: "POST",
+                    headers: this.getHeaders(),
+                },
+                this.imageTimeout,
+                options.signal,
+            );
+
+            if (!completeResponse.ok) {
+                await this.handleErrorResponse(completeResponse);
+            }
+
+            return completeResponse.json() as Promise<UploadResponse>;
+        }
+
+        const formData = new FormData();
         formData.append("file", blob, options.name || "upload");
         if (options.tags?.length) {
             formData.append("tags", options.tags.join(","));
@@ -1255,7 +1338,7 @@ export class Pollinations {
         const headers = this.getHeaders();
 
         const response = await fetchWithTimeout(
-            `https://media.pollinations.ai/upload`,
+            `${this.mediaBaseUrl}/upload`,
             {
                 method: "POST",
                 headers,

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -50,6 +50,7 @@ import type {
     KeyUsageOptions,
     Message,
     ModelInfo,
+    PollinationsConfig,
     TextGenerateOptions,
     TranscribeOptions,
     TranscriptionResponse,
@@ -91,10 +92,7 @@ export function resetClient(): void {
  * configure({ apiKey: 'your-api-key' });
  * ```
  */
-export function configure(options: {
-    apiKey?: string;
-    baseUrl?: string;
-}): void {
+export function configure(options: PollinationsConfig): void {
     defaultClient = new Pollinations(options);
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3,6 +3,10 @@ export interface PollinationsConfig {
     apiKey?: string;
     /** Base URL for the API (defaults to https://gen.pollinations.ai) */
     baseUrl?: string;
+    /** Base URL for media uploads (defaults to https://media.pollinations.ai) */
+    mediaBaseUrl?: string;
+    /** Media upload protocol (defaults to the current direct upload API) */
+    mediaUploadMode?: "direct" | "presigned";
     /** Default timeout in ms for all requests (default: 300000 = 5min) */
     timeout?: number;
     /** Timeout in ms for text requests (default: 300000 = 5min) */


### PR DESCRIPTION
- Adds an opt-in SDK media upload mode for the AWS presigned POST flow.
- Runs upload initialization, direct S3 multipart POST, and completion behind the existing `upload()` API.
- Keeps the current production endpoint and direct upload protocol as defaults; this PR does not change DNS, deployment, or production traffic.
- Prevents the Pollinations API key from being forwarded to S3 and keeps the existing upload response shape.
- Documents development usage with `https://media.dev.pollinations.ai`.

Checks:
- `npm test` — 32 passed
- `npm run typecheck`
- `npm run build`
- Biome check on changed TypeScript files

Live development upload was not completed because the repository's existing remote test token currently receives 401 from `gen.pollinations.ai/account/key`; no credential changes were made.