### PR TITLE
docs(chat): align DEPLOYMENT.md with Cloudflare Pages workflow

### DIFF
--- a/apps/chat/DEPLOYMENT.md
+++ b/apps/chat/DEPLOYMENT.md
@@ -1,40 +1,33 @@
-# GitHub Pages Deployment
+# Cloudflare Pages Deployment
 
-The React chat UI is configured to automatically deploy to GitHub Pages.
+The React chat UI is deployed to Cloudflare Pages as part of the monorepo apps workflow.
 
 ## Setup Instructions
 
-### 1. Enable GitHub Pages
+### 1. App registration
 
-In the repository settings:
-1. Go to Settings → Pages
-2. Under "Build and deployment", select "GitHub Actions" as the source
-3. Save the settings
+`apps/chat` is registered in `apps/apps.json`. The deploy workflow only deploys apps present in that registry.
 
 ### 2. Automatic Deployment
 
-The workflow `.github/workflows/deploy-pages.yml` will automatically:
-- Build the React app whenever code is pushed to `main` or `copilot/improve-react-chat-ui` branches
-- Deploy the built app to GitHub Pages
+The workflow `.github/workflows/apps-deploy-changed.yml` will automatically:
+- Detect changes under `apps/chat/` on push to `main`
+- Build the app with `npm run build`
+- Upload the build output to Cloudflare Pages
+- Verify the origin at `https://chat.myceli.ai`
+- Cut over the public URL to `https://chat.pollinations.ai`
 
 ### 3. Access the Deployed App
 
-Once deployed, the app will be available at:
-**https://cloudcompile.github.io/pollinations-chat-ui/**
-
-## Manual Deployment
-
-You can also trigger a deployment manually:
-1. Go to the "Actions" tab in the repository
-2. Select "Deploy React App to GitHub Pages" workflow
-3. Click "Run workflow"
+The live app is available at:
+**https://chat.pollinations.ai**
 
 ## Local Development
 
 To run the app locally:
 
 ```bash
-cd react-app
+cd apps/chat
 npm install
 npm run dev
 ```
@@ -46,8 +39,8 @@ The app will be available at http://localhost:5173
 To build the app locally:
 
 ```bash
-cd react-app
+cd apps/chat
 npm run build
 ```
 
-The built files will be in the `react-app/dist` directory.
+The built files will be in the `apps/chat/dist` directory.


### PR DESCRIPTION
Updates chat deployment instructions to reflect the actual Cloudflare Pages deployment path instead of the old GitHub Pages setup.