### PR TITLE
chore: allow chirag-gamer community publishing

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -32,6 +32,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     162339795, // meow18838
     130518306, // Lorodn4x
     198414737, // AkshayCoder48
+    205307392, // chirag-gamer
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `chirag-gamer`'s immutable GitHub user ID to the community-model publisher allowlist.
- Keeps the allowlist stable if the GitHub username changes.

Checks:
- `npx biome check --write shared/auth/github-id-list.ts`
- Direct allowlist membership and uniqueness assertion via Node

The full community-endpoint Vitest suite could not start in the isolated worktree because its Cloudflare test dependencies were not installed.