### PR TITLE
chore: allow pollinations-router community publishing

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -33,6 +33,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     130518306, // Lorodn4x
     198414737, // AkshayCoder48
     205307392, // chirag-gamer
+    240205932, // pollinations-router
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `pollinations-router`’s immutable GitHub user ID to the community-model publisher allowlist.
- Keeps the allowlist stable if the GitHub username changes.

Checks:
- `npx biome check --write shared/auth/github-id-list.ts`
- Direct allowlist membership and uniqueness assertion via Node