### PR TITLE
fix: remap upstream payment failures

### DIFF
--- a/gen.pollinations.ai/test/upstream-status.test.ts
+++ b/gen.pollinations.ai/test/upstream-status.test.ts
@@ -1,0 +1,6 @@
+import { remapUpstreamStatus } from "@shared/error.ts";
+import { expect, test } from "vitest";
+
+test("maps upstream payment failures to bad gateway", () => {
+    expect(remapUpstreamStatus(402)).toBe(502);
+});

--- a/shared/error.ts
+++ b/shared/error.ts
@@ -374,7 +374,7 @@ function createUpstreamErrorResponse(
  * (400/413/422) as-is since those can reflect user input we failed to validate.
  */
 export function remapUpstreamStatus(status: number): ContentfulStatusCode {
-    const remapTo502 = new Set([401, 403, 404, 409, 415, 429]);
+    const remapTo502 = new Set([401, 402, 403, 404, 409, 415, 429]);
     if (remapTo502.has(status)) return 502;
     return status as ContentfulStatusCode;
 }


### PR DESCRIPTION
- Maps provider-returned HTTP 402 responses to 502 Bad Gateway.
- Keeps Pollinations wallet and API-key budget failures as HTTP 402.
- Preserves the raw upstream 402 for fallback and observability.
- Adds focused regression coverage.

Root cause: OpenRouter credit exhaustion was being surfaced as a user `PAYMENT_REQUIRED` error even when their Paid Pollen was healthy.

Checks:
- Biome 2.3.10: clean
- Focused Vitest regression: 1 passed
- Full Cloudflare-worker test harness: CI pending

Fixes #13180