### PR TITLE
feat: separate official and community models

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-search.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search.ts
@@ -6,12 +6,13 @@ export const MODEL_CATEGORIES = [
     "audio",
     "realtime",
     "text",
-    "community-text",
-    "community-image",
     "embedding",
 ] as const;
 
 export type ModelCategory = (typeof MODEL_CATEGORIES)[number];
+
+export const MODEL_SCOPES = ["pollinations", "community"] as const;
+export type ModelScope = (typeof MODEL_SCOPES)[number];
 
 export const MODEL_SORT_KEYS = [
     "name",
@@ -25,6 +26,7 @@ export const MODEL_SORT_DIRECTIONS = ["asc", "desc"] as const;
 export type ModelSortDirection = (typeof MODEL_SORT_DIRECTIONS)[number];
 
 export type ModelSearch = {
+    scope?: ModelScope;
     category?: ModelCategory;
     q?: string;
     sort?: ModelSortKey;
@@ -41,11 +43,21 @@ function includes<T extends string>(
 export function validateModelSearch(
     search: Record<string, unknown>,
 ): ModelSearch {
+    const scope = includes(MODEL_SCOPES, search.scope)
+        ? search.scope
+        : "pollinations";
+    const category = includes(MODEL_CATEGORIES, search.category)
+        ? search.category
+        : "all";
+
     return {
+        scope: scope === "community" ? scope : undefined,
         category:
-            includes(MODEL_CATEGORIES, search.category) &&
-            search.category !== "all"
-                ? search.category
+            category !== "all" &&
+            (scope !== "community" ||
+                category === "text" ||
+                category === "image")
+                ? category
                 : undefined,
         q:
             typeof search.q === "string" && search.q.length > 0

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -40,8 +40,6 @@ type UnifiedModelTableProps = {
     videoModels: ModelPrice[];
     model3dModels: ModelPrice[];
     textModels: ModelPrice[];
-    communityTextModels: ModelPrice[];
-    communityImageModels: ModelPrice[];
     audioModels: ModelPrice[];
     realtimeModels: ModelPrice[];
     embeddingModels: ModelPrice[];
@@ -90,8 +88,6 @@ export const sectionLabels: Record<SectionType, string> = {
     audio: "Audio",
     realtime: "Realtime",
     text: "Text",
-    "community-text": "Community Text",
-    "community-image": "Community Image",
     embedding: "Embedding",
 };
 
@@ -317,8 +313,6 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
     videoModels,
     model3dModels,
     textModels,
-    communityTextModels,
-    communityImageModels,
     audioModels,
     realtimeModels,
     embeddingModels,
@@ -335,8 +329,6 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
         { type: "audio", models: audioModels },
         { type: "realtime", models: realtimeModels },
         { type: "text", models: textModels },
-        { type: "community-text", models: communityTextModels },
-        { type: "community-image", models: communityImageModels },
         { type: "embedding", models: embeddingModels },
     ];
 

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -12,7 +12,6 @@ import {
     TokensIcon,
     TrendUpIcon,
 } from "@pollinations/ui";
-import pollinationsMarkUrl from "@pollinations/ui/brand/mark.svg";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
     type FC,
@@ -70,11 +69,6 @@ const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
 const SCOPE_LABELS: Record<ModelScope, string> = {
     pollinations: "Official",
     community: "Community",
-};
-
-const SCOPE_LOGOS: Record<ModelScope, string> = {
-    pollinations: pollinationsMarkUrl,
-    community: "/brand-logos/community.svg",
 };
 
 const SEARCH_LABELS: Record<SectionType, string> = {
@@ -315,20 +309,6 @@ export const Models: FC<ModelsProps> = ({
                                     }
                                 >
                                     <span className="inline-flex items-center gap-1.5">
-                                        <span
-                                            aria-hidden="true"
-                                            className="h-5 w-5 shrink-0 bg-current opacity-55"
-                                            style={{
-                                                maskImage: `url(${SCOPE_LOGOS[scope]})`,
-                                                WebkitMaskImage: `url(${SCOPE_LOGOS[scope]})`,
-                                                maskRepeat: "no-repeat",
-                                                WebkitMaskRepeat: "no-repeat",
-                                                maskPosition: "center",
-                                                WebkitMaskPosition: "center",
-                                                maskSize: "contain",
-                                                WebkitMaskSize: "contain",
-                                            }}
-                                        />
                                         {SCOPE_LABELS[scope]}
                                         {scope === "community" && (
                                             <Chip intent="alpha" size="sm">
@@ -345,7 +325,6 @@ export const Models: FC<ModelsProps> = ({
                                     key={section}
                                     active={activeTab === section}
                                     onClick={() => setActiveTab(section)}
-                                    size="sm"
                                 >
                                     {sectionLabels[section]}
                                 </TabButton>

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -67,7 +67,7 @@ const COMMUNITY_SECTION_ORDER: SectionType[] = ["all", "text", "image"];
 const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
 
 const SCOPE_LABELS: Record<ModelScope, string> = {
-    pollinations: "Pollinations",
+    pollinations: "Official",
     community: "Community",
 };
 

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -30,9 +30,12 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayCategory } from "./model-categories.ts";
 import { getModelDisplayName } from "./model-info.ts";
-import type { ModelSortDirection, ModelSortKey } from "./model-search.ts";
+import type {
+    ModelScope,
+    ModelSortDirection,
+    ModelSortKey,
+} from "./model-search.ts";
 import {
     type SectionType,
     sectionLabels,
@@ -49,7 +52,7 @@ type ModelsProps = {
     canPublish?: boolean;
 };
 
-const SECTION_ORDER: SectionType[] = [
+const POLLINATIONS_SECTION_ORDER: SectionType[] = [
     "all",
     "image",
     "video",
@@ -57,10 +60,16 @@ const SECTION_ORDER: SectionType[] = [
     "audio",
     "realtime",
     "text",
-    "community-text",
-    "community-image",
     "embedding",
 ];
+
+const COMMUNITY_SECTION_ORDER: SectionType[] = ["all", "text", "image"];
+const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
+
+const SCOPE_LABELS: Record<ModelScope, string> = {
+    pollinations: "Pollinations",
+    community: "Community",
+};
 
 const SEARCH_LABELS: Record<SectionType, string> = {
     all: "all",
@@ -70,8 +79,6 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     audio: "audio",
     realtime: "realtime",
     text: "text",
-    "community-text": "community text",
-    "community-image": "community image",
     embedding: "embedding",
 };
 
@@ -100,15 +107,11 @@ function categorizeModels(
         audio: [],
         realtime: [],
         text: [],
-        "community-text": [],
-        "community-image": [],
         embedding: [],
     };
 
     for (const model of models) {
-        categorized[getModelDisplayCategory(model.type, model.community)].push(
-            model,
-        );
+        categorized[model.type].push(model);
     }
     return categorized;
 }
@@ -119,6 +122,7 @@ export const Models: FC<ModelsProps> = ({
 }) => {
     const navigate = useNavigate({ from: "/models" });
     const modelSearch = useSearch({ from: "/_dashboard/models" });
+    const activeScope = modelSearch.scope ?? "pollinations";
     const activeTab = modelSearch.category ?? "all";
     const urlSearch = modelSearch.q ?? "";
     const [search, setSearch] = useState(urlSearch);
@@ -133,10 +137,20 @@ export const Models: FC<ModelsProps> = ({
         [catalogModels, stats],
     );
     const query = search.trim().toLowerCase();
+    const scopedModels = useMemo(
+        () =>
+            allModels.filter(
+                (model) =>
+                    Boolean(model.community) === (activeScope === "community"),
+            ),
+        [activeScope, allModels],
+    );
     const filteredModels = useMemo(
         () =>
-            query ? allModels.filter((m) => matchesQuery(m, query)) : allModels,
-        [allModels, query],
+            query
+                ? scopedModels.filter((model) => matchesQuery(model, query))
+                : scopedModels,
+        [query, scopedModels],
     );
 
     const loadModelCatalog = useCallback(
@@ -162,7 +176,16 @@ export const Models: FC<ModelsProps> = ({
         () => categorizeModels(filteredModels),
         [filteredModels],
     );
+    const sectionOrder =
+        activeScope === "community"
+            ? COMMUNITY_SECTION_ORDER
+            : POLLINATIONS_SECTION_ORDER;
+    const scopeLabel = SCOPE_LABELS[activeScope];
     const searchLabel = SEARCH_LABELS[activeTab];
+    const searchTarget =
+        activeTab === "all"
+            ? `${scopeLabel} models`
+            : `${scopeLabel} ${searchLabel} models`;
 
     const pushSearch = useCallback(
         (nextSearch: string) => {
@@ -202,6 +225,21 @@ export const Models: FC<ModelsProps> = ({
             search: (previous) => ({
                 ...previous,
                 category: category === "all" ? undefined : category,
+            }),
+        });
+    };
+
+    const setActiveScope = (scope: ModelScope) => {
+        void navigate({
+            search: (previous) => ({
+                ...previous,
+                scope: scope === "pollinations" ? undefined : scope,
+                category:
+                    scope === "community" &&
+                    previous.category !== "text" &&
+                    previous.category !== "image"
+                        ? undefined
+                        : previous.category,
             }),
         });
     };
@@ -256,30 +294,41 @@ export const Models: FC<ModelsProps> = ({
                 }
             >
                 <div className="mb-4 flex flex-col items-start gap-3">
-                    <div className="flex flex-wrap gap-1.5">
-                        {SECTION_ORDER.map((section) => (
-                            <TabButton
-                                key={section}
-                                active={activeTab === section}
-                                onClick={() => setActiveTab(section)}
-                                ariaLabel={
-                                    section === "community-text" ||
-                                    section === "community-image"
-                                        ? `${sectionLabels[section]} alpha models`
-                                        : undefined
-                                }
-                            >
-                                <span className="inline-flex items-center gap-1.5">
+                    <div className="flex flex-col gap-2">
+                        <div className="flex flex-wrap gap-1.5">
+                            {SCOPE_ORDER.map((scope) => (
+                                <TabButton
+                                    key={scope}
+                                    active={activeScope === scope}
+                                    onClick={() => setActiveScope(scope)}
+                                    ariaLabel={
+                                        scope === "community"
+                                            ? "Community alpha models"
+                                            : undefined
+                                    }
+                                >
+                                    <span className="inline-flex items-center gap-1.5">
+                                        {SCOPE_LABELS[scope]}
+                                        {scope === "community" && (
+                                            <Chip intent="alpha" size="sm">
+                                                Alpha
+                                            </Chip>
+                                        )}
+                                    </span>
+                                </TabButton>
+                            ))}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                            {sectionOrder.map((section) => (
+                                <TabButton
+                                    key={section}
+                                    active={activeTab === section}
+                                    onClick={() => setActiveTab(section)}
+                                >
                                     {sectionLabels[section]}
-                                    {(section === "community-text" ||
-                                        section === "community-image") && (
-                                        <Chip intent="alpha" size="sm">
-                                            Alpha
-                                        </Chip>
-                                    )}
-                                </span>
-                            </TabButton>
-                        ))}
+                                </TabButton>
+                            ))}
+                        </div>
                     </div>
                     <div className="relative w-full sm:w-72">
                         <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
@@ -288,8 +337,8 @@ export const Models: FC<ModelsProps> = ({
                             value={search}
                             onChange={(e) => setSearch(e.target.value)}
                             onBlur={() => pushSearch(search)}
-                            placeholder={`Search ${searchLabel} models…`}
-                            aria-label={`Search ${searchLabel} models`}
+                            placeholder={`Search ${searchTarget}…`}
+                            aria-label={`Search ${searchTarget}`}
                             className="w-full pl-9"
                         />
                     </div>
@@ -301,8 +350,7 @@ export const Models: FC<ModelsProps> = ({
                 )}
                 {query && sectionModels[activeTab].length === 0 ? (
                     <p className="py-8 text-center text-sm text-theme-text-muted">
-                        No {sectionLabels[activeTab].toLowerCase()} models match
-                        “{search.trim()}”.
+                        No {searchTarget.toLowerCase()} match “{search.trim()}”.
                     </p>
                 ) : (
                     <div className="overflow-x-auto md:overflow-visible [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
@@ -314,12 +362,6 @@ export const Models: FC<ModelsProps> = ({
                             audioModels={sectionModels.audio}
                             realtimeModels={sectionModels.realtime}
                             textModels={sectionModels.text}
-                            communityTextModels={
-                                sectionModels["community-text"]
-                            }
-                            communityImageModels={
-                                sectionModels["community-image"]
-                            }
                             embeddingModels={sectionModels.embedding}
                             activeTab={activeTab}
                             sortKey={sortKey}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -12,6 +12,7 @@ import {
     TokensIcon,
     TrendUpIcon,
 } from "@pollinations/ui";
+import pollinationsMarkUrl from "@pollinations/ui/brand/mark.svg";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
     type FC,
@@ -69,6 +70,11 @@ const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
 const SCOPE_LABELS: Record<ModelScope, string> = {
     pollinations: "Official",
     community: "Community",
+};
+
+const SCOPE_LOGOS: Record<ModelScope, string> = {
+    pollinations: pollinationsMarkUrl,
+    community: "/brand-logos/community.svg",
 };
 
 const SEARCH_LABELS: Record<SectionType, string> = {
@@ -301,6 +307,7 @@ export const Models: FC<ModelsProps> = ({
                                     key={scope}
                                     active={activeScope === scope}
                                     onClick={() => setActiveScope(scope)}
+                                    size="lg"
                                     ariaLabel={
                                         scope === "community"
                                             ? "Community alpha models"
@@ -308,6 +315,20 @@ export const Models: FC<ModelsProps> = ({
                                     }
                                 >
                                     <span className="inline-flex items-center gap-1.5">
+                                        <span
+                                            aria-hidden="true"
+                                            className="h-5 w-5 shrink-0 bg-current opacity-55"
+                                            style={{
+                                                maskImage: `url(${SCOPE_LOGOS[scope]})`,
+                                                WebkitMaskImage: `url(${SCOPE_LOGOS[scope]})`,
+                                                maskRepeat: "no-repeat",
+                                                WebkitMaskRepeat: "no-repeat",
+                                                maskPosition: "center",
+                                                WebkitMaskPosition: "center",
+                                                maskSize: "contain",
+                                                WebkitMaskSize: "contain",
+                                            }}
+                                        />
                                         {SCOPE_LABELS[scope]}
                                         {scope === "community" && (
                                             <Chip intent="alpha" size="sm">
@@ -324,6 +345,7 @@ export const Models: FC<ModelsProps> = ({
                                     key={section}
                                     active={activeTab === section}
                                     onClick={() => setActiveTab(section)}
+                                    size="sm"
                                 >
                                     {sectionLabels[section]}
                                 </TabButton>

--- a/enter.pollinations.ai/test/model-categories.test.ts
+++ b/enter.pollinations.ai/test/model-categories.test.ts
@@ -80,15 +80,28 @@ describe("model categories", () => {
         ]);
     });
 
-    it("accepts both community category URLs", () => {
-        expect(validateModelSearch({ category: "community-text" })).toEqual({
-            category: "community-text",
+    it("uses a separate community scope with text and image categories", () => {
+        expect(validateModelSearch({ scope: "community" })).toEqual({
+            scope: "community",
+            category: undefined,
             q: undefined,
             sort: undefined,
             dir: undefined,
         });
-        expect(validateModelSearch({ category: "community-image" })).toEqual({
-            category: "community-image",
+        expect(
+            validateModelSearch({ scope: "community", category: "image" }),
+        ).toEqual({
+            scope: "community",
+            category: "image",
+            q: undefined,
+            sort: undefined,
+            dir: undefined,
+        });
+        expect(
+            validateModelSearch({ scope: "community", category: "video" }),
+        ).toEqual({
+            scope: "community",
+            category: undefined,
             q: undefined,
             sort: undefined,
             dir: undefined,

--- a/packages/ui/src/primitives/TabButton.tsx
+++ b/packages/ui/src/primitives/TabButton.tsx
@@ -5,7 +5,7 @@ export type TabButtonProps = {
     active: boolean;
     onClick: () => void;
     children: ReactNode;
-    size?: "md" | "sm";
+    size?: "lg" | "md" | "sm";
     variant?: "soft" | "ghost";
     ariaLabel?: string;
     disabled?: boolean;
@@ -17,6 +17,7 @@ const tabButtonBaseClass =
     "polli-control polli:inline-flex polli:items-center polli:justify-center polli:rounded-full polli:font-medium polli:leading-normal polli:transition-all polli:duration-200";
 
 const tabButtonSizeClass = {
+    lg: "polli:px-5 polli:py-2 polli:text-lg",
     md: "polli:px-4 polli:py-1.5 polli:text-base",
     sm: "polli:px-3 polli:py-1.5 polli:text-sm",
 } as const;


### PR DESCRIPTION
- Separates the model catalog into Official and Community scopes, with Official as the default.
- Limits Community filters to All, Text, and Image while keeping one contextual search.
- Preserves search queries across scopes and resets incompatible modality filters.
- Uses the large Package UI scope controls introduced by #13141.

Stacked on #13141; merge the Package UI PR first.

Checks:
- `npx tsc --noEmit`
- `npx vitest run test/model-categories.test.ts`
- Verified locally and on [staging](https://staging.enter.pollinations.ai/models)