### PR TITLE
feat: add large tab button size

### DIFF
--- a/packages/ui/src/primitives/TabButton.tsx
+++ b/packages/ui/src/primitives/TabButton.tsx
@@ -5,7 +5,7 @@ export type TabButtonProps = {
     active: boolean;
     onClick: () => void;
     children: ReactNode;
-    size?: "md" | "sm";
+    size?: "lg" | "md" | "sm";
     variant?: "soft" | "ghost";
     ariaLabel?: string;
     disabled?: boolean;
@@ -17,6 +17,7 @@ const tabButtonBaseClass =
     "polli-control polli:inline-flex polli:items-center polli:justify-center polli:rounded-full polli:font-medium polli:leading-normal polli:transition-all polli:duration-200";
 
 const tabButtonSizeClass = {
+    lg: "polli:px-5 polli:py-2 polli:text-lg",
     md: "polli:px-4 polli:py-1.5 polli:text-base",
     sm: "polli:px-3 polli:py-1.5 polli:text-sm",
 } as const;


### PR DESCRIPTION
- Adds a reusable `lg` size to the shared Package UI `TabButton`.
- Uses the existing size map without changing the default `md` behavior.
- Enables larger high-level selectors while preserving current tabs.

Checks:
- `npm run typecheck`
- `npm run test`
- `npm run build`