### PR TITLE
refactor: remove Polli legacy compatibility code

### DIFF
--- a/apps/polli/src/ai/client.py
+++ b/apps/polli/src/ai/client.py
@@ -167,7 +167,7 @@ class PollinationsClient:
                 else:
                     error_text = await response.text()
                     if response.status == 402:
-                        logger.warning(f"generate_text: insufficient balance (402), bailing")
+                        logger.warning("generate_text: insufficient balance (402), bailing")
                         return None
                     logger.error(f"generate_text error: HTTP {response.status}: {error_text[:200]}")
                     return None
@@ -763,66 +763,6 @@ class PollinationsClient:
         logger.error(f"All {MAX_RETRIES} API attempts failed. Last error: {last_error}")
         return None
 
-    async def process_message(
-        self,
-        user_message: str,
-        discord_username: str,
-        thread_history: list[dict] | None = None,
-        image_urls: list[str] | None = None,
-        context_data: dict | None = None,
-    ) -> dict | None:
-        """Legacy method - wraps new tool-based processing."""
-        result = await self.process_with_tools(
-            user_message=user_message,
-            discord_username=discord_username,
-            thread_history=thread_history,
-            image_urls=image_urls,
-        )
-
-        # Convert to legacy format
-        if result.get("error"):
-            return None
-
-        return {"action": "respond", "message": result["response"]}
-
-    async def format_search_results(self, user_query: str, issues: list[dict], discord_username: str) -> dict | None:
-        """Format search results (now handled by AI after tool call)."""
-        if not issues:
-            return {
-                "action": "respond",
-                "message": "No issues found matching your search.",
-            }
-
-        # Format for display
-        issues_text = "\n".join(
-            [f"- **#{i['number']}**: {i['title']} ({i['state']}) - {i['url']}" for i in issues[:10]]
-        )
-
-        return {
-            "action": "respond",
-            "message": f"Found {len(issues)} issue(s):\n{issues_text}",
-        }
-
-    async def format_issue_detail(self, issue: dict, comments: list[dict] | None = None) -> dict | None:
-        """Format issue detail (now handled by AI after tool call)."""
-        state_emoji = "🟢" if issue["state"] == "open" else "🔴"
-
-        msg = f"{state_emoji} **#{issue['number']}: {issue['title']}**\n"
-        msg += f"State: {issue['state']} | Author: {issue['author']}\n"
-
-        if issue.get("labels"):
-            msg += f"Labels: {', '.join(issue['labels'])}\n"
-
-        msg += f"\n{issue.get('body', 'No description')}\n"
-        msg += f"\n{issue['url']}"
-
-        if comments:
-            msg += "\n\n**Recent comments:**\n"
-            for c in comments[:3]:
-                msg += f"- {c['author']}: {c['body']}\n"
-
-        return {"action": "respond", "message": msg}
-
     def get_topic_summary_fast(self, message: str) -> str:
         words = message.lower().split()
         stop_words = {
@@ -1003,4 +943,3 @@ async def web_search_handler(query: str, **kwargs) -> dict:
     except Exception as e:
         logger.error(f"Web search error: {e}")
         return {"error": f"Search failed: {str(e)}"}
-

--- a/apps/polli/src/ai/prompts.py
+++ b/apps/polli/src/ai/prompts.py
@@ -148,7 +148,6 @@ API_TOOLS_SECTION = """- `github_overview` - Repo summary
 - `discord_search` - Search Discord server
 - `render_visual` - Render tables and charts as images (type: table/bar/pie/line/scatter/heatmap/etc.)"""
 
-# Keep TOOL_SYSTEM_PROMPT as backward-compatible alias (full Discord prompt)
 TOOL_SYSTEM_PROMPT = BASE_SYSTEM_PROMPT + DISCORD_PROMPT_ADDON
 
 # Tools section for ADMIN users - full access
@@ -199,8 +198,6 @@ def get_tool_system_prompt(is_admin: bool = True, is_collaborator: bool = False,
     Returns:
         The formatted system prompt appropriate for the user's permission level and mode.
     """
-    from datetime import datetime
-
     current_utc = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     if mode == "api":
@@ -220,11 +217,3 @@ def get_tool_system_prompt(is_admin: bool = True, is_collaborator: bool = False,
         current_utc=current_utc,
         tools_section=tools_section,
     )
-
-
-# Keep static version for backwards compatibility (without dynamic time) - uses admin version
-TOOL_SYSTEM_PROMPT_STATIC = TOOL_SYSTEM_PROMPT.format(
-    repo_info=REPO_INFO,
-    current_utc="[dynamic]",
-    tools_section=ADMIN_TOOLS_SECTION,
-)

--- a/apps/polli/src/ai/tool_filters.py
+++ b/apps/polli/src/ai/tool_filters.py
@@ -3,13 +3,12 @@
 from ..utils.regex import re
 from .tools import (
     CODE_SEARCH_TOOL,
-    DATA_VIZ_TOOL,
     DISCORD_SEARCH_TOOL,
-    GITHUB_TOOLS,
     RENDER_VISUAL_TOOL,
     WEB_SCRAPE_TOOL,
     WEB_SEARCH_TOOL,
 )
+
 
 def get_tools_with_embeddings(base_tools: list, code_search_enabled: bool) -> list:
     """Build the tool list, including code_search only when it is configured."""
@@ -25,7 +24,7 @@ def get_tools_with_embeddings(base_tools: list, code_search_enabled: bool) -> li
     tools.append(WEB_SEARCH_TOOL)
     tools.append(WEB_SCRAPE_TOOL)
     tools.append(DISCORD_SEARCH_TOOL)
-    tools.append(DATA_VIZ_TOOL)
+    tools.append(RENDER_VISUAL_TOOL)
 
     if code_search_enabled:
         tools.append(CODE_SEARCH_TOOL)
@@ -327,4 +326,3 @@ def filter_tools_by_intent(user_message: str, all_tools: list[dict], is_admin: b
 # =============================================================================
 # TOOL-BASED SYSTEM PROMPT - AI has FULL AUTONOMY
 # =============================================================================
-

--- a/apps/polli/src/ai/tools.py
+++ b/apps/polli/src/ai/tools.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 # Repo context injected into the system prompt.
 _REPO_INFO_PATH = Path(__file__).resolve().parent.parent / "context" / "repo_info.txt"
 REPO_INFO = (
@@ -940,8 +939,3 @@ Callable multiple times per turn; each call attaches one image (Discord caps at 
         },
     },
 }
-
-# Backward-compat alias — keep the old name pointing at the new schema so
-# any cached AI conversations or stale prompts that reference it still work.
-DATA_VIZ_TOOL = RENDER_VISUAL_TOOL
-

--- a/apps/polli/src/bot.py
+++ b/apps/polli/src/bot.py
@@ -7,17 +7,13 @@ import logging
 import random
 
 import aiohttp
-import discord
 from discord.ext import commands, tasks
 
-from .utils.regex import re
-from .core.config import config
+import discord
+
+from .ai.client import pollinations_client
 from .context import ConversationSession, session_manager
-from .integrations.github.client import github_manager
-from .integrations.github.handlers import TOOL_HANDLERS
-from .integrations.github.auth import github_app_auth, init_github_app
-from .integrations.github.graphql import github_graphql
-from .integrations.github.pull_requests import github_pr_manager
+from .core.config import config
 from .discord.media import (
     BLOCK_LATEX_PATTERN,
     PIL_AVAILABLE,
@@ -29,9 +25,14 @@ from .discord.media import (
     send_code_block,
     truncate_long_decimals,
 )
-from .ai.client import pollinations_client
+from .integrations.github.auth import github_app_auth, init_github_app
+from .integrations.github.client import github_manager
+from .integrations.github.graphql import github_graphql
+from .integrations.github.handlers import TOOL_HANDLERS
+from .integrations.github.pull_requests import github_pr_manager
 from .integrations.subscriptions import init_notifier
 from .integrations.webhook_server import start_webhook_server, stop_webhook_server
+from .utils.regex import re
 
 logger = logging.getLogger(__name__)
 
@@ -397,19 +398,6 @@ def extract_media_urls(
     return image_urls, video_urls, file_urls
 
 
-def extract_attachment_urls(message: discord.Message) -> list[str]:
-    """
-    Extract ALL attachment URLs from Discord message (legacy, returns combined list).
-    Use extract_media_urls() for separated image/video/file lists.
-    """
-    image_urls, video_urls, file_urls = extract_media_urls(message)
-    return image_urls + video_urls + file_urls
-
-
-# Keep old name for backward compatibility
-extract_image_urls = extract_attachment_urls
-
-
 async def fetch_thread_history(thread: discord.Thread, limit: int = THREAD_HISTORY_LIMIT) -> list[dict]:
     """
     Fetch message history from a thread and format for AI context.
@@ -541,12 +529,10 @@ class PolliBot(commands.Bot):
         logger.info("Registered web_scrape tool handler (Crawl4AI)")
 
         # Register render_visual handler (always available).
-        # Old tool name aliased for back-compat with cached AI sessions.
-        from .integrations.charts import data_visualization, render_visual
+        from .integrations.charts import render_visual
 
         pollinations_client.register_tool_handler("render_visual", render_visual)
-        pollinations_client.register_tool_handler("data_visualization", data_visualization)
-        logger.info("Registered render_visual tool handler (data_visualization alias)")
+        logger.info("Registered render_visual tool handler")
 
         # Register discord_search handler (full guild search capabilities)
         from .discord.search import tool_discord_search
@@ -856,13 +842,15 @@ async def on_message(message: discord.Message):
                 _, ref_msg = await _check_reply_to_bot(message)
             text = await handle_reply_context(message, text, ref_msg)
 
-        image_urls = extract_image_urls(message)
+        image_urls, video_urls, file_urls = extract_media_urls(message)
+        attachment_urls = image_urls + video_urls + file_urls
 
-        # If no text but replying or has images, let AI handle it
-        if not text and not image_urls:
-            text = "[User mentioned bot - respond to the conversation context]"
-        if not text and image_urls:
-            text = "[User attached screenshot(s)]"
+        if not text:
+            text = (
+                "[User attached media/files]"
+                if attachment_urls
+                else "[User mentioned bot - respond to the conversation context]"
+            )
 
         # Create session if needed (handles bot restart scenario)
         if not session:
@@ -874,10 +862,16 @@ async def on_message(message: discord.Message):
                 user_name=format_discord_identity(message.author),
                 initial_message=text,
                 topic_summary=topic,
-                image_urls=image_urls,
+                image_urls=attachment_urls,
             )
 
-        await handle_thread_message(message, session)
+        await handle_thread_message(
+            message,
+            session,
+            image_urls,
+            video_urls,
+            file_urls,
+        )
         return
 
     # Extract message text
@@ -1173,7 +1167,13 @@ async def handle_inline_polli_mention(message: discord.Message):
             await message.reply("Sorry, I encountered an error processing your request.", mention_author=False)
 
 
-async def handle_thread_message(message: discord.Message, session: ConversationSession):
+async def handle_thread_message(
+    message: discord.Message,
+    session: ConversationSession,
+    image_urls: list[str],
+    video_urls: list[str],
+    file_urls: list[str],
+):
     """Handle a message in an existing thread."""
     # Type guard: this function is only called for thread messages
     if not isinstance(message.channel, discord.Thread):
@@ -1181,8 +1181,6 @@ async def handle_thread_message(message: discord.Message, session: ConversationS
         return
 
     channel = message.channel  # Now typed as discord.Thread
-    image_urls, video_urls, file_urls = extract_media_urls(message)
-
     # Add to session
     session_manager.add_to_session(
         session=session,
@@ -1597,7 +1595,7 @@ async def _send_chunk(
                 await channel.send(chunk, files=files_to_send)
             elif files_to_send:
                 await channel.send(files=files_to_send)
-    
+
     while attachments:
         files_to_send = attachments[:10]
         attachments[:] = attachments[10:]

--- a/apps/polli/src/integrations/charts.py
+++ b/apps/polli/src/integrations/charts.py
@@ -23,6 +23,7 @@ import json
 import logging
 from typing import Any
 
+from ..discord.media import render_table_image
 from .chart_renderer import (
     CHARTS_AVAILABLE,
     get_executor,
@@ -31,8 +32,6 @@ from .chart_renderer import (
 from .chart_renderer import (
     SUPPORTED_TYPES as CHART_TYPES,
 )
-from ..discord.media import render_table_image
-
 from .diagrams import detect_diagram_type, render_mermaid_safe
 
 logger = logging.getLogger(__name__)
@@ -327,13 +326,3 @@ async def render_visual(
         logger.info("Unknown type '%s' and not valid Mermaid: %s", type, error)
 
     return _shape_help(chart_type, data)
-
-
-# =============================================================================
-# Backward-compat alias for the old tool name.
-# =============================================================================
-
-
-async def data_visualization(data: str = "", **kwargs) -> dict:
-    """Legacy alias — accepted for back-compat. Routes through the normal dispatch."""
-    return await render_visual(data=data, **kwargs)


### PR DESCRIPTION
- Removes the legacy `data_visualization` schema/handler alias, static prompt and attachment-extractor compatibility names, plus three uncalled AI client formatting/processing methods.
- Extracts thread media once and passes the separated lists into the live processing path; current `render_visual`, tool processing, topic-summary, and subscription behavior stays unchanged.
- Removes 93 net lines across six files, and repository call-site searches confirm no removed compatibility name remains.
- Validation: Ruff lint, `python3 -m compileall -q apps/polli/src apps/polli/tests`, and `git diff --check` passed. Ruff's format check still reports pre-existing formatting in untouched lines of four edited files.