### PR TITLE
refactor: simplify Sirius API client

### DIFF
--- a/apps/sirius-cybernetics-elevator-challenge/src/types.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/types.ts
@@ -1,5 +1,3 @@
-import type React from "react";
-
 // Game Configuration
 export const GAME_CONFIG = {
     FLOORS: 5,
@@ -36,20 +34,6 @@ export const ACTION_INDICATORS = {
     },
 } as const;
 
-// Consolidate message-related constants
-export const MESSAGE_CONFIG = {
-    STYLES: MESSAGE_STYLES,
-    PREFIXES: MESSAGE_PREFIXES,
-    ACTION_INDICATORS,
-} as const;
-
-// API Configuration
-export const API_CONFIG = {
-    MAX_RETRIES: 3,
-    RETRY_DELAY: 1000,
-    ENDPOINT: "https://gen.pollinations.ai/v1/chat/completions",
-} as const;
-
 // Game Types
 export type Persona = "user" | "marvin" | "elevator" | "guide";
 export type Action = "none" | "join" | "up" | "down" | "show_instructions";
@@ -71,13 +55,6 @@ export type GameState = {
     showInstruction: boolean;
     isLoading: boolean;
 };
-
-export type GameAction =
-    | { type: "CHEAT_CODE" }
-    | { type: "ADD_MESSAGE"; message: Message }
-    | { type: "SWITCH_PERSONA"; persona: Persona }
-    | { type: "START_AUTONOMOUS" }
-    | { type: "END_GAME" };
 
 // API Types
 export type PollingsMessage = {
@@ -106,12 +83,3 @@ export type ElevatorAsciiProps = {
     isMarvinMode?: boolean;
     hasMarvinJoined?: boolean;
 };
-
-// Utility Types
-export type LMMessage = {
-    role: "user" | "assistant" | "system";
-    content: string;
-    name?: "elevator" | "marvin" | "guide";
-};
-
-export type SetState<T> = React.Dispatch<React.SetStateAction<T>>;

--- a/apps/sirius-cybernetics-elevator-challenge/src/utils/api.ts
+++ b/apps/sirius-cybernetics-elevator-challenge/src/utils/api.ts
@@ -1,47 +1,9 @@
 import { getStoredApiKey, getStoredModel } from "@/hooks/ui";
-import {
-    API_CONFIG,
-    type PollingsMessage,
-    type PollingsResponse,
-} from "@/types";
+import type { PollingsMessage, PollingsResponse } from "@/types";
 
-function createFetchRequest(
-    messages: PollingsMessage[],
-    jsonMode = true,
-): RequestInit {
-    const apiKey = getStoredApiKey();
-    const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-    };
-    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-
-    const model = getStoredModel();
-
-    return {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-            messages,
-            model,
-            // DeepSeek is a reasoning model: even "low" lets it think for
-            // thousands of tokens, pushing replies past 10s on the long Guide
-            // prompt, so it gets "none". The other (non-reasoning) models stay
-            // at "low" — it's a harmless no-op for them.
-            reasoning_effort: model === "deepseek" ? "none" : "low",
-            response_format: jsonMode ? { type: "json_object" } : undefined,
-            seed: Math.floor(Math.random() * 1000000),
-        }),
-    };
-}
-
-// Thrown after all retries fail. Carries a short upstream detail (e.g.
-// "HTTP 429: rate limit exceeded") so the UI can speak it in the game's voice.
-export class PollingsError extends Error {
-    constructor(readonly detail: string) {
-        super(detail);
-        this.name = "PollingsError";
-    }
-}
+const ENDPOINT = "https://gen.pollinations.ai/v1/chat/completions";
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1000;
 
 // Pull the most useful line out of an upstream error body, which may be a JSON
 // envelope ({error:{message}} / {message}) or plain text.
@@ -61,52 +23,56 @@ const extractDetail = (raw: string): string => {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-export const retryFetch = async (
-    operation: () => Promise<Response>,
-    maxAttempts = API_CONFIG.MAX_RETRIES,
+export const fetchFromPollinations = async (
+    messages: PollingsMessage[],
 ): Promise<PollingsResponse> => {
     let lastDetail = "Sub-Etha signal lost";
 
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
         try {
-            const response = await operation();
+            const apiKey = getStoredApiKey();
+            const headers: Record<string, string> = {
+                "Content-Type": "application/json",
+            };
+            if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+            const model = getStoredModel();
+            const response = await fetch(ENDPOINT, {
+                method: "POST",
+                headers,
+                body: JSON.stringify({
+                    messages,
+                    model,
+                    reasoning_effort: model === "deepseek" ? "none" : "low",
+                    response_format: { type: "json_object" },
+                    seed: Math.floor(Math.random() * 1000000),
+                }),
+            });
             if (!response.ok) {
                 const body = await response.text().catch(() => "");
                 const detail = extractDetail(body).slice(0, 200);
-                throw new PollingsError(
+                throw new Error(
                     `HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
                 );
             }
 
             return (await response.json()) as PollingsResponse;
         } catch (error) {
-            lastDetail =
-                error instanceof PollingsError
-                    ? error.detail
-                    : (error as Error).message;
+            lastDetail = error instanceof Error ? error.message : String(error);
             console.warn(
-                `Attempt ${attempt + 1}/${maxAttempts} failed:`,
+                `Attempt ${attempt + 1}/${MAX_ATTEMPTS} failed:`,
                 error,
             );
 
-            if (attempt < maxAttempts - 1) {
-                await delay(API_CONFIG.RETRY_DELAY * 2 ** attempt);
+            if (attempt < MAX_ATTEMPTS - 1) {
+                await delay(RETRY_DELAY_MS * 2 ** attempt);
             }
         }
     }
 
     console.error(
-        `All ${maxAttempts} attempts failed. Last error:`,
+        `All ${MAX_ATTEMPTS} attempts failed. Last error:`,
         lastDetail,
     );
-    throw new PollingsError(lastDetail);
-};
-
-export const fetchFromPollinations = async (
-    messages: PollingsMessage[],
-    jsonMode = true,
-): Promise<PollingsResponse> => {
-    return retryFetch(() =>
-        fetch(API_CONFIG.ENDPOINT, createFetchRequest(messages, jsonMode)),
-    );
+    throw new Error(lastDetail);
 };


### PR DESCRIPTION
- Folds the one-caller request builder and retry wrapper into the Sirius generation client.
- Removes the custom error subclass, unused JSON-mode hook, configuration facade, and four orphan types/constants.
- Preserves authentication, model selection, request payloads, three exponential-backoff attempts, and upstream error details.
- Cuts 66 net lines; verified with Biome, TypeScript, and the production Vite build.