### PR TITLE
feat: deduplicate video generation requests

### DIFF
--- a/gen.pollinations.ai/src/durable-objects/MediaGeneration.ts
+++ b/gen.pollinations.ai/src/durable-objects/MediaGeneration.ts
@@ -1,0 +1,152 @@
+import { DurableObject } from "cloudflare:workers";
+import { UpstreamError } from "@shared/error.ts";
+import { R2_LIFECYCLE_TTL_MS } from "@shared/r2-storage.ts";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { generateDurableMediaResponse } from "@/image/handler.ts";
+import type { ImageParams } from "@/image/params.ts";
+import { putMediaResponse } from "@/utils/media-cache.ts";
+
+const STATE_KEY = "generation";
+
+export type MediaGenerationJob = {
+    cacheKey: string;
+    prompt: string;
+    params: ImageParams;
+    requestId: string;
+    responseHeaders: Record<string, string>;
+};
+
+type GenerationError = {
+    status: ContentfulStatusCode;
+    message: string;
+    errorCode?: string;
+};
+
+export type MediaGenerationStatus =
+    | { state: "queued" }
+    | { state: "running" }
+    | { state: "cached" }
+    | { state: "failed"; error: GenerationError };
+
+type StoredGeneration = MediaGenerationStatus & {
+    job?: MediaGenerationJob;
+    expiresAt?: number;
+};
+
+function expirationTime(): number {
+    // Successful state is redundant once R2 expires; failed state is a
+    // same-length tombstone that prevents an ambiguous resubmission.
+    return Date.now() + R2_LIFECYCLE_TTL_MS;
+}
+
+function publicStatus(generation: StoredGeneration): MediaGenerationStatus {
+    return generation.state === "failed"
+        ? { state: "failed", error: generation.error }
+        : { state: generation.state };
+}
+
+function generationError(error: unknown): GenerationError {
+    if (error instanceof UpstreamError) {
+        return {
+            status: error.status,
+            message: error.message,
+            ...(error.errorCode && { errorCode: error.errorCode }),
+        };
+    }
+    return {
+        status: 500,
+        message: error instanceof Error ? error.message : String(error),
+    };
+}
+
+export class MediaGeneration extends DurableObject<CloudflareBindings> {
+    async ensure(job: MediaGenerationJob): Promise<{
+        leader: boolean;
+        status: MediaGenerationStatus;
+    }> {
+        if (await this.env.IMAGE_BUCKET.head(job.cacheKey)) {
+            const status = { state: "cached" } as const;
+            const expiresAt = expirationTime();
+            await this.ctx.storage.put(STATE_KEY, { ...status, expiresAt });
+            await this.ctx.storage.setAlarm(expiresAt);
+            return { leader: false, status };
+        }
+
+        const current = await this.ctx.storage.get<StoredGeneration>(STATE_KEY);
+        if (!current || current.state === "cached") {
+            const queued: StoredGeneration = { state: "queued", job };
+            await this.ctx.storage.put(STATE_KEY, queued);
+            await this.ctx.storage.setAlarm(Date.now());
+            return { leader: true, status: { state: "queued" } };
+        }
+
+        return { leader: false, status: publicStatus(current) };
+    }
+
+    async getStatus(): Promise<MediaGenerationStatus | undefined> {
+        const current = await this.ctx.storage.get<StoredGeneration>(STATE_KEY);
+        return current ? publicStatus(current) : undefined;
+    }
+
+    async alarm(): Promise<void> {
+        const current = await this.ctx.storage.get<StoredGeneration>(STATE_KEY);
+        if (!current) return;
+
+        if (current.state === "cached" || current.state === "failed") {
+            if (!current.expiresAt || current.expiresAt <= Date.now()) {
+                await this.ctx.storage.deleteAll();
+            } else {
+                await this.ctx.storage.setAlarm(current.expiresAt);
+            }
+            return;
+        }
+
+        if (current.state === "running") {
+            const expiresAt = expirationTime();
+            await this.ctx.storage.put(STATE_KEY, {
+                state: "failed",
+                expiresAt,
+                error: {
+                    status: 500,
+                    message: "Generation was interrupted before completion",
+                },
+            } satisfies StoredGeneration);
+            await this.ctx.storage.setAlarm(expiresAt);
+            return;
+        }
+        if (current.state !== "queued" || !current.job) return;
+
+        await this.ctx.storage.put(STATE_KEY, {
+            state: "running",
+            job: current.job,
+        } satisfies StoredGeneration);
+
+        try {
+            const response = await generateDurableMediaResponse(
+                this.env,
+                current.job,
+            );
+            const stored = await putMediaResponse(
+                this.env.IMAGE_BUCKET,
+                current.job.cacheKey,
+                "video/mp4",
+                response,
+            );
+            if (!stored) throw new Error("Generated media response was empty");
+            const expiresAt = expirationTime();
+            await this.ctx.storage.put(STATE_KEY, {
+                state: "cached",
+                expiresAt,
+            } satisfies StoredGeneration);
+            await this.ctx.storage.setAlarm(expiresAt);
+        } catch (error) {
+            const expiresAt = expirationTime();
+            await this.ctx.storage.put(STATE_KEY, {
+                state: "failed",
+                expiresAt,
+                error: generationError(error),
+            } satisfies StoredGeneration);
+            await this.ctx.storage.setAlarm(expiresAt);
+        }
+    }
+}

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -2,9 +2,18 @@ import { remapUpstreamStatus, UpstreamError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
+import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type {
+    MediaGenerationJob,
+    MediaGenerationStatus,
+} from "@/durable-objects/MediaGeneration.ts";
 import type { Env } from "@/env.ts";
+import {
+    generateCacheKey,
+    setHttpMetadataHeaders,
+} from "@/utils/media-cache.ts";
 import { fallbackCandidates, withModelFallback } from "../fallback.ts";
 import type { GenerationModelEntry } from "../model-registry.ts";
 import {
@@ -43,6 +52,13 @@ import { buildTrackingHeaders } from "./utils/trackingHeaders.ts";
 
 type ImageContext = Context<Env>;
 type RuntimeImageParams = Omit<ImageParams, "model"> & { model: string };
+type MediaGenerationStub = DurableObjectStub & {
+    ensure(job: MediaGenerationJob): Promise<{
+        leader: boolean;
+        status: MediaGenerationStatus;
+    }>;
+    getStatus(): Promise<MediaGenerationStatus | undefined>;
+};
 
 const IMAGE_ENV_KEYS = [
     "AWS_ACCESS_KEY_ID",
@@ -471,6 +487,88 @@ async function generateVideoResult(
     );
 }
 
+export async function generateDurableMediaResponse(
+    env: CloudflareBindings,
+    job: MediaGenerationJob,
+): Promise<Response> {
+    syncImageEnvironment(env);
+    try {
+        const result = await createAndReturnVideo(
+            job.prompt,
+            job.params,
+            job.requestId,
+        );
+        assertNonEmptyMedia(result.buffer, "Video provider");
+        const headers = mediaHeaders(
+            job.prompt,
+            job.params,
+            result,
+            result.mimeType || detectMimeType(result.buffer),
+        );
+        for (const [name, value] of Object.entries(job.responseHeaders)) {
+            headers.set(name, value);
+        }
+        return new Response(bufferToUint8Array(result.buffer), { headers });
+    } catch (error) {
+        throwImageError(error);
+    }
+}
+
+async function generateDurableVideoResponse(
+    c: ImageContext,
+    prompt: string,
+    params: RuntimeImageParams,
+): Promise<Response> {
+    const cacheKey = generateCacheKey(
+        new URL(c.req.url),
+        c.req.header(SAFETY_HEADER_NAME),
+    );
+    const namespace = c.env.MEDIA_GENERATION;
+    const stub = namespace.get(
+        namespace.idFromName(cacheKey),
+    ) as MediaGenerationStub;
+    const job: MediaGenerationJob = {
+        cacheKey,
+        prompt,
+        params: params as ImageParams,
+        requestId: c.get("requestId"),
+        responseHeaders: c.get("safetyHeaders") ?? {},
+    };
+    const admission = await stub.ensure(job);
+
+    while (true) {
+        const status = await stub.getStatus();
+        if (status?.state === "failed") {
+            throw new UpstreamError(status.error.status, {
+                message: status.error.message,
+                errorCode: status.error.errorCode,
+            });
+        }
+        if (status?.state === "cached") {
+            const cached = await c.env.IMAGE_BUCKET.get(cacheKey);
+            if (!cached) {
+                throw new UpstreamError(500, {
+                    message: "Generated media was not found in cache",
+                });
+            }
+            setHttpMetadataHeaders(
+                c,
+                cached.httpMetadata,
+                "video/mp4",
+                cached.customMetadata,
+            );
+            c.header("Cache-Control", IMMUTABLE_CACHE_CONTROL);
+            c.header("X-Cache", admission.leader ? "MISS" : "HIT");
+            c.header(
+                "X-Cache-Type",
+                admission.leader ? "DURABLE" : "COALESCED",
+            );
+            return c.body(cached.body);
+        }
+        await sleep(1000);
+    }
+}
+
 export async function generateImageOrVideoResponse(
     c: ImageContext,
     prompt: string,
@@ -484,6 +582,10 @@ export async function generateImageOrVideoResponse(
         hasImage: (safeParams.image?.length ?? 0) > 0,
         megapixels: (safeParams.width * safeParams.height) / 1_000_000,
     });
+
+    if (c.req.method === "GET" && isVideoModel(safeParams.model)) {
+        return generateDurableVideoResponse(c, originalPrompt, safeParams);
+    }
 
     try {
         const { result, params, servedEntry, servedIndex } =

--- a/gen.pollinations.ai/src/index.ts
+++ b/gen.pollinations.ai/src/index.ts
@@ -31,6 +31,7 @@ import { modelStatusRoutes } from "./routes/model-status.ts";
 import { proxyRoutes } from "./routes/proxy.ts";
 import { docsLandingHtml, manifestResponse } from "./routes/seo.ts";
 
+export { MediaGeneration } from "./durable-objects/MediaGeneration.ts";
 export { PollenRateLimiter } from "./durable-objects/PollenRateLimiter.ts";
 
 const app = new Hono<Env>();

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -89,11 +89,17 @@ export function createMediaCache(config: MediaCacheConfig) {
 
         const contentType = c.res?.headers.get("content-type");
         const xCache = c.res?.headers.get("x-cache");
+        const xCacheType = c.res?.headers.get("x-cache-type");
 
         const isMatchingContent = config.mediaTypes.some((type) =>
             contentType?.includes(type),
         );
-        if (c.res?.ok && isMatchingContent && xCache !== "HIT") {
+        if (
+            c.res?.ok &&
+            isMatchingContent &&
+            xCache !== "HIT" &&
+            xCacheType !== "DURABLE"
+        ) {
             log.debug("Caching response");
             cacheMediaResponse(
                 c.env.IMAGE_BUCKET,

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -15,11 +15,13 @@ import type { Context } from "hono";
 // and "key" are request controls that must never affect the cache key.
 export const EXCLUDED_PARAMS = ["nofeed", "no-cache", "key"];
 export const SAFETY_CACHE_VERSION = "bedrock-input-v1";
-const CACHED_HEADER_PREFIXES = ["x-safety-"];
+const CACHED_HEADER_PREFIXES = ["x-safety-", "x-usage-"];
 const CACHED_HEADER_NAMES = [
     "content-disposition",
     "content-security-policy",
+    "x-fallback-target",
     "x-content-type-options",
+    "x-model-used",
 ];
 
 function hasActiveSafety(value: string | null | undefined): boolean {
@@ -107,6 +109,25 @@ function prepareCustomMetadata(response: Response): Record<string, string> {
     return metadata;
 }
 
+export async function putMediaResponse(
+    bucket: R2Bucket,
+    cacheKey: string,
+    defaultContentType: string,
+    response: Response,
+): Promise<boolean> {
+    const body = await response.clone().arrayBuffer();
+    if (body.byteLength === 0) return false;
+
+    await bucket.put(cacheKey, body, {
+        httpMetadata: removeUnset({
+            contentType:
+                response.headers.get("content-type") || defaultContentType,
+        } as R2HTTPMetadata),
+        customMetadata: prepareCustomMetadata(response),
+    });
+    return true;
+}
+
 type MediaCacheEnv = {
     Bindings: CloudflareBindings;
     Variables: {
@@ -123,26 +144,14 @@ export function cacheMediaResponse<TEnv extends MediaCacheEnv>(
     response: Response,
 ): void {
     c.executionCtx.waitUntil(
-        response
-            .clone()
-            .arrayBuffer()
-            .then((body) => {
-                if (body.byteLength === 0) {
+        putMediaResponse(bucket, cacheKey, defaultContentType, response)
+            .then((stored) => {
+                if (!stored) {
                     c.get("log").warn(
                         "Skipping empty media cache write for {cacheKey}",
                         { cacheKey },
                     );
-                    return null;
                 }
-
-                return bucket.put(cacheKey, body, {
-                    httpMetadata: removeUnset({
-                        contentType:
-                            response.headers.get("content-type") ||
-                            defaultContentType,
-                    } as R2HTTPMetadata),
-                    customMetadata: prepareCustomMetadata(response),
-                });
             })
             .catch((error) => {
                 c.get("log").error("Error caching response: {error}", {

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -187,6 +187,63 @@ describe("media cache", () => {
         expect(originHits).toBe(1);
     });
 
+    it("preserves billing headers written by a detached generation", async () => {
+        const app = new Hono<TestEnv>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                c.set("requestId", "test-request");
+                await next();
+            })
+            .get("/media/:prompt", imageCache, async () => {
+                return new Response("video", {
+                    headers: {
+                        "Content-Type": "video/mp4",
+                        "X-Model-Used": "wan-fast",
+                        "X-Usage-Completion-Video-Seconds": "5",
+                    },
+                });
+            });
+        const env = createMediaCacheEnv();
+
+        const miss = await dispatch(app, "/media/video", undefined, env);
+        await consumeAndWait(miss);
+        const hit = await dispatch(app, "/media/video", undefined, env);
+        await consumeAndWait(hit);
+
+        expect(hit.response.headers.get("X-Model-Used")).toBe("wan-fast");
+        expect(
+            hit.response.headers.get("X-Usage-Completion-Video-Seconds"),
+        ).toBe("5");
+    });
+
+    it("does not schedule a second cache write for durable responses", async () => {
+        const bucket = createTestR2Bucket();
+        const app = new Hono<TestEnv>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                c.set("requestId", "test-request");
+                await next();
+            })
+            .get("/media/:prompt", imageCache, async () => {
+                return new Response("video", {
+                    headers: {
+                        "Content-Type": "video/mp4",
+                        "X-Cache-Type": "DURABLE",
+                    },
+                });
+            });
+
+        const response = await dispatch(
+            app,
+            "/media/durable",
+            undefined,
+            createMediaCacheEnv(bucket),
+        );
+        await consumeAndWait(response);
+
+        expect(bucket.putCount).toBe(0);
+    });
+
     it("refreshes cached media TTL on aged cache hits", async () => {
         const media = createMediaCacheApp(imageCache, "image/png");
         const bucket = createTestR2Bucket();

--- a/gen.pollinations.ai/test/media-generation-durable.test.ts
+++ b/gen.pollinations.ai/test/media-generation-durable.test.ts
@@ -1,0 +1,88 @@
+import {
+    env,
+    runDurableObjectAlarm,
+    runInDurableObject,
+} from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type {
+    MediaGeneration,
+    MediaGenerationJob,
+} from "@/durable-objects/MediaGeneration.ts";
+import { ImageParamsSchema } from "@/image/params.ts";
+
+function createJob(cacheKey: string): MediaGenerationJob {
+    return {
+        cacheKey,
+        prompt: "a bee flying over flowers",
+        params: ImageParamsSchema.parse({ model: "wan-fast" }),
+        requestId: "test-request",
+        responseHeaders: {},
+    };
+}
+
+describe("MediaGeneration", () => {
+    it("elects one leader and makes identical requests join it", async () => {
+        const job = createJob("single-flight");
+        const stub = env.MEDIA_GENERATION.getByName(job.cacheKey);
+
+        await expect(stub.ensure(job)).resolves.toEqual({
+            leader: true,
+            status: { state: "queued" },
+        });
+        await expect(stub.ensure(job)).resolves.toEqual({
+            leader: false,
+            status: { state: "queued" },
+        });
+
+        await runInDurableObject(
+            stub,
+            async (_instance: MediaGeneration, state) => {
+                expect(await state.storage.getAlarm()).not.toBeNull();
+                await state.storage.deleteAlarm();
+            },
+        );
+    });
+
+    it("rechecks R2 before claiming a generation", async () => {
+        const job = createJob("already-cached");
+        await env.IMAGE_BUCKET.put(job.cacheKey, "video");
+        const stub = env.MEDIA_GENERATION.getByName(job.cacheKey);
+
+        await expect(stub.ensure(job)).resolves.toEqual({
+            leader: false,
+            status: { state: "cached" },
+        });
+        await runInDurableObject(
+            stub,
+            async (_instance: MediaGeneration, state) => {
+                expect(await state.storage.getAlarm()).not.toBeNull();
+                await state.storage.deleteAlarm();
+            },
+        );
+    });
+
+    it("fails closed instead of resubmitting an interrupted job", async () => {
+        const job = createJob("interrupted");
+        const stub = env.MEDIA_GENERATION.getByName(job.cacheKey);
+        await stub.ensure(job);
+        await runInDurableObject(
+            stub,
+            async (_instance: MediaGeneration, state) => {
+                await state.storage.put("generation", {
+                    state: "running",
+                    job,
+                });
+            },
+        );
+
+        await expect(runDurableObjectAlarm(stub)).resolves.toBe(true);
+        await expect(stub.getStatus()).resolves.toEqual({
+            state: "failed",
+            error: {
+                status: 500,
+                message: "Generation was interrupted before completion",
+            },
+        });
+        expect(await env.IMAGE_BUCKET.head(job.cacheKey)).toBeNull();
+    });
+});

--- a/gen.pollinations.ai/vitest.config.ts
+++ b/gen.pollinations.ai/vitest.config.ts
@@ -13,6 +13,7 @@ const sharedSrc = fileURLToPath(new URL("../shared/", import.meta.url));
 const genAliases = [
     "content-filter.ts",
     "cache",
+    "durable-objects/MediaGeneration.ts",
     "durable-objects/PollenRateLimiter.ts",
     "env.ts",
     "error.ts",

--- a/gen.pollinations.ai/worker-bindings.d.ts
+++ b/gen.pollinations.ai/worker-bindings.d.ts
@@ -70,6 +70,9 @@ interface CloudflareBindings {
     XAI_API_KEY: string;
     POLLEN_REFILL_PER_HOUR?: number;
     POLLEN_RATE_LIMITER?: DurableObjectNamespace;
+    MEDIA_GENERATION: DurableObjectNamespace<
+        import("./src/durable-objects/MediaGeneration.ts").MediaGeneration
+    >;
     EDGE_RATE_LIMITER?: RateLimit;
 }
 

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -34,9 +34,17 @@ bucket_name = "pollinations-text-enter"
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[durable_objects.bindings]]
+name = "MEDIA_GENERATION"
+class_name = "MediaGeneration"
+
 [[migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["MediaGeneration"]
 
 [vars]
 ENVIRONMENT = "development"
@@ -109,9 +117,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.production.durable_objects.bindings]]
+name = "MEDIA_GENERATION"
+class_name = "MediaGeneration"
+
 [[env.production.migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[env.production.migrations]]
+tag = "v2"
+new_sqlite_classes = ["MediaGeneration"]
 
 [env.production.vars]
 ENVIRONMENT = "production"
@@ -169,9 +185,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.staging.durable_objects.bindings]]
+name = "MEDIA_GENERATION"
+class_name = "MediaGeneration"
+
 [[env.staging.migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[env.staging.migrations]]
+tag = "v2"
+new_sqlite_classes = ["MediaGeneration"]
 
 [env.staging.vars]
 ENVIRONMENT = "staging"
@@ -221,9 +245,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.test.durable_objects.bindings]]
+name = "MEDIA_GENERATION"
+class_name = "MediaGeneration"
+
 [[env.test.migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[env.test.migrations]]
+tag = "v2"
+new_sqlite_classes = ["MediaGeneration"]
 
 [env.test.vars]
 ENVIRONMENT = "test"

--- a/shared/r2-storage.ts
+++ b/shared/r2-storage.ts
@@ -1,6 +1,6 @@
 /// <reference types="@cloudflare/workers-types" />
 
-const R2_LIFECYCLE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const R2_LIFECYCLE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 export const DEFAULT_R2_TTL_REFRESH_AGE_MS = R2_LIFECYCLE_TTL_MS / 2;
 


### PR DESCRIPTION
- Adds one SQLite Durable Object per existing media cache key for video GETs.
- Re-checks R2 inside the object, elects one leader, and runs the current video generator unchanged from an alarm.
- Waits for the R2 write before releasing callers; joined callers return `X-Cache: HIT` / `COALESCED`, avoiding duplicate billing and community rewards.
- Fails closed on alarm redelivery instead of submitting twice, then expires terminal state with the 30-day R2 lifecycle.
- Keeps the synchronous 200 response contract, provider implementations, cache-key identity, and seed behavior unchanged. No 202 API, provider job IDs, or new generation deadline.

Testing:
- `biome 2.3.10 check`
- `tsc --noEmit`
- Full Vite Worker build
- Added Durable Object and cache interaction tests. The local Workers Vitest harness exits before collecting both these tests and an unchanged baseline test (`usage-headers.test.ts`).