### PR TITLE
fix: correct cost variant boundaries and roll back undeployed telemetry

### DIFF
--- a/enter.pollinations.ai/observability/datasources/generation_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event.datasource
@@ -54,8 +54,6 @@ SCHEMA >
 `resolved_model_requested`  LowCardinality(String) `json:$.resolvedModelRequested` DEFAULT 'undefined',
 `model_used`                LowCardinality(String) `json:$.modelUsed` DEFAULT 'undefined',
 `model_provider_used`       LowCardinality(String) `json:$.modelProviderUsed` DEFAULT 'undefined',
-`cost_variant`              LowCardinality(String) `json:$.costVariant` DEFAULT 'undefined',
-`cost_variant_status`       LowCardinality(String) `json:$.costVariantStatus` DEFAULT 'not_evaluated',
 `fallback_used`             Bool                   `json:$.fallbackUsed` DEFAULT false,
 `is_billed_usage`           Bool                   `json:$.isBilledUsage`,
 
@@ -93,8 +91,6 @@ SCHEMA >
 
 -- Totals
 `total_cost`    Float64 `json:$.totalCost` DEFAULT 0,
-`provider_reported_cost` Nullable(Float64) `json:$.providerReportedCost`,
-`provider_cost_delta` Nullable(Float64) `json:$.providerCostDelta`,
 `total_price`   Float64 `json:$.totalPrice` DEFAULT 0,
 `dev_price`     Float64 `json:$.devPrice` DEFAULT 0,
 `markup_rate` Float64 `json:$.markupRate` DEFAULT 0,

--- a/enter.pollinations.ai/observability/datasources/generation_event_v2.datasource
+++ b/enter.pollinations.ai/observability/datasources/generation_event_v2.datasource
@@ -54,7 +54,6 @@ SCHEMA >
 `model_used`                LowCardinality(String) `json:$.modelUsed` DEFAULT 'undefined',
 `model_provider_used`       LowCardinality(String) `json:$.modelProviderUsed` DEFAULT 'undefined',
 `cost_variant`              LowCardinality(String) `json:$.costVariant` DEFAULT 'undefined',
-`cost_variant_status`       LowCardinality(String) `json:$.costVariantStatus` DEFAULT 'not_evaluated',
 `fallback_used`             Bool                   `json:$.fallbackUsed` DEFAULT false,
 -- This row says how the request ENDED, rather than recording one upstream call
 -- that was moved on from.
@@ -104,8 +103,6 @@ SCHEMA >
 
 -- Totals
 `total_cost`    Float64 `json:$.totalCost` DEFAULT 0,
-`provider_reported_cost` Nullable(Float64) `json:$.providerReportedCost`,
-`provider_cost_delta` Nullable(Float64) `json:$.providerCostDelta`,
 `total_price`   Float64 `json:$.totalPrice` DEFAULT 0,
 `dev_price`     Float64 `json:$.devPrice` DEFAULT 0,
 `markup_rate` Float64 `json:$.markupRate` DEFAULT 0,

--- a/enter.pollinations.ai/observability/materializations/byop_app_daily_mv.pipe
+++ b/enter.pollinations.ai/observability/materializations/byop_app_daily_mv.pipe
@@ -2,9 +2,6 @@ DESCRIPTION >
     Materializes cleanly attributed BYOP traffic from generation_event_v2 at
     daily app and model grain, including the isolated staging fixture.
 
-    DEPLOYMENT_METHOD 'alter': see generation_usage_hourly_mv. History predates
-    attempt rows, so re-materializing would reproduce the stored values.
-
 NODE byop_app_daily_mv_node
 SQL >
     SELECT
@@ -71,4 +68,3 @@ SQL >
 
 TYPE MATERIALIZED
 DATASOURCE byop_app_daily
-DEPLOYMENT_METHOD 'alter'

--- a/enter.pollinations.ai/observability/materializations/generation_usage_hourly_mv.pipe
+++ b/enter.pollinations.ai/observability/materializations/generation_usage_hourly_mv.pipe
@@ -3,11 +3,6 @@ DESCRIPTION >
     Includes production plus the isolated debug-prod-copy staging fixture.
     Reportable production history begins after the known January window.
 
-    DEPLOYMENT_METHOD 'alter' swaps the view definition in place instead of
-    recomputing history: every row written before fallback attempts existed
-    already satisfies is_final, so a backfill would rewrite millions
-    of rows to the values they already hold.
-
 NODE generation_usage_hourly_mv_node
 SQL >
     SELECT
@@ -130,4 +125,3 @@ SQL >
 
 TYPE MATERIALIZED
 DATASOURCE generation_usage_hourly
-DEPLOYMENT_METHOD 'alter'

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -49,7 +49,7 @@ describe("long-context cost variants", () => {
         ).toBe("long_context");
     });
 
-    it("Gemini uses Google's strict greater-than 200K boundary", () => {
+    it("Gemini uses OpenRouter's inclusive 200K boundary", () => {
         expect(
             bill("gemini-large", {
                 promptTextTokens: 199_999,
@@ -59,7 +59,7 @@ describe("long-context cost variants", () => {
             bill("gemini-large", {
                 promptTextTokens: 200_000,
             }).costVariant,
-        ).toBeUndefined();
+        ).toBe("long_context");
         expect(
             bill("gemini-large", {
                 promptTextTokens: 200_001,
@@ -67,7 +67,7 @@ describe("long-context cost variants", () => {
         ).toBe("long_context");
     });
 
-    it("Qwen uses OpenRouter's strict greater-than 256K boundary", () => {
+    it("Qwen uses OpenRouter's inclusive 256K boundary", () => {
         expect(
             bill("qwen-large", {
                 promptTextTokens: 255_999,
@@ -77,7 +77,7 @@ describe("long-context cost variants", () => {
             bill("qwen-large", {
                 promptTextTokens: 256_000,
             }).costVariant,
-        ).toBeUndefined();
+        ).toBe("long_context");
         expect(
             bill("qwen-large", {
                 promptTextTokens: 256_001,
@@ -85,7 +85,7 @@ describe("long-context cost variants", () => {
         ).toBe("long_context");
     });
 
-    it("Grok uses OpenRouter's strict greater-than 200K boundary", () => {
+    it("Grok uses OpenRouter's inclusive 200K boundary", () => {
         expect(
             bill("grok-4.5", {
                 promptTextTokens: 199_999,
@@ -95,7 +95,7 @@ describe("long-context cost variants", () => {
             bill("grok-4.5", {
                 promptTextTokens: 200_000,
             }).costVariant,
-        ).toBeUndefined();
+        ).toBe("long_context");
         expect(
             bill("grok-4.5", {
                 promptTextTokens: 200_001,
@@ -105,10 +105,10 @@ describe("long-context cost variants", () => {
 
     it.each([
         [31_999, undefined],
-        [32_000, undefined],
+        [32_000, "context_32k"],
         [32_001, "context_32k"],
         [255_999, "context_32k"],
-        [256_000, "context_32k"],
+        [256_000, "context_256k"],
         [256_001, "context_256k"],
     ] as const)("Qwen3.7 Flash selects the expected sheet at %s prompt tokens", (promptTextTokens, expectedVariant) => {
         expect(bill("qwen3.7-flash", { promptTextTokens }).costVariant).toBe(
@@ -123,7 +123,7 @@ describe("long-context cost variants", () => {
                 promptCachedTokens: 5_000,
                 promptCacheWriteTokens: 2_000,
                 promptImageTokens: 2_000,
-                promptVideoTokens: 3_001,
+                promptVideoTokens: 3_000,
             }).costVariant,
         ).toBe("context_32k");
         expect(
@@ -132,7 +132,7 @@ describe("long-context cost variants", () => {
                 promptCachedTokens: 20_000,
                 promptCacheWriteTokens: 10_000,
                 promptImageTokens: 10_000,
-                promptVideoTokens: 16_001,
+                promptVideoTokens: 16_000,
             }).costVariant,
         ).toBe("context_256k");
     });
@@ -152,7 +152,7 @@ describe("long-context cost variants", () => {
                 },
             ],
             [
-                32_001,
+                32_000,
                 "context_32k",
                 {
                     promptTextTokens: 0.1,
@@ -164,7 +164,7 @@ describe("long-context cost variants", () => {
                 },
             ],
             [
-                256_001,
+                256_000,
                 "context_256k",
                 {
                     promptTextTokens: 0.2,
@@ -319,7 +319,7 @@ describe("long-context cost variants", () => {
     it("Qwen and Grok apply their advertised long-context sheets", () => {
         expect(
             bill("qwen-large", {
-                promptTextTokens: 256_001,
+                promptTextTokens: 256_000,
             }).priceDefinition,
         ).toMatchObject({
             promptTextTokens: 0.96 / 1e6,
@@ -329,7 +329,7 @@ describe("long-context cost variants", () => {
         });
         expect(
             bill("grok-4.5", {
-                promptTextTokens: 200_001,
+                promptTextTokens: 200_000,
             }).priceDefinition,
         ).toMatchObject({
             promptTextTokens: 4 / 1e6,

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -399,7 +399,6 @@ export async function callOpenRouterSeedreamProAPI(
         isChild: false,
         trackingData: {
             actualModel: "seedream-pro",
-            providerReportedCost: data.usage?.cost ?? undefined,
             usage: {
                 completionImageTokens: 1,
                 totalTokenCount: 1,
@@ -459,7 +458,6 @@ export async function callOpenRouterGrokImagineProAPI(
         isChild: false,
         trackingData: {
             actualModel: "grok-imagine-pro",
-            providerReportedCost: data.usage?.cost ?? undefined,
             usage: {
                 ...(referenceImage ? { promptImageTokens: 1 } : {}),
                 completionImageTokens: 1,
@@ -565,7 +563,6 @@ export async function callOpenRouterGeminiImageAPI(
         isChild: false,
         trackingData: {
             actualModel: safeParams.model,
-            providerReportedCost: data.usage?.cost ?? undefined,
             usage,
         },
     };
@@ -648,7 +645,6 @@ export async function callOpenRouterRecraftVectorAPI(
         isChild: false,
         trackingData: {
             actualModel: "recraft-v4.1-vector",
-            providerReportedCost: data.usage?.cost ?? undefined,
             // OpenRouter bills this endpoint a fixed $0.08 per output image.
             usage: { completionImageTokens: 1 },
         },

--- a/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
@@ -114,7 +114,6 @@ export async function callHappyHorseAPI(
         durationSeconds: duration,
         trackingData: {
             actualModel: "happyhorse-1.1",
-            providerReportedCost: providerCost ?? undefined,
             usage: { completionVideoSeconds: duration },
         },
     };
@@ -184,7 +183,6 @@ export async function callOpenRouterGrokVideoAPI(
         durationSeconds: duration,
         trackingData: {
             actualModel: "grok-video-pro",
-            providerReportedCost: providerCost ?? undefined,
             usage: {
                 ...(safeParams.image?.[0] ? { promptImageTokens: 1 } : {}),
                 completionVideoSeconds: duration,

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -44,7 +44,6 @@ export interface VideoGenerationResult {
     durationSeconds: number;
     trackingData: {
         actualModel: string;
-        providerReportedCost?: number;
         usage: {
             completionVideoSeconds?: number; // For Veo, Wan (billed by seconds)
             completionVideoTokens?: number; // For Seedance (billed by tokens)

--- a/gen.pollinations.ai/src/image/utils/trackingHeaders.ts
+++ b/gen.pollinations.ai/src/image/utils/trackingHeaders.ts
@@ -3,15 +3,11 @@
  */
 
 import type { Usage } from "@shared/registry/registry.ts";
-import {
-    buildUsageHeaders,
-    PROVIDER_REPORTED_COST_HEADER,
-} from "@shared/registry/usage-headers.ts";
+import { buildUsageHeaders } from "@shared/registry/usage-headers.ts";
 
 export interface TrackingData {
     actualModel?: string;
     usage: Usage & Record<string, unknown>; // Allow extra fields like totalTokenCount
-    providerReportedCost?: number;
 }
 
 /**
@@ -27,15 +23,6 @@ export function buildTrackingHeaders(
     }
     const modelUsed = trackingData?.actualModel || model;
     const headers = buildUsageHeaders(modelUsed, trackingData.usage);
-    if (
-        typeof trackingData.providerReportedCost === "number" &&
-        Number.isFinite(trackingData.providerReportedCost) &&
-        trackingData.providerReportedCost >= 0
-    ) {
-        headers[PROVIDER_REPORTED_COST_HEADER] = String(
-            trackingData.providerReportedCost,
-        );
-    }
     if (!Object.keys(headers).some((header) => header.startsWith("x-usage-"))) {
         throw new Error(`Missing billable usage for ${model}`);
     }

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -33,7 +33,6 @@ import {
     type PriceDefinition,
     type PricingInput,
     type Usage,
-    type UsageBilling,
     type UsageCost,
     type UsagePrice,
 } from "@shared/registry/registry.ts";
@@ -41,7 +40,6 @@ import {
     FALLBACK_TARGET_HEADER,
     MODEL_USED_HEADER,
     openaiUsageToUsage,
-    PROVIDER_REPORTED_COST_HEADER,
     parseUsageHeaders,
     USAGE_MISSING_HEADER,
 } from "@shared/registry/usage-headers.ts";
@@ -83,7 +81,6 @@ export type ModelUsage = {
     model: string;
     usage: Usage;
     output?: unknown;
-    providerReportedCost?: number;
 };
 
 type RequestTrackingData = {
@@ -120,13 +117,6 @@ type ResponseTrackingData = {
     // Applied cost variant name (financial identity; modelUsed stays
     // observational).
     costVariant?: string;
-    // Separates a normal base-rate request from selector fallback failures.
-    costVariantStatus?: UsageBilling["costVariantStatus"];
-    // OpenRouter's own billed USD amount, when returned by the provider.
-    // This is reconciliation telemetry only and never changes user billing.
-    providerReportedCost?: number;
-    // Pollinations-calculated provider cost minus OpenRouter-reported cost.
-    providerCostDelta?: number;
     contentFilterResults?: GenerationEventContentFilterParams;
 };
 
@@ -681,7 +671,6 @@ export async function trackResponse(
         servedPrice,
         priceDefinition,
         costVariant,
-        costVariantStatus,
     } = calculateUsageBilling({
         model: resolvedModelRequested,
         usage: modelUsage.usage,
@@ -690,30 +679,6 @@ export async function trackResponse(
         output: modelUsage.output,
         input: pricingInput,
     });
-    const providerReportedCost =
-        requestTracking.modelProvider === "openrouter"
-            ? modelUsage.providerReportedCost
-            : undefined;
-    const providerCostDelta =
-        providerReportedCost === undefined
-            ? undefined
-            : cost.totalCost - providerReportedCost;
-    if (
-        providerReportedCost !== undefined &&
-        providerCostDelta !== undefined &&
-        Math.abs(providerCostDelta) >
-            Math.max(0.000001, providerReportedCost * 0.01)
-    ) {
-        log.warn(
-            "OpenRouter cost mismatch for model {model}: calculated={calculatedCost}, provider={providerCost}, delta={delta}",
-            {
-                model: resolvedModelRequested,
-                calculatedCost: cost.totalCost,
-                providerCost: providerReportedCost,
-                delta: providerCostDelta,
-            },
-        );
-    }
     return {
         responseStatus: response.status,
         cacheHit,
@@ -725,9 +690,6 @@ export async function trackResponse(
         adjustments,
         priceDefinition,
         costVariant,
-        costVariantStatus,
-        providerReportedCost,
-        providerCostDelta,
         modelUsed: modelUsage.model,
         usage: modelUsage.usage,
         contentFilterResults,
@@ -924,7 +886,6 @@ function createTrackingEvent({
         modelUsed: responseTracking.modelUsed,
         modelProviderUsed: requestTracking.modelProvider,
         costVariant: responseTracking.costVariant,
-        costVariantStatus: responseTracking.costVariantStatus,
         fallbackUsed: responseTracking.fallbackUsed,
         isFinal: responseTracking.isFinal ?? true,
 
@@ -942,8 +903,6 @@ function createTrackingEvent({
         ...usageToEventParams(responseTracking.usage),
 
         totalCost: responseTracking.cost?.totalCost || 0,
-        providerReportedCost: responseTracking.providerReportedCost,
-        providerCostDelta: responseTracking.providerCostDelta,
         totalPrice: billedPrice,
         devPrice: responseTracking.price?.totalPrice || 0,
         markupRate: markup?.markupRate ?? 0,
@@ -1005,20 +964,7 @@ function extractUsageHeaders(response: Response): ModelUsage | null {
     return {
         model: modelUsed,
         usage,
-        providerReportedCost: parseProviderReportedCost(
-            response.headers.get(PROVIDER_REPORTED_COST_HEADER),
-        ),
     };
-}
-
-function parseProviderReportedCost(value: unknown): number | undefined {
-    const parsed =
-        typeof value === "string" && value.trim() !== ""
-            ? Number(value)
-            : value;
-    return typeof parsed === "number" && Number.isFinite(parsed) && parsed >= 0
-        ? parsed
-        : undefined;
 }
 
 async function extractResponseJsonOutput(
@@ -1080,10 +1026,8 @@ async function extractUsageAndContentFilterResultsStream(
     const log = getLogger(["hono", "track", "stream"]);
     const EventSchema = z.object({
         model: z.string(),
-        // Providers use different cost shapes: OpenRouter reports a number,
-        // while Perplexity reports an object with request_cost/total_cost.
-        // Preserve either shape here; reconciliation accepts only a valid
-        // numeric value below, and billing rules inspect the original event.
+        // Preserve Perplexity's provider-reported request cost for billing
+        // rules that inspect the original event.
         usage: CompletionUsageSchema.extend({
             cost: z.unknown().nullish(),
         }).nullish(),
@@ -1103,7 +1047,6 @@ async function extractUsageAndContentFilterResultsStream(
 
     let model: string | undefined;
     let usage: CompletionUsage | undefined;
-    let providerReportedCost: number | undefined;
     let promptFilterResults: ContentFilterResult = {};
     let completionFilterResults: ContentFilterResult = {};
     const streamEvents: unknown[] = [];
@@ -1136,9 +1079,6 @@ async function extractUsageAndContentFilterResultsStream(
             }
             usage = parseResult.data?.usage;
             model = parseResult.data?.model;
-            providerReportedCost = parseProviderReportedCost(
-                parseResult.data.usage.cost,
-            );
         }
     }
 
@@ -1166,7 +1106,6 @@ async function extractUsageAndContentFilterResultsStream(
             model: servedModel,
             usage: openaiUsageToUsage(usage),
             output,
-            providerReportedCost,
         },
         output,
         contentFilterResults,

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -6,7 +6,6 @@ import {
     FALLBACK_TARGET_HEADER,
     MODEL_USED_HEADER,
     openaiUsageToUsage,
-    PROVIDER_REPORTED_COST_HEADER,
 } from "@shared/registry/usage-headers.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -176,22 +175,6 @@ function usageHeaders(
     }
     if (completion?.fallbackTarget) {
         headers.set(FALLBACK_TARGET_HEADER, completion.fallbackTarget);
-    }
-    // Reconciliation is optional: forward a numeric provider cost when the
-    // upstream wrapper exposes one. Portkey may omit it even when OpenRouter
-    // returns token usage, in which case the telemetry remains absent.
-    const providerReportedCost = (
-        completion?.usage as { cost?: unknown } | undefined
-    )?.cost;
-    if (
-        typeof providerReportedCost === "number" &&
-        Number.isFinite(providerReportedCost) &&
-        providerReportedCost >= 0
-    ) {
-        headers.set(
-            PROVIDER_REPORTED_COST_HEADER,
-            String(providerReportedCost),
-        );
     }
     return headers;
 }

--- a/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
@@ -150,14 +150,12 @@ test("qwen-image selects text-to-image and edit billing from the real handler in
         tokenPriceCompletionImage: 0.025,
         totalCost: 0.025,
         totalPrice: 0.025,
-        costVariantStatus: "base",
     });
     expect(textToImage.costVariant).toBeUndefined();
     expect(edit).toMatchObject({
         modelRequested: "qwen-image",
         modelUsed: "qwen-image-edit",
         costVariant: "edit",
-        costVariantStatus: "selected",
         tokenCountCompletionImage: 1,
         tokenPriceCompletionImage: 0.03,
         totalCost: 0.03,
@@ -186,7 +184,6 @@ test("p-video sends the selected resolution upstream and bills its variant", asy
         modelRequested: "p-video",
         modelUsed: "p-video",
         costVariant: "1080p",
-        costVariantStatus: "selected",
         tokenCountCompletionVideoSeconds: 5,
         tokenPriceCompletionVideoSeconds: 0.04,
         totalCost: 0.2,

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -98,7 +98,6 @@ describe("OpenRouter Grok Imagine Pro", () => {
         expect(result.buffer).toEqual(Buffer.from([1, 2, 3]));
         expect(result.trackingData).toEqual({
             actualModel: "grok-imagine-pro",
-            providerReportedCost: 0.05,
             usage: { completionImageTokens: 1 },
         });
     });
@@ -232,7 +231,6 @@ describe("OpenRouter Gemini image", () => {
         ]);
         expect(result.trackingData).toEqual({
             actualModel: "nanobanana",
-            providerReportedCost: 0.0387027,
             usage: {
                 promptTextTokens: 9,
                 completionImageTokens: 1290,
@@ -283,7 +281,6 @@ describe("OpenRouter Gemini image", () => {
         ]);
         expect(result.trackingData).toEqual({
             actualModel: "nanobanana-2",
-            providerReportedCost: 0.151254,
             usage: {
                 promptTextTokens: 12,
                 completionTextTokens: 12,
@@ -297,27 +294,30 @@ describe("OpenRouter Gemini image", () => {
         [1024, 1024, "1K"],
         [1920, 1080, "2K"],
         [3840, 2160, "4K"],
-    ] as const)("maps %sx%s NanoBanana 2 requests to %s", async (width, height, expectedResolution) => {
-        syncImageEnv(
-            {
-                OPENROUTER_API_KEY: "openrouter-test-key",
-            } as CloudflareBindings,
-            ["OPENROUTER_API_KEY"],
-        );
-        const requests: Record<string, unknown>[] = [];
-        mockGeminiFetch(requests);
+    ] as const)(
+        "maps %sx%s NanoBanana 2 requests to %s",
+        async (width, height, expectedResolution) => {
+            syncImageEnv(
+                {
+                    OPENROUTER_API_KEY: "openrouter-test-key",
+                } as CloudflareBindings,
+                ["OPENROUTER_API_KEY"],
+            );
+            const requests: Record<string, unknown>[] = [];
+            mockGeminiFetch(requests);
 
-        await callOpenRouterGeminiImageAPI("test prompt", {
-            ...baseParams,
-            model: "nanobanana-2",
-            width,
-            height,
-            reasoning: "fast",
-        });
+            await callOpenRouterGeminiImageAPI("test prompt", {
+                ...baseParams,
+                model: "nanobanana-2",
+                width,
+                height,
+                reasoning: "fast",
+            });
 
-        expect(requests[0].resolution).toBe(expectedResolution);
-        expect(requests[0].reasoning_effort).toBe("low");
-    });
+            expect(requests[0].resolution).toBe(expectedResolution);
+            expect(requests[0].reasoning_effort).toBe("low");
+        },
+    );
 
     it("pins NanoBanana 2 Lite to 1K Vertex with no fallback", async () => {
         syncImageEnv(
@@ -362,7 +362,6 @@ describe("OpenRouter Gemini image", () => {
         ]);
         expect(result.trackingData).toEqual({
             actualModel: "nanobanana-2-lite",
-            providerReportedCost: 0.0336135,
             usage: {
                 promptTextTokens: 10,
                 completionReasoningTokens: 4,
@@ -413,7 +412,6 @@ describe("OpenRouter Gemini image", () => {
         ]);
         expect(result.trackingData).toEqual({
             actualModel: "nanobanana-pro",
-            providerReportedCost: 0.240124,
             usage: {
                 promptTextTokens: 14,
                 completionReasoningTokens: 8,
@@ -622,7 +620,6 @@ describe("OpenRouter Seedream 4.5 Pro", () => {
         expect(result.buffer).toEqual(PNG);
         expect(result.trackingData).toEqual({
             actualModel: "seedream-pro",
-            providerReportedCost: 0.04,
             usage: {
                 completionImageTokens: 1,
                 totalTokenCount: 1,
@@ -780,7 +777,6 @@ describe("OpenRouter Recraft vector", () => {
         expect(result.mimeType).toBe("image/svg+xml");
         expect(result.trackingData).toEqual({
             actualModel: "recraft-v4.1-vector",
-            providerReportedCost: 0.08,
             usage: { completionImageTokens: 1 },
         });
     });
@@ -820,28 +816,28 @@ describe("OpenRouter Recraft vector", () => {
         });
     });
 
-    it.each([
-        null,
-        "image/png",
-    ])("rejects an unsupported %s response media type", async (mediaType) => {
-        syncImageEnv(
-            {
-                OPENROUTER_API_KEY: "openrouter-test-key",
-            } as CloudflareBindings,
-            ["OPENROUTER_API_KEY"],
-        );
-        mockRecraftResponse([], mediaType);
+    it.each([null, "image/png"])(
+        "rejects an unsupported %s response media type",
+        async (mediaType) => {
+            syncImageEnv(
+                {
+                    OPENROUTER_API_KEY: "openrouter-test-key",
+                } as CloudflareBindings,
+                ["OPENROUTER_API_KEY"],
+            );
+            mockRecraftResponse([], mediaType);
 
-        await expect(
-            callOpenRouterRecraftVectorAPI("vector prompt", {
-                ...baseParams,
-                model: "recraft-v4.1-vector",
-            }),
-        ).rejects.toMatchObject({
-            status: 502,
-            upstreamUrl: OPENROUTER_IMAGE_URL,
-        });
-    });
+            await expect(
+                callOpenRouterRecraftVectorAPI("vector prompt", {
+                    ...baseParams,
+                    model: "recraft-v4.1-vector",
+                }),
+            ).rejects.toMatchObject({
+                status: 502,
+                upstreamUrl: OPENROUTER_IMAGE_URL,
+            });
+        },
+    );
 
     it("preserves provider capacity responses as retryable 429 errors", async () => {
         syncImageEnv(

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -294,30 +294,27 @@ describe("OpenRouter Gemini image", () => {
         [1024, 1024, "1K"],
         [1920, 1080, "2K"],
         [3840, 2160, "4K"],
-    ] as const)(
-        "maps %sx%s NanoBanana 2 requests to %s",
-        async (width, height, expectedResolution) => {
-            syncImageEnv(
-                {
-                    OPENROUTER_API_KEY: "openrouter-test-key",
-                } as CloudflareBindings,
-                ["OPENROUTER_API_KEY"],
-            );
-            const requests: Record<string, unknown>[] = [];
-            mockGeminiFetch(requests);
+    ] as const)("maps %sx%s NanoBanana 2 requests to %s", async (width, height, expectedResolution) => {
+        syncImageEnv(
+            {
+                OPENROUTER_API_KEY: "openrouter-test-key",
+            } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGeminiFetch(requests);
 
-            await callOpenRouterGeminiImageAPI("test prompt", {
-                ...baseParams,
-                model: "nanobanana-2",
-                width,
-                height,
-                reasoning: "fast",
-            });
+        await callOpenRouterGeminiImageAPI("test prompt", {
+            ...baseParams,
+            model: "nanobanana-2",
+            width,
+            height,
+            reasoning: "fast",
+        });
 
-            expect(requests[0].resolution).toBe(expectedResolution);
-            expect(requests[0].reasoning_effort).toBe("low");
-        },
-    );
+        expect(requests[0].resolution).toBe(expectedResolution);
+        expect(requests[0].reasoning_effort).toBe("low");
+    });
 
     it("pins NanoBanana 2 Lite to 1K Vertex with no fallback", async () => {
         syncImageEnv(
@@ -816,28 +813,28 @@ describe("OpenRouter Recraft vector", () => {
         });
     });
 
-    it.each([null, "image/png"])(
-        "rejects an unsupported %s response media type",
-        async (mediaType) => {
-            syncImageEnv(
-                {
-                    OPENROUTER_API_KEY: "openrouter-test-key",
-                } as CloudflareBindings,
-                ["OPENROUTER_API_KEY"],
-            );
-            mockRecraftResponse([], mediaType);
+    it.each([
+        null,
+        "image/png",
+    ])("rejects an unsupported %s response media type", async (mediaType) => {
+        syncImageEnv(
+            {
+                OPENROUTER_API_KEY: "openrouter-test-key",
+            } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        mockRecraftResponse([], mediaType);
 
-            await expect(
-                callOpenRouterRecraftVectorAPI("vector prompt", {
-                    ...baseParams,
-                    model: "recraft-v4.1-vector",
-                }),
-            ).rejects.toMatchObject({
-                status: 502,
-                upstreamUrl: OPENROUTER_IMAGE_URL,
-            });
-        },
-    );
+        await expect(
+            callOpenRouterRecraftVectorAPI("vector prompt", {
+                ...baseParams,
+                model: "recraft-v4.1-vector",
+            }),
+        ).rejects.toMatchObject({
+            status: 502,
+            upstreamUrl: OPENROUTER_IMAGE_URL,
+        });
+    });
 
     it("preserves provider capacity responses as retryable 429 errors", async () => {
         syncImageEnv(

--- a/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
@@ -353,20 +353,19 @@ describe("OpenRouter Grok Video Pro", () => {
         expect(pollAttempts).toBe(6);
     });
 
-    it.each([0.5, 4.5, 15.5])(
-        "rejects non-integer duration %s before submitting a job",
-        async (duration) => {
-            setOpenRouterEnv();
-            const fetchSpy = vi.spyOn(globalThis, "fetch");
+    it.each([
+        0.5, 4.5, 15.5,
+    ])("rejects non-integer duration %s before submitting a job", async (duration) => {
+        setOpenRouterEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-            await expect(
-                callOpenRouterGrokVideoAPI("a calm ocean at sunrise", {
-                    ...baseParams,
-                    model: "grok-video-pro",
-                    duration,
-                }),
-            ).rejects.toMatchObject({ status: 400 });
-            expect(fetchSpy).not.toHaveBeenCalled();
-        },
-    );
+        await expect(
+            callOpenRouterGrokVideoAPI("a calm ocean at sunrise", {
+                ...baseParams,
+                model: "grok-video-pro",
+                duration,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
 });

--- a/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
@@ -248,7 +248,6 @@ describe("OpenRouter Grok Video Pro", () => {
             durationSeconds: 5,
             trackingData: {
                 actualModel: "grok-video-pro",
-                providerReportedCost: 0.35,
                 usage: { completionVideoSeconds: 5 },
             },
         });
@@ -354,19 +353,20 @@ describe("OpenRouter Grok Video Pro", () => {
         expect(pollAttempts).toBe(6);
     });
 
-    it.each([
-        0.5, 4.5, 15.5,
-    ])("rejects non-integer duration %s before submitting a job", async (duration) => {
-        setOpenRouterEnv();
-        const fetchSpy = vi.spyOn(globalThis, "fetch");
+    it.each([0.5, 4.5, 15.5])(
+        "rejects non-integer duration %s before submitting a job",
+        async (duration) => {
+            setOpenRouterEnv();
+            const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-        await expect(
-            callOpenRouterGrokVideoAPI("a calm ocean at sunrise", {
-                ...baseParams,
-                model: "grok-video-pro",
-                duration,
-            }),
-        ).rejects.toMatchObject({ status: 400 });
-        expect(fetchSpy).not.toHaveBeenCalled();
-    });
+            await expect(
+                callOpenRouterGrokVideoAPI("a calm ocean at sunrise", {
+                    ...baseParams,
+                    model: "grok-video-pro",
+                    duration,
+                }),
+            ).rejects.toMatchObject({ status: 400 });
+            expect(fetchSpy).not.toHaveBeenCalled();
+        },
+    );
 });

--- a/gen.pollinations.ai/test/image/trackingHeaders.test.ts
+++ b/gen.pollinations.ai/test/image/trackingHeaders.test.ts
@@ -18,30 +18,6 @@ describe("buildTrackingHeaders", () => {
         });
     });
 
-    it("forwards a valid provider-reported cost for reconciliation", () => {
-        expect(
-            buildTrackingHeaders("grok-video-pro", {
-                actualModel: "grok-video-pro",
-                usage: { completionVideoSeconds: 5 },
-                providerReportedCost: 0.35,
-            }),
-        ).toMatchObject({
-            "x-model-used": "grok-video-pro",
-            "x-usage-completion-video-seconds": "5",
-            "x-provider-reported-cost": "0.35",
-        });
-    });
-
-    it("ignores malformed provider-reported costs", () => {
-        expect(
-            buildTrackingHeaders("flux", {
-                actualModel: "flux",
-                usage: { completionImageTokens: 1 },
-                providerReportedCost: Number.NaN,
-            }),
-        ).not.toHaveProperty("x-provider-reported-cost");
-    });
-
     it("rejects missing usage instead of inventing an image unit", () => {
         expect(() => buildTrackingHeaders("flux", undefined as never)).toThrow(
             "Missing billable usage for flux",

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -197,7 +197,6 @@ function createWrongContentTypeApp(
 function createSseStreamApp(
     chunkDelayMs: number,
     modelName: ModelName = "openai",
-    providerReportedCost?: number,
 ) {
     const app = new Hono<Env>();
 
@@ -240,9 +239,6 @@ function createSseStreamApp(
                     prompt_tokens: 1000,
                     completion_tokens: 500,
                     total_tokens: 1500,
-                    ...(providerReportedCost === undefined
-                        ? {}
-                        : { cost: providerReportedCost }),
                 },
             }),
             "data: [DONE]\n\n",
@@ -768,7 +764,6 @@ describe("tracking observability", () => {
             modelRequested: "gpt-5.4",
             resolvedModelRequested: "gpt-5.4",
             costVariant: "long_context",
-            costVariantStatus: "selected",
             tokenPricePromptText: 5 / 1e6,
             tokenPriceCompletionText: 22.5 / 1e6,
             tokenCountPromptText: 272_001,
@@ -778,63 +773,6 @@ describe("tracking observability", () => {
             devPrice: expectedCost,
         });
         expect(consumePollen).toHaveBeenCalledWith(expectedCost);
-    });
-
-    it("records OpenRouter provider cost without changing billing", async () => {
-        const tinybirdRequests: Request[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(
-            async (input, init) => {
-                tinybirdRequests.push(new Request(input, init));
-                return new Response("ok");
-            },
-        );
-        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
-            async () => {},
-        );
-        const model: ModelVariables["model"] = {
-            requested: "qwen-large",
-            resolved: "qwen-large",
-            definition: getRegistryModelDefinition("qwen-large"),
-        };
-
-        const ctx = createExecutionContext();
-        await createTestApp(consumePollen, trackingUser, model, undefined, {
-            "x-provider-reported-cost": "0.123",
-        }).fetch(
-            new Request("https://gen.pollinations.ai/v1/chat/completions", {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({
-                    model: "qwen-large",
-                    stream: false,
-                    messages: [{ role: "user", content: "test" }],
-                }),
-            }),
-            {
-                DB: env.DB,
-                ENVIRONMENT: "test",
-                LOG_LEVEL: "debug",
-                LOG_FORMAT: "text",
-                BETTER_AUTH_SECRET: "test_secret",
-                TINYBIRD_INGEST_URL:
-                    "https://tinybird.test/v0/events?name=generation_event_v2",
-                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
-            } as CloudflareBindings,
-            ctx,
-        );
-
-        await waitOnExecutionContext(ctx);
-
-        const event = (await tinybirdRequests[0].json()) as TinybirdEvent;
-        const providerReportedCost = event.providerReportedCost;
-        expect(providerReportedCost).toBe(0.123);
-        if (providerReportedCost === undefined) {
-            throw new Error("Expected provider-reported cost");
-        }
-        expect(event.providerCostDelta).toBeCloseTo(
-            event.totalCost - providerReportedCost,
-        );
-        expect(consumePollen).toHaveBeenCalledWith(event.devPrice);
     });
 
     it("does not emit Tinybird generation events for cache hits", async () => {
@@ -1650,52 +1588,6 @@ describe("tracking observability", () => {
         expect(event.tokenCountCompletionText).toBe(500);
         expect(event.modelUsed).toBe("gpt-5-nano-2025-08-07");
         expect(event.isBilledUsage).toBe(true);
-    });
-
-    it("extracts OpenRouter provider cost from streamed usage", async () => {
-        const tinybirdRequests: Request[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(
-            async (input, init) => {
-                tinybirdRequests.push(new Request(input, init));
-                return new Response("ok");
-            },
-        );
-
-        const ctx = createExecutionContext();
-        await createSseStreamApp(0, "qwen-large", 0.456).fetch(
-            new Request("https://gen.pollinations.ai/v1/chat/completions", {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({
-                    model: "qwen-large",
-                    stream: true,
-                    messages: [{ role: "user", content: "test" }],
-                }),
-            }),
-            {
-                DB: env.DB,
-                ENVIRONMENT: "test",
-                LOG_LEVEL: "debug",
-                LOG_FORMAT: "text",
-                BETTER_AUTH_SECRET: "test_secret",
-                TINYBIRD_INGEST_URL:
-                    "https://tinybird.test/v0/events?name=generation_event_v2",
-                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
-            } as CloudflareBindings,
-            ctx,
-        );
-
-        await waitOnExecutionContext(ctx);
-
-        const event = (await tinybirdRequests[0].json()) as TinybirdEvent;
-        const providerReportedCost = event.providerReportedCost;
-        expect(providerReportedCost).toBe(0.456);
-        if (providerReportedCost === undefined) {
-            throw new Error("Expected provider-reported cost");
-        }
-        expect(event.providerCostDelta).toBeCloseTo(
-            event.totalCost - providerReportedCost,
-        );
     });
 
     it("records fallbackUsed=true when Portkey served a non-primary target", async () => {

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -52,6 +52,15 @@ export function longContextAbove(minPromptTokens: number) {
         totalPromptTokens(usage) > minPromptTokens ? "long_context" : undefined;
 }
 
+// OpenRouter pricing tiers apply when prompt tokens meet or exceed the
+// advertised minimum.
+export function longContextAtLeast(minPromptTokens: number) {
+    return ({ usage }: CostVariantContext): "long_context" | undefined =>
+        totalPromptTokens(usage) >= minPromptTokens
+            ? "long_context"
+            : undefined;
+}
+
 // Selects a named rate sheet when the request explicitly uses one of the
 // model's non-default resolutions. The default resolution stays on base rates.
 export function matchResolution<const R extends string>(...resolutions: R[]) {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,6 +1,7 @@
 import {
     defineCostVariants,
     longContextAbove,
+    longContextAtLeast,
     totalPromptTokens,
 } from "./cost-variants";
 import {
@@ -839,8 +840,8 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-07-18").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // OpenRouter's min_prompt_tokens override is strict: the higher tier
-        // applies above 200K total prompt tokens.
+        // OpenRouter's min_prompt_tokens override applies from 200K total
+        // prompt tokens.
         cost: {
             promptTextTokens: perMillion(2),
             promptCachedTokens: perMillion(0.3),
@@ -854,12 +855,12 @@ export const TEXT_SERVICES = {
                     completionTextTokens: perMillion(12),
                 },
             },
-            longContextAbove(200_000),
+            longContextAtLeast(200_000),
             {
                 long_context: {
-                    label: "Long context (>200K)",
+                    label: "Long context (200K+)",
                     description:
-                        "More than 200,000 prompt tokens; the higher rates apply to the whole request.",
+                        "At least 200,000 prompt tokens; the higher rates apply to the whole request.",
                 },
             },
         ),
@@ -1535,7 +1536,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(12.0),
         },
         // The pinned OpenRouter Google Vertex route reprices the whole request
-        // above 200K prompt tokens. Image tokens retain their separately
+        // from 200K prompt tokens. Image tokens retain their separately
         // advertised base rate; cache storage remains an independent
         // adjustment below.
         ...defineCostVariants(
@@ -1549,12 +1550,12 @@ export const TEXT_SERVICES = {
                     completionTextTokens: perMillion(18.0),
                 },
             },
-            longContextAbove(200_000),
+            longContextAtLeast(200_000),
             {
                 long_context: {
-                    label: "Long context (>200K)",
+                    label: "Long context (200K+)",
                     description:
-                        "More than 200,000 prompt tokens; text, cached, cache-write, audio, video, and output rates increase while image input stays at its separately advertised base price.",
+                        "At least 200,000 prompt tokens; text, cached, cache-write, audio, video, and output rates increase while image input stays at its separately advertised base price.",
                 },
             },
         ),
@@ -1851,7 +1852,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-06-12").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // OpenRouter triples all token rates above 256K prompt tokens.
+        // OpenRouter triples all token rates from 256K prompt tokens.
         cost: {
             promptTextTokens: perMillion(0.32),
             promptCachedTokens: perMillion(0.064),
@@ -1867,12 +1868,12 @@ export const TEXT_SERVICES = {
                     completionTextTokens: perMillion(3.84),
                 },
             },
-            longContextAbove(256_000),
+            longContextAtLeast(256_000),
             {
                 long_context: {
-                    label: "Long context (>256K)",
+                    label: "Long context (256K+)",
                     description:
-                        "More than 256,000 prompt tokens; the higher rates apply to the whole request.",
+                        "At least 256,000 prompt tokens; the higher rates apply to the whole request.",
                 },
             },
         ),
@@ -1919,8 +1920,8 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-07-30").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // OpenRouter's min_prompt_tokens overrides are strict: the higher tiers
-        // apply above 32K and 256K total prompt tokens.
+        // OpenRouter's min_prompt_tokens overrides apply from 32K and 256K
+        // total prompt tokens.
         cost: {
             promptTextTokens: perMillion(0.03),
             promptCachedTokens: perMillion(0.006),
@@ -1950,20 +1951,20 @@ export const TEXT_SERVICES = {
             },
             ({ usage }) => {
                 const promptTokens = totalPromptTokens(usage);
-                if (promptTokens > 256_000) return "context_256k";
-                if (promptTokens > 32_000) return "context_32k";
+                if (promptTokens >= 256_000) return "context_256k";
+                if (promptTokens >= 32_000) return "context_32k";
                 return undefined;
             },
             {
                 context_32k: {
-                    label: ">32K context",
+                    label: "32K+ context",
                     description:
-                        "More than 32,000 prompt tokens; the higher rates apply to the whole request.",
+                        "At least 32,000 prompt tokens; the higher rates apply to the whole request.",
                 },
                 context_256k: {
-                    label: ">256K context",
+                    label: "256K+ context",
                     description:
-                        "More than 256,000 prompt tokens; the highest rates apply to the whole request.",
+                        "At least 256,000 prompt tokens; the highest rates apply to the whole request.",
                 },
             },
         ),

--- a/shared/registry/usage-headers.ts
+++ b/shared/registry/usage-headers.ts
@@ -20,7 +20,6 @@ export const USAGE_TYPE_HEADERS: Record<UsageType, string> = {
     completionVideoTokens: "x-usage-completion-video-tokens",
 };
 
-export const PROVIDER_REPORTED_COST_HEADER = "x-provider-reported-cost";
 export const USAGE_MISSING_HEADER = "x-usage-missing";
 
 export const OPENAI_CHAT_USAGE_TYPES = [

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -63,8 +63,6 @@ export type TinybirdEvent = {
     modelProviderUsed?: string;
     /** Named conditional pricing sheet selected for this billed request. */
     costVariant?: string;
-    /** Outcome of conditional pricing selection for this billed request. */
-    costVariantStatus?: "base" | "selected" | "unknown" | "selector_error";
     /** True when Portkey served from a non-primary fallback target. */
     fallbackUsed?: boolean;
     /**
@@ -116,10 +114,6 @@ export type TinybirdEvent = {
 
     // Totals
     totalCost: number;
-    /** OpenRouter's billed USD amount, when supplied by its response. */
-    providerReportedCost?: number;
-    /** Pollinations-calculated provider cost minus providerReportedCost. */
-    providerCostDelta?: number;
     totalPrice: number;
     devPrice?: number;
     markupRate?: number;


### PR DESCRIPTION
## What

- Make OpenRouter `min_prompt_tokens` cost-variant boundaries inclusive for Grok 4.5, Gemini Large, Qwen Large, and Qwen3.7 Flash.
- Keep Azure/OpenAI's separate 272K boundary strict.
- Retain only `cost_variant` on the live `generation_event_v2` datasource.
- Roll back the undeployed `cost_variant_status`, `provider_reported_cost`, and `provider_cost_delta` telemetry and reconciliation plumbing.
- Remove the prior `DEPLOYMENT_METHOD 'alter'` directives from `generation_usage_hourly_mv` and `byop_app_daily_mv`.

## Impact

- Requests exactly at an OpenRouter boundary use the higher rate sheet.
- Rates, routing, aliases, token aggregation, multipliers, and paid-only behavior are otherwise unchanged.
- Perplexity request-fee billing still reads `usage.cost.request_cost`; `x-usage-missing` remains.
- No Tinybird deployment has been performed.

## Checks

- Gen: 820 passed, 6 skipped.
- Enter pricing suites: 367 passed.
- Gen and Enter typechecks pass.
- Biome and `git diff --check` pass.
- Prior Tinybird staging and production deployment checks were non-destructive and copied no data.

## Deployment gate

Immediately before deployment, rerun `deployment create --check --no-allow-destructive-operations` for each workspace. Confirm that neither `generation_usage_hourly_mv` nor `byop_app_daily_mv` will be repopulated before proceeding.