### PR TITLE
refactor: simplify model info helpers

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/index.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/index.ts
@@ -1,2 +1,2 @@
 export { Models } from "./models.tsx";
-export type { Modalities, ModelPrice } from "./types.ts";
+export type { ModelPrice } from "./types.ts";

--- a/enter.pollinations.ai/frontend/src/components/models/model-info.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-info.ts
@@ -1,4 +1,4 @@
-import type { Modalities, ModelCapability, ModelPrice } from "./types.ts";
+import type { ModelCapability, ModelPrice } from "./types.ts";
 
 const BRAND_LOGOS: Record<string, string> = {
     Alibaba: "alibaba",
@@ -37,84 +37,44 @@ const BRAND_LOGOS: Record<string, string> = {
     xAI: "xai",
 };
 
-const MODEL_LOGOS: Record<string, string> = {};
-
-const getSourceDescription = (model: ModelPrice): string | undefined => {
-    if (!model.description) return model.displayName;
-    return model.displayName
-        ? `${model.displayName} - ${model.description}`
-        : model.description;
-};
-
-export const getModalities = (model: ModelPrice): Modalities => {
-    return {
-        input: model.inputModalities || ["text"],
-        output: model.outputModalities || ["text"],
-    };
-};
-
-export const getModelDescription = (model: ModelPrice): string | undefined => {
-    return getSourceDescription(model);
-};
+const getInputModalities = (model: ModelPrice): string[] =>
+    model.inputModalities || ["text"];
 
 export const getModelDisplayName = (model: ModelPrice): string | undefined => {
     if (model.displayName) return model.displayName;
-    const description = getSourceDescription(model);
+    const description = model.description;
     if (!description) return undefined;
     return description.split(" - ")[0];
 };
 
 export const getModelDescriptionWithoutName = (
     model: ModelPrice,
-): string | undefined => {
-    if (model.description) return model.description;
-    const description = getSourceDescription(model);
-    if (!description) return undefined;
-    if (model.displayName && description.trim() === model.displayName.trim()) {
-        return undefined;
-    }
-    const prefix = model.displayName ? `${model.displayName} - ` : "";
-    if (prefix && description.startsWith(prefix)) {
-        return description.slice(prefix.length).trim() || undefined;
-    }
-    const parts = description.split(" - ");
-    if (parts.length < 2) return undefined;
-    return parts.slice(1).join(" - ").trim() || undefined;
-};
+): string | undefined => model.description || undefined;
 
 export const getModelBrandLogoPath = (
     model: ModelPrice,
 ): string | undefined => {
-    const logoName =
-        MODEL_LOGOS[model.name] ??
-        (model.brand ? BRAND_LOGOS[model.brand] : undefined);
+    const logoName = model.brand ? BRAND_LOGOS[model.brand] : undefined;
     return logoName ? `/brand-logos/${logoName}.svg` : undefined;
 };
 
 export type InputModality = "text" | "image" | "video" | "audio";
 
 export const getModelInputModalities = (model: ModelPrice): InputModality[] => {
-    const modalities = getModalities(model);
+    const modalities = getInputModalities(model);
     const keys: InputModality[] = [];
 
-    if (modalities.input.includes("text")) keys.push("text");
-    if (modalities.input.includes("image")) keys.push("image");
-    if (modalities.input.includes("video")) keys.push("video");
-    if (modalities.input.includes("audio")) keys.push("audio");
+    if (modalities.includes("text")) keys.push("text");
+    if (modalities.includes("image")) keys.push("image");
+    if (modalities.includes("video")) keys.push("video");
+    if (modalities.includes("audio")) keys.push("audio");
 
     return keys;
 };
 
 export const getModelModalityLabel = (model: ModelPrice): string => {
-    const modalities = getModalities(model);
-    const labels: string[] = [];
-
-    if (modalities.input.includes("text")) labels.push("text");
-    if (modalities.input.includes("image")) labels.push("image");
-    if (modalities.input.includes("video")) labels.push("video");
-    if (modalities.input.includes("audio")) labels.push("audio");
-
-    return labels.length > 0 ? `Input: ${labels.join(", ")}` : "Input";
+    const modalities = getModelInputModalities(model);
+    return modalities.length > 0 ? `Input: ${modalities.join(", ")}` : "Input";
 };
 
 export type DisplayCapability = "reasoning" | "web_search" | "code_execution";
@@ -146,29 +106,14 @@ const hasCapability = (
     capability: ModelCapability,
 ): boolean => model.capabilities.includes(capability);
 
-export const hasReasoning = (model: ModelPrice): boolean =>
+const hasReasoning = (model: ModelPrice): boolean =>
     hasCapability(model, "reasoning");
 
-export const hasSearch = (model: ModelPrice): boolean =>
+const hasSearch = (model: ModelPrice): boolean =>
     hasCapability(model, "web_search");
 
-export const hasCodeExecution = (model: ModelPrice): boolean =>
+const hasCodeExecution = (model: ModelPrice): boolean =>
     hasCapability(model, "code_execution");
-
-export const hasVision = (model: ModelPrice): boolean => {
-    const modalities = getModalities(model);
-    return modalities.input.includes("image");
-};
-
-export const hasAudioInput = (model: ModelPrice): boolean => {
-    const modalities = getModalities(model);
-    return modalities.input.includes("audio");
-};
-
-export const hasAudioOutput = (model: ModelPrice): boolean => {
-    const modalities = getModalities(model);
-    return modalities.output.includes("audio");
-};
 
 /**
  * Check if a model is "new" (added within the last 7 days).

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -60,8 +60,3 @@ export type ModelPrice = {
     // Real usage data from Tinybird (rolling 7-day average)
     realAvgCost?: number;
 };
-
-export type Modalities = {
-    input: string[];
-    output: string[];
-};


### PR DESCRIPTION
- Collapses an unreachable model-description fallback chain to its actual source field.
- Removes unused modality helpers, output handling, exports, and the empty per-model logo override layer.
- Reuses canonical input-modality extraction for labels instead of duplicating the same checks.
- Reduces the helper surface by 60 net lines; Biome and the full Enter frontend production build pass.