### PR TITLE
refactor: share project classification

### DIFF
--- a/.github/docs/TRIAGE.md
+++ b/.github/docs/TRIAGE.md
@@ -70,7 +70,7 @@ Priority is only set on Support items. The AI picks one of two values; `Urgent` 
 
 | Priority | Who applies it | When |
 | -------- | -------------- | ---- |
-| `Urgent` | `project-manager.py` (override) | Issue author's GitHub ID matches a paid Stripe customer (`paid_customers.json` Tinybird endpoint) |
+| `Urgent` | `project_manager.py` (override) | Issue author's GitHub ID matches a paid Stripe customer (`paid_customers.json` Tinybird endpoint) |
 | `High`   | AI | Bugs breaking functionality, blocking issues, billing problems, outages |
 | `Low`    | AI | Minor issues, cosmetic bugs, questions, docs, feature requests, integration help |
 
@@ -138,9 +138,9 @@ flowchart TD
 
 | Script                 | Purpose        | AI Model                  | Trigger               |
 | ---------------------- | -------------- | ------------------------- | --------------------- |
-| `project-manager.py`   | Auto-kanban    | openai (via pollinations) | Issue/PR opened       |
+| `project_manager.py`   | Auto-kanban    | openai (via pollinations) | Issue/PR opened       |
 
-**project-manager.py details:**
+**project_manager.py details:**
 
 - Retry: 3 attempts with exponential backoff + random seed
 - Timeout: 5 minutes for AI, 30s for GraphQL
@@ -166,12 +166,12 @@ flowchart TD
 
 | Label          | Purpose                                          | Applied by           |
 | -------------- | ------------------------------------------------ | -------------------- |
-| `DEV-BUG`      | Something is broken                              | `project-manager.py` |
-| `DEV-FEATURE`  | New functionality request                        | `project-manager.py` |
-| `DEV-TRACKING` | Meta-issue tracking other items                  | `project-manager.py` |
-| `DEV-DOCS`     | Documentation - dev docs, API docs, READMEs      | `project-manager.py` |
-| `DEV-INFRA`    | Infrastructure - CI/CD, deployments, monitoring  | `project-manager.py` |
-| `DEV-CHORE`    | Maintenance - dependency updates, cleanup        | `project-manager.py` |
+| `DEV-BUG`      | Something is broken                              | `project_manager.py` |
+| `DEV-FEATURE`  | New functionality request                        | `project_manager.py` |
+| `DEV-TRACKING` | Meta-issue tracking other items                  | `project_manager.py` |
+| `DEV-DOCS`     | Documentation - dev docs, API docs, READMEs      | `project_manager.py` |
+| `DEV-INFRA`    | Infrastructure - CI/CD, deployments, monitoring  | `project_manager.py` |
+| `DEV-CHORE`    | Maintenance - dependency updates, cleanup        | `project_manager.py` |
 | `DEV-VOTING`   | Community vote on a proposal                     | Manual               |
 
 ### Support Labels
@@ -180,30 +180,30 @@ flowchart TD
 
 | Label          | Purpose             | Applied by           |
 | -------------- | ------------------- | -------------------- |
-| `.BUG`         | Something broken    | `project-manager.py` |
-| `.OUTAGE`      | Service down        | `project-manager.py` |
-| `.QUESTION`    | How-to/usage        | `project-manager.py` |
-| `.REQUEST`     | Feature request     | `project-manager.py` |
-| `.DOCS`        | Documentation issue | `project-manager.py` |
-| `.INTEGRATION` | SDK/API integration | `project-manager.py` |
+| `.BUG`         | Something broken    | `project_manager.py` |
+| `.OUTAGE`      | Service down        | `project_manager.py` |
+| `.QUESTION`    | How-to/usage        | `project_manager.py` |
+| `.REQUEST`     | Feature request     | `project_manager.py` |
+| `.DOCS`        | Documentation issue | `project_manager.py` |
+| `.INTEGRATION` | SDK/API integration | `project_manager.py` |
 
 **SERVICE (pick 1 or more):**
 
 | Label     | Purpose               | Applied by           |
 | --------- | --------------------- | -------------------- |
-| `IMAGE`   | Image generation      | `project-manager.py` |
-| `TEXT`    | Text/chat completion  | `project-manager.py` |
-| `AUDIO`   | Audio/TTS             | `project-manager.py` |
-| `VIDEO`   | Video generation      | `project-manager.py` |
-| `API`     | API/SDK general       | `project-manager.py` |
-| `WEB`     | Website/dashboard     | `project-manager.py` |
-| `CREDITS` | Pollen balance and usage quota issues | `project-manager.py` |
-| `BILLING` | Payment/credit card   | `project-manager.py` |
-| `ACCOUNT` | Account/login/auth    | `project-manager.py` |
+| `IMAGE`   | Image generation      | `project_manager.py` |
+| `TEXT`    | Text/chat completion  | `project_manager.py` |
+| `AUDIO`   | Audio/TTS             | `project_manager.py` |
+| `VIDEO`   | Video generation      | `project_manager.py` |
+| `API`     | API/SDK general       | `project_manager.py` |
+| `WEB`     | Website/dashboard     | `project_manager.py` |
+| `CREDITS` | Pollen balance and usage quota issues | `project_manager.py` |
+| `BILLING` | Payment/credit card   | `project_manager.py` |
+| `ACCOUNT` | Account/login/auth    | `project_manager.py` |
 
 ### News Labels
 
-The `NEWS` label is used by the social pipeline (`social/` workflows), not by Project Manager routing. Issues/PRs carrying it are skipped by `project-manager.py` and don't land on any project board.
+The `NEWS` label is used by the social pipeline (`social/` workflows), not by Project Manager routing. Issues/PRs carrying it are skipped by `project_manager.py` and don't land on any project board.
 
 | Label  | Purpose                | Applied by                                          |
 | ------ | ---------------------- | --------------------------------------------------- |

--- a/.github/scripts/project-backfill-labels.py
+++ b/.github/scripts/project-backfill-labels.py
@@ -40,18 +40,10 @@ Environment:
 
 import argparse
 import sys
-import os
 import time
-import json
 import re
 import requests
-import importlib.util
-
-# Import shared functions from project-manager.py (hyphen in filename requires special import)
-script_dir = os.path.dirname(os.path.abspath(__file__))
-spec = importlib.util.spec_from_file_location("project_manager", os.path.join(script_dir, "project-manager.py"))
-pm = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(pm)
+import project_manager as pm
 
 CONFIG = pm.CONFIG
 VALID_LABELS = pm.VALID_LABELS
@@ -63,14 +55,27 @@ REPO_OWNER = pm.REPO_OWNER
 REPO_NAME = pm.REPO_NAME
 log_debug = pm.log_debug
 log_error = pm.log_error
-read_prompt_file = pm.read_prompt_file
 normalize_labels = pm.normalize_labels
 graphql_request = pm.graphql_request
 set_project_field = pm.set_project_field
 is_paid_customer = pm.is_paid_customer
 
-POLLINATIONS_API = "https://gen.pollinations.ai/v1/chat/completions"
-POLLINATIONS_TOKEN = os.getenv("POLLINATIONS_TOKEN")
+
+def classify_issue(
+    title: str,
+    body: str,
+    author: str,
+    is_internal: bool,
+    is_pr: bool = False,
+) -> dict:
+    classification = pm.classify_with_ai(
+        is_internal,
+        title=title,
+        body=body,
+        author=author,
+        is_pull_request=is_pr,
+    )
+    return classification if classification.get("project") else {}
 
 
 def get_project_issues(project_id: str, include_prs: bool = False, priority_field_id: str = None) -> list:
@@ -225,61 +230,6 @@ def remove_project_labels(issue_number: int, project_key: str, dry_run: bool) ->
     return [l for l in current_labels if l not in to_remove]
 
 
-def classify_issue(title: str, body: str, author: str, is_internal: bool, is_pr: bool = False) -> dict:
-    """Classify an issue or PR using the AI (same as project-manager.py)."""
-    base_prompt = read_prompt_file()
-    item_kind = "pull request" if is_pr else "issue"
-
-    system_prompt = f"""{base_prompt}
-
----
-**Context:** This is a {item_kind}. Author type is {"internal" if is_internal else "external"}
-"""
-
-    user_prompt = f"""
-Item Type: {item_kind}
-Author: {author}
-Author Type: {"Internal" if is_internal else "External"}
-Title: {title}
-Body: {(body or "")[:2000]}
-"""
-
-    for attempt in range(3):
-        try:
-            r = requests.post(
-                POLLINATIONS_API,
-                headers={
-                    "content-type": "application/json",
-                    "Authorization": f"Bearer {POLLINATIONS_TOKEN}"
-                },
-                json={
-                    "model": "openai-large",
-                    "messages": [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    "response_format": {"type": "json_object"},
-                    "max_tokens": 400,
-                },
-                timeout=120,
-            )
-
-            if r.status_code != 200:
-                log_error(f"AI HTTP {r.status_code}: {r.text}")
-                time.sleep(2 ** attempt)
-                continue
-
-            data = r.json()
-            content = data.get("choices", [{}])[0].get("message", {}).get("content", "{}")
-            
-            return json.loads(content)
-        except Exception as e:
-            log_error(f"Classification error: {e}")
-            time.sleep(2 ** attempt)
-    
-    return {}
-
-
 def add_to_project(project_id: str, content_node_id: str) -> str:
     """Add an issue/PR to a project. Returns new project item id."""
     mutation = """
@@ -399,7 +349,9 @@ def main():
 
             real_author, real_author_id = get_real_author(author, author_id, body)
             is_internal = pm.is_org_member(real_author_id)
-            classification = classify_issue(title, body, real_author, is_internal, is_pr=is_pr)
+            classification = classify_issue(
+                title, body, real_author, is_internal, is_pr=is_pr
+            )
             if not classification:
                 log_error(f"Failed to classify #{issue_number}; skipping migration")
                 time.sleep(1)
@@ -465,7 +417,9 @@ def main():
             real_author, real_author_id = get_real_author(author, author_id, body)
             is_internal = pm.is_org_member(real_author_id)
             log_debug(f"Author: {author} -> Real: {real_author}, Internal: {is_internal}")
-            classification = classify_issue(title, body, real_author, is_internal)
+            classification = classify_issue(
+                title, body, real_author, is_internal
+            )
             
             if not classification:
                 log_error(f"Failed to classify #{issue_number}")
@@ -482,7 +436,9 @@ def main():
             if not classification:
                 real_author, real_author_id = get_real_author(author, author_id, body)
                 is_internal = pm.is_org_member(real_author_id)
-                classification = classify_issue(title, body, real_author, is_internal)
+                classification = classify_issue(
+                    title, body, real_author, is_internal
+                )
             
             if classification:
                 priority = classification.get("priority")

--- a/.github/scripts/project_manager.py
+++ b/.github/scripts/project_manager.py
@@ -222,9 +222,21 @@ def get_fallback_classification(_: bool) -> dict:
     }
 
 
-def classify_with_ai(is_internal: bool, tracking_issues: Optional[list] = None) -> dict:
+def classify_with_ai(
+    is_internal: bool,
+    tracking_issues: Optional[list] = None,
+    *,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+    author: Optional[str] = None,
+    is_pull_request: Optional[bool] = None,
+) -> dict:
+    title = ISSUE_TITLE if title is None else title
+    body = ISSUE_BODY if body is None else body
+    author = ISSUE_AUTHOR if author is None else author
+    is_pull_request = IS_PULL_REQUEST if is_pull_request is None else is_pull_request
     base_prompt = read_prompt_file()
-    item_kind = "pull request" if IS_PULL_REQUEST else "issue"
+    item_kind = "pull request" if is_pull_request else "issue"
 
     tracking_block = ""
     if tracking_issues:
@@ -242,10 +254,10 @@ def classify_with_ai(is_internal: bool, tracking_issues: Optional[list] = None) 
 
     user_prompt = f"""
 Item Type: {item_kind}
-Author: {ISSUE_AUTHOR}
+Author: {author}
 Author Type: {"Internal" if is_internal else "External"}
-Title: {ISSUE_TITLE}
-Body: {ISSUE_BODY[:2000]}
+Title: {title}
+Body: {body[:2000]}
 """
 
     for attempt in range(3):

--- a/.github/workflows/repo-organize-issues-prs.yml
+++ b/.github/workflows/repo-organize-issues-prs.yml
@@ -43,4 +43,4 @@ jobs:
           GITHUB_EVENT: ${{ toJSON(github.event) }}
           POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
           TINYBIRD_READ_TOKEN: ${{ secrets.TINYBIRD_READ_TOKEN }}
-        run: python .github/scripts/project-manager.py
+        run: python .github/scripts/project_manager.py

--- a/enter.pollinations.ai/observability/endpoints/paid_customers.pipe
+++ b/enter.pollinations.ai/observability/endpoints/paid_customers.pipe
@@ -3,7 +3,7 @@ TOKEN tinybird_read READ
 DESCRIPTION >
     GitHub user IDs (numeric, stable across renames) of users who have ever
     completed a paid Stripe checkout. Used by
-    .github/scripts/project-manager.py to flag support issues from paid
+    .github/scripts/project_manager.py to flag support issues from paid
     customers as Urgent priority.
 
 NODE paid_customers_node


### PR DESCRIPTION
- Reuses the live project-manager classifier for project backfills instead of maintaining a second API client and response parser.
- Renames the module to an importable Python name and removes the dynamic-import scaffold.
- Preserves backfill failure semantics: an unclassified item remains empty and migrations skip it.
- Updates the workflow and existing filename references; removes 32 lines overall.

Tests:
- Python AST parse for both scripts
- Mocked classifier request, response normalization, explicit backfill context, import, and failure-contract checks
- `git diff --check`