### PR TITLE
refactor: remove unused Gen and registry APIs

### DIFF
--- a/gen.pollinations.ai/src/image/utils/azureContentSafety.ts
+++ b/gen.pollinations.ai/src/image/utils/azureContentSafety.ts
@@ -10,16 +10,16 @@ const logError = debug("pollinations:error");
 const CATEGORIES = ["Hate", "SelfHarm", "Sexual", "Violence"] as const;
 const SEVERITY_THRESHOLD = 4;
 
-export type ContentSafetyResults = {
+type ContentSafetyResults = {
     safe: boolean;
     violations: ContentViolation[];
     formattedViolations: string;
 };
 
-export type ContentViolationCategory = (typeof CATEGORIES)[number];
-export type ContentViolationSeverity = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+type ContentViolationCategory = (typeof CATEGORIES)[number];
+type ContentViolationSeverity = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export type ContentViolation = {
+type ContentViolation = {
     category: ContentViolationCategory;
     severity: ContentViolationSeverity;
 };
@@ -132,14 +132,6 @@ export async function analyzeImageSafety(
         image: { content },
     });
 }
-
-export const config = {
-    SEVERITY_THRESHOLD,
-    CATEGORIES,
-    get isConfigured() {
-        return !!getConfig();
-    },
-};
 
 /**
  * Checks prompt safety with Azure Content Safety, logs the result, and throws

--- a/gen.pollinations.ai/src/image/utils/imageTransform.ts
+++ b/gen.pollinations.ai/src/image/utils/imageTransform.ts
@@ -19,10 +19,6 @@ export function setImagesBinding(binding: ImagesBinding | undefined): void {
     imagesBinding = binding || null;
 }
 
-export function getImagesBinding(): ImagesBinding | null {
-    return imagesBinding;
-}
-
 export async function transformImage(
     inputBuffer: ArrayBuffer | Buffer,
     options: TransformOptions = {},

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -118,7 +118,3 @@ export const GenerateImageRequestQueryParamsSchema =
             });
         }
     });
-
-export type GenerateImageRequestQueryParams = z.infer<
-    typeof GenerateImageRequestQueryParamsSchema
->;

--- a/gen.pollinations.ai/src/schemas/model3d.ts
+++ b/gen.pollinations.ai/src/schemas/model3d.ts
@@ -54,7 +54,3 @@ export const Generate3dRequestQueryParamsSchema = z.object({
     }),
     safe: SafeSchema,
 });
-
-export type Generate3dRequestQueryParams = z.infer<
-    typeof Generate3dRequestQueryParamsSchema
->;

--- a/gen.pollinations.ai/src/schemas/realtime.ts
+++ b/gen.pollinations.ai/src/schemas/realtime.ts
@@ -20,10 +20,6 @@ export const RealtimeRequestQueryParamsSchema = z
     })
     .strict();
 
-export type RealtimeRequestQueryParams = z.infer<
-    typeof RealtimeRequestQueryParamsSchema
->;
-
 // Shape of `response.usage` in the Realtime `response.done` event. Only the
 // fields used for billing are declared; everything else is ignored.
 const tokenCount = z.number().nonnegative().nullish();
@@ -62,5 +58,3 @@ export const RealtimeUsageSchema = z
     })
     .partial()
     .passthrough();
-
-export type RealtimeUsage = z.infer<typeof RealtimeUsageSchema>;

--- a/gen.pollinations.ai/src/schemas/text.ts
+++ b/gen.pollinations.ai/src/schemas/text.ts
@@ -36,7 +36,3 @@ export const GenerateTextRequestQueryParamsSchema = z.object({
     }),
     safe: SafeSchema,
 });
-
-export type GenerateTextRequestQueryParams = z.infer<
-    typeof GenerateTextRequestQueryParamsSchema
->;

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -1,4 +1,3 @@
-import debug from "debug";
 import { findModelByName } from "./availableModels.js";
 import { sanitizeCohereResponse } from "./cohereCommandAPlus.js";
 import { genericOpenAIClient } from "./genericOpenAIClient.js";
@@ -13,8 +12,6 @@ import type {
     TransformResult,
 } from "./types.js";
 import { resolveModelConfig } from "./utils/modelResolver.js";
-
-export const log = debug("pollinations:portkey");
 
 const clientConfig = {
     defaultOptions: {

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -476,17 +476,6 @@ export function calculateCostForModelDefinition(
 }
 
 /**
- * Calculate cost from an explicit cost definition.
- */
-export function calculateCostWithDefinition(
-    model: string,
-    usage: Usage,
-    costDefinition: CostDefinition,
-): UsageCost {
-    return calculateLinearCost(model, usage, costDefinition);
-}
-
-/**
  * Calculate price for a model based on usage
  */
 export function calculatePrice(
@@ -509,22 +498,4 @@ export function calculatePriceForModelDefinition(
     output?: unknown,
 ): UsagePrice {
     return calculateUsageBilling({ model, usage, servedBy: svc, output }).price;
-}
-
-/**
- * Calculate price from an explicit price definition.
- */
-export function calculatePriceWithDefinition(
-    model: string,
-    usage: Usage,
-    priceDefinition: PriceDefinition,
-): UsagePrice {
-    const usagePrice = convertUsage(usage, priceDefinition, model);
-    const totalPrice = roundPollenLedgerAmount(
-        Object.values(usagePrice).reduce((total, price) => total + price, 0),
-    );
-    return {
-        ...usagePrice,
-        totalPrice,
-    };
 }


### PR DESCRIPTION
- Removes unused Gen request and usage aliases, a dead image binding getter, the unused Azure safety config export, and an unused Portkey logger.
- Removes the unused explicit cost and price calculation exports from the shared registry, leaving calculateUsageBilling-backed model billing as the single implementation.
- Deletes 66 net lines with no runtime behavior change or remaining callers.
- Combined validation: Biome, repository-wide removed-symbol search, and git diff checks. The component branches previously passed Gen typecheck, focused Gen tests, and the 28-test pricing suite.