### PR TITLE
fix: queue production Cloudflare deploys

### DIFF
--- a/.github/workflows/deploy-enter-cloudflare.yml
+++ b/.github/workflows/deploy-enter-cloudflare.yml
@@ -17,6 +17,7 @@ on:
 concurrency:
   group: pollinations-cloudflare-production
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -15,6 +15,7 @@ on:
 concurrency:
   group: pollinations-cloudflare-production
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-media-cloudflare.yml
+++ b/.github/workflows/deploy-media-cloudflare.yml
@@ -16,6 +16,7 @@ on:
 concurrency:
   group: pollinations-cloudflare-production
   cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: read


### PR DESCRIPTION
- Keeps Gen, Enter, and Media deployments serialized in the shared production concurrency group.
- Enables GitHub Actions’ `queue: max` behavior so a third triggered workflow waits instead of replacing the existing pending workflow.
- Fixes recurring zero-job cancellations when a production commit triggers all three backend deploys.

Validation:
- `git diff --check`
- Biome check on all three workflow files
- Syntax matches GitHub’s documented May 2026 concurrency queue feature