### PR TITLE
fix: persist source image dimensions for edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2026-07-16
+
+- Hardened community endpoint URL validation to reject link-local, private IPv6, IPv4-mapped loopback, and unspecified IP hosts before proxying upstream requests.
+
+## 2026-08-01
+
+- Preserved source image aspect ratios for image-edit requests when `size` is omitted, with format-aware dimension parsing, proportional scaling, and explicit-size preservation.

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -136,3 +136,78 @@ export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
+
+
+const DIMENSIONS_CACHE_TTL_SECONDS = 86_400;
+const DIMENSIONS_CACHE_PREFIX = "image:dimensions:v1:";
+
+type ImageDimensions = { width: number; height: number };
+
+async function dimensionsCacheKey(imageUrl: string): Promise<string> {
+    const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(imageUrl),
+    );
+    const bytes = new Uint8Array(digest);
+    return `${DIMENSIONS_CACHE_PREFIX}${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function cachedDimensions(value: unknown): ImageDimensions | null {
+    if (!value || typeof value !== "object") return null;
+    const { width, height } = value as Record<string, unknown>;
+    return typeof width === "number" &&
+        typeof height === "number" &&
+        Number.isInteger(width) &&
+        Number.isInteger(height) &&
+        width > 0 &&
+        height > 0
+        ? { width, height }
+        : null;
+}
+
+function decodeDataUri(
+    dataUri: string,
+): { buffer: Buffer; mimeType: string } | null {
+    const match = dataUri.match(/^data:([^;,]+)[^,]*,(.*)$/s);
+    if (!match || !match[1].startsWith("image/")) return null;
+    try {
+        const encoded = match[2];
+        const buffer = dataUri.includes(";base64,")
+            ? base64ToBuffer(`data:${match[1]};base64,${encoded}`)
+            : Buffer.from(decodeURIComponent(encoded));
+        return { buffer, mimeType: match[1] };
+    } catch {
+        return null;
+    }
+}
+
+export async function getSourceImageDimensions(
+    imageUrl: string,
+    kv?: KVNamespace,
+): Promise<ImageDimensions | null> {
+    const inlineImage = imageUrl.startsWith("data:")
+        ? decodeDataUri(imageUrl)
+        : null;
+    if (inlineImage) {
+        return readImageDimensions(inlineImage.buffer, inlineImage.mimeType);
+    }
+
+    const cacheKey = kv ? await dimensionsCacheKey(imageUrl) : undefined;
+    if (kv && cacheKey) {
+        const cached = cachedDimensions(await kv.get(cacheKey, "json"));
+        if (cached) return cached;
+    }
+
+    try {
+        const { buffer, mimeType } = await downloadUserImage(imageUrl);
+        const dimensions = readImageDimensions(buffer, mimeType);
+        if (kv && cacheKey && dimensions) {
+            await kv.put(cacheKey, JSON.stringify(dimensions), {
+                expirationTtl: DIMENSIONS_CACHE_TTL_SECONDS,
+            });
+        }
+        return dimensions;
+    } catch {
+        return null;
+    }
+}

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -115,3 +115,151 @@ export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
+
+export function readImageDimensions(
+    buffer: Uint8Array,
+    mimeType = detectMimeType(buffer),
+): { width: number; height: number } | null {
+    if (mimeType === "image/png" && buffer.length >= 24) {
+        const view = new DataView(
+            buffer.buffer,
+            buffer.byteOffset,
+            buffer.byteLength,
+        );
+        const width = view.getUint32(16);
+        const height = view.getUint32(20);
+        return width > 0 && height > 0 ? { width, height } : null;
+    }
+    if (mimeType === "image/gif" && buffer.length >= 10) {
+        const width = buffer[6] | (buffer[7] << 8);
+        const height = buffer[8] | (buffer[9] << 8);
+        return width > 0 && height > 0 ? { width, height } : null;
+    }
+    if (mimeType === "image/jpeg") {
+        for (let offset = 2; offset + 9 < buffer.length; ) {
+            if (buffer[offset] !== 0xff) {
+                offset += 1;
+                continue;
+            }
+            const marker = buffer[offset + 1];
+            offset += 2;
+            if (
+                marker === 0xd8 ||
+                marker === 0xd9 ||
+                (marker >= 0xd0 && marker <= 0xd7)
+            ) {
+                continue;
+            }
+            if (offset + 2 > buffer.length) break;
+            const segmentLength = (buffer[offset] << 8) | buffer[offset + 1];
+            if (segmentLength < 2 || offset + segmentLength > buffer.length)
+                break;
+            if (
+                (marker >= 0xc0 && marker <= 0xc3) ||
+                (marker >= 0xc5 && marker <= 0xc7) ||
+                (marker >= 0xc9 && marker <= 0xcb) ||
+                (marker >= 0xcd && marker <= 0xcf)
+            ) {
+                if (segmentLength >= 7) {
+                    const height =
+                        (buffer[offset + 3] << 8) | buffer[offset + 4];
+                    const width =
+                        (buffer[offset + 5] << 8) | buffer[offset + 6];
+                    return width > 0 && height > 0 ? { width, height } : null;
+                }
+                break;
+            }
+            offset += segmentLength;
+        }
+    }
+    if (mimeType === "image/webp" && buffer.length >= 30) {
+        const subtype = String.fromCharCode(
+            buffer[12],
+            buffer[13],
+            buffer[14],
+            buffer[15],
+        );
+        if (subtype === "VP8X") {
+            const width =
+                1 + buffer[24] + (buffer[25] << 8) + (buffer[26] << 16);
+            const height =
+                1 + buffer[27] + (buffer[28] << 8) + (buffer[29] << 16);
+            return width > 0 && height > 0 ? { width, height } : null;
+        }
+    }
+    return null;
+}
+
+const DIMENSIONS_CACHE_TTL_SECONDS = 86_400;
+const DIMENSIONS_CACHE_PREFIX = "image:dimensions:v1:";
+
+type ImageDimensions = { width: number; height: number };
+
+async function dimensionsCacheKey(imageUrl: string): Promise<string> {
+    const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(imageUrl),
+    );
+    const bytes = new Uint8Array(digest);
+    return `${DIMENSIONS_CACHE_PREFIX}${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function cachedDimensions(value: unknown): ImageDimensions | null {
+    if (!value || typeof value !== "object") return null;
+    const { width, height } = value as Record<string, unknown>;
+    return typeof width === "number" &&
+        typeof height === "number" &&
+        Number.isInteger(width) &&
+        Number.isInteger(height) &&
+        width > 0 &&
+        height > 0
+        ? { width, height }
+        : null;
+}
+
+function decodeDataUri(
+    dataUri: string,
+): { buffer: Buffer; mimeType: string } | null {
+    const match = dataUri.match(/^data:([^;,]+)[^,]*,(.*)$/s);
+    if (!match || !match[1].startsWith("image/")) return null;
+    try {
+        const encoded = match[2];
+        const buffer = dataUri.includes(";base64,")
+            ? base64ToBuffer(`data:${match[1]};base64,${encoded}`)
+            : Buffer.from(decodeURIComponent(encoded));
+        return { buffer, mimeType: match[1] };
+    } catch {
+        return null;
+    }
+}
+
+export async function getSourceImageDimensions(
+    imageUrl: string,
+    kv?: KVNamespace,
+): Promise<ImageDimensions | null> {
+    const inlineImage = imageUrl.startsWith("data:")
+        ? decodeDataUri(imageUrl)
+        : null;
+    if (inlineImage) {
+        return readImageDimensions(inlineImage.buffer, inlineImage.mimeType);
+    }
+
+    const cacheKey = kv ? await dimensionsCacheKey(imageUrl) : undefined;
+    if (kv && cacheKey) {
+        const cached = cachedDimensions(await kv.get(cacheKey, "json"));
+        if (cached) return cached;
+    }
+
+    try {
+        const { buffer, mimeType } = await downloadUserImage(imageUrl);
+        const dimensions = readImageDimensions(buffer, mimeType);
+        if (kv && cacheKey && dimensions) {
+            await kv.put(cacheKey, JSON.stringify(dimensions), {
+                expirationTtl: DIMENSIONS_CACHE_TTL_SECONDS,
+            });
+        }
+        return dimensions;
+    } catch {
+        return null;
+    }
+}

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -16,6 +16,7 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -168,6 +169,17 @@ async function parseEditInput(c: Context): Promise<{
     };
 }
 
+function computeAspectRatioSize(
+    width: number,
+    height: number,
+    maxPixels = 1_048_576,
+): string {
+    const area = width * height;
+    const scale = area > maxPixels ? Math.sqrt(maxPixels / area) : 1;
+    const snap = (value: number) => Math.max(16, Math.round(value / 16) * 16);
+    return `${snap(width * scale)}x${snap(height * scale)}`;
+}
+
 // --- Exported handlers ---
 
 export async function handleImageGeneration(c: Context<Env>) {
@@ -225,8 +237,21 @@ export async function handleImageEdit(c: Context<Env>) {
 
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
+    let effectiveSize = size;
+    if (!effectiveSize) {
+        const dimensions = await getSourceImageDimensions(
+            imageUrls[0],
+            c.env.KV,
+        );
+        if (dimensions) {
+            effectiveSize = computeAspectRatioSize(
+                dimensions.width,
+                dimensions.height,
+            );
+        }
+    }
     const safePrompt = await applySafety(c, prompt, safe);
-    const resolved = resolveParams({ size, quality, seed });
+    const resolved = resolveParams({ size: effectiveSize, quality, seed });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -23,6 +23,7 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -198,6 +199,17 @@ async function parseEditInput(c: Context): Promise<{
     };
 }
 
+function computeAspectRatioSize(
+    width: number,
+    height: number,
+    maxPixels = 1_048_576,
+): string {
+    const area = width * height;
+    const scale = area > maxPixels ? Math.sqrt(maxPixels / area) : 1;
+    const snap = (value: number) => Math.max(16, Math.round(value / 16) * 16);
+    return `${snap(width * scale)}x${snap(height * scale)}`;
+}
+
 // --- Exported handlers ---
 
 export async function handleImageGeneration(c: Context<Env>) {
@@ -280,8 +292,21 @@ export async function handleImageEdit(c: Context<Env>) {
 
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
+    let effectiveSize = size;
+    if (!effectiveSize) {
+        const dimensions = await getSourceImageDimensions(
+            imageUrls[0],
+            c.env.KV,
+        );
+        if (dimensions) {
+            effectiveSize = computeAspectRatioSize(
+                dimensions.width,
+                dimensions.height,
+            );
+        }
+    }
     const safePrompt = await applySafety(c, prompt, safe);
-    const resolved = resolveParams({ size, quality, seed });
+    const resolved = resolveParams({ size: effectiveSize, quality, seed });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/test/image/imageDownloadDimensions.test.ts
+++ b/gen.pollinations.ai/test/image/imageDownloadDimensions.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+    getSourceImageDimensions,
+    readImageDimensions,
+} from "../../src/image/utils/imageDownload.ts";
+
+function dataUri(bytes: Uint8Array, mimeType: string): string {
+    return `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+function makeKv() {
+    const store = new Map<string, string>();
+    const puts: string[] = [];
+    return {
+        store,
+        puts,
+        async get(key: string, _type?: "json") {
+            const raw = store.get(key);
+            return raw === undefined ? null : JSON.parse(raw);
+        },
+        async put(key: string, value: string) {
+            puts.push(key);
+            store.set(key, value);
+        },
+    } as unknown as KVNamespace & { puts: string[] };
+}
+
+describe("readImageDimensions", () => {
+    it("reads PNG dimensions", () => {
+        const png = new Uint8Array(24);
+        png.set([0x89, 0x50, 0x4e, 0x47]);
+        new DataView(png.buffer).setUint32(16, 1920, false);
+        new DataView(png.buffer).setUint32(20, 1080, false);
+        expect(readImageDimensions(png, "image/png")).toEqual({
+            width: 1920,
+            height: 1080,
+        });
+    });
+
+    it("reads JPEG dimensions", () => {
+        const jpeg = Uint8Array.from([
+            0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x02, 0xd0, 0x05, 0x00,
+            0x03, 0x01, 0x11, 0x00,
+        ]);
+        expect(readImageDimensions(jpeg, "image/jpeg")).toEqual({
+            width: 1280,
+            height: 720,
+        });
+    });
+
+    it("reads WEBP VP8X dimensions", () => {
+        const webp = new Uint8Array(30);
+        webp.set([0x52, 0x49, 0x46, 0x46], 0);
+        webp.set([0x57, 0x45, 0x42, 0x50], 8);
+        webp.set([0x56, 0x50, 0x38, 0x58], 12);
+        webp[24] = 0xff;
+        webp[25] = 0x03;
+        webp[27] = 0xff;
+        webp[28] = 0x01;
+        expect(readImageDimensions(webp, "image/webp")).toEqual({
+            width: 1024,
+            height: 512,
+        });
+    });
+});
+
+describe("getSourceImageDimensions", () => {
+    it("reads inline image data without fetching", async () => {
+        const png = new Uint8Array(24);
+        png.set([0x89, 0x50, 0x4e, 0x47]);
+        new DataView(png.buffer).setUint32(16, 768, false);
+        new DataView(png.buffer).setUint32(20, 1024, false);
+        await expect(
+            getSourceImageDimensions(dataUri(png, "image/png")),
+        ).resolves.toEqual({
+            width: 768,
+            height: 1024,
+        });
+    });
+
+    it("returns null for unreadable input", async () => {
+        await expect(
+            getSourceImageDimensions("data:text/plain;base64,aGVsbG8="),
+        ).resolves.toBeNull();
+    });
+
+    it("caches remote dimensions in KV and reads the persisted value", async () => {
+        const kv = makeKv();
+        const originalFetch = globalThis.fetch;
+        let fetches = 0;
+        globalThis.fetch = async () => {
+            fetches += 1;
+            const png = new Uint8Array(24);
+            png.set([0x89, 0x50, 0x4e, 0x47]);
+            new DataView(png.buffer).setUint32(16, 2048, false);
+            new DataView(png.buffer).setUint32(20, 1024, false);
+            return new Response(png, { status: 200 });
+        };
+        try {
+            await expect(
+                getSourceImageDimensions("https://example.com/source.png", kv),
+            ).resolves.toEqual({ width: 2048, height: 1024 });
+            await expect(
+                getSourceImageDimensions("https://example.com/source.png", kv),
+            ).resolves.toEqual({ width: 2048, height: 1024 });
+            expect(fetches).toBe(1);
+            expect(kv.puts).toHaveLength(1);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it("does not cache inline data URIs", async () => {
+        const kv = makeKv();
+        const png = new Uint8Array(24);
+        png.set([0x89, 0x50, 0x4e, 0x47]);
+        new DataView(png.buffer).setUint32(16, 768, false);
+        new DataView(png.buffer).setUint32(20, 1024, false);
+        await expect(
+            getSourceImageDimensions(dataUri(png, "image/png"), kv),
+        ).resolves.toEqual({ width: 768, height: 1024 });
+        expect(kv.puts).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Fixes #12583
Ref #10944

## Summary

- Preserve portrait and landscape source aspect ratios when `/v1/images/edits` omits `size`.
- Keep explicit `size` requests unchanged.
- Parse PNG, GIF, JPEG, and WebP dimensions from inline data URIs and remote images.
- Scale derived dimensions proportionally to a 1MP target on 16px boundaries.
- Persist remote source dimensions in the existing Cloudflare KV binding for 24 hours, avoiding repeated downloads across requests.
- Add parser, inline/remote input, KV persistence/cache-hit, unreadable input, and provider regression coverage.

## Validation

- `npx biome check` passed on modified files.
- `npx tsc --noEmit -p gen.pollinations.ai/tsconfig.json` passed.
- Focused dimension/KV tests: 7 passed.
- Related image provider tests: 37 passed.

No existing production KV binding or unrelated files were changed.