### PR TITLE
refactor: simplify Polli CLI request handling

### DIFF
--- a/packages/polli-cli/src/commands/docs.ts
+++ b/packages/polli-cli/src/commands/docs.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import open from "open";
 import { BASE_URL } from "../lib/config.js";
 import {
+    fail,
     getOutputMode,
     printError,
     printInfo,
@@ -72,10 +73,7 @@ export const docsCommand = new Command("docs")
                     process.stdout.write("\n");
                 }
             } catch (err) {
-                printError(
-                    `Failed to fetch docs: ${err instanceof Error ? err.message : "unknown"}`,
-                );
-                process.exit(1);
+                fail("Failed to fetch docs", err);
             }
             return;
         }

--- a/packages/polli-cli/src/commands/gen/audio.ts
+++ b/packages/polli-cli/src/commands/gen/audio.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -33,7 +31,6 @@ export function createAudioCommand() {
         .option("--output <path>", "Save to file", "speech.mp3")
         .option("--play", "Play the audio after saving (platform player)")
         .action(async (textArg, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
             const inputText = textArg || (await readStdin());
             if (!inputText) {
@@ -53,25 +50,12 @@ export function createAudioCommand() {
             if (opts.seed) params.set("seed", opts.seed);
 
             const encodedText = encodeURIComponent(inputText);
-            const url = `${BASE_URL}/audio/${encodedText}?${params}`;
+            const path = `/audio/${encodedText}?${params}`;
 
             if (isHuman) printInfo("Generating audio...");
 
             try {
-                const res = await fetch(url, {
-                    headers: { Authorization: `Bearer ${key}` },
-                });
-                if (!res.ok) {
-                    const errText = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, errText);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(
-                        `${res.status} ${res.statusText}: ${errText}`,
-                    );
-                }
+                const res = await fetchGen(path);
 
                 const buffer = Buffer.from(await res.arrayBuffer());
                 writeFileSync(opts.output, buffer);
@@ -86,11 +70,8 @@ export function createAudioCommand() {
                     const ok = await playAudio(opts.output);
                     if (!ok) printWarn(playerMissingHint());
                 }
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/image.ts
+++ b/packages/polli-cli/src/commands/gen/image.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -26,7 +24,6 @@ export function createImageCommand() {
         )
         .option("--output <path>", "Save to file", "image.png")
         .action(async (prompt, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
 
             const params = new URLSearchParams({
@@ -51,23 +48,12 @@ export function createImageCommand() {
             }
 
             const encodedPrompt = encodeURIComponent(prompt);
-            const url = `${BASE_URL}/image/${encodedPrompt}?${params}`;
+            const path = `/image/${encodedPrompt}?${params}`;
 
             if (isHuman) printInfo("Generating image...");
 
             try {
-                const res = await fetch(url, {
-                    headers: { Authorization: `Bearer ${key}` },
-                });
-                if (!res.ok) {
-                    const text = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, text);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(`${res.status} ${res.statusText}: ${text}`);
-                }
+                const res = await fetchGen(path);
 
                 const buffer = Buffer.from(await res.arrayBuffer());
                 writeFileSync(opts.output, buffer);
@@ -77,11 +63,8 @@ export function createImageCommand() {
                     size: buffer.length,
                     model: opts.model,
                 });
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/text.ts
+++ b/packages/polli-cli/src/commands/gen/text.ts
@@ -1,9 +1,7 @@
 import { writeFileSync } from "node:fs";
 import chalk from "chalk";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -49,7 +47,6 @@ export function createTextCommand() {
             "Wait for full response instead of streaming tokens",
         )
         .action(async (promptArg, opts) => {
-            const key = requireKey();
             const stdinText = await readStdin();
             const prompt = promptArg || stdinText;
 
@@ -122,26 +119,13 @@ export function createTextCommand() {
             if (isHuman && !useStream) printInfo("Generating...");
 
             try {
-                const res = await fetch(`${BASE_URL}/v1/chat/completions`, {
+                const res = await fetchGen("/v1/chat/completions", {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
-                        Authorization: `Bearer ${key}`,
                     },
                     body: JSON.stringify(body),
                 });
-
-                if (!res.ok) {
-                    const errText = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, errText);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(
-                        `${res.status} ${res.statusText}: ${errText}`,
-                    );
-                }
 
                 if (useStream) {
                     // Dim the model's streamed output in TTY mode so it's
@@ -180,11 +164,8 @@ export function createTextCommand() {
                         : content;
                     process.stdout.write(`${out}\n`);
                 }
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/transcribe.ts
+++ b/packages/polli-cli/src/commands/gen/transcribe.ts
@@ -1,15 +1,8 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
-import {
-    getOutputMode,
-    printError,
-    printInfo,
-    printResult,
-} from "../../lib/output.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
+import { getOutputMode, printInfo, printResult } from "../../lib/output.js";
 
 export function createTranscribeCommand() {
     return new Command("transcribe")
@@ -22,7 +15,6 @@ export function createTranscribeCommand() {
         )
         .option("--language <lang>", "Language hint (ISO code)")
         .action(async (file, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
             if (isHuman) printInfo("Transcribing...");
 
@@ -35,21 +27,10 @@ export function createTranscribeCommand() {
                 formData.append("model", opts.model);
                 if (opts.language) formData.append("language", opts.language);
 
-                const res = await fetch(`${BASE_URL}/v1/audio/transcriptions`, {
+                const res = await fetchGen("/v1/audio/transcriptions", {
                     method: "POST",
-                    headers: { Authorization: `Bearer ${key}` },
                     body: formData,
                 });
-
-                if (!res.ok) {
-                    const text = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, text);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(`${res.status}: ${text}`);
-                }
 
                 const data = (await res.json()) as { text: string };
 
@@ -58,11 +39,8 @@ export function createTranscribeCommand() {
                 } else {
                     process.stdout.write(`${data.text}\n`);
                 }
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/video.ts
+++ b/packages/polli-cli/src/commands/gen/video.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -27,7 +25,6 @@ export function createVideoCommand() {
         .option("--image <url>", "Reference frame URL")
         .option("--output <path>", "Save to file", "video.mp4")
         .action(async (prompt, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
 
             const params = new URLSearchParams({
@@ -50,24 +47,13 @@ export function createVideoCommand() {
             }
 
             const encodedPrompt = encodeURIComponent(prompt);
-            const url = `${BASE_URL}/video/${encodedPrompt}?${params}`;
+            const path = `/video/${encodedPrompt}?${params}`;
 
             if (isHuman)
                 printInfo("Generating video (this can take up to 60s)...");
 
             try {
-                const res = await fetch(url, {
-                    headers: { Authorization: `Bearer ${key}` },
-                });
-                if (!res.ok) {
-                    const text = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, text);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(`${res.status} ${res.statusText}: ${text}`);
-                }
+                const res = await fetchGen(path);
 
                 const buffer = Buffer.from(await res.arrayBuffer());
                 writeFileSync(opts.output, buffer);
@@ -76,11 +62,8 @@ export function createVideoCommand() {
                     size: buffer.length,
                     model: opts.model,
                 });
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/keys.ts
+++ b/packages/polli-cli/src/commands/keys.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printInfo,
     printResult,
     printSuccess,
@@ -117,10 +117,7 @@ const list = new Command("list")
                 : ["name", "prefix", "balance", "expires", "permissions"];
             printTable(rows, cols);
         } catch (err) {
-            printError(
-                `Failed to list keys: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to list keys", err);
         }
     });
 
@@ -150,10 +147,7 @@ const info = new Command("info")
                     keyInfo.permissions?.account?.join(", ") ?? "none",
             });
         } catch (err) {
-            printError(
-                `Failed to fetch key info: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch key info", err);
         }
     });
 
@@ -197,12 +191,10 @@ Examples:
                 type: opts.type,
             };
             if (opts.redirectUri && opts.type !== "publishable") {
-                printError("--redirect-uri requires --type publishable");
-                process.exit(1);
+                fail("--redirect-uri requires --type publishable");
             }
             if (opts.earnings === true && opts.type !== "publishable") {
-                printError("--earnings requires --type publishable");
-                process.exit(1);
+                fail("--earnings requires --type publishable");
             }
             if (opts.expiresIn !== undefined)
                 body.expiresIn = Number(opts.expiresIn);
@@ -210,8 +202,7 @@ Examples:
             if (opts.budget !== undefined) {
                 const budget = Number(opts.budget);
                 if (!Number.isFinite(budget) || budget < 0) {
-                    printError("--budget must be a non-negative number");
-                    process.exit(1);
+                    fail("--budget must be a non-negative number");
                 }
                 body.pollenBudget = budget;
             }
@@ -244,10 +235,7 @@ Examples:
                 earnings: created.metadata?.earningsEnabled,
             });
         } catch (err) {
-            printError(
-                `Failed to create key: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to create key", err);
         }
     });
 
@@ -265,10 +253,7 @@ const revoke = new Command("revoke")
 
             printSuccess(`Key ${id} revoked.`);
         } catch (err) {
-            printError(
-                `Failed to revoke key: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to revoke key", err);
         }
     });
 

--- a/packages/polli-cli/src/commands/models.ts
+++ b/packages/polli-cli/src/commands/models.ts
@@ -1,12 +1,7 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import { gen } from "../lib/api.js";
-import {
-    getOutputMode,
-    printError,
-    printResult,
-    printTable,
-} from "../lib/output.js";
+import { fail, getOutputMode, printResult, printTable } from "../lib/output.js";
 import { fetchModelStats } from "./stats.js";
 
 const MAX_STATS_WINDOW_MINUTES = 7 * 24 * 60;
@@ -90,10 +85,9 @@ export const modelsCommand = new Command("models")
                     windowMinutes < 1 ||
                     windowMinutes > MAX_STATS_WINDOW_MINUTES
                 ) {
-                    printError(
+                    fail(
                         `--window must be an integer between 1 and ${MAX_STATS_WINDOW_MINUTES}`,
                     );
-                    process.exit(1);
                 }
 
                 const rows = await fetchModelStats(windowMinutes);
@@ -133,10 +127,7 @@ export const modelsCommand = new Command("models")
                     printTable(curated);
                 }
             } catch (err) {
-                printError(
-                    `Failed to fetch stats: ${err instanceof Error ? err.message : "unknown"}`,
-                );
-                process.exit(1);
+                fail("Failed to fetch stats", err);
             }
             return;
         }
@@ -193,9 +184,6 @@ export const modelsCommand = new Command("models")
                 : ["name", "type", "capabilities", "description"];
             printTable(rows, cols);
         } catch (err) {
-            printError(
-                `Failed to fetch models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch models", err);
         }
     });

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printResult,
     printSuccess,
     printTable,
@@ -64,10 +64,9 @@ function readPriceOptions(opts: Record<string, unknown>) {
         if (opts[key] === undefined) continue;
         const value = Number(opts[key]);
         if (!Number.isFinite(value) || value < 0) {
-            printError(
+            fail(
                 `--${key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} must be a non-negative number`,
             );
-            process.exit(1);
         }
         prices[key] = value;
     }
@@ -93,8 +92,7 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
 
     if (opts.visibility !== undefined) {
         if (opts.visibility !== "private" && opts.visibility !== "public") {
-            printError("--visibility must be 'private' or 'public'");
-            process.exit(1);
+            fail("--visibility must be 'private' or 'public'");
         }
         body.visibility = opts.visibility;
     }
@@ -111,10 +109,9 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
     if (includeRequired) {
         for (const required of ["name", "title", "baseUrl", "bearerToken"]) {
             if (!body[required]) {
-                printError(
+                fail(
                     `--${required.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} is required`,
                 );
-                process.exit(1);
             }
         }
     }
@@ -161,10 +158,7 @@ const list = new Command("list")
             });
             printModels(res.data ?? []);
         } catch (err) {
-            printError(
-                `Failed to list my models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to list my models", err);
         }
     });
 
@@ -199,10 +193,7 @@ const create = addPriceOptions(
             printModels([created]);
         }
     } catch (err) {
-        printError(
-            `Failed to create model: ${err instanceof Error ? err.message : "unknown"}`,
-        );
-        process.exit(1);
+        fail("Failed to create model", err);
     }
 });
 
@@ -241,10 +232,7 @@ const update = addPriceOptions(
             printModels([updated]);
         }
     } catch (err) {
-        printError(
-            `Failed to update model: ${err instanceof Error ? err.message : "unknown"}`,
-        );
-        process.exit(1);
+        fail("Failed to update model", err);
     }
 });
 
@@ -264,10 +252,7 @@ const remove = new Command("delete")
             printSuccess(`Model deleted: ${id}`);
             if (getOutputMode() === "json") printResult({ id });
         } catch (err) {
-            printError(
-                `Failed to delete model: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to delete model", err);
         }
     });
 
@@ -297,10 +282,7 @@ const models = new Command("models")
                     ["model"],
                 );
         } catch (err) {
-            printError(
-                `Failed to fetch upstream models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch upstream models", err);
         }
     });
 
@@ -326,10 +308,7 @@ const test = new Command("test")
             );
             printResult(res);
         } catch (err) {
-            printError(
-                `Failed to test model: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to test model", err);
         }
     });
 

--- a/packages/polli-cli/src/commands/quests.ts
+++ b/packages/polli-cli/src/commands/quests.ts
@@ -3,8 +3,8 @@ import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import { ENTER_URL } from "../lib/config.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printInfo,
     printResult,
     printTable,
@@ -143,9 +143,6 @@ export const questsCommand = new Command("quests")
 
             renderQuests(filterQuests(all, opts));
         } catch (err) {
-            printError(
-                `Failed to fetch quests: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch quests", err);
         }
     });

--- a/packages/polli-cli/src/commands/upload.ts
+++ b/packages/polli-cli/src/commands/upload.ts
@@ -3,7 +3,7 @@ import { basename, extname } from "node:path";
 import { Command } from "commander";
 import { requireKey } from "../lib/api.js";
 import { MEDIA_URL } from "../lib/config.js";
-import { getOutputMode, printError, printMeta } from "../lib/output.js";
+import { fail, getOutputMode, printMeta } from "../lib/output.js";
 
 const MIME_BY_EXT: Record<string, string> = {
     ".jpg": "image/jpeg",
@@ -41,8 +41,7 @@ export const uploadCommand = new Command("upload")
         const isHuman = getOutputMode() === "human";
 
         if (!existsSync(file)) {
-            printError(`File not found: ${file}`);
-            process.exit(1);
+            fail(`File not found: ${file}`);
         }
 
         const mime =
@@ -63,8 +62,7 @@ export const uploadCommand = new Command("upload")
 
         if (!res.ok) {
             const text = await res.text().catch(() => "");
-            printError(`${res.status} ${res.statusText}: ${text}`);
-            process.exit(1);
+            fail(`${res.status} ${res.statusText}: ${text}`);
         }
 
         const data = (await res.json()) as UploadResponse;

--- a/packages/polli-cli/src/lib/api.ts
+++ b/packages/polli-cli/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { BASE_URL, resolveApiKey } from "./config.js";
-import { printError } from "./output.js";
+import { fail, printError } from "./output.js";
 
 export class ApiError extends Error {
     constructor(
@@ -15,10 +15,9 @@ export const requireKey = (): string => {
     const key = resolveApiKey();
     if (!key) {
         printError("Not logged in. Run: polli auth login");
-        printError(
+        fail(
             "Or pipe a key: printf '%s' '<your-key>' | polli auth login --with-token",
         );
-        process.exit(1);
     }
     return key;
 };

--- a/packages/polli-cli/src/lib/errors.ts
+++ b/packages/polli-cli/src/lib/errors.ts
@@ -1,4 +1,6 @@
-import { gen, requireKey } from "./api.js";
+import { ApiError, gen, requireKey } from "./api.js";
+import { BASE_URL } from "./config.js";
+import { printError } from "./output.js";
 
 // Returns null for non-402 so callers fall through to their generic error path.
 export async function budgetHint(
@@ -19,4 +21,28 @@ export async function budgetHint(
     if (balance != null) lines.push(`Account balance: ${balance} pollen`);
     lines.push(`Server said: ${bodyText}`);
     return lines.join("\n");
+}
+
+export async function fetchGen(
+    path: string,
+    init: RequestInit = {},
+): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${requireKey()}`);
+    const response = await fetch(`${BASE_URL}${path}`, {
+        ...init,
+        headers,
+    });
+    if (response.ok) return response;
+
+    const body = await response.text().catch(() => "");
+    const message =
+        (await budgetHint(response.status, body)) ??
+        `${response.status} ${response.statusText}: ${body}`;
+    throw new ApiError(response.status, message);
+}
+
+export function exitWithError(error: unknown): never {
+    printError(error instanceof Error ? error.message : "unknown error");
+    process.exit(1);
 }

--- a/packages/polli-cli/src/lib/output.ts
+++ b/packages/polli-cli/src/lib/output.ts
@@ -122,6 +122,16 @@ export const printError = (msg: string) => {
     process.stderr.write(`${chalk.red.bold("error:")} ${chalk.red(msg)}\n`);
 };
 
+/** Print a fatal command error and terminate with the CLI's standard exit code. */
+export const fail = (message: string, error?: unknown): never => {
+    const detail =
+        error === undefined
+            ? ""
+            : `: ${error instanceof Error ? error.message : "unknown"}`;
+    printError(`${message}${detail}`);
+    process.exit(1);
+};
+
 /** Warning message — always shown, always stderr */
 export const printWarn = (msg: string) => {
     process.stderr.write(


### PR DESCRIPTION
- Centralizes authenticated Gen requests, response-body errors, and 402 balance hints across image, video, audio, text, and transcription commands.
- Adds one fatal-error primitive reused by keys, models, community models, quests, docs, uploads, and missing authentication while keeping interactive chat nonfatal.
- Removes 114 net lines across 14 files without changing command messages or exit status behavior.
- Validation: Biome passed on all 14 files; the full tsup/DTS build passed with the CLI's locked dependencies; `git diff --check` passed. `npm test` has no test files and exits 1 for that existing reason.