### PR TITLE
feat: add Grok Transcribe

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -698,6 +698,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000125,
     },
   },
+  "grok-transcribe": {
+    "cost": {
+      "promptAudioSeconds": 0.0000277777777777778,
+    },
+    "price": {
+      "promptAudioSeconds": 0.0000277777777777778,
+    },
+  },
   "grok-video-pro": {
     "cost": {
       "completionVideoSeconds": 0.07,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -763,6 +763,7 @@ export async function transcribeWithXai(opts: {
     if (responseFormat === "diarized_json") {
         formData.append("diarize", "true");
     }
+    // xAI requires the file to be the final multipart field.
     formData.append("file", file, file.name || "audio");
 
     const xaiUrl = "https://api.x.ai/v1/stt";
@@ -817,13 +818,19 @@ function groupXaiWordsBySpeaker(
 ): NormalizedDiarizedSegment[] {
     if (!words?.length) return [];
 
+    const cjk = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
     const segments: NormalizedDiarizedSegment[] = [];
     for (const word of words) {
         const speaker =
             word.speaker === undefined ? null : String(word.speaker);
         const current = segments.at(-1);
         if (current?.speaker === speaker) {
-            current.text = `${current.text} ${word.text}`;
+            const separator =
+                cjk.test(current.text.at(-1) ?? "") &&
+                cjk.test(word.text[0] ?? "")
+                    ? ""
+                    : " ";
+            current.text = `${current.text}${separator}${word.text}`;
             current.end = word.end;
         } else {
             segments.push({

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -39,7 +39,10 @@ import {
     withModelFallbackResponse,
 } from "../fallback.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
-import { buildTranscriptionResponse } from "./transcription-response.ts";
+import {
+    buildTranscriptionResponse,
+    type NormalizedDiarizedSegment,
+} from "./transcription-response.ts";
 
 const CreateSpeechRequestSchema = z
     .object({
@@ -714,6 +717,124 @@ interface ElevenLabsTranscriptionResponse {
         speaker_id?: string | null;
         type?: string;
     }[];
+}
+
+interface XaiTranscriptionResponse {
+    text: string;
+    language?: string;
+    duration: number;
+    words?: {
+        text: string;
+        start: number;
+        end: number;
+        speaker?: number;
+    }[];
+}
+
+export async function transcribeWithXai(opts: {
+    file: File;
+    language?: string;
+    responseFormat?: string;
+    apiKey: string;
+    log: Logger;
+}): Promise<Response> {
+    const { file, language, responseFormat = "json", apiKey, log } = opts;
+
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: "xAI transcription service is not configured",
+        });
+    }
+    if (
+        !["json", "text", "verbose_json", "diarized_json"].includes(
+            responseFormat,
+        )
+    ) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Unsupported response_format for grok-transcribe: ${responseFormat}. Supported: json, text, verbose_json, diarized_json`,
+        });
+    }
+
+    const formData = new FormData();
+    if (language) {
+        formData.append("language", language);
+        formData.append("format", "true");
+    }
+    if (responseFormat === "diarized_json") {
+        formData.append("diarize", "true");
+    }
+    formData.append("file", file, file.name || "audio");
+
+    const xaiUrl = "https://api.x.ai/v1/stt";
+    const response = await ensureUpstreamOk(
+        await fetch(xaiUrl, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${apiKey}` },
+            body: formData,
+        }),
+        xaiUrl,
+    );
+    const transcript = (await response.json()) as XaiTranscriptionResponse;
+    if (
+        typeof transcript.text !== "string" ||
+        typeof transcript.duration !== "number" ||
+        !Number.isFinite(transcript.duration) ||
+        transcript.duration < 0
+    ) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "xAI returned an invalid transcription response",
+        });
+    }
+
+    log.info("xAI transcription success: {chars} chars, {duration}s", {
+        chars: transcript.text.length,
+        duration: transcript.duration,
+    });
+
+    return buildTranscriptionResponse({
+        normalized: {
+            text: transcript.text,
+            language: transcript.language || undefined,
+            duration: transcript.duration,
+            words:
+                transcript.words?.map((word) => ({
+                    word: word.text,
+                    start: word.start,
+                    end: word.end,
+                })) ?? [],
+            diarizedSegments: groupXaiWordsBySpeaker(transcript.words),
+        },
+        responseFormat,
+        usageHeaders: buildUsageHeaders(
+            "grok-transcribe",
+            createAudioSecondsUsage(transcript.duration),
+        ),
+    });
+}
+
+function groupXaiWordsBySpeaker(
+    words: XaiTranscriptionResponse["words"],
+): NormalizedDiarizedSegment[] {
+    if (!words?.length) return [];
+
+    const segments: NormalizedDiarizedSegment[] = [];
+    for (const word of words) {
+        const speaker =
+            word.speaker === undefined ? null : String(word.speaker);
+        const current = segments.at(-1);
+        if (current?.speaker === speaker) {
+            current.text = `${current.text} ${word.text}`;
+            current.end = word.end;
+        } else {
+            segments.push({
+                speaker,
+                text: word.text,
+                start: word.start,
+                end: word.end,
+            });
+        }
+    }
+    return segments;
 }
 
 export async function transcribeWithElevenLabs(opts: {
@@ -2943,6 +3064,7 @@ export const audioRoutes = new Hono<Env>()
                 "- `whisper-large-v3` (default) — OpenAI Whisper via OVHcloud",
                 "- `whisper-1` — Alias for whisper-large-v3",
                 "- `scribe` — ElevenLabs Scribe (90+ languages, word-level timestamps)",
+                "- `grok-transcribe` — xAI speech recognition with word timestamps, speaker labels, and text formatting",
                 "- `universal-2` — AssemblyAI Universal-2 (99 languages)",
                 "- `universal-3.5-pro` — AssemblyAI Universal-3.5 Pro (18 languages, code switching, prompting)",
             ].join("\n"),
@@ -2964,7 +3086,7 @@ export const audioRoutes = new Hono<Env>()
                                     type: "string",
                                     default: "whisper-large-v3",
                                     description:
-                                        "The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `universal-2`, `universal-3.5-pro`.",
+                                        "The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `grok-transcribe`, `universal-2`, `universal-3.5-pro`.",
                                 },
                                 language: {
                                     type: "string",
@@ -3098,6 +3220,16 @@ export const audioRoutes = new Hono<Env>()
             }
 
             const result = await withAudioFallback(c, async (candidate) => {
+                if (candidate.id === "grok-transcribe") {
+                    return transcribeWithXai({
+                        file,
+                        language: language || undefined,
+                        responseFormat: responseFormat || undefined,
+                        apiKey: c.env.XAI_API_KEY,
+                        log,
+                    });
+                }
+
                 if (candidate.id === "scribe") {
                     return transcribeWithElevenLabs({
                         file,

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -1,7 +1,7 @@
 /**
  * Shared OpenAI-compatible transcription-response formatter.
  *
- * Providers (ElevenLabs Scribe, AssemblyAI) each normalize their upstream
+ * Providers (ElevenLabs Scribe, AssemblyAI, xAI) each normalize their upstream
  * payload into the seconds-based `NormalizedTranscript` intermediate below
  * — keeping their own grouping and unit conversion — then call
  * `buildTranscriptionResponse` to emit the four response branches

--- a/gen.pollinations.ai/test/xai-transcription.test.ts
+++ b/gen.pollinations.ai/test/xai-transcription.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { transcribeWithXai } from "../src/routes/audio.ts";
+
+const log = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+} as never;
+
+describe("transcribeWithXai", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it("forwards REST options and bills the returned audio duration", async () => {
+        const fetchMock = vi.fn().mockResolvedValueOnce(
+            Response.json({
+                text: "hello there",
+                language: "en",
+                duration: 3.25,
+                words: [
+                    { text: "hello", start: 0, end: 0.5, speaker: 0 },
+                    { text: "there", start: 0.6, end: 1.1, speaker: 1 },
+                ],
+            }),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await transcribeWithXai({
+            file: new File(["audio"], "audio.wav", { type: "audio/wav" }),
+            language: "en",
+            responseFormat: "diarized_json",
+            apiKey: "test-key",
+            log,
+        });
+
+        const request = fetchMock.mock.calls[0];
+        expect(request[0]).toBe("https://api.x.ai/v1/stt");
+        expect(request[1].headers).toEqual({
+            Authorization: "Bearer test-key",
+        });
+        const form = request[1].body as FormData;
+        expect([...form.keys()]).toEqual([
+            "language",
+            "format",
+            "diarize",
+            "file",
+        ]);
+        expect(response.headers.get("x-model-used")).toBe("grok-transcribe");
+        expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe(
+            "3.25",
+        );
+        await expect(response.json()).resolves.toMatchObject({
+            text: "hello there",
+            duration: 3.25,
+            segments: [
+                { speaker: "0", text: "hello", start: 0, end: 0.5 },
+                { speaker: "1", text: "there", start: 0.6, end: 1.1 },
+            ],
+        });
+    });
+
+    it("rejects responses without billable duration", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValueOnce(Response.json({ text: "hello" })),
+        );
+
+        await expect(
+            transcribeWithXai({
+                file: new File(["audio"], "audio.wav"),
+                apiKey: "test-key",
+                log,
+            }),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+});

--- a/gen.pollinations.ai/test/xai-transcription.test.ts
+++ b/gen.pollinations.ai/test/xai-transcription.test.ts
@@ -16,12 +16,15 @@ describe("transcribeWithXai", () => {
     it("forwards REST options and bills the returned audio duration", async () => {
         const fetchMock = vi.fn().mockResolvedValueOnce(
             Response.json({
-                text: "hello there",
-                language: "en",
+                text: "今日は hello there",
+                language: "ja",
                 duration: 3.25,
                 words: [
-                    { text: "hello", start: 0, end: 0.5, speaker: 0 },
-                    { text: "there", start: 0.6, end: 1.1, speaker: 1 },
+                    { text: "今", start: 0, end: 0.2, speaker: 0 },
+                    { text: "日", start: 0.2, end: 0.4, speaker: 0 },
+                    { text: "は", start: 0.4, end: 0.6, speaker: 0 },
+                    { text: "hello", start: 0.7, end: 1, speaker: 1 },
+                    { text: "there", start: 1, end: 1.3, speaker: 1 },
                 ],
             }),
         );
@@ -29,7 +32,7 @@ describe("transcribeWithXai", () => {
 
         const response = await transcribeWithXai({
             file: new File(["audio"], "audio.wav", { type: "audio/wav" }),
-            language: "en",
+            language: "ja",
             responseFormat: "diarized_json",
             apiKey: "test-key",
             log,
@@ -52,11 +55,11 @@ describe("transcribeWithXai", () => {
             "3.25",
         );
         await expect(response.json()).resolves.toMatchObject({
-            text: "hello there",
+            text: "今日は hello there",
             duration: 3.25,
             segments: [
-                { speaker: "0", text: "hello", start: 0, end: 0.5 },
-                { speaker: "1", text: "there", start: 0.6, end: 1.1 },
+                { speaker: "0", text: "今日は", start: 0, end: 0.6 },
+                { speaker: "1", text: "hello there", start: 0.7, end: 1.3 },
             ],
         });
     });

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -347,6 +347,25 @@ export const AUDIO_SERVICES = {
         outputModalities: ["text"],
         supportedEndpoints: ["/v1/audio/transcriptions"],
     },
+    "grok-transcribe": {
+        aliases: [],
+        provider: "xai",
+        brand: "xAI",
+        category: "audio",
+        addedDate: new Date("2026-08-07").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // xAI REST speech-to-text: $0.10/hour.
+            promptAudioSeconds: 0.1 / 3600,
+        },
+        title: "Grok Transcribe",
+        description:
+            "Fast multilingual speech recognition with word timestamps, speaker labels, and text formatting",
+        inputModalities: ["audio"],
+        outputModalities: ["text"],
+        supportedEndpoints: ["/v1/audio/transcriptions"],
+    },
     "universal-2": {
         aliases: ["assemblyai-universal-2", "assemblyai-u2"],
         provider: "assemblyai",


### PR DESCRIPTION
- Adds paid-only `grok-transcribe` through xAI REST `POST /v1/stt` at the exact $0.10/hour provider rate.
- Exposes audio-to-text on `/v1/audio/transcriptions` with no aliases, Pollinations GPU, or fallback.
- Supports `json`, `text`, `verbose_json`, and `diarized_json`, including language formatting and speaker labels.
- Adds one focused handler test and the required effective-price snapshot.

Validation:
- Direct xAI: 7/7 formats; 60-second audio in 1.51s; 10/10 burst, 1.39s max.
- Local E2E: formats, outputs, parameters, paid-only permissions, errors, catalogs, no-cache behavior, and exact duration billing; 60-second audio in 2.60s; 10/10 burst, 1.39s max.
- Gen: 63 tests; Enter: 376 tests; both typechecks and Biome pass.
- PR #13059 endpoint metadata/enforcement verified in production.

Draft gate: confirm the staging Tinybird billing row before marking ready.

Addresses #11027