### PR TITLE
refactor: share GSoC frontmatter parsing

### DIFF
--- a/apps/gsoc/src/utils/parseFaq.js
+++ b/apps/gsoc/src/utils/parseFaq.js
@@ -1,26 +1,18 @@
-import fm from "front-matter";
+import { parseFrontmatterDocuments } from "./parseFrontmatterDocuments.js";
 
 /**
  * Parse FAQ from FAQ.md using front-matter
  */
 export async function parseFaq(url = "/GSOC/FAQ.md") {
-    const response = await fetch(url);
-    const text = await response.text();
-
-    const regex = /---\n([\s\S]*?)\n---\n([\s\S]*?)(?=\n---\n|$)/g;
     const faq = [];
 
-    for (const match of text.matchAll(regex)) {
-        const [, yaml, body] = match;
-        const fmString = `---\n${yaml}\n---\n${body}`;
-        const { attributes } = fm(fmString);
-
+    for (const { attributes, body } of await parseFrontmatterDocuments(url)) {
         if (attributes.question) {
             faq.push({
                 id: parseInt(attributes.id, 10) || faq.length + 1,
                 category: attributes.category,
                 question: attributes.question,
-                answer: body.trim(),
+                answer: body,
             });
         }
     }

--- a/apps/gsoc/src/utils/parseFrontmatterDocuments.js
+++ b/apps/gsoc/src/utils/parseFrontmatterDocuments.js
@@ -1,0 +1,13 @@
+import fm from "front-matter";
+
+const documentPattern = /---\n([\s\S]*?)\n---\n([\s\S]*?)(?=\n---\n|$)/g;
+
+export async function parseFrontmatterDocuments(url) {
+    const response = await fetch(url);
+    const text = await response.text();
+
+    return Array.from(text.matchAll(documentPattern), ([, yaml, body]) => ({
+        attributes: fm(`---\n${yaml}\n---\n`).attributes,
+        body: body.trim(),
+    }));
+}

--- a/apps/gsoc/src/utils/parseMentors.js
+++ b/apps/gsoc/src/utils/parseMentors.js
@@ -1,16 +1,9 @@
-import fm from "front-matter";
-export async function parseMentors(url = "/GSOC/MENTORS.md") {
-    const response = await fetch(url);
-    const text = await response.text();
+import { parseFrontmatterDocuments } from "./parseFrontmatterDocuments.js";
 
-    const regex = /---\n([\s\S]*?)\n---\n([\s\S]*?)(?=\n---\n|$)/g;
+export async function parseMentors(url = "/GSOC/MENTORS.md") {
     const mentors = [];
 
-    for (const match of text.matchAll(regex)) {
-        const [, yaml, body] = match;
-        const fmString = `---\n${yaml}\n---\n${body}`;
-        const { attributes } = fm(fmString);
-
+    for (const { attributes, body } of await parseFrontmatterDocuments(url)) {
         if (attributes.name) {
             mentors.push({
                 id: attributes.id,
@@ -25,7 +18,7 @@ export async function parseMentors(url = "/GSOC/MENTORS.md") {
                 linkedin: attributes.linkedin,
                 github: attributes.github,
                 email: attributes.email,
-                longDescription: body.trim(),
+                longDescription: body,
             });
         }
     }

--- a/apps/gsoc/src/utils/parseProjects.js
+++ b/apps/gsoc/src/utils/parseProjects.js
@@ -1,4 +1,4 @@
-import fm from "front-matter";
+import { parseFrontmatterDocuments } from "./parseFrontmatterDocuments.js";
 
 /**
  * Parse projects from PROJECTS.md using front-matter for YAML frontmatter
@@ -11,22 +11,11 @@ import fm from "front-matter";
  * Description content here.
  */
 export async function parseProjects(url = "/GSOC/PROJECTS.md") {
-    const response = await fetch(url);
-    const text = await response.text();
-
-    // Match complete frontmatter blocks: ---\nyaml\n---\nbody
-    // Each match captures: full block with frontmatter + body until next --- or end
-    const regex = /---\n([\s\S]*?)\n---\n([\s\S]*?)(?=\n---\n|$)/g;
     const projects = [];
 
-    for (const match of text.matchAll(regex)) {
-        const [, yaml, body] = match;
-        // Reconstruct as valid frontmatter string for fm()
-        const fmString = `---\n${yaml}\n---\n${body}`;
-        const { attributes } = fm(fmString);
-
+    for (const { attributes, body } of await parseFrontmatterDocuments(url)) {
         if (attributes.title) {
-            const paragraphs = body.trim().split("\n\n").filter(Boolean);
+            const paragraphs = body.split("\n\n").filter(Boolean);
             projects.push({
                 ...attributes,
                 technologies: attributes.technologies?.split(", ") || [],

--- a/apps/gsoc/src/utils/parseTimeline.js
+++ b/apps/gsoc/src/utils/parseTimeline.js
@@ -1,20 +1,12 @@
-import fm from "front-matter";
+import { parseFrontmatterDocuments } from "./parseFrontmatterDocuments.js";
 
 /**
  * Parse timeline from TIMELINE.md using front-matter
  */
 export async function parseTimeline(url = "/GSOC/TIMELINE.md") {
-    const response = await fetch(url);
-    const text = await response.text();
-
-    const regex = /---\n([\s\S]*?)\n---/g;
     const timeline = [];
 
-    for (const match of text.matchAll(regex)) {
-        const [, yaml] = match;
-        const fmString = `---\n${yaml}\n---\n`;
-        const { attributes } = fm(fmString);
-
+    for (const { attributes } of await parseFrontmatterDocuments(url)) {
         if (attributes.title) {
             timeline.push({
                 title: attributes.title,


### PR DESCRIPTION
- Consolidates the duplicated fetch, document matching, YAML parsing, and body trimming used by four GSoC content parsers.
- Keeps the project, mentor, timeline, and FAQ output shapes unchanged.
- Removes 21 net lines while giving the parser mechanics one implementation.

Validation:
- `npx biome check --write src/utils/parseFrontmatterDocuments.js src/utils/parseProjects.js src/utils/parseMentors.js src/utils/parseTimeline.js src/utils/parseFaq.js`
- Focused ESLint on all five files
- Smoke parse: 6 projects, 3 mentors, 10 timeline entries, 18 FAQs
- `npm run build`