### PR TITLE
fix: route GLM through pinned Novita endpoint

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -398,14 +398,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "glm": {
     "cost": {
-      "completionTextTokens": 0.0000044,
-      "promptCachedTokens": 0.00000014,
-      "promptTextTokens": 0.0000014,
+      "completionTextTokens": 0.0000002552,
+      "promptCachedTokens": 0.00000001508,
+      "promptTextTokens": 0.0000000812,
     },
     "price": {
-      "completionTextTokens": 0.0000044,
-      "promptCachedTokens": 0.00000014,
-      "promptTextTokens": 0.0000014,
+      "completionTextTokens": 0.0000002552,
+      "promptCachedTokens": 0.00000001508,
+      "promptTextTokens": 0.0000000812,
     },
   },
   "gpt-5.4": {

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -857,11 +857,13 @@ test("Google text model providers match their configured routes", () => {
     }
 });
 
-test("OpenRouter models require paid balance", () => {
+test("OpenRouter models require paid balance except free GLM", () => {
     for (const model of getModels()) {
         const definition = getRegistryModelDefinition(model);
         if (definition.provider === "openrouter") {
-            expect(definition.paidOnly, `${model} paid-only status`).toBe(true);
+            expect(definition.paidOnly, `${model} paid-only status`).toBe(
+                model !== "glm",
+            );
         }
     }
 });

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -389,7 +389,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "glm",
-        config: portkeyConfig["accounts/fireworks/models/glm-5p2"],
+        config: portkeyConfig["z-ai/glm-5.2"],
         transform: pipe(stripCacheControl, fireworksThinking),
     },
     {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -164,6 +164,21 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "qwen/qwen3.7-max",
             defaultOptions: { provider: { sort: "price" } },
         }),
+    "z-ai/glm-5.2": () => ({
+        provider: "openrouter",
+        authKey: process.env.OPENROUTER_API_KEY,
+        model: "z-ai/glm-5.2",
+        defaultOptions: {
+            provider: {
+                only: ["novita/fp8"],
+                allow_fallbacks: false,
+                max_price: {
+                    prompt: 0.0812,
+                    completion: 0.2552,
+                },
+            },
+        },
+    }),
     "qwen/qwen3.8-max": () =>
         createOpenRouterModelConfig({
             model: "qwen/qwen3.8-max",
@@ -380,10 +395,6 @@ export const portkeyConfig: PortkeyConfigMap = {
     "sonar-reasoning-pro": () =>
         createPerplexityModelConfig({ model: "sonar-reasoning-pro" }),
 
-    "accounts/fireworks/models/glm-5p2": () =>
-        createFireworksModelConfig({
-            model: "accounts/fireworks/models/glm-5p2",
-        }),
     "accounts/fireworks/models/minimax-m2p7": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/minimax-m2p7",

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -101,7 +101,7 @@ test("media routes own their endpoint-specific model defaults", async () => {
     expect(editResponse.status).toBe(403);
 });
 
-test("filters OpenRouter text models by paid balance", async ({
+test("filters paid-only OpenRouter text models while keeping GLM free", async ({
     apiKey,
     paidApiKey,
 }) => {
@@ -121,19 +121,28 @@ test("filters OpenRouter text models by paid balance", async ({
     const paidModels = (await paidResponse.json()) as {
         data: { id: string }[];
     };
-    const openRouterModelNames = getVisibleTextModels().filter(
-        (model) => getRegistryModelDefinition(model).provider === "openrouter",
+    const paidOnlyOpenRouterModelNames = getVisibleTextModels().filter(
+        (model) => {
+            const definition = getRegistryModelDefinition(model);
+            return definition.provider === "openrouter" && definition.paidOnly;
+        },
     );
     const freeModelNames = new Set(freeModels.data.map((model) => model.id));
     const paidModelNames = new Set(paidModels.data.map((model) => model.id));
 
-    expect(openRouterModelNames.length).toBeGreaterThan(0);
+    expect(paidOnlyOpenRouterModelNames.length).toBeGreaterThan(0);
     expect(
-        openRouterModelNames.every((model) => !freeModelNames.has(model)),
+        paidOnlyOpenRouterModelNames.every(
+            (model) => !freeModelNames.has(model),
+        ),
     ).toBe(true);
     expect(
-        openRouterModelNames.every((model) => paidModelNames.has(model)),
+        paidOnlyOpenRouterModelNames.every((model) =>
+            paidModelNames.has(model),
+        ),
     ).toBe(true);
+    expect(freeModelNames.has("glm")).toBe(true);
+    expect(paidModelNames.has("glm")).toBe(true);
 
     const generation = await fetchWorker(
         "/text/paid-only-check?model=mistral",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -137,6 +137,24 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("pins GLM 5.2 to Novita on OpenRouter with a price ceiling", () => {
+        const result = resolveModelConfig(messages, { model: "glm" });
+
+        expect(result.options.model).toBe("z-ai/glm-5.2");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openrouter",
+        });
+        expect(result.options.modelConfig).not.toHaveProperty("custom-host");
+        expect(result.options.provider).toEqual({
+            only: ["novita/fp8"],
+            allow_fallbacks: false,
+            max_price: {
+                prompt: 0.0812,
+                completion: 0.2552,
+            },
+        });
+    });
+
     it("routes Kimi K3 directly to Fireworks without fallback", () => {
         const result = resolveModelConfig(messages, { model: "kimi-k3" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1540,15 +1540,16 @@ export const TEXT_SERVICES = {
     },
     "glm": {
         aliases: ["glm-5.2", "glm-5p2"],
-        provider: "fireworks",
+        provider: "openrouter",
         brand: "Z.ai",
         category: "text",
         addedDate: new Date("2026-01-06").getTime(),
+        paidOnly: false,
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(1.4),
-            promptCachedTokens: perMillion(0.14),
-            completionTextTokens: perMillion(4.4),
+            promptTextTokens: perMillion(0.0812),
+            promptCachedTokens: perMillion(0.01508),
+            completionTextTokens: perMillion(0.2552),
         },
         title: "Z.ai GLM-5.2",
         description:


### PR DESCRIPTION
- Routes the existing `glm` service from Fireworks to OpenRouter model `z-ai/glm-5.2`, pinned to `novita/fp8` with fallback disabled.
- Keeps canonical `glm`, aliases `glm-5.2` and `glm-5p2`, `paidOnly: false`, multiplier `1`, no Pollinations GPU, and the existing text/tools/reasoning contract.
- Uses exact current rates: $0.0812/M input, $0.01508/M cached input, and $0.2552/M output. `max_price` fails closed if OpenRouter raises input/output pricing.
- Updates the effective-price snapshot and the OpenRouter free-access exception.

Validation:

- Full local E2E confirmed OpenRouter served Novita and Pollinations billing matched OpenRouter's reported cost, including cached input.
- Basic, streaming, aliases, tools, reasoning, max-token, catalog, malformed-request, cache, and 5/15/30 burst tests passed; 30/30 completed with no errors.
- Focused registry, permissions, billing, VCR, safety, typecheck, and Biome checks passed.

Draft: do not merge until the production OpenRouter account/key is confirmed funded. OpenRouter cannot independently cap cached-input pricing, so that rate still requires catalog monitoring.