### PR TITLE
refactor: share credential query redaction

### DIFF
--- a/gen.pollinations.ai/src/middleware/logger.ts
+++ b/gen.pollinations.ai/src/middleware/logger.ts
@@ -1,6 +1,7 @@
 import { getLogger, type Logger, withContext } from "@logtape/logtape";
 import { getRealClientIp } from "@shared/client-ip.ts";
 import { ensureConfigured } from "@shared/logger.ts";
+import { redactCredentialQueryParams } from "@shared/observability/request-inputs.ts";
 import { getPublicUrl } from "@shared/public-origin.ts";
 import { createMiddleware } from "hono/factory";
 
@@ -13,22 +14,6 @@ type Env = {
     Bindings: CloudflareBindings;
     Variables: LoggerVariables;
 };
-
-function redactCredentialQueryParams(url: URL): string {
-    const redacted = new URL(url);
-    const credentialParams = new Set([
-        "access_token",
-        "api_key",
-        "key",
-        "token",
-    ]);
-    for (const param of redacted.searchParams.keys()) {
-        if (credentialParams.has(param.toLowerCase())) {
-            redacted.searchParams.set(param, "[redacted]");
-        }
-    }
-    return redacted.toString();
-}
 
 export const logger = createMiddleware<Env>(async (c, next) => {
     await ensureConfigured({

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -11,6 +11,7 @@ import {
     truncateIpToSubnet,
 } from "@shared/client-ip.ts";
 import { sendToTinybird } from "@shared/events.ts";
+import { redactCredentialQueryParams } from "@shared/observability/request-inputs.ts";
 import type { RealtimeModelName } from "@shared/registry/realtime.ts";
 import {
     type BillingAdjustment,
@@ -69,12 +70,6 @@ const REALTIME_ROUTES: Record<
         apiKeyEnv: "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
     },
 };
-const CREDENTIAL_QUERY_PARAMS = new Set([
-    "access_token",
-    "api_key",
-    "key",
-    "token",
-]);
 const UNSUPPORTED_TRANSCRIPTION_MESSAGE =
     "Realtime input transcription is not supported yet.";
 type WebSocketResponse = Response & { webSocket?: WebSocket };
@@ -415,16 +410,6 @@ function extractReferrerHeader(c: Context<Env>): {
     } catch {
         return {};
     }
-}
-
-function redactCredentialQueryParams(url: URL): string {
-    const redacted = new URL(url);
-    for (const param of redacted.searchParams.keys()) {
-        if (CREDENTIAL_QUERY_PARAMS.has(param.toLowerCase())) {
-            redacted.searchParams.set(param, "[redacted]");
-        }
-    }
-    return redacted.toString();
 }
 
 function getPostDeductionBalances(

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -909,7 +909,7 @@ test("redacts credential query parameters from realtime referrer telemetry", asy
             headers: {
                 Authorization: `Bearer ${key}`,
                 Referer:
-                    "https://app.example/call?key=pk_secret&token=t&api_key=a&access_token=b&ok=1",
+                    "https://app.example/call?key=pk_secret&token=t&api_key=a&access_token=b&apikey=c&bearerToken=d&ok=1",
                 Upgrade: "websocket",
             },
         },
@@ -939,7 +939,7 @@ test("redacts credential query parameters from realtime referrer telemetry", asy
     ) as Record<string, unknown>;
     expect(telemetry.referrerDomain).toBe("app.example");
     expect(telemetry.referrerUrl).toBe(
-        "https://app.example/call?key=%5Bredacted%5D&token=%5Bredacted%5D&api_key=%5Bredacted%5D&access_token=%5Bredacted%5D&ok=1",
+        "https://app.example/call?key=%5Bredacted%5D&token=%5Bredacted%5D&api_key=%5Bredacted%5D&access_token=%5Bredacted%5D&apikey=%5Bredacted%5D&bearerToken=%5Bredacted%5D&ok=1",
     );
 });
 

--- a/shared/observability/request-inputs.ts
+++ b/shared/observability/request-inputs.ts
@@ -20,6 +20,16 @@ const CREDENTIAL_QUERY_PARAMS = new Set([
 ]);
 const REDACTED = "[redacted]";
 
+export function redactCredentialQueryParams(url: URL): string {
+    const redacted = new URL(url);
+    for (const param of redacted.searchParams.keys()) {
+        if (CREDENTIAL_QUERY_PARAMS.has(param.toLowerCase())) {
+            redacted.searchParams.set(param, REDACTED);
+        }
+    }
+    return redacted.toString();
+}
+
 export async function collectRequestInputs(c: Context): Promise<RequestInputs> {
     const inputs: RequestInputs = {
         params: removeEmptyRecord(safeParams(c)),


### PR DESCRIPTION
- Moves credential query-string redaction into the existing shared observability utility.
- Replaces duplicate logger and realtime implementations with the same canonical credential-name set.
- Expands both paths to cover aliases such as `apikey` and `bearerToken` without changing non-credential query parameters.
- Tests: 32 realtime/error-observability tests, Gen typecheck, and Biome.