### PR TITLE
feat: add Inkling Small

### DIFF
--- a/enter.pollinations.ai/frontend/public/brand-logos/thinking-machines.svg
+++ b/enter.pollinations.ai/frontend/public/brand-logos/thinking-machines.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <title>Thinking Machines</title>
+  <rect x="3" y="3" width="18" height="18" rx="1.5"/>
+</svg>

--- a/enter.pollinations.ai/frontend/src/components/models/model-info.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-info.ts
@@ -34,6 +34,7 @@ const BRAND_LOGOS: Record<string, string> = {
     Sesame: "sesame",
     "Stability AI": "stability",
     StepFun: "stepfun",
+    "Thinking Machines": "thinking-machines",
     Xiaomi: "xiaomi",
     "Z.ai": "zai",
     xAI: "xai",

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -736,6 +736,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.03,
     },
   },
+  "inkling": {
+    "cost": {
+      "completionTextTokens": 0.0000012,
+      "promptCachedTokens": 0.0000001,
+      "promptTextTokens": 0.0000005,
+    },
+    "price": {
+      "completionTextTokens": 0.0000012,
+      "promptCachedTokens": 0.0000001,
+      "promptTextTokens": 0.0000005,
+    },
+  },
   "kimi": {
     "cost": {
       "completionTextTokens": 0.000004,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -369,6 +369,14 @@ const models: ModelDefinition[] = [
         ),
     },
     {
+        name: "inkling",
+        config: portkeyConfig["thinkingmachines/inkling-small"],
+        transform: pipe(
+            sanitizeToolSchemas,
+            createReasoningEffortTransform("toggle"),
+        ),
+    },
+    {
         name: "nemotron",
         config: portkeyConfig["nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"],
         transform: createReasoningEffortTransform("toggle"),

--- a/gen.pollinations.ai/src/text/cohereCommandAPlus.ts
+++ b/gen.pollinations.ai/src/text/cohereCommandAPlus.ts
@@ -4,13 +4,18 @@ import {
 } from "eventsource-parser/stream";
 import type { ChatCompletion, ServiceError, TransformFn } from "./types.js";
 
-const COHERE_CONTROL_TOKENS = [
+const RESPONSE_CONTROL_TOKENS = [
     "<|START_THINKING|>",
     "<|END_THINKING|>",
     "<|START_TEXT|>",
     "<|END_TEXT|>",
     "<|START_RESPONSE|>",
     "<|END_RESPONSE|>",
+    "<|content_text|>",
+    "<|content_thinking|>",
+    "<|content_model_end_sampling|>",
+    "<|end_message|>",
+    "<|endoftext|>",
 ] as const;
 
 function stripBoundaryControlTokens(
@@ -19,7 +24,7 @@ function stripBoundaryControlTokens(
 ): string {
     let cleaned = text;
     while (true) {
-        const token = COHERE_CONTROL_TOKENS.find((value) =>
+        const token = RESPONSE_CONTROL_TOKENS.find((value) =>
             boundary === "start"
                 ? cleaned.startsWith(value)
                 : cleaned.endsWith(value),
@@ -36,7 +41,7 @@ function possibleTrailingControlLength(text: string): number {
     for (let index = 0; index < text.length; index += 1) {
         let remaining = text.slice(index);
         while (remaining) {
-            const token = COHERE_CONTROL_TOKENS.find((value) =>
+            const token = RESPONSE_CONTROL_TOKENS.find((value) =>
                 remaining.startsWith(value),
             );
             if (!token) break;
@@ -44,7 +49,7 @@ function possibleTrailingControlLength(text: string): number {
         }
         if (
             !remaining ||
-            COHERE_CONTROL_TOKENS.some((value) => value.startsWith(remaining))
+            RESPONSE_CONTROL_TOKENS.some((value) => value.startsWith(remaining))
         ) {
             return text.length - index;
         }
@@ -52,7 +57,7 @@ function possibleTrailingControlLength(text: string): number {
     return 0;
 }
 
-class CohereContentSanitizer {
+class FramedContentSanitizer {
     private pending = "";
     private atStart = true;
 
@@ -63,7 +68,7 @@ class CohereContentSanitizer {
             this.pending = stripBoundaryControlTokens(this.pending, "start");
             if (!this.pending) return "";
             if (
-                COHERE_CONTROL_TOKENS.some((token) =>
+                RESPONSE_CONTROL_TOKENS.some((token) =>
                     token.startsWith(this.pending),
                 )
             ) {
@@ -93,7 +98,7 @@ class CohereContentSanitizer {
 }
 
 function sanitizeContent(text: string): string {
-    const sanitizer = new CohereContentSanitizer();
+    const sanitizer = new FramedContentSanitizer();
     return sanitizer.push(text) + sanitizer.finish();
 }
 
@@ -101,13 +106,13 @@ function sanitizeStream(
     source: ReadableStream<Uint8Array<ArrayBuffer>>,
 ): ReadableStream<Uint8Array> {
     const encoder = new TextEncoder();
-    const contentSanitizers = new Map<number, CohereContentSanitizer>();
+    const contentSanitizers = new Map<number, FramedContentSanitizer>();
     let lastChunkMetadata: Record<string, unknown> = {};
 
-    function sanitizerFor(index: number): CohereContentSanitizer {
+    function sanitizerFor(index: number): FramedContentSanitizer {
         const existing = contentSanitizers.get(index);
         if (existing) return existing;
-        const sanitizer = new CohereContentSanitizer();
+        const sanitizer = new FramedContentSanitizer();
         contentSanitizers.set(index, sanitizer);
         return sanitizer;
     }
@@ -216,7 +221,7 @@ function sanitizeStream(
         );
 }
 
-export function sanitizeCohereResponse(
+export function sanitizeFramedResponse(
     completion: ChatCompletion,
 ): ChatCompletion {
     if (completion.stream && completion.responseStream) {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -194,6 +194,16 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
+    "thinkingmachines/inkling-small": () =>
+        createOpenRouterModelConfig({
+            model: "thinkingmachines/inkling-small",
+            defaultOptions: {
+                provider: {
+                    only: ["Together"],
+                    allow_fallbacks: false,
+                },
+            },
+        }),
 
     // -- DeepInfra (NVIDIA) ---------------------------------------------------
     "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": () =>

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
 import { findModelByName } from "./availableModels.js";
-import { sanitizeCohereResponse } from "./cohereCommandAPlus.js";
+import { sanitizeFramedResponse } from "./cohereCommandAPlus.js";
 import { genericOpenAIClient } from "./genericOpenAIClient.js";
 import { generateHeaders } from "./transforms/headerGenerator.js";
 import { imageUrlToBase64Transform } from "./transforms/imageUrlToBase64Transform.js";
@@ -75,7 +75,7 @@ export async function generateTextPortkey(
         state.options,
         requestConfig,
     );
-    return modelDef?.name === "command-a-plus"
-        ? sanitizeCohereResponse(completion)
+    return modelDef && ["command-a-plus", "inkling"].includes(modelDef.name)
+        ? sanitizeFramedResponse(completion)
         : completion;
 }

--- a/gen.pollinations.ai/src/text/genericOpenAIClient.ts
+++ b/gen.pollinations.ai/src/text/genericOpenAIClient.ts
@@ -18,10 +18,10 @@ const log = debug("pollinations:genericopenai");
 const errorLog = debug("pollinations:error");
 const DONE_EVENT_PATTERN = /data:\s*\[DONE\]/;
 
-function isUnsupportedInputError(details: unknown): boolean {
+function isClientInputError(details: unknown): boolean {
     const serialized =
         typeof details === "string" ? details : JSON.stringify(details);
-    return /no endpoints found that support (?:image|audio|video) input/i.test(
+    return /no endpoints found that support (?:image|audio|video) input|multimodal processing failed|(?:image|audio) decode error|invalid or unsupported audio file|failed to load image|cannot identify image file/i.test(
         serialized,
     );
 }
@@ -111,7 +111,7 @@ function createApiError(
     const error = new Error(
         detailMessage ? `${statusMessage}: ${detailMessage}` : statusMessage,
     ) as ServiceError;
-    error.status = isUnsupportedInputError(details)
+    error.status = isClientInputError(details)
         ? 400
         : remapUpstreamStatus(response.status);
     error.upstreamStatus = response.status;
@@ -283,10 +283,11 @@ export async function genericOpenAIClient(
             const error = new Error(
                 errorDetails.message || "Text generation failed",
             ) as ServiceError;
-            error.status =
-                typeof errorDetails.status === "number"
-                    ? remapUpstreamStatus(errorDetails.status)
-                    : 502;
+            error.status = isClientInputError(errorDetails)
+                ? 400
+                : typeof errorDetails.status === "number"
+                  ? remapUpstreamStatus(errorDetails.status)
+                  : 502;
             error.upstreamStatus =
                 typeof errorDetails.status === "number"
                     ? errorDetails.status

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -378,6 +378,31 @@ describe("genericOpenAIClient", () => {
         ).rejects.toMatchObject({ status: 400, upstreamStatus: 404 });
     });
 
+    it.each([
+        "Multimodal processing failed: image decode error",
+        '{"error":{"message":"Invalid or unsupported audio file."}}',
+    ])("maps malformed media errors to a client error: %s", async (message) => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json(
+                {
+                    error: {
+                        message: "Provider returned error",
+                        metadata: { raw: message },
+                    },
+                },
+                { status: 500, statusText: "Internal Server Error" },
+            ),
+        );
+
+        await expect(
+            genericOpenAIClient(
+                [{ role: "user", content: "hello" }],
+                { model: "provider-model" },
+                { endpoint: "https://portkey.test/chat" },
+            ),
+        ).rejects.toMatchObject({ status: 400, upstreamStatus: 500 });
+    });
+
     it("maps 429 from an upstream error envelope to 502", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
             Response.json({
@@ -395,6 +420,23 @@ describe("genericOpenAIClient", () => {
                 { endpoint: "https://portkey.test/chat" },
             ),
         ).rejects.toMatchObject({ status: 502, upstreamStatus: 429 });
+    });
+
+    it.each([
+        '{"error":{"message":"Failed to load image: cannot identify image file","code":400}}',
+        '{"error":{"message":"Invalid or unsupported audio file.","code":400}}',
+    ])("maps malformed media in a successful error envelope to 400: %s", async (message) => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json({ error: { message } }),
+        );
+
+        await expect(
+            genericOpenAIClient(
+                [{ role: "user", content: "hello" }],
+                { model: "provider-model" },
+                { endpoint: "https://portkey.test/chat" },
+            ),
+        ).rejects.toMatchObject({ status: 400 });
     });
 
     it("maps invalid upstream JSON to 502 with gateway context", async () => {

--- a/gen.pollinations.ai/test/text/transforms/sanitizeCohereResponse.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/sanitizeCohereResponse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-    sanitizeCohereResponse,
+    sanitizeFramedResponse,
     validateCohereRequest,
 } from "../../../src/text/cohereCommandAPlus.js";
 import type { ChatCompletion } from "../../../src/text/types.js";
@@ -18,11 +18,11 @@ async function streamText(
         },
     });
 
-    const sanitized = sanitizeCohereResponse(completion);
+    const sanitized = sanitizeFramedResponse(completion);
     return new Response(sanitized.responseStream).text();
 }
 
-describe("sanitizeCohereResponse", () => {
+describe("sanitizeFramedResponse", () => {
     it("removes Cohere framing from text while preserving reasoning", () => {
         const completion: ChatCompletion = {
             choices: [
@@ -37,7 +37,7 @@ describe("sanitizeCohereResponse", () => {
             ],
         };
 
-        sanitizeCohereResponse(completion);
+        sanitizeFramedResponse(completion);
 
         expect(completion.choices?.[0].message).toEqual({
             role: "assistant",
@@ -60,7 +60,7 @@ describe("sanitizeCohereResponse", () => {
             ],
         };
 
-        sanitizeCohereResponse(completion);
+        sanitizeFramedResponse(completion);
 
         expect(completion.choices?.[0].message?.content).toBe("Hello");
     });
@@ -79,7 +79,7 @@ describe("sanitizeCohereResponse", () => {
             ],
         };
 
-        sanitizeCohereResponse(completion);
+        sanitizeFramedResponse(completion);
 
         expect(completion.choices?.[0].message?.content).toBe(
             "Print <|END_TEXT|> literally.",
@@ -125,6 +125,38 @@ describe("sanitizeCohereResponse", () => {
             ],
             content: "answer",
         });
+    });
+
+    it("removes Inkling response framing at content boundaries", () => {
+        const completion: ChatCompletion = {
+            choices: [
+                {
+                    message: {
+                        role: "assistant",
+                        content:
+                            "<|content_text|>Hello<|content_model_end_sampling|><|end_message|>",
+                    },
+                },
+            ],
+        };
+
+        sanitizeFramedResponse(completion);
+
+        expect(completion.choices?.[0].message?.content).toBe("Hello");
+    });
+
+    it("removes Inkling framing split across SSE events", async () => {
+        const result = await streamText({ stream: true }, [
+            'data: {"choices":[{"index":0,"delta":{"content":"Answer<|end_"}}]}\n\n',
+            'data: {"choices":[{"index":0,"delta":{"content":"message|>"},"finish_reason":"stop"}]}\n\n',
+            "data: [DONE]\n\n",
+        ]);
+
+        expect(result).toBe(
+            'data: {"choices":[{"index":0,"delta":{"content":"Answer"}}]}\n\n' +
+                'data: {"choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}\n\n' +
+                "data: [DONE]\n\n",
+        );
     });
 });
 

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -63,6 +63,16 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("pins Inkling to Together on OpenRouter without fallback", () => {
+        const result = resolveModelConfig(messages, { model: "inkling" });
+
+        expect(result.options.model).toBe("thinkingmachines/inkling-small");
+        expect(result.options.provider).toEqual({
+            only: ["Together"],
+            allow_fallbacks: false,
+        });
+    });
+
     it("pins Mercury to Inception on OpenRouter without fallback", () => {
         const result = resolveModelConfig(messages, { model: "mercury" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1281,6 +1281,32 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "inkling": {
+        aliases: ["inkling-small", "inkling-small-20260730"],
+        provider: "openrouter",
+        brand: "Thinking Machines",
+        category: "text",
+        addedDate: new Date("2026-08-01").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter Together route rates (2026-08-01). Image and audio
+            // inputs are tokenized into promptTextTokens; no separate usage is
+            // reported or billed for either modality.
+            promptTextTokens: perMillion(0.5),
+            promptCachedTokens: perMillion(0.1),
+            completionTextTokens: perMillion(1.2),
+        },
+        title: "Inkling Small",
+        description:
+            "Multimodal reasoning for agents, coding, image analysis and audio understanding",
+        inputModalities: ["text", "image", "audio"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 524288,
+        isSpecialized: false,
+    },
     "nemotron": {
         aliases: [
             "nemotron-3-ultra",


### PR DESCRIPTION
- Adds `inkling` with versioned aliases through OpenRouter, pinned to Together with fallback disabled.
- Exposes paid text, image, and audio understanding with tools and reasoning at 0.50/M input, 0.10/M cached input, and 1.20/M output.
- Adds the Thinking Machines brand mark, exact pricing metadata, response framing cleanup, and clear 400 responses for malformed media.
- Verifies direct and local text, reasoning, tools, streaming, image, multi-image, real WAV audio, aliases, cache, errors, usage, wallet deduction, Tinybird billing, and 5/15/30 bursts.
- Passes focused and mandatory suites (481 tests total), both worker typechecks, Biome, and diff checks.

Route limits: Together supports image and audio independently but rejects them together in one request. JSON mode is not advertised. An early direct 30-request probe saw one transient 503; the final local bursts passed 5/5, 15/15, and 30/30.

Sources: https://thinkingmachines.ai/news/introducing-inkling/ · https://thinkingmachines.ai/model-card/inkling/ · https://openrouter.ai/thinkingmachines/inkling-small
