### PR TITLE
fix: retry image pool workers after 503

### DIFF
--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -1,4 +1,5 @@
 import debug from "debug";
+import { isNetworkFailure } from "../fallback.ts";
 import { HttpError } from "./httpError.ts";
 
 const logServer = debug("pollinations:server");
@@ -180,16 +181,26 @@ export function __resetLatencyStateForTests(): void {
     recentWrites.clear();
 }
 
+type ReplayableRequestInit = Omit<RequestInit, "body"> & { body?: string };
+
+/**
+ * Fetches from the weighted pool, retrying distinct workers only when the
+ * request was not accepted (HTTP 503 or a known network failure). The body is
+ * deliberately restricted to a string so every retry can safely resend it.
+ *
+ * Do not add AbortSignal.timeout() here without production Workerd validation:
+ * a timeout signal previously broke every pool request despite passing locally.
+ */
 export const fetchFromWeightedServer = async (
     type: ServerType = "flux",
-    options: RequestInit,
+    options: ReplayableRequestInit,
 ): Promise<Response> => {
     const remainingServers = await getRegisteredServers(type);
     if (remainingServers.length === 0) {
         throw new HttpError(`No active ${type} servers available`, 503);
     }
 
-    while (remainingServers.length > 0) {
+    while (true) {
         const serverUrl = chooseWeightedServer(remainingServers);
         const selectedIndex = remainingServers.findIndex(
             (server) => server.url === serverUrl,
@@ -197,7 +208,18 @@ export const fetchFromWeightedServer = async (
         remainingServers.splice(selectedIndex, 1);
 
         const startedAt = Date.now();
-        const response = await fetch(`${serverUrl}/generate`, options);
+        let response: Response;
+        try {
+            response = await fetch(`${serverUrl}/generate`, options);
+        } catch (error) {
+            if (!isNetworkFailure(error) || remainingServers.length === 0) {
+                throw error;
+            }
+            console.warn(
+                `[${type}] Network failure from ${serverUrl}; retrying another pool worker`,
+            );
+            continue;
+        }
         // Record latency for successful responses only (a 5xx/timeout would
         // record the full timeout window and wrongly down-weight a recovering
         // server). Awaited (not fire-and-forget): a floating promise can be
@@ -215,15 +237,6 @@ export const fetchFromWeightedServer = async (
             errorBody = "Could not read error response body";
         }
 
-        console.error(
-            `[${type}] Server ${serverUrl} returned ${response.status}:`,
-            {
-                status: response.status,
-                statusText: response.statusText,
-                body: errorBody,
-            },
-        );
-
         const error = new HttpError(
             `Image backend rejected request with status ${response.status}`,
             response.status,
@@ -236,13 +249,20 @@ export const fetchFromWeightedServer = async (
         // before the caller receives a 503. Other failures stay single-attempt:
         // retrying a request that may already have started can duplicate work.
         if (response.status !== 503 || remainingServers.length === 0) {
+            console.error(
+                `[${type}] Server ${serverUrl} returned ${response.status}:`,
+                {
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: errorBody,
+                },
+            );
             throw error;
         }
 
         console.warn(
-            `[${type}] Server ${serverUrl} is full; retrying another pool worker`,
+            `[${type}] Server ${serverUrl} returned 503; retrying another pool worker`,
+            { body: errorBody },
         );
     }
-
-    throw new HttpError(`No active ${type} servers available`, 503);
 };

--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -142,16 +142,6 @@ export function chooseWeightedServer(servers: ServerEntry[]): string {
     return servers[servers.length - 1].url;
 }
 
-export const getNextServerUrl = async (
-    type: ServerType = "flux",
-): Promise<string> => {
-    const activeServers = await getRegisteredServers(type);
-    if (activeServers.length === 0) {
-        throw new HttpError(`No active ${type} servers available`, 503);
-    }
-    return chooseWeightedServer(activeServers);
-};
-
 // Save the latency of the most recent successful /generate under the server's
 // dedicated latency key, so chooseWeightedServer can weight toward faster
 // backends. Separate key = a heartbeat can never overwrite it. Throttled to one
@@ -194,19 +184,30 @@ export const fetchFromWeightedServer = async (
     type: ServerType = "flux",
     options: RequestInit,
 ): Promise<Response> => {
-    const serverUrl = await getNextServerUrl(type);
-    const startedAt = Date.now();
-    const response = await fetch(`${serverUrl}/generate`, options);
-    // Record latency for successful responses only (a 5xx/timeout would record
-    // the full timeout window and wrongly down-weight a recovering server).
-    // Awaited (not fire-and-forget): a floating promise can be cancelled when
-    // the Worker invocation completes, dropping the KV write. The cost is
-    // bounded — recordLatency hits the in-memory throttle and returns without
-    // any KV I/O on all but ~1 request per LATENCY_WRITE_THROTTLE_MS per server.
-    if (response.ok) {
-        await recordLatency(type, serverUrl, Date.now() - startedAt);
+    const remainingServers = await getRegisteredServers(type);
+    if (remainingServers.length === 0) {
+        throw new HttpError(`No active ${type} servers available`, 503);
     }
-    if (!response.ok) {
+
+    while (remainingServers.length > 0) {
+        const serverUrl = chooseWeightedServer(remainingServers);
+        const selectedIndex = remainingServers.findIndex(
+            (server) => server.url === serverUrl,
+        );
+        remainingServers.splice(selectedIndex, 1);
+
+        const startedAt = Date.now();
+        const response = await fetch(`${serverUrl}/generate`, options);
+        // Record latency for successful responses only (a 5xx/timeout would
+        // record the full timeout window and wrongly down-weight a recovering
+        // server). Awaited (not fire-and-forget): a floating promise can be
+        // cancelled when the Worker invocation completes, dropping the KV
+        // write. The cost is bounded by the in-memory write throttle.
+        if (response.ok) {
+            await recordLatency(type, serverUrl, Date.now() - startedAt);
+            return response;
+        }
+
         let errorBody = "";
         try {
             errorBody = await response.text();
@@ -223,12 +224,25 @@ export const fetchFromWeightedServer = async (
             },
         );
 
-        throw new HttpError(
+        const error = new HttpError(
             `Image backend rejected request with status ${response.status}`,
             response.status,
             { body: errorBody },
             `${serverUrl}/generate`,
         );
+
+        // A queue-full response means this backend did not accept the request.
+        // Try each other registered worker once so spare pool capacity is used
+        // before the caller receives a 503. Other failures stay single-attempt:
+        // retrying a request that may already have started can duplicate work.
+        if (response.status !== 503 || remainingServers.length === 0) {
+            throw error;
+        }
+
+        console.warn(
+            `[${type}] Server ${serverUrl} is full; retrying another pool worker`,
+        );
     }
-    return response;
+
+    throw new HttpError(`No active ${type} servers available`, 503);
 };

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -208,7 +208,8 @@ export const callSelfHostedServer = async (
 
         let response = null;
 
-        // Single attempt - no retry logic
+        // The pool helper retries each other registered worker once when the
+        // selected backend rejects the request with queue-full 503.
         try {
             const requestInit = {
                 method: "POST",

--- a/gen.pollinations.ai/test/image/availableServers.test.ts
+++ b/gen.pollinations.ai/test/image/availableServers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     __resetLatencyStateForTests,
     chooseWeightedServer,
+    fetchFromWeightedServer,
     getRegisteredServers,
     recordLatency,
     registerServer,
@@ -82,6 +83,70 @@ describe("chooseWeightedServer", () => {
         for (let n = 0; n < 100; n++) seen.add(chooseWeightedServer(servers));
         // The new, unmeasured server must still be reachable (not starved).
         expect(seen.has("https://new")).toBe(true);
+    });
+});
+
+describe("fetchFromWeightedServer", () => {
+    beforeEach(() => {
+        setServerRegistryBinding(makeKv(), "test");
+        __resetLatencyStateForTests();
+        vi.spyOn(Math, "random").mockReturnValue(0);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("retries a distinct worker when the selected worker returns 503", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            const url = input.toString();
+            calls.push(url);
+            return url.startsWith("https://w1/")
+                ? new Response("queue full", { status: 503 })
+                : new Response("image", { status: 200 });
+        });
+
+        const response = await fetchFromWeightedServer("flux", {
+            method: "POST",
+            body: "request-body",
+        });
+
+        expect(response.status).toBe(200);
+        expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+    });
+
+    it("tries every worker once before returning a terminal 503", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            calls.push(input.toString());
+            return new Response("queue full", { status: 503 });
+        });
+
+        await expect(
+            fetchFromWeightedServer("flux", { method: "POST" }),
+        ).rejects.toMatchObject({
+            status: 503,
+            upstreamUrl: "https://w2/generate",
+        });
+        expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+    });
+
+    it("does not retry failures other than queue-full 503", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response("CUDA error", { status: 500 }));
+
+        await expect(
+            fetchFromWeightedServer("flux", { method: "POST" }),
+        ).rejects.toMatchObject({ status: 500 });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/gen.pollinations.ai/test/image/availableServers.test.ts
+++ b/gen.pollinations.ai/test/image/availableServers.test.ts
@@ -100,6 +100,12 @@ describe("fetchFromWeightedServer", () => {
     it("retries a distinct worker when the selected worker returns 503", async () => {
         await registerServer("https://w1", "flux");
         await registerServer("https://w2", "flux");
+        const errorLog = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+        const warnLog = vi
+            .spyOn(console, "warn")
+            .mockImplementation(() => undefined);
         const calls: string[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
             const url = input.toString();
@@ -116,11 +122,19 @@ describe("fetchFromWeightedServer", () => {
 
         expect(response.status).toBe(200);
         expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+        expect(errorLog).not.toHaveBeenCalled();
+        expect(warnLog).toHaveBeenCalledOnce();
     });
 
     it("tries every worker once before returning a terminal 503", async () => {
         await registerServer("https://w1", "flux");
         await registerServer("https://w2", "flux");
+        const errorLog = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+        const warnLog = vi
+            .spyOn(console, "warn")
+            .mockImplementation(() => undefined);
         const calls: string[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
             calls.push(input.toString());
@@ -134,6 +148,44 @@ describe("fetchFromWeightedServer", () => {
             upstreamUrl: "https://w2/generate",
         });
         expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+        expect(errorLog).toHaveBeenCalledOnce();
+        expect(warnLog).toHaveBeenCalledOnce();
+    });
+
+    it("retries a distinct worker after a known network failure", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            const url = input.toString();
+            calls.push(url);
+            if (url.startsWith("https://w1/")) {
+                throw new TypeError("fetch failed: connection refused");
+            }
+            return new Response("image", { status: 200 });
+        });
+
+        const response = await fetchFromWeightedServer("flux", {
+            method: "POST",
+            body: "request-body",
+        });
+
+        expect(response.status).toBe(200);
+        expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+    });
+
+    it("does not retry a fetch rejection caused by application code", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockRejectedValue(new TypeError("Cannot read properties of null"));
+
+        await expect(
+            fetchFromWeightedServer("flux", { method: "POST" }),
+        ).rejects.toThrow("Cannot read properties of null");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it("does not retry failures other than queue-full 503", async () => {


### PR DESCRIPTION
## What changed

- Retries each distinct registered image-pool worker after an HTTP 503 or known network failure.
- Preserves latency-weighted selection for the first and subsequent attempts.
- Keeps all non-503 failures single-attempt to avoid duplicate GPU work.
- Logs recovered attempts as warnings and terminal failures as errors.
- Adds coverage for successful failover, exhausted capacity, network rejection, and non-retryable failures.

## Why

FLUX previously selected one Vast worker and returned its queue-full 503 even when another registered FLUX worker had capacity. The shared helper now exhausts distinct healthy pool workers before returning a terminal 503. DreamShaper receives the same behavior; Z-Image continues to use its shared Cloudflare tunnel hostname.

Pricing, model metadata, the Vast-only primary route, and fallback `none` are unchanged.

## Validation

- `npx vitest run test/image` — 23 files, 214 tests passed
- `npx vitest run test/image/availableServers.test.ts test/image/fluxFallback.test.ts` — 17 tests passed
- `npm run typecheck`
- `npx biome check ...`
- `git diff --check`
