### PR TITLE
chore: sync main into production

### DIFF
--- a/gen.pollinations.ai/src/image/availableServers.ts
+++ b/gen.pollinations.ai/src/image/availableServers.ts
@@ -1,4 +1,5 @@
 import debug from "debug";
+import { isNetworkFailure } from "../fallback.ts";
 import { HttpError } from "./httpError.ts";
 
 const logServer = debug("pollinations:server");
@@ -142,16 +143,6 @@ export function chooseWeightedServer(servers: ServerEntry[]): string {
     return servers[servers.length - 1].url;
 }
 
-export const getNextServerUrl = async (
-    type: ServerType = "flux",
-): Promise<string> => {
-    const activeServers = await getRegisteredServers(type);
-    if (activeServers.length === 0) {
-        throw new HttpError(`No active ${type} servers available`, 503);
-    }
-    return chooseWeightedServer(activeServers);
-};
-
 // Save the latency of the most recent successful /generate under the server's
 // dedicated latency key, so chooseWeightedServer can weight toward faster
 // backends. Separate key = a heartbeat can never overwrite it. Throttled to one
@@ -190,23 +181,55 @@ export function __resetLatencyStateForTests(): void {
     recentWrites.clear();
 }
 
+type ReplayableRequestInit = Omit<RequestInit, "body"> & { body?: string };
+
+/**
+ * Fetches from the weighted pool, retrying distinct workers only when the
+ * request was not accepted (HTTP 503 or a known network failure). The body is
+ * deliberately restricted to a string so every retry can safely resend it.
+ *
+ * Do not add AbortSignal.timeout() here without production Workerd validation:
+ * a timeout signal previously broke every pool request despite passing locally.
+ */
 export const fetchFromWeightedServer = async (
     type: ServerType = "flux",
-    options: RequestInit,
+    options: ReplayableRequestInit,
 ): Promise<Response> => {
-    const serverUrl = await getNextServerUrl(type);
-    const startedAt = Date.now();
-    const response = await fetch(`${serverUrl}/generate`, options);
-    // Record latency for successful responses only (a 5xx/timeout would record
-    // the full timeout window and wrongly down-weight a recovering server).
-    // Awaited (not fire-and-forget): a floating promise can be cancelled when
-    // the Worker invocation completes, dropping the KV write. The cost is
-    // bounded — recordLatency hits the in-memory throttle and returns without
-    // any KV I/O on all but ~1 request per LATENCY_WRITE_THROTTLE_MS per server.
-    if (response.ok) {
-        await recordLatency(type, serverUrl, Date.now() - startedAt);
+    const remainingServers = await getRegisteredServers(type);
+    if (remainingServers.length === 0) {
+        throw new HttpError(`No active ${type} servers available`, 503);
     }
-    if (!response.ok) {
+
+    while (true) {
+        const serverUrl = chooseWeightedServer(remainingServers);
+        const selectedIndex = remainingServers.findIndex(
+            (server) => server.url === serverUrl,
+        );
+        remainingServers.splice(selectedIndex, 1);
+
+        const startedAt = Date.now();
+        let response: Response;
+        try {
+            response = await fetch(`${serverUrl}/generate`, options);
+        } catch (error) {
+            if (!isNetworkFailure(error) || remainingServers.length === 0) {
+                throw error;
+            }
+            console.warn(
+                `[${type}] Network failure from ${serverUrl}; retrying another pool worker`,
+            );
+            continue;
+        }
+        // Record latency for successful responses only (a 5xx/timeout would
+        // record the full timeout window and wrongly down-weight a recovering
+        // server). Awaited (not fire-and-forget): a floating promise can be
+        // cancelled when the Worker invocation completes, dropping the KV
+        // write. The cost is bounded by the in-memory write throttle.
+        if (response.ok) {
+            await recordLatency(type, serverUrl, Date.now() - startedAt);
+            return response;
+        }
+
         let errorBody = "";
         try {
             errorBody = await response.text();
@@ -214,21 +237,32 @@ export const fetchFromWeightedServer = async (
             errorBody = "Could not read error response body";
         }
 
-        console.error(
-            `[${type}] Server ${serverUrl} returned ${response.status}:`,
-            {
-                status: response.status,
-                statusText: response.statusText,
-                body: errorBody,
-            },
-        );
-
-        throw new HttpError(
+        const error = new HttpError(
             `Image backend rejected request with status ${response.status}`,
             response.status,
             { body: errorBody },
             `${serverUrl}/generate`,
         );
+
+        // A queue-full response means this backend did not accept the request.
+        // Try each other registered worker once so spare pool capacity is used
+        // before the caller receives a 503. Other failures stay single-attempt:
+        // retrying a request that may already have started can duplicate work.
+        if (response.status !== 503 || remainingServers.length === 0) {
+            console.error(
+                `[${type}] Server ${serverUrl} returned ${response.status}:`,
+                {
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: errorBody,
+                },
+            );
+            throw error;
+        }
+
+        console.warn(
+            `[${type}] Server ${serverUrl} returned 503; retrying another pool worker`,
+            { body: errorBody },
+        );
     }
-    return response;
 };

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -208,7 +208,8 @@ export const callSelfHostedServer = async (
 
         let response = null;
 
-        // Single attempt - no retry logic
+        // The pool helper retries each other registered worker once when the
+        // selected backend rejects the request with queue-full 503.
         try {
             const requestInit = {
                 method: "POST",

--- a/gen.pollinations.ai/test/image/availableServers.test.ts
+++ b/gen.pollinations.ai/test/image/availableServers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     __resetLatencyStateForTests,
     chooseWeightedServer,
+    fetchFromWeightedServer,
     getRegisteredServers,
     recordLatency,
     registerServer,
@@ -82,6 +83,122 @@ describe("chooseWeightedServer", () => {
         for (let n = 0; n < 100; n++) seen.add(chooseWeightedServer(servers));
         // The new, unmeasured server must still be reachable (not starved).
         expect(seen.has("https://new")).toBe(true);
+    });
+});
+
+describe("fetchFromWeightedServer", () => {
+    beforeEach(() => {
+        setServerRegistryBinding(makeKv(), "test");
+        __resetLatencyStateForTests();
+        vi.spyOn(Math, "random").mockReturnValue(0);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("retries a distinct worker when the selected worker returns 503", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const errorLog = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+        const warnLog = vi
+            .spyOn(console, "warn")
+            .mockImplementation(() => undefined);
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            const url = input.toString();
+            calls.push(url);
+            return url.startsWith("https://w1/")
+                ? new Response("queue full", { status: 503 })
+                : new Response("image", { status: 200 });
+        });
+
+        const response = await fetchFromWeightedServer("flux", {
+            method: "POST",
+            body: "request-body",
+        });
+
+        expect(response.status).toBe(200);
+        expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+        expect(errorLog).not.toHaveBeenCalled();
+        expect(warnLog).toHaveBeenCalledOnce();
+    });
+
+    it("tries every worker once before returning a terminal 503", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const errorLog = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+        const warnLog = vi
+            .spyOn(console, "warn")
+            .mockImplementation(() => undefined);
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            calls.push(input.toString());
+            return new Response("queue full", { status: 503 });
+        });
+
+        await expect(
+            fetchFromWeightedServer("flux", { method: "POST" }),
+        ).rejects.toMatchObject({
+            status: 503,
+            upstreamUrl: "https://w2/generate",
+        });
+        expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+        expect(errorLog).toHaveBeenCalledOnce();
+        expect(warnLog).toHaveBeenCalledOnce();
+    });
+
+    it("retries a distinct worker after a known network failure", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            const url = input.toString();
+            calls.push(url);
+            if (url.startsWith("https://w1/")) {
+                throw new TypeError("fetch failed: connection refused");
+            }
+            return new Response("image", { status: 200 });
+        });
+
+        const response = await fetchFromWeightedServer("flux", {
+            method: "POST",
+            body: "request-body",
+        });
+
+        expect(response.status).toBe(200);
+        expect(calls).toEqual(["https://w1/generate", "https://w2/generate"]);
+    });
+
+    it("does not retry a fetch rejection caused by application code", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockRejectedValue(new TypeError("Cannot read properties of null"));
+
+        await expect(
+            fetchFromWeightedServer("flux", { method: "POST" }),
+        ).rejects.toThrow("Cannot read properties of null");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry failures other than queue-full 503", async () => {
+        await registerServer("https://w1", "flux");
+        await registerServer("https://w2", "flux");
+        const fetchMock = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(new Response("CUDA error", { status: 500 }));
+
+        await expect(
+            fetchFromWeightedServer("flux", { method: "POST" }),
+        ).rejects.toMatchObject({ status: 500 });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/image.pollinations.ai/GPU_INSTANCES.md
+++ b/image.pollinations.ai/GPU_INSTANCES.md
@@ -1,19 +1,32 @@
 # GPU Instances
 
-Last updated: 2026-08-06
+Last updated: 2026-08-09
 
 ## Capacity Summary
 
 | Model | Workers | GPUs | Provider | Cost/hr | Status |
 |-------|---------|------|----------|---------|--------|
-| Flux (FP4) | 2 | RTX 5090 + RTX PRO 4000 Blackwell | Vast.ai | $0.648889/hr all-in | **ACTIVE — two production** (Replicate fallback) |
-| Z-Image | 2 | 2x RTX 5090 | Vast.ai | $0.742222/hr all-in | **ACTIVE — two production** |
-| Klein 4B | 1 active + 1 rollback | RTX 3090 + A5000 | Vast.ai + RunPod | $0.1656 + $0.27 while rollback runs | **ACTIVE — Vast production; RunPod stop-ready** |
+| Flux (FP4) | 2 | RTX 5090 + RTX PRO 4000 Blackwell | Vast.ai | $0.591111/hr all-in | **ACTIVE — two production, Vast-only** |
+| Z-Image | 2 | 2x RTX 5090 | Vast.ai | $0.712593/hr all-in | **ACTIVE — two production** |
+| Klein 4B | 1 | RTX 3090 | Vast.ai | $0.147778/hr all-in | **ACTIVE — Vast production** |
 | DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 2 | 2x RTX 3090 | Vast.ai | $0.303333/hr all-in | **ACTIVE — production** |
-| LTX-2 + ACE-Step | 1 | GH200 | Lambda Labs | — | **ACTIVE — Sana drained, `sana.service` can be stopped** |
+| LTX-2 + ACE-Step | 0 active routes | GH200 (historical) | Lambda Labs | Verify provider account | **RETIRED from production** |
 
-At capture time, the seven running Vast instances cost **$1.860000/hr** in total.
+At capture time, the seven running Vast instances cost **$1.754815/hr** in total
+(**$1,263.47 per 30-day month**).
 All seven are production workers; there is no isolated canary left running.
+
+Live verification on 2026-08-09 confirmed that all seven instances are in both
+`actual_status=running` and `intended_status=running`, every model server and
+named tunnel is healthy, and the registry contains both Flux hostnames, the
+shared Z-Image hostname, and both DreamShaper hostnames. Klein is not in the
+heartbeat registry because production reaches it through the `KLEIN_VPC`
+Workers VPC binding.
+
+Two dashboard labels are historical: `zimage-vast-canary` on `46003779` and
+`flux-maintenance-canary-44731147` on `46491202`. Both are production workers,
+not spare canaries. Vast labels do not control routing; instance IDs,
+registered hostnames, and the Klein VPC tunnel are authoritative.
 
 ## Provider: Vast.ai — DreamShaper 8 LCM (RTX 3090)
 
@@ -81,42 +94,52 @@ post-cutover documentation PR.
 
 ## Provider: Vast.ai — Flux (RTX 5090 + RTX PRO 4000 Blackwell, FP4)
 
-Two single-GPU instances, each fronted by a named Cloudflare Tunnel. Flux
-routes pool-first with automatic Replicate fallback
-(`gen.pollinations.ai/src/image/createAndReturnImages.ts` → `callFluxWithFallback`).
+Two single-GPU instances, each fronted by a named Cloudflare Tunnel. Flux is
+Vast-only and has no external provider fallback. The gen worker dispatches to
+the registered `flux` pool through `callSelfHostedServer`.
 
-| Worker | Vast instance | GPU | Listed rate | Status |
-|--------|---------------|-----|-------------|--------|
-| flux-vast-04 | 46491202 | RTX 5090 | $0.361111/hr | ACTIVE (promoted 2026-08-01) — named tunnel `flux-vast-04.pollinations.ai` |
-| flux-vast-06 | 47018211 | RTX PRO 4000 Blackwell 24 GB | $0.287778/hr | ACTIVE (promoted 2026-08-06) — named tunnel `flux-vast-06.pollinations.ai` |
+| Worker | Vast instance | Machine / region | GPU | All-in rate | Status |
+|--------|---------------|------------------|-----|-------------|--------|
+| flux-vast-04 | 46491202 | 138472 / California, US | RTX 5090 | $0.361111/hr | ACTIVE (promoted 2026-08-01) — registered hostname `flux-vast-04.pollinations.ai` |
+| flux-vast-06 | 47259458 | 102863 / Quebec, CA | RTX PRO 4000 Blackwell 24 GB | $0.230000/hr | ACTIVE (promoted 2026-08-09) — registered hostname `flux-vast-06.pollinations.ai` |
 
-Instance `47018211` adds production capacity slot 2 while instance `46491202`
-remains active. The Ontario host is machine `53737`, has Vast reliability
-`0.9944`, and costs **$207.20 per 30-day month** in Vast credits. At the
-account's 50% credit acquisition cost, that is about **$103.60/month cash
-equivalent**. The two-worker FLUX pool costs `$0.648889/hr` all-in.
+Instance `47259458` replaced `47018211` while instance `46491202` remained
+active. The Quebec host is machine `102863`, has Vast reliability `0.99595`,
+and costs **$165.60 per 30-day month** in Vast credits. It saves
+**$0.057778/hr**, or **$41.60 per 30-day month**, compared with the replaced
+slot. The two-worker FLUX pool now costs `$0.591111/hr` all-in.
 
-Qualification on the RTX PRO 4000 passed authentication rejection, dimension
-limits, 512x512 and 1024x1024 generation, model and tunnel restart recovery,
-and isolated external routing. Direct load completed 30/30 1024x1024 requests
-at 29.54 images/minute with 6.12s p50 and 8.17s p95; external load completed
-15/15 at 29.84 images/minute with 6.06s p50 and 8.06s p95. After promotion,
-the worker received four attributed production requests within 25 seconds;
-the final log sample contained 104 successful `/generate` responses and zero
-5xx, OOM, CUDA, or traceback errors. The original RTX 5090 stayed healthy
-throughout the additive cutover.
+Qualification on the replacement passed authentication rejection, 512x512,
+1024x1024, 1024x768, and 768x1024 generation, four-request burst handling,
+model restart recovery in 12 seconds, and shared-tunnel production routing.
+Direct generation took 1.30s at 512x512, 1.95s at 1024x1024, and 1.42s for
+both wide and tall tests. The worker served **116/116 attributed production
+requests** with zero 4xx/5xx, OOM, CUDA, or traceback errors before the old
+instance was destroyed. Fixed-seed byte output varied on both the candidate and
+the replaced production worker, so it was recorded as existing Nunchaku
+behavior rather than a host regression.
 
-The canary exposed a pre-existing queue caveat: the synchronous inference call
+The replacement reconfirmed a queue caveat: the synchronous inference call
 blocks the FastAPI event loop, so `QUEUE_LIMIT=3` does not currently guarantee
-fast 503 shedding under concurrent load. Treat the two-worker pool as the
-capacity guard and keep Replicate enabled as fallback until queue admission is
-hardened separately.
+fast 503 shedding under concurrent load. Treat the two-worker Vast pool as the
+capacity guard. Queue admission must be hardened separately; there is no
+Replicate fallback.
+
+The post-promotion audit found that `47259458` still had
+`HEARTBEAT_ENABLED=false` even though its named tunnel was healthy. That made
+the second paid worker invisible to normal Flux dispatch and left
+`46491202` carrying the pool alone. The flag was corrected, the worker was
+restarted, both Flux hostnames appeared in `/register`, and real production
+requests reached `flux-vast-06`. Always finish a promotion by checking the
+exact new hostname in `/register` and an attributed request in that worker's
+`/tmp/flux.log`; a healthy tunnel alone is insufficient.
 
 > Instance IDs/IPs/ports change on recreate — check `vastai show instances`.
 > CRITICAL: workers MUST be behind a named Cloudflare tunnel created in the
 > authoritative Pollinations account. The gen Worker cannot fetch a Vast
 > raw-IP/non-standard-port origin, and a successful registry heartbeat alone
-> does not prove the data path works. Replicate can hide either failure.
+> does not prove the data path works. Historical external fallbacks could hide
+> either failure, but the current FLUX route is Vast-only.
 
 **The quick-tunnel warning above is not theoretical — it caused the #12254
 outage.** flux-vast-03 was left on a `trycloudflare.com` quick tunnel (free,
@@ -128,7 +151,8 @@ Never point production at a quick tunnel; use a named tunnel.
 
 Instance `46491202` replaced maintenance-bound instance `44731147`, which was
 destroyed after cutover. The California host is machine `138472` with Vast
-reliability `0.9971`. Qualification passed 512x512 and 1024x1024 generation,
+reliability `0.99476` at the 2026-08-09 audit. Qualification passed 512x512 and
+1024x1024 generation,
 four concurrent requests, authentication rejection, 17-second restart
 recovery, and an external Cloudflare generation in 3.46 seconds. After the old
 connector drained, the new worker served 47 production generations with zero
@@ -144,7 +168,7 @@ connections.
 ```bash
 vastai search offers 'gpu_name=RTX_5090 num_gpus=1 verified=true rentable=true reliability>0.99 duration>=30 inet_down>=500 cpu_cores>=8 disk_space>=60' --order dph_total
 vastai create instance <OFFER> --image "vastai/base-image:cuda-13.0.2-cudnn-devel-ubuntu24.04-py312" --disk 60 --ssh --direct --env '-p 8765:8765'
-vastai attach ssh <INSTANCE> "$(cat ~/.ssh/pollinations_services_2026.pub)"
+vastai attach ssh <INSTANCE> "$(cat ~/.ssh/id_ed25519.pub)"
 # Isolated canary: heartbeat and production tunnel are disabled by default.
 PLN_GPU_TOKEN=... HF_TOKEN=... PUBLIC_HOSTNAME=flux-vast-NN.pollinations.ai \
 GIT_BRANCH=main bash setup-vast.sh
@@ -179,8 +203,8 @@ POLLINATIONS_API_KEY=... bash image.pollinations.ai/nunchaku/verify-vast.sh  # r
 
 **Key behavior:** FP4 nunchaku, 4 steps, full 1024x1024
 (`MAX_PIXELS=1048576`). `QUEUE_LIMIT=3` is configured, but the synchronous
-inference path currently prevents it from reliably shedding concurrent load;
-Replicate remains the overflow and failure fallback.
+inference path currently prevents it from reliably shedding concurrent load.
+FLUX is Vast-only, so both production workers must remain healthy.
 
 ## Provider: Vast.ai — Z-Image Turbo (RTX 5090)
 
@@ -188,17 +212,35 @@ Z-Image uses one remotely managed Cloudflare Tunnel shared by the Vast
 workers. Cloudflare balances requests across its connectors, while the registry
 sees one stable backend URL.
 
-| Worker | Vast instance | Region | Listed rate | Status |
-|--------|---------------|--------|-------------|--------|
-| zimage-vast-canary | 46003779 | California | $0.351111/hr | ACTIVE — production |
-| zimage-vast-03 | 46598648 | Estonia | $0.391111/hr | ACTIVE — production (promoted 2026-08-02) |
+| Worker | Vast instance | Machine / region | Reliability | All-in rate | Status |
+|--------|---------------|------------------|-------------|-------------|--------|
+| zimage-vast-canary | 46003779 | 56097 / California, US | 0.99487 | $0.351111/hr | ACTIVE — production |
+| zimage-vast-04 | 47267292 | 137833 / California, US | 0.99507 | $0.361481/hr | ACTIVE — production (promoted 2026-08-09) |
 
-The active two-worker fleet costs `$0.742222/hr`. Instance `46598648` replaced
-`45313816`, saving `$0.031111/hr` or `$22.40` per 30-day month; the replaced
+The active two-worker fleet costs `$0.712593/hr`. Instance `47267292` replaced
+`46598648`, saving `$0.029630/hr` or `$21.33` per 30-day month; the replaced
 instance was destroyed immediately after production verification. Compared
-with the original `$0.844444/hr` pair, the current fleet saves `$73.60` per
-30-day month. Total live Vast fleet burn after this cleanup was
-`$1.572222/hr`.
+with the original `$0.844444/hr` pair, the current fleet saves `$94.93` per
+30-day month. Both replicas are now in California on separate machines, so
+machine diversity remains but regional diversity is reduced.
+
+**Replacement validation (2026-08-09):**
+
+- The isolated candidate passed authentication rejection, 512x512,
+  1024x1024, 768x1152, and 1536x1536 generation, fixed-seed byte parity, and
+  the 2,359,296-pixel limit.
+- A 63.8-second concurrency-4 run completed 65 images with zero errors at
+  **1.019 img/s**, 3.92-second p50, and 4.01-second p95 latency.
+- Cached restart restored health in 25 seconds and produced a valid 1024x1024
+  image while the production tunnel remained disabled.
+- After joining the shared tunnel, the worker served real production traffic
+  with zero 5xx, OOM, traceback, or tunnel errors. With the replaced connector
+  drained, 8/8 attributed images passed at 3.89-second p50 and 5.30-second max.
+- After `46598648` was destroyed, shared health passed 5/5 and 4/4 attributed
+  1024x1024 images passed at 2.02-second p50 with zero 5xx or tunnel errors.
+- The host's Hugging Face Xet and standard-HTTP cold downloads both suffered
+  transient connection failures. Disabling Xet and resuming partial standard-
+  HTTP downloads completed the 32.8 GB cache; subsequent starts were fast.
 
 **Replacement validation (2026-08-02):**
 
@@ -249,13 +291,17 @@ with the original `$0.844444/hr` pair, the current fleet saves `$73.60` per
 
 ## Provider: Vast.ai — FLUX.2 Klein 4B (RTX 3090)
 
-Production Klein runs on a dedicated Indiana RTX 3090. The gen Worker reaches
+Production Klein runs on a dedicated California RTX 3090. The gen Worker reaches
 port 8000 through a remotely managed Cloudflare Tunnel bound as the private
 `KLEIN_VPC` Workers VPC network; there is no public hostname or raw-IP route.
 
-| Worker | Vast instance | GPU | Listed rate | Tunnel | Status |
-|--------|---------------|-----|-------------|--------|--------|
-| klein-vast-01 | 44766948 | RTX 3090 24GB | $0.165556/hr including 60GB disk | `c340d8d9-c1f3-4a13-8115-38b59faac3d5` | Active; 4 HA connections |
+| Worker | Vast instance | Machine / region | GPU | Listed rate | Tunnel | Status |
+|--------|---------------|------------------|-----|-------------|--------|--------|
+| klein-vast-01 | 47259457 | 47340 / California, US | RTX 3090 24GB | $0.147778/hr including 60GB disk | `c340d8d9-c1f3-4a13-8115-38b59faac3d5` | Active; 4 HA connections |
+
+Instance `47259457` replaced `44766948` on 2026-08-09. The host has Vast
+reliability `0.997194` and saves **$0.017778/hr**, or **$12.80 per 30-day
+month**.
 
 **Provisioning:** use `image.pollinations.ai/klein-runpod/setup-vast.sh` with
 `pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel`. The model is public and does not
@@ -269,9 +315,21 @@ vastai create instance <OFFER> \
   --env '-p 8000:8000' --cancel-unavail
 vastai attach ssh <INSTANCE> "$(cat ~/.ssh/id_ed25519.pub)"
 
-PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... \
+PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... TUNNEL_ENABLED=false \
   bash image.pollinations.ai/klein-runpod/setup-vast.sh
 ```
+
+The setup defaults to an isolated canary. After direct tests and explicit
+human approval, rerun setup so it enables the stored scoped tunnel token and
+enforces the Workers VPC QUIC qualification:
+
+```bash
+PLN_GPU_TOKEN=... TUNNEL_ENABLED=true \
+  bash image.pollinations.ai/klein-runpod/setup-vast.sh
+```
+
+Do not manually create `/root/.cloudflared_tunnel_enabled`; doing so bypasses
+the UDP precheck and four-connection gate.
 
 **Routing and rollback:** when `KLEIN_VPC` exists, the Klein handler uses
 `http://127.0.0.1:8000/generate` through the binding. `KLEIN_URL` remains the
@@ -280,13 +338,27 @@ There is no automatic runtime fallback for Klein. To roll back, remove the
 production `KLEIN_VPC` binding and redeploy the gen Worker; it will immediately
 resume using `KLEIN_URL`.
 
+Workers VPC tunnel replicas provide high availability, not balanced canary
+traffic: requests select the nearest replica. For an end-to-end replacement
+test, keep the old GPU server healthy, pause only its `cloudflared` connector,
+verify real traffic on the new worker, then restore the old connector until
+human promotion approval. See Cloudflare's
+[Workers VPC tunnel documentation](https://developers.cloudflare.com/workers-vpc/configuration/tunnel/).
+
+Workers VPC requires QUIC over UDP/7844; HTTP/2 is not a valid transport for
+this binding. `setup-vast.sh` therefore pins `--protocol quic`, requires
+`cloudflared` 2026.5.2 or newer for startup connectivity prechecks, and fails
+qualification if the UDP precheck fails or the tunnel does not establish four
+healthy connections with zero request errors. A host that briefly registers
+four connections after a failed UDP precheck is still disqualified.
+
 **Health and restart:** Vast runs `/root/onstart.sh` on container startup. It
 supervises `klein` and `cloudflared` screen sessions with restart loops. Tokens
 are mode-600 files and cloudflared uses `--token-file`, keeping its token out of
 process listings.
 
 ```bash
-vastai show instance 44766948 --raw
+vastai show instance 47259457 --raw
 # On the host:
 screen -ls
 tail -f /root/klein.log
@@ -294,7 +366,33 @@ tail -f /root/cloudflared.log
 curl -s http://127.0.0.1:8000/health
 ```
 
-**Cutover results (2026-07-14):**
+**Replacement qualification (2026-08-09):**
+
+- Authentication rejection, invalid-image handling, and the 2,359,296-pixel
+  limit returned the expected 403, 400, and 422 responses.
+- 512x512, 1024x1024, and 1536x1536 generation passed in 3.02s, 3.57s, and
+  8.41s respectively with no OOM.
+- Single-reference and two-reference edits passed in 3.89s and 7.07s.
+- Three concurrent 512x512 requests all succeeded; a full restart restored
+  health in 42 seconds and the first post-restart image completed in 2.56s.
+- The tunnel health gate prevented routing during model load. Seven attributed
+  production requests completed with zero 4xx/5xx, OOM, or traceback errors;
+  three were forced through the new worker by pausing only the old connector.
+
+**Post-cutover incident (2026-08-09):** the replacement's startup log reported
+failed UDP connectivity even though four QUIC connections initially
+registered. Production latency later rose from roughly 6–9 seconds to
+70–100 seconds, then all four connections cycled between 12:44 and 12:45 UTC.
+Eight gateway 5xx responses (`destination_not_found` / handshake timeout)
+occurred while the local model remained healthy and generated a direct 512x512
+image in 1.21 seconds. This is a tunnel/host-network failure, not a GPU error.
+
+Future Klein canaries must keep all four QUIC connections healthy for at least
+30 minutes, show no tunnel reconnects or 5xx, and keep the attributed Workers
+VPC path below 15 seconds p95 before promotion. Local health, direct inference,
+or a momentary four-connection count is insufficient.
+
+**Original cutover results (2026-07-14):**
 
 - 512x512 generation: 2.83s; single-reference edit: 2.97s.
 - Two-reference edit: 3.36s and both inputs influenced the output.
@@ -321,9 +419,11 @@ runpodctl pod list             # list pods
 runpodctl pod get <id>         # pod details
 ```
 
-### Pod jmrbmje2fyuy46 — Klein 4B rollback
+### Historical/manual Klein 4B rollback configuration
 
-> Pod ID changes if recreated. Check `runpodctl pod list` and the `KLEIN_URL` env var (sops: `gen.pollinations.ai/secrets/prod.vars.json`).
+> RunPod state was not available during the 2026-08-09 Vast audit. Do not infer
+> that this pod is running from this document: check `runpodctl pod list` and
+> the `KLEIN_URL` value before relying on it or attributing cost to it.
 
 - **GPU**: 1x RTX A5000 (24GB) | **Cost**: $0.27/hr via API ($0.29/hr in UI)
 - **SSH**: full SSH using `SSH_RUNPOD_KLEIN` from SOPS; current runtime port changes on recreate/start
@@ -339,12 +439,12 @@ runpodctl pod get <id>         # pod details
 curl -s https://jmrbmje2fyuy46-8000.proxy.runpod.net/health
 ```
 
-Keeping this pod running costs $0.27/hr in addition to Vast. Once the Vast
-deployment has met the desired soak period, stop the pod to remove that cost;
-retain its `KLEIN_URL` value for a manual restart-and-redeploy rollback.
+If this pod is running, it costs $0.27/hr in addition to Vast. Production does
+not call it while the `KLEIN_VPC` binding exists; it is only a manual
+restart-and-redeploy rollback path.
 
 **Shutdown checklist:** stop the pod; do not terminate it. Then confirm Klein
-still reports `provider=vast`, a successful request reaches instance `44766948`,
+still reports `provider=vast`, a successful request reaches instance `47259457`,
 and the production status window remains free of 5xx. To roll back, restart the
 pod, verify its health endpoint, remove `KLEIN_VPC`, and deploy gen through CI.
 
@@ -363,7 +463,11 @@ curl -s https://gen.pollinations.ai/register -H "Authorization: Bearer $PLN_GPU_
 
 ## Provider: Lambda Labs
 
-### LTX-2.3 Video + ACE-Step Music + Sana (GH200)
+### Historical LTX-2.3 Video + ACE-Step Music + Sana (GH200)
+
+LTX-2 and ACE-Step are retired from production. DreamShaper replaced the
+legacy Sana route. Confirm the Lambda instance is terminated in the provider
+account before assuming there is no remaining Lambda charge.
 
 - **Host**: `192.222.51.105`
 - **SSH**: `ssh -i <SSH_LAMBDA_SANA_LTX2_ACESTEP from SOPS> ubuntu@192.222.51.105`
@@ -384,7 +488,7 @@ The legacy `image-pollinations.service` (port 16384) and `text-pollinations.serv
 
 GPU workers send heartbeats to the gen worker registry:
 - **URL**: `https://gen.pollinations.ai/register`
-- **Check registered**: `curl -s https://gen.pollinations.ai/register`
+- **Check registered**: `curl -s https://gen.pollinations.ai/register -H "Authorization: Bearer $PLN_GPU_TOKEN"`
 
 ## SSH Keys
 
@@ -406,7 +510,6 @@ Non-SOPS keys:
 
 | Key | Provider | Location |
 |-----|----------|----------|
-| `~/.ssh/pollinations_services_2026` | Vast.ai | Flux 5090 workers (attach via `vastai attach ssh`) |
-| Vast account SSH key | Vast.ai | Klein instance 44766948; query current proxy host/port with `vastai show instance` |
+| `~/.ssh/id_ed25519` | Vast.ai | All seven active Vast workers; query the current proxy host/port with `vastai show instance` |
 | `~/.ssh/enter-services-shared` | EC2 prod | enter services |
 | `~/.ssh/enter-services-staging` | EC2 staging | enter services |

--- a/image.pollinations.ai/klein-runpod/setup-vast.sh
+++ b/image.pollinations.ai/klein-runpod/setup-vast.sh
@@ -11,6 +11,11 @@
 #   PLN_GPU_TOKEN=... \
 #   CLOUDFLARED_TUNNEL_TOKEN=... \
 #   bash setup-vast.sh
+#
+# This defaults to an isolated canary. Set TUNNEL_ENABLED=true only after the
+# worker passes direct tests and receives explicit human promotion approval.
+# Rerun this setup for promotion; manually creating the tunnel marker bypasses
+# the required Workers VPC QUIC qualification below.
 
 set -e
 
@@ -18,17 +23,33 @@ WORK_DIR="${WORK_DIR:-/workspace/pollinations}"
 GIT_BRANCH="${GIT_BRANCH:-main}"
 VENV="${VENV:-/workspace/klein-venv}"
 CACHE_DIR="${CACHE_DIR:-/workspace/hf-cache}"
+TUNNEL_ENABLED="${TUNNEL_ENABLED:-false}"
+TUNNEL_TOKEN_FILE="/root/.cloudflared_token"
+TUNNEL_ENABLED_FILE="/root/.cloudflared_tunnel_enabled"
+CLOUDFLARED_MIN_VERSION="2026.5.2"
+CLOUDFLARED_METRICS="127.0.0.1:20241"
 
-if [ -z "$PLN_GPU_TOKEN" ] || [ -z "$CLOUDFLARED_TUNNEL_TOKEN" ]; then
-    echo "Usage: PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... bash setup-vast.sh" >&2
+if [ -z "${PLN_GPU_TOKEN:-}" ]; then
+    echo "Usage: PLN_GPU_TOKEN=... bash setup-vast.sh" >&2
+    exit 1
+fi
+
+if [ "$TUNNEL_ENABLED" = true ] && \
+    [ -z "${CLOUDFLARED_TUNNEL_TOKEN:-}" ] && \
+    [ ! -s "$TUNNEL_TOKEN_FILE" ]; then
+    echo "TUNNEL_ENABLED=true requires CLOUDFLARED_TUNNEL_TOKEN" >&2
     exit 1
 fi
 
 apt-get update -qq
 apt-get install -y -qq curl git screen python3-venv
 
-if ! command -v cloudflared >/dev/null || \
-    ! cloudflared tunnel run --help 2>&1 | grep -q -- '--token-file'; then
+cloudflared_version=""
+if command -v cloudflared >/dev/null; then
+    cloudflared_version=$(cloudflared --version 2>/dev/null | awk '{print $3}')
+fi
+if [ -z "$cloudflared_version" ] || \
+    ! dpkg --compare-versions "$cloudflared_version" ge "$CLOUDFLARED_MIN_VERSION"; then
     curl -fsSL --retry 5 -o /tmp/cloudflared.deb \
         https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
     dpkg -i /tmp/cloudflared.deb >/dev/null
@@ -55,9 +76,20 @@ fi
     -r "$KLEIN_DIR/requirements.txt"
 
 printf '%s' "$PLN_GPU_TOKEN" > /root/.pln_gpu_token
-printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > /root/.cloudflared_token
-chmod 600 /root/.pln_gpu_token /root/.cloudflared_token
+if [ -n "${CLOUDFLARED_TUNNEL_TOKEN:-}" ]; then
+    printf '%s' "$CLOUDFLARED_TUNNEL_TOKEN" > "$TUNNEL_TOKEN_FILE"
+fi
+chmod 600 /root/.pln_gpu_token
+if [ -f "$TUNNEL_TOKEN_FILE" ]; then
+    chmod 600 "$TUNNEL_TOKEN_FILE"
+fi
 unset PLN_GPU_TOKEN CLOUDFLARED_TUNNEL_TOKEN
+
+if [ "$TUNNEL_ENABLED" = true ]; then
+    touch "$TUNNEL_ENABLED_FILE"
+else
+    rm -f "$TUNNEL_ENABLED_FILE"
+fi
 
 cat > /root/run-klein.sh <<EOF
 #!/bin/bash
@@ -73,10 +105,58 @@ cat > /root/onstart.sh <<'EOF'
 screen -S klein -X quit 2>/dev/null || true
 screen -S cloudflared -X quit 2>/dev/null || true
 screen -dmS klein bash -c 'while true; do /root/run-klein.sh >> /root/klein.log 2>&1; sleep 5; done'
-screen -dmS cloudflared bash -c 'while true; do cloudflared tunnel --no-autoupdate run --token-file /root/.cloudflared_token >> /root/cloudflared.log 2>&1; sleep 5; done'
+
+if [ ! -f /root/.cloudflared_tunnel_enabled ]; then
+    echo "Production tunnel disabled; verify Klein locally before promotion"
+    exit 0
+fi
+
+if [ ! -s /root/.cloudflared_token ]; then
+    echo "Production tunnel enabled but token file is missing" >> /root/cloudflared.log
+    exit 1
+fi
+
+screen -dmS cloudflared bash -c 'until curl -fsS --max-time 3 http://127.0.0.1:8000/health >/dev/null; do echo "Waiting for Klein health before joining the production tunnel" >> /root/cloudflared.log; sleep 3; done; while true; do cloudflared tunnel --no-autoupdate --protocol quic --metrics 127.0.0.1:20241 run --token-file /root/.cloudflared_token >> /root/cloudflared.log 2>&1; sleep 5; done'
 EOF
 chmod 700 /root/run-klein.sh /root/onstart.sh
 
+TUNNEL_LOG_START=0
+if [ -f /root/cloudflared.log ]; then
+    TUNNEL_LOG_START=$(wc -l < /root/cloudflared.log)
+fi
 /root/onstart.sh
 
 echo "Klein is starting. Follow logs with: tail -f /root/klein.log"
+if [ "$TUNNEL_ENABLED" = true ]; then
+    tunnel_ready=false
+    reject_tunnel() {
+        screen -S cloudflared -X quit 2>/dev/null || true
+        rm -f "$TUNNEL_ENABLED_FILE"
+        echo "$1" >&2
+        echo "Tunnel stopped and disabled; do not promote this host" >&2
+        exit 1
+    }
+
+    for _ in $(seq 1 30); do
+        current_log=$(tail -n "+$((TUNNEL_LOG_START + 1))" /root/cloudflared.log 2>/dev/null || true)
+        if printf '%s\n' "$current_log" | grep -Eq 'UDP Connectivity.*FAIL'; then
+            reject_tunnel "Klein Workers VPC requires QUIC, but the UDP/7844 precheck failed"
+        fi
+
+        metrics=$(curl -fsS --max-time 2 "http://$CLOUDFLARED_METRICS/metrics" 2>/dev/null || true)
+        connections=$(printf '%s\n' "$metrics" | awk '$1 == "cloudflared_tunnel_ha_connections" {print $2; exit}')
+        request_errors=$(printf '%s\n' "$metrics" | awk '$1 == "cloudflared_tunnel_request_errors" {print $2; exit}')
+        if [ "$connections" = "4" ] && [ "${request_errors:-0}" = "0" ]; then
+            tunnel_ready=true
+            break
+        fi
+        sleep 2
+    done
+
+    if [ "$tunnel_ready" != true ]; then
+        reject_tunnel "Klein tunnel did not reach four healthy QUIC connections within 60 seconds"
+    fi
+    echo "Klein QUIC preflight passed: four connections, zero request errors."
+else
+    echo "Production tunnel disabled pending direct tests and human approval."
+fi

--- a/image.pollinations.ai/nunchaku/README.md
+++ b/image.pollinations.ai/nunchaku/README.md
@@ -1,7 +1,8 @@
 # Flux Schnell on Vast.ai
 
-The production Flux worker runs FLUX.1 Schnell with Nunchaku FP4 on a single
-RTX 5090. Vast instances are containers without systemd, so
+The production Flux pool runs FLUX.1 Schnell with Nunchaku FP4 on two Vast
+workers: an RTX 5090 and a 24 GB RTX PRO 4000 Blackwell. Vast instances are
+containers without systemd, so
 [`setup-vast.sh`](./setup-vast.sh) installs the pinned runtime and supervises
 the model server and Cloudflare Tunnel in `screen` restart loops.
 
@@ -21,7 +22,7 @@ a Vast NAT address on a non-standard port.
 
 ## Deploy
 
-On a fresh Vast RTX 5090 instance:
+On a fresh compatible Vast Blackwell instance with at least 24 GB VRAM:
 
 ```bash
 PLN_GPU_TOKEN=... \
@@ -56,8 +57,9 @@ automatically use a local DNS-over-HTTPS resolver.
 ## Verify before traffic cutover
 
 A healthy `/docs` response and registry heartbeat are control-plane checks;
-they do not prove that `gen.pollinations.ai` can reach the tunnel. Replicate can
-otherwise hide a broken Vast route.
+they do not prove that `gen.pollinations.ai` can reach the tunnel. Flux is
+Vast-only, so a broken or unregistered worker reduces production capacity
+directly.
 
 Before promotion, expose the worker through a dedicated test-only endpoint and
 compare that external path with localhost. Never use the production hostname
@@ -67,13 +69,15 @@ for this step:
 CANARY_URL=https://<test-only-hostname> bash verify-vast.sh
 ```
 
-The canary creates a unique uncached prompt, generates it locally and through
-the external endpoint with the same seed, and compares decoded pixels. Do not
-change production routing until this passes and a human explicitly approves
-the promotion. After cutover, run `verify-vast.sh` with
-`POLLINATIONS_API_KEY` and no `CANARY_URL`, confirm real production requests
-are served by the replacement, then drain and immediately destroy the old
-worker.
+The canary creates unique uncached prompts, validates local and external image
+dimensions, and checks that the external request appears in the candidate's
+own log. Fixed-seed byte and pixel output are not a valid parity test for this
+Nunchaku runtime: repeated requests vary on both qualified production hosts.
+Do not change production routing until the isolated path passes and a human
+explicitly approves the promotion. After cutover, run `verify-vast.sh` with
+`POLLINATIONS_API_KEY` and no `CANARY_URL`; it checks registration and makes a
+bounded number of production requests until one is attributed to this worker.
+Only then destroy the replaced worker.
 The fleet-wide qualification and approval policy is documented in
 [`manage-vast-gpu-fleet`](../../.claude/skills/manage-vast-gpu-fleet/SKILL.md).
 
@@ -93,7 +97,9 @@ because stalled Xet connections were observed on Vast; standard HTTP resumes
 reliably from partial downloads. Override defaults only through the documented
 environment variables in `setup-vast.sh`.
 
-`QUEUE_LIMIT=3` means one request can run while two wait. Additional requests
-receive 503 immediately so the gateway can use Replicate rather than building a
-long user-facing queue. Keep Replicate enabled as burst capacity; add a second
-Vast GPU only when its measured avoided fallback cost exceeds its hourly cost.
+`QUEUE_LIMIT=3` is the intended admission limit, but inference currently runs
+synchronously on the FastAPI event loop. Under concurrent load it therefore
+does not reliably shed excess requests quickly. The two-worker Vast pool is the
+current capacity guard, and there is no Replicate or other external fallback.
+Monitor worker attribution and 503s together: a paid worker that is healthy but
+missing from `/register` leaves the other worker overloaded.

--- a/image.pollinations.ai/nunchaku/setup-vast.sh
+++ b/image.pollinations.ai/nunchaku/setup-vast.sh
@@ -35,9 +35,9 @@
 #                     use mit-han-lab/svdq-int4-flux.1-schnell on Ada GPUs
 #   MAX_PIXELS        default 1048576 (1024x1024, matches FP4/5090);
 #                     use 810000 on RTX 4090
-#   QUEUE_LIMIT       default 3 (one running plus two waiting; server.py sheds
-#                     additional load with 503 so the gateway falls back to
-#                     Replicate instead of building a long user-facing queue)
+#   QUEUE_LIMIT       default 3 (intended as one running plus two waiting;
+#                     synchronous inference currently prevents this from being
+#                     a reliable hard cap — see GPU_INSTANCES.md)
 #   SERVICE_TYPE      default flux
 #   HEARTBEAT_ENABLED default false; enable only for an approved production worker
 #   TUNNEL_ENABLED    default false; enable only after human promotion approval
@@ -70,6 +70,11 @@ fi
 
 if [ "$TUNNEL_ENABLED" = true ] && { [ -z "${CLOUDFLARED_TUNNEL_TOKEN:-}" ] || [ "$PUBLIC_HOSTNAME" = localhost ]; }; then
     echo "TUNNEL_ENABLED=true requires CLOUDFLARED_TUNNEL_TOKEN and PUBLIC_HOSTNAME" >&2
+    exit 1
+fi
+
+if [ "$HEARTBEAT_ENABLED" = true ] && [ "$TUNNEL_ENABLED" != true ]; then
+    echo "HEARTBEAT_ENABLED=true requires TUNNEL_ENABLED=true" >&2
     exit 1
 fi
 
@@ -261,8 +266,10 @@ log "  Logs:       tail -f /tmp/flux.log"
 log "  Attach:     screen -r flux   (detach: Ctrl+A, D)"
 log "  Local test: curl -s localhost:$PORT/docs >/dev/null && echo up"
 log "  Canary:     POLLINATIONS_API_KEY=... bash verify-vast.sh"
-if [ "$TUNNEL_ENABLED" = true ]; then
-    log "  Registered: curl -s https://gen.pollinations.ai/register | grep -o '$SERVICE_TYPE[^,]*'"
+if [ "$HEARTBEAT_ENABLED" = true ] && [ "$TUNNEL_ENABLED" = true ]; then
+    log "  Production: verify https://$PUBLIC_IP in the authenticated /register response and confirm an attributed request in /tmp/flux.log"
+elif [ "$TUNNEL_ENABLED" = true ]; then
+    log "  Isolated external canary enabled; registry heartbeat remains disabled"
 else
     log "  Production heartbeat and tunnel are disabled pending human approval"
 fi

--- a/image.pollinations.ai/nunchaku/verify-vast.sh
+++ b/image.pollinations.ai/nunchaku/verify-vast.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Run on the Vast host after setup-vast.sh. This makes the same deterministic
-# request locally and through either CANARY_URL or gen.pollinations.ai, then
-# compares decoded image pixels. A registry heartbeat or public /docs check
-# alone does not prove that the image path works.
+# Run on the Vast host after setup-vast.sh. This validates local generation,
+# then proves that either an isolated canary URL or the production route reaches
+# this exact worker. A registry heartbeat or public /docs check alone does not
+# prove that the image path works.
 
 set -euo pipefail
 
@@ -33,70 +33,100 @@ WIDTH="${WIDTH:-512}"
 HEIGHT="${HEIGHT:-512}"
 CANARY_URL="${CANARY_URL:-}"
 CANARY_URL="${CANARY_URL%/}"
+PRODUCTION_ATTEMPTS="${PRODUCTION_ATTEMPTS:-8}"
+WORKER_LOG="${WORKER_LOG:-/tmp/flux.log}"
+
+if [ ! -f "$WORKER_LOG" ]; then
+    echo "Missing $WORKER_LOG; the Flux worker has not produced a log yet" >&2
+    exit 1
+fi
+
+decode_json_image() {
+    "$PYTHON" - "$1" "$2" "$WIDTH" "$HEIGHT" <<'PY'
+import base64
+import json
+import sys
+from PIL import Image
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    response = json.load(source)
+with open(sys.argv[2], "wb") as image:
+    image.write(base64.b64decode(response[0]["image"]))
+with Image.open(sys.argv[2]) as image:
+    expected = (int(sys.argv[3]), int(sys.argv[4]))
+    if image.size != expected:
+        raise SystemExit(f"FAIL: expected {expected}, got {image.size}")
+PY
+}
+
+validate_image() {
+    "$PYTHON" - "$1" "$WIDTH" "$HEIGHT" <<'PY'
+import sys
+from PIL import Image
+
+with Image.open(sys.argv[1]) as image:
+    expected = (int(sys.argv[2]), int(sys.argv[3]))
+    if image.size != expected:
+        raise SystemExit(f"FAIL: expected {expected}, got {image.size}")
+    image.verify()
+PY
+}
 
 echo "Checking local server..."
 curl -fsS --max-time 10 "http://localhost:${PORT:-8765}/docs" >/dev/null
 
-echo "Generating the local Vast reference..."
+echo "Generating and validating a local image..."
 curl -fsS --max-time 180 "http://localhost:${PORT:-8765}/generate" \
     -H "Content-Type: application/json" \
     -H "x-backend-token: $PLN_GPU_TOKEN" \
-    --data "{\"prompts\":[\"$PROMPT\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
-    > "$CANARY_DIR/direct.json"
-
-"$PYTHON" - "$CANARY_DIR/direct.json" "$CANARY_DIR/direct.jpg" <<'PY'
-import base64
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as source:
-    response = json.load(source)
-with open(sys.argv[2], "wb") as image:
-    image.write(base64.b64decode(response[0]["image"]))
-PY
+    --data "{\"prompts\":[\"$PROMPT-local\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
+    > "$CANARY_DIR/local.json"
+decode_json_image "$CANARY_DIR/local.json" "$CANARY_DIR/local.jpg"
 
 if [ -n "$CANARY_URL" ]; then
+    external_prompt="$PROMPT-external"
+    before=$(grep -Fc "$external_prompt" "$WORKER_LOG" 2>/dev/null || true)
     echo "Generating through the isolated canary URL..."
     curl -fsS --max-time 180 "$CANARY_URL/generate" \
         -H "Content-Type: application/json" \
         -H "x-backend-token: $PLN_GPU_TOKEN" \
-        --data "{\"prompts\":[\"$PROMPT\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
-        > "$CANARY_DIR/public.json"
-    "$PYTHON" - "$CANARY_DIR/public.json" "$CANARY_DIR/public.jpg" <<'PY'
-import base64
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as source:
-    response = json.load(source)
-with open(sys.argv[2], "wb") as image:
-    image.write(base64.b64decode(response[0]["image"]))
-PY
-else
-    : "${POLLINATIONS_API_KEY:?Set POLLINATIONS_API_KEY for production-route verification}"
-    : "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
-    curl -fsS --max-time 10 https://gen.pollinations.ai/register \
-        -H "Authorization: Bearer $PLN_GPU_TOKEN" | grep -Fq "https://$PUBLIC_IP"
-    PUBLIC_URL="https://gen.pollinations.ai/image/$PROMPT?model=flux&width=$WIDTH&height=$HEIGHT&seed=$SEED&nologo=true"
-    echo "Generating through the production Flux route..."
-    curl -fsS --max-time 180 "$PUBLIC_URL" \
-        -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
-        > "$CANARY_DIR/public.jpg"
+        --data "{\"prompts\":[\"$external_prompt\"],\"width\":$WIDTH,\"height\":$HEIGHT,\"steps\":4,\"seed\":$SEED}" \
+        > "$CANARY_DIR/external.json"
+    decode_json_image "$CANARY_DIR/external.json" "$CANARY_DIR/external.jpg"
+    after=$(grep -Fc "$external_prompt" "$WORKER_LOG" 2>/dev/null || true)
+    if [ "$after" -le "$before" ]; then
+        echo "FAIL: isolated request was not attributed in $WORKER_LOG" >&2
+        exit 1
+    fi
+    echo "PASS: isolated URL returned a valid image from this worker"
+    exit 0
 fi
 
-"$PYTHON" - "$CANARY_DIR/direct.jpg" "$CANARY_DIR/public.jpg" <<'PY'
-import sys
-from PIL import Image, ImageChops, ImageStat
+: "${POLLINATIONS_API_KEY:?Set POLLINATIONS_API_KEY for production-route verification}"
+: "${PUBLIC_IP:?PUBLIC_IP missing from $ENV_FILE}"
 
-with Image.open(sys.argv[1]) as direct_image, Image.open(sys.argv[2]) as public_image:
-    direct = direct_image.convert("RGB")
-    public = public_image.convert("RGB")
-    if direct.size != public.size:
-        raise SystemExit(f"FAIL: dimensions differ: Vast={direct.size}, public={public.size}")
-    rms = sum(ImageStat.Stat(ImageChops.difference(direct, public)).rms) / 3
-    if rms > 12:
-        raise SystemExit(
-            f"FAIL: public image differs from Vast reference (RMS={rms:.2f}); fallback may be active"
-        )
-    print(f"PASS: external Flux matched the local Vast reference (RMS={rms:.2f})")
-PY
+registry=$(curl -fsS --max-time 10 https://gen.pollinations.ai/register \
+    -H "Authorization: Bearer $PLN_GPU_TOKEN")
+if ! grep -Fq "https://$PUBLIC_IP" <<<"$registry"; then
+    echo "FAIL: https://$PUBLIC_IP is missing from the production registry" >&2
+    exit 1
+fi
+
+echo "Checking production attribution (up to $PRODUCTION_ATTEMPTS requests)..."
+for attempt in $(seq 1 "$PRODUCTION_ATTEMPTS"); do
+    public_prompt="$PROMPT-production-$attempt"
+    before=$(grep -Fc "$public_prompt" "$WORKER_LOG" 2>/dev/null || true)
+    public_url="https://gen.pollinations.ai/image/$public_prompt?model=flux&width=$WIDTH&height=$HEIGHT&seed=$SEED&nologo=true"
+    curl -fsS --max-time 180 "$public_url" \
+        -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+        > "$CANARY_DIR/production-$attempt.jpg"
+    validate_image "$CANARY_DIR/production-$attempt.jpg"
+    after=$(grep -Fc "$public_prompt" "$WORKER_LOG" 2>/dev/null || true)
+    if [ "$after" -gt "$before" ]; then
+        echo "PASS: production returned a valid image from this worker on attempt $attempt"
+        exit 0
+    fi
+done
+
+echo "FAIL: no production request was attributed to this worker" >&2
+exit 1

--- a/image.pollinations.ai/sana/SERVERS.md
+++ b/image.pollinations.ai/sana/SERVERS.md
@@ -1,39 +1,36 @@
-# SANA Sprint Servers
+# Sana compatibility route
 
-Last updated: 2026-03-08
+Last updated: 2026-08-09
 
-## Current Deployment
+## Current deployment
 
-Sana Sprint 0.6B runs on the Taiwan vast.ai instance (GPU 0), serving the legacy `image.pollinations.ai` endpoint.
+SANA Sprint is no longer in the production image route. The public `sana`
+model name is retained as an alias of `dreamshaper`, which serves DreamShaper 8
+LCM from two Vast RTX 3090 workers. The internal registry pool key also remains
+`sana` for compatibility.
 
-| Host | Instance | IP | GPU | Port (int/ext) | Model |
-|------|----------|-----|-----|----------------|-------|
-| vast.ai Taiwan | 30937024 | 211.72.13.202 | GPU 0 (RTX 5090) | 8765 / 47190 | Sana Sprint 0.6B |
+| Worker | Vast instance | Machine / region | All-in rate | Registered hostname |
+|--------|---------------|------------------|-------------|---------------------|
+| dreamshaper-vast-01 | 46607014 | 4749 / Oregon, US | $0.150000/hr | `dreamshaper-canary-46600159.myceli.ai` |
+| dreamshaper-vast-02 | 46387155 | 123712 / California, US | $0.153333/hr | `dreamshaper-vast-02.pollinations.ai` |
 
-- Max resolution: 512x512 (clamped)
-- Inference steps: 2
-- Generation time: ~0.2-0.5s
+The route is:
 
-Traffic reaches Sana via SSH tunnel from Scaleway (legacy gateway):
-```
-image.pollinations.ai → Cloudflare → Scaleway:16384 (legacy service)
-  → SSH tunnel (localhost:19876 → vast.ai:8765) → Sana 0.6B
-```
-
-## SSH Access
-
-```bash
-ssh -o StrictHostKeyChecking=no -i ~/.ssh/pollinations_services_2026 -p 17024 root@ssh3.vast.ai
-screen -r sana-gpu0
-tail -f /tmp/sana.log
+```text
+model=sana -> registry alias dreamshaper -> pool type sana
+           -> named Cloudflare tunnels -> DreamShaper workers
 ```
 
-## Legacy Scaleway Sana Instances (Decommissioned)
+There is no automatic external fallback. Both workers run
+`dreamshaper-lcm/setup-vast.sh`, and Vast restores `/root/onstart.sh` after a
+container restart. See [`../GPU_INSTANCES.md`](../GPU_INSTANCES.md) for the
+live fleet and qualification evidence, and
+[`../dreamshaper-lcm/README.md`](../dreamshaper-lcm/README.md) for deployment
+and API details.
 
-These Scaleway GPU instances previously ran Sana Sprint 1.6B but are no longer in use for Sana.
+## Historical Sana infrastructure
 
-| Host | SSH Alias | IP | GPUs | Provider |
-|------|-----------|-----|------|----------|
-| sana-1 | `sana-1` | 51.158.101.128 | 2x L4 (24GB) | Scaleway PAR1 |
-| sana-2 | `sana-2` | 51.159.129.211 | 2x L4 (24GB) | Scaleway PAR2 |
-| comfystream | `comfystream` | 3.239.212.66 | 1x L40S (46GB) | AWS |
+Vast instance `30937024`, the Scaleway Sana workers, and the legacy SSH-tunnel
+route are historical and are not part of production dispatch. Do not use old
+IP addresses or SSH commands from prior runbooks when diagnosing the current
+`sana` alias.

--- a/image.pollinations.ai/video_gen_ltx2modal/README.md
+++ b/image.pollinations.ai/video_gen_ltx2modal/README.md
@@ -1,5 +1,10 @@
 # LTX2 ComfyUI on Modal (Async API)
 
+> **Status: retired from Pollinations production.** LTX-2 and ACE-Step have no
+> active production routes. This directory is retained only as historical
+> deployment code; running `modal deploy` creates a separate billable service
+> and does not restore a registered Pollinations model.
+
 Deploys ComfyUI as an async, cost-efficient API for video generation on Modal. Jobs are queued in ComfyUI, GPUs scale to zero when idle, and clients poll for status/result instead of holding long HTTP connections.
 
 ## Project layout

--- a/image.pollinations.ai/z-image/README.md
+++ b/image.pollinations.ai/z-image/README.md
@@ -72,7 +72,9 @@ stored only in mode-0600 files on the rental host. Some Vast hosts drop the SRV
 DNS responses required by cloudflared despite resolving ordinary A records.
 `setup-vast.sh` detects that condition and enables a reboot-safe local
 DNS-over-HTTPS fallback; its log is `/root/tunnel-dns.log`. Hosts with working
-SRV resolution retain the provider's resolver.
+SRV resolution retain the provider's resolver. Hugging Face Xet is disabled by
+default because its token/download path failed on otherwise healthy Vast hosts;
+standard HTTP and process-level retries resume reliably from the local cache.
 
 ### July 2026 RTX 5090 canary
 

--- a/image.pollinations.ai/z-image/setup-vast.sh
+++ b/image.pollinations.ai/z-image/setup-vast.sh
@@ -24,6 +24,7 @@ MODEL_CACHE="${MODEL_CACHE:-/workspace/zimage-cache}"
 SERVICE_TYPE="${SERVICE_TYPE:-zimage}"
 PORT="${PORT:-10002}"
 HEARTBEAT_ENABLED="${HEARTBEAT_ENABLED:-false}"
+HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
 SUDO=""
 [ "$(id -u)" != "0" ] && SUDO="sudo"
 
@@ -129,7 +130,15 @@ print("CUDA OK:", torch.__version__, torch.version.cuda, torch.cuda.get_device_n
 PY
 
 log "Downloading SPAN upscaler"
-MODEL_CACHE="$MODEL_CACHE" "$VENV/bin/python" - <<'PY'
+SPAN_MODEL_PATH="$MODEL_CACHE/span/2xNomosUni_span_multijpg.safetensors"
+span_ready=false
+if [ -s "$SPAN_MODEL_PATH" ]; then
+    span_ready=true
+fi
+for attempt in $(seq 1 10); do
+    [ "$span_ready" = true ] && break
+    if MODEL_CACHE="$MODEL_CACHE" HF_HUB_DISABLE_XET="$HF_HUB_DISABLE_XET" \
+        "$VENV/bin/python" - <<'PY'
 import os
 from huggingface_hub import hf_hub_download
 
@@ -139,6 +148,17 @@ hf_hub_download(
     local_dir=os.path.join(os.environ["MODEL_CACHE"], "span"),
 )
 PY
+    then
+        span_ready=true
+        break
+    fi
+    log "SPAN download attempt $attempt failed; retrying with the partial cache"
+    sleep 5
+done
+if [ "$span_ready" != true ] || [ ! -s "$SPAN_MODEL_PATH" ]; then
+    echo "SPAN download failed after 10 resumable attempts" >&2
+    exit 1
+fi
 
 ENV_FILE="$ZIMAGE_DIR/.env.zimage"
 log "Writing runtime environment to $ENV_FILE"
@@ -151,9 +171,9 @@ log "Writing runtime environment to $ENV_FILE"
     printf 'export HEARTBEAT_ENABLED=%q\n' "$HEARTBEAT_ENABLED"
     printf 'export VENV=%q\n' "$VENV"
     printf 'export MODEL_CACHE=%q\n' "$MODEL_CACHE"
-    printf 'export SPAN_MODEL_PATH=%q\n' "$MODEL_CACHE/span/2xNomosUni_span_multijpg.safetensors"
+    printf 'export SPAN_MODEL_PATH=%q\n' "$SPAN_MODEL_PATH"
     printf 'export HF_HUB_CACHE=%q\n' "$MODEL_CACHE/hub"
-    printf 'export HF_XET_HIGH_PERFORMANCE=1\n'
+    printf 'export HF_HUB_DISABLE_XET=%q\n' "$HF_HUB_DISABLE_XET"
     printf 'export CUDA_VISIBLE_DEVICES=0\n'
     # cuDNN v8's VAE convolution path segfaults with exit 139 on the tested
     # RTX 5090 / driver 570 / cu128 stack. The legacy API remains GPU-backed


### PR DESCRIPTION
Promote the latest merged changes from `main` to `production`.

Included pull requests:
- [#13217](https://github.com/pollinations/pollinations/pull/13217) — harden and reconcile the Vast production fleet.
- [#13218](https://github.com/pollinations/pollinations/pull/13218) — retry image pool workers after 503/network failures.

Verification:
- Production source guard must confirm this PR comes from `main`.
- CodeQL analysis and merge protection must pass.
- Repository automation and deployment checks must pass.