### PR TITLE
fix: preserve source image aspect ratio for image edits

### DIFF
--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -100,6 +100,21 @@ export const ImageParamsSchema = z
             ])
             .optional(),
         audio: sanitizedBoolean.catch(true), // generateAudio defaults to true
+        // Internal signal, not a public request parameter: lets a route
+        // override the width/height-based guess at whether the caller
+        // explicitly requested a size. Used by /v1/images/edits (#12583) so
+        // an aspect-ratio derived from the source image doesn't get treated
+        // as an explicit `size` by seedream-4's custom-vs-preset routing.
+        dimensionsExplicit: z
+            .union([z.string(), z.boolean()])
+            .optional()
+            .transform((value) =>
+                value === undefined
+                    ? undefined
+                    : typeof value === "boolean"
+                      ? value
+                      : value.toLowerCase() === "true",
+            ),
     })
     .superRefine((data, ctx) => {
         if (data.resolution) {
@@ -130,7 +145,8 @@ export const ImageParamsSchema = z
         // pixel-precise "custom" upstream path when this is true, instead of
         // approximating to a preset aspect ratio.
         const dimensionsExplicit =
-            data.width !== undefined || data.height !== undefined;
+            data.dimensionsExplicit ??
+            (data.width !== undefined || data.height !== undefined);
         const { width, height } = adjustImageSizeForModel(
             data.model,
             data.width,

--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -136,3 +136,96 @@ export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
+
+const DIMENSIONS_CACHE_TTL_SECONDS = 86_400;
+const DIMENSIONS_CACHE_PREFIX = "image:dimensions:v1:";
+
+type ImageDimensions = { width: number; height: number };
+
+async function dimensionsCacheKey(imageUrl: string): Promise<string> {
+    const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(imageUrl),
+    );
+    const bytes = new Uint8Array(digest);
+    return `${DIMENSIONS_CACHE_PREFIX}${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function cachedDimensions(value: unknown): ImageDimensions | null {
+    if (!value || typeof value !== "object") return null;
+    const { width, height } = value as Record<string, unknown>;
+    return typeof width === "number" &&
+        typeof height === "number" &&
+        Number.isInteger(width) &&
+        Number.isInteger(height) &&
+        width > 0 &&
+        height > 0
+        ? { width, height }
+        : null;
+}
+
+function decodeInlineImage(
+    dataUri: string,
+): { buffer: Buffer; mimeType: string } | null {
+    const match = dataUri.match(/^data:([^;,]+)[^,]*,(.*)$/s);
+    if (!match || !match[1].startsWith("image/")) return null;
+    try {
+        const buffer = dataUri.includes(";base64,")
+            ? base64ToBuffer(dataUri)
+            : Buffer.from(decodeURIComponent(match[2]));
+        return { buffer, mimeType: match[1] };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Resolve the pixel dimensions of a user-supplied source image, used to
+ * preserve aspect ratio on `/v1/images/edits` when the caller omits `size`
+ * (see #12583).
+ *
+ * Inline data URIs are decoded in place — no network call. Remote URLs are
+ * downloaded once and, when `kv` is provided, the resulting dimensions are
+ * cached for 24h so repeated edits of the same source image (a common
+ * workflow: apply several prompts to one upload) skip the re-download.
+ */
+export async function getSourceImageDimensions(
+    imageUrl: string,
+    kv?: KVNamespace,
+): Promise<ImageDimensions | null> {
+    const inline = imageUrl.startsWith("data:")
+        ? decodeInlineImage(imageUrl)
+        : null;
+    if (inline) {
+        return readImageDimensions(
+            bufferToUint8Array(inline.buffer),
+            inline.mimeType,
+        );
+    }
+
+    const cacheKey = kv ? await dimensionsCacheKey(imageUrl) : undefined;
+    if (kv && cacheKey) {
+        const cached = cachedDimensions(await kv.get(cacheKey, "json"));
+        if (cached) return cached;
+    }
+
+    try {
+        const { buffer, mimeType } = await downloadUserImage(imageUrl);
+        const dimensions = readImageDimensions(
+            bufferToUint8Array(buffer),
+            mimeType,
+        );
+        if (kv && cacheKey && dimensions) {
+            await kv.put(cacheKey, JSON.stringify(dimensions), {
+                expirationTtl: DIMENSIONS_CACHE_TTL_SECONDS,
+            });
+        }
+        return dimensions;
+    } catch {
+        // A source image we can't download or can't decode just falls back
+        // to the model's default size — this is a best-effort enhancement,
+        // not a hard requirement, and the caller's edit request should still
+        // succeed.
+        return null;
+    }
+}

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -23,6 +23,7 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -70,11 +71,16 @@ function resolveParams(opts: {
     size?: string;
     quality?: string;
     seed?: number;
+    // Overrides the image-param schema's own width/height-based guess at
+    // whether `size` was explicit. Only the edits route needs this — see
+    // the call site in handleImageEdit for why.
+    dimensionsExplicit?: boolean;
 }): {
     width?: number;
     height?: number;
     quality: string;
     seed: number;
+    dimensionsExplicit?: boolean;
 } {
     // Width/height are only emitted when the caller actually passed `size`.
     // Leaving them undefined lets the image-param schema fill model-specific
@@ -87,9 +93,28 @@ function resolveParams(opts: {
     return {
         ...(Number.isInteger(width) ? { width } : {}),
         ...(Number.isInteger(height) ? { height } : {}),
+        ...(opts.dimensionsExplicit !== undefined
+            ? { dimensionsExplicit: opts.dimensionsExplicit }
+            : {}),
         quality: QUALITY_MAP[opts.quality || ""] || opts.quality || "medium",
         seed: opts.seed ?? Math.floor(Math.random() * 2147483647),
     };
+}
+
+/**
+ * Scale (width, height) to fit within `maxPixels` while preserving aspect
+ * ratio, snapped to a 16px grid — most providers reject arbitrary source
+ * resolutions and expect multiples of 8 or 16.
+ */
+export function computeAspectRatioSize(
+    width: number,
+    height: number,
+    maxPixels = 1_048_576, // ~1 megapixel
+): string {
+    const scale = Math.min(1, Math.sqrt(maxPixels / (width * height)));
+    const snap = (value: number) =>
+        Math.max(16, Math.round((value * scale) / 16) * 16);
+    return `${snap(width)}x${snap(height)}`;
 }
 
 /** Collect passthrough params from request body. */
@@ -280,8 +305,37 @@ export async function handleImageEdit(c: Context<Env>) {
 
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
+
+    // #12583: preserve the source image's aspect ratio when the caller
+    // omits `size`, instead of falling through to the model's (often
+    // square) default. An explicit `size` always wins and is left alone.
+    let effectiveSize = size;
+    let sizeWasDerived = false;
+    if (!effectiveSize) {
+        const dimensions = await getSourceImageDimensions(
+            imageUrls[0],
+            c.env.KV,
+        );
+        if (dimensions) {
+            effectiveSize = computeAspectRatioSize(
+                dimensions.width,
+                dimensions.height,
+            );
+            sizeWasDerived = true;
+        }
+    }
+
     const safePrompt = await applySafety(c, prompt, safe);
-    const resolved = resolveParams({ size, quality, seed });
+    const resolved = resolveParams({
+        size: effectiveSize,
+        quality,
+        seed,
+        // A size derived from the source image is not a caller-provided
+        // `size` — don't let it flip the `dimensionsExplicit` signal that
+        // seedream-4 and others use to choose pixel-precise vs. preset
+        // sizing (see ImageParamsSchema in image/params.ts).
+        dimensionsExplicit: sizeWasDerived ? false : undefined,
+    });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/test/image/computeAspectRatioSize.test.ts
+++ b/gen.pollinations.ai/test/image/computeAspectRatioSize.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { computeAspectRatioSize } from "../../src/routes/images.ts";
+
+function parse(size: string): { width: number; height: number } {
+    const [width, height] = size.split("x").map(Number);
+    return { width, height };
+}
+
+describe("computeAspectRatioSize", () => {
+    it("keeps a landscape source under the pixel budget close to its ratio", () => {
+        const { width, height } = parse(computeAspectRatioSize(1920, 1080));
+        expect(width).toBeGreaterThan(height);
+        expect(width * height).toBeLessThanOrEqual(1_048_576);
+        expect(width / height).toBeCloseTo(1920 / 1080, 1);
+    });
+
+    it("keeps a portrait source portrait", () => {
+        const { width, height } = parse(computeAspectRatioSize(1080, 1920));
+        expect(height).toBeGreaterThan(width);
+        expect(width / height).toBeCloseTo(1080 / 1920, 1);
+    });
+
+    it("does not upscale a source already under the pixel budget", () => {
+        expect(computeAspectRatioSize(512, 384)).toBe("512x384");
+    });
+
+    it("snaps every dimension to a multiple of 16", () => {
+        const { width, height } = parse(computeAspectRatioSize(1000, 700));
+        expect(width % 16).toBe(0);
+        expect(height % 16).toBe(0);
+    });
+
+    it("never snaps a dimension below 16", () => {
+        const { width, height } = parse(computeAspectRatioSize(4000, 8));
+        expect(width).toBeGreaterThanOrEqual(16);
+        expect(height).toBeGreaterThanOrEqual(16);
+    });
+
+    it("treats a square source as square", () => {
+        expect(computeAspectRatioSize(2000, 2000)).toBe("1024x1024");
+    });
+});

--- a/gen.pollinations.ai/test/image/imageDownload.test.ts
+++ b/gen.pollinations.ai/test/image/imageDownload.test.ts
@@ -2,8 +2,34 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { HttpError } from "../../src/image/httpError.ts";
 import {
     downloadUserImage,
+    getSourceImageDimensions,
     readImageDimensions,
 } from "../../src/image/utils/imageDownload.ts";
+
+function makeKv() {
+    const store = new Map<string, string>();
+    const puts: string[] = [];
+    return {
+        store,
+        puts,
+        async get(key: string, _type?: "json") {
+            const raw = store.get(key);
+            return raw === undefined ? null : JSON.parse(raw);
+        },
+        async put(key: string, value: string) {
+            puts.push(key);
+            store.set(key, value);
+        },
+    } as unknown as KVNamespace & { puts: string[] };
+}
+
+function pngDataUri(width: number, height: number): string {
+    const png = Buffer.alloc(24);
+    png.set([0x89, 0x50, 0x4e, 0x47]);
+    png.writeUInt32BE(width, 16);
+    png.writeUInt32BE(height, 20);
+    return `data:image/png;base64,${png.toString("base64")}`;
+}
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -242,5 +268,82 @@ describe("readImageDimensions", () => {
             width: 1280,
             height: 720,
         });
+    });
+});
+
+describe("getSourceImageDimensions", () => {
+    it("reads an inline data URI without fetching", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            getSourceImageDimensions(pngDataUri(768, 1024)),
+        ).resolves.toEqual({ width: 768, height: 1024 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns null for an unreadable inline image", async () => {
+        await expect(
+            getSourceImageDimensions("data:text/plain;base64,aGVsbG8="),
+        ).resolves.toBeNull();
+    });
+
+    it("downloads and caches remote dimensions, then reuses the cache", async () => {
+        const kv = makeKv();
+        let fetches = 0;
+        vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+            fetches += 1;
+            const png = new Uint8Array(24);
+            png.set([0x89, 0x50, 0x4e, 0x47]);
+            new DataView(png.buffer).setUint32(16, 2048, false);
+            new DataView(png.buffer).setUint32(20, 1024, false);
+            return new Response(png, {
+                status: 200,
+                headers: { "content-type": "image/png" },
+            });
+        });
+
+        await expect(
+            getSourceImageDimensions("https://example.com/source.png", kv),
+        ).resolves.toEqual({ width: 2048, height: 1024 });
+        await expect(
+            getSourceImageDimensions("https://example.com/source.png", kv),
+        ).resolves.toEqual({ width: 2048, height: 1024 });
+
+        expect(fetches).toBe(1);
+        expect(kv.puts).toHaveLength(1);
+    });
+
+    it("does not cache inline data URIs", async () => {
+        const kv = makeKv();
+
+        await expect(
+            getSourceImageDimensions(pngDataUri(768, 1024), kv),
+        ).resolves.toEqual({ width: 768, height: 1024 });
+
+        expect(kv.puts).toHaveLength(0);
+    });
+
+    it("returns null instead of throwing when the source can't be downloaded", async () => {
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            new TypeError("fetch failed"),
+        );
+
+        await expect(
+            getSourceImageDimensions("https://example.com/gone.png"),
+        ).resolves.toBeNull();
+    });
+
+    it("works without a kv binding", async () => {
+        const png = Buffer.alloc(24);
+        png.set([0x89, 0x50, 0x4e, 0x47]);
+        png.writeUInt32BE(400, 16);
+        png.writeUInt32BE(300, 20);
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(png, { status: 200 }),
+        );
+
+        await expect(
+            getSourceImageDimensions("https://example.com/untyped.png"),
+        ).resolves.toEqual({ width: 400, height: 300 });
     });
 });

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -71,3 +71,51 @@ describe("ImageParamsSchema", () => {
         }
     });
 });
+
+describe("ImageParamsSchema dimensionsExplicit", () => {
+    it("defaults to false when no dimensions are given", () => {
+        const result = ImageParamsSchema.parse({ model: "flux" });
+        expect(result.dimensionsExplicit).toBe(false);
+    });
+
+    it("defaults to true when width/height are given", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            width: 800,
+            height: 600,
+        });
+        expect(result.dimensionsExplicit).toBe(true);
+    });
+
+    // #12583: /v1/images/edits sets width/height from the source image's
+    // own aspect ratio when the caller omits `size`. That's not an explicit
+    // request for those dimensions, so the route overrides the signal —
+    // this is what keeps seedream-4's custom-vs-preset routing correct.
+    it("can be overridden to false even when width/height are given", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            width: 800,
+            height: 600,
+            dimensionsExplicit: false,
+        });
+        expect(result.dimensionsExplicit).toBe(false);
+    });
+
+    it("can be overridden to true even without width/height", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            dimensionsExplicit: true,
+        });
+        expect(result.dimensionsExplicit).toBe(true);
+    });
+
+    it("accepts the override as a query-string boolean", () => {
+        const result = ImageParamsSchema.parse({
+            model: "flux",
+            width: 800,
+            height: 600,
+            dimensionsExplicit: "false",
+        });
+        expect(result.dimensionsExplicit).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #12583 by preserving the source image aspect ratio for `/v1/images/edits` when the `size` parameter is omitted.

Previously, edit requests without an explicit `size` defaulted to the model's square resolution, which could unintentionally change the original image proportions. This change derives the default output dimensions from the uploaded source image instead, while preserving the existing behavior for requests that explicitly specify `size`.

## Changes

- Preserve the source image aspect ratio when `size` is omitted.
- Reuse the existing image dimension parser for PNG, JPEG, GIF, BMP, and WebP.
- Preserve the existing `dimensionsExplicit` behavior for explicit sizes.
- Add regression tests for aspect-ratio size calculation.
- Extend image dimension and parameter tests.

## Validation

- ✅ `npx tsc --noEmit`
- ✅ `npx vitest run test/image` (24 test files, 226 tests passed)
- ✅ `npx biome check .` (only existing warnings, no new issues)

## Benefits

- Preserves the original image aspect ratio by default.
- Does not affect requests that already specify `size`.
- Reuses existing logic instead of introducing duplicate image parsing.
- Adds regression coverage to prevent future regressions.