### PR TITLE
fix: bound Z-Image queue for Fal spillover

### DIFF
--- a/operations/infrastructure/gpu/zimage/README.md
+++ b/operations/infrastructure/gpu/zimage/README.md
@@ -33,6 +33,18 @@ Using one remotely managed tunnel for the pool creates a Cloudflare replica per
 Vast worker. Cloudflare balances requests across those replicas, while the
 Pollinations registry sees one stable backend URL.
 
+Each worker admits at most three generation requests: one running and two
+waiting. Additional requests receive `503 Queue full`, which lets gen route
+the request to the configured Fal fallback instead of building an unbounded
+local queue. `QUEUE_LIMIT=3` is persisted by `setup-vast.sh` and can be
+overridden when provisioning. This absorbs short local bursts before paying
+for Fal while still bounding worst-case queue growth.
+
+Deploy the gen fallback before enabling this queue limit on production workers.
+After updating a worker, verify local saturation returns 503, normal generation
+still succeeds, and production telemetry attributes any overflow to
+`zimage-fal`. Only then drain and destroy a redundant Vast connector.
+
 The setup defaults to `HEARTBEAT_ENABLED=false`, which prevents registry
 registration but does not isolate a connector in the shared named tunnel.
 Validate local health and generation while cloudflared is stopped. The setup

--- a/operations/infrastructure/gpu/zimage/generation_queue.py
+++ b/operations/infrastructure/gpu/zimage/generation_queue.py
@@ -1,0 +1,20 @@
+import threading
+from contextlib import contextmanager
+
+from fastapi import HTTPException
+
+
+class GenerationQueue:
+    def __init__(self, limit: int):
+        if limit < 1:
+            raise ValueError("QUEUE_LIMIT must be at least 1")
+        self._slots = threading.BoundedSemaphore(limit)
+
+    @contextmanager
+    def slot(self):
+        if not self._slots.acquire(blocking=False):
+            raise HTTPException(status_code=503, detail="Queue full")
+        try:
+            yield
+        finally:
+            self._slots.release()

--- a/operations/infrastructure/gpu/zimage/server.py
+++ b/operations/infrastructure/gpu/zimage/server.py
@@ -21,6 +21,7 @@ from contextlib import asynccontextmanager
 import math
 from utility import StableDiffusionSafetyChecker, replace_numpy_with_python, replace_sets_with_lists, numpy_to_pil
 from transformers import AutoFeatureExtractor
+from generation_queue import GenerationQueue
 
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["TQDM_DISABLE"] = "1"
@@ -94,8 +95,10 @@ UPSCALE_FACTOR = 2
 MAX_GEN_PIXELS = 768 * 768  # Generate natively up to this size
 MAX_FINAL_PIXELS = 768 * 768 * 4  # Max output size with 2x upscaling
 ENABLE_SPAN_UPSCALER = True
+QUEUE_LIMIT = int(os.getenv("QUEUE_LIMIT", "3"))
 
 generate_lock = threading.Lock()
+generation_queue = GenerationQueue(QUEUE_LIMIT)
 
 
 class ImageRequest(BaseModel):
@@ -333,8 +336,17 @@ def check_nsfw(image_array, safety_checker_adj: float = 0.0):
     )
 
 
+def reserve_generation_slot():
+    with generation_queue.slot():
+        yield
+
+
 @app.post("/generate")
-def generate(request: ImageRequest, _auth: bool = Depends(verify_backend_token)):
+def generate(
+    request: ImageRequest,
+    _auth: bool = Depends(verify_backend_token),
+    _slot: None = Depends(reserve_generation_slot),
+):
     logger.info(f"Request: {request}")
     if pipe is None:
         raise HTTPException(status_code=503, detail="Model not loaded")

--- a/operations/infrastructure/gpu/zimage/setup-vast.sh
+++ b/operations/infrastructure/gpu/zimage/setup-vast.sh
@@ -25,6 +25,7 @@ SERVICE_TYPE="${SERVICE_TYPE:-zimage}"
 PORT="${PORT:-10002}"
 HEARTBEAT_ENABLED="${HEARTBEAT_ENABLED:-false}"
 HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}"
+QUEUE_LIMIT="${QUEUE_LIMIT:-3}"
 SUDO=""
 [ "$(id -u)" != "0" ] && SUDO="sudo"
 
@@ -174,6 +175,7 @@ log "Writing runtime environment to $ENV_FILE"
     printf 'export SPAN_MODEL_PATH=%q\n' "$SPAN_MODEL_PATH"
     printf 'export HF_HUB_CACHE=%q\n' "$MODEL_CACHE/hub"
     printf 'export HF_HUB_DISABLE_XET=%q\n' "$HF_HUB_DISABLE_XET"
+    printf 'export QUEUE_LIMIT=%q\n' "$QUEUE_LIMIT"
     printf 'export CUDA_VISIBLE_DEVICES=0\n'
     # cuDNN v8's VAE convolution path segfaults with exit 139 on the tested
     # RTX 5090 / driver 570 / cu128 stack. The legacy API remains GPU-backed

--- a/operations/infrastructure/gpu/zimage/test_generation_queue.py
+++ b/operations/infrastructure/gpu/zimage/test_generation_queue.py
@@ -1,0 +1,38 @@
+import unittest
+
+from fastapi import HTTPException
+
+from generation_queue import GenerationQueue
+
+
+class GenerationQueueTest(unittest.TestCase):
+    def test_rejects_requests_beyond_the_limit(self):
+        queue = GenerationQueue(3)
+
+        with queue.slot():
+            with queue.slot():
+                with queue.slot():
+                    with self.assertRaises(HTTPException) as raised:
+                        with queue.slot():
+                            self.fail("queue admitted a fourth request")
+
+                    self.assertEqual(raised.exception.status_code, 503)
+                    self.assertEqual(raised.exception.detail, "Queue full")
+
+    def test_releases_slot_after_generation_failure(self):
+        queue = GenerationQueue(1)
+
+        with self.assertRaises(RuntimeError):
+            with queue.slot():
+                raise RuntimeError("generation failed")
+
+        with queue.slot():
+            pass
+
+    def test_rejects_invalid_limit(self):
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            GenerationQueue(0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Caps each Z-Image worker at three admitted generations: one running and two waiting.
- Returns `503 Queue full` immediately for further requests so the deployed Fal fallback absorbs sustained bursts.
- Persists `QUEUE_LIMIT=3` through Vast restarts and documents the consolidation rollout order.
- Keeps the public model, pricing, registry provider, and fallback policy unchanged; includes no secret changes.

Root cause: the Fal fallback was wired for Vast 503/network failures, but Z-Image serialized excess work behind an unbounded lock instead of signalling saturation.

Validation:
- 3/3 queue unit tests pass, including exception cleanup.
- Python compile, Black formatting check, setup script syntax, and `git diff --check` pass.
- 18/18 gen fallback tests pass, including end-to-end Vast 503 → Fal generation, billing, and Tinybird attribution.

After merge: deploy `QUEUE_LIMIT=3` to both Z-Image workers, verify concurrency and production spillover, drain instance `47267292`, then destroy it after a healthy 30–60 minute observation window.
