### PR TITLE
feat: show app screenshots in website v2

### DIFF
--- a/pollinations.ai/src/data/publicStats.ts
+++ b/pollinations.ai/src/data/publicStats.ts
@@ -11,11 +11,12 @@ const TINYBIRD = "https://api.europe-west2.gcp.tinybird.co/v0/pipes";
 const PUBLIC_READ_TOKEN =
     "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
 
-/** One row of the community app directory — i.e. a row of apps/APPS.md. */
+/** One row of the community app directory synced from apps/catalog.json. */
 export type DirectoryApp = {
     emoji: string;
     name: string;
     web_url: string;
+    screenshot_url: string;
     description: string;
     language: string;
     category: string;

--- a/pollinations.ai/src/routes/apps.tsx
+++ b/pollinations.ai/src/routes/apps.tsx
@@ -225,7 +225,7 @@ function AppsPage() {
                                     ? `by ${lead.github_username}`
                                     : "community built"
                             }
-                            image={appCover(lead.name)}
+                            image={appCover(lead.name, lead.screenshot_url)}
                             action={
                                 <span className="text-sm font-semibold text-theme-text-soft">
                                     Open ↗

--- a/pollinations.ai/src/ui/apps/cards.tsx
+++ b/pollinations.ai/src/ui/apps/cards.tsx
@@ -9,7 +9,7 @@ import {
     platformsOf,
 } from "../../data/publicStats";
 import { ArrowLink, Card, PixelBadge } from "../site/kit";
-import { appCover } from "./cover";
+import { appCover, isAppScreenshot } from "./cover";
 
 /**
  * The three shapes an app takes on this site. They live together because
@@ -38,7 +38,7 @@ export function AppTile({
     imageClassName?: string;
     className?: string;
 }) {
-    const cover = appCover(app.name);
+    const cover = appCover(app.name, app.screenshot_url);
 
     return (
         <Card
@@ -56,7 +56,7 @@ export function AppTile({
                     loading="lazy"
                     width={1200}
                     height={600}
-                    className={`block w-full bg-theme-bg-subtle object-cover ${imageClassName}`}
+                    className={`block w-full bg-theme-bg-subtle object-cover ${isAppScreenshot(cover) ? "object-top" : "object-center"} ${imageClassName}`}
                 />
             ) : (
                 <div
@@ -113,7 +113,7 @@ export function AppHero({
                     loading="lazy"
                     width={1200}
                     height={600}
-                    className="block aspect-[2/1] w-full bg-theme-bg-subtle object-cover sm:h-60 sm:aspect-auto"
+                    className={`block aspect-[2/1] w-full bg-theme-bg-subtle object-cover sm:h-60 sm:aspect-auto ${isAppScreenshot(image) ? "object-top" : "object-center"}`}
                 />
             ) : (
                 <div

--- a/pollinations.ai/src/ui/apps/cover.ts
+++ b/pollinations.ai/src/ui/apps/cover.ts
@@ -1,9 +1,9 @@
 import COVERS from "./covers.json";
 
 /**
- * Cover art for app cards — one unique image per app, generated from that
- * app's own name and description by scripts/generate-app-art.mjs and committed
- * under public/app-art/.
+ * Real product screenshots come from the public app directory. Generated art
+ * committed under public/app-art/ remains the fallback for apps that do not
+ * have a screenshot yet.
  *
  * Static, not generated at page load: anonymous generation is no longer
  * possible (the legacy prompt endpoint 403s, gen 401s, and the site's
@@ -11,13 +11,14 @@ import COVERS from "./covers.json";
  * would mean seven generations per Apps view, seconds each, billed to whatever
  * key sat in the markup.
  *
- * Only apps that can reach an image slot have art — the spotlight, and the top
- * of the directory that Hello's shelf and the Apps hero read from. Anything
- * else returns null and the card renders without a picture rather than
- * borrowing someone else's. Re-run the script when the directory shifts.
+ * Only apps that can reach an image slot need generated fallback art. Anything
+ * without a screenshot or generated fallback renders without a picture rather
+ * than borrowing someone else's.
  */
 
 const HAS_COVER = new Set<string>(COVERS);
+const PLAYGROUND_SCREENSHOT =
+    "https://media.pollinations.ai/7158f20b-4d9c-4026-a6f9-9fe452064a7a";
 
 /** Must match slugify() in scripts/generate-app-art.mjs. */
 function coverSlug(name: string): string {
@@ -28,7 +29,14 @@ function coverSlug(name: string): string {
         .slice(0, 60);
 }
 
-export function appCover(name: string): string | null {
+export function appCover(name: string, screenshotUrl = ""): string | null {
+    if (screenshotUrl) return screenshotUrl;
+    if (name === "Pollinations Playground") return PLAYGROUND_SCREENSHOT;
+
     const slug = coverSlug(name);
     return HAS_COVER.has(slug) ? `/app-art/${slug}.webp` : null;
+}
+
+export function isAppScreenshot(src: string | null): boolean {
+    return src?.startsWith("https://media.pollinations.ai/") ?? false;
 }

--- a/pollinations.ai/src/ui/home/LiveApps.tsx
+++ b/pollinations.ai/src/ui/home/LiveApps.tsx
@@ -20,7 +20,7 @@ export function LiveApps() {
                     (app) =>
                         isBuzz(app) &&
                         Boolean(app.description) &&
-                        appCover(app.name) !== null,
+                        appCover(app.name, app.screenshot_url) !== null,
                 )
                 .slice()
                 .sort(sortApps)


### PR DESCRIPTION
- Reads the new `screenshot_url` field from the public app directory.
- Uses real product screenshots for Apps cards, the hand-picked hero, and the Hello app shelf.
- Uses the official Playground screenshot and keeps generated app art as the fallback when no screenshot exists.
- Top-aligns product screenshots so their navigation and primary UI remain visible inside card crops.

Validation:
- `npx biome check --write` on all changed files
- `npm run build` in `pollinations.ai`
- Browser checks on `/` and `/apps`: all media screenshots loaded at 1200×600 with no console warnings or errors

Depends on #13142, which is merged and synced to Tinybird production.
