### PR TITLE
feat: update DeepSeek V4 Flash to 0731

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -131,12 +131,12 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "deepseek": {
     "cost": {
       "completionTextTokens": 0.00000028,
-      "promptCachedTokens": 0.00000003,
+      "promptCachedTokens": 0.000000028,
       "promptTextTokens": 0.00000014,
     },
     "price": {
       "completionTextTokens": 0.00000028,
-      "promptCachedTokens": 0.00000003,
+      "promptCachedTokens": 0.000000028,
       "promptTextTokens": 0.00000014,
     },
   },

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -150,7 +150,9 @@ const models: ModelDefinition[] = [
     },
     {
         name: "deepseek",
-        config: portkeyConfig["accounts/fireworks/models/deepseek-v4-flash"],
+        config: portkeyConfig[
+            "accounts/fireworks/models/deepseek-v4-flash-0731"
+        ],
         transform: fireworksThinking,
     },
     {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -230,9 +230,9 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- Fireworks AI (DeepSeek) ---------------------------------------------
-    "accounts/fireworks/models/deepseek-v4-flash": () =>
+    "accounts/fireworks/models/deepseek-v4-flash-0731": () =>
         createFireworksModelConfig({
-            model: "accounts/fireworks/models/deepseek-v4-flash",
+            model: "accounts/fireworks/models/deepseek-v4-flash-0731",
         }),
     "accounts/fireworks/models/deepseek-v4-pro": () =>
         createFireworksModelConfig({

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -97,6 +97,19 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes DeepSeek to the exact Fireworks 0731 checkpoint", () => {
+        const result = resolveModelConfig(messages, { model: "deepseek" });
+
+        expect(result.options.model).toBe(
+            "accounts/fireworks/models/deepseek-v4-flash-0731",
+        );
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Command A+ to the exact Azure deployment without fallback", () => {
         const result = resolveModelConfig(messages, {
             model: "command-a-plus",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -565,10 +565,10 @@ export const TEXT_SERVICES = {
         priceMultiplier: 1,
         cost: {
             promptTextTokens: perMillion(0.14),
-            promptCachedTokens: perMillion(0.03),
+            promptCachedTokens: perMillion(0.028),
             completionTextTokens: perMillion(0.28),
         },
-        title: "DeepSeek V4 Flash (Lite)",
+        title: "DeepSeek V4 Flash 0731",
         description: "Fast reasoning and coding at bargain prices",
         inputModalities: ["text"],
         outputModalities: ["text"],


### PR DESCRIPTION
- Routes `deepseek` and its existing aliases to Fireworks’ exact `deepseek-v4-flash-0731` checkpoint.
- Updates the catalog title while preserving provider, free access, multiplier, capabilities, aliases, and no-fallback behavior.
- Aligns cached-input billing with Fireworks’ posted `$0.028/M` rate; input/output remain `$0.14/M` and `$0.28/M`.
- Adds an exact-route resolver regression test and updates the effective-price snapshot.

Testing:
- Direct Fireworks: basic, reasoning, tools, JSON, streaming, cache, invalid input, and 5/15/30-request bursts.
- Local gateway E2E: all aliases, reasoning, tools, JSON, streaming, usage headers, billing deduction, errors, and 5/15/30-request bursts.
- 84 gen tests, 320 applicable enter tests, and both TypeScript checks pass.

Known main-branch issue: the unrelated DreamShaper catalog entry is missing its Lykon brand logo, so that single existing logo assertion remains red.