### PR TITLE
refactor: share Polli CLI fatal errors

### DIFF
--- a/packages/polli-cli/src/commands/docs.ts
+++ b/packages/polli-cli/src/commands/docs.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import open from "open";
 import { BASE_URL } from "../lib/config.js";
 import {
+    fail,
     getOutputMode,
     printError,
     printInfo,
@@ -72,10 +73,7 @@ export const docsCommand = new Command("docs")
                     process.stdout.write("\n");
                 }
             } catch (err) {
-                printError(
-                    `Failed to fetch docs: ${err instanceof Error ? err.message : "unknown"}`,
-                );
-                process.exit(1);
+                fail("Failed to fetch docs", err);
             }
             return;
         }

--- a/packages/polli-cli/src/commands/keys.ts
+++ b/packages/polli-cli/src/commands/keys.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printInfo,
     printResult,
     printSuccess,
@@ -117,10 +117,7 @@ const list = new Command("list")
                 : ["name", "prefix", "balance", "expires", "permissions"];
             printTable(rows, cols);
         } catch (err) {
-            printError(
-                `Failed to list keys: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to list keys", err);
         }
     });
 
@@ -150,10 +147,7 @@ const info = new Command("info")
                     keyInfo.permissions?.account?.join(", ") ?? "none",
             });
         } catch (err) {
-            printError(
-                `Failed to fetch key info: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch key info", err);
         }
     });
 
@@ -197,12 +191,10 @@ Examples:
                 type: opts.type,
             };
             if (opts.redirectUri && opts.type !== "publishable") {
-                printError("--redirect-uri requires --type publishable");
-                process.exit(1);
+                fail("--redirect-uri requires --type publishable");
             }
             if (opts.earnings === true && opts.type !== "publishable") {
-                printError("--earnings requires --type publishable");
-                process.exit(1);
+                fail("--earnings requires --type publishable");
             }
             if (opts.expiresIn !== undefined)
                 body.expiresIn = Number(opts.expiresIn);
@@ -210,8 +202,7 @@ Examples:
             if (opts.budget !== undefined) {
                 const budget = Number(opts.budget);
                 if (!Number.isFinite(budget) || budget < 0) {
-                    printError("--budget must be a non-negative number");
-                    process.exit(1);
+                    fail("--budget must be a non-negative number");
                 }
                 body.pollenBudget = budget;
             }
@@ -244,10 +235,7 @@ Examples:
                 earnings: created.metadata?.earningsEnabled,
             });
         } catch (err) {
-            printError(
-                `Failed to create key: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to create key", err);
         }
     });
 
@@ -265,10 +253,7 @@ const revoke = new Command("revoke")
 
             printSuccess(`Key ${id} revoked.`);
         } catch (err) {
-            printError(
-                `Failed to revoke key: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to revoke key", err);
         }
     });
 

--- a/packages/polli-cli/src/commands/models.ts
+++ b/packages/polli-cli/src/commands/models.ts
@@ -1,12 +1,7 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import { gen } from "../lib/api.js";
-import {
-    getOutputMode,
-    printError,
-    printResult,
-    printTable,
-} from "../lib/output.js";
+import { fail, getOutputMode, printResult, printTable } from "../lib/output.js";
 import { fetchModelStats } from "./stats.js";
 
 const MAX_STATS_WINDOW_MINUTES = 7 * 24 * 60;
@@ -90,10 +85,9 @@ export const modelsCommand = new Command("models")
                     windowMinutes < 1 ||
                     windowMinutes > MAX_STATS_WINDOW_MINUTES
                 ) {
-                    printError(
+                    fail(
                         `--window must be an integer between 1 and ${MAX_STATS_WINDOW_MINUTES}`,
                     );
-                    process.exit(1);
                 }
 
                 const rows = await fetchModelStats(windowMinutes);
@@ -133,10 +127,7 @@ export const modelsCommand = new Command("models")
                     printTable(curated);
                 }
             } catch (err) {
-                printError(
-                    `Failed to fetch stats: ${err instanceof Error ? err.message : "unknown"}`,
-                );
-                process.exit(1);
+                fail("Failed to fetch stats", err);
             }
             return;
         }
@@ -193,9 +184,6 @@ export const modelsCommand = new Command("models")
                 : ["name", "type", "capabilities", "description"];
             printTable(rows, cols);
         } catch (err) {
-            printError(
-                `Failed to fetch models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch models", err);
         }
     });

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printResult,
     printSuccess,
     printTable,
@@ -64,10 +64,9 @@ function readPriceOptions(opts: Record<string, unknown>) {
         if (opts[key] === undefined) continue;
         const value = Number(opts[key]);
         if (!Number.isFinite(value) || value < 0) {
-            printError(
+            fail(
                 `--${key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} must be a non-negative number`,
             );
-            process.exit(1);
         }
         prices[key] = value;
     }
@@ -93,8 +92,7 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
 
     if (opts.visibility !== undefined) {
         if (opts.visibility !== "private" && opts.visibility !== "public") {
-            printError("--visibility must be 'private' or 'public'");
-            process.exit(1);
+            fail("--visibility must be 'private' or 'public'");
         }
         body.visibility = opts.visibility;
     }
@@ -111,10 +109,9 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
     if (includeRequired) {
         for (const required of ["name", "title", "baseUrl", "bearerToken"]) {
             if (!body[required]) {
-                printError(
+                fail(
                     `--${required.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} is required`,
                 );
-                process.exit(1);
             }
         }
     }
@@ -161,10 +158,7 @@ const list = new Command("list")
             });
             printModels(res.data ?? []);
         } catch (err) {
-            printError(
-                `Failed to list my models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to list my models", err);
         }
     });
 
@@ -199,10 +193,7 @@ const create = addPriceOptions(
             printModels([created]);
         }
     } catch (err) {
-        printError(
-            `Failed to create model: ${err instanceof Error ? err.message : "unknown"}`,
-        );
-        process.exit(1);
+        fail("Failed to create model", err);
     }
 });
 
@@ -241,10 +232,7 @@ const update = addPriceOptions(
             printModels([updated]);
         }
     } catch (err) {
-        printError(
-            `Failed to update model: ${err instanceof Error ? err.message : "unknown"}`,
-        );
-        process.exit(1);
+        fail("Failed to update model", err);
     }
 });
 
@@ -264,10 +252,7 @@ const remove = new Command("delete")
             printSuccess(`Model deleted: ${id}`);
             if (getOutputMode() === "json") printResult({ id });
         } catch (err) {
-            printError(
-                `Failed to delete model: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to delete model", err);
         }
     });
 
@@ -297,10 +282,7 @@ const models = new Command("models")
                     ["model"],
                 );
         } catch (err) {
-            printError(
-                `Failed to fetch upstream models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch upstream models", err);
         }
     });
 
@@ -326,10 +308,7 @@ const test = new Command("test")
             );
             printResult(res);
         } catch (err) {
-            printError(
-                `Failed to test model: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to test model", err);
         }
     });
 

--- a/packages/polli-cli/src/commands/quests.ts
+++ b/packages/polli-cli/src/commands/quests.ts
@@ -3,8 +3,8 @@ import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import { ENTER_URL } from "../lib/config.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printInfo,
     printResult,
     printTable,
@@ -143,9 +143,6 @@ export const questsCommand = new Command("quests")
 
             renderQuests(filterQuests(all, opts));
         } catch (err) {
-            printError(
-                `Failed to fetch quests: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch quests", err);
         }
     });

--- a/packages/polli-cli/src/commands/upload.ts
+++ b/packages/polli-cli/src/commands/upload.ts
@@ -3,7 +3,7 @@ import { basename, extname } from "node:path";
 import { Command } from "commander";
 import { requireKey } from "../lib/api.js";
 import { MEDIA_URL } from "../lib/config.js";
-import { getOutputMode, printError, printMeta } from "../lib/output.js";
+import { fail, getOutputMode, printMeta } from "../lib/output.js";
 
 const MIME_BY_EXT: Record<string, string> = {
     ".jpg": "image/jpeg",
@@ -41,8 +41,7 @@ export const uploadCommand = new Command("upload")
         const isHuman = getOutputMode() === "human";
 
         if (!existsSync(file)) {
-            printError(`File not found: ${file}`);
-            process.exit(1);
+            fail(`File not found: ${file}`);
         }
 
         const mime =
@@ -63,8 +62,7 @@ export const uploadCommand = new Command("upload")
 
         if (!res.ok) {
             const text = await res.text().catch(() => "");
-            printError(`${res.status} ${res.statusText}: ${text}`);
-            process.exit(1);
+            fail(`${res.status} ${res.statusText}: ${text}`);
         }
 
         const data = (await res.json()) as UploadResponse;

--- a/packages/polli-cli/src/lib/api.ts
+++ b/packages/polli-cli/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { BASE_URL, resolveApiKey } from "./config.js";
-import { printError } from "./output.js";
+import { fail, printError } from "./output.js";
 
 export class ApiError extends Error {
     constructor(
@@ -15,10 +15,9 @@ export const requireKey = (): string => {
     const key = resolveApiKey();
     if (!key) {
         printError("Not logged in. Run: polli auth login");
-        printError(
+        fail(
             "Or pipe a key: printf '%s' '<your-key>' | polli auth login --with-token",
         );
-        process.exit(1);
     }
     return key;
 };

--- a/packages/polli-cli/src/lib/output.ts
+++ b/packages/polli-cli/src/lib/output.ts
@@ -122,6 +122,16 @@ export const printError = (msg: string) => {
     process.stderr.write(`${chalk.red.bold("error:")} ${chalk.red(msg)}\n`);
 };
 
+/** Print a fatal command error and terminate with the CLI's standard exit code. */
+export const fail = (message: string, error?: unknown): never => {
+    const detail =
+        error === undefined
+            ? ""
+            : `: ${error instanceof Error ? error.message : "unknown"}`;
+    printError(`${message}${detail}`);
+    process.exit(1);
+};
+
 /** Warning message — always shown, always stderr */
 export const printWarn = (msg: string) => {
     process.stderr.write(


### PR DESCRIPTION
- Adds one fatal-error primitive for consistent stderr output and exit status.
- Reuses it across keys, models, community models, quests, docs, uploads, and missing authentication.
- Removes 46 net lines without changing command messages or exit code 1 behavior.
- Verified with Biome, the production build, and a real invalid-window CLI smoke. `npm test` has no test files and exits 1 for that existing reason.