### PR TITLE
fix: restore long Portkey request timeout

### DIFF
--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -96,6 +96,23 @@ function upstreamStatus(failure: UpstreamFailure): number | undefined {
     return typeof status === "number" ? status : undefined;
 }
 
+/** The deadline we send to Portkey is the request's terminal time budget. */
+function isPortkeyRequestTimeout(failure: UpstreamFailure): boolean {
+    if (upstreamStatus(failure) !== 408) return false;
+    const details = failure.details;
+    if (!details || typeof details !== "object") return false;
+    const error = (details as { error?: unknown }).error;
+    if (!error || typeof error !== "object") return false;
+    const timeoutError = error as { message?: unknown; type?: unknown };
+    return (
+        timeoutError.type === "timeout_error" &&
+        typeof timeoutError.message === "string" &&
+        timeoutError.message.startsWith(
+            "Request exceeded the timeout sent in the request:",
+        )
+    );
+}
+
 /**
  * Every place a provider might have put its reason. Content-policy detection is
  * a case-insensitive substring match, so the whole details bag is worth handing
@@ -136,6 +153,10 @@ export function isRetryableFallbackError(error: unknown): boolean {
     const failure = error as UpstreamFailure;
     const status = upstreamStatus(failure);
     if (!status) return false;
+    // A generic provider 408 can benefit from a fallback. Portkey's exact
+    // timeout envelope is our own total deadline and must not multiply across
+    // fallback candidates.
+    if (isPortkeyRequestTimeout(failure)) return false;
     // A dead endpoint reaches us as the gateway's own 400 rather than as a
     // network error, because the gateway is the one that could not connect.
     if (

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -24,6 +24,10 @@ const clientConfig = {
     },
 };
 
+// Portkey applies this millisecond deadline per attempt until provider response
+// headers arrive. Keep retries disabled unless the total deadline is reconsidered.
+const PORTKEY_REQUEST_TIMEOUT_MS = 290_000;
+
 function buildEndpoint(gatewayUrl: unknown): string {
     const base =
         typeof gatewayUrl === "string" && gatewayUrl
@@ -63,10 +67,13 @@ export async function generateTextPortkey(
     const requestConfig = {
         ...clientConfig,
         endpoint: () => buildEndpoint(portkeyGatewayUrl),
-        additionalHeaders: (state.options.additionalHeaders || {}) as Record<
-            string,
-            string
-        >,
+        additionalHeaders: {
+            "x-portkey-request-timeout": String(PORTKEY_REQUEST_TIMEOUT_MS),
+            ...((state.options.additionalHeaders || {}) as Record<
+                string,
+                string
+            >),
+        },
         fetcher,
     };
 

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -170,6 +170,23 @@ describe("isRetryableFallbackError", () => {
         );
     });
 
+    it("does not multiply the owned Portkey timeout across fallbacks", () => {
+        expect(
+            isRetryableFallbackError(
+                textFailure(408, {
+                    error: {
+                        message:
+                            "Request exceeded the timeout sent in the request: 290000ms",
+                        type: "timeout_error",
+                        param: null,
+                        code: null,
+                    },
+                }),
+            ),
+        ).toBe(false);
+        expect(isRetryableFallbackError(textFailure(408))).toBe(true);
+    });
+
     it("does not fail over on caller errors", () => {
         expect(isRetryableFallbackError(textFailure(400))).toBe(false);
         expect(isRetryableFallbackError(new HttpError("bad input", 422))).toBe(

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateTextPortkey } from "../../src/text/generateTextPortkey.js";
+
+describe("generateTextPortkey", () => {
+    it("sets an owned request deadline below the public gateway limit", async () => {
+        const fetcher = vi.fn(
+            async (_input: RequestInfo | URL, init?: RequestInit) => {
+                const headers = new Headers(init?.headers);
+                expect(headers.get("x-portkey-request-timeout")).toBe("290000");
+                expect(headers.get("x-portkey-strict-open-ai-compliance")).toBe(
+                    "false",
+                );
+
+                return Response.json({
+                    model: "provider-model",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                });
+            },
+        );
+
+        const completion = await generateTextPortkey(
+            [{ role: "user", content: "hello" }],
+            {
+                model: "provider-model",
+                modelConfig: {
+                    provider: "openai",
+                    model: "provider-model",
+                },
+                portkeyGatewayUrl: "https://portkey.test",
+            },
+            fetcher,
+        );
+
+        expect(fetcher).toHaveBeenCalledOnce();
+        expect(completion.choices?.[0]?.message?.content).toBe("ok");
+    });
+});

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -76,10 +76,6 @@ custom_domain = true
 binding = "ENTER"
 service = "pollinations-enter-production"
 
-[[env.production.services]]
-binding = "PORTKEY"
-service = "rubeus-pollinations"
-
 [[env.production.vpc_networks]]
 binding = "KLEIN_VPC"
 tunnel_id = "c340d8d9-c1f3-4a13-8115-38b59faac3d5"
@@ -145,10 +141,6 @@ custom_domain = true
 [[env.staging.services]]
 binding = "ENTER"
 service = "pollinations-enter-staging"
-
-[[env.staging.services]]
-binding = "PORTKEY"
-service = "rubeus-dev"
 
 [[env.staging.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
- Removes the production and staging Portkey service bindings, restoring the public `portkey.myceli.ai` route and its ~300s provider-read allowance.
- Sends `x-portkey-request-timeout: 290000` so silent providers return a structured 408 before Cloudflare emits a 524.
- Treats that exact Portkey timeout envelope as terminal, preventing the owned deadline from multiplying across model fallbacks; ordinary provider 408s can still fall back.
- Staging verification: `staging.gen.pollinations.ai` returned 200 after 203.44s; the paired `staging.gen.myceli.ai` request returned JSON 408 after 290.33s. Both survived the former ~125s boundary.
- Validation: 38 focused tests, typecheck, staging build, and `git diff --check`.