### PR TITLE
chore: allow AkshayCoder48 community publishing

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -31,6 +31,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     184364250, // Takax62
     162339795, // meow18838
     130518306, // Lorodn4x
+    198414737, // AkshayCoder48
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `AkshayCoder48` (GitHub ID `198414737`) to the community-model publisher allowlist.
- Changes only the immutable GitHub ID allowlist.

Checks:
- `biome check shared/auth/github-id-list.ts`
- `git diff --check`

Addresses #12578
