### PR TITLE
docs: record the DreamShaper deployment and add a WORKERS knob

### DIFF
--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -244,13 +244,14 @@ The registry is Cloudflare KV-backed (`image:server:<env>:<type>:<hash>`, 240s T
 
 ### 6. `sana` pool — DreamShaper 8 LCM (Vast 3090) + Sana Sprint (GH200)
 
-Since PR #12900 the `sana` **pool key** serves the `dreamshaper` model. Two
-members are registered and load-balanced by observed latency:
+Since PR #12900 the `sana` **pool key** serves the `dreamshaper` model, on two
+Vast 3090s load-balanced by observed latency. The GH200 Sana backend has been
+drained out of the pool.
 
 | Backend | Model | Host | Registered URL |
 |---------|-------|------|----------------|
 | dreamshaper-vast-01 | DreamShaper 8 LCM | Vast 3090 `46307858` | `https://dreamshaper-vast-01.pollinations.ai` |
-| GH200 | SANA-Sprint | Lambda `192.222.51.105` | `https://ltx2-backend.pollinations.ai` |
+| dreamshaper-vast-02 | DreamShaper 8 LCM | Vast 3090 `46387155` | `https://dreamshaper-vast-02.pollinations.ai` |
 
 ```bash
 # both members must be present, and the Vast one must show the HOSTNAME,
@@ -261,12 +262,14 @@ curl -s https://gen.pollinations.ai/register -H "authorization: Bearer $PLN_GPU_
 curl -s --max-time 10 https://dreamshaper-vast-01.pollinations.ai/health
 ```
 
-**The GH200 is load-bearing.** One 3090 plateaus at ~4.3 img/s in production
-(GPU only 26-45% busy — the limit is the worker's Python path, not the GPU), so
-it cannot carry peak alone. Do not switch off `sana.service` until the Vast side
-has real headroom. The GH200's pool entry is refreshed by
-`gh200_keepalive.sh` on the Vast host; nothing else heartbeats it, so if that
-loop dies the entry expires after 180s and latency spikes.
+Each host runs `WORKERS=3` uvicorn processes and sustains ~8 img/s; a single
+process plateaus at ~4.3 img/s with the GPU 26-45% idle, because the limit is
+the Python path (global lock, JPEG + base64), not the GPU. Combined ~16 img/s
+against a 5.72 img/s peak, so either card can carry production alone.
+
+If latency climbs steadily rather than spiking, that is a queue building because
+arrival exceeds service rate — check `WORKERS` is really >1 (`ps` shows
+`spawn_main` children) before adding hardware.
 
 Cloudflare bot protection 403s `User-Agent: Python-urllib/*` on these tunnel
 hostnames. Use curl or set a UA, or health checks will look broken when they

--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -242,9 +242,37 @@ The registry is Cloudflare KV-backed (`image:server:<env>:<type>:<hash>`, 240s T
 
 ---
 
-### 6. Sana Sprint 1.6B Worker (GH200 - same host as LTX-2)
+### 6. `sana` pool — DreamShaper 8 LCM (Vast 3090) + Sana Sprint (GH200)
 
-One worker registered as `sana` type with OVH legacy service via heartbeat.
+Since PR #12900 the `sana` **pool key** serves the `dreamshaper` model. Two
+members are registered and load-balanced by observed latency:
+
+| Backend | Model | Host | Registered URL |
+|---------|-------|------|----------------|
+| dreamshaper-vast-01 | DreamShaper 8 LCM | Vast 3090 `46307858` | `https://dreamshaper-vast-01.pollinations.ai` |
+| GH200 | SANA-Sprint | Lambda `192.222.51.105` | `https://ltx2-backend.pollinations.ai` |
+
+```bash
+# both members must be present, and the Vast one must show the HOSTNAME,
+# never a raw IP:port — gen cannot fetch a Vast IP:port, and the heartbeat
+# stays green while every request through it fails
+curl -s https://gen.pollinations.ai/register -H "authorization: Bearer $PLN_GPU_TOKEN" \
+  | python3 -c "import json,sys;[print(s['type'],s['url'],s.get('lastMs')) for s in json.load(sys.stdin)]"
+curl -s --max-time 10 https://dreamshaper-vast-01.pollinations.ai/health
+```
+
+**The GH200 is load-bearing.** One 3090 plateaus at ~4.3 img/s in production
+(GPU only 26-45% busy — the limit is the worker's Python path, not the GPU), so
+it cannot carry peak alone. Do not switch off `sana.service` until the Vast side
+has real headroom. The GH200's pool entry is refreshed by
+`gh200_keepalive.sh` on the Vast host; nothing else heartbeats it, so if that
+loop dies the entry expires after 180s and latency spikes.
+
+Cloudflare bot protection 403s `User-Agent: Python-urllib/*` on these tunnel
+hostnames. Use curl or set a UA, or health checks will look broken when they
+are fine.
+
+Sana on the GH200, for reference:
 
 | Instance | GPU | Host | Port | SSH |
 |----------|-----|------|------|-----|

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,6 +1,6 @@
 # GPU Instances
 
-Last updated: 2026-07-30
+Last updated: 2026-07-31
 
 ## Capacity Summary
 
@@ -9,7 +9,42 @@ Last updated: 2026-07-30
 | Flux (FP4) | 1 | RTX 5090 | Vast.ai | $0.3744/hr | **ACTIVE — production** (Replicate fallback) |
 | Z-Image | 2 active + 1 stopped rollback | 3x RTX 5090 | Vast.ai | $0.773333/hr active + $0.022222/hr stopped storage | **ACTIVE — two production** |
 | Klein 4B | 1 active + 1 rollback | RTX 3090 + A5000 | Vast.ai + RunPod | $0.1656 + $0.27 while rollback runs | **ACTIVE — Vast production; RunPod stop-ready** |
-| LTX-2 + ACE-Step + Sana | 1 | GH200 | Lambda Labs | — | **ACTIVE** |
+| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 1 | RTX 3090 | Vast.ai | $0.1756/hr | **ACTIVE — production, sharing the pool with the GH200** |
+| LTX-2 + ACE-Step + Sana | 1 | GH200 | Lambda Labs | — | **ACTIVE — Sana still load-bearing, see below** |
+
+## Provider: Vast.ai — DreamShaper 8 LCM (RTX 3090)
+
+Replaced SANA-Sprint on the GH200 (PR #12900). Model slug is `dreamshaper` with
+`sana` kept as an alias; the **registry pool key is still `sana`** because
+`/register` rejects unknown types, so a worker cannot join a pool that only
+exists after the routing change deploys.
+
+| Worker | Vast instance | GPU | Listed rate | Status |
+|--------|---------------|-----|-------------|--------|
+| dreamshaper-vast-01 | 46307858 | RTX 3090 | $0.1756/hr | ACTIVE — named tunnel `dreamshaper-vast-01.pollinations.ai` |
+
+Config: `Lykon/dreamshaper-8` + fused `lcm-lora-sdv1-5`, `LCMScheduler`, TAESD
+tiny decoder, guidance 0.0, 512x512. Worker code in `dreamshaper-lcm/`.
+
+**Capacity reality check.** Bench numbers overstate this worker. A 3090 measured
+6.18 img/s single-client but plateaued at **~4.3 img/s under real production
+load, with the GPU only 26-45% busy** — the ceiling is the worker's Python path
+(one uvicorn process, a global lock, JPEG + base64 per response), not the GPU or
+the step count. Dropping 3 steps to 2 changed nothing, which confirms it. Size
+from measured production throughput, never from a single-client benchmark.
+
+**The GH200 Sana backend is therefore still in the pool** as a second member and
+must not be switched off until this worker has enough headroom alone. It is kept
+registered by `gh200_keepalive.sh` on the Vast host, because gen used to reach it
+through a hardcoded URL and nothing ever heartbeated it.
+
+Two traps that fail silently:
+
+- gen hardcodes `steps: 4` into every self-hosted request body, so the worker
+  **ignores caller-supplied steps**. Honouring them overrides the 3-step config.
+- Without `PUBLIC_HOSTNAME` the worker registers its raw Vast `IP:port`, which
+  the gen Worker cannot fetch — while the heartbeat still reports healthy. This
+  happened during rollout; always confirm the registered URL is the hostname.
 
 ## Vast replacement operations
 

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -9,8 +9,8 @@ Last updated: 2026-07-31
 | Flux (FP4) | 1 | RTX 5090 | Vast.ai | $0.3744/hr | **ACTIVE — production** (Replicate fallback) |
 | Z-Image | 2 active + 1 stopped rollback | 3x RTX 5090 | Vast.ai | $0.773333/hr active + $0.022222/hr stopped storage | **ACTIVE — two production** |
 | Klein 4B | 1 active + 1 rollback | RTX 3090 + A5000 | Vast.ai + RunPod | $0.1656 + $0.27 while rollback runs | **ACTIVE — Vast production; RunPod stop-ready** |
-| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 1 | RTX 3090 | Vast.ai | $0.1756/hr | **ACTIVE — production, sharing the pool with the GH200** |
-| LTX-2 + ACE-Step + Sana | 1 | GH200 | Lambda Labs | — | **ACTIVE — Sana still load-bearing, see below** |
+| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 2 | 2x RTX 3090 | Vast.ai | $0.2956/hr | **ACTIVE — production** |
+| LTX-2 + ACE-Step | 1 | GH200 | Lambda Labs | — | **ACTIVE — Sana drained, `sana.service` can be stopped** |
 
 ## Provider: Vast.ai — DreamShaper 8 LCM (RTX 3090)
 
@@ -22,21 +22,25 @@ exists after the routing change deploys.
 | Worker | Vast instance | GPU | Listed rate | Status |
 |--------|---------------|-----|-------------|--------|
 | dreamshaper-vast-01 | 46307858 | RTX 3090 | $0.1756/hr | ACTIVE — named tunnel `dreamshaper-vast-01.pollinations.ai` |
+| dreamshaper-vast-02 | 46387155 | RTX 3090 | $0.1200/hr | ACTIVE — named tunnel `dreamshaper-vast-02.pollinations.ai` |
 
 Config: `Lykon/dreamshaper-8` + fused `lcm-lora-sdv1-5`, `LCMScheduler`, TAESD
-tiny decoder, guidance 0.0, 512x512. Worker code in `dreamshaper-lcm/`.
+tiny decoder, guidance 0.0, 3 steps, 512x512, `WORKERS=3`. Code in
+`dreamshaper-lcm/`; each host runs `supervise.sh` under `screen`, relaunched on
+reboot by `/workspace/onstart.sh`.
 
-**Capacity reality check.** Bench numbers overstate this worker. A 3090 measured
-6.18 img/s single-client but plateaued at **~4.3 img/s under real production
-load, with the GPU only 26-45% busy** — the ceiling is the worker's Python path
-(one uvicorn process, a global lock, JPEG + base64 per response), not the GPU or
-the step count. Dropping 3 steps to 2 changed nothing, which confirms it. Size
-from measured production throughput, never from a single-client benchmark.
+**Run several uvicorn workers per card.** A single process plateaued at
+**~4.3 img/s with the GPU only 26-45% busy** — the ceiling is the Python path
+(global lock, JPEG + base64 per response), not the GPU or the step count.
+Dropping 3 steps to 2 changed nothing, which proved it. With `WORKERS=3` each
+3090 sustains **~8 img/s** at concurrency 8 (GPU still only ~36%, so there is
+more left). The model is ~2.5 GB, so three copies fit easily in 24 GB.
 
-**The GH200 Sana backend is therefore still in the pool** as a second member and
-must not be switched off until this worker has enough headroom alone. It is kept
-registered by `gh200_keepalive.sh` on the Vast host, because gen used to reach it
-through a hardcoded URL and nothing ever heartbeated it.
+Measured capacity is ~16 img/s across both cards against a 5.72 img/s peak, so
+either card can carry production alone. **Never size this from a single-client
+benchmark** — the first rollout did, sized one card at 6.18 img/s, and produced
+a latency climb to 57s in production before the GH200 was put back in the pool
+as emergency capacity.
 
 Two traps that fail silently:
 

--- a/image.pollinations.ai/dreamshaper-lcm/server.py
+++ b/image.pollinations.ai/dreamshaper-lcm/server.py
@@ -210,4 +210,16 @@ async def health():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8766")))
+    port = int(os.getenv("PORT", "8766"))
+    # One process serialises on generate_lock and leaves the GPU idle ~60% of
+    # the time: at 512x512 the per-request cost is mostly Python (JPEG encode,
+    # base64, HTTP) and the GIL caps how much of that overlaps. Measured on a
+    # 3090 in production, a single process plateaued at ~4.3 img/s with the GPU
+    # at 26-45%. Each worker is a separate process with its own pipeline and
+    # lock, so both the GPU work and the Python overhead actually overlap.
+    # The model is only ~3 GB of the card's 24 GB, so several copies fit.
+    workers = int(os.getenv("WORKERS", "1"))
+    if workers > 1:
+        uvicorn.run("server:app", host="0.0.0.0", port=port, workers=workers)
+    else:
+        uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
Follow-up to #12900, documenting the deployment as it actually ended up.

**Two Vast RTX 3090s now serve the `sana` pool** (`dreamshaper-vast-01/02`). The GH200 Sana backend has been drained out — `sana.service` can be stopped, freeing the **$1,672/mo** GH200 for LTX-2 + ACE-Step only. New image cost is **$0.2956/hr (~$216/mo)**.

### The throughput fix

A single uvicorn process plateaued at **~4.3 img/s with the GPU only 26–45% busy** — the ceiling was the worker's Python path (global lock, JPEG + base64 per response), not the GPU or the step count. Dropping 3 steps to 2 changed nothing, which proved it.

Adds `WORKERS`, so each card runs 3 uvicorn processes with their own pipeline and lock:

| | img/s @ conc 8 | GPU |
|---|---|---|
| 1 process | ~4.3 | 26–45% |
| 3 processes | **~8** | ~36% |

Model is ~2.5 GB, so three copies fit easily in 24 GB. Combined ~16 img/s against a 5.72 img/s peak — either card can carry production alone.

### Why this matters

The first rollout sized one card from a **single-client** benchmark (6.18 img/s). Under real concurrent load it did 4.3, the queue grew, and production latency climbed to 57s before the GH200 was put back in the pool as emergency capacity. The docs now say to size from measured production throughput.

Also records two traps that fail silently:

- gen hardcodes `steps: 4` into every self-hosted request body, so the worker must ignore caller-supplied steps
- without `PUBLIC_HOSTNAME` a worker registers its raw Vast `IP:port`, which gen cannot fetch — while the heartbeat still reports healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)