### PR TITLE
feat: add deterministic API model ordering

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -35,10 +35,16 @@ import {
 } from "@shared/db/better-auth.ts";
 import { handleError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
+import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
+import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
+import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import {
     calculateUsageBilling,
     getRegistryModelDefinition,
 } from "@shared/registry/registry.ts";
+import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
 import {
@@ -1611,6 +1617,158 @@ fixtureTest(
                     ]),
                 }),
             ]),
+        );
+    },
+);
+
+fixtureTest(
+    "orders every model catalog for practical discovery",
+    async ({ restrictedApiKey }) => {
+        const ownerGithubUsername = `order-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubUsername: ownerGithubUsername,
+        });
+        const newestDate = new Date("2100-01-02T00:00:00Z");
+        const tiedDate = new Date("2100-01-01T00:00:00Z");
+        for (const [name, createdAt] of [
+            ["newest", newestDate],
+            ["a-tie", tiedDate],
+            ["b-tie", tiedDate],
+        ] as const) {
+            await db.insert(communityEndpointTable).values({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name,
+                description: `Ordering test ${name}`,
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-4.1-mini",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                createdAt,
+                updatedAt: createdAt,
+            });
+        }
+
+        const [allResponse, openaiResponse, textResponse, restrictedResponse] =
+            await Promise.all([
+                SELF.fetch("https://gen.pollinations.ai/models"),
+                SELF.fetch("https://gen.pollinations.ai/v1/models"),
+                SELF.fetch("https://gen.pollinations.ai/text/models"),
+                SELF.fetch("https://gen.pollinations.ai/models", {
+                    headers: {
+                        Authorization: `Bearer ${restrictedApiKey}`,
+                    },
+                }),
+            ]);
+
+        expect(allResponse.status).toBe(200);
+        expect(openaiResponse.status).toBe(200);
+        expect(textResponse.status).toBe(200);
+        expect(restrictedResponse.status).toBe(200);
+
+        type ListedModel = {
+            name: string;
+            category: string;
+            community?: boolean;
+            alpha?: boolean;
+            added_date?: number;
+        };
+        const allModels = (await allResponse.json()) as ListedModel[];
+        const openaiModels = (await openaiResponse.json()) as {
+            data: { id: string }[];
+        };
+        const textModels = (await textResponse.json()) as ListedModel[];
+        const restrictedModels =
+            (await restrictedResponse.json()) as ListedModel[];
+        const officialModels = allModels.filter((model) => !model.community);
+        const communityModels = allModels.filter((model) => model.community);
+        const allNames = allModels.map((model) => model.name);
+
+        expect(allNames).toEqual(openaiModels.data.map((model) => model.id));
+        expect(textModels.map((model) => model.name)).toEqual(
+            allModels
+                .filter((model) => model.category === "text")
+                .map((model) => model.name),
+        );
+        expect(allNames).toEqual([
+            ...officialModels.map((model) => model.name),
+            ...communityModels.map((model) => model.name),
+        ]);
+
+        const categoryOrder = [
+            "text",
+            "image",
+            "video",
+            "3d",
+            "audio",
+            "realtime",
+            "embedding",
+        ];
+        expect([
+            ...new Set(officialModels.map((model) => model.category)),
+        ]).toEqual(
+            categoryOrder.filter((category) =>
+                officialModels.some((model) => model.category === category),
+            ),
+        );
+
+        const defaults: Record<string, string> = {
+            text: DEFAULT_TEXT_MODEL,
+            image: DEFAULT_IMAGE_MODEL,
+            "3d": DEFAULT_3D_MODEL,
+            audio: DEFAULT_AUDIO_MODEL,
+            realtime: DEFAULT_REALTIME_MODEL,
+            embedding: DEFAULT_EMBEDDING_MODEL,
+        };
+        for (const category of categoryOrder) {
+            const models = officialModels.filter(
+                (model) => model.category === category,
+            );
+            const defaultModel = defaults[category];
+            const hasDefault = models.some(
+                (model) => model.name === defaultModel,
+            );
+            if (hasDefault) expect(models[0]?.name).toBe(defaultModel);
+            const remainingModels = hasDefault ? models.slice(1) : models;
+            expect(remainingModels).toEqual(
+                [...remainingModels].sort(
+                    (left, right) =>
+                        Number(left.alpha === true) -
+                            Number(right.alpha === true) ||
+                        (right.added_date ?? 0) - (left.added_date ?? 0) ||
+                        (left.name < right.name
+                            ? -1
+                            : left.name > right.name
+                              ? 1
+                              : 0),
+                ),
+            );
+        }
+
+        expect(communityModels.slice(0, 3)).toMatchObject([
+            {
+                name: communityModelId(ownerGithubUsername, "newest"),
+                added_date: newestDate.getTime(),
+            },
+            {
+                name: communityModelId(ownerGithubUsername, "a-tie"),
+                added_date: tiedDate.getTime(),
+            },
+            {
+                name: communityModelId(ownerGithubUsername, "b-tie"),
+                added_date: tiedDate.getTime(),
+            },
+        ]);
+
+        const restrictedNames = restrictedModels.map((model) => model.name);
+        expect(restrictedNames).toEqual(
+            allNames.filter((name) => restrictedNames.includes(name)),
         );
     },
 );

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1731,11 +1731,11 @@ fixtureTest(
                 (model) => model.category === category,
             );
             const defaultModel = defaults[category];
-            const hasDefault = models.some(
-                (model) => model.name === defaultModel,
-            );
-            if (hasDefault) expect(models[0]?.name).toBe(defaultModel);
-            const remainingModels = hasDefault ? models.slice(1) : models;
+            if (defaultModel !== undefined) {
+                expect(models[0]?.name).toBe(defaultModel);
+            }
+            const remainingModels =
+                defaultModel === undefined ? models : models.slice(1);
             expect(remainingModels).toEqual(
                 [...remainingModels].sort(
                     (left, right) =>

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -83,6 +83,7 @@ export async function getCommunityModelRegistryEntries(
             fallbackModelIds: schema.communityEndpoint.fallbackModelIds,
             disabledAt: schema.communityEndpoint.disabledAt,
             disabledReason: schema.communityEndpoint.disabledReason,
+            createdAt: schema.communityEndpoint.createdAt,
         })
         .from(schema.communityEndpoint)
         .innerJoin(
@@ -118,7 +119,10 @@ export async function getCommunityModelRegistryEntries(
             disabledReason: row.disabledReason,
             ...communityEndpointPrices(row),
         };
-        const definition = communityModelDefinition(communityEndpoint);
+        const definition = communityModelDefinition({
+            ...communityEndpoint,
+            addedDate: row.createdAt.getTime(),
+        });
         return [
             {
                 id: modelId,

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -1,14 +1,20 @@
 import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
+import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
+import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
+import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import {
     type ModelInfo,
     modelInfoFromDefinition,
 } from "@shared/registry/model-info.ts";
+import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import {
     type Category,
     getModels,
     getRegistryModelDefinition,
     type ModelDefinition,
 } from "@shared/registry/registry.ts";
+import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
 import type { EventType } from "@shared/schemas/generation-event.ts";
 import {
     type CommunityModelRegistryEntry,
@@ -29,6 +35,23 @@ const IMAGE_MODEL_ENDPOINTS = [
     "/v1/images/edits",
     "/image/{prompt}",
 ];
+const CATEGORY_ORDER: Record<Category, number> = {
+    text: 0,
+    image: 1,
+    video: 2,
+    "3d": 3,
+    audio: 4,
+    realtime: 5,
+    embedding: 6,
+};
+const DEFAULT_MODELS = new Set<string>([
+    DEFAULT_TEXT_MODEL,
+    DEFAULT_IMAGE_MODEL,
+    DEFAULT_3D_MODEL,
+    DEFAULT_AUDIO_MODEL,
+    DEFAULT_REALTIME_MODEL,
+    DEFAULT_EMBEDDING_MODEL,
+]);
 
 export type GenerationModelEntry = {
     id: string;
@@ -116,12 +139,45 @@ function communityEntryToGenerationEntry(
     };
 }
 
+function compareModelEntries(
+    left: GenerationModelEntry,
+    right: GenerationModelEntry,
+): number {
+    const leftCommunity = left.communityEndpoint !== undefined;
+    const rightCommunity = right.communityEndpoint !== undefined;
+    if (leftCommunity !== rightCommunity) return leftCommunity ? 1 : -1;
+
+    if (!leftCommunity) {
+        const categoryDifference =
+            CATEGORY_ORDER[left.definition.category] -
+            CATEGORY_ORDER[right.definition.category];
+        if (categoryDifference !== 0) return categoryDifference;
+
+        const defaultDifference =
+            Number(DEFAULT_MODELS.has(right.id)) -
+            Number(DEFAULT_MODELS.has(left.id));
+        if (defaultDifference !== 0) return defaultDifference;
+
+        const alphaDifference =
+            Number(left.definition.alpha === true) -
+            Number(right.definition.alpha === true);
+        if (alphaDifference !== 0) return alphaDifference;
+    }
+
+    const addedDateDifference =
+        right.definition.addedDate - left.definition.addedDate;
+    if (addedDateDifference !== 0) return addedDateDifference;
+    return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+}
+
 function buildRegistry(
     sourceEntries: GenerationModelEntry[],
 ): GenerationModelRegistry {
     // Link on copies: STATIC_ENTRIES is module-level and shared across registry
     // rebuilds, so resolution must never mutate the originals.
-    const entries = sourceEntries.map((entry) => ({ ...entry }));
+    const entries = sourceEntries
+        .map((entry) => ({ ...entry }))
+        .sort(compareModelEntries);
     const byIdOrAlias = new Map<string, GenerationModelEntry>();
     for (const entry of entries) {
         if (!byIdOrAlias.has(entry.id)) {

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -44,14 +44,14 @@ const CATEGORY_ORDER: Record<Category, number> = {
     realtime: 5,
     embedding: 6,
 };
-const DEFAULT_MODELS = new Set<string>([
-    DEFAULT_TEXT_MODEL,
-    DEFAULT_IMAGE_MODEL,
-    DEFAULT_3D_MODEL,
-    DEFAULT_AUDIO_MODEL,
-    DEFAULT_REALTIME_MODEL,
-    DEFAULT_EMBEDDING_MODEL,
-]);
+const DEFAULT_MODEL_BY_CATEGORY: Partial<Record<Category, string>> = {
+    text: DEFAULT_TEXT_MODEL,
+    image: DEFAULT_IMAGE_MODEL,
+    "3d": DEFAULT_3D_MODEL,
+    audio: DEFAULT_AUDIO_MODEL,
+    realtime: DEFAULT_REALTIME_MODEL,
+    embedding: DEFAULT_EMBEDDING_MODEL,
+};
 
 export type GenerationModelEntry = {
     id: string;
@@ -153,9 +153,11 @@ function compareModelEntries(
             CATEGORY_ORDER[right.definition.category];
         if (categoryDifference !== 0) return categoryDifference;
 
+        const defaultModel =
+            DEFAULT_MODEL_BY_CATEGORY[left.definition.category];
         const defaultDifference =
-            Number(DEFAULT_MODELS.has(right.id)) -
-            Number(DEFAULT_MODELS.has(left.id));
+            Number(right.id === defaultModel) -
+            Number(left.id === defaultModel);
         if (defaultDifference !== 0) return defaultDifference;
 
         const alphaDifference =
@@ -175,9 +177,9 @@ function buildRegistry(
 ): GenerationModelRegistry {
     // Link on copies: STATIC_ENTRIES is module-level and shared across registry
     // rebuilds, so resolution must never mutate the originals.
-    const entries = sourceEntries
-        .map((entry) => ({ ...entry }))
-        .sort(compareModelEntries);
+    const entries = sourceEntries.map((entry) => ({ ...entry }));
+    // Build lookup keys before presentation sorting so duplicate aliases keep
+    // their declaration-order, first-wins resolution behavior.
     const byIdOrAlias = new Map<string, GenerationModelEntry>();
     for (const entry of entries) {
         if (!byIdOrAlias.has(entry.id)) {
@@ -192,6 +194,7 @@ function buildRegistry(
         }
     }
     linkFallbackEntries(entries, byIdOrAlias);
+    entries.sort(compareModelEntries);
 
     return {
         resolve: (model) => {

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -291,24 +291,6 @@ async function getVisibleVideoModelEntries(c: Context<Env>) {
     ).filter((entry) => entry.definition.category === "video");
 }
 
-async function getOrderedVisibleModelEntries(c: Context<Env>) {
-    const entries = await getVisibleModelEntries(c);
-    return [
-        ...entries.filter(
-            (entry) =>
-                entry.eventType === "generate.text" && !entry.communityEndpoint,
-        ),
-        ...entries.filter(
-            (entry) =>
-                entry.eventType === "generate.text" && entry.communityEndpoint,
-        ),
-        ...entries.filter((entry) => entry.eventType === "generate.image"),
-        ...entries.filter((entry) => entry.eventType === "generate.realtime"),
-        ...entries.filter((entry) => entry.eventType === "generate.audio"),
-        ...entries.filter((entry) => entry.eventType === "generate.embedding"),
-    ];
-}
-
 export const proxyRoutes = new Hono<Env>()
     // Edge rate limiter: first line of defense (10 req/s per IP)
     .use("*", edgeRateLimit)
@@ -327,7 +309,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                "Returns available models (text, community text/image, image, realtime, audio, embeddings) in the OpenAI-compatible format (`{object: \"list\", data: [...]}`). Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns available models in the OpenAI-compatible format (`{object: \"list\", data: [...]}`). Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
             responses: {
                 200: {
                     description: "Success",
@@ -344,7 +326,7 @@ export const proxyRoutes = new Hono<Env>()
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
             const modelEntries = filterEntriesByPermissions(
-                await getOrderedVisibleModelEntries(c),
+                await getVisibleModelEntries(c),
                 allowedModels,
                 paidBalance,
             );
@@ -378,7 +360,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available text, community text/image, image, video, 3D, realtime, audio, and embedding models with pricing, capabilities, and metadata. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
             responses: {
                 200: {
                     description: "Success",
@@ -396,7 +378,7 @@ export const proxyRoutes = new Hono<Env>()
                 ...errorResponseDescriptions(500),
             },
         }),
-        modelsListHandler(getOrderedVisibleModelEntries),
+        modelsListHandler(getVisibleModelEntries),
     )
     .get(
         "/3d/models",

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -176,11 +176,11 @@ test("filters paid-only audio models by paid balance", async ({
 
     expect(expectedFreeModelNames.length).toBeGreaterThan(0);
     expect(expectedPaidOnlyModelNames.length).toBeGreaterThan(0);
-    expect(freeModels.map((model) => model.name)).toEqual(
-        expectedFreeModelNames,
+    expect(new Set(freeModels.map((model) => model.name))).toEqual(
+        new Set(expectedFreeModelNames),
     );
-    expect(paidModels.map((model) => model.name)).toEqual(
-        expectedPaidModelNames,
+    expect(new Set(paidModels.map((model) => model.name))).toEqual(
+        new Set(expectedPaidModelNames),
     );
     expect(freeModels.some((model) => model.paid_only)).toBe(false);
     expect(paidModels.some((model) => model.paid_only)).toBe(true);

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -311,6 +311,7 @@ export type CommunityEndpointRuntime = {
 
 export type CommunityModelDefinitionInput = {
     modelId: string;
+    addedDate?: number;
     title?: string | null;
     description: string | null;
     providerName?: string | null;
@@ -539,7 +540,7 @@ export function communityModelDefinition(
         category: isImage ? "image" : "text",
         cost: communityPriceDefinition(endpoint, modality, imagePricing),
         priceMultiplier: 1,
-        addedDate: 0,
+        addedDate: endpoint.addedDate ?? 0,
         title: communityEndpointTitle(endpoint),
         description: description || undefined,
         inputModalities,


### PR DESCRIPTION
- Orders Official models by modality: text, image, video, 3D, audio, realtime, then embedding.
- Places each category’s configured default first, then stable models before alpha/preview models, with newest additions first and model ID as the final tie-break.
- Places Community models after Official models, ordered by registration date and then model ID; Community creation time is exposed through existing `added_date` metadata.
- Applies ordering once in the generation registry so `/models`, `/v1/models`, modality catalogs, visibility, permission, and balance filters preserve the same sequence.
- Keeps alias resolution tied to declaration order, independent of catalog presentation sorting.

Visible ordering changes: Community text models move from the second group to the end, and audio now appears before realtime.

Checks: `npx vitest run src/community-endpoints.test.ts`; `npx vitest run test/openapi-json.test.ts`; `npm run typecheck`; Biome on changed files.