### PR TITLE
chore: allow guus6457 community publishing

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -34,6 +34,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     198414737, // AkshayCoder48
     205307392, // chirag-gamer
     240205932, // pollinations-router
+    57826942, // guus6457
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `guus6457`’s immutable GitHub user ID to the community-model publisher allowlist.
- Keeps the approval stable if the username changes.

Checks:
- Biome 2.3.10
- Allowlist membership and uniqueness assertion
- `git diff --check`

Fixes #13019