### PR TITLE
chore: sync main into production

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
   
   <p><strong>Open-source AI for people who make things.</strong></p>
 
-[![Stars](https://img.shields.io/github/stars/pollinations/pollinations?style=flat-square&logo=github)](https://github.com/pollinations/pollinations/stargazers)
-[![License](https://img.shields.io/github/license/pollinations/pollinations?style=flat-square)](LICENSE)
-[![Discord](https://img.shields.io/discord/885844321461485618?style=flat-square&logo=discord&label=Discord&color=5865F2)](https://discord.gg/pollinations-ai-885844321461485618)
+[![Stars](https://img.shields.io/github/stars/pollinations/pollinations?style=for-the-badge&logo=github)](https://github.com/pollinations/pollinations/stargazers)
+[![License](https://img.shields.io/github/license/pollinations/pollinations?style=for-the-badge)](LICENSE)
+[![Discord](https://img.shields.io/discord/885844321461485618?style=for-the-badge&logo=discord&label=Discord&color=5865F2)](https://discord.gg/pollinations-ai-885844321461485618)
 
-[Website](https://pollinations.ai) · [Dashboard](https://enter.pollinations.ai) · [API Docs](APIDOCS.md) · [Discord](https://discord.gg/pollinations-ai-885844321461485618)
+[Website](https://pollinations.ai) · [Dashboard](https://enter.pollinations.ai) · [Playground](https://pollinations.ai/play) · [API Docs](APIDOCS.md) · [Discord](https://discord.gg/pollinations-ai-885844321461485618)
 
 </div>
 
@@ -32,11 +32,11 @@
 | [🖼️ Sparkle Studio](https://sparkle-studio-pollinations-a031.onbelmo.uk) | Draw jewelry, then make it sparkle. A playful web app for kids: sketch a piece of jewelry (or just describe it), and an AI turns it into a polished, photorealistic render. Powered entirely by Pollinat | [@mtonk](https://github.com/mtonk) |
 
 [Browse all apps →](apps/GREENHOUSE.md)
-## 🚀 New Unified API — Now Live
+## 🚀 Unified API
 
 We've launched **https://gen.pollinations.ai** — a single endpoint for all your AI generation needs: text, images, audio, video, 3D, embeddings — all in one place.
 
-### What's New
+### What's Included
 
 - **Unified endpoint** — single API at `gen.pollinations.ai` for all generation
 - **Pollen credits** — simple pay-as-you-go system ($1 ≈ 1 Pollen)
@@ -68,12 +68,13 @@ We've launched **https://gen.pollinations.ai** — a single endpoint for all you
 
 - 🔓 **100% Open Source** — code, decisions, roadmap all public
 - 🤝 **Community-Built** — 500+ projects already using our APIs
-- 🌱 **Pollen Quests** — earn Pollen by completing Quests (in alpha)
+- 🌱 **Pollen Quests** — earn Pollen by completing Quests
 - 🖼️ **Image Generation** — Text-to-image and image editing
 - 📝 **Text Generation** — Chat, reasoning, vision, function calling, structured outputs 
 - 🎬 **Video Generation** — Text-to-video and image-to-video
 - 🎵 **Audio** — Text-to-speech and speech-to-text
 - 🧊 **3D Generation** — Text-to-3D and image-to-3D
+- 🎙️ **Real-time API** — OpenAI-compatible WebSocket for streaming conversations
 - 🔢 **Embeddings Creation** — Semantic search, retrieval, similarity matching
 - 🎣 **_Easy-to-use Packages_** ([Packages](packages/))
 
@@ -84,6 +85,20 @@ We've launched **https://gen.pollinations.ai** — a single endpoint for all you
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=pollinations/pollinations&type=Date" width="600" />
  </picture>
 </a>
+
+## 🧩 Community Models
+
+Community members run their own models on the Pollinations platform — text, image, video, audio, embeddings, and more.
+
+- **Host your own model** — register an upstream endpoint with the [`/account/my-models`](APIDOCS.md) API, then serve it to everyone or keep it private to your account.
+- **Automatic fallback routing** — nominate up to three compatible backup models so generations keep moving when an upstream model goes down.
+- **Discover and monitor** — browse community models via [gen.pollinations.ai/v1/models](https://gen.pollinations.ai/v1/models) and watch live health and community leaderboards at [model-monitor.pollinations.ai](https://model-monitor.pollinations.ai).
+
+For billing details when building apps on top, see [Bring Your Own Pollen](./BRING_YOUR_OWN_POLLEN.md).
+
+## 🚀 Getting Started
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pollinations/pollinations)
 
 ### Quick Start (3 Steps)
 
@@ -102,23 +117,18 @@ Pollinations supports:
 3️⃣ **Make your first request**  
 Use one of the examples below to generate your first AI output in seconds.
 
-
-## 🚀 Getting Started
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pollinations/pollinations)
-
 ### Image Generation
 
 ```bash
-curl 'https://gen.pollinations.ai/image/a%20beautiful%20sunset' -o image.jpg
+curl -H "Authorization: Bearer YOUR_API_KEY" 'https://gen.pollinations.ai/image/a%20beautiful%20sunset' -o image.jpg
 ```
 
-Or visit [pollinations.ai](https://pollinations.ai) for an interactive experience.
+Or visit [pollinations.ai/play](https://pollinations.ai/play) for an interactive experience.
 
 ### Text Generation
 
 ```bash
-curl 'https://gen.pollinations.ai/text/Hello%20world'
+curl 'https://gen.pollinations.ai/text/Hello%20world?key=YOUR_API_KEY'
 ```
 
 ### Audio Generation
@@ -140,6 +150,66 @@ curl 'https://gen.pollinations.ai/v1/audio/speech' \
 ```
 
 Available voices: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`, plus [30+ ElevenLabs voices](https://gen.pollinations.ai/docs).
+
+**Speech-to-text:**
+
+```bash
+curl 'https://gen.pollinations.ai/v1/audio/transcriptions' \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F file=@audio.mp3 \
+  -F model=whisper-large-v3
+```
+
+### Video Generation
+
+```bash
+curl 'https://gen.pollinations.ai/video/a%20sunset%20timelapse%20over%20the%20ocean?key=YOUR_API_KEY' -o video.mp4
+```
+
+Use `duration` to set video length, `aspectRatio` for orientation, and `image[0]`/`image[1]` to pass start/end reference frames. See available video models and capabilities at [gen.pollinations.ai/video/models](https://gen.pollinations.ai/video/models).
+
+### 3D Generation
+
+```bash
+curl 'https://gen.pollinations.ai/3d/a%20low-poly%20treasure%20chest?model=trellis-2&resolution=low&key=YOUR_API_KEY&image=IMAGE_URL' -o model.glb
+```
+
+Pass reference image URL(s) via the `image` parameter for image-to-3D models (put `image=` last in the URL, or URL-encode it). See available 3D models at [gen.pollinations.ai/3d/models](https://gen.pollinations.ai/3d/models).
+
+### Embeddings
+
+```bash
+curl 'https://gen.pollinations.ai/v1/embeddings' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -d '{"model": "openai-3-small", "input": "Hello world!"}'
+```
+
+Pass a string or an array of up to 32 strings (text or multimodal content parts). See available embedding models at [gen.pollinations.ai/embeddings/models](https://gen.pollinations.ai/embeddings/models).
+
+### Pollinations CLI
+
+Generate text, images, audio, video, and more right from your terminal:
+
+```bash
+npx @pollinations/cli gen image "cyberpunk city at night" --model flux --output city.png
+npx @pollinations/cli gen text "Explain quantum tunneling in one sentence"
+npx @pollinations/cli gen audio "Hello world" --voice nova --output speech.mp3
+npx @pollinations/cli gen video "a waterfall in slow motion" --duration 5 --output clip.mp4
+npx @pollinations/cli gen transcribe speech.mp3
+```
+
+Install globally and use the shorter `polli` command: `npm install -g @pollinations/cli`. Run `polli models` to list models, `polli auth login` to authenticate, and `polli docs` for the full API reference in your terminal.
+
+### Real-time API
+
+Stream AI responses over an OpenAI-compatible WebSocket:
+
+```
+wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2.1&key=pk_YOUR_API_KEY
+```
+
+Browser clients pass the key as a query parameter (`?key=`); server clients can use the `Authorization: Bearer` header instead.
 
 ### MCP Server for AI Assistants
 
@@ -166,7 +236,7 @@ Add this to your MCP client configuration:
 npx @pollinations/mcp
 ```
 
-Community alternatives like [MCPollinations](https://github.com/pinkpixel-dev/MCPollinations) and [Sequa MCP Server](https://mcp.sequa.ai/v1/pollinations/contribute) are also available.
+A community alternative, [MCPollinations](https://github.com/pinkpixel-dev/MCPollinations), is also available.
 
 AI assistants can:
 
@@ -176,7 +246,7 @@ AI assistants can:
 - Access all pollinations.ai models and services
 - List available models, voices, and capabilities
 
-**For more advanced usage, check out our [API documentation](APIDOCS.md).**
+**For more advanced usage, check out our full API docs — [APIDOCS.md](./APIDOCS.md) or the live docs at [gen.pollinations.ai/docs](https://gen.pollinations.ai/docs).**
 
 ## 🔐 Authentication
 
@@ -220,64 +290,72 @@ See [full API docs](APIDOCS.md) for detailed authentication information.
 
 Our web interface is user-friendly and doesn't require any technical knowledge. Simply visit [https://pollinations.ai](https://pollinations.ai) and start creating!
 
-### API
-
-Use our API directly in your browser or applications:
-
-    https://pollinations.ai/p/a_cozy_pixel_art_robot_and_bee_in_a_digital_garden_8-bit_warm_stardew_valley_vibes
-
-Replace the description with your own, and you'll get a unique image based on your words!
-
-Here's an example of a generated image:
+Here are some examples of what you can generate:
 
 <p align="center"><img src="https://media.pollinations.ai/9e0df3b04d27666c" alt="Pixel art robot and bee in a cozy digital garden — Stardew Valley vibes" width="800" /></p>
 
 <p align="center"><img src="https://media.pollinations.ai/ec34c8a3c45c42d9" alt="Robot holding generated image saying I CAN SEE, nomnom creature eating prompt text" width="800" /></p>
-
-## 🎨 Examples
-
-### Image Generation
-
-Python code to download the generated image:
-
-    import requests
-
-    def download_image(prompt):
-        url = f"https://pollinations.ai/p/{prompt}"
-        response = requests.get(url)
-        with open('generated_image.jpg', 'wb') as file:
-            file.write(response.content)
-        print('Image downloaded!')
-
-    download_image("a_cozy_pixel_art_robot_and_bee_in_a_digital_garden_8-bit_warm_stardew_valley_vibes")
-
-### Text Generation
-
-To generate text:
-
-    https://gen.pollinations.ai/text/What%20is%20artificial%20intelligence?
-
-### Audio Generation
-
-Generate speech from text:
-
-    https://gen.pollinations.ai/audio/Hello%20from%20Pollinations?voice=alloy&key=YOUR_API_KEY
-
-Or use the OpenAI TTS-compatible endpoint:
-
-```bash
-curl 'https://gen.pollinations.ai/v1/audio/speech' \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer YOUR_API_KEY' \
-  -d '{"model": "tts-1", "input": "Hello from Pollinations!", "voice": "alloy"}' \
-  -o speech.mp3
-```
 
 ## 🛠️ Integration
 
 ### SDK
 
 Check out our [Pollinations SDK](./packages/sdk/README.md) for Node.js, browser, and React integration.
+
+### OpenAI SDK Compatibility
+
+The API is OpenAI-compatible, so the official OpenAI SDKs work out of the box — just point them at `https://gen.pollinations.ai/v1`.
+
+**Node.js:**
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://gen.pollinations.ai/v1",
+  apiKey: "YOUR_API_KEY",
+});
+
+const response = await client.chat.completions.create({
+  model: "openai",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(response.choices[0].message.content);
+```
+
+**Python:**
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://gen.pollinations.ai/v1", api_key="YOUR_API_KEY")
+
+response = client.chat.completions.create(
+    model="openai",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+Other OpenAI SDKs work too: [Go](https://github.com/openai/openai-go), [Java](https://github.com/openai/openai-java), [.NET](https://github.com/openai/openai-dotnet), [Rust (async-openai, community)](https://github.com/64bit/async-openai) — plus compatible frameworks like [Vercel AI SDK](https://ai-sdk.dev/).
+
+**Vercel AI SDK:**
+
+```typescript
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+const client = createOpenAI({
+  baseURL: "https://gen.pollinations.ai/v1",
+  apiKey: "YOUR_API_KEY",
+});
+
+const { text } = await generateText({
+  model: client("openai"),
+  prompt: "Hello!",
+});
+console.log(text);
+```
 
 ## Architecture
 
@@ -301,21 +379,14 @@ graph LR
     R --> GEN
     MCP --> GEN
 
-    GEN["gen.pollinations.ai"]:::cfWorker --> ENTER["enter.pollinations.ai Gateway"]:::cfWorker
+    GEN["gen.pollinations.ai — Edge Router + Generation Worker"]:::cfWorker -->|auth and billing| ENTER["enter.pollinations.ai — Auth Gateway + Billing"]:::cfWorker
 
-    ENTER --> IMG["Image Service"]:::ec2
-    ENTER --> AUD["Audio Service"]:::ec2
+    GEN --> IMG["Image — gen Worker dispatch to providers / GPU backends"]:::cfWorkerLight
+    IMG --> D["Flux, Z-Image, Seedream, ... — GPU VMs"]:::gpuNode
 
-    IMG --> CF["Cloudflare Worker with R2 Cache"]:::cfWorkerLight
-    CF --> B["image-origin.pollinations.ai"]:::ec2
-    B --> D["FLUX / GPT Image / Seedream - GPU VMs"]:::gpuNode
-
-    AUD --> EL["ElevenLabs TTS API"]:::provider
-
-    GEN --> SC["Scaleway API"]:::provider
-    GEN --> DS["Deepseek API"]:::provider
-    GEN --> G["Azure-hosted LLMs"]:::provider
-    GEN --> CFM["Cloudflare AI"]:::provider
+    GEN --> TXT["Text — Portkey multi-provider"]:::provider
+    GEN --> VID["Video — Wan / Veo / Seedance"]:::provider
+    GEN --> AUD["Audio — ElevenLabs / OVH (Whisper)"]:::provider
 
     style CLIENTS fill:none,stroke:#888,stroke-width:2px,stroke-dasharray: 5 5
 
@@ -323,7 +394,6 @@ graph LR
 
     classDef cfWorker fill:#E65100,color:#fff,stroke:#FFB300,stroke-width:2px,font-weight:bold
     classDef cfWorkerLight fill:#BF360C,color:#fff,stroke:#FFB300,stroke-width:1px
-    classDef ec2 fill:#1F2937,color:#fff,stroke:#F59E0B,stroke-width:2px
     classDef gpuNode fill:#064E3B,stroke:#34D399,color:#ECFDF5,stroke-width:2px
     classDef provider fill:#1E3A8A,stroke:#60A5FA,color:#EFF6FF,stroke-width:1px
 ```
@@ -356,11 +426,11 @@ We're committed to developing AI technology that serves humanity while respectin
 
 We believe in community-driven development. You can contribute to pollinations.ai in several ways:
 
-1. **Coding Assistant**: The easiest way to contribute! Just [create a GitHub issue](https://github.com/pollinations/pollinations/issues/new) describing the feature you'd like to see implemented. The [MentatBot AI assistant](https://mentat.ai/) will analyze and implement it directly! No coding required - just describe what you want.
+1. **Coding Assistant**: The easiest way to contribute! Just [create a GitHub issue](https://github.com/pollinations/pollinations/issues/new) describing the feature you'd like to see implemented. The Polli assistant will analyze and implement it directly! No coding required - just describe what you want.
 
 2. **Project Submissions**: Have you built something with pollinations.ai? [Use our app submission template](https://github.com/pollinations/pollinations/issues/new?template=app-submission.yml) to share it with the community and get it featured in our README.
 
-3. **Feature Requests & Bug Reports**: Have an idea or found a bug? [Open an issue](https://github.com/pollinations/pollinations/issues/new) and let us know. Our team and the MentatBot assistant will review it.
+3. **Feature Requests & Bug Reports**: Have an idea or found a bug? [Open an issue](https://github.com/pollinations/pollinations/issues/new) and let us know. Our team and the Polli assistant will review it.
 
 4. **Community Engagement**: Join our vibrant [Discord community](https://discord.gg/pollinations-ai-885844321461485618) to:
    - Share your creations
@@ -374,11 +444,21 @@ For any questions or support, please visit our [Discord channel](https://discord
 
 Our codebase is organized into several key folders, each serving a specific purpose in the pollinations.ai ecosystem:
 
-- [`pollinations.ai/`](./app/): The main React application for the Pollinations.ai website.
-
-- [`image.pollinations.ai/`](./image.pollinations.ai/): Backend service for image generation and caching with Cloudflare Workers and R2 storage.
+- [`pollinations.ai/`](./pollinations.ai/): The main React application for the Pollinations.ai website.
 
 - [`gen.pollinations.ai/`](./gen.pollinations.ai/): Cloudflare Worker for API routing, auth handoff, text generation, and caching.
+
+- [`enter.pollinations.ai/`](./enter.pollinations.ai/): Auth gateway and billing — API keys, Pollen credits, and pack checkout.
+
+- [`image.pollinations.ai/`](./image.pollinations.ai/): Image and video GPU/backend assets and deployment scripts; the public gateway code lives in `gen.pollinations.ai/`.
+
+- [`shared/`](./shared/): Auth, model registries, IP queue, and utilities shared across the services.
+
+- [`apps/`](./apps/): Community apps and the app catalog (`catalog.json`, `GREENHOUSE.md`).
+
+- [`media.pollinations.ai/`](./media.pollinations.ai/): Media upload service — upload files and get a URL to use with Pollinations models, with public tag galleries.
+
+- [`social/`](./social/): Automated social media pipeline (X, LinkedIn, Instagram, Reddit, Discord).
 
 - [`packages/polli-cli/`](./packages/polli-cli/): The Pollinations CLI — for humans, AI agents, and everything in between.
 
@@ -416,8 +496,9 @@ For development setup and environment management, see [DEVELOP.md](./DEVELOP.md)
 The best way to support pollinations.ai is by using our product! Get your API key and start building at **[enter.pollinations.ai](https://enter.pollinations.ai/keys)**.
 
 ## 📣 Stay Connected
+[Status](https://model-monitor.pollinations.ai) ·
 [News & FAQ](https://enter.pollinations.ai/news) ·
-[𝕏 Twitter](https://twitter.com/pollinations_ai) · [Instagram](https://instagram.com/pollinations_ai) · [LinkedIn](https://www.linkedin.com/company/pollinations-ai) · [Facebook](https://facebook.com/pollinations) · [Reddit](https://www.reddit.com/r/pollinations_ai/) · [YouTube](https://www.youtube.com/c/pollinations)
+[𝕏 Twitter](https://x.com/pollinations_ai) · [Instagram](https://instagram.com/pollinations_ai) · [LinkedIn](https://www.linkedin.com/company/pollinations-ai) · [Facebook](https://facebook.com/pollinations) · [Reddit](https://www.reddit.com/r/pollinations_ai/) · [YouTube](https://www.youtube.com/c/pollinations)
 
 ## 📜 License
 

--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -96,6 +96,23 @@ function upstreamStatus(failure: UpstreamFailure): number | undefined {
     return typeof status === "number" ? status : undefined;
 }
 
+/** The deadline we send to Portkey is the request's terminal time budget. */
+function isPortkeyRequestTimeout(failure: UpstreamFailure): boolean {
+    if (upstreamStatus(failure) !== 408) return false;
+    const details = failure.details;
+    if (!details || typeof details !== "object") return false;
+    const error = (details as { error?: unknown }).error;
+    if (!error || typeof error !== "object") return false;
+    const timeoutError = error as { message?: unknown; type?: unknown };
+    return (
+        timeoutError.type === "timeout_error" &&
+        typeof timeoutError.message === "string" &&
+        timeoutError.message.startsWith(
+            "Request exceeded the timeout sent in the request:",
+        )
+    );
+}
+
 /**
  * Every place a provider might have put its reason. Content-policy detection is
  * a case-insensitive substring match, so the whole details bag is worth handing
@@ -136,6 +153,10 @@ export function isRetryableFallbackError(error: unknown): boolean {
     const failure = error as UpstreamFailure;
     const status = upstreamStatus(failure);
     if (!status) return false;
+    // A generic provider 408 can benefit from a fallback. Portkey's exact
+    // timeout envelope is our own total deadline and must not multiply across
+    // fallback candidates.
+    if (isPortkeyRequestTimeout(failure)) return false;
     // A dead endpoint reaches us as the gateway's own 400 rather than as a
     // network error, because the gateway is the one that could not connect.
     if (

--- a/gen.pollinations.ai/src/model3d/handler.ts
+++ b/gen.pollinations.ai/src/model3d/handler.ts
@@ -52,20 +52,11 @@ export async function handle3dPrompt(
     c: Model3dContext,
     prompt: string,
 ): Promise<Response> {
-    return generate3dResponse(c, prompt, await readJsonBody(c));
-}
-
-export async function readJsonBody(
-    c: Model3dContext,
-): Promise<Record<string, unknown>> {
-    if (c.req.method !== "POST") return {};
-    const contentType = c.req.header("content-type") || "";
-    if (!contentType.includes("application/json")) return {};
-    try {
-        return (await c.req.json()) as Record<string, unknown>;
-    } catch {
-        return {};
-    }
+    const body =
+        c.req.method === "POST"
+            ? (c.req.valid("json" as never) as Record<string, unknown>)
+            : {};
+    return generate3dResponse(c, prompt, body);
 }
 
 export function decodePrompt(rawPrompt: string): string {

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -70,7 +70,10 @@ import {
     GenerateImageRequestQueryParamsSchema,
     GenerateVideoRequestQueryParamsSchema,
 } from "@/schemas/image.ts";
-import { Generate3dRequestQueryParamsSchema } from "@/schemas/model3d.ts";
+import {
+    Generate3dRequestBodySchema,
+    Generate3dRequestQueryParamsSchema,
+} from "@/schemas/model3d.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
 import {
@@ -903,13 +906,73 @@ export const proxyRoutes = new Hono<Env>()
             z.object({
                 prompt: z.string().min(1).meta({
                     description:
-                        "Text description of the 3D model to generate (required for text-to-3D models; ignored by image-only models)",
+                        "Text description of the 3D model to generate (required for text-to-3D models such as Hyper3D Rodin; ignored by image-only models such as Trellis 2)",
                     example: "a low-poly treasure chest",
                 }),
             }),
         ),
         validator("query", Generate3dRequestQueryParamsSchema),
         ...model3dHandlers,
+    )
+    .post(
+        "/3d/:prompt{[\\s\\S]+}",
+        describeRoute({
+            tags: ["🧊 3D"],
+            summary: "Generate 3D Model With JSON",
+            description:
+                "Generate a 3D model from a text prompt or reference image using JSON parameters. POST requests bypass the server-side media cache, so repeated requests regenerate and are billed. `trellis-2` supports `low`, `medium`, and `high` resolution with variable pricing.",
+            responses: {
+                200: {
+                    description: "Success - Returns the generated 3D model",
+                    content: {
+                        "model/gltf-binary": {
+                            schema: {
+                                type: "string",
+                                format: "binary",
+                            },
+                        },
+                    },
+                },
+                ...errorResponseDescriptions(400, 401, 402, 403, 429, 500),
+            },
+        }),
+        validator(
+            "param",
+            z.object({
+                prompt: z.string().min(1).meta({
+                    description:
+                        "Text description of the 3D model to generate (required for text-to-3D models; ignored by image-only models)",
+                    example: "a low-poly treasure chest",
+                }),
+            }),
+        ),
+        validator(
+            "query",
+            z
+                .object({
+                    key: z.string().optional().meta({
+                        description:
+                            "API key (alternative to Authorization header)",
+                    }),
+                    safe: SafeSchema,
+                })
+                .strict(),
+        ),
+        validator("json", Generate3dRequestBodySchema),
+        resolveModel("generate.image", { defaultModel: DEFAULT_3D_MODEL }),
+        track("generate.image"),
+        generationAccess,
+        async (c) => {
+            const query = c.req.valid("query" as never) as {
+                safe?: SafeValue;
+            };
+            const prompt = await applySafety(
+                c,
+                c.req.param("prompt") || "",
+                query.safe,
+            );
+            return withSafetyHeaders(c, await handle3dPrompt(c, prompt));
+        },
     )
     .get(
         "/audio/:text",

--- a/gen.pollinations.ai/src/schemas/model3d.ts
+++ b/gen.pollinations.ai/src/schemas/model3d.ts
@@ -61,3 +61,51 @@ export const Generate3dRequestQueryParamsSchema = z.object({
 export type Generate3dRequestQueryParams = z.infer<
     typeof Generate3dRequestQueryParamsSchema
 >;
+
+export const Generate3dRequestBodySchema = z
+    .object({
+        model: z
+            .enum(VALID_3D_MODELS as unknown as [string, ...string[]])
+            .optional()
+            .default(DEFAULT_3D_MODEL)
+            .meta({
+                description:
+                    "Model to use for 3D generation. See /3d/models for the full list and per-model input requirements.",
+            }),
+        image: z
+            .union([z.string(), z.array(z.string())])
+            .optional()
+            .refine(
+                (value) => {
+                    if (value === undefined) return true;
+                    const urls = Array.isArray(value) ? value : [value];
+                    return urls.every(
+                        (url) =>
+                            url.startsWith("http://") ||
+                            url.startsWith("https://"),
+                    );
+                },
+                { message: "Invalid image URL." },
+            )
+            .transform((value) => {
+                if (value === undefined || Array.isArray(value)) return value;
+                return [value];
+            })
+            .meta({
+                description:
+                    "Reference image URL or array of URLs for image-to-3D generation, optionally guided by the path prompt on supported models. A string is treated as one complete URL.",
+            }),
+        resolution: z
+            .enum(["low", "medium", "high"])
+            .optional()
+            .default("low")
+            .meta({
+                description:
+                    "Output voxel-grid resolution for `trellis-2`: `low` (512³), `medium` (1024³), or `high` (1536³). Higher resolutions add detail, take longer, and cost more.",
+            }),
+        seed: z.number().int().optional().meta({
+            description:
+                "Seed for varied generations. Passed to models that support it.",
+        }),
+    })
+    .strict();

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -24,6 +24,10 @@ const clientConfig = {
     },
 };
 
+// Portkey applies this millisecond deadline per attempt until provider response
+// headers arrive. Keep retries disabled unless the total deadline is reconsidered.
+const PORTKEY_REQUEST_TIMEOUT_MS = 290_000;
+
 function buildEndpoint(gatewayUrl: unknown): string {
     const base =
         typeof gatewayUrl === "string" && gatewayUrl
@@ -63,10 +67,13 @@ export async function generateTextPortkey(
     const requestConfig = {
         ...clientConfig,
         endpoint: () => buildEndpoint(portkeyGatewayUrl),
-        additionalHeaders: (state.options.additionalHeaders || {}) as Record<
-            string,
-            string
-        >,
+        additionalHeaders: {
+            "x-portkey-request-timeout": String(PORTKEY_REQUEST_TIMEOUT_MS),
+            ...((state.options.additionalHeaders || {}) as Record<
+                string,
+                string
+            >),
+        },
         fetcher,
     };
 

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -419,15 +419,9 @@ async function generateTextResponse(
         const servedEntry = candidate.entry;
         if (servedEntry) c.set("servedModelEntry", servedEntry);
 
-        // Only override the provider's own name where it is misleading. A
-        // community endpoint reports its upstream — "gemini-2.0-flash" for what
-        // everyone calls "alice/pro" — and after a rescue that upstream belongs
-        // to a different owner's model. A static model instead reports the
-        // exact version behind our id ("gpt-5-nano-2025-08-07" for "openai"),
-        // which is strictly more information, so leave it alone.
-        const servedModelId =
-            servedEntry?.id ??
-            (c.var.model?.communityEndpoint ? c.var.model.resolved : undefined);
+        // The successful candidate always carries the canonical registry id,
+        // including aliases, community models, and fallback targets.
+        const servedModelId = candidate.id || undefined;
         if (normalizedRequestData.stream)
             return sendTextStreamResponse(completion, servedModelId);
         // Provider-reported cost is read post-response in track (clamp-and-alert

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -137,6 +137,32 @@ describe("docs routes", () => {
         expect(schema.paths["/v1/chat/completions"]).toBeDefined();
         expect(schema.paths["/v1/realtime"]).toBeDefined();
         expect(schema.paths["/image/{prompt}"]).toBeDefined();
+        const model3dPost = (
+            schema.paths["/3d/{prompt}"] as Record<string, unknown>
+        )?.post as Record<string, unknown>;
+        expect(model3dPost).toBeDefined();
+        const model3dRequestBody = model3dPost.requestBody as {
+            content: {
+                "application/json": {
+                    schema: {
+                        additionalProperties?: boolean;
+                        properties: Record<string, unknown>;
+                    };
+                };
+            };
+        };
+        const model3dBodySchema =
+            model3dRequestBody.content["application/json"].schema;
+        expect(Object.keys(model3dBodySchema.properties)).toHaveLength(4);
+        expect(Object.keys(model3dBodySchema.properties)).toEqual(
+            expect.arrayContaining(["model", "image", "resolution", "seed"]),
+        );
+        expect(model3dBodySchema.properties.safe).toBeUndefined();
+        expect(
+            (model3dBodySchema.properties.resolution as { default?: string })
+                .default,
+        ).toBe("low");
+        expect(model3dBodySchema.additionalProperties).toBe(false);
         expect(schema.paths["/account/key"]).toBeDefined();
         expect(schema.paths["/account/profile"]).toBeDefined();
         expect(schema.paths["/account/quests"]).toBeDefined();

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -170,6 +170,23 @@ describe("isRetryableFallbackError", () => {
         );
     });
 
+    it("does not multiply the owned Portkey timeout across fallbacks", () => {
+        expect(
+            isRetryableFallbackError(
+                textFailure(408, {
+                    error: {
+                        message:
+                            "Request exceeded the timeout sent in the request: 290000ms",
+                        type: "timeout_error",
+                        param: null,
+                        code: null,
+                    },
+                }),
+            ),
+        ).toBe(false);
+        expect(isRetryableFallbackError(textFailure(408))).toBe(true);
+    });
+
     it("does not fail over on caller errors", () => {
         expect(isRetryableFallbackError(textFailure(400))).toBe(false);
         expect(isRetryableFallbackError(new HttpError("bad input", 422))).toBe(

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -193,6 +193,9 @@ async function fakePortkeyResponse(request: Request) {
     const model = body.model || "openai-fast";
     const prompt =
         body.messages?.map((m) => contentToText(m.content)).join("\n") || "";
+    const reportedModel = prompt.includes("provider model mismatch")
+        ? "provider-model-version"
+        : model;
 
     if (body.stream) {
         const streamUsageExtras = prompt.includes("vcr perplexity stream cost")
@@ -207,7 +210,7 @@ async function fakePortkeyResponse(request: Request) {
         const streamEvent = {
             id: "chatcmpl_vcr_stream",
             object: "chat.completion.chunk",
-            model,
+            model: reportedModel,
             choices: [
                 {
                     index: 0,
@@ -359,7 +362,7 @@ async function fakePortkeyResponse(request: Request) {
             id: "chatcmpl_vcr",
             object: "chat.completion",
             created: 1,
-            model,
+            model: reportedModel,
             citations: selectedCase?.citations,
             prompt_filter_results: selectedCase?.promptFilterResults,
             choices: [
@@ -475,6 +478,68 @@ test("chat completions use local text generation with VCR-backed Portkey", async
     );
 });
 
+test("canonical model headers preserve provider-reported payload models", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "portkeyDirect");
+
+    const { response, wait } = await fetchWorker("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${paidApiKey}`,
+        },
+        body: JSON.stringify({
+            model: "openai-fast",
+            messages: [
+                { role: "user", content: "provider model mismatch json" },
+            ],
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-model-used")).toBe("openai-fast");
+    await expect(response.json()).resolves.toMatchObject({
+        model: "provider-model-version",
+    });
+    await wait();
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        modelUsed: "openai-fast",
+    });
+
+    const { response: streamResponse, wait: waitForStream } = await fetchWorker(
+        "/v1/chat/completions",
+        {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${paidApiKey}`,
+            },
+            body: JSON.stringify({
+                model: "openai-fast",
+                stream: true,
+                messages: [
+                    {
+                        role: "user",
+                        content: "provider model mismatch stream",
+                    },
+                ],
+            }),
+        },
+    );
+
+    expect(streamResponse.status).toBe(200);
+    expect(streamResponse.headers.get("x-model-used")).toBe("openai-fast");
+    const streamBody = await streamResponse.text();
+    expect(streamBody).toContain('"model":"provider-model-version"');
+    expect(streamBody).not.toContain('"model":"openai-fast"');
+    await waitForStream();
+    expect(mocks.tinybird.state.events[1]).toMatchObject({
+        modelUsed: "openai-fast",
+    });
+});
+
 test("chat completions bill provider-reported Perplexity request cost without exposing it", async ({
     paidApiKey,
     mocks,
@@ -554,7 +619,7 @@ test("Perplexity aliases add no options and allow explicit override", async ({
         });
 
         expect(response.status).toBe(200);
-        expect(response.headers.get("x-model-used")).toBe("sonar");
+        expect(response.headers.get("x-model-used")).toBe("perplexity-fast");
         await response.text();
         await wait();
     }

--- a/gen.pollinations.ai/test/model3d/post.test.ts
+++ b/gen.pollinations.ai/test/model3d/post.test.ts
@@ -1,0 +1,310 @@
+import {
+    createExecutionContext,
+    env,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { getUserBalance } from "@shared/billing/balance.ts";
+import { createTestApiKey, test } from "@shared/test/fixtures/index.ts";
+import {
+    createFetchMock,
+    teardownFetchMock,
+} from "@shared/test/mocks/fetch.ts";
+import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { afterEach, beforeEach, expect } from "vitest";
+import worker from "../../src/index.ts";
+import { syncModel3dEnvironment } from "../../src/model3d/env.ts";
+
+type ProviderBody = Record<string, unknown>;
+
+function create3dMocks() {
+    const inferenceportBodies: ProviderBody[] = [];
+    const falBodies: ProviderBody[] = [];
+    const tinybird = createMockTinybird();
+    const tinybirdHandler =
+        tinybird.handlerMap["api.europe-west2.gcp.tinybird.co"];
+    tinybird.handlerMap["api.europe-west2.gcp.tinybird.co"] = async (
+        request: Request,
+    ) => {
+        if (request.url.includes("public_model_stats.json")) {
+            return Response.json({ data: [] });
+        }
+        return tinybirdHandler(request);
+    };
+
+    return createFetchMock({
+        tinybird,
+        inferenceport: {
+            state: { bodies: inferenceportBodies },
+            handlerMap: {
+                "api.inferenceport.ai": async (request: Request) => {
+                    inferenceportBodies.push(await request.json());
+                    return Response.json({
+                        data: [{ model_glb_b64_bytes: btoa("glTF") }],
+                    });
+                },
+            },
+            reset: () => {
+                inferenceportBodies.length = 0;
+            },
+        },
+        fal: {
+            state: { bodies: falBodies },
+            handlerMap: {
+                "queue.fal.run": async (request: Request) => {
+                    const pathname = new URL(request.url).pathname;
+                    if (request.method === "POST") {
+                        falBodies.push(await request.json());
+                        return Response.json(
+                            {
+                                request_id: "request-1",
+                                status_url:
+                                    "https://queue.fal.run/requests/request-1/status",
+                                response_url:
+                                    "https://queue.fal.run/requests/request-1/result",
+                            },
+                            { status: 202 },
+                        );
+                    }
+                    if (pathname.endsWith("/status")) {
+                        return Response.json({ status: "COMPLETED" });
+                    }
+                    return Response.json({
+                        model_mesh: {
+                            url: "https://models.example.test/model.glb",
+                        },
+                    });
+                },
+                "models.example.test": async () =>
+                    new Response(new TextEncoder().encode("glTF")),
+            },
+            reset: () => {
+                falBodies.length = 0;
+            },
+        },
+    });
+}
+
+let mocks: ReturnType<typeof create3dMocks>;
+
+beforeEach(() => {
+    mocks = create3dMocks();
+});
+
+afterEach(async () => {
+    await teardownFetchMock();
+    mocks.tinybird.reset();
+    mocks.inferenceport.reset();
+    mocks.fal.reset();
+});
+
+async function fetch3d(
+    path: string,
+    init: RequestInit = {},
+): Promise<Response> {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request(`https://gen.pollinations.ai${path}`, init),
+        env,
+        ctx,
+    );
+    await response.clone().arrayBuffer();
+    await waitOnExecutionContext(ctx);
+    return response;
+}
+
+test("POST /3d sends JSON Trellis parameters through billing without URL-only caching", async () => {
+    syncModel3dEnvironment({
+        ...env,
+        INFERENCEPORT_API_KEY: "ip_test_token",
+    } as CloudflareBindings);
+    await mocks.enable("tinybird", "inferenceport");
+    const { key, userId } = await createTestApiKey({
+        user: { tierBalance: 2 },
+    });
+    const prompt = crypto.randomUUID();
+
+    for (const [resolution, seed] of [
+        ["low", 101],
+        ["high", 202],
+    ] as const) {
+        const response = await fetch3d(`/3d/${prompt}`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${key}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model: "trellis-2",
+                image: ["https://example.com/reference.jpg"],
+                resolution,
+                seed,
+            }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("X-Cache")).toBeNull();
+        expect(await response.text()).toBe("glTF");
+    }
+
+    expect(mocks.inferenceport.state.bodies).toEqual([
+        {
+            model: "trellis2",
+            image_urls: ["https://example.com/reference.jpg"],
+            resolution: "low",
+        },
+        {
+            model: "trellis2",
+            image_urls: ["https://example.com/reference.jpg"],
+            resolution: "high",
+        },
+    ]);
+    expect(mocks.tinybird.state.events).toHaveLength(2);
+    expect(mocks.tinybird.state.events).toEqual([
+        expect.objectContaining({
+            modelRequested: "trellis-2",
+            modelUsed: "trellis-2",
+            tokenPriceCompletionImage: 0.24,
+            totalPrice: 0.24,
+        }),
+        expect.objectContaining({
+            modelRequested: "trellis-2",
+            modelUsed: "trellis-2",
+            costVariant: "high",
+            tokenPriceCompletionImage: 0.35,
+            totalPrice: 0.35,
+        }),
+    ]);
+    const balance = await getUserBalance(drizzle(env.DB), userId);
+    expect(balance.tierBalance).toBeCloseTo(1.41, 10);
+});
+
+test("POST /3d sends JSON image and seed to the existing Rodin provider path", async () => {
+    syncModel3dEnvironment({
+        ...env,
+        FAL_KEY: "fal_test_key",
+    } as CloudflareBindings);
+    await mocks.enable("tinybird", "fal");
+    const { key } = await createTestApiKey({
+        user: { packBalance: 1 },
+    });
+
+    const response = await fetch3d(`/3d/${crypto.randomUUID()}`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model: "hyper3d-rodin",
+            image: "https://example.com/reference.jpg?crop=1,2",
+            seed: 42,
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.fal.state.bodies).toEqual([
+        {
+            image_urls: ["https://example.com/reference.jpg?crop=1,2"],
+            prompt: expect.any(String),
+            seed: 42,
+        },
+    ]);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        modelRequested: "hyper3d-rodin",
+        modelUsed: "hyper3d-rodin",
+        tokenPriceCompletionImage: 0.1,
+        totalPrice: 0.1,
+    });
+}, 10_000);
+
+test("POST /3d preserves authentication and rejects ignored parameters", async ({
+    apiKey,
+}) => {
+    syncModel3dEnvironment({
+        ...env,
+        INFERENCEPORT_API_KEY: "ip_test_token",
+    } as CloudflareBindings);
+    await mocks.enable("tinybird", "inferenceport");
+    const body = {
+        model: "trellis-2",
+        image: "https://example.com/reference.jpg",
+        resolution: "low",
+    };
+
+    const unauthenticated = await fetch3d("/3d/auth-check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const queryAuthenticated = await fetch3d(
+        `/3d/query-auth?key=${apiKey}&safe=false`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+        },
+    );
+    expect(queryAuthenticated.status).toBe(200);
+    await queryAuthenticated.arrayBuffer();
+
+    for (const invalidBody of [
+        { ...body, safe: true },
+        { ...body, format: "glb" },
+        { ...body, resolution: "ultra" },
+        { ...body, image: "ftp://example.com/reference.jpg" },
+        { ...body, seed: "42" },
+    ]) {
+        const response = await fetch3d("/3d/validation-check", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(invalidBody),
+        });
+        expect(response.status).toBe(400);
+    }
+
+    for (const query of [
+        "model=hyper3d-rodin",
+        `image=${encodeURIComponent("https://example.com/other.jpg")}`,
+        "resolution=high",
+        "seed=42",
+    ]) {
+        const response = await fetch3d(`/3d/query-validation?${query}`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
+        expect(response.status).toBe(400);
+    }
+
+    expect(mocks.inferenceport.state.bodies).toHaveLength(1);
+});
+
+test("GET /3d keeps query behavior and Trellis resolution", async ({
+    apiKey,
+}) => {
+    syncModel3dEnvironment({
+        ...env,
+        INFERENCEPORT_API_KEY: "ip_test_token",
+    } as CloudflareBindings);
+    await mocks.enable("tinybird", "inferenceport");
+
+    const response = await fetch3d(
+        `/3d/${crypto.randomUUID()}?model=trellis-2&image=${encodeURIComponent("https://example.com/reference.jpg")}&resolution=medium`,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Cache")).toBe("MISS");
+    expect(mocks.inferenceport.state.bodies[0]).toMatchObject({
+        resolution: "medium",
+    });
+});

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateTextPortkey } from "../../src/text/generateTextPortkey.js";
+
+describe("generateTextPortkey", () => {
+    it("sets an owned request deadline below the public gateway limit", async () => {
+        const fetcher = vi.fn(
+            async (_input: RequestInfo | URL, init?: RequestInit) => {
+                const headers = new Headers(init?.headers);
+                expect(headers.get("x-portkey-request-timeout")).toBe("290000");
+                expect(headers.get("x-portkey-strict-open-ai-compliance")).toBe(
+                    "false",
+                );
+
+                return Response.json({
+                    model: "provider-model",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                });
+            },
+        );
+
+        const completion = await generateTextPortkey(
+            [{ role: "user", content: "hello" }],
+            {
+                model: "provider-model",
+                modelConfig: {
+                    provider: "openai",
+                    model: "provider-model",
+                },
+                portkeyGatewayUrl: "https://portkey.test",
+            },
+            fetcher,
+        );
+
+        expect(fetcher).toHaveBeenCalledOnce();
+        expect(completion.choices?.[0]?.message?.content).toBe("ok");
+    });
+});

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -76,10 +76,6 @@ custom_domain = true
 binding = "ENTER"
 service = "pollinations-enter-production"
 
-[[env.production.services]]
-binding = "PORTKEY"
-service = "rubeus-pollinations"
-
 [[env.production.vpc_networks]]
 binding = "KLEIN_VPC"
 tunnel_id = "c340d8d9-c1f3-4a13-8115-38b59faac3d5"
@@ -145,10 +141,6 @@ custom_domain = true
 [[env.staging.services]]
 binding = "ENTER"
 service = "pollinations-enter-staging"
-
-[[env.staging.services]]
-binding = "PORTKEY"
-service = "rubeus-dev"
 
 [[env.staging.d1_databases]]
 binding = "DB"

--- a/pollinations.ai/public/.well-known/security.txt
+++ b/pollinations.ai/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:hello@pollinations.ai
+Contact: https://github.com/pollinations/pollinations/security/advisories/new
+Expires: 2027-08-01T00:00:00Z
+Preferred-Languages: en
+Canonical: https://pollinations.ai/.well-known/security.txt


### PR DESCRIPTION
Promote the latest merged changes from `main` to `production`.

Included pull requests:
- #13164 — restore the long Portkey request window and owned 290s deadline.
- #13156 — add `security.txt`.
- #13070 — report canonical text model IDs.
- #13069 — add JSON POST support for 3D.
- #13160 — refresh the README.

Verification:
- Staging returned 200 after 203.44s and a controlled response after ~290.27s through both ingress hostnames.
- Production source guard, CI, CodeQL, and deployment checks must pass.