### PR TITLE
fix: harden Flux Vast maintenance cutovers

### DIFF
--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -66,7 +66,7 @@ with automatic Replicate fallback
 
 | Worker | Vast instance | GPU | Listed rate | Status |
 |--------|---------------|-----|-------------|--------|
-| flux-vast-03 | 44731147 | RTX 5090 | $0.374444/hr | ACTIVE (reactivated 2026-07-22) — named tunnel `flux-vast-04.pollinations.ai` |
+| flux-vast-04 | 46491202 | RTX 5090 | $0.361111/hr | ACTIVE (promoted 2026-08-01) — named tunnel `flux-vast-04.pollinations.ai` |
 
 > Instance IDs/IPs/ports change on recreate — check `vastai show instances`.
 > CRITICAL: workers MUST be behind a named Cloudflare tunnel created in the
@@ -82,26 +82,42 @@ localhost. Requests exceeded the CloudFront timeout, so users saw indefinite
 hangs, not errors — and the worker kept heartbeating green the whole time.
 Never point production at a quick tunnel; use a named tunnel.
 
-When reprovisioning, check the host's HuggingFace throughput before committing
-to it (`curl -r 0-5000000 -L <hf-model-url>`): this host previously managed
-384 KB/s and stalled during its cold download. It was reactivated only after
-its 17 GB model cache was complete, so a cold rebuild on this host remains a
-risk.
+Instance `46491202` replaced maintenance-bound instance `44731147`, which was
+destroyed after cutover. The California host is machine `138472` with Vast
+reliability `0.9971`. Qualification passed 512x512 and 1024x1024 generation,
+four concurrent requests, authentication rejection, 17-second restart
+recovery, and an external Cloudflare generation in 3.46 seconds. After the old
+connector drained, the new worker served 47 production generations with zero
+backend errors before final verification.
+
+This host exposed two provisioning edge cases now handled by `setup-vast.sh`:
+Hugging Face Xet connections repeatedly stopped advancing and Cloudflare Tunnel
+SRV lookups failed through the host resolver. Standard HTTP completed the model
+download, while the local DNS-over-HTTPS fallback established four named-tunnel
+connections.
 
 **Provision a new instance** (see `nunchaku/setup-vast.sh` header for all env):
 ```bash
 vastai search offers 'gpu_name=RTX_5090 num_gpus=1 verified=true rentable=true reliability>0.99 duration>=30 inet_down>=500 cpu_cores>=8 disk_space>=60' --order dph_total
 vastai create instance <OFFER> --image "vastai/base-image:cuda-13.0.2-cudnn-devel-ubuntu24.04-py312" --disk 60 --ssh --direct --env '-p 8765:8765'
 vastai attach ssh <INSTANCE> "$(cat ~/.ssh/pollinations_services_2026.pub)"
-# First create a remote tunnel + hostname routing to localhost:8765 in Cloudflare, then:
+# Isolated canary: heartbeat and production tunnel are disabled by default.
+PLN_GPU_TOKEN=... HF_TOKEN=... PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
+GIT_BRANCH=main bash setup-vast.sh
+# After verification and explicit human approval, rerun with the scoped tunnel
+# token plus HEARTBEAT_ENABLED=true and TUNNEL_ENABLED=true.
 PLN_GPU_TOKEN=... HF_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... \
-PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai GIT_BRANCH=main bash setup-vast.sh
+PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai HEARTBEAT_ENABLED=true \
+TUNNEL_ENABLED=true GIT_BRANCH=main bash setup-vast.sh
 ```
 Gotchas (all hit in practice): rent hosts with `duration>=30`; verify
 `intended_status=running` after create (GPU can be taken between create/start);
 some hosts have broken direct SSH (use the `ssh_host:ssh_port` proxy); some
 drop bulk CDN downloads mid-transfer (setup-vast.sh passes pip
-`--resume-retries` so downloads resume instead of restarting); hosts with
+`--resume-retries` so downloads resume instead of restarting); Hugging Face Xet
+can hang with established but idle connections (standard HTTP is the Vast
+default); some hosts drop Cloudflare Tunnel SRV responses (setup starts a local
+DNS-over-HTTPS resolver only on affected hosts); hosts with
 driver < 580 hit CUDA Error 804 with the cuda-13 image (GeForce can't use
 forward-compat libs — setup-vast.sh disables them so the host driver is used);
 machine-to-machine rsync between vast instances is NOT reliable (hosts kill

--- a/image.pollinations.ai/nunchaku/README.md
+++ b/image.pollinations.ai/nunchaku/README.md
@@ -8,7 +8,7 @@ the model server and Cloudflare Tunnel in `screen` restart loops.
 ## Cloudflare preparation
 
 Create a remotely-managed tunnel in the authoritative Pollinations Cloudflare
-account before provisioning the Vast host:
+account before production promotion:
 
 1. Route a stable hostname such as `flux-vast-NN.pollinations.ai` to
    `http://localhost:8765`.
@@ -26,15 +26,32 @@ On a fresh Vast RTX 5090 instance:
 ```bash
 PLN_GPU_TOKEN=... \
 HF_TOKEN=... \
-CLOUDFLARED_TUNNEL_TOKEN=... \
 PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
 bash setup-vast.sh
 ```
 
-The tunnel token is written to a mode `0600` token file and is not included in
-the `cloudflared` process arguments. Model and server settings are persisted in
-the ignored `.env.flux` file. The setup also installs `/root/onstart.sh`, which
-Vast runs after a container restart to restore both supervised services.
+This is canary-safe by default: the model starts locally, while registry
+heartbeat and the production tunnel remain disabled. Model and server settings
+are persisted in the ignored `.env.flux` file. The setup also installs
+`/root/onstart.sh`, which Vast runs after a container restart.
+
+After the canary passes and a human approves promotion, rerun setup with the
+same model tokens plus the scoped tunnel token:
+
+```bash
+PLN_GPU_TOKEN=... \
+HF_TOKEN=... \
+CLOUDFLARED_TUNNEL_TOKEN=... \
+PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
+HEARTBEAT_ENABLED=true \
+TUNNEL_ENABLED=true \
+bash setup-vast.sh
+```
+
+The tunnel token is written to a mode `0600` file and never included in the
+`cloudflared` process arguments. The tunnel waits for local model health before
+joining production. Hosts that cannot resolve Cloudflare SRV records
+automatically use a local DNS-over-HTTPS resolver.
 
 ## Verify before traffic cutover
 
@@ -42,17 +59,21 @@ A healthy `/docs` response and registry heartbeat are control-plane checks;
 they do not prove that `gen.pollinations.ai` can reach the tunnel. Replicate can
 otherwise hide a broken Vast route.
 
-Run the end-to-end canary on the Vast host with a valid Pollinations API key:
+Before promotion, expose the worker through a dedicated test-only endpoint and
+compare that external path with localhost. Never use the production hostname
+for this step:
 
 ```bash
-POLLINATIONS_API_KEY=... bash verify-vast.sh
+CANARY_URL=https://<test-only-hostname> bash verify-vast.sh
 ```
 
-The canary creates a unique uncached prompt, generates it directly on Vast and
-through the public Flux route with the same seed, and compares decoded pixels.
-Do not change production routing until this passes and a human explicitly
-approves the promotion. After cutover, confirm real production requests are
-served by the replacement, then drain and immediately destroy the old worker.
+The canary creates a unique uncached prompt, generates it locally and through
+the external endpoint with the same seed, and compares decoded pixels. Do not
+change production routing until this passes and a human explicitly approves
+the promotion. After cutover, run `verify-vast.sh` with
+`POLLINATIONS_API_KEY` and no `CANARY_URL`, confirm real production requests
+are served by the replacement, then drain and immediately destroy the old
+worker.
 The fleet-wide qualification and approval policy is documented in
 [`manage-vast-gpu-fleet`](../../.claude/skills/manage-vast-gpu-fleet/SKILL.md).
 
@@ -67,7 +88,9 @@ screen -r cloudflared
 ```
 
 The setup defaults are `QUEUE_LIMIT=3`, `MAX_PIXELS=1048576`, and
-`mit-han-lab/svdq-fp4-flux.1-schnell`. Override them only through the documented
+`mit-han-lab/svdq-fp4-flux.1-schnell`. Hugging Face Xet is disabled by default
+because stalled Xet connections were observed on Vast; standard HTTP resumes
+reliably from partial downloads. Override defaults only through the documented
 environment variables in `setup-vast.sh`.
 
 `QUEUE_LIMIT=3` means one request can run while two wait. Additional requests

--- a/image.pollinations.ai/nunchaku/server.py
+++ b/image.pollinations.ai/nunchaku/server.py
@@ -48,6 +48,11 @@ BACKEND_TOKEN = os.getenv("PLN_GPU_TOKEN")
 # Shed load instead of building unbounded backlog: beyond this many in-flight
 # requests, reply 503 so the gateway falls back to its secondary provider.
 QUEUE_LIMIT = int(os.getenv("QUEUE_LIMIT", "3"))
+HEARTBEAT_ENABLED = os.getenv("HEARTBEAT_ENABLED", "true").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 pending_requests = 0
 
 # Function to get public IP address
@@ -117,23 +122,26 @@ async def lifespan(app: FastAPI):
         ).to("cuda")
         print("FLUX pipeline loaded successfully")
         
-        # Send initial heartbeat and start periodic task
-        try:
-            await send_heartbeat()
-            logger.info("Initial heartbeat sent successfully")
-            # Store the task in app.state to prevent garbage collection
-            heartbeat_task = asyncio.create_task(periodic_heartbeat())
-            app.state.heartbeat_task = heartbeat_task
-            logger.info("Periodic heartbeat task started")
-        except Exception as e:
-            logger.error(f"Error in heartbeat initialization: {str(e)}")
-            if heartbeat_task:
-                heartbeat_task.cancel()
-                try:
-                    await heartbeat_task
-                except asyncio.CancelledError:
-                    pass
-            raise
+        if HEARTBEAT_ENABLED:
+            # Send initial heartbeat and start periodic task
+            try:
+                await send_heartbeat()
+                logger.info("Initial heartbeat sent successfully")
+                # Store the task in app.state to prevent garbage collection
+                heartbeat_task = asyncio.create_task(periodic_heartbeat())
+                app.state.heartbeat_task = heartbeat_task
+                logger.info("Periodic heartbeat task started")
+            except Exception as e:
+                logger.error(f"Error in heartbeat initialization: {str(e)}")
+                if heartbeat_task:
+                    heartbeat_task.cancel()
+                    try:
+                        await heartbeat_task
+                    except asyncio.CancelledError:
+                        pass
+                raise
+        else:
+            logger.warning("Production heartbeat disabled")
     except Exception as e:
         logger.error(f"Error during startup: {str(e)}")
         if heartbeat_task:
@@ -278,8 +286,8 @@ async def _generate(request: ImageRequest):
             "prompt": request.prompts[0]
         }]
         
-        # Send heartbeat after successful generation
-        await send_heartbeat()
+        if HEARTBEAT_ENABLED:
+            await send_heartbeat()
         return JSONResponse(content=response_content)
     
     except torch.cuda.OutOfMemoryError as e:

--- a/image.pollinations.ai/nunchaku/setup-vast.sh
+++ b/image.pollinations.ai/nunchaku/setup-vast.sh
@@ -18,9 +18,12 @@
 # Usage (on the instance):
 #   PLN_GPU_TOKEN=... \
 #   HF_TOKEN=... \
-#   CLOUDFLARED_TUNNEL_TOKEN=... \
 #   PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
 #   bash setup-vast.sh
+#
+# This defaults to an isolated canary: no registry heartbeat and no production
+# tunnel. After verification and human approval, provide the scoped tunnel
+# token, set HEARTBEAT_ENABLED=true and TUNNEL_ENABLED=true, then rerun setup.
 #
 # Required env details:
 #   HF_TOKEN          black-forest-labs/FLUX.1-schnell is gated (accept-terms);
@@ -36,6 +39,9 @@
 #                     additional load with 503 so the gateway falls back to
 #                     Replicate instead of building a long user-facing queue)
 #   SERVICE_TYPE      default flux
+#   HEARTBEAT_ENABLED default false; enable only for an approved production worker
+#   TUNNEL_ENABLED    default false; enable only after human promotion approval
+#   HF_HUB_DISABLE_XET default 1; standard HTTP is more reliable on Vast hosts
 #   GIT_BRANCH        default main
 #   SKIP_CLONE        use files already in $WORK_DIR (hosts w/ broken GitHub egress)
 #   WORK_DIR          default /workspace/pollinations
@@ -47,14 +53,23 @@ WORK_DIR="${WORK_DIR:-/workspace/pollinations}"
 QUANT_MODEL_PATH="${QUANT_MODEL_PATH:-mit-han-lab/svdq-fp4-flux.1-schnell}"
 MAX_PIXELS="${MAX_PIXELS:-1048576}"
 SERVICE_TYPE="${SERVICE_TYPE:-flux}"
+HEARTBEAT_ENABLED="${HEARTBEAT_ENABLED:-false}"
+TUNNEL_ENABLED="${TUNNEL_ENABLED:-false}"
+HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
+PUBLIC_HOSTNAME="${PUBLIC_HOSTNAME:-localhost}"
 PORT="${PORT:-8765}"
 SUDO=""
 [ "$(id -u)" != "0" ] && SUDO="sudo"
 
 log() { echo -e "\033[0;32m[setup-vast]\033[0m $1"; }
 
-if [ -z "$PLN_GPU_TOKEN" ] || [ -z "$HF_TOKEN" ] || [ -z "$CLOUDFLARED_TUNNEL_TOKEN" ] || [ -z "$PUBLIC_HOSTNAME" ]; then
-    echo "Usage: PLN_GPU_TOKEN=... HF_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai bash setup-vast.sh" >&2
+if [ -z "${PLN_GPU_TOKEN:-}" ] || [ -z "${HF_TOKEN:-}" ]; then
+    echo "Usage: PLN_GPU_TOKEN=... HF_TOKEN=... PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai bash setup-vast.sh" >&2
+    exit 1
+fi
+
+if [ "$TUNNEL_ENABLED" = true ] && { [ -z "${CLOUDFLARED_TUNNEL_TOKEN:-}" ] || [ "$PUBLIC_HOSTNAME" = localhost ]; }; then
+    echo "TUNNEL_ENABLED=true requires CLOUDFLARED_TUNNEL_TOKEN and PUBLIC_HOSTNAME" >&2
     exit 1
 fi
 
@@ -67,15 +82,16 @@ esac
 
 log "Installing system packages..."
 $SUDO apt-get update -qq
-$SUDO apt-get install -y -qq curl git screen python3.12-venv python3.12-dev
+$SUDO apt-get install -y -qq curl dnsutils git screen python3.12-venv python3.12-dev
 
 # CUDA forward-compat libs (shipped in cuda-13 images) fail on GeForce when the
 # host driver is older than the toolkit (CUDA Error 804) — always use the host
 # driver instead.
-if ls /usr/local/cuda*/compat/libcuda.so* >/dev/null 2>&1; then
+if find /usr/local -maxdepth 3 -path '/usr/local/cuda-*/compat/libcuda.so*' -print -quit 2>/dev/null | grep -q .; then
     log "Disabling CUDA forward-compat libs (using host driver)..."
     mkdir -p /root/cuda-compat-disabled
-    mv /usr/local/cuda*/compat/libcuda.so* /root/cuda-compat-disabled/
+    find /usr/local -maxdepth 3 -path '/usr/local/cuda-*/compat/libcuda.so*' \
+        -exec mv -t /root/cuda-compat-disabled/ {} +
     $SUDO ldconfig
 fi
 
@@ -90,16 +106,40 @@ fi
 # token-file keeps the remotely-managed tunnel token out of process listings.
 # It requires cloudflared 2025.4.0 or newer; fresh hosts install latest above.
 TUNNEL_TOKEN_FILE="$HOME/.cloudflared/tunnel-token"
+TUNNEL_ENABLED_FILE="$HOME/.cloudflared/tunnel-enabled"
+TUNNEL_DNS_FALLBACK_MARKER="$HOME/.cloudflared/use-local-doh"
+TUNNEL_RESOLV_BACKUP="/etc/resolv.conf.vast-original"
+TUNNEL_SRV_NAME="_v2-origintunneld._tcp.argotunnel.com"
 install -d -m 700 "$HOME/.cloudflared"
-printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
-chmod 600 "$TUNNEL_TOKEN_FILE"
-unset CLOUDFLARED_TUNNEL_TOKEN
+if [ -n "${CLOUDFLARED_TUNNEL_TOKEN:-}" ]; then
+    printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
+    chmod 600 "$TUNNEL_TOKEN_FILE"
+    unset CLOUDFLARED_TUNNEL_TOKEN
+fi
 
-log "Starting Cloudflare Tunnel for $PUBLIC_HOSTNAME..."
-screen -S cloudflared -X quit 2>/dev/null || true
-screen -dmS cloudflared bash -c "while true; do cloudflared tunnel run --token-file '$TUNNEL_TOKEN_FILE' 2>&1 | tee -a /tmp/cloudflared.log; sleep 5; done"
+if [ "$TUNNEL_ENABLED" = true ]; then
+    touch "$TUNNEL_ENABLED_FILE"
+else
+    rm -f "$TUNNEL_ENABLED_FILE"
+fi
+
+# A small subset of Vast hosts resolves A records but drops the SRV responses
+# cloudflared needs. Mark those hosts once so every reboot starts a local DoH
+# resolver before the tunnel. Hosts with working SRV DNS keep their resolver.
+if [ -f "$TUNNEL_DNS_FALLBACK_MARKER" ]; then
+    log "Reusing the local DoH fallback selected on this host"
+elif ! dig +time=3 +tries=1 +short SRV "$TUNNEL_SRV_NAME" | grep -q argotunnel.com; then
+    log "Vast DNS does not return Cloudflare Tunnel SRV records; enabling local DoH"
+    [ -s "$TUNNEL_RESOLV_BACKUP" ] || cp /etc/resolv.conf "$TUNNEL_RESOLV_BACKUP"
+    touch "$TUNNEL_DNS_FALLBACK_MARKER"
+fi
+
 PUBLIC_IP="$PUBLIC_HOSTNAME"
-PUBLIC_PORT=443
+if [ "$PUBLIC_HOSTNAME" = localhost ]; then
+    PUBLIC_PORT="$PORT"
+else
+    PUBLIC_PORT=443
+fi
 
 # Some Vast hosts have unreliable egress to GitHub; SKIP_CLONE=1 uses files
 # already placed in $WORK_DIR (e.g. scp'd from the operator's machine).
@@ -150,11 +190,12 @@ log "Writing run environment to $NUNCHAKU_DIR/.env.flux..."
     printf 'export PUBLIC_PORT=%q\n' "$PUBLIC_PORT"
     printf 'export PUBLIC_IP=%q\n' "$PUBLIC_IP"
     printf 'export SERVICE_TYPE=%q\n' "$SERVICE_TYPE"
+    printf 'export HEARTBEAT_ENABLED=%q\n' "$HEARTBEAT_ENABLED"
     printf 'export QUANT_MODEL_PATH=%q\n' "$QUANT_MODEL_PATH"
     printf 'export MAX_PIXELS=%q\n' "$MAX_PIXELS"
     printf 'export QUEUE_LIMIT=%q\n' "${QUEUE_LIMIT:-3}"
     printf 'export CUDA_VISIBLE_DEVICES=%q\n' "${CUDA_VISIBLE_DEVICES:-0}"
-    printf 'export HF_XET_HIGH_PERFORMANCE=1\n'
+    printf 'export HF_HUB_DISABLE_XET=%q\n' "$HF_HUB_DISABLE_XET"
 } > "$NUNCHAKU_DIR/.env.flux"
 chmod 600 "$NUNCHAKU_DIR/.env.flux"
 
@@ -168,19 +209,60 @@ EOF
 
 cat > /root/onstart.sh <<EOF
 #!/bin/bash
+set -euo pipefail
+
 screen -S flux -X quit 2>/dev/null || true
 screen -S cloudflared -X quit 2>/dev/null || true
+screen -S tunnel-dns -X quit 2>/dev/null || true
+
 screen -dmS flux bash -c 'while true; do /root/run-flux.sh 2>&1 | tee -a /tmp/flux.log; echo "[setup-vast] server exited, restarting in 5s" | tee -a /tmp/flux.log; sleep 5; done'
-screen -dmS cloudflared bash -c 'while true; do cloudflared tunnel run --token-file "$TUNNEL_TOKEN_FILE" 2>&1 | tee -a /tmp/cloudflared.log; sleep 5; done'
+
+if [ ! -f "$TUNNEL_ENABLED_FILE" ]; then
+    echo "Production tunnel disabled; verify locally before promotion"
+    exit 0
+fi
+
+if [ ! -s "$TUNNEL_TOKEN_FILE" ]; then
+    echo "Production tunnel enabled but token file is missing" >> /tmp/cloudflared.log
+    exit 1
+fi
+
+if [ -f "$TUNNEL_DNS_FALLBACK_MARKER" ]; then
+    screen -dmS tunnel-dns bash -c 'while true; do cloudflared proxy-dns --address 127.0.0.1 --port 53 --upstream https://cloudflare-dns.com/dns-query --bootstrap https://162.159.36.1/dns-query --bootstrap https://162.159.46.1/dns-query >> /tmp/tunnel-dns.log 2>&1; sleep 5; done'
+
+    tunnel_dns_ready=false
+    for _ in \$(seq 1 20); do
+        if dig @127.0.0.1 +time=2 +tries=1 +short SRV "$TUNNEL_SRV_NAME" | grep -q argotunnel.com; then
+            {
+                printf 'nameserver 127.0.0.1\n'
+                grep -v '^nameserver ' "$TUNNEL_RESOLV_BACKUP" || true
+            } > /etc/resolv.conf
+            tunnel_dns_ready=true
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "\$tunnel_dns_ready" != true ]; then
+        echo "Local DoH did not become ready; production tunnel remains stopped" >> /tmp/tunnel-dns.log
+        exit 1
+    fi
+fi
+
+screen -dmS cloudflared bash -c 'until curl -fsS --max-time 3 http://127.0.0.1:$PORT/docs >/dev/null; do echo "Waiting for Flux health before joining the production tunnel" >> /tmp/cloudflared.log; sleep 3; done; while true; do cloudflared tunnel --no-autoupdate run --token-file "$TUNNEL_TOKEN_FILE" >> /tmp/cloudflared.log 2>&1; sleep 5; done'
 EOF
 chmod 700 /root/run-flux.sh /root/onstart.sh
 
-log "Starting durable Flux and tunnel services (logs: /tmp/flux.log, /tmp/cloudflared.log)..."
+log "Starting durable Flux service (logs: /tmp/flux.log, /tmp/cloudflared.log)..."
 /root/onstart.sh
 
 log "Done. Model load takes 2-3 min on first start."
 log "  Logs:       tail -f /tmp/flux.log"
 log "  Attach:     screen -r flux   (detach: Ctrl+A, D)"
 log "  Local test: curl -s localhost:$PORT/docs >/dev/null && echo up"
-log "  Registered: curl -s https://gen.pollinations.ai/register | grep -o '$SERVICE_TYPE[^,]*'"
 log "  Canary:     POLLINATIONS_API_KEY=... bash verify-vast.sh"
+if [ "$TUNNEL_ENABLED" = true ]; then
+    log "  Registered: curl -s https://gen.pollinations.ai/register | grep -o '$SERVICE_TYPE[^,]*'"
+else
+    log "  Production heartbeat and tunnel are disabled pending human approval"
+fi

--- a/image.pollinations.ai/nunchaku/verify-vast.sh
+++ b/image.pollinations.ai/nunchaku/verify-vast.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # Run on the Vast host after setup-vast.sh. This makes the same deterministic
-# request directly and through gen.pollinations.ai, then compares decoded image
-# pixels. A registry heartbeat or public /docs check alone does not prove that a
-# Cloudflare Worker can reach the tunnel; the public request may silently use a
-# fallback provider.
+# request locally and through either CANARY_URL or gen.pollinations.ai, then
+# compares decoded image pixels. A registry heartbeat or public /docs check
+# alone does not prove that the image path works.
 
 set -euo pipefail
 
@@ -17,9 +16,7 @@ fi
 
 # shellcheck disable=SC1090
 source "$ENV_FILE"
-: "${POLLINATIONS_API_KEY:?Set POLLINATIONS_API_KEY to a valid API key}"
 : "${PLN_GPU_TOKEN:?PLN_GPU_TOKEN missing from $ENV_FILE}"
-: "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
 
 PYTHON="$SCRIPT_DIR/venv/bin/python"
 if [ ! -x "$PYTHON" ]; then
@@ -34,15 +31,14 @@ PROMPT="vast-canary-$(date +%s)"
 SEED="${SEED:-424242}"
 WIDTH="${WIDTH:-512}"
 HEIGHT="${HEIGHT:-512}"
-PUBLIC_URL="https://gen.pollinations.ai/image/$PROMPT?model=flux&width=$WIDTH&height=$HEIGHT&seed=$SEED&nologo=true"
+CANARY_URL="${CANARY_URL:-}"
+CANARY_URL="${CANARY_URL%/}"
 
-echo "Checking local server and registered hostname..."
+echo "Checking local server..."
 curl -fsS --max-time 10 "http://localhost:${PORT:-8765}/docs" >/dev/null
-curl -fsS --max-time 10 https://gen.pollinations.ai/register \
-    -H "Authorization: Bearer $PLN_GPU_TOKEN" | grep -Fq "https://$PUBLIC_IP"
 
-echo "Generating the direct Vast reference..."
-curl -fsS --max-time 180 "https://$PUBLIC_IP/generate" \
+echo "Generating the local Vast reference..."
+curl -fsS --max-time 180 "http://localhost:${PORT:-8765}/generate" \
     -H "Content-Type: application/json" \
     -H "x-backend-token: $PLN_GPU_TOKEN" \
     --data "{\"prompts\":[\"$PROMPT\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
@@ -59,10 +55,34 @@ with open(sys.argv[2], "wb") as image:
     image.write(base64.b64decode(response[0]["image"]))
 PY
 
-echo "Generating through the public Flux route..."
-curl -fsS --max-time 180 "$PUBLIC_URL" \
-    -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
-    > "$CANARY_DIR/public.jpg"
+if [ -n "$CANARY_URL" ]; then
+    echo "Generating through the isolated canary URL..."
+    curl -fsS --max-time 180 "$CANARY_URL/generate" \
+        -H "Content-Type: application/json" \
+        -H "x-backend-token: $PLN_GPU_TOKEN" \
+        --data "{\"prompts\":[\"$PROMPT\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
+        > "$CANARY_DIR/public.json"
+    "$PYTHON" - "$CANARY_DIR/public.json" "$CANARY_DIR/public.jpg" <<'PY'
+import base64
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    response = json.load(source)
+with open(sys.argv[2], "wb") as image:
+    image.write(base64.b64decode(response[0]["image"]))
+PY
+else
+    : "${POLLINATIONS_API_KEY:?Set POLLINATIONS_API_KEY for production-route verification}"
+    : "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
+    curl -fsS --max-time 10 https://gen.pollinations.ai/register \
+        -H "Authorization: Bearer $PLN_GPU_TOKEN" | grep -Fq "https://$PUBLIC_IP"
+    PUBLIC_URL="https://gen.pollinations.ai/image/$PROMPT?model=flux&width=$WIDTH&height=$HEIGHT&seed=$SEED&nologo=true"
+    echo "Generating through the production Flux route..."
+    curl -fsS --max-time 180 "$PUBLIC_URL" \
+        -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+        > "$CANARY_DIR/public.jpg"
+fi
 
 "$PYTHON" - "$CANARY_DIR/direct.jpg" "$CANARY_DIR/public.jpg" <<'PY'
 import sys
@@ -78,5 +98,5 @@ with Image.open(sys.argv[1]) as direct_image, Image.open(sys.argv[2]) as public_
         raise SystemExit(
             f"FAIL: public image differs from Vast reference (RMS={rms:.2f}); fallback may be active"
         )
-    print(f"PASS: public Flux matched Vast reference (RMS={rms:.2f})")
+    print(f"PASS: external Flux matched the local Vast reference (RMS={rms:.2f})")
 PY


### PR DESCRIPTION
- Records the production cutover from maintenance-bound Vast instance `44731147` to `46491202`.
- Makes fresh Flux deployments isolated canaries by default; heartbeat and the production tunnel require explicit promotion.
- Hardens setup for CUDA compatibility paths, Hugging Face downloads, DNS fallback, and model-health gating.
- Adds direct canary verification through `CANARY_URL` before registry promotion.

Validation:
- `bash -n image.pollinations.ai/nunchaku/setup-vast.sh`
- `bash -n image.pollinations.ai/nunchaku/verify-vast.sh`
- `python3 -m py_compile image.pollinations.ai/nunchaku/server.py`
- Live production: 47 requests after cutover, all successful; four tunnel connections; old instance destroyed.