### PR TITLE
fix: don't share the model-registry promise across requests

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -93,7 +93,12 @@ export async function fetchModelCatalog(
     if (options.refresh) modelCatalogPromise = null;
     modelCatalogPromise ??= import("../../config.ts")
         .then(({ config }) =>
-            fetch(`${config.genBaseUrl}/models`, { cache: "no-store" }),
+            // Without a timeout a stalled edge leaves this promise pending
+            // forever, which renders as an empty table with no error.
+            fetch(`${config.genBaseUrl}/models`, {
+                cache: "no-store",
+                signal: AbortSignal.timeout(15_000),
+            }),
         )
         .then((response) => {
             if (!response.ok) {

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -55,13 +55,7 @@ type CachedRegistry = {
     registry: GenerationModelRegistry;
 };
 
-type PendingRegistryLoad = {
-    dbBinding: CloudflareBindings["DB"] | undefined;
-    promise: Promise<GenerationModelRegistry>;
-};
-
 let cachedRegistry: CachedRegistry | null = null;
-let pendingRegistryLoad: PendingRegistryLoad | null = null;
 
 function eventTypeForCategory(category: Category): EventType {
     if (category === "audio") return "generate.audio";
@@ -178,40 +172,28 @@ async function loadGenerationModelRegistry(
 export async function getGenerationModelRegistry(
     env: Pick<CloudflareBindings, "DB">,
 ): Promise<GenerationModelRegistry> {
-    const now = Date.now();
     if (
         cachedRegistry &&
         cachedRegistry.dbBinding === env.DB &&
-        cachedRegistry.expiresAt > now
+        cachedRegistry.expiresAt > Date.now()
     ) {
         return cachedRegistry.registry;
     }
 
-    if (!pendingRegistryLoad || pendingRegistryLoad.dbBinding !== env.DB) {
-        const dbBinding = env.DB;
-        pendingRegistryLoad = {
-            dbBinding,
-            promise: loadGenerationModelRegistry(dbBinding)
-                .then((registry) => {
-                    cachedRegistry = {
-                        dbBinding,
-                        expiresAt: Date.now() + REGISTRY_TTL_MS,
-                        registry,
-                    };
-                    return registry;
-                })
-                .finally(() => {
-                    if (pendingRegistryLoad?.dbBinding === dbBinding) {
-                        pendingRegistryLoad = null;
-                    }
-                }),
-        };
-    }
-
-    return pendingRegistryLoad.promise;
+    // Deliberately no in-flight promise cache: sharing one pending promise
+    // across requests hands request A's D1 I/O to requests B..N, and if A is
+    // cancelled the promise can never settle, wedging the isolate for good.
+    // Racing a few cheap SELECTs on cache expiry is the better trade.
+    const dbBinding = env.DB;
+    const registry = await loadGenerationModelRegistry(dbBinding);
+    cachedRegistry = {
+        dbBinding,
+        expiresAt: Date.now() + REGISTRY_TTL_MS,
+        registry,
+    };
+    return registry;
 }
 
 export function resetGenerationModelRegistryCache(): void {
     cachedRegistry = null;
-    pendingRegistryLoad = null;
 }


### PR DESCRIPTION
- `getGenerationModelRegistry` cached its **in-flight promise** in a module global and returned it to every concurrent request, handing request A's D1 I/O to requests B..N. If A is cancelled the promise can never settle, the `.finally()` that clears the global never runs, and that isolate serves zero-byte hangs until recycled.
- Every model-list route (`/models`, `/v1/models`, `/text/models`, `/image/models`, `/3d/models`, audio, video, embeddings) and `resolveModel` await it — matching reports where the catalog *and* generation break together.
- Fix: cache only the resolved value; each request awaits its own D1 read. The dedupe it removed saved a handful of cheap SELECTs per isolate per 60s and never deduped across isolates anyway.
- Adds a 15s timeout to the dashboard catalog fetch so a stall renders the existing "Could not load models." banner instead of a silent empty table.

Landed in `bd5ea5781` (2026-06-30); first hang report #12289 was 2026-07-07.

Note: this is one of two causes. The larger driver is that `pollinations.ai` is on a Cloudflare **Free** plan while `myceli.ai` is Enterprise in the same account — measured 499 rates on `/v1/models` are TW 71.7% / SG 58.7% / IN 35.1% vs DE 4.9% / AT 0.3%. Tracked separately.

Addresses #13017, #12870, #12289, #12514