### PR TITLE
refactor: share OpenRouter image requests

### DIFF
--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -134,6 +134,34 @@ interface OpenRouterImageUsage {
     };
 }
 
+function requireOpenRouterImageApiKey(): string {
+    const apiKey = getImageEnv("OPENROUTER_API_KEY");
+    if (!apiKey) {
+        throw new HttpError(
+            "OPENROUTER_API_KEY environment variable is required",
+            500,
+        );
+    }
+    return apiKey;
+}
+
+async function postOpenRouterImage(
+    apiKey: string,
+    requestBody: Record<string, unknown>,
+    errorLabel: string,
+): Promise<OpenRouterImageResponse> {
+    const response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+        errorLabel,
+    });
+    return (await response.json()) as OpenRouterImageResponse;
+}
+
 function isTokenCount(value: unknown): value is number {
     return Number.isSafeInteger(value) && (value as number) >= 0;
 }
@@ -308,13 +336,7 @@ export async function callOpenRouterSeedreamProAPI(
         );
     }
 
-    const apiKey = getImageEnv("OPENROUTER_API_KEY");
-    if (!apiKey) {
-        throw new HttpError(
-            "OPENROUTER_API_KEY environment variable is required",
-            500,
-        );
-    }
+    const apiKey = requireOpenRouterImageApiKey();
 
     const downloadedImages = await Promise.all(
         safeParams.image.map((image) => downloadUserImage(image)),
@@ -356,16 +378,11 @@ export async function callOpenRouterSeedreamProAPI(
         requestBody.input_references = inputReferences;
     }
 
-    const response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-        errorLabel: "OpenRouter Seedream image generation request failed",
-    });
-    const data = (await response.json()) as OpenRouterImageResponse;
+    const data = await postOpenRouterImage(
+        apiKey,
+        requestBody,
+        "OpenRouter Seedream image generation request failed",
+    );
     const encodedImage = data.data?.[0]?.b64_json;
     if (!encodedImage) {
         throw buildOpenRouterNoImageError(data);
@@ -394,14 +411,7 @@ export async function callOpenRouterGrokImagineProAPI(
     prompt: string,
     safeParams: ImageParams,
 ): Promise<ImageGenerationResult> {
-    const apiKey = getImageEnv("OPENROUTER_API_KEY");
-    if (!apiKey) {
-        throw new HttpError(
-            "OPENROUTER_API_KEY environment variable is required",
-            500,
-        );
-    }
-
+    const apiKey = requireOpenRouterImageApiKey();
     const referenceImage = safeParams.image?.[0];
     const requestBody: Record<string, unknown> = {
         model: GROK_IMAGINE_QUALITY_MODEL,
@@ -422,16 +432,11 @@ export async function callOpenRouterGrokImagineProAPI(
         ];
     }
 
-    const response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-        errorLabel: "OpenRouter image generation request failed",
-    });
-    const data = (await response.json()) as OpenRouterImageResponse;
+    const data = await postOpenRouterImage(
+        apiKey,
+        requestBody,
+        "OpenRouter image generation request failed",
+    );
     const encodedImage = data.data?.[0]?.b64_json;
     if (!encodedImage) {
         throw new HttpError(
@@ -482,13 +487,7 @@ export async function callOpenRouterGeminiImageAPI(
         );
     }
 
-    const apiKey = getImageEnv("OPENROUTER_API_KEY");
-    if (!apiKey) {
-        throw new HttpError(
-            "OPENROUTER_API_KEY environment variable is required",
-            500,
-        );
-    }
+    const apiKey = requireOpenRouterImageApiKey();
 
     const requestBody: Record<string, unknown> = {
         model: config.upstreamModel,
@@ -521,16 +520,11 @@ export async function callOpenRouterGeminiImageAPI(
         requestBody.input_references = inputReferences;
     }
 
-    const response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-        errorLabel: "OpenRouter Gemini image generation request failed",
-    });
-    const data = (await response.json()) as OpenRouterImageResponse;
+    const data = await postOpenRouterImage(
+        apiKey,
+        requestBody,
+        "OpenRouter Gemini image generation request failed",
+    );
     const encodedImage = data.data?.[0]?.b64_json;
     if (!encodedImage) {
         throw buildOpenRouterNoImageError(data);
@@ -578,14 +572,7 @@ export async function callOpenRouterRecraftVectorAPI(
     prompt: string,
     safeParams: ImageParams,
 ): Promise<ImageGenerationResult> {
-    const apiKey = getImageEnv("OPENROUTER_API_KEY");
-    if (!apiKey) {
-        throw new HttpError(
-            "OPENROUTER_API_KEY environment variable is required",
-            500,
-        );
-    }
-
+    const apiKey = requireOpenRouterImageApiKey();
     const referenceImage = safeParams.image?.[0];
     const requestBody: Record<string, unknown> = {
         model: RECRAFT_VECTOR_MODEL,
@@ -609,17 +596,13 @@ export async function callOpenRouterRecraftVectorAPI(
         ];
     }
 
-    let response: Response;
+    let data: OpenRouterImageResponse;
     try {
-        response = await fetchUpstream(OPENROUTER_IMAGE_URL, {
-            method: "POST",
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(requestBody),
-            errorLabel: "OpenRouter vector generation request failed",
-        });
+        data = await postOpenRouterImage(
+            apiKey,
+            requestBody,
+            "OpenRouter vector generation request failed",
+        );
     } catch (error) {
         if (error instanceof HttpError && error.status === 429) {
             throw new UpstreamError(429, {
@@ -632,8 +615,6 @@ export async function callOpenRouterRecraftVectorAPI(
         }
         throw error;
     }
-
-    const data = (await response.json()) as OpenRouterImageResponse;
     const generatedImage = data.data?.[0];
     if (!generatedImage?.b64_json) {
         throw new HttpError(


### PR DESCRIPTION
- Centralizes OpenRouter image credential validation, authenticated POST construction, and JSON parsing.
- Removes four transport copies across Seedream, Grok Imagine, Gemini, and Recraft while leaving model-specific request bodies and billing intact.
- Preserves validation order, error labels, and Recraft's retryable 429 mapping.
- Tests: 24 focused adapter tests, Gen typecheck, and Biome.