### PR TITLE
fix: lower GPT-5.6 Luna price

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -455,10 +455,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
       },
     },
     "price": {
-      "completionTextTokens": 0.000003,
-      "promptCacheWriteTokens": 0.000000625,
-      "promptCachedTokens": 0.00000005,
-      "promptTextTokens": 0.0000005,
+      "completionTextTokens": 0.0000012,
+      "promptCacheWriteTokens": 0.00000025,
+      "promptCachedTokens": 0.00000002,
+      "promptTextTokens": 0.0000002,
     },
   },
   "gpt-5.6-sol": {

--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -124,7 +124,9 @@ test("GPT-5.6 models are quest-eligible at the promotional multiplier", () => {
 
         expect(definition.provider).toBe("azure");
         expect(definition.paidOnly).toBeUndefined();
-        expect(definition.priceMultiplier).toBe(0.5);
+        expect(definition.priceMultiplier).toBe(
+            model === "gpt-5.6-luna" ? 0.2 : 0.5,
+        );
     }
 });
 

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -228,11 +228,12 @@ describe("long-context cost variants", () => {
         });
 
         expect(billing.costVariant).toBe("long_context");
+        const multiplier = model === "gpt-5.6-luna" ? 0.2 : 0.5;
         expect(billing.priceDefinition).toMatchObject({
-            promptTextTokens: (input * 0.5) / 1e6,
-            promptCachedTokens: (cached * 0.5) / 1e6,
-            promptCacheWriteTokens: (cacheWrite * 0.5) / 1e6,
-            completionTextTokens: (output * 0.5) / 1e6,
+            promptTextTokens: (input / 1e6) * multiplier,
+            promptCachedTokens: (cached / 1e6) * multiplier,
+            promptCacheWriteTokens: (cacheWrite / 1e6) * multiplier,
+            completionTextTokens: (output / 1e6) * multiplier,
         });
         expect(billing.cost.totalCost).toBeCloseTo(
             272_001 * (input / 1e6) +

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -304,7 +304,7 @@ export const TEXT_SERVICES = {
         brand: "OpenAI",
         category: "text",
         addedDate: new Date("2026-07-10").getTime(),
-        priceMultiplier: 0.5,
+        priceMultiplier: 0.2,
         cost: {
             promptTextTokens: perMillion(1.0),
             promptCachedTokens: perMillion(0.1),


### PR DESCRIPTION
- Lowers `gpt-5.6-luna`'s price multiplier from `0.5` to `0.2`; routing, aliases, access, capabilities, and fallback remain unchanged.
- Matches [OpenAI's current Luna pricing](https://developers.openai.com/api/docs/pricing): $0.20/M input, $0.02/M cached input, $0.25/M cache write, and $1.20/M output; long-context pricing is $0.40/$0.04/$0.50/$1.80.
- Keeps the existing Azure OpenAI East US deployment `gpt-5.6-luna`, Quest-Pollen access, and no fallback. Azure is still billing its older sheet, so Pollinations absorbs the difference until Azure updates.
- Updates only the existing multiplier assertions and effective-price snapshot.
- Verified 376 focused pricing/alias tests, Gen model-catalog tests, canonical plus both aliases, text/image inputs, tools, streaming, cache MISS/HIT, Quest-only billing, unauthorized rejection, and a 5-request burst. Tinybird confirmed Azure, no fallback, and exact `0.2` cost-to-price ratios.