### PR TITLE
ci: simplify app review and metrics automation

### DIFF
--- a/.github/scripts/app-update-metrics.js
+++ b/.github/scripts/app-update-metrics.js
@@ -199,59 +199,18 @@ function fetchTinybirdPipe(pipeName) {
     });
 }
 
-/**
- * Fetch BYOP hostnames from Tinybird pipe — api_key_name values that look like hostnames.
- * Returns Set<string> of hostnames for BYOP apps.
- */
-async function fetchBYOPHostnames() {
-    const result = await fetchTinybirdPipe("app_byop_hostnames");
-    if (!result || !result.data) return new Set();
-
-    const hostnames = new Set();
-    for (const row of result.data) {
-        const name = row.hostname;
-        if (name) {
-            hostnames.add(name);
-        }
-    }
-    return hostnames;
+async function fetchTinybirdValues(pipeName, field) {
+    const rows = (await fetchTinybirdPipe(pipeName))?.data ?? [];
+    return new Set(rows.map((row) => row[field]).filter(Boolean));
 }
 
-/**
- * Fetch request counts by GitHub user ID from Tinybird pipe — last 24 hours.
- * Returns Map<string, number> mapping github_user_id -> request count.
- */
-async function fetchRequestCounts() {
-    const result = await fetchTinybirdPipe("app_request_counts");
-    if (!result || !result.data) return new Map();
-
-    const counts = new Map();
-    for (const row of result.data) {
-        const githubUserId = row.github_user_id;
-        if (githubUserId) {
-            counts.set(String(githubUserId), row.requests);
-        }
-    }
-    return counts;
-}
-
-/**
- * Fetch request counts by BYOP hostname from Tinybird pipe — last 24 hours.
- * Counts ALL requests through a BYOP app's API key (all end users).
- * Returns Map<string, number> mapping hostname -> request count.
- */
-async function fetchBYOPRequestCounts() {
-    const result = await fetchTinybirdPipe("app_byop_request_counts");
-    if (!result || !result.data) return new Map();
-
-    const counts = new Map();
-    for (const row of result.data) {
-        const hostname = row.hostname;
-        if (hostname) {
-            counts.set(hostname, row.requests);
-        }
-    }
-    return counts;
+async function fetchTinybirdCounts(pipeName, keyField) {
+    const rows = (await fetchTinybirdPipe(pipeName))?.data ?? [];
+    return new Map(
+        rows
+            .filter((row) => row[keyField])
+            .map((row) => [String(row[keyField]), row.requests]),
+    );
 }
 
 function formatStars(count) {
@@ -283,9 +242,9 @@ async function main() {
             `${colors.cyan}Fetching Tinybird metrics...${colors.reset}`,
         );
         [byopHostnames, requestCounts, byopRequestCounts] = await Promise.all([
-            fetchBYOPHostnames(),
-            fetchRequestCounts(),
-            fetchBYOPRequestCounts(),
+            fetchTinybirdValues("app_byop_hostnames", "hostname"),
+            fetchTinybirdCounts("app_request_counts", "github_user_id"),
+            fetchTinybirdCounts("app_byop_request_counts", "hostname"),
         ]);
         console.log(
             `  BYOP hostnames: ${byopHostnames.size}, GitHub users with requests: ${requestCounts.size}, BYOP hostnames with requests: ${byopRequestCounts.size}\n`,

--- a/.github/workflows/apps-review-submissions.yml
+++ b/.github/workflows/apps-review-submissions.yml
@@ -35,24 +35,6 @@ jobs:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
-      - name: Ensure app review labels
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ISSUE: ${{ github.event.issue.number }}
-          INPUT_ISSUE: ${{ inputs.issue_number }}
-        run: |
-          gh label create APP-SUBMISSION --repo "$GITHUB_REPOSITORY" --color 7057ff --description "Community app submission" --force
-          gh label create APP-NEEDS-INFO --repo "$GITHUB_REPOSITORY" --color d876e3 --description "App submission needs more information" --force
-          gh label create APP-REVIEW --repo "$GITHUB_REPOSITORY" --color fbca04 --description "App submission ready for human review" --force
-          gh label create APP-APPROVED --repo "$GITHUB_REPOSITORY" --color 0e8a16 --description "App submission approved for publishing" --force
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            ISSUE_NUMBER="$INPUT_ISSUE"
-          else
-            ISSUE_NUMBER="$EVENT_ISSUE"
-          fi
-          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label APP-SUBMISSION
-
       - name: Resolve issue
         id: issue
         env:
@@ -66,6 +48,7 @@ jobs:
           else
             ISSUE_NUMBER="$EVENT_ISSUE"
           fi
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label APP-SUBMISSION
           ISSUE_AUTHOR=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}" --jq .user.login)
           echo "number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
           echo "author=$ISSUE_AUTHOR" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- Replaces three repeated Tinybird result mappers with two collection helpers while preserving pipe names, normalization, and empty-result behavior.
- Stops force-recreating the four established app-review labels on every run.
- Resolves the issue number once and keeps applying the persistent `APP-SUBMISSION` label before validation.
- Removes 58 net lines and reduces repository-level mutations from app issue edits.

Checks:
- `npx biome check --write .github/scripts/app-update-metrics.js`
- `node --check .github/scripts/app-update-metrics.js`
- `actionlint .github/workflows/apps-review-submissions.yml`
- Ruby YAML parse
- `git diff --check origin/main...HEAD`
