### PR TITLE
refactor: share community endpoint error parsing

### DIFF
--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -1,6 +1,7 @@
 import {
     type CommunityEndpointImagePricing,
     communityChatCompletionsUrl,
+    communityEndpointErrorBodyMessage,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
     communityOpenAIBaseUrl,
@@ -69,7 +70,7 @@ async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
 }
 
 function endpointErrorMessage(status: number, body: unknown): string {
-    const message = endpointBodyMessage(body);
+    const message = communityEndpointErrorBodyMessage(body);
     const prefix =
         status === 401
             ? "Endpoint responded 401 after we sent Authorization"
@@ -77,24 +78,6 @@ function endpointErrorMessage(status: number, body: unknown): string {
               ? `Endpoint responded ${status} with a redirect, which is not supported`
               : `Endpoint responded ${status}`;
     return message ? `${prefix}: ${message}` : prefix;
-}
-
-function endpointBodyMessage(body: unknown): string | null {
-    if (!body || typeof body !== "object") return null;
-    if (
-        "error" in body &&
-        body.error &&
-        typeof body.error === "object" &&
-        "message" in body.error &&
-        typeof body.error.message === "string"
-    ) {
-        return body.error.message;
-    }
-    if ("error" in body && typeof body.error === "string") return body.error;
-    if ("message" in body && typeof body.message === "string") {
-        return body.message;
-    }
-    return null;
 }
 
 export async function listCommunityEndpointModels({

--- a/gen.pollinations.ai/src/image/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/image/communityEndpoint.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import {
     type CommunityEndpointRuntime,
+    communityEndpointErrorBodyMessage,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
     normalizeCommunityAssetUrl,
@@ -302,26 +303,8 @@ function parseJson(text: string): unknown {
 }
 
 function endpointErrorMessage(status: number, body: unknown): string {
-    const message = endpointBodyMessage(body);
+    const message = communityEndpointErrorBodyMessage(body);
     return message
         ? `Community image endpoint responded ${status}: ${message}`
         : `Community image endpoint responded ${status}`;
-}
-
-function endpointBodyMessage(body: unknown): string | null {
-    if (!body || typeof body !== "object") return null;
-    if (
-        "error" in body &&
-        body.error &&
-        typeof body.error === "object" &&
-        "message" in body.error &&
-        typeof body.error.message === "string"
-    ) {
-        return body.error.message;
-    }
-    if ("error" in body && typeof body.error === "string") return body.error;
-    if ("message" in body && typeof body.message === "string") {
-        return body.message;
-    }
-    return null;
 }

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -293,6 +293,25 @@ export function normalizeCommunityEndpointBearerToken(value: string): string {
     return token;
 }
 
+export function communityEndpointErrorBodyMessage(
+    body: unknown,
+): string | null {
+    if (!body || typeof body !== "object") return null;
+    const { error, message } = body as {
+        error?: string | { message?: unknown };
+        message?: unknown;
+    };
+    if (
+        error &&
+        typeof error === "object" &&
+        typeof error.message === "string"
+    ) {
+        return error.message;
+    }
+    if (typeof error === "string") return error;
+    return typeof message === "string" ? message : null;
+}
+
 export function isCommunityEndpointOwnerAllowed(
     owner: CommunityEndpointOwnerLike | null | undefined,
 ): boolean {


### PR DESCRIPTION
- Moves shared OpenAI-style error envelope parsing into the community endpoint utilities.
- Keeps Gen and Enter status prefixes and remapping behavior unchanged.
- Removes duplicate parser implementations so accepted upstream shapes stay in sync.
- Tests: 35 Gen community endpoint tests, 8 Enter endpoint tests, both typechecks, and Biome.