### PR TITLE
test: share realtime session setup

### DIFF
--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -137,6 +137,82 @@ async function waitForTinybirdRequests(
     }
 }
 
+async function openPaidRealtimeSession({
+    name,
+    model = "gpt-realtime-2",
+    referrer,
+}: {
+    name: string;
+    model?: string;
+    referrer?: string;
+}) {
+    const { key, userId } = await createTestApiKey({
+        name,
+        pollenBudget: 1,
+        user: { tierBalance: 0, packBalance: 1 },
+    });
+    const upstream = mockOpenAIRealtime();
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${key}`,
+        Upgrade: "websocket",
+    };
+    if (referrer) headers.Referer = referrer;
+
+    const { response, ctx } = await fetchWorkerWithContext(
+        `/v1/realtime?model=${model}`,
+        { headers },
+    );
+
+    expect(response.status).toBe(101);
+    const client = response.webSocket;
+    if (!client) throw new Error("Expected downstream WebSocket");
+    client.accept();
+    upstream.server.accept();
+
+    return { client, ctx, upstream, userId };
+}
+
+type PaidRealtimeSession = Awaited<ReturnType<typeof openPaidRealtimeSession>>;
+
+async function closeRealtimeSession(session: PaidRealtimeSession) {
+    session.client.close();
+    session.upstream.server.close();
+    await waitOnExecutionContext(session.ctx);
+}
+
+async function closeAndReadTelemetry(session: PaidRealtimeSession) {
+    await closeRealtimeSession(session);
+    expect(session.upstream.tinybirdRequests).toHaveLength(1);
+    return JSON.parse(
+        await session.upstream.tinybirdRequests[0].text(),
+    ) as Record<string, unknown>;
+}
+
+const cachedModalityUsageEvent = JSON.stringify({
+    type: "response.done",
+    response: {
+        usage: {
+            input_tokens: 100,
+            output_tokens: 30,
+            input_token_details: {
+                text_tokens: 40,
+                audio_tokens: 50,
+                image_tokens: 10,
+                cached_tokens: 30,
+                cached_tokens_details: {
+                    text_tokens: 10,
+                    audio_tokens: 15,
+                    image_tokens: 5,
+                },
+            },
+            output_token_details: {
+                text_tokens: 20,
+                audio_tokens: 10,
+            },
+        },
+    },
+});
+
 async function expectClientEventRejected(
     paidApiKey: string,
     event: unknown,
@@ -388,36 +464,17 @@ test("closes instead of forwarding client input transcription events", async ({
 });
 
 test("closes instead of forwarding upstream input transcription events", async () => {
-    const { key, userId } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "upstream-transcription-realtime-key",
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockOpenAIRealtime();
-
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
 
     let clientReceived = false;
-    client.addEventListener("message", () => {
+    session.client.addEventListener("message", () => {
         clientReceived = true;
     });
 
-    const closeEvent = nextClose(client);
-    upstream.server.send(
+    const closeEvent = nextClose(session.client);
+    session.upstream.server.send(
         JSON.stringify({
             type: "conversation.item.input_audio_transcription.delta",
             usage: { input_tokens: 10 },
@@ -429,42 +486,23 @@ test("closes instead of forwarding upstream input transcription events", async (
         reason: "Realtime input transcription is not supported yet.",
     });
     expect(clientReceived).toBe(false);
-    upstream.server.close();
-    await waitForTinybirdRequests(upstream);
-    await waitOnExecutionContext(ctx);
+    session.upstream.server.close();
+    await waitForTinybirdRequests(session.upstream);
+    await waitOnExecutionContext(session.ctx);
 
-    const user = await waitForPackBalanceBelow(userId, 1);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeLessThan(1);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
+    expect(session.upstream.tinybirdRequests).toHaveLength(1);
     const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
+        await session.upstream.tinybirdRequests[0].text(),
     ) as Record<string, unknown>;
     expect(telemetry.tokenCountPromptText).toBe(10);
 });
 
 test("deducts aggregate session usage from paid pack balance on close", async () => {
-    const { key, userId } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "paid-budgeted-realtime-key",
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockOpenAIRealtime();
-
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
 
     const usageEvent = JSON.stringify({
         type: "response.done",
@@ -491,25 +529,17 @@ test("deducts aggregate session usage from paid pack balance on close", async ()
         },
     });
 
-    upstream.server.send(usageEvent);
-    upstream.server.send(usageEvent);
+    session.upstream.server.send(usageEvent);
+    session.upstream.server.send(usageEvent);
 
     await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(upstream.tinybirdRequests).toHaveLength(0);
+    expect(session.upstream.tinybirdRequests).toHaveLength(0);
 
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
-
-    const user = await waitForPackBalanceBelow(userId, 1);
+    const telemetry = await closeAndReadTelemetry(session);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
 
     const expectedCharge = 0.003553 * 2 * 0.75;
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
     expect(telemetry.eventType).toBe("generate.realtime");
     expect(telemetry.responseStatus).toBe(200);
     expect(telemetry.resolvedModelRequested).toBe("gpt-realtime-2");
@@ -523,165 +553,68 @@ test("deducts aggregate session usage from paid pack balance on close", async ()
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 8);
 });
 
-test.each([
-    "gpt-realtime-2",
-    "gpt-realtime-2.1",
-] as const)("bills %s cached image tokens at $0.50/M", async (model) => {
-    const { key, userId } = await createTestApiKey({
-        name: `${model}-cache-realtime-key`,
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
-    });
-    const upstream = mockOpenAIRealtime();
+test.each(["gpt-realtime-2", "gpt-realtime-2.1"] as const)(
+    "bills %s cached image tokens at $0.50/M",
+    async (model) => {
+        const session = await openPaidRealtimeSession({
+            name: `${model}-cache-realtime-key`,
+            model,
+        });
 
-    const { response, ctx } = await fetchWorkerWithContext(
-        `/v1/realtime?model=${model}`,
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
+        for (let eventCount = 0; eventCount < 2; eventCount++) {
+            const forwardedEvent = nextMessage(session.client);
+            session.upstream.server.send(cachedModalityUsageEvent);
+            await expect(forwardedEvent).resolves.toBe(
+                cachedModalityUsageEvent,
+            );
+        }
 
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
+        const telemetry = await closeAndReadTelemetry(session);
 
-    const usageEvent = JSON.stringify({
-        type: "response.done",
-        response: {
-            usage: {
-                input_tokens: 100,
-                output_tokens: 30,
-                input_token_details: {
-                    text_tokens: 40,
-                    audio_tokens: 50,
-                    image_tokens: 10,
-                    cached_tokens: 30,
-                    cached_tokens_details: {
-                        text_tokens: 10,
-                        audio_tokens: 15,
-                        image_tokens: 5,
-                    },
-                },
-                output_token_details: {
-                    text_tokens: 20,
-                    audio_tokens: 10,
-                },
-            },
-        },
-    });
-
-    const firstForwardedEvent = nextMessage(client);
-    upstream.server.send(usageEvent);
-    await expect(firstForwardedEvent).resolves.toBe(usageEvent);
-    const secondForwardedEvent = nextMessage(client);
-    upstream.server.send(usageEvent);
-    await expect(secondForwardedEvent).resolves.toBe(usageEvent);
-
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
-
-    const expectedCost = 0.0023975 * 2;
-    const expectedCharge = expectedCost * 0.75;
-    const user = await waitForPackBalanceBelow(userId, 1);
-    expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
-    expect(telemetry.resolvedModelRequested).toBe(model);
-    expect(telemetry.tokenCountPromptText).toBe(60);
-    expect(telemetry.tokenCountPromptCached).toBe(60);
-    expect(telemetry.tokenCountPromptAudio).toBe(70);
-    expect(telemetry.tokenCountPromptImage).toBe(10);
-    expect(telemetry.tokenCountCompletionText).toBe(40);
-    expect(telemetry.tokenCountCompletionAudio).toBe(20);
-    expect(telemetry.adjustmentUnits).toEqual({
-        "openai.realtime.cached_image_delta.v1": 10,
-    });
-    const adjustmentCosts = telemetry.adjustmentCosts as Record<string, number>;
-    expect(
-        adjustmentCosts["openai.realtime.cached_image_delta.v1"],
-    ).toBeCloseTo(0.000001, 12);
-    expect(telemetry.totalCost).toBeCloseTo(expectedCost, 10);
-    expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 10);
-});
+        const expectedCost = 0.0023975 * 2;
+        const expectedCharge = expectedCost * 0.75;
+        const user = await waitForPackBalanceBelow(session.userId, 1);
+        expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
+        expect(telemetry.resolvedModelRequested).toBe(model);
+        expect(telemetry.tokenCountPromptText).toBe(60);
+        expect(telemetry.tokenCountPromptCached).toBe(60);
+        expect(telemetry.tokenCountPromptAudio).toBe(70);
+        expect(telemetry.tokenCountPromptImage).toBe(10);
+        expect(telemetry.tokenCountCompletionText).toBe(40);
+        expect(telemetry.tokenCountCompletionAudio).toBe(20);
+        expect(telemetry.adjustmentUnits).toEqual({
+            "openai.realtime.cached_image_delta.v1": 10,
+        });
+        const adjustmentCosts = telemetry.adjustmentCosts as Record<
+            string,
+            number
+        >;
+        expect(
+            adjustmentCosts["openai.realtime.cached_image_delta.v1"],
+        ).toBeCloseTo(0.000001, 12);
+        expect(telemetry.totalCost).toBeCloseTo(expectedCost, 10);
+        expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 10);
+    },
+);
 
 test("bills mini cached audio and image tokens at their exact rates", async () => {
-    const { key, userId } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "mini-cache-realtime-key",
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
-    });
-    const upstream = mockOpenAIRealtime();
-
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2.1-mini",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
-
-    const usageEvent = JSON.stringify({
-        type: "response.done",
-        response: {
-            usage: {
-                input_tokens: 100,
-                output_tokens: 30,
-                input_token_details: {
-                    text_tokens: 40,
-                    audio_tokens: 50,
-                    image_tokens: 10,
-                    cached_tokens: 30,
-                    cached_tokens_details: {
-                        text_tokens: 10,
-                        audio_tokens: 15,
-                        image_tokens: 5,
-                    },
-                },
-                output_token_details: {
-                    text_tokens: 20,
-                    audio_tokens: 10,
-                },
-            },
-        },
+        model: "gpt-realtime-2.1-mini",
     });
 
-    const firstForwardedEvent = nextMessage(client);
-    upstream.server.send(usageEvent);
-    await expect(firstForwardedEvent).resolves.toBe(usageEvent);
-    const secondForwardedEvent = nextMessage(client);
-    upstream.server.send(usageEvent);
-    await expect(secondForwardedEvent).resolves.toBe(usageEvent);
+    for (let eventCount = 0; eventCount < 2; eventCount++) {
+        const forwardedEvent = nextMessage(session.client);
+        session.upstream.server.send(cachedModalityUsageEvent);
+        await expect(forwardedEvent).resolves.toBe(cachedModalityUsageEvent);
+    }
 
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
+    const telemetry = await closeAndReadTelemetry(session);
 
     const expectedCost = 0.0006255 * 2;
     const expectedCharge = 0.00093825;
-    const user = await waitForPackBalanceBelow(userId, 1);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
     expect(telemetry.tokenCountPromptText).toBe(60);
     expect(telemetry.tokenCountPromptCached).toBe(60);
     expect(telemetry.tokenCountPromptAudio).toBe(70);
@@ -704,28 +637,10 @@ test("bills mini cached audio and image tokens at their exact rates", async () =
 });
 
 test("uses the cached-text rate when cache details are absent", async () => {
-    const { key, userId } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "mini-missing-cache-details-key",
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
+        model: "gpt-realtime-2.1-mini",
     });
-    const upstream = mockOpenAIRealtime();
-
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2.1-mini",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
 
     const warn = vi.spyOn(getLogger(["hono", "realtime"]), "warn");
     const usageEvent = JSON.stringify({
@@ -742,11 +657,11 @@ test("uses the cached-text rate when cache details are absent", async () => {
             },
         },
     });
-    const firstForwardedEvent = nextMessage(client);
-    upstream.server.send(usageEvent);
+    const firstForwardedEvent = nextMessage(session.client);
+    session.upstream.server.send(usageEvent);
     await expect(firstForwardedEvent).resolves.toBe(usageEvent);
-    const secondForwardedEvent = nextMessage(client);
-    upstream.server.send(usageEvent);
+    const secondForwardedEvent = nextMessage(session.client);
+    session.upstream.server.send(usageEvent);
     await expect(secondForwardedEvent).resolves.toBe(usageEvent);
 
     expect(warn).toHaveBeenCalledOnce();
@@ -755,19 +670,12 @@ test("uses the cached-text rate when cache details are absent", async () => {
         { model: "gpt-realtime-2.1-mini" },
     );
 
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
+    const telemetry = await closeAndReadTelemetry(session);
 
     const expectedCost = 0.0000678 * 2;
     const expectedCharge = 0.00005085 * 2;
-    const user = await waitForPackBalanceBelow(userId, 1);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
     expect(telemetry.tokenCountPromptText).toBe(140);
     expect(telemetry.tokenCountPromptCached).toBe(60);
     expect(telemetry.tokenCountCompletionText).toBe(20);
@@ -777,30 +685,11 @@ test("uses the cached-text rate when cache details are absent", async () => {
 });
 
 test("falls back to aggregate realtime token totals when details are absent", async () => {
-    const { key, userId } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "aggregate-only-realtime-key",
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockOpenAIRealtime();
 
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
-
-    upstream.server.send(
+    session.upstream.server.send(
         JSON.stringify({
             type: "response.done",
             response: {
@@ -812,48 +701,22 @@ test("falls back to aggregate realtime token totals when details are absent", as
         }),
     );
 
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
+    const telemetry = await closeAndReadTelemetry(session);
 
     const expectedCharge = 0.0002 * 0.75;
-    const user = await waitForPackBalanceBelow(userId, 1);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
     expect(telemetry.tokenCountPromptText).toBe(20);
     expect(telemetry.tokenCountCompletionText).toBe(5);
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 8);
 });
 
 test("bills partial realtime token details from aggregate remainders", async () => {
-    const { key, userId } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "partial-detail-realtime-key",
-        pollenBudget: 1,
-        user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockOpenAIRealtime();
 
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
-
-    upstream.server.send(
+    session.upstream.server.send(
         JSON.stringify({
             type: "response.done",
             response: {
@@ -874,18 +737,11 @@ test("bills partial realtime token details from aggregate remainders", async () 
         }),
     );
 
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
+    const telemetry = await closeAndReadTelemetry(session);
 
     const expectedCharge = 0.003353 * 0.75;
-    const user = await waitForPackBalanceBelow(userId, 1);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
     expect(telemetry.tokenCountPromptText).toBe(100);
     expect(telemetry.tokenCountPromptCached).toBe(20);
     expect(telemetry.tokenCountPromptAudio).toBe(10);
@@ -896,47 +752,20 @@ test("bills partial realtime token details from aggregate remainders", async () 
 });
 
 test("redacts credential query parameters from realtime referrer telemetry", async () => {
-    const { key } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "referrer-redaction-realtime-key",
-        pollenBudget: 1,
-        user: { packBalance: 1 },
+        referrer:
+            "https://app.example/call?key=pk_secret&token=t&api_key=a&access_token=b&ok=1",
     });
-    const upstream = mockOpenAIRealtime();
 
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Referer:
-                    "https://app.example/call?key=pk_secret&token=t&api_key=a&access_token=b&ok=1",
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
-
-    upstream.server.send(
+    session.upstream.server.send(
         JSON.stringify({
             type: "response.done",
             response: { usage: { input_tokens: 1, output_tokens: 1 } },
         }),
     );
 
-    client.close();
-    upstream.server.close();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    await waitOnExecutionContext(ctx);
-
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
+    const telemetry = await closeAndReadTelemetry(session);
     expect(telemetry.referrerDomain).toBe("app.example");
     expect(telemetry.referrerUrl).toBe(
         "https://app.example/call?key=%5Bredacted%5D&token=%5Bredacted%5D&api_key=%5Bredacted%5D&access_token=%5Bredacted%5D&ok=1",
@@ -944,46 +773,19 @@ test("redacts credential query parameters from realtime referrer telemetry", asy
 });
 
 test("omits invalid realtime referrers instead of storing raw credential strings", async () => {
-    const { key } = await createTestApiKey({
+    const session = await openPaidRealtimeSession({
         name: "invalid-referrer-realtime-key",
-        pollenBudget: 1,
-        user: { packBalance: 1 },
+        referrer: "not a url?key=pk_secret&token=t",
     });
-    const upstream = mockOpenAIRealtime();
 
-    const { response, ctx } = await fetchWorkerWithContext(
-        "/v1/realtime?model=gpt-realtime-2",
-        {
-            headers: {
-                Authorization: `Bearer ${key}`,
-                Referer: "not a url?key=pk_secret&token=t",
-                Upgrade: "websocket",
-            },
-        },
-    );
-
-    expect(response.status).toBe(101);
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
-
-    upstream.server.send(
+    session.upstream.server.send(
         JSON.stringify({
             type: "response.done",
             response: { usage: { input_tokens: 1, output_tokens: 1 } },
         }),
     );
 
-    client.close();
-    upstream.server.close();
-    await waitForTinybirdRequests(upstream);
-    await waitOnExecutionContext(ctx);
-
-    expect(upstream.tinybirdRequests).toHaveLength(1);
-    const telemetry = JSON.parse(
-        await upstream.tinybirdRequests[0].text(),
-    ) as Record<string, unknown>;
+    const telemetry = await closeAndReadTelemetry(session);
     expect(telemetry.referrerUrl).toBeUndefined();
     expect(telemetry.referrerDomain).toBeUndefined();
 });


### PR DESCRIPTION
- Shares paid realtime WebSocket setup, shutdown, and telemetry parsing across billing tests.
- Reuses the identical cached-modality usage event for full and mini model assertions.
- Keeps model-specific pricing, forwarding, fallback, referrer, and telemetry expectations explicit.
- Removes 198 lines without changing production behavior.

Tests:
- `npx vitest run test/realtime.test.ts`
- `npm run typecheck`
- `npx biome check --write gen.pollinations.ai/test/realtime.test.ts`