### PR TITLE
feat: add Fal fallback for Z-Image

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1695,5 +1695,13 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.004,
     },
   },
+  "zimage-fal": {
+    "cost": {
+      "completionImageTokens": 0,
+    },
+    "price": {
+      "completionImageTokens": 0,
+    },
+  },
 }
 `;

--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -147,7 +147,10 @@ function upstreamFailureText(failure: UpstreamFailure): (string | null)[] {
  * delegating endpoint, a failed secret decryption all reach here as a plain
  * Error and are rethrown untouched.
  */
-export function isRetryableFallbackError(error: unknown): boolean {
+export function isRetryableFallbackError(
+    error: unknown,
+    allowedStatusCodes: readonly number[] = FALLBACK_ON_STATUS_CODES,
+): boolean {
     if (isNetworkFailure(error)) return true;
     if (!(error instanceof Error)) return false;
     const failure = error as UpstreamFailure;
@@ -159,10 +162,10 @@ export function isRetryableFallbackError(error: unknown): boolean {
     if (isPortkeyRequestTimeout(failure)) return false;
     // A dead endpoint reaches us as the gateway's own 400 rather than as a
     // network error, because the gateway is the one that could not connect.
-    if (
-        !FALLBACK_ON_STATUS_CODES.includes(status) &&
-        !isGatewayRoutingFailure(failure)
-    ) {
+    const gatewayRoutingFailure =
+        allowedStatusCodes === FALLBACK_ON_STATUS_CODES &&
+        isGatewayRoutingFailure(failure);
+    if (!allowedStatusCodes.includes(status) && !gatewayRoutingFailure) {
         return false;
     }
     return !firstContentPolicyMessage(upstreamFailureText(failure));
@@ -302,6 +305,7 @@ export async function withModelFallback<T>(
     attempt: (candidate: FallbackCandidate) => Promise<T>,
     failures?: FailedCall[],
 ): Promise<{ result: T; candidate: FallbackCandidate; index: number }> {
+    const allowedStatusCodes = candidates[0]?.definition?.fallbackOnStatusCodes;
     for (const [index, candidate] of candidates.entries()) {
         // Timed from this attempt's own start. Measured from the request's, a
         // second attempt would report the first one's timeout as part of its
@@ -312,7 +316,7 @@ export async function withModelFallback<T>(
         } catch (error) {
             const terminal =
                 index === candidates.length - 1 ||
-                !isRetryableFallbackError(error);
+                !isRetryableFallbackError(error, allowedStatusCodes);
             failures?.push({
                 candidate,
                 error,

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -32,6 +32,7 @@ import {
 } from "./models/seedreamReplicateModel.ts";
 import { callWanImageAPI } from "./models/wanImageModel.ts";
 import { callXaiImageAPI } from "./models/xaiModel.ts";
+import { callZImageFalAPI } from "./models/zImageFalModel.ts";
 import type { ImageParams } from "./params.ts";
 import { sanitizeString } from "./util.ts";
 import { closestByRatio } from "./utils/aspectRatio.ts";
@@ -812,6 +813,9 @@ const generateImage = async (
 
         case "flux":
             return await callSelfHostedServer(prompt, safeParams, "flux");
+
+        case "zimage-fal":
+            return await callZImageFalAPI(prompt, safeParams);
 
         default:
             // zimage is the only model that reaches the default branch

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -482,6 +482,7 @@ export async function generateImageOrVideoResponse(
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
         hasImage: (safeParams.image?.length ?? 0) > 0,
+        megapixels: (safeParams.width * safeParams.height) / 1_000_000,
     });
 
     try {

--- a/gen.pollinations.ai/src/image/models/zImageFalModel.ts
+++ b/gen.pollinations.ai/src/image/models/zImageFalModel.ts
@@ -1,0 +1,80 @@
+import type { ImageGenerationResult } from "../createAndReturnImages.ts";
+import { getImageEnv } from "../env.ts";
+import { HttpError } from "../httpError.ts";
+import type { ImageParams } from "../params.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
+
+const ZIMAGE_FAL_ENDPOINT = "https://fal.run/fal-ai/z-image/turbo";
+const ZIMAGE_FAL_TIMEOUT_MS = 120_000;
+
+type FalZImageResponse = {
+    images?: Array<{
+        url?: string;
+        content_type?: string;
+    }>;
+    has_nsfw_concepts?: boolean[];
+};
+
+async function readFalResponse(response: Response): Promise<FalZImageResponse> {
+    try {
+        return (await response.json()) as FalZImageResponse;
+    } catch {
+        throw new HttpError("Z-Image Fal returned invalid JSON", 502);
+    }
+}
+
+export async function callZImageFalAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    const apiKey = getImageEnv("FAL_KEY");
+    if (!apiKey) {
+        throw new HttpError("Z-Image Fal fallback is not configured", 500);
+    }
+
+    const response = await fetchUpstream(ZIMAGE_FAL_ENDPOINT, {
+        method: "POST",
+        headers: {
+            Authorization: `Key ${apiKey}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            prompt,
+            image_size: {
+                width: safeParams.width,
+                height: safeParams.height,
+            },
+            num_inference_steps: 4,
+            seed: safeParams.seed,
+            num_images: 1,
+            output_format: "jpeg",
+            enable_prompt_expansion: false,
+        }),
+        signal: AbortSignal.timeout(ZIMAGE_FAL_TIMEOUT_MS),
+        errorLabel: "Z-Image Fal generation failed",
+    });
+    const result = await readFalResponse(response);
+    const image = result.images?.[0];
+    if (!image?.url) {
+        throw new HttpError("Z-Image Fal returned no image", 502);
+    }
+
+    const imageResponse = await fetchUpstream(image.url, {
+        signal: AbortSignal.timeout(ZIMAGE_FAL_TIMEOUT_MS),
+        errorLabel: "Failed to download Z-Image Fal output",
+    });
+
+    return {
+        buffer: Buffer.from(await imageResponse.arrayBuffer()),
+        mimeType:
+            image.content_type ||
+            imageResponse.headers.get("content-type") ||
+            undefined,
+        isMature: result.has_nsfw_concepts?.[0] ?? false,
+        isChild: false,
+        trackingData: {
+            actualModel: "zimage-fal",
+            usage: { completionImageTokens: 1 },
+        },
+    };
+}

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -170,6 +170,33 @@ describe("isRetryableFallbackError", () => {
         );
     });
 
+    it("honors a model-specific fallback status list", () => {
+        expect(
+            isRetryableFallbackError(new HttpError("queue full", 503), [503]),
+        ).toBe(true);
+        expect(
+            isRetryableFallbackError(
+                new HttpError("backend failed", 500),
+                [503],
+            ),
+        ).toBe(false);
+        expect(
+            isRetryableFallbackError(
+                new TypeError("fetch failed: connection refused"),
+                [503],
+            ),
+        ).toBe(true);
+        expect(
+            isRetryableFallbackError(
+                new HttpError("gateway failed", 400, {
+                    status: "failure",
+                    message: "Invalid custom host",
+                }),
+                [503],
+            ),
+        ).toBe(false);
+    });
+
     it("does not multiply the owned Portkey timeout across fallbacks", () => {
         expect(
             isRetryableFallbackError(
@@ -352,6 +379,25 @@ describe("withModelFallback", () => {
         // Nothing was moved on from, but the 400 still came from a named
         // model, and that name is the only thing the response cannot carry.
         expect(seen(failures)).toEqual(["primary!"]);
+    });
+
+    it("uses the primary model's configured fallback status list", async () => {
+        const primary = registryEntry("primary", ["second"]);
+        const second = registryEntry("second");
+        primary.definition.fallbackOnStatusCodes = [503];
+        primary.fallbackEntries = [second];
+        const candidates = fallbackCandidates({
+            resolved: primary.id,
+            definition: primary.definition,
+            fallbackEntries: primary.fallbackEntries,
+        });
+        const attempt = vi.fn(async () => "served");
+        attempt.mockRejectedValueOnce(new HttpError("backend failed", 500));
+
+        await expect(withModelFallback(candidates, attempt)).rejects.toThrow(
+            "backend failed",
+        );
+        expect(attempt).toHaveBeenCalledTimes(1);
     });
 
     it("reports only the failures it moved on from once a model serves", async () => {

--- a/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
+++ b/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
@@ -1,0 +1,157 @@
+import {
+    createExecutionContext,
+    env,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { test as baseTest } from "@shared/test/fixtures/index.ts";
+import {
+    createFetchMock,
+    teardownFetchMock,
+} from "@shared/test/mocks/fetch.ts";
+import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
+import { afterEach, expect } from "vitest";
+import worker from "../../src/index.ts";
+
+const imageBackendHost = "zimage-backend.test";
+const falHost = "fal.run";
+const falMediaHost = "fal.media";
+const png1x1Base64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==";
+
+afterEach(async () => {
+    await teardownFetchMock();
+});
+
+function createZImageFallbackMocks() {
+    const state = { falRequests: [] as Record<string, unknown>[] };
+    return createFetchMock({
+        tinybird: createMockTinybird(),
+        zimageBackend: {
+            state: {},
+            handlerMap: {
+                [imageBackendHost]: async () =>
+                    new Response("queue full", { status: 503 }),
+            },
+            reset: () => {},
+        },
+        fal: {
+            state,
+            handlerMap: {
+                [falHost]: async (request: Request) => {
+                    state.falRequests.push(
+                        (await request.json()) as Record<string, unknown>,
+                    );
+                    return Response.json({
+                        images: [
+                            {
+                                url: `https://${falMediaHost}/output.png`,
+                                content_type: "image/png",
+                                width: 1024,
+                                height: 1024,
+                            },
+                        ],
+                        seed: 42,
+                        has_nsfw_concepts: [false],
+                    });
+                },
+                [falMediaHost]: async () =>
+                    new Response(Buffer.from(png1x1Base64, "base64"), {
+                        headers: { "content-type": "image/png" },
+                    }),
+            },
+            reset: () => {
+                state.falRequests = [];
+            },
+        },
+    });
+}
+
+const test = baseTest.extend<{
+    mocks: ReturnType<typeof createZImageFallbackMocks>;
+}>({
+    // biome-ignore lint/correctness/noEmptyPattern: vitest fixture pattern requires object destructuring
+    mocks: async ({}, use) => {
+        env.FAL_KEY = "fal-test-key";
+        const mocks = createZImageFallbackMocks();
+        await use(mocks);
+    },
+});
+
+async function fetchWorker(path: string, init: RequestInit) {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request(`https://gen.pollinations.ai${path}`, init),
+        env,
+        ctx,
+    );
+    return { response, wait: () => waitOnExecutionContext(ctx) };
+}
+
+test("uses Fal only after the Vast Z-Image pool exhausts its 503s", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    const existing = await env.KV.list({ prefix: "image:server:test:zimage:" });
+    await Promise.all(existing.keys.map((key) => env.KV.delete(key.name)));
+
+    const { response: registerResponse } = await fetchWorker("/register", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${env.PLN_GPU_TOKEN}`,
+        },
+        body: JSON.stringify({
+            url: `https://${imageBackendHost}`,
+            type: "zimage",
+        }),
+    });
+    expect(registerResponse.status).toBe(200);
+    await mocks.enable("tinybird", "zimageBackend", "fal");
+
+    const { response, wait } = await fetchWorker(
+        "/image/a%20red%20apple?model=zimage&width=1024&height=1024&seed=42",
+        { headers: { authorization: `Bearer ${paidApiKey}` } },
+    );
+
+    const failureBody =
+        response.status === 200 ? "" : await response.clone().text();
+    expect(response.status, failureBody).toBe(200);
+    expect(response.headers.get("x-model-used")).toBe("zimage-fal");
+    expect(response.headers.get("x-fallback-target")).toBe("config.targets[1]");
+    expect(mocks.fal.state.falRequests).toEqual([
+        {
+            prompt: "a red apple",
+            image_size: { width: 1024, height: 1024 },
+            num_inference_steps: 4,
+            seed: 42,
+            num_images: 1,
+            output_format: "jpeg",
+            enable_prompt_expansion: false,
+        },
+    ]);
+    await wait();
+
+    expect(mocks.tinybird.state.events).toHaveLength(2);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        modelRequested: "zimage",
+        modelUsed: "zimage",
+        modelProviderUsed: "vast",
+        responseStatus: 503,
+        isFinal: false,
+        isBilledUsage: false,
+    });
+    expect(mocks.tinybird.state.events[1]).toMatchObject({
+        modelRequested: "zimage",
+        modelUsed: "zimage-fal",
+        modelProviderUsed: "fal",
+        responseStatus: 200,
+        fallbackUsed: true,
+        totalPrice: 0.004,
+        isFinal: true,
+        isBilledUsage: true,
+    });
+    expect(mocks.tinybird.state.events[1].totalCost).toBeCloseTo(
+        1.048576 * 0.005,
+        10,
+    );
+});

--- a/gen.pollinations.ai/test/image/zImageFalModel.test.ts
+++ b/gen.pollinations.ai/test/image/zImageFalModel.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { syncImageEnv } from "../../src/image/env.ts";
+import { callZImageFalAPI } from "../../src/image/models/zImageFalModel.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+
+const FAL_ENDPOINT = "https://fal.run/fal-ai/z-image/turbo";
+const IMAGE_URL = "https://fal.media/zimage-output.jpg";
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+
+const params: ImageParams = {
+    model: "zimage-fal",
+    width: 1024,
+    height: 768,
+    dimensionsExplicit: true,
+    seed: 42,
+    safe: false,
+    quality: "medium",
+    image: [],
+    transparent: false,
+    reasoning: "balanced",
+    audio: false,
+};
+
+beforeEach(() => {
+    syncImageEnv({ FAL_KEY: "test-fal-key" } as CloudflareBindings, [
+        "FAL_KEY",
+    ]);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("callZImageFalAPI", () => {
+    it("generates one image with the public Z-Image parameters", async () => {
+        const requests: Array<{ url: string; init?: RequestInit }> = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+            const href = url.toString();
+            requests.push({ url: href, init });
+            if (href === FAL_ENDPOINT) {
+                return Response.json({
+                    images: [
+                        {
+                            url: IMAGE_URL,
+                            content_type: "image/jpeg",
+                            width: 1024,
+                            height: 768,
+                        },
+                    ],
+                    seed: 42,
+                    has_nsfw_concepts: [false],
+                });
+            }
+            if (href === IMAGE_URL) {
+                return new Response(JPEG_BYTES, {
+                    headers: { "content-type": "image/jpeg" },
+                });
+            }
+            return new Response("unexpected URL", { status: 404 });
+        });
+
+        const result = await callZImageFalAPI("a red apple", params);
+
+        expect(requests.map(({ url }) => url)).toEqual([
+            FAL_ENDPOINT,
+            IMAGE_URL,
+        ]);
+        expect(JSON.parse(requests[0].init?.body as string)).toEqual({
+            prompt: "a red apple",
+            image_size: { width: 1024, height: 768 },
+            num_inference_steps: 4,
+            seed: 42,
+            num_images: 1,
+            output_format: "jpeg",
+            enable_prompt_expansion: false,
+        });
+        expect(requests[0].init?.headers).toMatchObject({
+            Authorization: "Key test-fal-key",
+        });
+        expect(result.buffer).toEqual(Buffer.from(JPEG_BYTES));
+        expect(result.mimeType).toBe("image/jpeg");
+        expect(result.trackingData).toEqual({
+            actualModel: "zimage-fal",
+            usage: { completionImageTokens: 1 },
+        });
+    });
+
+    it("rejects a successful response without an image", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json({ images: [] }),
+        );
+
+        await expect(
+            callZImageFalAPI("a red apple", params),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it("rejects invalid Fal JSON as an upstream error", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            new Response("not json"),
+        );
+
+        await expect(
+            callZImageFalAPI("a red apple", params),
+        ).rejects.toMatchObject({
+            status: 502,
+            message: "Z-Image Fal returned invalid JSON",
+        });
+    });
+});

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -18,6 +18,7 @@ import type {
 export type PricingInput = {
     resolution?: string;
     hasImage?: boolean;
+    megapixels?: number;
     searchContextSize?: "low" | "high";
 };
 

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -353,12 +353,55 @@ export const IMAGE_SERVICES = {
     "zimage": {
         aliases: ["z-image", "z-image-turbo"],
         provider: "vast",
+        fallbacks: ["zimage-fal"],
+        // Fal is capacity insurance only: do not move provider errors or bad
+        // requests away from the Pollinations-operated Vast pool.
+        fallbackOnStatusCodes: [503],
         brand: "Alibaba",
         category: "image",
         addedDate: new Date("2025-12-08").getTime(),
         priceMultiplier: 1,
         cost: {
             completionImageTokens: 0.004, // per image
+        },
+        title: "Z-Image Turbo",
+        description:
+            "Instant, budget-friendly images with crisp upscaled output",
+        inputModalities: ["text"],
+        outputModalities: ["image"],
+    },
+    "zimage-fal": {
+        aliases: [],
+        provider: "fal",
+        brand: "Alibaba",
+        category: "image",
+        addedDate: new Date("2026-08-10").getTime(),
+        paidOnly: true,
+        hidden: true,
+        priceMultiplier: 1,
+        // Fal bills $0.005 per output megapixel. The token line stays at zero;
+        // the adjustment below records the exact provider cost while the
+        // caller keeps the public zimage flat price when this serves as fallback.
+        cost: {
+            completionImageTokens: 0,
+        },
+        billing: {
+            adjustments: [
+                {
+                    id: "fal.zimage.output_megapixels.v1",
+                    description: "Fal output image megapixels",
+                    kind: "image",
+                    unit: "megapixel",
+                    unitCost: 0.005,
+                    publicPricing: {
+                        label: "Output megapixels",
+                        quantity: 1,
+                        unit: "megapixel",
+                    },
+                    countUnits: (_output, input) =>
+                        Math.max(0, input?.megapixels ?? 0),
+                },
+            ],
         },
         title: "Z-Image Turbo",
         description:

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -148,6 +148,8 @@ export type ModelDefinition = {
     provider: string;
     /** Ordered model ids to try when this model's upstream fails. */
     fallbacks?: string[];
+    /** Override the shared fallback status list for this model. Network failures always retry. */
+    fallbackOnStatusCodes?: number[];
     brand: string;
     category: Category;
     cost: CostDefinition;


### PR DESCRIPTION
- Adds `fal-ai/z-image/turbo` as a fallback only after the Z-Image Vast pool fails with HTTP 503 or a network error.
- Keeps the public `zimage` model, aliases, Vast provider attribution, and $0.004/image customer price unchanged.
- Adds a hidden, paid-only internal Fal route and records Fal's $0.005/MP provider cost plus fallback attribution in Tinybird.
- Reuses the existing production `FAL_KEY`; no secret changes are included.

Validation:
- Live Fal probes at 512×512 and 1024×1024; the 1024×1024 request returned a valid JPEG in 1.33s.
- 21 focused fallback tests, 81 surrounding gen tests, and 332 registry/pricing tests pass.
- Gen typecheck and Biome checks pass.

Fal API reference: https://fal.ai/docs/model-api-reference/image-generation-api/z-image-turbo
