### PR TITLE
chore: sync main into production

### DIFF
--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -40,7 +40,6 @@ import {
     type ContentSafetyFlags,
     requireSafePrompt,
 } from "./utils/azureContentSafety.ts";
-import { isAccountLevelBlock } from "./utils/contentModeration.ts";
 import { logGptImageError } from "./utils/gptImageLogger.ts";
 import {
     base64ToBuffer,
@@ -351,36 +350,12 @@ const GPTIMAGE_CONFIGS: Record<string, GPTImageConfig[]> = {
 
 let gptImageEndpointIndex = 0;
 
-function orderedGPTImageConfigs(model: string): GPTImageConfig[] {
+/** Round robins the Azure regions to spread load. One region per request. */
+function nextGPTImageConfig(model: string): GPTImageConfig {
     const configs = GPTIMAGE_CONFIGS[model] || GPTIMAGE_CONFIGS.gptimage;
-    if (configs.length === 1) return configs;
-
-    const start = gptImageEndpointIndex;
-    gptImageEndpointIndex += 1;
-    if (gptImageEndpointIndex === configs.length) gptImageEndpointIndex = 0;
-    return [...configs.slice(start), ...configs.slice(0, start)];
-}
-
-function isRetryableGPTImageError(error: unknown): boolean {
-    if (error instanceof HttpError) {
-        // Azure blocks a resource (403) after aggregate abuse, and every prompt
-        // on it fails until the block lifts. The block is per-resource, so the
-        // sibling region still serves — fail over instead of failing the caller.
-        // A genuine content rejection is NOT retried: it would be refused in
-        // every region, so retrying only burns a second upstream call.
-        const blockText = `${error.message} ${
-            typeof error.details === "string"
-                ? error.details
-                : JSON.stringify(error.details ?? "")
-        }`;
-        if (isAccountLevelBlock(blockText)) return true;
-        return error.status === 429 || error.status >= 500;
-    }
-    return (
-        error instanceof TypeError ||
-        (error instanceof Error &&
-            error.message === "Invalid response from GPT Image API")
-    );
+    const config = configs[gptImageEndpointIndex % configs.length];
+    gptImageEndpointIndex = (gptImageEndpointIndex + 1) % configs.length;
+    return config;
 }
 
 const callGPTImageWithEndpoint = async (
@@ -651,31 +626,24 @@ export const callGPTImage = async (
     userInfo: AuthResult,
     model: string = "gptimage",
 ): Promise<ImageGenerationResult> => {
-    const configs = orderedGPTImageConfigs(model);
-    let lastError: unknown;
-
-    for (let index = 0; index < configs.length; index++) {
-        const config = configs[index];
-        try {
-            return await callGPTImageWithEndpoint(
-                prompt,
-                safeParams,
-                userInfo,
-                config,
-            );
-        } catch (error) {
-            lastError = error;
-            const retry =
-                index < configs.length - 1 && isRetryableGPTImageError(error);
-            logError(
-                `Error calling Azure GPT Image API (${config.modelName}, ${config.region})${retry ? "; trying next region" : ""}:`,
-                error,
-            );
-            if (!retry) throw error;
-        }
+    // One region, one attempt. Azure bills a generation it completed even when
+    // we never saw the response, so a second region would pay for a second
+    // image to answer a request the caller has already been told failed.
+    const config = nextGPTImageConfig(model);
+    try {
+        return await callGPTImageWithEndpoint(
+            prompt,
+            safeParams,
+            userInfo,
+            config,
+        );
+    } catch (error) {
+        logError(
+            `Error calling Azure GPT Image API (${config.modelName}, ${config.region}):`,
+            error,
+        );
+        throw error;
     }
-
-    throw lastError;
 };
 
 /**

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -51,6 +51,9 @@ function successResponse(): Response {
     });
 }
 
+/** Client error, rate limit, and a timeout that may already have been billed. */
+const UPSTREAM_FAILURES = [400, 429, 524];
+
 syncImageEnv(AZURE_KEY_ENV as CloudflareBindings, AZURE_KEY_NAMES);
 
 afterEach(() => {
@@ -75,45 +78,20 @@ describe("gpt-image-2 Azure routing", () => {
         expect(urls.every((url) => url.includes("api-version="))).toBe(true);
     });
 
-    it("tries the next Azure region after a retryable response", async () => {
-        const urls: string[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-            urls.push(String(input));
-            return urls.length === 1
-                ? new Response("rate limited", { status: 429 })
-                : successResponse();
+    // A second region would pay Azure for a second image, and a timeout is
+    // exactly the case where the first one may already have been generated.
+    for (const status of UPSTREAM_FAILURES) {
+        it(`fails a ${status} to the caller instead of trying another region`, async () => {
+            const fetchMock = vi
+                .spyOn(globalThis, "fetch")
+                .mockResolvedValue(
+                    new Response("upstream said no", { status }),
+                );
+
+            await expect(
+                callGPTImage("test", params, userInfo, "gpt-image-2"),
+            ).rejects.toMatchObject({ status } satisfies Partial<HttpError>);
+            expect(fetchMock).toHaveBeenCalledOnce();
         });
-
-        await callGPTImage("test", params, userInfo, "gpt-image-2");
-
-        expect(urls).toHaveLength(2);
-        expect(new URL(urls[0]).host).not.toBe(new URL(urls[1]).host);
-    });
-
-    it("does not retry client errors", async () => {
-        const fetchMock = vi
-            .spyOn(globalThis, "fetch")
-            .mockResolvedValue(new Response("bad request", { status: 400 }));
-
-        await expect(
-            callGPTImage("test", params, userInfo, "gpt-image-2"),
-        ).rejects.toMatchObject({ status: 400 } satisfies Partial<HttpError>);
-        expect(fetchMock).toHaveBeenCalledOnce();
-    });
-
-    it("stops after all Azure regions are rate limited", async () => {
-        const urls: string[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-            urls.push(String(input));
-            return new Response("rate limited", { status: 429 });
-        });
-
-        await expect(
-            callGPTImage("test", params, userInfo, "gpt-image-2"),
-        ).rejects.toMatchObject({ status: 429 } satisfies Partial<HttpError>);
-        expect(urls).toHaveLength(EXPECTED_HOSTS.size);
-        expect(new Set(urls.map((url) => new URL(url).host))).toEqual(
-            EXPECTED_HOSTS,
-        );
-    });
+    }
 });


### PR DESCRIPTION
Promotes #13173 — removes the gpt-image-2 Azure region failover so a timed-out request cannot pay Azure for a second image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3UjxnjfYc3EX8jYvgnGwa