### PR TITLE
fix: move OpenAI embeddings to Azure

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1109,7 +1109,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000013,
     },
     "price": {
-      "promptTextTokens": 0.00000013,
+      "promptTextTokens": 0.0000000975,
     },
   },
   "openai-3-small": {
@@ -1117,7 +1117,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000002,
     },
     "price": {
-      "promptTextTokens": 0.00000002,
+      "promptTextTokens": 0.000000015,
     },
   },
   "openai-audio": {

--- a/gen.pollinations.ai/src/embeddings/handler.ts
+++ b/gen.pollinations.ai/src/embeddings/handler.ts
@@ -15,7 +15,7 @@ import {
     inputToText,
     normalizeInputs,
 } from "./input.ts";
-import { callOpenAIEmbed, extractOpenAIUsage } from "./openai.ts";
+import { callAzureOpenAIEmbed, extractOpenAIUsage } from "./openai.ts";
 import type { EmbeddingRequest } from "./types.ts";
 import {
     callGeminiEmbed,
@@ -71,11 +71,17 @@ export async function generateEmbeddings(
         return await generateGeminiEmbeddings(env, request, responseModel);
     }
 
-    if (serviceDef.provider === "openai") {
-        return await generateOpenAIEmbeddings(env, request, responseModel);
-    }
-
     if (serviceDef.provider === "azure") {
+        if (
+            responseModel === "openai-3-small" ||
+            responseModel === "openai-3-large"
+        ) {
+            return await generateAzureOpenAIEmbeddings(
+                env,
+                request,
+                responseModel,
+            );
+        }
         return await generateCohereAzureEmbeddings(env, request, responseModel);
     }
 
@@ -210,7 +216,7 @@ async function generateGeminiEmbeddings(
     return embeddingsResponse(responseModel, data, aggregatedUsage);
 }
 
-async function generateOpenAIEmbeddings(
+async function generateAzureOpenAIEmbeddings(
     env: CloudflareBindings,
     request: EmbeddingRequest,
     responseModel: string,
@@ -228,7 +234,7 @@ async function generateOpenAIEmbeddings(
         return embeddingsResponse(responseModel, [], { promptTextTokens: 0 });
     }
 
-    const result = await callOpenAIEmbed(
+    const result = await callAzureOpenAIEmbed(
         env,
         request.model,
         textInputs,

--- a/gen.pollinations.ai/src/embeddings/openai.ts
+++ b/gen.pollinations.ai/src/embeddings/openai.ts
@@ -1,7 +1,8 @@
 import { ensureUpstreamOk } from "@shared/error.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 
-const OPENAI_EMBEDDINGS_ENDPOINT = "https://api.openai.com/v1/embeddings";
+const AZURE_OPENAI_EMBEDDINGS_ENDPOINT =
+    "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/v1/embeddings";
 
 type OpenAIEmbeddingRequest = {
     model: string;
@@ -25,16 +26,16 @@ export type OpenAIEmbeddingResponse = {
     };
 };
 
-export async function callOpenAIEmbed(
+export async function callAzureOpenAIEmbed(
     env: CloudflareBindings,
     modelId: string,
     input: string[],
     dimensions?: number,
 ): Promise<OpenAIEmbeddingResponse> {
-    const apiKey = env.OPENAI_API_KEY;
+    const apiKey = env.AZURE_MYCELI_PROD_API_KEY;
 
     if (!apiKey) {
-        throw new Error("OPENAI_API_KEY is not configured");
+        throw new Error("AZURE_MYCELI_PROD_API_KEY is not configured");
     }
 
     const body: OpenAIEmbeddingRequest = {
@@ -43,16 +44,16 @@ export async function callOpenAIEmbed(
         ...(dimensions ? { dimensions } : {}),
     };
 
-    const response = await fetch(OPENAI_EMBEDDINGS_ENDPOINT, {
+    const response = await fetch(AZURE_OPENAI_EMBEDDINGS_ENDPOINT, {
         method: "POST",
         headers: {
             "content-type": "application/json",
-            authorization: `Bearer ${apiKey}`,
+            "api-key": apiKey,
         },
         body: JSON.stringify(body),
     });
 
-    await ensureUpstreamOk(response, OPENAI_EMBEDDINGS_ENDPOINT);
+    await ensureUpstreamOk(response, AZURE_OPENAI_EMBEDDINGS_ENDPOINT);
     return response.json() as Promise<OpenAIEmbeddingResponse>;
 }
 

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -28,8 +28,7 @@ const TEST_QWEN_MODEL = "qwen3-embedding-8b";
 const TEST_QWEN_PROVIDER_MODEL = "accounts/fireworks/models/qwen3-embedding-8b";
 const TEST_EMBEDDING_INPUT = "Hello world";
 const VERTEX_HOST = "aiplatform.us.rep.googleapis.com";
-const OPENAI_HOST = "api.openai.com";
-const COHERE_AZURE_HOST = "myceli-prod-eastus.cognitiveservices.azure.com";
+const AZURE_HOST = "myceli-prod-eastus.cognitiveservices.azure.com";
 const FIREWORKS_HOST = "api.fireworks.ai";
 const TINYBIRD_STATS_HOST = "api.europe-west2.gcp.tinybird.co";
 
@@ -78,7 +77,7 @@ function createEmbeddingMocks() {
             },
             reset: () => {},
         } satisfies MockAPI<Record<string, never>>,
-        openai: createOpenAIMock(),
+        azureOpenAI: createAzureOpenAIMock(),
         cohereAzure: createCohereAzureMock(),
         fireworks: createFireworksMock(),
         vertex: createVertexMock(),
@@ -137,15 +136,27 @@ function createVertexMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
     };
 }
 
-function createOpenAIMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
-    const state: { requests: unknown[]; urls: string[] } = {
+function createAzureOpenAIMock(): MockAPI<{
+    requests: unknown[];
+    urls: string[];
+    apiKeys: (string | null)[];
+    authorization: (string | null)[];
+}> {
+    const state: {
+        requests: unknown[];
+        urls: string[];
+        apiKeys: (string | null)[];
+        authorization: (string | null)[];
+    } = {
         requests: [],
         urls: [],
+        apiKeys: [],
+        authorization: [],
     };
     return {
         state,
         handlerMap: {
-            [OPENAI_HOST]: async (request) => {
+            [AZURE_HOST]: async (request) => {
                 const body = (await request.json()) as {
                     input?: string[];
                     dimensions?: number;
@@ -153,6 +164,8 @@ function createOpenAIMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
                 };
                 state.urls.push(request.url);
                 state.requests.push(body);
+                state.apiKeys.push(request.headers.get("api-key"));
+                state.authorization.push(request.headers.get("authorization"));
 
                 const inputs = body.input ?? [];
                 const dimensions =
@@ -182,6 +195,8 @@ function createOpenAIMock(): MockAPI<{ requests: unknown[]; urls: string[] }> {
         reset: () => {
             state.requests = [];
             state.urls = [];
+            state.apiKeys = [];
+            state.authorization = [];
         },
     };
 }
@@ -197,7 +212,7 @@ function createCohereAzureMock(): MockAPI<{
     return {
         state,
         handlerMap: {
-            [COHERE_AZURE_HOST]: async (request) => {
+            [AZURE_HOST]: async (request) => {
                 const body = (await request.json()) as {
                     input?: (string | { image: string; text?: string })[];
                     input_type?: string;
@@ -492,11 +507,11 @@ describe("POST /v1/embeddings", () => {
         await wait();
     });
 
-    test("supports direct OpenAI text-embedding-3-small", async ({
+    test("supports Azure OpenAI text-embedding-3-small", async ({
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        await mocks.enable("tinybird", "tinybirdStats", "azureOpenAI");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -529,13 +544,15 @@ describe("POST /v1/embeddings", () => {
             TEST_OPENAI_SMALL_MODEL,
         );
         expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("8");
-        expect(mocks.openai.state.requests).toEqual([
+        expect(mocks.azureOpenAI.state.requests).toEqual([
             {
                 model: TEST_OPENAI_SMALL_PROVIDER_MODEL,
                 input: ["Hello", "World"],
                 dimensions: 512,
             },
         ]);
+        expect(mocks.azureOpenAI.state.apiKeys).toEqual(["test-azure-api-key"]);
+        expect(mocks.azureOpenAI.state.authorization).toEqual([null]);
 
         await wait();
 
@@ -547,15 +564,17 @@ describe("POST /v1/embeddings", () => {
             resolvedModelRequested: TEST_OPENAI_SMALL_MODEL,
             modelUsed: TEST_OPENAI_SMALL_MODEL,
             tokenCountPromptText: 8,
+            totalCost: 0.00000016,
+            totalPrice: 0.00000012,
             isBilledUsage: true,
         });
     });
 
-    test("supports direct OpenAI text-embedding-3-large", async ({
+    test("supports Azure OpenAI text-embedding-3-large", async ({
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        await mocks.enable("tinybird", "tinybirdStats", "azureOpenAI");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -581,7 +600,7 @@ describe("POST /v1/embeddings", () => {
         expect(data.model).toBe(TEST_OPENAI_LARGE_MODEL);
         expect(data.data).toHaveLength(1);
         expect(data.data[0].embedding).toHaveLength(256);
-        expect(mocks.openai.state.requests).toEqual([
+        expect(mocks.azureOpenAI.state.requests).toEqual([
             {
                 model: TEST_OPENAI_LARGE_PROVIDER_MODEL,
                 input: [TEST_EMBEDDING_INPUT],
@@ -589,6 +608,18 @@ describe("POST /v1/embeddings", () => {
             },
         ]);
         await wait();
+
+        expect(mocks.tinybird.state.events).toHaveLength(1);
+        expect(mocks.tinybird.state.events[0]).toMatchObject({
+            eventType: "generate.embedding",
+            modelRequested: TEST_OPENAI_LARGE_MODEL,
+            resolvedModelRequested: TEST_OPENAI_LARGE_MODEL,
+            modelUsed: TEST_OPENAI_LARGE_MODEL,
+            tokenCountPromptText: 4,
+            totalCost: 0.00000052,
+            totalPrice: 0.00000039,
+            isBilledUsage: true,
+        });
     });
 
     test("supports Cohere Embed v4 through Azure", async ({
@@ -794,7 +825,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        await mocks.enable("tinybird", "tinybirdStats", "azureOpenAI");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -810,7 +841,7 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("supports dimensions up to 1536");
-        expect(mocks.openai.state.requests).toHaveLength(0);
+        expect(mocks.azureOpenAI.state.requests).toHaveLength(0);
         await wait();
     });
 
@@ -856,11 +887,11 @@ describe("POST /v1/embeddings", () => {
         await wait();
     });
 
-    test("rejects multimodal input for direct OpenAI embeddings", async ({
+    test("rejects multimodal input for Azure OpenAI embeddings", async ({
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        await mocks.enable("tinybird", "tinybirdStats", "azureOpenAI");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -883,15 +914,15 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("text input only");
-        expect(mocks.openai.state.requests).toHaveLength(0);
+        expect(mocks.azureOpenAI.state.requests).toHaveLength(0);
         await wait();
     });
 
-    test("rejects Gemini task hints for direct OpenAI embeddings", async ({
+    test("rejects Gemini task hints for Azure OpenAI embeddings", async ({
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        await mocks.enable("tinybird", "tinybirdStats", "azureOpenAI");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -907,7 +938,7 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("task_type");
-        expect(mocks.openai.state.requests).toHaveLength(0);
+        expect(mocks.azureOpenAI.state.requests).toHaveLength(0);
         await wait();
     });
 
@@ -915,7 +946,7 @@ describe("POST /v1/embeddings", () => {
         apiKey,
         mocks,
     }) => {
-        await mocks.enable("tinybird", "tinybirdStats", "openai");
+        await mocks.enable("tinybird", "tinybirdStats", "azureOpenAI");
         const { response, wait } = await fetchWorker("/v1/embeddings", {
             method: "POST",
             headers: {
@@ -931,7 +962,7 @@ describe("POST /v1/embeddings", () => {
 
         expect(response.status).toBe(400);
         expect(body).toContain("input_type");
-        expect(mocks.openai.state.requests).toHaveLength(0);
+        expect(mocks.azureOpenAI.state.requests).toHaveLength(0);
         await wait();
     });
 

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -29,11 +29,11 @@ export const EMBEDDING_SERVICES = {
     },
     "openai-3-small": {
         aliases: ["embedding-small"],
-        provider: "openai",
+        provider: "azure",
         brand: "OpenAI",
         category: "embedding",
         addedDate: new Date("2026-05-08").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: 0.75,
         cost: {
             promptTextTokens: perMillion(0.02),
         },
@@ -46,11 +46,11 @@ export const EMBEDDING_SERVICES = {
     },
     "openai-3-large": {
         aliases: ["embedding-large"],
-        provider: "openai",
+        provider: "azure",
         brand: "OpenAI",
         category: "embedding",
         addedDate: new Date("2026-05-08").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: 0.75,
         cost: {
             promptTextTokens: perMillion(0.13),
         },


### PR DESCRIPTION
## What changed

- Routes `openai-3-small` and `openai-3-large` through their exact existing Azure Global Standard deployments.
- Keeps canonical names, aliases, model IDs, capabilities, free access, and provider base costs unchanged; no fallback and no secret change.
- Applies the standard Azure `0.75` price multiplier: `$0.015/M` for Small and `$0.0975/M` for Large.
- Uses Azure's `api-key` authentication while preserving the existing OpenAI-compatible response and usage mapping.

## Why

The direct OpenAI routes currently return `429 credit_balance_exhausted`. Both Azure deployments are healthy, already funded, and have 100K TPM / about 600 RPM deployed capacity each, with 45M TPM subscription quota available per model family.

## Validation

- Direct Azure probes: both exact deployments, batch input, custom dimensions, and usage.
- Local E2E: canonical names and aliases, default/custom dimensions, float/base64, catalog prices, billing headers, auth and validation errors, 8192-token rejection, and 5/15/30-request bursts with zero failures.
- Gen: typecheck, 26 embedding tests, and full suite (803/803).
- Enter: typecheck, alias tests, and effective-price snapshot passed. The broader targeted run has one unrelated existing DreamShaper/Lykon logo failure.
