### PR TITLE
fix: harden fallback gating and deferred disclosure (#12890)

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -238,7 +238,7 @@ async function resolveFallbackModelId(
           })
         : undefined;
     if (!target) {
-        throw new HTTPException(400, {
+        throw new HTTPException(404, {
             message: `Fallback target ${fallbackModelId} does not exist`,
         });
     }

--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -234,6 +234,7 @@ export function linkFallbackEntries(
                 ) {
                     continue;
                 }
+                if (targetEndpoint?.delegatesGeneration) continue;
                 if (!isUsableCommunityFallback(entry, target)) continue;
             }
             if (targets.some((linked) => linked.id === target.id)) continue;

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -143,6 +143,25 @@ describe("registry fallback linking", () => {
             registryPrimary.fallbackEntries?.map((entry) => entry.id),
         ).toEqual(["public", "owner/private", "owner/disabled"]);
     });
+    it("excludes delegating community endpoints from registry fallbacks", () => {
+        const ownPrimary = communityEntry(
+            "owner/primary",
+            "owner",
+            "public",
+            null,
+            ["owner/delegate"],
+            20,
+        );
+        const delegate = communityEntry("owner/delegate", "owner", "public");
+        delegate.communityEndpoint = {
+            ...(delegate.communityEndpoint as GenerationModelEntry["communityEndpoint"]),
+            delegatesGeneration: true,
+        };
+        const entries = [ownPrimary, delegate];
+        const byId = new Map(entries.map((entry) => [entry.id, entry]));
+        linkFallbackEntries(entries, byId);
+        expect(ownPrimary.fallbackEntries).toBeUndefined();
+    });
 });
 
 /**


### PR DESCRIPTION
- return 404 instead of 400 when a fallback target does not exist
- exclude delegating community endpoints from fallback candidates
- add regression test for delegatesGeneration gating