### PR TITLE
refactor: share account permission guards

### DIFF
--- a/enter.pollinations.ai/src/routes/account-permissions.ts
+++ b/enter.pollinations.ai/src/routes/account-permissions.ts
@@ -1,23 +1,26 @@
+import { HTTPException } from "hono/http-exception";
+
 export type AccountPermission = "profile" | "usage" | "keys";
 
 export type AccountPermissionApiKey = {
     permissions?: Record<string, string[]>;
 };
 
-export function hasDirectAccountPermission(
+export function hasAccountPermission(
     apiKey: AccountPermissionApiKey | undefined,
     permission: AccountPermission,
 ): boolean {
-    return !!apiKey?.permissions?.account?.includes(permission);
+    if (!apiKey) return true;
+    return !!apiKey.permissions?.account?.includes(permission);
 }
 
-/**
- * Read APIs have one canonical read permission (`profile` or `usage`).
- */
-export function hasAccountReadPermission(
+export function requireAccountPermission(
     apiKey: AccountPermissionApiKey | undefined,
-    permission: Exclude<AccountPermission, "keys">,
-): boolean {
-    if (!apiKey) return true;
-    return hasDirectAccountPermission(apiKey, permission);
+    permission: AccountPermission,
+): void {
+    if (!hasAccountPermission(apiKey, permission)) {
+        throw new HTTPException(403, {
+            message: `API key does not have 'account:${permission}' permission`,
+        });
+    }
 }

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -31,8 +31,8 @@ import {
     requireTinybirdReadToken,
 } from "../services/tinybird.ts";
 import {
-    hasAccountReadPermission,
-    hasDirectAccountPermission,
+    hasAccountPermission,
+    requireAccountPermission,
 } from "./account-permissions.ts";
 import { communityEndpointsRoutes } from "./community-endpoints.ts";
 import { parseMetadata } from "./metadata-utils.ts";
@@ -82,33 +82,6 @@ export function resolveUsageTargetUserId(
         userId: debugUserId,
         overridden: debugUserId !== currentUserId,
     };
-}
-
-/**
- * Require that the caller has `account:keys` permission.
- * Session-authenticated users (no apiKey) are always allowed.
- */
-function requireKeysPermission(apiKey?: {
-    permissions?: Record<string, string[]>;
-    metadata?: Record<string, unknown>;
-}): void {
-    if (!apiKey) return; // session auth — always allowed
-    if (!hasDirectAccountPermission(apiKey, "keys")) {
-        throw new HTTPException(403, {
-            message: "API key does not have 'account:keys' permission",
-        });
-    }
-}
-
-function requireUsagePermission(apiKey?: {
-    permissions?: Record<string, string[]>;
-    metadata?: Record<string, unknown>;
-}): void {
-    if (apiKey && !hasAccountReadPermission(apiKey, "usage")) {
-        throw new HTTPException(403, {
-            message: "API key does not have 'account:usage' permission",
-        });
-    }
 }
 
 // Schema for creating an API key via the API
@@ -820,8 +793,7 @@ export const accountRoutes = new Hono<Env>()
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
-            const includeProfilePII =
-                !apiKey || hasAccountReadPermission(apiKey, "profile");
+            const includeProfilePII = hasAccountPermission(apiKey, "profile");
 
             const db = drizzle(c.env.DB);
             const users = await db
@@ -879,7 +851,7 @@ export const accountRoutes = new Hono<Env>()
         async (c) => {
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
-            requireUsagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "usage");
 
             const db = drizzle(c.env.DB, { schema });
             const [cards, rewardRows] = await Promise.all([
@@ -974,7 +946,7 @@ export const accountRoutes = new Hono<Env>()
             }
 
             // Beyond that, reading account balance requires usage or admin.
-            if (apiKey && !hasAccountReadPermission(apiKey, "usage")) {
+            if (!hasAccountPermission(apiKey, "usage")) {
                 throw new HTTPException(403, {
                     message:
                         "API key does not have 'account:usage' permission and no budget of its own. Add `account:usage` or set a budget on the key.",
@@ -1031,7 +1003,7 @@ export const accountRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
 
-            requireUsagePermission(apiKey);
+            requireAccountPermission(apiKey, "usage");
 
             const {
                 format,
@@ -1115,7 +1087,7 @@ export const accountRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
 
-            requireUsagePermission(apiKey);
+            requireAccountPermission(apiKey, "usage");
 
             const {
                 format,
@@ -1217,7 +1189,7 @@ export const accountRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
 
-            requireUsagePermission(apiKey);
+            requireAccountPermission(apiKey, "usage");
 
             const { limit, days, granularity, period } = c.req.valid("query");
             const { userId: devUserId } = resolveUsageTargetUserId(
@@ -1289,7 +1261,7 @@ export const accountRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
 
-            requireUsagePermission(apiKey);
+            requireAccountPermission(apiKey, "usage");
 
             const { format, days, granularity, period } = c.req.valid("query");
             const grain = granularity === "day" ? "hour" : "day";
@@ -1359,7 +1331,7 @@ export const accountRoutes = new Hono<Env>()
         async (c) => {
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
-            requireKeysPermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
 
             const db = drizzle(c.env.DB);
             const keys = await db
@@ -1434,7 +1406,7 @@ export const accountRoutes = new Hono<Env>()
         async (c) => {
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
-            requireKeysPermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
 
             const {
                 name,
@@ -1493,7 +1465,7 @@ export const accountRoutes = new Hono<Env>()
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
             const callerKey = c.var.auth.apiKey;
-            requireKeysPermission(callerKey);
+            requireAccountPermission(callerKey, "keys");
 
             const { id } = c.req.param();
 

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -46,7 +46,7 @@ import {
     testCommunityEndpoint,
     testCommunityImageEndpoint,
 } from "../services/community-endpoint-openai.ts";
-import { hasDirectAccountPermission } from "./account-permissions.ts";
+import { requireAccountPermission } from "./account-permissions.ts";
 
 const ModalitySchema = z
     .enum(COMMUNITY_ENDPOINT_MODALITIES)
@@ -499,18 +499,6 @@ function throwEndpointTestError(error: unknown): never {
 
 type EndpointProbeKind = "models" | "test";
 
-function requireCommunityEndpointManagePermission(apiKey?: {
-    permissions?: Record<string, string[]>;
-    metadata?: Record<string, unknown>;
-}): void {
-    if (!apiKey) return;
-    if (!hasDirectAccountPermission(apiKey, "keys")) {
-        throw new HTTPException(403, {
-            message: "API key does not have 'account:keys' permission",
-        });
-    }
-}
-
 // Publishing is allowlist-gated. Pricing is independent: public endpoints may
 // be free or owner-priced.
 async function enforcePublishingAccess(
@@ -578,7 +566,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
@@ -616,7 +604,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
@@ -689,7 +677,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
@@ -780,7 +768,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             await requireCommunityEndpointPublishAccess(db, user.id);
             const throttled = await enforceEndpointProbeThrottle(
                 c,
@@ -825,7 +813,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             await requireCommunityEndpointPublishAccess(db, user.id);
             const throttled = await enforceEndpointProbeThrottle(
                 c,
@@ -881,7 +869,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const input = c.req.valid("json");
             const { id } = c.req.param();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
@@ -1035,7 +1023,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const { id } = c.req.param();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             await requireOwnedEndpoint(db, id, user.id);
             await db
                 .delete(schema.communityEndpoint)

--- a/enter.pollinations.ai/src/routes/device.ts
+++ b/enter.pollinations.ai/src/routes/device.ts
@@ -7,7 +7,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "../env.ts";
 import { type AuthVariables, auth } from "../middleware/auth.ts";
-import { hasAccountReadPermission } from "./account-permissions.ts";
+import { hasAccountPermission } from "./account-permissions.ts";
 
 type AuthedContext = Context<{
     Bindings: Env["Bindings"];
@@ -344,9 +344,10 @@ export async function exchangeDeviceCode(
  */
 export async function handleUserinfo(c: AuthedContext) {
     const user = c.var.auth.requireUser();
-    const includeProfilePII =
-        !c.var.auth.apiKey ||
-        hasAccountReadPermission(c.var.auth.apiKey, "profile");
+    const includeProfilePII = hasAccountPermission(
+        c.var.auth.apiKey,
+        "profile",
+    );
     const db = drizzle(c.env.DB, { schema });
     const row = await db.query.user.findFirst({
         where: eq(schema.user.id, user.id),

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -16,7 +16,7 @@ import type {
     QuestCard,
     QuestEvaluationContext,
 } from "../services/quests/types.ts";
-import { hasAccountReadPermission } from "./account-permissions.ts";
+import { requireAccountPermission } from "./account-permissions.ts";
 
 // Bumped to v23: use_app and app_active (7 Pollen) are now available;
 // app_paid_request reward set to 15 while still coming_soon.
@@ -68,17 +68,6 @@ const claimRewardResponseSchema = z.object({
     newBalance: z.number().nullable(),
     reward: rewardSchema,
 });
-
-function requireUsagePermission(apiKey?: {
-    permissions?: Record<string, string[]>;
-    metadata?: Record<string, unknown>;
-}): void {
-    if (apiKey && !hasAccountReadPermission(apiKey, "usage")) {
-        throw new HTTPException(403, {
-            message: "API key does not have 'account:usage' permission",
-        });
-    }
-}
 
 function formatRewardTimestamp(value: Date | number | string): string {
     return value instanceof Date
@@ -201,7 +190,7 @@ export const questsRoutes = new Hono<Env>()
                 message: "Authentication required to view quest rewards",
             });
             const user = c.var.auth.requireUser();
-            requireUsagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "usage");
 
             const db = drizzle(c.env.DB);
             const rewardRows = await db


### PR DESCRIPTION
- Centralizes account scope checks in one predicate and one throwing guard.
- Replaces duplicate `account:usage` and `account:keys` guards across account, quest, device, and community-model routes.
- Preserves session bypass, API-key 403 behavior, and existing error messages.
- Tests: 99 focused tests, Enter typecheck, and Biome.