### PR TITLE
fix: surface catalog fetch failure instead of rendering empty models table

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -85,6 +85,21 @@ const formatEstimatedTtsPricePerSecond = (pricePerChar: number): string => {
         : pricePerSecond.toFixed(4);
 };
 
+// A 200 response with an empty array, a non-array body, or entries that all
+// lack an identifiable name/id is indistinguishable from "no models" to the
+// caller — it must be treated as a fetch failure, not a valid empty catalog,
+// so the UI surfaces an error instead of silently rendering an empty table.
+export function parseModelCatalogResponse(data: unknown): ApiModelInfo[] {
+    if (!Array.isArray(data) || data.length === 0) {
+        throw new Error("Model catalog response was empty or malformed");
+    }
+    const models = data as ApiModelInfo[];
+    if (!models.some((model) => getCatalogModelId(model))) {
+        throw new Error("Model catalog response had no usable model entries");
+    }
+    return models;
+}
+
 let modelCatalogPromise: Promise<ApiModelInfo[]> | null = null;
 
 export async function fetchModelCatalog(
@@ -99,8 +114,9 @@ export async function fetchModelCatalog(
             if (!response.ok) {
                 throw new Error(`Failed to fetch models (${response.status})`);
             }
-            return response.json() as Promise<ApiModelInfo[]>;
+            return response.json();
         })
+        .then(parseModelCatalogResponse)
         .catch((error) => {
             modelCatalogPromise = null;
             throw error;

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -146,7 +146,8 @@ export const Models: FC<ModelsProps> = ({
                     setCatalogModels(models);
                     setCatalogError(null);
                 })
-                .catch(() => {
+                .catch((error) => {
+                    console.error("Model catalog fetch failed:", error);
                     setCatalogModels([]);
                     setCatalogError("Could not load models.");
                 }),

--- a/enter.pollinations.ai/test/model-catalog.test.ts
+++ b/enter.pollinations.ai/test/model-catalog.test.ts
@@ -1,0 +1,25 @@
+import { parseModelCatalogResponse } from "@frontend/components/models/model-catalog.ts";
+import { describe, expect, it } from "vitest";
+
+describe("parseModelCatalogResponse", () => {
+    it("returns the array when entries have identifiable models", () => {
+        const data = [{ name: "openai" }, { id: "flux" }];
+
+        expect(parseModelCatalogResponse(data)).toEqual(data);
+    });
+
+    it("throws on a non-array response", () => {
+        expect(() => parseModelCatalogResponse({ models: [] })).toThrow();
+        expect(() => parseModelCatalogResponse(null)).toThrow();
+    });
+
+    it("throws on an empty array", () => {
+        expect(() => parseModelCatalogResponse([])).toThrow();
+    });
+
+    it("throws when every entry lacks a name and id", () => {
+        expect(() =>
+            parseModelCatalogResponse([{ title: "Mystery" }, {}]),
+        ).toThrow();
+    });
+});


### PR DESCRIPTION
## Summary
- `fetchModelCatalog` now validates the parsed `/models` response and throws when it is empty, not an array, or every entry is missing a `name`/`id` — instead of silently resolving with unusable data.
- That throw routes through the existing `catalogError` handling in `models.tsx`, so the dashboard shows **"Could not load models."** instead of a blank table with no indication anything failed.
- Adds `parseModelCatalogResponse` unit tests covering valid, non-array, empty, and all-unidentifiable-entries responses.

## Why
Across #12289 and #12870, the recurring symptom was a **silently empty models table** — page skeleton loads, console is clean, no error banner — traced each time to a different edge/DNS failure (Cuba DNS, SIN edge timeout, Italy edge returning malformed 200s). The #12870 investigation flagged the actual gap: `getModelPricesFromCatalog`'s `.filter(Boolean)` swallows any unusable response with no signal to the user. This does not (and cannot) fix the underlying regional edge/DNS issue — that is infra-side — but it closes the frontend gap so any future recurrence is visible instead of silent.

Addresses #12289, #12870

## Test plan
- [x] `npx vitest run test/model-catalog.test.ts` — 4/4 passing
- [x] `npx tsc --noEmit` on the frontend project — clean
- [ ] Manual check on a deploy preview: confirm the models page still renders normally against the live catalog