### PR TITLE
refactor: trust normalized image params

### DIFF
--- a/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
+++ b/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
@@ -45,7 +45,7 @@ export async function callAzureFluxKontext(
     }
 
     // Check if we need to use the edits endpoint instead of generations
-    const isEditMode = safeParams.image && safeParams.image.length > 0;
+    const isEditMode = safeParams.image.length > 0;
 
     // Add the appropriate endpoint path and API version
     let endpoint: string;
@@ -85,20 +85,8 @@ export async function callAzureFluxKontext(
 
         // Handle images based on their type
         try {
-            // Convert to array if it's a string (backward compatible)
-            const imageUrls = Array.isArray(safeParams.image)
-                ? safeParams.image
-                : [safeParams.image];
-
-            if (imageUrls.length === 0) {
-                throw new HttpError(
-                    "Image URL is required for Flux Kontext edit mode but was not provided",
-                    400,
-                );
-            }
-
             // Process the first image (Flux Kontext typically uses single image)
-            const imageUrl = imageUrls[0];
+            const imageUrl = safeParams.image[0];
             logCloudflare(`Fetching image from URL: ${imageUrl}`);
 
             const { buffer, mimeType } = await downloadUserImage(imageUrl);

--- a/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
+++ b/gen.pollinations.ai/src/image/models/fluxKleinModel.ts
@@ -36,23 +36,14 @@ export const callFluxKleinAPI = async (
     safeParams: ImageParams,
 ): Promise<ImageGenerationResult> => {
     try {
-        const hasReferenceImages =
-            safeParams.image && safeParams.image.length > 0;
-
         // Download and encode reference images if provided
-        let imagesB64: string[] = [];
-        if (hasReferenceImages) {
-            const imageUrls = (safeParams.image || []).slice(
-                0,
-                MAX_INPUT_IMAGES,
-            );
-            const downloads = await Promise.all(
-                imageUrls.map((url) => downloadUserImage(url)),
-            );
-            imagesB64 = downloads.map(({ buffer }) =>
-                buffer.toString("base64"),
-            );
-        }
+        const imageUrls = safeParams.image.slice(0, MAX_INPUT_IMAGES);
+        const downloads = await Promise.all(
+            imageUrls.map((url) => downloadUserImage(url)),
+        );
+        const imagesB64 = downloads.map(({ buffer }) =>
+            buffer.toString("base64"),
+        );
 
         const body: Record<string, unknown> = {
             prompts: [prompt],

--- a/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
@@ -73,11 +73,7 @@ export async function callNovaCanvasAPI(
     );
 
     // Check if image input is provided for editing mode
-    const rawImageUrl = safeParams.image
-        ? Array.isArray(safeParams.image)
-            ? safeParams.image[0]
-            : safeParams.image
-        : undefined;
+    const rawImageUrl = safeParams.image?.[0];
     const mode = rawImageUrl ? "IMAGE_VARIATION" : "TEXT_IMAGE";
 
     logOps(`Calling Nova Canvas API (${mode}):`, {

--- a/gen.pollinations.ai/src/image/utils/gptImageLogger.ts
+++ b/gen.pollinations.ai/src/image/utils/gptImageLogger.ts
@@ -38,8 +38,8 @@ export async function logGptImageError(
             prompt,
             model: safeParams.model,
             size: `${safeParams.width}x${safeParams.height}`,
-            hasImageInput: !!safeParams.image,
-            imageUrls: safeParams.image ?? [],
+            hasImageInput: safeParams.image.length > 0,
+            imageUrls: safeParams.image,
             contentSafety: contentSafetyResults
                 ? {
                       safe: contentSafetyResults.safe,

--- a/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
+++ b/gen.pollinations.ai/src/image/vertexAIImageGenerator.ts
@@ -210,15 +210,13 @@ export async function callVertexAIGemini(
             width: safeParams.width,
             height: safeParams.height,
             model: safeParams.model,
-            hasReferenceImages: !!(
-                safeParams.image && safeParams.image.length > 0
-            ),
+            hasReferenceImages: safeParams.image.length > 0,
         });
 
         // Process reference image URLs into base64 format
         const processedImages: VertexAIImageData[] = [];
 
-        if (safeParams.image && safeParams.image.length > 0) {
+        if (safeParams.image.length > 0) {
             log(`Processing ${safeParams.image.length} reference image URLs`);
 
             for (let i = 0; i < safeParams.image.length; i++) {


### PR DESCRIPTION
- Removes obsolete scalar/null branches from image adapters after `ImageParamsSchema` normalization.
- Processes Flux Klein's normalized reference list directly and fixes GPT Image's empty-input logging.
- Preserves Nova Canvas's tested direct-call tolerance instead of broadening the normalization assumption.
- Supersedes the broader #12925 with the re-audited safe subset.

Checks:
- Biome on all five files
- Gen TypeScript typecheck
- Schema smoke coverage for missing, scalar, and array inputs
- Focused image tests: 3 files, 15 tests