### PR TITLE
refactor: share model debugging queries

### DIFF
--- a/.claude/skills/model-debugging/scripts/check-user-errors.sh
+++ b/.claude/skills/model-debugging/scripts/check-user-errors.sh
@@ -14,15 +14,7 @@ if [[ ! "$USER_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(dirname "$0")"
-ENTER_DIR="$SCRIPT_DIR/../../../../enter.pollinations.ai"
-
-# Get Tinybird admin token
-TINYBIRD_TOKEN=$(jq -r '.token' "$ENTER_DIR/observability/.tinyb" 2>/dev/null)
-if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
-    echo "Error: Could not read Tinybird token" >&2
-    exit 1
-fi
+source "$(dirname "$0")/tinybird-query.sh"
 
 QUERY="SELECT start_time, response_status, model_requested, error_message
 FROM generation_event_v2
@@ -32,5 +24,4 @@ ORDER BY start_time DESC
 LIMIT 50"
 
 echo "=== Errors for $USER_ID (Last ${HOURS}h) ==="
-curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TINYBIRD_TOKEN" \
-    --data-urlencode "q=$QUERY"
+run_tinybird_query "$QUERY"

--- a/.claude/skills/model-debugging/scripts/find-402-users.sh
+++ b/.claude/skills/model-debugging/scripts/find-402-users.sh
@@ -6,15 +6,7 @@
 HOURS="${1:-24}"
 MIN_ERRORS="${2:-10}"
 
-SCRIPT_DIR="$(dirname "$0")"
-ENTER_DIR="$SCRIPT_DIR/../../../../enter.pollinations.ai"
-
-# Get Tinybird admin token
-TINYBIRD_TOKEN=$(jq -r '.token' "$ENTER_DIR/observability/.tinyb" 2>/dev/null)
-if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
-    echo "Error: Could not read Tinybird token from $ENTER_DIR/observability/.tinyb" >&2
-    exit 1
-fi
+source "$(dirname "$0")/tinybird-query.sh"
 
 QUERY="SELECT ge.user_id, any(users.github_username) as github_username, count() as error_count
 FROM generation_event_v2 ge
@@ -28,6 +20,4 @@ GROUP BY ge.user_id
 HAVING error_count >= $MIN_ERRORS
 ORDER BY error_count DESC"
 
-# Execute query
-curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TINYBIRD_TOKEN" \
-    --data-urlencode "q=$QUERY"
+run_tinybird_query "$QUERY"

--- a/.claude/skills/model-debugging/scripts/find-403-users.sh
+++ b/.claude/skills/model-debugging/scripts/find-403-users.sh
@@ -6,15 +6,7 @@
 HOURS="${1:-24}"
 MIN_ERRORS="${2:-10}"
 
-SCRIPT_DIR="$(dirname "$0")"
-ENTER_DIR="$SCRIPT_DIR/../../../../enter.pollinations.ai"
-
-# Get Tinybird admin token
-TINYBIRD_TOKEN=$(jq -r '.token' "$ENTER_DIR/observability/.tinyb" 2>/dev/null)
-if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
-    echo "Error: Could not read Tinybird token from $ENTER_DIR/observability/.tinyb" >&2
-    exit 1
-fi
+source "$(dirname "$0")/tinybird-query.sh"
 
 QUERY="SELECT ge.user_id, any(users.github_username) as github_username, count() as error_count
 FROM generation_event_v2 ge
@@ -28,6 +20,4 @@ GROUP BY ge.user_id
 HAVING error_count >= $MIN_ERRORS
 ORDER BY error_count DESC"
 
-# Execute query
-curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TINYBIRD_TOKEN" \
-    --data-urlencode "q=$QUERY"
+run_tinybird_query "$QUERY"

--- a/.claude/skills/model-debugging/scripts/find-500-errors.sh
+++ b/.claude/skills/model-debugging/scripts/find-500-errors.sh
@@ -5,15 +5,7 @@
 
 HOURS="${1:-24}"
 
-SCRIPT_DIR="$(dirname "$0")"
-ENTER_DIR="$SCRIPT_DIR/../../../../enter.pollinations.ai"
-
-# Get Tinybird admin token
-TINYBIRD_TOKEN=$(jq -r '.token' "$ENTER_DIR/observability/.tinyb" 2>/dev/null)
-if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
-    echo "Error: Could not read Tinybird token from $ENTER_DIR/observability/.tinyb" >&2
-    exit 1
-fi
+source "$(dirname "$0")/tinybird-query.sh"
 
 QUERY="SELECT ge.user_id, any(users.github_username) as github_username, ge.model_requested, ge.error_message, count() as error_count
 FROM generation_event_v2 ge
@@ -26,5 +18,4 @@ ORDER BY error_count DESC
 LIMIT 50"
 
 echo "=== 500+ Errors (Last ${HOURS}h) ==="
-curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TINYBIRD_TOKEN" \
-    --data-urlencode "q=$QUERY"
+run_tinybird_query "$QUERY"

--- a/.claude/skills/model-debugging/scripts/tinybird-query.sh
+++ b/.claude/skills/model-debugging/scripts/tinybird-query.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TINYBIRD_CONFIG="$(dirname "${BASH_SOURCE[0]}")/../../../../enter.pollinations.ai/observability/.tinyb"
+TINYBIRD_TOKEN=$(jq -r '.token' "$TINYBIRD_CONFIG" 2>/dev/null)
+
+if [ -z "$TINYBIRD_TOKEN" ] || [ "$TINYBIRD_TOKEN" = "null" ]; then
+    echo "Error: Could not read Tinybird token from $TINYBIRD_CONFIG" >&2
+    exit 1
+fi
+
+run_tinybird_query() {
+    curl -s "https://api.europe-west2.gcp.tinybird.co/v0/sql?token=$TINYBIRD_TOKEN" \
+        --data-urlencode "q=$1"
+}


### PR DESCRIPTION
- Adds one private helper for Tinybird token loading, validation, and SQL requests
- Removes the same transport setup from four model-debugging commands
- Keeps each command's arguments, SQL, and output unchanged
- Cuts 24 net lines across the debugging scripts

Check:
- `bash -n .claude/skills/model-debugging/scripts/*.sh`