### PR TITLE
refactor: share MCP chat request handling

### DIFF
--- a/packages/mcp/src/services/textService.js
+++ b/packages/mcp/src/services/textService.js
@@ -1,10 +1,8 @@
 import { z } from "zod";
-import { getAuthHeaders, requireApiKey } from "../utils/authUtils.js";
+import { requireApiKey } from "../utils/authUtils.js";
 import {
-    API_BASE_URL,
     createMCPResponse,
     createTextContent,
-    parseApiError,
     postChatCompletion,
 } from "../utils/coreUtils.js";
 import {
@@ -64,8 +62,7 @@ async function generateText(params) {
     }
 
     try {
-        const response = await postChatCompletion(requestBody);
-        const result = await response.json();
+        const result = await postChatCompletion(requestBody);
         const content = result.choices?.[0]?.message?.content || "";
 
         return createMCPResponse([createTextContent(content)]);
@@ -147,8 +144,7 @@ async function chatCompletion(params) {
     };
 
     try {
-        const response = await postChatCompletion(requestBody);
-        const result = await response.json();
+        const result = await postChatCompletion(requestBody);
 
         const choice = result.choices?.[0];
         const assistantMessage = choice?.message;
@@ -327,14 +323,16 @@ async function webSearch(params) {
         throw new Error("Query is required and must be a string");
     }
 
-    const searchModels = [
-        "perplexity-fast",
-        "perplexity-reasoning",
-        "gemini-search",
-    ];
-    if (!searchModels.includes(model)) {
+    const validation = await validateTextModel(model);
+    if (!validation.valid) {
         throw new Error(
-            `Model "${model}" doesn't support web search. Use: ${searchModels.join(", ")}`,
+            `${validation.error} Did you mean: ${validation.suggestions.join(", ")}? ` +
+                `Use listTextModels to see all ${validation.availableCount} available models.`,
+        );
+    }
+    if (!validation.model.capabilities?.includes("web_search")) {
+        throw new Error(
+            `Model "${model}" doesn't support web search. Use listTextModels to find models with the web_search capability.`,
         );
     }
 
@@ -351,23 +349,7 @@ async function webSearch(params) {
     };
 
     try {
-        const response = await fetch(`${API_BASE_URL}/v1/chat/completions`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                ...getAuthHeaders(),
-            },
-            body: JSON.stringify(requestBody),
-        });
-
-        if (!response.ok) {
-            const errorText = await response
-                .text()
-                .catch(() => "Unknown error");
-            throw new Error(parseApiError(response.status, errorText));
-        }
-
-        const result = await response.json();
+        const result = await postChatCompletion(requestBody);
         const answer = result.choices?.[0]?.message?.content || "";
 
         const responseData = {
@@ -758,14 +740,10 @@ export const textTools = [
         {
             query: z.string().describe("The search query or question"),
             model: z
-                .enum([
-                    "perplexity-fast",
-                    "perplexity-reasoning",
-                    "gemini-search",
-                ])
+                .string()
                 .optional()
                 .describe(
-                    "Search model (default: 'perplexity-fast'):\n- perplexity-fast: Quick answers with web search\n- perplexity-reasoning: Deeper analysis with web search\n- gemini-search: Google's Gemini with Google Search",
+                    "Search-capable text model (default: 'perplexity-fast'). Use listTextModels for the live list of models with the web_search capability.",
                 ),
             detailed: z
                 .boolean()

--- a/packages/mcp/src/utils/coreUtils.js
+++ b/packages/mcp/src/utils/coreUtils.js
@@ -142,29 +142,15 @@ export async function chatWithMedia({ model, prompt, mediaType, mediaUrl }) {
             ? { type: "input_audio", input_audio: { url: mediaUrl } }
             : { type: mediaType, [mediaType]: { url: mediaUrl } };
 
-    const response = await fetchWithAuth(
-        `${API_BASE_URL}/v1/chat/completions`,
-        {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                model,
-                messages: [
-                    {
-                        role: "user",
-                        content: [{ type: "text", text: prompt }, mediaBlock],
-                    },
-                ],
-            }),
-        },
-    );
-
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => "Unknown error");
-        throw new Error(parseApiError(response.status, errorText));
-    }
-
-    const result = await response.json();
+    const result = await postChatCompletion({
+        model,
+        messages: [
+            {
+                role: "user",
+                content: [{ type: "text", text: prompt }, mediaBlock],
+            },
+        ],
+    });
     return {
         content: result.choices?.[0]?.message?.content || "",
         model: result.model || model,
@@ -174,11 +160,10 @@ export async function chatWithMedia({ model, prompt, mediaType, mediaUrl }) {
 /**
  * POST a chat-completion request body to /v1/chat/completions.
  * Strips null/undefined keys, reuses the 30s timeout in fetchWithAuth, and maps
- * errors (with the dedicated rate-limit message). Returns the raw Response so
- * callers can shape the JSON themselves.
+ * errors, and parses the JSON response.
  *
  * @param {Object} body - Request body (null/undefined fields are stripped)
- * @returns {Promise<Response>} - Raw fetch response (already checked for !ok)
+ * @returns {Promise<Object>} - Parsed chat-completion response
  */
 export async function postChatCompletion(body) {
     const cleanedBody = {};
@@ -188,25 +173,12 @@ export async function postChatCompletion(body) {
         }
     }
 
-    const response = await fetchWithAuth(
-        `${API_BASE_URL}/v1/chat/completions`,
-        {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(cleanedBody),
-            timeoutMs: 30000,
-        },
-    );
-
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => "Unknown error");
-        if (response.status === 429) {
-            throw new Error("Rate limited. Please wait before retrying.");
-        }
-        throw new Error(parseApiError(response.status, errorText));
-    }
-
-    return response;
+    return fetchJsonWithAuth(`${API_BASE_URL}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(cleanedBody),
+        timeoutMs: 30000,
+    });
 }
 
 /**


### PR DESCRIPTION
- Routes simple text, advanced chat, media analysis, and web search through one authenticated chat-completion helper.
- Makes that helper own body cleanup, JSON decoding, and standard API error mapping.
- Replaces the hardcoded web-search model enum with live registry capability validation.
- Removes 50 net lines; verified with Biome, syntax checks, MCP stdio startup/tool discovery, and deterministic auth, media, search, citation, capability, and error-path smoke checks.