### PR TITLE
ci: deduplicate CodeQL compatibility job

### DIFF
--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -9,25 +9,28 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    permissions:
+    permissions: &codeql_permissions
       security-events: write
       contents: read
 
-    strategy:
+    strategy: &codeql_strategy
       fail-fast: false
       matrix:
         language: [actions, javascript-typescript, python]
 
     steps:
-      - name: Checkout repository
+      - &checkout_repository
+        name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Initialize CodeQL
+      - &initialize_codeql
+        name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
-      - name: Autobuild
+      - &autobuild
+        name: Autobuild
         uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
@@ -39,26 +42,13 @@ jobs:
   analyze_legacy:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [actions, javascript-typescript, python]
+    permissions: *codeql_permissions
+    strategy: *codeql_strategy
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - *checkout_repository
+      - *initialize_codeql
+      - *autobuild
 
       - name: Perform legacy CodeQL analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- Shares CodeQL permissions, language strategy, checkout, initialization, and autobuild steps through supported YAML aliases.
- Keeps the primary `analyze` job ID and language-only matrix, preserving all three required check names.
- Keeps the PR-only legacy job and its historical SARIF category unchanged.
- Checks: `actionlint` and Prettier pass; the CodeQL jobs run on this PR.