### PR TITLE
refactor: share social publisher setup

### DIFF
--- a/social/scripts/buffer_publish.py
+++ b/social/scripts/buffer_publish.py
@@ -5,7 +5,6 @@ Triggered when a post PR is merged
 """
 
 import os
-import json
 import time
 import requests
 import yaml
@@ -14,8 +13,8 @@ from datetime import datetime, timezone, timedelta
 
 from common import (
     LINKEDIN_MAX_CHARS,
-    get_env,
     get_post_image_urls,
+    read_news_file,
 )
 from buffer_utils import (
     get_channel_by_service,
@@ -268,3 +267,33 @@ def publish_instagram_post(post_data: dict, access_token: str) -> bool:
         multi_image=True,
         metadata_fn=_instagram_metadata,
     )
+
+
+def stage_buffer_posts(
+    post_dir: str,
+    publishers: dict,
+    access_token: str,
+    github_token: str,
+    owner: str,
+    repo: str,
+) -> dict[str, bool]:
+    """Load and stage the configured news posts to Buffer."""
+    results = {}
+
+    for platform, publish_fn in publishers.items():
+        filename = f"{platform}.json"
+        post_data = read_news_file(
+            os.path.join(post_dir, filename), github_token, owner, repo
+        )
+        if not post_data:
+            print(f"  No {filename} found — skipping {platform}")
+            continue
+
+        print(f"\n  Staging {platform}...")
+        try:
+            results[platform] = publish_fn(post_data, access_token)
+        except Exception as error:
+            print(f"  Error staging {platform}: {error}")
+            results[platform] = False
+
+    return results

--- a/social/scripts/common.py
+++ b/social/scripts/common.py
@@ -969,6 +969,37 @@ def commit_files_to_branch(
 
 # ── VPS deployment ───────────────────────────────────────────────────
 
+def deploy_reddit_news_post(
+    post_dir: str,
+    github_token: str,
+    owner: str,
+    repo: str,
+) -> Optional[bool]:
+    """Deploy reddit.json when the shared VPS configuration is available."""
+    vps_host = get_env("REDDIT_VPS_HOST", required=False)
+    vps_user = get_env("REDDIT_VPS_USER", required=False)
+    vps_ssh_key = (get_env("REDDIT_VPS_SSH_KEY", required=False) or "").strip()
+    if not (vps_host and vps_user and vps_ssh_key):
+        print("  Reddit VPS credentials not configured — skipping")
+        return None
+
+    import base64
+    import io
+    import paramiko
+
+    private_key = base64.b64decode(vps_ssh_key).decode("utf-8")
+    pkey = paramiko.Ed25519Key.from_private_key(io.StringIO(private_key))
+    reddit_data = read_news_file(
+        os.path.join(post_dir, "reddit.json"), github_token, owner, repo
+    )
+    if not reddit_data:
+        print("  No reddit.json — skipping")
+        return None
+
+    print("  Reddit...")
+    return deploy_reddit_post(reddit_data, vps_host, vps_user, pkey)
+
+
 def deploy_reddit_post(
     reddit_data: Dict,
     vps_host: str,

--- a/social/scripts/publish_daily.py
+++ b/social/scripts/publish_daily.py
@@ -15,18 +15,11 @@ See social/PIPELINE.md for full architecture.
 import os
 import sys
 from datetime import datetime, timezone, timedelta
-from typing import Dict
-import base64
-import io
 from common import (
+    deploy_reddit_news_post,
     get_env,
-    read_news_file,
-    deploy_reddit_post,
 )
-from buffer_publish import publish_twitter_post
-
-# Paths
-DAILY_DIR = "social/news/daily"
+from buffer_publish import publish_twitter_post, stage_buffer_posts
 
 
 def get_target_date() -> str:
@@ -37,30 +30,6 @@ def get_target_date() -> str:
         return date_str
     yesterday = datetime.now(timezone.utc) - timedelta(days=1)
     return yesterday.strftime("%Y-%m-%d")
-
-
-def stage_buffer_posts(daily_dir: str, buffer_token: str, github_token: str, owner: str, repo: str) -> Dict[str, bool]:
-    """Stage all platform posts to Buffer. Returns {platform: success}."""
-    results = {}
-
-    for platform, filename, publish_fn in [
-        ("twitter", "twitter.json", publish_twitter_post),
-    ]:
-        post_path = os.path.join(daily_dir, filename)
-        post_data = read_news_file(post_path, github_token, owner, repo)
-
-        if not post_data:
-            print(f"  No {filename} found — skipping {platform}")
-            continue
-
-        print(f"\n  Staging {platform}...")
-        try:
-            results[platform] = publish_fn(post_data, buffer_token)
-        except Exception as e:
-            print(f"  Error staging {platform}: {e}")
-            results[platform] = False
-
-    return results
 
 
 # ── Main ─────────────────────────────────────────────────────────────
@@ -86,7 +55,14 @@ def main():
     if publish_mode in ("buffer", "all"):
         buffer_token = get_env("BUFFER_ACCESS_TOKEN")
         print(f"\n[Buffer] Staging to Buffer...")
-        buffer_results = stage_buffer_posts(daily_dir, buffer_token, github_token, owner, repo)
+        buffer_results = stage_buffer_posts(
+            daily_dir,
+            {"twitter": publish_twitter_post},
+            buffer_token,
+            github_token,
+            owner,
+            repo,
+        )
         results.update(buffer_results)
         for platform, success in buffer_results.items():
             status = "OK" if success else "FAILED"
@@ -95,26 +71,11 @@ def main():
     # ── Direct channels (Reddit) ─────────────────────────────────
     if publish_mode in ("direct", "all"):
         print(f"\n[Direct] Deploying Reddit to VPS...")
-        vps_host = get_env("REDDIT_VPS_HOST", required=False)
-        vps_user = get_env("REDDIT_VPS_USER", required=False)
-        vps_ssh_key_raw = get_env("REDDIT_VPS_SSH_KEY", required=False)
-        vps_ssh_key = vps_ssh_key_raw.strip() if vps_ssh_key_raw else None
-
-        if vps_host and vps_user and vps_ssh_key:
-            import paramiko
-            private_key_str = base64.b64decode(vps_ssh_key).decode("utf-8")
-            key_file = io.StringIO(private_key_str)
-            pkey = paramiko.Ed25519Key.from_private_key(key_file)
-
-            reddit_path = os.path.join(daily_dir, "reddit.json")
-            reddit_data = read_news_file(reddit_path, github_token, owner, repo)
-
-            if reddit_data:
-                results["reddit"] = deploy_reddit_post(reddit_data, vps_host, vps_user, pkey)
-            else:
-                print("  No reddit.json — skipping VPS deployment")
-        else:
-            print("  VPS credentials not configured — skipping VPS deployment")
+        reddit_result = deploy_reddit_news_post(
+            daily_dir, github_token, owner, repo
+        )
+        if reddit_result is not None:
+            results["reddit"] = reddit_result
 
     failed = [p for p, s in results.items() if not s]
     if failed:

--- a/social/scripts/publish_weekly.py
+++ b/social/scripts/publish_weekly.py
@@ -10,33 +10,26 @@ Publishes weekly content from the news branch. Two modes via PUBLISH_MODE env va
 See social/PIPELINE.md for full architecture.
 """
 
-import base64
-import io
 import json
 import os
 import sys
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Dict
 
 import requests
 from buffer_publish import (
     publish_instagram_post,
     publish_linkedin_post,
     publish_twitter_post,
+    stage_buffer_posts,
 )
 from common import (
     DISCORD_CHUNK_SIZE,
-    deploy_reddit_post,
+    deploy_reddit_news_post,
     get_env,
     get_post_image_urls,
     read_news_file,
 )
-
-# ── Constants ────────────────────────────────────────────────────────
-
-WEEKLY_REL_DIR = "social/news/weekly"
-
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -128,8 +121,6 @@ def post_to_discord(webhook_url: str, message: str, image_url: str = None) -> bo
             try:
                 data = resp.json()
                 channel_id, msg_id = data.get("channel_id"), data.get("id")
-                import os
-
                 token = os.environ.get("DISCORD_TOKEN")
                 if token and channel_id and msg_id:
                     requests.post(
@@ -158,34 +149,6 @@ def post_to_discord(webhook_url: str, message: str, image_url: str = None) -> bo
     return True
 
 
-def stage_buffer_posts(
-    weekly_dir: str, buffer_token: str, github_token: str, owner: str, repo: str
-) -> Dict[str, bool]:
-    """Stage Twitter + LinkedIn + Instagram to Buffer. Returns {platform: success}."""
-    results = {}
-
-    for platform, filename, publish_fn in [
-        ("twitter", "twitter.json", publish_twitter_post),
-        ("linkedin", "linkedin.json", publish_linkedin_post),
-        ("instagram", "instagram.json", publish_instagram_post),
-    ]:
-        post_path = os.path.join(weekly_dir, filename)
-        post_data = read_news_file(post_path, github_token, owner, repo)
-
-        if not post_data:
-            print(f"  No {filename} found — skipping {platform}")
-            continue
-
-        print(f"\n  Staging {platform}...")
-        try:
-            results[platform] = publish_fn(post_data, buffer_token)
-        except Exception as e:
-            print(f"  Error staging {platform}: {e}")
-            results[platform] = False
-
-    return results
-
-
 # ── Main ─────────────────────────────────────────────────────────────
 
 
@@ -210,7 +173,16 @@ def main():
         buffer_token = get_env("BUFFER_ACCESS_TOKEN")
         print("\n[Buffer] Staging to Buffer...")
         buffer_results = stage_buffer_posts(
-            weekly_dir, buffer_token, github_token, owner, repo
+            weekly_dir,
+            {
+                "twitter": publish_twitter_post,
+                "linkedin": publish_linkedin_post,
+                "instagram": publish_instagram_post,
+            },
+            buffer_token,
+            github_token,
+            owner,
+            repo,
         )
         results.update(buffer_results)
         for platform, success in buffer_results.items():
@@ -221,31 +193,11 @@ def main():
     if publish_mode in ("direct", "all"):
         print("\n[Direct] Publishing direct channels...")
 
-        # Reddit (VPS deployment)
-        vps_host = get_env("REDDIT_VPS_HOST", required=False)
-        vps_user = get_env("REDDIT_VPS_USER", required=False)
-        vps_ssh_key_raw = get_env("REDDIT_VPS_SSH_KEY", required=False)
-        vps_ssh_key = vps_ssh_key_raw.strip() if vps_ssh_key_raw else None
-
-        if vps_host and vps_user and vps_ssh_key:
-            import paramiko
-
-            private_key_str = base64.b64decode(vps_ssh_key).decode("utf-8")
-            key_file = io.StringIO(private_key_str)
-            pkey = paramiko.Ed25519Key.from_private_key(key_file)
-
-            reddit_path = os.path.join(weekly_dir, "reddit.json")
-            reddit_data = read_news_file(reddit_path, github_token, owner, repo)
-
-            if reddit_data:
-                print("  Reddit...")
-                results["reddit"] = deploy_reddit_post(
-                    reddit_data, vps_host, vps_user, pkey
-                )
-            else:
-                print("  No reddit.json — skipping")
-        else:
-            print("  Reddit VPS credentials not configured — skipping")
+        reddit_result = deploy_reddit_news_post(
+            weekly_dir, github_token, owner, repo
+        )
+        if reddit_result is not None:
+            results["reddit"] = reddit_result
 
         # Discord
         discord_webhook = get_env("DISCORD_WEEKLY_WEBHOOK_URL", required=False)


### PR DESCRIPTION
- Shares Buffer artifact loading, staging, and error handling between daily and weekly publishers.
- Shares Reddit VPS credential/key setup and artifact deployment while preserving skip and failure semantics.
- Keeps daily and weekly platform selections explicit and removes dead imports/constants.
- Checks: Python compileall, focused helper behavior checks, diff check.