### PR TITLE
fix: record model_used on failed generations

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -448,7 +448,7 @@ function withFinalResponseHeaders(
     });
 }
 
-async function trackResponse(
+export async function trackResponse(
     eventType: EventType,
     requestTracking: RequestTrackingData,
     response: Response,
@@ -467,8 +467,21 @@ async function trackResponse(
         ...extra,
     });
 
-    if (!response.ok || cacheHit) {
+    // A cache hit called no model, so it must not claim one. A failure did
+    // call a model, and recording which one is the only way an error row can
+    // say what failed — otherwise model_used falls back to the datasource
+    // DEFAULT 'undefined' and per-model upstream health is unqueryable.
+    //
+    // resolvedModelRequested is the model that was called: the model is
+    // resolved once per request and no path re-dispatches to a different
+    // Pollinations model id. Portkey's multi-target config (see fallbackUsed /
+    // x-portkey-last-used-option-index) only changes which upstream provider
+    // target served a single model id, not the id itself.
+    if (cacheHit) {
         return notBilled();
+    }
+    if (!response.ok) {
+        return notBilled({ modelUsed: resolvedModelRequested });
     }
 
     // Verify the response content-type matches the expected output before
@@ -490,7 +503,7 @@ async function trackResponse(
                 kind: contentTypeGuard.kind,
             },
         );
-        return notBilled();
+        return notBilled({ modelUsed: resolvedModelRequested });
     }
 
     const { modelUsage, contentFilterResults } =
@@ -503,7 +516,10 @@ async function trackResponse(
         log.error("Failed to extract model usage for model {model}", {
             model: resolvedModelRequested,
         });
-        return notBilled({ contentFilterResults });
+        return notBilled({
+            contentFilterResults,
+            modelUsed: resolvedModelRequested,
+        });
     }
     // Single pass: cost, price, and the per-rule fee breakdown all derive from
     // one walk over the billing rules, so the event's adjustment maps always

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -13,6 +13,7 @@ import {
 import { user as userTable } from "@shared/db/better-auth.ts";
 import {
     type BillingAdjustment,
+    getPriceDefinitionForModel,
     getRegistryModelDefinition,
     type ModelName,
 } from "@shared/registry/registry.ts";
@@ -26,7 +27,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
 import { logger } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
-import { reduceAdjustmentsToEventFields, track } from "@/middleware/track.ts";
+import {
+    reduceAdjustmentsToEventFields,
+    track,
+    trackResponse,
+} from "@/middleware/track.ts";
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -454,6 +459,60 @@ describe("tracking observability", () => {
         expect(tinybirdFetch).not.toHaveBeenCalled();
     });
 
+    it("records the resolved model on a failed generation", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn(async (_amount: number) => {});
+
+        const ctx = createExecutionContext();
+        const response = await createHeaderApp(
+            {},
+            trackingUser,
+            502,
+            consumePollen,
+        ).fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "openai",
+                    stream: false,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(502);
+        expect(tinybirdRequests).toHaveLength(1);
+        // modelUsed comes from the resolved model, not the upstream
+        // x-model-used header, so error rows attribute the failure instead of
+        // falling back to the datasource DEFAULT 'undefined'.
+        await expect(tinybirdRequests[0].json()).resolves.toMatchObject({
+            responseStatus: 502,
+            resolvedModelRequested: "openai",
+            modelUsed: "openai",
+            isBilledUsage: false,
+        });
+    });
+
     it("does not emit Tinybird generation events for unauthenticated requests", async () => {
         const tinybirdFetch = vi
             .spyOn(globalThis, "fetch")
@@ -701,6 +760,7 @@ describe("tracking observability", () => {
             eventType: "generate.image",
             responseStatus: 200,
             isBilledUsage: false,
+            modelUsed: "openai",
         });
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
@@ -1070,6 +1130,87 @@ describe("tracking observability", () => {
     it("records fallbackUsed=false when no fallback header is present", async () => {
         const event = await captureFallbackEvent({});
         expect(event.fallbackUsed).toBe(false);
+    });
+});
+
+function requestTrackingFixture(
+    streamRequested = false,
+    model: ModelName = "openai",
+) {
+    const definition = getRegistryModelDefinition(model);
+    const modelCostDefinition = definition.cost;
+    const modelPriceDefinition = getPriceDefinitionForModel(definition);
+    if (!modelCostDefinition || !modelPriceDefinition) {
+        throw new Error(`Missing cost/price definition for ${model}`);
+    }
+    return {
+        modelRequested: model,
+        resolvedModelRequested: model,
+        modelProvider: definition.provider,
+        modelDefinition: definition,
+        modelCostDefinition,
+        modelPriceDefinition,
+        streamRequested,
+        referrerData: {},
+    };
+}
+
+describe("trackResponse modelUsed", () => {
+    it("attributes a failed generation to the resolved model", async () => {
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(),
+            new Response("upstream exploded", { status: 502 }),
+        );
+        expect(tracking).toMatchObject({
+            responseStatus: 502,
+            cacheHit: false,
+            isBilledUsage: false,
+            modelUsed: "openai",
+        });
+    });
+
+    it("attributes a 200 with an unexpected content-type to the resolved model", async () => {
+        const tracking = await trackResponse(
+            "generate.image",
+            requestTrackingFixture(),
+            // A JSON error body served with HTTP 200 instead of an image.
+            Response.json({ error: "boom" }),
+        );
+        expect(tracking).toMatchObject({
+            responseStatus: 200,
+            isBilledUsage: false,
+            modelUsed: "openai",
+        });
+    });
+
+    it("attributes a 200 with unextractable usage to the resolved model", async () => {
+        // A well-formed SSE stream that never carries a usage object, so
+        // extraction returns no ModelUsage and the request is not billed.
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(true),
+            new Response(
+                'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n',
+                { headers: { "content-type": "text/event-stream" } },
+            ),
+        );
+        expect(tracking).toMatchObject({
+            responseStatus: 200,
+            isBilledUsage: false,
+            modelUsed: "openai",
+        });
+    });
+
+    it("does not attribute a model to a cache hit", async () => {
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(),
+            Response.json({ choices: [] }, { headers: { "x-cache": "HIT" } }),
+        );
+        expect(tracking.cacheHit).toBe(true);
+        expect(tracking.isBilledUsage).toBe(false);
+        expect(tracking.modelUsed).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
- `trackResponse` built every not-billed result without `modelUsed`, so `model_used` fell back to the datasource DEFAULT `'undefined'` on every failed generation and error rows could not say which model failed.
- Sets `modelUsed` to `resolvedModelRequested` on the three not-billed paths where a model was actually called: upstream error, 200 with an unexpected content-type, and 200 with unextractable usage.
- Cache hits are excluded and keep `modelUsed` unset — a cache hit called no model, so attributing one would be false. This required splitting `!response.ok || cacheHit` into two checks, with `cacheHit` tested first.
- Verified assumption: `resolvedModelRequested` is the model that was called. `resolveModel` runs once per request and no path re-dispatches to a different Pollinations model id. Portkey's multi-target config (`x-portkey-last-used-option-index` / `x-fallback-target`, surfaced as `fallbackUsed`) and `callFluxWithFallback` swap the upstream provider target behind a single model id, not the id itself. The success path already falls back to `c.var.model.resolved` for `x-model-used` when upstream omits a model name, so mixing the two is existing behaviour.
- Tests: 4 direct `trackResponse` cases (three attributed paths + cache hit) and one end-to-end assertion that the Tinybird payload carries `modelUsed` on a 502. No existing assertions weakened.

Fixes #12897

🤖 Generated with [Claude Code](https://claude.com/claude-code)