### PR TITLE
chore: sync migration hotfix to production

### DIFF
--- a/enter.pollinations.ai/drizzle/0043_canonicalize-model-permissions.sql
+++ b/enter.pollinations.ai/drizzle/0043_canonicalize-model-permissions.sql
@@ -8,18 +8,29 @@ WITH alias_map(alias, canonical) AS (
         ('p-video-720p', 'p-video'),
         ('p-video-1080p', 'p-video')
 ),
+-- Avoid expanding and grouping the permissions JSON for every API key. The
+-- production table is large, while only keys containing retired aliases need
+-- the canonicalization below.
+candidate_keys AS MATERIALIZED (
+    SELECT id, permissions
+    FROM apikey
+    WHERE instr(permissions, '"veo-1080p"') > 0
+       OR instr(permissions, '"wan-pro-1080p"') > 0
+       OR instr(permissions, '"p-video-720p"') > 0
+       OR instr(permissions, '"p-video-1080p"') > 0
+),
 canonicalized AS (
     SELECT
-        apikey.id,
+        candidate_keys.id,
         CAST(model.key AS integer) AS position,
         COALESCE(alias_map.canonical, model.value) AS model_id,
         alias_map.canonical IS NOT NULL AS changed
-    FROM apikey
-    JOIN json_each(apikey.permissions, '$.models') AS model
+    FROM candidate_keys
+    JOIN json_each(candidate_keys.permissions, '$.models') AS model
     LEFT JOIN alias_map
         ON model.type = 'text' AND model.value = alias_map.alias
-    WHERE json_valid(apikey.permissions)
-      AND json_type(apikey.permissions, '$.models') = 'array'
+    WHERE json_valid(candidate_keys.permissions)
+      AND json_type(candidate_keys.permissions, '$.models') = 'array'
 ),
 deduplicated AS (
     SELECT id, model_id, MIN(position) AS position

--- a/enter.pollinations.ai/test/canonicalize-model-permissions-migration.test.ts
+++ b/enter.pollinations.ai/test/canonicalize-model-permissions-migration.test.ts
@@ -1,0 +1,69 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import migrationSql from "../drizzle/0043_canonicalize-model-permissions.sql?raw";
+
+describe("canonicalize model permissions migration", () => {
+    it("limits JSON processing to candidate keys and preserves permission data", async () => {
+        expect(migrationSql).toContain("candidate_keys AS MATERIALIZED");
+        expect(migrationSql).toContain("FROM candidate_keys");
+
+        await env.DB.prepare(`
+            CREATE TABLE migration_apikey (
+                id TEXT PRIMARY KEY,
+                permissions TEXT
+            )
+        `).run();
+        await env.DB.prepare(`
+            WITH RECURSIVE seq(x) AS (
+                VALUES(1)
+                UNION ALL
+                SELECT x + 1 FROM seq WHERE x < 10000
+            )
+            INSERT INTO migration_apikey
+            SELECT
+                printf('key-%06d', x),
+                json_object('models', json_array('flux', 'openai'), 'role', 'keep')
+            FROM seq
+        `).run();
+        await env.DB.prepare(`
+            INSERT INTO migration_apikey VALUES
+                ('veo', json_object('models', json_array('veo-1080p', 'flux'), 'note', 'keep')),
+                ('p-video', json_object('models', json_array('p-video-720p', 'flux', 'p-video-1080p', 'p-video'), 'note', 'keep')),
+                ('unrelated', json_object('models', json_array('flux'), 'note', 'veo-1080p'))
+        `).run();
+
+        await env.DB.prepare(
+            migrationSql.replace(/\bapikey\b/g, "migration_apikey"),
+        ).run();
+
+        const rows = await env.DB.prepare(
+            "SELECT id, permissions FROM migration_apikey WHERE id IN ('veo', 'p-video', 'unrelated') ORDER BY id",
+        ).all<{ id: string; permissions: string }>();
+
+        const permissions = Object.fromEntries(
+            rows.results.map((row) => [row.id, JSON.parse(row.permissions)]),
+        );
+
+        expect(permissions.veo).toEqual({
+            models: ["veo", "flux"],
+            note: "keep",
+        });
+        expect(permissions["p-video"]).toEqual({
+            models: ["p-video", "flux"],
+            note: "keep",
+        });
+        expect(permissions.unrelated).toEqual({
+            models: ["flux"],
+            note: "veo-1080p",
+        });
+
+        const changedUnaffectedKeys = await env.DB.prepare(`
+            SELECT count(*) AS count
+            FROM migration_apikey
+            WHERE id LIKE 'key-%'
+              AND permissions != json_object('models', json_array('flux', 'openai'), 'role', 'keep')
+        `).first<{ count: number }>();
+
+        expect(changedUnaffectedKeys?.count).toBe(0);
+    });
+});


### PR DESCRIPTION
- Promotes the bounded API-key permission migration from `main`.
- Filters candidate keys before JSON expansion to stay within D1 CPU limits.
- Includes the D1 regression test from #13041.
- Restarts the production rollout that failed on migration `0043`.