### PR TITLE
docs: move GPU fleet inventory under operations

### DIFF
--- a/.claude/skills/enter-services/token-rotation.md
+++ b/.claude/skills/enter-services/token-rotation.md
@@ -97,14 +97,14 @@ Rollback below).
 
 | Worker | Pod / Host | SSH target | Restart |
 |---|---|---|---|
-| Flux | Vast.ai 5090 instance(s) — see `image.pollinations.ai/GPU_INSTANCES.md` for current instance | `vastai show instances` for IP/port | restart `flux` screen |
+| Flux | Vast.ai instance(s) — see `operations/infrastructure/gpu/GPU_INSTANCES.md` for the current fleet | `vastai show instances` for IP/port | restart `flux` screen |
 | Z-Image | 3× RunPod single-GPU pods (`runpodctl pod list`) | rotating tcp port via RunPod GraphQL | `/root/relaunch-zimage.sh` |
 | Klein 4B | RunPod (id changes if recreated — verify with `runpodctl pod list` and `KLEIN_URL` in `gen.pollinations.ai/secrets/prod.vars.json`) | RunPod relay, interactive-only | `/workspace/restart.sh` (token baked in via `export`; edit + re-run inside an interactive session) |
 | LTX-2 + ACE-Step + Sana | Lambda Labs GH200 | SSH key in enter SOPS | `systemctl restart ltx2 acestep sana` |
 
 Hosts move (pods get recreated, Flux migrated from RunPod to Vast.ai in
 2026-07) — confirm current host/pod identity against
-`image.pollinations.ai/GPU_INSTANCES.md` before rotating; don't trust this
+`operations/infrastructure/gpu/GPU_INSTANCES.md` before rotating; don't trust this
 table's specifics as current without checking.
 
 ## SOPS recipient rotation

--- a/.claude/skills/manage-vast-gpu-fleet/SKILL.md
+++ b/.claude/skills/manage-vast-gpu-fleet/SKILL.md
@@ -7,7 +7,7 @@ description: "Inspect, price, canary, replace, and document Pollinations-operate
 
 Use one repository-owned workflow for every current and future Vast workload.
 Treat
-[`GPU_INSTANCES.md`](../../../image.pollinations.ai/GPU_INSTANCES.md) as the
+[`GPU_INSTANCES.md`](../../../operations/infrastructure/gpu/GPU_INSTANCES.md) as the
 live inventory and each model directory as the source of truth for its setup
 and verification commands.
 
@@ -192,7 +192,7 @@ are ready.
 After a successful cutover and old-instance destruction, create a focused
 repository PR:
 
-1. Update `image.pollinations.ai/GPU_INSTANCES.md` with the new instance,
+1. Update `operations/infrastructure/gpu/GPU_INSTANCES.md` with the new instance,
    machine/region, rate, status, total fleet burn, savings, validation evidence,
    and `Last updated` date.
 2. Update the model README only when deployment behavior, limits, commands,

--- a/.claude/skills/monitor-services/SKILL.md
+++ b/.claude/skills/monitor-services/SKILL.md
@@ -327,7 +327,8 @@ ssh -i ~/.ssh/id_rsa_ovh ubuntu@57.130.31.42 "sudo truncate -s 0 /var/log/syslog
 Flux is self-hosted on Vast.ai 5090s since 2026-07-02 (PR #12171) with automatic
 Fireworks fallback: the worker sheds load with 503 beyond `QUEUE_LIMIT`, and the
 gateway retries those requests on Fireworks. Instance coordinates, provisioning
-one-liner, and host gotchas live in `image.pollinations.ai/GPU_INSTANCES.md`
+one-liner, and host gotchas live in
+`operations/infrastructure/gpu/GPU_INSTANCES.md`
 (source of truth — instance IDs/IPs/ports change on recreate).
 
 **Check:**

--- a/image.pollinations.ai/sana/SERVERS.md
+++ b/image.pollinations.ai/sana/SERVERS.md
@@ -23,7 +23,8 @@ model=sana -> registry alias dreamshaper -> pool type sana
 
 There is no automatic external fallback. Both workers run
 `dreamshaper-lcm/setup-vast.sh`, and Vast restores `/root/onstart.sh` after a
-container restart. See [`../GPU_INSTANCES.md`](../GPU_INSTANCES.md) for the
+container restart. See
+[`GPU_INSTANCES.md`](../../operations/infrastructure/gpu/GPU_INSTANCES.md) for the
 live fleet and qualification evidence, and
 [`../dreamshaper-lcm/README.md`](../dreamshaper-lcm/README.md) for deployment
 and API details.

--- a/operations/infrastructure/gpu/GPU_INSTANCES.md
+++ b/operations/infrastructure/gpu/GPU_INSTANCES.md
@@ -93,7 +93,7 @@ Two traps that fail silently:
 ## Vast replacement operations
 
 The repository skill
-[`manage-vast-gpu-fleet`](../.claude/skills/manage-vast-gpu-fleet/SKILL.md)
+[`manage-vast-gpu-fleet`](../../../.claude/skills/manage-vast-gpu-fleet/SKILL.md)
 is the source of truth for scheduled offer scouting, candidate qualification,
 isolated canaries, the human promotion gate, cutover, instance cleanup, and the
 post-cutover documentation PR.


### PR DESCRIPTION
- Moves the live Vast GPU fleet inventory to operations/infrastructure/gpu.
- Updates GPU management, monitoring, token-rotation, and SANA runbook references.
- Starts the staged removal of the image.pollinations.ai root without moving model runtimes yet.
- Does not change production routing, deployment workflows, credentials, or running GPU instances.

Validation:
- git diff --check
- repository-wide stale-path scan
- relative link and file existence checks

Follow-ups will move active model backends one workload at a time before legacy assets are reviewed and the old root is removed.