### PR TITLE
fix(polli-cli): add output modalities and video capabilities flags to my-models

### DIFF
--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -115,6 +115,20 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
             .filter((modality) => modality.length > 0);
     }
 
+    if (opts.outputModalities !== undefined) {
+        body.outputModalities = String(opts.outputModalities)
+            .split(",")
+            .map((modality) => modality.trim())
+            .filter((modality) => modality.length > 0);
+    }
+
+    if (opts.videoCapabilities !== undefined) {
+        body.videoCapabilities = String(opts.videoCapabilities)
+            .split(",")
+            .map((capability) => capability.trim())
+            .filter((capability) => capability.length > 0);
+    }
+
     if (includeRequired) {
         for (const required of ["name", "title", "baseUrl", "bearerToken"]) {
             if (!body[required]) {
@@ -195,6 +209,14 @@ const create = addPriceOptions(
         .option(
             "--input-modalities <types>",
             "Comma-separated accepted inputs: text,image,audio,video",
+        )
+        .option(
+            "--output-modalities <types>",
+            "Comma-separated produced outputs: text,image,audio,video",
+        )
+        .option(
+            "--video-capabilities <caps>",
+            "Comma-separated video capabilities: text-to-video,image-to-video",
         ),
 ).action(async (opts) => {
     const key = requireKey();
@@ -238,6 +260,14 @@ const update = addPriceOptions(
         .option(
             "--input-modalities <types>",
             "Comma-separated accepted inputs: text,image,audio,video",
+        )
+        .option(
+            "--output-modalities <types>",
+            "Comma-separated produced outputs: text,image,audio,video",
+        )
+        .option(
+            "--video-capabilities <caps>",
+            "Comma-separated video capabilities: text-to-video,image-to-video",
         ),
 ).action(async (id, opts) => {
     const key = requireKey();


### PR DESCRIPTION
Closes #12853
- add `--output-modalities`
- add `--video-capabilities`
- keep existing `--input-modalities` behavior