### PR TITLE
chore: sync main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -85,6 +85,21 @@ const formatEstimatedTtsPricePerSecond = (pricePerChar: number): string => {
         : pricePerSecond.toFixed(4);
 };
 
+// A 200 response with an empty array, a non-array body, or entries that all
+// lack an identifiable name/id is indistinguishable from "no models" to the
+// caller — it must be treated as a fetch failure, not a valid empty catalog,
+// so the UI surfaces an error instead of silently rendering an empty table.
+export function parseModelCatalogResponse(data: unknown): ApiModelInfo[] {
+    if (!Array.isArray(data) || data.length === 0) {
+        throw new Error("Model catalog response was empty or malformed");
+    }
+    const models = data as ApiModelInfo[];
+    if (!models.some((model) => getCatalogModelId(model))) {
+        throw new Error("Model catalog response had no usable model entries");
+    }
+    return models;
+}
+
 let modelCatalogPromise: Promise<ApiModelInfo[]> | null = null;
 
 export async function fetchModelCatalog(
@@ -104,8 +119,9 @@ export async function fetchModelCatalog(
             if (!response.ok) {
                 throw new Error(`Failed to fetch models (${response.status})`);
             }
-            return response.json() as Promise<ApiModelInfo[]>;
+            return response.json();
         })
+        .then(parseModelCatalogResponse)
         .catch((error) => {
             modelCatalogPromise = null;
             throw error;

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -146,7 +146,8 @@ export const Models: FC<ModelsProps> = ({
                     setCatalogModels(models);
                     setCatalogError(null);
                 })
-                .catch(() => {
+                .catch((error) => {
+                    console.error("Model catalog fetch failed:", error);
                     setCatalogModels([]);
                     setCatalogError("Could not load models.");
                 }),

--- a/enter.pollinations.ai/test/model-catalog.test.ts
+++ b/enter.pollinations.ai/test/model-catalog.test.ts
@@ -1,0 +1,25 @@
+import { parseModelCatalogResponse } from "@frontend/components/models/model-catalog.ts";
+import { describe, expect, it } from "vitest";
+
+describe("parseModelCatalogResponse", () => {
+    it("returns the array when entries have identifiable models", () => {
+        const data = [{ name: "openai" }, { id: "flux" }];
+
+        expect(parseModelCatalogResponse(data)).toEqual(data);
+    });
+
+    it("throws on a non-array response", () => {
+        expect(() => parseModelCatalogResponse({ models: [] })).toThrow();
+        expect(() => parseModelCatalogResponse(null)).toThrow();
+    });
+
+    it("throws on an empty array", () => {
+        expect(() => parseModelCatalogResponse([])).toThrow();
+    });
+
+    it("throws when every entry lacks a name and id", () => {
+        expect(() =>
+            parseModelCatalogResponse([{ title: "Mystery" }, {}]),
+        ).toThrow();
+    });
+});

--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -32,6 +32,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     162339795, // meow18838
     130518306, // Lorodn4x
     198414737, // AkshayCoder48
+    205307392, // chirag-gamer
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Promotes `main` to `production`.
- Includes the catalog fetch error fix from #13020.
- Includes the `chirag-gamer` community-model allowlist entry from #13028.