### PR TITLE
refactor: trust normalized image parameters

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -420,7 +420,7 @@ const callGPTImageWithEndpoint = async (
         );
     }
 
-    const isEditMode = safeParams.image && safeParams.image.length > 0;
+    const isEditMode = safeParams.image.length > 0;
     const path = isEditMode ? "images/edits" : "images/generations";
     const endpoint = `${config.baseUrl}/${path}?api-version=${AZURE_API_VERSION}`;
     logCloudflare(
@@ -512,18 +512,7 @@ const callGPTImageWithEndpoint = async (
 
         // Handle images based on their type
         try {
-            // Convert to array if it's a string (backward compatible)
-            const imageUrls = Array.isArray(safeParams.image)
-                ? safeParams.image
-                : [safeParams.image];
-
-            if (imageUrls.length === 0) {
-                // Handle errors for missing image
-                throw new HttpError(
-                    "Image URL is required for GPT Image edit mode but was not provided",
-                    400,
-                );
-            }
+            const imageUrls = safeParams.image;
 
             // Process each image in the array
             for (let i = 0; i < imageUrls.length; i++) {

--- a/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
+++ b/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
@@ -45,7 +45,7 @@ export async function callAzureFluxKontext(
     }
 
     // Check if we need to use the edits endpoint instead of generations
-    const isEditMode = safeParams.image && safeParams.image.length > 0;
+    const isEditMode = safeParams.image.length > 0;
 
     // Add the appropriate endpoint path and API version
     let endpoint: string;
@@ -85,20 +85,8 @@ export async function callAzureFluxKontext(
 
         // Handle images based on their type
         try {
-            // Convert to array if it's a string (backward compatible)
-            const imageUrls = Array.isArray(safeParams.image)
-                ? safeParams.image
-                : [safeParams.image];
-
-            if (imageUrls.length === 0) {
-                throw new HttpError(
-                    "Image URL is required for Flux Kontext edit mode but was not provided",
-                    400,
-                );
-            }
-
             // Process the first image (Flux Kontext typically uses single image)
-            const imageUrl = imageUrls[0];
+            const imageUrl = safeParams.image[0];
             logCloudflare(`Fetching image from URL: ${imageUrl}`);
 
             const { buffer, mimeType } = await downloadUserImage(imageUrl);
@@ -173,7 +161,7 @@ export async function callAzureFluxKontext(
         }>;
     };
 
-    if (!data.data || !data.data[0] || !data.data[0].b64_json) {
+    if (!data.data?.[0]?.b64_json) {
         throw new HttpError(
             "Invalid response from Azure Flux Kontext API",
             500,

--- a/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
+++ b/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
@@ -36,16 +36,12 @@ export const callFluxKleinAPI = async (
     safeParams: ImageParams,
 ): Promise<ImageGenerationResult> => {
     try {
-        const hasReferenceImages =
-            safeParams.image && safeParams.image.length > 0;
+        const hasReferenceImages = safeParams.image.length > 0;
 
         // Download and encode reference images if provided
         let imagesB64: string[] = [];
         if (hasReferenceImages) {
-            const imageUrls = (safeParams.image || []).slice(
-                0,
-                MAX_INPUT_IMAGES,
-            );
+            const imageUrls = safeParams.image.slice(0, MAX_INPUT_IMAGES);
             const downloads = await Promise.all(
                 imageUrls.map((url) => downloadUserImage(url)),
             );

--- a/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
@@ -73,11 +73,7 @@ export async function callNovaCanvasAPI(
     );
 
     // Check if image input is provided for editing mode
-    const rawImageUrl = safeParams.image
-        ? Array.isArray(safeParams.image)
-            ? safeParams.image[0]
-            : safeParams.image
-        : undefined;
+    const rawImageUrl = safeParams.image[0];
     const mode = rawImageUrl ? "IMAGE_VARIATION" : "TEXT_IMAGE";
 
     logOps(`Calling Nova Canvas API (${mode}):`, {

--- a/gen.pollinations.ai/src/image/models/novaReelModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaReelModel.ts
@@ -48,10 +48,10 @@ function validateNovaReelRequest({
 }: {
     prompt: string;
     duration?: number;
-    image?: string | string[];
+    image: string[];
 }): void {
     const durationSeconds = getNovaReelDurationSeconds(duration);
-    const hasImage = Boolean(image && image.length > 0);
+    const hasImage = image.length > 0;
     const isMultiShot = durationSeconds > 6;
 
     if (hasImage && isMultiShot) {
@@ -104,14 +104,13 @@ export async function callNovaReelAPI(
 ): Promise<VideoGenerationResult> {
     // Duration must be a multiple of 6. TEXT_VIDEO = 6s only. MULTI_SHOT_AUTOMATED = 12-120s.
     const durationSeconds = getNovaReelDurationSeconds(safeParams.duration);
-    const imageParam = safeParams.image as string | string[] | undefined;
-    const hasImage = Boolean(imageParam && imageParam.length > 0);
+    const hasImage = safeParams.image.length > 0;
     const isMultiShot = durationSeconds > 6;
 
     validateNovaReelRequest({
         prompt,
         duration: safeParams.duration,
-        image: imageParam,
+        image: safeParams.image,
     });
 
     const accessKeyId = getImageEnv("AWS_ACCESS_KEY_ID");
@@ -158,10 +157,7 @@ export async function callNovaReelAPI(
 
     // Support image-to-video if an input image is provided
     if (hasImage) {
-        const imageUrl = Array.isArray(imageParam) ? imageParam[0] : imageParam;
-        if (!imageUrl) {
-            throw new HttpError("Nova Reel reference image is missing", 400);
-        }
+        const imageUrl = safeParams.image[0];
         logOps("Adding reference image for I2V:", imageUrl);
         const buffer = await normalizeReferenceImage(imageUrl);
         textToVideoParams.images = [

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -115,11 +115,10 @@ const generateVeoVideo = async (
     });
 
     // Check for input image (image-to-video)
-    const hasImage = safeParams.image && safeParams.image.length > 0;
+    const hasImage = safeParams.image.length > 0;
 
     // Check if we have a second image for last frame interpolation
-    const hasLastFrame =
-        Array.isArray(safeParams.image) && safeParams.image.length > 1;
+    const hasLastFrame = safeParams.image.length > 1;
 
     logOps("Video params:", {
         durationSeconds,
@@ -141,9 +140,7 @@ const generateVeoVideo = async (
 
     // Add image for I2V generation (Veo supports 1 reference image as first frame)
     if (hasImage) {
-        const imageUrl = Array.isArray(safeParams.image)
-            ? safeParams.image[0]
-            : safeParams.image;
+        const imageUrl = safeParams.image[0];
         logOps("Adding first frame image for I2V:", imageUrl);
         instance.image = await processImageForVeo(imageUrl, "first frame");
     }

--- a/gen.pollinations.ai/src/image/utils/gptImageLogger.ts
+++ b/gen.pollinations.ai/src/image/utils/gptImageLogger.ts
@@ -38,8 +38,8 @@ export async function logGptImageError(
             prompt,
             model: safeParams.model,
             size: `${safeParams.width}x${safeParams.height}`,
-            hasImageInput: !!safeParams.image,
-            imageUrls: safeParams.image ?? [],
+            hasImageInput: safeParams.image.length > 0,
+            imageUrls: safeParams.image,
             contentSafety: contentSafetyResults
                 ? {
                       safe: contentSafetyResults.safe,

--- a/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
+++ b/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
@@ -210,15 +210,13 @@ export async function callVertexAIGemini(
             width: safeParams.width,
             height: safeParams.height,
             model: safeParams.model,
-            hasReferenceImages: !!(
-                safeParams.image && safeParams.image.length > 0
-            ),
+            hasReferenceImages: safeParams.image.length > 0,
         });
 
         // Process reference image URLs into base64 format
         const processedImages: VertexAIImageData[] = [];
 
-        if (safeParams.image && safeParams.image.length > 0) {
+        if (safeParams.image.length > 0) {
             log(`Processing ${safeParams.image.length} reference image URLs`);
 
             for (let i = 0; i < safeParams.image.length; i++) {


### PR DESCRIPTION
- Removes stale `string | string[] | undefined` handling after `ImageParamsSchema` has normalized every image input to `string[]`.
- Deletes impossible zero-image guards inside edit-only branches across Azure, Vertex, Bedrock, and self-hosted adapters.
- Keeps generation/edit routing and provider request shapes unchanged.
- Corrects GPT Image error telemetry so an empty normalized image list is not reported as an image input.

Tests:
- `npx vitest run test/image/params.test.ts test/image/gptImageRouting.test.ts test/image/novaCanvasModel.test.ts test/image/veoVideoModel.test.ts`
- `npm run typecheck`
- `npx biome check --write` on all changed files