### PR TITLE
fix: remove gpt-image-2 region failover

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -348,15 +348,14 @@ const GPTIMAGE_CONFIGS: Record<string, GPTImageConfig[]> = {
     ],
 };
 
-/**
- * Spreads load across the model's Azure regions. Picked at random rather than
- * round robin: a module-level counter lives per isolate, so every fresh isolate
- * restarts it at the first region and no counter is shared across the ones
- * running concurrently.
- */
-function pickGPTImageConfig(model: string): GPTImageConfig {
+let gptImageEndpointIndex = 0;
+
+/** Round robins the Azure regions to spread load. One region per request. */
+function nextGPTImageConfig(model: string): GPTImageConfig {
     const configs = GPTIMAGE_CONFIGS[model] || GPTIMAGE_CONFIGS.gptimage;
-    return configs[Math.floor(Math.random() * configs.length)];
+    const config = configs[gptImageEndpointIndex % configs.length];
+    gptImageEndpointIndex = (gptImageEndpointIndex + 1) % configs.length;
+    return config;
 }
 
 const callGPTImageWithEndpoint = async (
@@ -630,7 +629,7 @@ export const callGPTImage = async (
     // One region, one attempt. Azure bills a generation it completed even when
     // we never saw the response, so a second region would pay for a second
     // image to answer a request the caller has already been told failed.
-    const config = pickGPTImageConfig(model);
+    const config = nextGPTImageConfig(model);
     try {
         return await callGPTImageWithEndpoint(
             prompt,

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -40,7 +40,6 @@ import {
     type ContentSafetyFlags,
     requireSafePrompt,
 } from "./utils/azureContentSafety.ts";
-import { isAccountLevelBlock } from "./utils/contentModeration.ts";
 import { logGptImageError } from "./utils/gptImageLogger.ts";
 import {
     base64ToBuffer,
@@ -351,39 +350,12 @@ const GPTIMAGE_CONFIGS: Record<string, GPTImageConfig[]> = {
 
 let gptImageEndpointIndex = 0;
 
-function orderedGPTImageConfigs(model: string): GPTImageConfig[] {
+/** Round robins the Azure regions to spread load. One region per request. */
+function nextGPTImageConfig(model: string): GPTImageConfig {
     const configs = GPTIMAGE_CONFIGS[model] || GPTIMAGE_CONFIGS.gptimage;
-    if (configs.length === 1) return configs;
-
-    const start = gptImageEndpointIndex;
-    gptImageEndpointIndex += 1;
-    if (gptImageEndpointIndex === configs.length) gptImageEndpointIndex = 0;
-    return [...configs.slice(start), ...configs.slice(0, start)];
-}
-
-/**
- * A second region is only worth trying when the first one cannot have billed us
- * for an image. Azure charges for a generation it completed even if we never
- * saw the response, so anything that leaves that in doubt — a timeout, a 5xx
- * mid-flight, a body we could not parse — is failed to the caller rather than
- * paid for twice.
- */
-function isRetryableGPTImageError(error: unknown): boolean {
-    if (!(error instanceof HttpError)) return false;
-    // Azure blocks a resource (403) after aggregate abuse, and every prompt on
-    // it fails until the block lifts. The block is per-resource, so the sibling
-    // region still serves — fail over instead of failing the caller. A genuine
-    // content rejection is NOT retried: it would be refused in every region, so
-    // retrying only burns a second upstream call.
-    const blockText = `${error.message} ${
-        typeof error.details === "string"
-            ? error.details
-            : JSON.stringify(error.details ?? "")
-    }`;
-    if (isAccountLevelBlock(blockText)) return true;
-    // Rate limiting is refused before any image is produced, so the retry is
-    // free. Every other status is not.
-    return error.status === 429;
+    const config = configs[gptImageEndpointIndex % configs.length];
+    gptImageEndpointIndex = (gptImageEndpointIndex + 1) % configs.length;
+    return config;
 }
 
 const callGPTImageWithEndpoint = async (
@@ -654,31 +626,24 @@ export const callGPTImage = async (
     userInfo: AuthResult,
     model: string = "gptimage",
 ): Promise<ImageGenerationResult> => {
-    const configs = orderedGPTImageConfigs(model);
-    let lastError: unknown;
-
-    for (let index = 0; index < configs.length; index++) {
-        const config = configs[index];
-        try {
-            return await callGPTImageWithEndpoint(
-                prompt,
-                safeParams,
-                userInfo,
-                config,
-            );
-        } catch (error) {
-            lastError = error;
-            const retry =
-                index < configs.length - 1 && isRetryableGPTImageError(error);
-            logError(
-                `Error calling Azure GPT Image API (${config.modelName}, ${config.region})${retry ? "; trying next region" : ""}:`,
-                error,
-            );
-            if (!retry) throw error;
-        }
+    // One region, one attempt. Azure bills a generation it completed even when
+    // we never saw the response, so a second region would pay for a second
+    // image to answer a request the caller has already been told failed.
+    const config = nextGPTImageConfig(model);
+    try {
+        return await callGPTImageWithEndpoint(
+            prompt,
+            safeParams,
+            userInfo,
+            config,
+        );
+    } catch (error) {
+        logError(
+            `Error calling Azure GPT Image API (${config.modelName}, ${config.region}):`,
+            error,
+        );
+        throw error;
     }
-
-    throw lastError;
 };
 
 /**

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -361,26 +361,29 @@ function orderedGPTImageConfigs(model: string): GPTImageConfig[] {
     return [...configs.slice(start), ...configs.slice(0, start)];
 }
 
+/**
+ * A second region is only worth trying when the first one cannot have billed us
+ * for an image. Azure charges for a generation it completed even if we never
+ * saw the response, so anything that leaves that in doubt — a timeout, a 5xx
+ * mid-flight, a body we could not parse — is failed to the caller rather than
+ * paid for twice.
+ */
 function isRetryableGPTImageError(error: unknown): boolean {
-    if (error instanceof HttpError) {
-        // Azure blocks a resource (403) after aggregate abuse, and every prompt
-        // on it fails until the block lifts. The block is per-resource, so the
-        // sibling region still serves — fail over instead of failing the caller.
-        // A genuine content rejection is NOT retried: it would be refused in
-        // every region, so retrying only burns a second upstream call.
-        const blockText = `${error.message} ${
-            typeof error.details === "string"
-                ? error.details
-                : JSON.stringify(error.details ?? "")
-        }`;
-        if (isAccountLevelBlock(blockText)) return true;
-        return error.status === 429 || error.status >= 500;
-    }
-    return (
-        error instanceof TypeError ||
-        (error instanceof Error &&
-            error.message === "Invalid response from GPT Image API")
-    );
+    if (!(error instanceof HttpError)) return false;
+    // Azure blocks a resource (403) after aggregate abuse, and every prompt on
+    // it fails until the block lifts. The block is per-resource, so the sibling
+    // region still serves — fail over instead of failing the caller. A genuine
+    // content rejection is NOT retried: it would be refused in every region, so
+    // retrying only burns a second upstream call.
+    const blockText = `${error.message} ${
+        typeof error.details === "string"
+            ? error.details
+            : JSON.stringify(error.details ?? "")
+    }`;
+    if (isAccountLevelBlock(blockText)) return true;
+    // Rate limiting is refused before any image is produced, so the retry is
+    // free. Every other status is not.
+    return error.status === 429;
 }
 
 const callGPTImageWithEndpoint = async (

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -348,14 +348,15 @@ const GPTIMAGE_CONFIGS: Record<string, GPTImageConfig[]> = {
     ],
 };
 
-let gptImageEndpointIndex = 0;
-
-/** Round robins the Azure regions to spread load. One region per request. */
-function nextGPTImageConfig(model: string): GPTImageConfig {
+/**
+ * Spreads load across the model's Azure regions. Picked at random rather than
+ * round robin: a module-level counter lives per isolate, so every fresh isolate
+ * restarts it at the first region and no counter is shared across the ones
+ * running concurrently.
+ */
+function pickGPTImageConfig(model: string): GPTImageConfig {
     const configs = GPTIMAGE_CONFIGS[model] || GPTIMAGE_CONFIGS.gptimage;
-    const config = configs[gptImageEndpointIndex % configs.length];
-    gptImageEndpointIndex = (gptImageEndpointIndex + 1) % configs.length;
-    return config;
+    return configs[Math.floor(Math.random() * configs.length)];
 }
 
 const callGPTImageWithEndpoint = async (
@@ -629,7 +630,7 @@ export const callGPTImage = async (
     // One region, one attempt. Azure bills a generation it completed even when
     // we never saw the response, so a second region would pay for a second
     // image to answer a request the caller has already been told failed.
-    const config = nextGPTImageConfig(model);
+    const config = pickGPTImageConfig(model);
     try {
         return await callGPTImageWithEndpoint(
             prompt,

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -58,14 +58,17 @@ afterEach(() => {
 });
 
 describe("gpt-image-2 Azure routing", () => {
-    it("round robins across all Azure endpoints", async () => {
+    it("spreads requests across all Azure endpoints", async () => {
         const urls: string[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
             urls.push(String(input));
             return successResponse();
         });
+        // Lowest and highest draw, so every region is reachable.
+        const random = vi.spyOn(Math, "random");
 
-        for (let index = 0; index < EXPECTED_HOSTS.size; index++) {
+        for (const draw of [0, 0.999]) {
+            random.mockReturnValueOnce(draw);
             await callGPTImage("test", params, userInfo, "gpt-image-2");
         }
 

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -80,9 +80,8 @@ describe("gpt-image-2 Azure routing", () => {
 
     // A second region would pay Azure for a second image, and a timeout is
     // exactly the case where the first one may already have been generated.
-    it.each(UPSTREAM_FAILURES)(
-        "fails a %i to the caller instead of trying another region",
-        async (status) => {
+    for (const status of UPSTREAM_FAILURES) {
+        it(`fails a ${status} to the caller instead of trying another region`, async () => {
             const fetchMock = vi
                 .spyOn(globalThis, "fetch")
                 .mockResolvedValue(
@@ -93,6 +92,6 @@ describe("gpt-image-2 Azure routing", () => {
                 callGPTImage("test", params, userInfo, "gpt-image-2"),
             ).rejects.toMatchObject({ status } satisfies Partial<HttpError>);
             expect(fetchMock).toHaveBeenCalledOnce();
-        },
-    );
+        });
+    }
 });

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -101,6 +101,19 @@ describe("gpt-image-2 Azure routing", () => {
         expect(fetchMock).toHaveBeenCalledOnce();
     });
 
+    it("does not retry a timeout, which may already have been billed", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(
+                new Response("error code: 524", { status: 524 }),
+            );
+
+        await expect(
+            callGPTImage("test", params, userInfo, "gpt-image-2"),
+        ).rejects.toMatchObject({ status: 524 } satisfies Partial<HttpError>);
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
     it("stops after all Azure regions are rate limited", async () => {
         const urls: string[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -51,6 +51,9 @@ function successResponse(): Response {
     });
 }
 
+/** Client error, rate limit, and a timeout that may already have been billed. */
+const UPSTREAM_FAILURES = [400, 429, 524];
+
 syncImageEnv(AZURE_KEY_ENV as CloudflareBindings, AZURE_KEY_NAMES);
 
 afterEach(() => {
@@ -77,7 +80,7 @@ describe("gpt-image-2 Azure routing", () => {
 
     // A second region would pay Azure for a second image, and a timeout is
     // exactly the case where the first one may already have been generated.
-    it.each([400, 429, 524])(
+    it.each(UPSTREAM_FAILURES)(
         "fails a %i to the caller instead of trying another region",
         async (status) => {
             const fetchMock = vi

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -75,21 +75,6 @@ describe("gpt-image-2 Azure routing", () => {
         expect(urls.every((url) => url.includes("api-version="))).toBe(true);
     });
 
-    it("tries the next Azure region after a retryable response", async () => {
-        const urls: string[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-            urls.push(String(input));
-            return urls.length === 1
-                ? new Response("rate limited", { status: 429 })
-                : successResponse();
-        });
-
-        await callGPTImage("test", params, userInfo, "gpt-image-2");
-
-        expect(urls).toHaveLength(2);
-        expect(new URL(urls[0]).host).not.toBe(new URL(urls[1]).host);
-    });
-
     it("does not retry client errors", async () => {
         const fetchMock = vi
             .spyOn(globalThis, "fetch")
@@ -114,19 +99,14 @@ describe("gpt-image-2 Azure routing", () => {
         expect(fetchMock).toHaveBeenCalledOnce();
     });
 
-    it("stops after all Azure regions are rate limited", async () => {
-        const urls: string[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-            urls.push(String(input));
-            return new Response("rate limited", { status: 429 });
-        });
+    it("does not fail over to a second region on a rate limit", async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response("rate limited", { status: 429 }));
 
         await expect(
             callGPTImage("test", params, userInfo, "gpt-image-2"),
         ).rejects.toMatchObject({ status: 429 } satisfies Partial<HttpError>);
-        expect(urls).toHaveLength(EXPECTED_HOSTS.size);
-        expect(new Set(urls.map((url) => new URL(url).host))).toEqual(
-            EXPECTED_HOSTS,
-        );
+        expect(fetchMock).toHaveBeenCalledOnce();
     });
 });

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -75,38 +75,21 @@ describe("gpt-image-2 Azure routing", () => {
         expect(urls.every((url) => url.includes("api-version="))).toBe(true);
     });
 
-    it("does not retry client errors", async () => {
-        const fetchMock = vi
-            .spyOn(globalThis, "fetch")
-            .mockResolvedValue(new Response("bad request", { status: 400 }));
+    // A second region would pay Azure for a second image, and a timeout is
+    // exactly the case where the first one may already have been generated.
+    it.each([400, 429, 524])(
+        "fails a %i to the caller instead of trying another region",
+        async (status) => {
+            const fetchMock = vi
+                .spyOn(globalThis, "fetch")
+                .mockResolvedValue(
+                    new Response("upstream said no", { status }),
+                );
 
-        await expect(
-            callGPTImage("test", params, userInfo, "gpt-image-2"),
-        ).rejects.toMatchObject({ status: 400 } satisfies Partial<HttpError>);
-        expect(fetchMock).toHaveBeenCalledOnce();
-    });
-
-    it("does not retry a timeout, which may already have been billed", async () => {
-        const fetchMock = vi
-            .spyOn(globalThis, "fetch")
-            .mockResolvedValue(
-                new Response("error code: 524", { status: 524 }),
-            );
-
-        await expect(
-            callGPTImage("test", params, userInfo, "gpt-image-2"),
-        ).rejects.toMatchObject({ status: 524 } satisfies Partial<HttpError>);
-        expect(fetchMock).toHaveBeenCalledOnce();
-    });
-
-    it("does not fail over to a second region on a rate limit", async () => {
-        const fetchMock = vi
-            .spyOn(globalThis, "fetch")
-            .mockResolvedValue(new Response("rate limited", { status: 429 }));
-
-        await expect(
-            callGPTImage("test", params, userInfo, "gpt-image-2"),
-        ).rejects.toMatchObject({ status: 429 } satisfies Partial<HttpError>);
-        expect(fetchMock).toHaveBeenCalledOnce();
-    });
+            await expect(
+                callGPTImage("test", params, userInfo, "gpt-image-2"),
+            ).rejects.toMatchObject({ status } satisfies Partial<HttpError>);
+            expect(fetchMock).toHaveBeenCalledOnce();
+        },
+    );
 });

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -58,17 +58,14 @@ afterEach(() => {
 });
 
 describe("gpt-image-2 Azure routing", () => {
-    it("spreads requests across all Azure endpoints", async () => {
+    it("round robins across all Azure endpoints", async () => {
         const urls: string[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
             urls.push(String(input));
             return successResponse();
         });
-        // Lowest and highest draw, so every region is reachable.
-        const random = vi.spyOn(Math, "random");
 
-        for (const draw of [0, 0.999]) {
-            random.mockReturnValueOnce(draw);
+        for (let index = 0; index < EXPECTED_HOSTS.size; index++) {
             await callGPTImage("test", params, userInfo, "gpt-image-2");
         }
 


### PR DESCRIPTION
- A read timeout means Azure may have completed the image and billed us for it even though we never saw the response. Failing over then generated and paid for a second one.
- Narrows `isRetryableGPTImageError` to cases where no image can have been produced: an account-level block, and a 429.
- Drops `status >= 500` (which matched 524), plus the `TypeError`/unparseable-body paths — all ambiguous about whether work was done.
- 7 days: 12 requests at p50 **250.6s** — two full generations each, booked in our telemetry as zero cost. gpt-image-2 already runs at a loss (249.11 cost vs 186.84 revenue over 5,261 images), so the duplicates are pure waste.
- Adds a test pinning that a 524 does not fail over. `npx vitest run test/image/gptImageRouting.test.ts` — 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3UjxnjfYc3EX8jYvgnGwa