### PR TITLE
fix: set Myceli proxy timeout to 300 seconds

### DIFF
--- a/.github/workflows/configure-cloudflare-proxy-timeout.yml
+++ b/.github/workflows/configure-cloudflare-proxy-timeout.yml
@@ -1,0 +1,64 @@
+name: Configure / Cloudflare proxy timeout
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  configure:
+    if: github.ref == 'refs/heads/production'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Myceli proxy read timeout to 300 seconds
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
+        run: |
+          zone_response=$(curl --fail-with-body --silent --show-error \
+            --get "https://api.cloudflare.com/client/v4/zones" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --data-urlencode "name=myceli.ai" \
+            --data-urlencode "account.id=$CLOUDFLARE_ACCOUNT_ID")
+
+          zone_id=$(jq -r \
+            'if .success and (.result | length) == 1 then .result[0].id else empty end' \
+            <<<"$zone_response")
+          if [[ -z "$zone_id" ]]; then
+            echo "Could not resolve exactly one myceli.ai zone"
+            exit 1
+          fi
+
+          setting_url="https://api.cloudflare.com/client/v4/zones/$zone_id/settings/proxy_read_timeout"
+          current_response=$(curl --fail-with-body --silent --show-error \
+            "$setting_url" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+          current_value=$(jq -r '.result.value' <<<"$current_response")
+          editable=$(jq -r '.result.editable' <<<"$current_response")
+          echo "Current proxy_read_timeout: ${current_value}s"
+
+          if [[ "$editable" != "true" ]]; then
+            echo "proxy_read_timeout is not editable for the myceli.ai zone"
+            exit 1
+          fi
+
+          if [[ "$current_value" != "300" ]]; then
+            curl --fail-with-body --silent --show-error \
+              --request PATCH "$setting_url" \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --header "Content-Type: application/json" \
+              --data '{"value":300}' \
+              | jq -e '.success and .result.value == 300' >/dev/null
+          fi
+
+          verified_value=$(curl --fail-with-body --silent --show-error \
+            "$setting_url" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            | jq -r '.result.value')
+          if [[ "$verified_value" != "300" ]]; then
+            echo "Verification failed: expected 300s, got ${verified_value}s"
+            exit 1
+          fi
+
+          echo "Verified proxy_read_timeout: ${verified_value}s"


### PR DESCRIPTION
- Adds a manual production-only workflow for the `myceli.ai` zone.
- Reads and reports the current `proxy_read_timeout` before changing it.
- Sets the value to 300 seconds and verifies it through the Cloudflare API.
- Fails without changing anything if the zone is missing, the setting is not editable, or the existing credential lacks permission.

Validation: Prettier, `git diff --check`, and actionlint.