### PR TITLE
fix(image-edit): preserve source aspect ratio when size is omitted

### DIFF
--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -136,3 +136,39 @@ export async function toDataUri(url: string): Promise<string> {
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
+
+/** Extract image dimensions from a data URI without a network request. */
+function getImageDimensionsFromDataUri(
+    dataUri: string,
+): { width: number; height: number } | null {
+    try {
+        const buf = base64ToBuffer(dataUri);
+        const mimeType = detectImageMimeType(buf);
+        if (!mimeType) return null;
+        return readImageDimensions(buf, mimeType);
+    } catch {
+        return null;
+    }
+}
+
+/** Extract image dimensions from a remote URL by fetching the image. */
+export async function getImageDimensionsFromUrl(
+    url: string,
+): Promise<{ width: number; height: number } | null> {
+    try {
+        const { buffer, mimeType } = await downloadUserImage(url);
+        return readImageDimensions(buffer, mimeType);
+    } catch {
+        return null;
+    }
+}
+
+/** Get image dimensions from either a data URI or a remote URL. */
+export async function getSourceImageDimensions(
+    imageUrl: string,
+): Promise<{ width: number; height: number } | null> {
+    if (imageUrl.startsWith("data:")) {
+        return getImageDimensionsFromDataUri(imageUrl);
+    }
+    return getImageDimensionsFromUrl(imageUrl);
+}

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -23,6 +23,7 @@ import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { getSourceImageDimensions } from "@/image/utils/imageDownload.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -280,8 +281,17 @@ export async function handleImageEdit(c: Context<Env>) {
 
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
+
+    let effectiveSize = size;
+    if (!effectiveSize && imageUrls.length > 0) {
+        const dims = await getSourceImageDimensions(imageUrls[0]);
+        if (dims) {
+            effectiveSize = `${dims.width}x${dims.height}`;
+        }
+    }
+
     const safePrompt = await applySafety(c, prompt, safe);
-    const resolved = resolveParams({ size, quality, seed });
+    const resolved = resolveParams({ size: effectiveSize, quality, seed });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {
         prompt: safePrompt,

--- a/gen.pollinations.ai/test/image/image-edits.test.ts
+++ b/gen.pollinations.ai/test/image/image-edits.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getSourceImageDimensions } from "../src/image/utils/imageDownload.ts";
+
+describe("getSourceImageDimensions (image-edit aspect ratio fallback)", () => {
+    it("extracts PNG dimensions from a minimal data URI", async () => {
+        const png = new Uint8Array(24);
+        png[0] = 0x89;
+        png[1] = 0x50;
+        png[2] = 0x4e;
+        png[3] = 0x47;
+        const view = new DataView(png.buffer);
+        view.setUint32(16, 1920, false);
+        view.setUint32(20, 1080, false);
+
+        const dims = await getSourceImageDimensions(
+            `data:image/png;base64,${Buffer.from(png).toString("base64")}`,
+        );
+        expect(dims).toEqual({ width: 1920, height: 1080 });
+    });
+
+    it("extracts JPEG dimensions from a data URI", async () => {
+        const jpeg = Uint8Array.from([
+            0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x02, 0xd0, 0x05, 0x00,
+            0x03, 0x01, 0x11, 0x00,
+        ]);
+        const dims = await getSourceImageDimensions(
+            `data:image/jpeg;base64,${Buffer.from(jpeg).toString("base64")}`,
+        );
+        expect(dims).toEqual({ width: 1280, height: 720 });
+    });
+
+    it("extracts WEBP VP8X dimensions from a data URI", async () => {
+        const webp = new Uint8Array(30);
+        webp.set([0x52, 0x49, 0x46, 0x46], 0);
+        webp.set([0x57, 0x45, 0x42, 0x50], 8);
+        webp.set([0x56, 0x50, 0x38, 0x58], 12);
+        webp[24] = 0xff;
+        webp[25] = 0x03;
+        webp[27] = 0xff;
+        webp[28] = 0x01;
+
+        const dims = await getSourceImageDimensions(
+            `data:image/webp;base64,${Buffer.from(webp).toString("base64")}`,
+        );
+        expect(dims).toEqual({ width: 1024, height: 512 });
+    });
+
+    it("returns null for unsupported input", async () => {
+        const dims = await getSourceImageDimensions(
+            "data:text/plain;base64,aGVsbG8=",
+        );
+        expect(dims).toBeNull();
+    });
+});


### PR DESCRIPTION
Closes #12583

When `size` is omitted on `/v1/images/edits`, infer the source image dimensions from the first input image and preserve its aspect ratio instead of falling back to model defaults.

- Adds `getSourceImageDimensions()` in `gen.pollinations.ai/src/image/utils/imageDownload.ts` for data URI and remote URL inputs.
- Uses inferred dimensions in `handleImageEdit` only; generation path unchanged.
- Adds focused tests for data URI dimension extraction.
