### PR TITLE
refactor: remove dead Weaver scaffolding

### DIFF
--- a/apps/weaver/src/weaver/api.py
+++ b/apps/weaver/src/weaver/api.py
@@ -284,9 +284,7 @@ async def chat_completions(request: ChatRequest, http_request: Request) -> Any:
     token = _api_key_override.set(api_key or None)
     try:
         result = await run_agent(_to_openai_messages(request.messages))
-        markdown, content_parts = await _build_content(
-            result["text"], result["artifacts"]
-        )
+        _, content_parts = await _build_content(result["text"], result["artifacts"])
         content_block: Any = (
             content_parts[0]["text"] if len(content_parts) == 1 else content_parts
         )

--- a/apps/weaver/src/weaver/knowledge.py
+++ b/apps/weaver/src/weaver/knowledge.py
@@ -70,9 +70,7 @@ def models_summary(kind: str | None = None) -> str:
 
 def _best_at_block() -> str:
     return "\n".join(
-        f"  - {m}: {why}"
-        for m, why in BEST_AT.items()
-        if m in get_model_catalog() or True
+        f"  - {model}: {description}" for model, description in BEST_AT.items()
     )
 
 

--- a/apps/weaver/src/weaver/registry.py
+++ b/apps/weaver/src/weaver/registry.py
@@ -267,23 +267,6 @@ def get_model_catalog() -> dict[str, dict[str, Any]]:
     return reg.get("models", {})
 
 
-def get_modalities_for_model(model_id: str) -> list[str]:
-    reg = _registry_cache or {}
-    model = reg.get("models", {}).get(model_id, {})
-    return model.get("modalities", [])
-
-
-def get_model_params(model_id: str) -> dict[str, Any]:
-    reg = _registry_cache or {}
-    model = reg.get("models", {}).get(model_id, {})
-    return dict(model.get("params", {}))
-
-
-def get_model_meta(model_id: str) -> dict[str, Any]:
-    reg = _registry_cache or {}
-    return reg.get("models", {}).get(model_id, {})
-
-
 def get_voices() -> list[str]:
     reg = _registry_cache or {}
     audio_models = reg.get("by_modality", {}).get("audio", {})

--- a/apps/weaver/src/weaver/tools/gen.py
+++ b/apps/weaver/src/weaver/tools/gen.py
@@ -16,7 +16,6 @@ import urllib.parse
 from typing import Any
 
 import httpx
-from openai import AsyncOpenAI
 
 from weaver.config import resolve_api_key, settings
 
@@ -53,10 +52,6 @@ def _base() -> str:
 def _v1() -> str:
     """Chat/completions live under /v1; the bare host 404s."""
     return f"{_base()}/v1"
-
-
-def _client() -> AsyncOpenAI:
-    return AsyncOpenAI(base_url=_v1(), api_key=_key())
 
 
 def _encode(text: str) -> str:


### PR DESCRIPTION
- Removes three registry accessor functions with no callers in source, tests, scripts, or the repository.
- Removes an unused OpenAI client constructor/import from the tool module.
- Replaces a permanently disabled `or True` model filter with its actual all-guidance behavior.
- Drops an unused content tuple binding; checks: Ruff undefined/unused rules and full Weaver suite (48 passed, 8 skipped).