### PR TITLE
feat: single-flight generation so identical requests never generate twice

### DIFF
--- a/gen.pollinations.ai/src/image/models/novaReelModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaReelModel.ts
@@ -2,7 +2,11 @@ import debug from "debug";
 import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
-import { sleep } from "../util.ts";
+import {
+    GENERATION_BUDGET_MINUTES,
+    GENERATION_BUDGET_MS,
+    sleep,
+} from "../util.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 import { transformImage } from "../utils/imageTransform.ts";
 import type { VideoGenerationResult } from "./veoVideoModel.ts";
@@ -226,11 +230,15 @@ export async function callNovaReelAPI(
 
     // Poll for completion
 
-    const maxAttempts = 60; // 5 minutes max
+    // Was 60 attempts with 1.1x backoff capped at 15s, which sums to ~14
+    // minutes despite the "5 minutes" the code claimed.
+    const deadline = Date.now() + GENERATION_BUDGET_MS;
     let delayMs = 5000;
+    let attempt = 0;
 
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        logOps(`Poll attempt ${attempt}/${maxAttempts}...`);
+    while (Date.now() < deadline) {
+        attempt++;
+        logOps(`Poll attempt ${attempt}...`);
 
         const getCommand = new GetAsyncInvokeCommand({
             invocationArn,
@@ -292,7 +300,7 @@ export async function callNovaReelAPI(
     }
 
     throw new HttpError(
-        "Nova Reel video generation timed out after 5 minutes",
+        `Nova Reel video generation timed out after ${GENERATION_BUDGET_MINUTES} minutes`,
         504,
     );
 }

--- a/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
@@ -3,7 +3,7 @@ import type { VideoGenerationResult } from "../createAndReturnVideos.ts";
 import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
-import { sleep } from "../util.ts";
+import { GENERATION_BUDGET_MS, sleep } from "../util.ts";
 import {
     ASPECT_RATIOS,
     closestAspectRatio,
@@ -20,8 +20,8 @@ const GROK_VIDEO_MODEL = "x-ai/grok-imagine-video";
 const GROK_VIDEO_15_MODEL = "x-ai/grok-imagine-video-1.5";
 const POLL_INTERVAL_MS = 3000;
 const MAX_POLL_DELAY_MS = 30000;
-const HAPPYHORSE_POLL_TIMEOUT_MS = 5 * 60 * 1000;
-const GROK_POLL_TIMEOUT_MS = 3 * 60 * 1000;
+const HAPPYHORSE_POLL_TIMEOUT_MS = GENERATION_BUDGET_MS;
+const GROK_POLL_TIMEOUT_MS = GENERATION_BUDGET_MS;
 const HAPPYHORSE_ASPECT_RATIOS = [
     "16:9",
     "9:16",

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -3,7 +3,11 @@ import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
 import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
-import { sleep } from "../util.ts";
+import {
+    GENERATION_BUDGET_MINUTES,
+    GENERATION_BUDGET_MS,
+    sleep,
+} from "../util.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { downloadUserImage } from "../utils/imageDownload.ts";
 import { calculateVideoResolution } from "../utils/videoResolution.ts";
@@ -260,11 +264,16 @@ async function pollVeoOperation(
     const pollUrl = `https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/publishers/google/models/${model}:fetchPredictOperation`;
     logOps("Poll URL:", pollUrl);
 
-    const maxAttempts = 90; // 3 minutes max
+    // Was 90 attempts with 1.2x backoff capped at 30s, which sums to ~40
+    // minutes despite the "3 minutes" the code claimed. Bounded by wall clock
+    // now so the number in the message is the number that happens.
+    const deadline = Date.now() + GENERATION_BUDGET_MS;
     let delayMs = 2000;
+    let attempt = 0;
 
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        logOps(`Poll attempt ${attempt}/${maxAttempts}...`);
+    while (Date.now() < deadline) {
+        attempt++;
+        logOps(`Poll attempt ${attempt}...`);
 
         const pollResponse = await fetch(pollUrl, {
             method: "POST",
@@ -356,7 +365,7 @@ async function pollVeoOperation(
     }
 
     throw new HttpError(
-        "Video generation timed out after 3 minutes",
+        `Video generation timed out after ${GENERATION_BUDGET_MINUTES} minutes`,
         504,
         undefined,
         pollUrl,

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -19,6 +19,7 @@ import debug from "debug";
 import type { VideoGenerationResult } from "../createAndReturnVideos.ts";
 import { HttpError } from "../httpError.ts";
 import type { ImageParams } from "../params.ts";
+import { GENERATION_BUDGET_MINUTES } from "../util.ts";
 import { closestRatioLogSpace } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { toDataUri } from "../utils/imageDownload.ts";
@@ -60,7 +61,7 @@ const WAN_FAST_FIXED_SECONDS = 5;
 const WAN_26_DURATIONS = [5, 10, 15] as const;
 const WAN_PRO_MIN_DURATION = 2;
 const WAN_PRO_MAX_DURATION = 15;
-const WAN_PRO_PREDICTION_DEADLINE_MINUTES = 15;
+const WAN_PRO_PREDICTION_DEADLINE_MINUTES = GENERATION_BUDGET_MINUTES;
 
 /** Pick the supported aspect ratio closest to the request. */
 function pickAspect<T extends string>(

--- a/gen.pollinations.ai/src/image/util.ts
+++ b/gen.pollinations.ai/src/image/util.ts
@@ -2,6 +2,20 @@ export async function sleep(ms: number) {
     await new Promise<void>((resolve, _) => setTimeout(resolve, ms));
 }
 
+/**
+ * The single wall-clock ceiling every provider poller must respect.
+ *
+ * It exists because the single-flight lease in the media cache has to outlive
+ * the slowest generation it guards: if a lease expires while its holder is
+ * still polling, a second caller starts a duplicate paid generation. One
+ * shared budget keeps that relationship checkable instead of spread across
+ * six unrelated attempt counters.
+ *
+ * Kept below LEASE_TTL_MS so lease expiry can never race a live poller.
+ */
+export const GENERATION_BUDGET_MINUTES = 9;
+export const GENERATION_BUDGET_MS = GENERATION_BUDGET_MINUTES * 60 * 1000;
+
 // Strip control characters while preserving valid Unicode characters.
 export function sanitizeString(str: string) {
     if (!str) return str;

--- a/gen.pollinations.ai/src/image/utils/replicateClient.ts
+++ b/gen.pollinations.ai/src/image/utils/replicateClient.ts
@@ -10,14 +10,14 @@
 
 import { getImageEnv } from "../env.ts";
 import { HttpError } from "../httpError.ts";
-import { sleep } from "../util.ts";
+import { GENERATION_BUDGET_MINUTES, sleep } from "../util.ts";
 
 const API_BASE = "https://api.replicate.com/v1";
 const PREFER_WAIT_SECONDS = 60;
 const POLL_INTERVAL_MS = 5000;
 // One deadline controls both Replicate's Cancel-After header and local polling
 // so the upstream and Worker ceilings cannot drift apart.
-const DEFAULT_PREDICTION_DEADLINE_MINUTES = 6;
+const DEFAULT_PREDICTION_DEADLINE_MINUTES = GENERATION_BUDGET_MINUTES;
 const CANCEL_REQUEST_TIMEOUT_MS = 5000;
 
 export class ReplicateError extends Error {

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -8,17 +8,36 @@
  * TODO: Rename to MEDIA_BUCKET when ready to consolidate.
  */
 
+import type { Logger } from "@logtape/logtape";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { refreshR2ObjectTtl } from "@shared/r2-storage.ts";
 import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { RequestIdVariables } from "hono/request-id";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import {
+    acquireGenerationLease,
     cacheMediaResponse,
     generateCacheKey,
+    leaseKeyFor,
+    releaseGenerationLease,
     setHttpMetadataHeaders,
 } from "@/utils/media-cache.ts";
+
+/**
+ * How long a joined caller waits for the in-flight generation before it is
+ * told to come back.
+ *
+ * This must stay below the smallest edge read timeout in front of this worker
+ * (gen is served from both a free and an Enterprise zone), so that we answer
+ * with a 202 rather than the edge answering with a 524. 75s leaves margin
+ * against the ~100s free-zone default.
+ */
+const JOIN_BUDGET_MS = 75_000;
+const JOIN_POLL_INITIAL_MS = 250;
+const JOIN_POLL_MAX_MS = 2_000;
+const RETRY_AFTER_SECONDS = 5;
 
 type MediaCacheEnv = {
     Bindings: CloudflareBindings;
@@ -50,33 +69,36 @@ export function createMediaCache(config: MediaCacheConfig) {
         );
         log.debug("Cache key: {key}", { key: cacheKey });
 
+        const serveCached = (cached: R2ObjectBody, cacheType: string) => {
+            setHttpMetadataHeaders(
+                c,
+                cached.httpMetadata,
+                config.defaultContentType,
+                cached.customMetadata,
+            );
+            c.header("Cache-Control", IMMUTABLE_CACHE_CONTROL);
+            c.header("X-Cache", "HIT");
+            c.header("X-Cache-Type", cacheType);
+            return c.body(
+                refreshR2ObjectTtl(
+                    c.env.IMAGE_BUCKET,
+                    cacheKey,
+                    cached,
+                    (promise) => c.executionCtx.waitUntil(promise),
+                    (error) => {
+                        log.error("Error refreshing media cache TTL: {error}", {
+                            error,
+                        });
+                    },
+                ),
+            );
+        };
+
         try {
             const cached = await c.env.IMAGE_BUCKET.get(cacheKey);
             if (cached) {
                 log.info("Cache HIT");
-                setHttpMetadataHeaders(
-                    c,
-                    cached.httpMetadata,
-                    config.defaultContentType,
-                    cached.customMetadata,
-                );
-                c.header("Cache-Control", IMMUTABLE_CACHE_CONTROL);
-                c.header("X-Cache", "HIT");
-                c.header("X-Cache-Type", "EXACT");
-                return c.body(
-                    refreshR2ObjectTtl(
-                        c.env.IMAGE_BUCKET,
-                        cacheKey,
-                        cached,
-                        (promise) => c.executionCtx.waitUntil(promise),
-                        (error) => {
-                            log.error(
-                                "Error refreshing media cache TTL: {error}",
-                                { error },
-                            );
-                        },
-                    ),
-                );
+                return serveCached(cached, "EXACT");
             }
 
             log.debug("Cache MISS");
@@ -85,26 +107,134 @@ export function createMediaCache(config: MediaCacheConfig) {
             log.error("Error retrieving cached response: {error}", { error });
         }
 
-        await next();
-
-        const contentType = c.res?.headers.get("content-type");
-        const xCache = c.res?.headers.get("x-cache");
-
-        const isMatchingContent = config.mediaTypes.some((type) =>
-            contentType?.includes(type),
+        const isGenerator = await acquireGenerationLease(
+            c.env.IMAGE_BUCKET,
+            cacheKey,
+            log,
         );
-        if (c.res?.ok && isMatchingContent && xCache !== "HIT") {
-            log.debug("Caching response");
-            // Swaps in the client's half of the tee'd body. Without this the
-            // cache would hold a branch nobody drains.
-            c.res = cacheMediaResponse(
+
+        if (!isGenerator) {
+            log.info("Joining in-flight generation for {cacheKey}", {
+                cacheKey,
+            });
+            const joined = await waitForGeneratedMedia(
                 c.env.IMAGE_BUCKET,
                 cacheKey,
-                c,
-                config.defaultContentType,
-                c.res,
+                log,
             );
+            if (joined) return serveCached(joined, "COALESCED");
+            return pendingResponse(c);
         }
+
+        // Hand the generation to waitUntil before awaiting it, so a client
+        // that gives up does not cancel the work it already paid for. The
+        // result still lands in R2 and the caller's retry is a free hit.
+        const generation = next();
+        c.executionCtx.waitUntil(generation.catch(() => {}));
+        try {
+            await generation;
+        } catch (error) {
+            await releaseGenerationLease(c.env.IMAGE_BUCKET, cacheKey, log);
+            throw error;
+        }
+
+        const write = writeBack(c, config, cacheKey, log);
+        if (write) {
+            // Hold the lease until the object exists, or a joiner released
+            // early would see neither a lease nor an object and generate again.
+            c.executionCtx.waitUntil(
+                write.finally(() =>
+                    releaseGenerationLease(c.env.IMAGE_BUCKET, cacheKey, log),
+                ),
+            );
+        } else {
+            await releaseGenerationLease(c.env.IMAGE_BUCKET, cacheKey, log);
+        }
+    });
+}
+
+/**
+ * Persists the response when it is cacheable media. Returns the write promise
+ * so a lease holder can keep the lease until the object is readable, or
+ * undefined when there is nothing to cache.
+ */
+function writeBack(
+    c: Context<MediaCacheEnv>,
+    config: MediaCacheConfig,
+    cacheKey: string,
+    log: Logger,
+): Promise<void> | undefined {
+    const contentType = c.res?.headers.get("content-type");
+    const xCache = c.res?.headers.get("x-cache");
+    const isMatchingContent = config.mediaTypes.some((type) =>
+        contentType?.includes(type),
+    );
+    if (!c.res?.ok || !isMatchingContent || xCache === "HIT") return undefined;
+
+    log.debug("Caching response");
+    const { response, write } = cacheMediaResponse(
+        c.env.IMAGE_BUCKET,
+        cacheKey,
+        c,
+        config.defaultContentType,
+        c.res,
+    );
+    // Swap in the client's half of the tee'd body.
+    c.res = response;
+    return write;
+}
+
+/**
+ * Polls for the object the current generation holder is producing. Gives up
+ * early when the lease disappears without an object, which means that attempt
+ * failed and this caller should be told to retry rather than keep waiting.
+ */
+async function waitForGeneratedMedia(
+    bucket: R2Bucket,
+    cacheKey: string,
+    log: Logger,
+): Promise<R2ObjectBody | null> {
+    const deadline = Date.now() + JOIN_BUDGET_MS;
+    let delay = JOIN_POLL_INITIAL_MS;
+
+    while (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay = Math.min(delay * 1.5, JOIN_POLL_MAX_MS);
+
+        try {
+            const cached = await bucket.get(cacheKey);
+            if (cached) return cached;
+            const lease = await bucket.head(leaseKeyFor(cacheKey));
+            if (!lease) {
+                log.info(
+                    "Joined generation ended without media for {cacheKey}",
+                    {
+                        cacheKey,
+                    },
+                );
+                return null;
+            }
+        } catch (error) {
+            log.error("Error polling for joined generation: {error}", {
+                error,
+            });
+            return null;
+        }
+    }
+    return null;
+}
+
+/**
+ * Emitted where the edge would otherwise time the caller out. Unlike a 524
+ * this says the work was accepted and is still running, so retrying the same
+ * URL is both safe and free.
+ */
+function pendingResponse(c: Context<MediaCacheEnv>): Response {
+    return c.body(null, 202, {
+        "Retry-After": String(RETRY_AFTER_SECONDS),
+        "Cache-Control": "no-store",
+        "X-Cache": "MISS",
+        "X-Cache-Type": "PENDING",
     });
 }
 

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -323,6 +323,10 @@ export const track = (eventType: EventType) =>
                         ),
                     });
                 }
+                // 202 means the caller joined an in-flight generation and is
+                // being told to come back. No generation ran for this request,
+                // so it must not be billed or counted as a generation.
+                if (response.status === 202) return;
                 const servedEntry = c.var.servedModelEntry;
                 const responseTracking = await trackResponse(
                     eventType,

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -8,6 +8,7 @@ import type { Logger } from "@logtape/logtape";
 import { parseSafeFeatures } from "@shared/schemas/safety.ts";
 import { removeUnset } from "@shared/util.ts";
 import type { Context } from "hono";
+import { GENERATION_BUDGET_MS } from "@/image/util.ts";
 
 // "nofeed" is a removed/no-op param kept here on purpose: external and
 // community clients still send `?nofeed=true`, and excluding it from the
@@ -116,19 +117,19 @@ type MediaCacheEnv = {
 };
 
 /**
- * Caches a media response and returns the response to send to the client.
+ * Splits a media response: the client gets one half, the cache the other.
  *
- * The body is split with `tee()` rather than `clone()`, and our branch is
- * consumed immediately. That matters because a cloned Response signals
- * backpressure at the rate of the *faster* consumer: if one branch is never
- * read, workerd buffers the whole body with no limit. Under `clone()` the
- * cache write was therefore only as reliable as the client's willingness to
- * read — fine for the fully buffered image/video/3D handlers, but for the
- * audio routes, which pass the provider's stream straight through, a caller
- * that hung up could stall the write and the media was silently never cached.
+ * `tee()` rather than `clone()`, with our branch consumed immediately. A
+ * cloned Response signals backpressure at the rate of the *faster* consumer,
+ * so a branch nobody reads makes workerd buffer the whole body with no limit.
+ * Under `clone()` the cache write was therefore only as reliable as the
+ * client's willingness to read — invisible for the fully buffered image,
+ * video and 3D handlers, but the audio routes pass the provider's stream
+ * straight through, so a caller that hung up could stall the write and the
+ * media was silently never cached.
  *
- * Reading our branch ourselves makes the write independent of the client, so
- * every media type caches the same way.
+ * Returns the write promise as well, because the single-flight lease holder
+ * must keep its lease until the object is actually readable.
  */
 export function cacheMediaResponse<TEnv extends MediaCacheEnv>(
     bucket: R2Bucket,
@@ -136,21 +137,21 @@ export function cacheMediaResponse<TEnv extends MediaCacheEnv>(
     c: Context<TEnv>,
     defaultContentType: string,
     response: Response,
-): Response {
-    if (!response.body) return response;
+): { response: Response; write: Promise<void> } {
+    if (!response.body) {
+        return { response, write: Promise.resolve() };
+    }
 
     const [clientBody, cacheBody] = response.body.tee();
-    c.executionCtx.waitUntil(
-        storeMediaBody(
-            bucket,
-            cacheKey,
-            c.get("log"),
-            defaultContentType,
-            cacheBody,
-            response,
-        ),
+    const write = storeMediaBody(
+        bucket,
+        cacheKey,
+        c.get("log"),
+        defaultContentType,
+        cacheBody,
+        response,
     );
-    return new Response(clientBody, response);
+    return { response: new Response(clientBody, response), write };
 }
 
 async function storeMediaBody(
@@ -179,5 +180,89 @@ async function storeMediaBody(
         });
     } catch (error) {
         log.error("Error caching response: {error}", { error });
+    }
+}
+
+// --- Single-flight generation lease -----------------------------------------
+//
+// R2 conditional writes give us an atomic create-if-absent: `put` with
+// `onlyIf: { etagDoesNotMatch: "*" }` resolves to an R2Object when this call
+// created the object and to null when it already existed. That is enough to
+// elect exactly one generator per cache key without any new binding.
+//
+// The lease is deliberately advisory: it is released as soon as the media
+// object exists (or the attempt fails), and it self-expires so a worker that
+// dies mid-generation cannot wedge a key forever.
+
+/**
+ * Derived, not chosen: a lease that expires while its holder is still polling
+ * a provider would let a second caller start a duplicate paid generation. It
+ * therefore has to outlive the longest generation we allow, plus room for the
+ * download and the R2 write.
+ */
+export const LEASE_TTL_MS = GENERATION_BUDGET_MS + 60_000;
+
+export function leaseKeyFor(cacheKey: string): string {
+    return `${cacheKey}.lease`;
+}
+
+/**
+ * Returns true when this caller is now the sole generator for `cacheKey`.
+ *
+ * Fails closed: any R2 error (including the 429 R2 returns when a key is
+ * written more than once per second) is reported as "someone else holds it",
+ * never as "go ahead and generate". Duplicating a paid generation is worse
+ * than making a caller wait.
+ */
+export async function acquireGenerationLease(
+    bucket: R2Bucket,
+    cacheKey: string,
+    log: Logger,
+): Promise<boolean> {
+    const leaseKey = leaseKeyFor(cacheKey);
+    try {
+        const created = await bucket.put(leaseKey, "", {
+            onlyIf: { etagDoesNotMatch: "*" },
+            customMetadata: { startedAt: new Date().toISOString() },
+        });
+        if (created) return true;
+
+        // A lease exists. Take it over if it is older than the TTL, which means
+        // its holder died without releasing.
+        const existing = await bucket.head(leaseKey);
+        if (!existing) return false;
+        const startedAt = Date.parse(
+            existing.customMetadata?.startedAt ??
+                existing.uploaded.toISOString(),
+        );
+        if (Number.isNaN(startedAt) || Date.now() - startedAt < LEASE_TTL_MS) {
+            return false;
+        }
+
+        const takenOver = await bucket.put(leaseKey, "", {
+            onlyIf: { etagMatches: existing.etag },
+            customMetadata: { startedAt: new Date().toISOString() },
+        });
+        if (takenOver) {
+            log.warn("Took over expired generation lease for {cacheKey}", {
+                cacheKey,
+            });
+        }
+        return takenOver !== null;
+    } catch (error) {
+        log.error("Error acquiring generation lease: {error}", { error });
+        return false;
+    }
+}
+
+export async function releaseGenerationLease(
+    bucket: R2Bucket,
+    cacheKey: string,
+    log: Logger,
+): Promise<void> {
+    try {
+        await bucket.delete(leaseKeyFor(cacheKey));
+    } catch (error) {
+        log.error("Error releasing generation lease: {error}", { error });
     }
 }

--- a/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
@@ -5,6 +5,7 @@ import {
     callOpenRouterGrokVideoAPI,
 } from "../../src/image/models/openRouterVideoModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
+import { GENERATION_BUDGET_MS } from "../../src/image/util.ts";
 
 const SUBMIT_URL = "https://openrouter.ai/api/v1/videos";
 const POLL_URL = "https://openrouter.ai/api/v1/videos/job-happyhorse-test";
@@ -114,7 +115,7 @@ describe("openRouterVideoModel", () => {
         });
     });
 
-    it("times out after five minutes of rate-limited polls", async () => {
+    it("times out at the generation budget after rate-limited polls", async () => {
         vi.useFakeTimers();
         setOpenRouterEnv();
 
@@ -152,9 +153,10 @@ describe("openRouterVideoModel", () => {
             status: 504,
         });
 
-        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+        await vi.advanceTimersByTimeAsync(GENERATION_BUDGET_MS);
         await rejection;
-        expect(pollAttempts).toBe(10);
+        // These polls are spaced 30s apart by the mocked Retry-After.
+        expect(pollAttempts).toBe(GENERATION_BUDGET_MS / 30_000);
     });
 
     it("rejects non-integer durations before submitting a job", async () => {
@@ -335,7 +337,7 @@ describe("OpenRouter Grok Video Pro", () => {
         expect(result.durationSeconds).toBe(15);
     });
 
-    it("enforces a three-minute timeout", async () => {
+    it("enforces the generation budget as its timeout", async () => {
         vi.useFakeTimers();
         setOpenRouterEnv();
 
@@ -373,9 +375,9 @@ describe("OpenRouter Grok Video Pro", () => {
             status: 504,
         });
 
-        await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+        await vi.advanceTimersByTimeAsync(GENERATION_BUDGET_MS);
         await rejection;
-        expect(pollAttempts).toBe(6);
+        expect(pollAttempts).toBe(GENERATION_BUDGET_MS / 30_000);
     });
 
     it.each([

--- a/gen.pollinations.ai/test/image/replicateClient.test.ts
+++ b/gen.pollinations.ai/test/image/replicateClient.test.ts
@@ -2,6 +2,10 @@ import { env } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { syncImageEnvironment } from "../../src/image/handler.ts";
 import {
+    GENERATION_BUDGET_MINUTES,
+    GENERATION_BUDGET_MS,
+} from "../../src/image/util.ts";
+import {
     ReplicateError,
     runReplicatePrediction,
     toReplicateHttpError,
@@ -58,7 +62,9 @@ describe("runReplicatePrediction", () => {
         const headers = new Headers(init.headers);
         expect(headers.get("Authorization")).toBe("Bearer r8_test_token");
         expect(headers.get("Prefer")).toBe("wait=60");
-        expect(headers.get("Cancel-After")).toBe("6m");
+        expect(headers.get("Cancel-After")).toBe(
+            `${GENERATION_BUDGET_MINUTES}m`,
+        );
         const body = JSON.parse(init.body as string);
         expect(body.input).toEqual({ prompt: "test" });
         expect(body.version).toBeUndefined();
@@ -131,6 +137,7 @@ describe("runReplicatePrediction", () => {
             status: 504,
         });
 
+        // An explicit predictionDeadlineMinutes still wins over the default.
         const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
         expect(new Headers(init.headers).get("Cancel-After")).toBe("15m");
         await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
@@ -298,7 +305,7 @@ describe("runReplicatePrediction", () => {
             name: "ReplicateError",
             status: 504,
         });
-        await vi.advanceTimersByTimeAsync(6 * 60_000 + 1_000);
+        await vi.advanceTimersByTimeAsync(GENERATION_BUDGET_MS + 1_000);
         await assertion;
 
         const [requestUrl, init] = fetchSpy.mock.calls.at(-1) as [
@@ -353,7 +360,7 @@ describe("runReplicatePrediction", () => {
             name: "ReplicateError",
             status: 504,
         });
-        await vi.advanceTimersByTimeAsync(6 * 60_000 + 1_000);
+        await vi.advanceTimersByTimeAsync(GENERATION_BUDGET_MS + 1_000);
         await assertion;
 
         const [requestUrl, init] = fetchSpy.mock.calls.at(-1) as [
@@ -395,7 +402,7 @@ describe("runReplicatePrediction", () => {
             name: "ReplicateError",
             status: 504,
         });
-        await vi.advanceTimersByTimeAsync(6 * 60_000 + 5_001);
+        await vi.advanceTimersByTimeAsync(GENERATION_BUDGET_MS + 5_001);
         await assertion;
 
         expect(cancelSignals).toHaveLength(1);

--- a/gen.pollinations.ai/test/image/wanVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wanVideoModel.test.ts
@@ -6,6 +6,7 @@ import {
     callWanProAPI,
 } from "../../src/image/models/wanVideoModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
+import { GENERATION_BUDGET_MINUTES } from "../../src/image/util.ts";
 
 const REPLICATE_PREDICTIONS =
     /^https:\/\/api\.replicate\.com\/v1\/models\/(.+)\/predictions$/;
@@ -117,7 +118,7 @@ describe("wanVideoModel billing usage", () => {
         expect(calls).toHaveLength(1);
         expect(calls[0].model).toBe("wan-video/wan-2.7-t2v");
         expect(calls[0].input.resolution).toBe("720p");
-        expect(calls[0].cancelAfter).toBe("15m");
+        expect(calls[0].cancelAfter).toBe(`${GENERATION_BUDGET_MINUTES}m`);
         expect(result.mimeType).toBe("video/mp4");
         // No separate completionAudioSeconds — audio is bundled into the rate.
         expect(result.trackingData).toEqual({
@@ -138,7 +139,7 @@ describe("wanVideoModel billing usage", () => {
 
         expect(calls[0].model).toBe("wan-video/wan-2.7-t2v");
         expect(calls[0].input.resolution).toBe("1080p");
-        expect(calls[0].cancelAfter).toBe("15m");
+        expect(calls[0].cancelAfter).toBe(`${GENERATION_BUDGET_MINUTES}m`);
         expect(result.trackingData).toEqual({
             actualModel: "wan-pro",
             usage: { completionVideoSeconds: 5 },
@@ -160,7 +161,7 @@ describe("wanVideoModel billing usage", () => {
         // Landscape dims -> 720p landscape size; duration snapped to 5.
         expect(calls[0].input.size).toBe("1280*720");
         expect(calls[0].input.duration).toBe(5);
-        expect(calls[0].cancelAfter).toBe("6m");
+        expect(calls[0].cancelAfter).toBe(`${GENERATION_BUDGET_MINUTES}m`);
         expect(result.trackingData).toEqual({
             actualModel: "wan",
             usage: { completionVideoSeconds: 5 },
@@ -179,7 +180,7 @@ describe("wanVideoModel billing usage", () => {
 
         expect(calls[0].model).toBe("wan-video/wan-2.2-t2v-fast");
         expect(calls[0].input.resolution).toBe("480p");
-        expect(calls[0].cancelAfter).toBe("6m");
+        expect(calls[0].cancelAfter).toBe(`${GENERATION_BUDGET_MINUTES}m`);
         expect(result.trackingData).toEqual({
             actualModel: "wan-fast",
             usage: { completionVideoSeconds: 5 },
@@ -200,7 +201,7 @@ describe("wanVideoModel image-to-video routing", () => {
 
         expect(calls[0].model).toBe("wan-video/wan-2.7-i2v");
         expect(calls[0].input.resolution).toBe("720p");
-        expect(calls[0].cancelAfter).toBe("15m");
+        expect(calls[0].cancelAfter).toBe(`${GENERATION_BUDGET_MINUTES}m`);
         expect(calls[0].input.first_frame as string).toMatch(EXPECTED_DATA_URI);
     });
 
@@ -217,7 +218,7 @@ describe("wanVideoModel image-to-video routing", () => {
 
         expect(calls[0].model).toBe("wan-video/wan-2.7-i2v");
         expect(calls[0].input.resolution).toBe("1080p");
-        expect(calls[0].cancelAfter).toBe("15m");
+        expect(calls[0].cancelAfter).toBe(`${GENERATION_BUDGET_MINUTES}m`);
         expect(calls[0].input.first_frame as string).toMatch(EXPECTED_DATA_URI);
     });
 

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -10,7 +10,7 @@ import type { RequestIdVariables } from "hono/request-id";
 import { describe, expect, it } from "vitest";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { audioCache, imageCache } from "@/middleware/media-cache.ts";
-import { generateCacheKey } from "@/utils/media-cache.ts";
+import { generateCacheKey, leaseKeyFor } from "@/utils/media-cache.ts";
 
 const testLog = {
     getChild: () => testLog,
@@ -203,13 +203,164 @@ describe("media cache", () => {
             env,
         );
         expect(await consumeAndWait(warm)).toBe("origin:1");
-        expect(bucket.putCount).toBe(1);
+        // Media write plus the single-flight lease the generator took.
+        expect(bucket.putCount).toBe(2);
 
         const cached = await dispatch(media.app, path, undefined, env);
         expect(await consumeAndWait(cached)).toBe("origin:1");
         expect(cached.response.headers.get("X-Cache")).toBe("HIT");
         expect(media.originHits).toBe(1);
-        expect(bucket.putCount).toBe(2);
+        expect(bucket.putCount).toBe(3);
+    });
+});
+
+/** App whose origin takes `delayMs`, so a second request overlaps the first. */
+function createSlowMediaApp(
+    cache: MediaCache,
+    delayMs: number,
+    contentType = "image/png",
+) {
+    let originHits = 0;
+    const app = new Hono<TestEnv>()
+        .use("*", async (c, next) => {
+            c.set("log", testLog);
+            c.set("requestId", "test-request");
+            await next();
+        })
+        .get("/media/:prompt", cache, async () => {
+            originHits += 1;
+            const body = `origin:${originHits}`;
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            return new Response(body, {
+                headers: { "Content-Type": contentType },
+            });
+        });
+
+    return {
+        app,
+        get originHits() {
+            return originHits;
+        },
+    };
+}
+
+describe("single-flight generation", () => {
+    it("runs one generation when identical requests overlap and serves the second from it", async () => {
+        const media = createSlowMediaApp(imageCache, 400);
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/overlapping";
+
+        const [generator, joiner] = await Promise.all([
+            dispatch(media.app, path, undefined, env),
+            // Start just after the generator has taken the lease.
+            new Promise<Awaited<ReturnType<typeof dispatch>>>((resolve) =>
+                setTimeout(
+                    () => resolve(dispatch(media.app, path, undefined, env)),
+                    50,
+                ),
+            ),
+        ]);
+
+        expect(await consumeAndWait(generator)).toBe("origin:1");
+        expect(await consumeAndWait(joiner)).toBe("origin:1");
+
+        // The whole point: the provider was called once, and paid for once.
+        expect(media.originHits).toBe(1);
+        expect(joiner.response.status).toBe(200);
+        expect(joiner.response.headers.get("X-Cache")).toBe("HIT");
+        expect(joiner.response.headers.get("X-Cache-Type")).toBe("COALESCED");
+    });
+
+    it("releases the lease once the media is readable", async () => {
+        const media = createSlowMediaApp(imageCache, 10);
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+
+        const first = await dispatch(
+            media.app,
+            "/media/released",
+            undefined,
+            env,
+        );
+        expect(await consumeAndWait(first)).toBe("origin:1");
+
+        const leaseKey = leaseKeyFor(
+            generateCacheKey(
+                new URL("https://gen.pollinations.ai/media/released"),
+            ),
+        );
+        expect(bucket.getObject(leaseKey)).toBeUndefined();
+    });
+
+    it("releases the lease when the request is rejected before generating", async () => {
+        const media = createMediaCacheApp(imageCache, "image/png");
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+
+        // No Authorization header: the downstream auth check rejects it.
+        const denied = await dispatch(
+            media.app,
+            "/media/denied",
+            undefined,
+            env,
+        );
+        expect(denied.response.status).toBe(401);
+        await consumeAndWait(denied);
+
+        const leaseKey = leaseKeyFor(
+            generateCacheKey(
+                new URL("https://gen.pollinations.ai/media/denied"),
+            ),
+        );
+        expect(bucket.getObject(leaseKey)).toBeUndefined();
+        expect(media.originHits).toBe(0);
+    });
+
+    it("tells a joined caller to retry when the generation ended without media", async () => {
+        const media = createSlowMediaApp(imageCache, 10);
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/abandoned";
+        const cacheKey = generateCacheKey(
+            new URL(`https://gen.pollinations.ai${path}`),
+        );
+
+        // Simulate a generator that took the lease and then died.
+        await bucket.put(leaseKeyFor(cacheKey), "", {
+            customMetadata: { startedAt: new Date().toISOString() },
+        });
+        setTimeout(() => bucket.delete(leaseKeyFor(cacheKey)), 50);
+
+        const joiner = await dispatch(media.app, path, undefined, env);
+        await consumeAndWait(joiner);
+
+        expect(joiner.response.status).toBe(202);
+        expect(joiner.response.headers.get("Retry-After")).toBeTruthy();
+        expect(joiner.response.headers.get("Cache-Control")).toBe("no-store");
+        expect(joiner.response.headers.get("X-Cache-Type")).toBe("PENDING");
+        // No duplicate generation was started while the lease was held.
+        expect(media.originHits).toBe(0);
+    });
+
+    it("coordinates audio too, now that the write no longer depends on the client", async () => {
+        const media = createSlowMediaApp(audioCache, 200, "audio/mpeg");
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+        const path = "/media/streaming";
+
+        const [a, b] = await Promise.all([
+            dispatch(media.app, path, undefined, env),
+            dispatch(media.app, path, undefined, env),
+        ]);
+        await consumeAndWait(a);
+        await consumeAndWait(b);
+
+        expect(media.originHits).toBe(1);
+        const leaseKey = leaseKeyFor(
+            generateCacheKey(new URL(`https://gen.pollinations.ai${path}`)),
+        );
+        expect(bucket.getObject(leaseKey)).toBeUndefined();
     });
 });
 
@@ -253,7 +404,8 @@ describe("media cache write independence", () => {
         const miss = await dispatch(app, "/media/streamed", undefined, env);
         await miss.wait();
 
-        expect(bucket.putCount).toBe(1);
+        // Media write plus the single-flight lease.
+        expect(bucket.putCount).toBe(2);
         const stored = bucket.getObject(
             generateCacheKey(
                 new URL("https://gen.pollinations.ai/media/streamed"),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -235,6 +235,29 @@ export class Pollinations {
         throw await pollinationsErrorFromResponse(response);
     }
 
+    /**
+     * Guards a media response before its body is read.
+     *
+     * A 202 is `response.ok`, but its body is empty: the gateway accepted the
+     * generation, someone else is already running it, and the caller should
+     * retry the identical request. Reading it as media would silently hand
+     * back zero bytes, so surface it as a typed, retryable error instead.
+     */
+    private async checkResponse(response: Response): Promise<void> {
+        if (response.status === 202) {
+            const retryAfter = Number(response.headers.get("retry-after"));
+            throw new PollinationsError(
+                "Generation is already in progress. Retry the same request to receive it.",
+                "GENERATION_PENDING",
+                202,
+                undefined,
+                undefined,
+                Number.isFinite(retryAfter) ? retryAfter : undefined,
+            );
+        }
+        if (!response.ok) await this.handleErrorResponse(response);
+    }
+
     private async getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
         const response = await fetchWithTimeout(
             url,
@@ -357,9 +380,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const buffer = await response.arrayBuffer();
         const contentType =
@@ -416,9 +437,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const json = (await response.json()) as {
             data: Array<{ url?: string; b64_json?: string }>;
@@ -504,9 +523,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const json = (await response.json()) as {
             data: Array<{ url?: string; b64_json?: string }>;
@@ -641,9 +658,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const buffer = await response.arrayBuffer();
         const contentType = response.headers.get("content-type") || "video/mp4";
@@ -715,9 +730,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const data = (await response.json()) as ChatResponse;
         return data.choices[0]?.message?.content || "";
@@ -781,9 +794,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const reader = response.body?.getReader();
         if (!reader) {
@@ -888,9 +899,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         return response.json() as Promise<ChatResponse>;
     }
@@ -932,9 +941,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const reader = response.body?.getReader();
         if (!reader) {
@@ -1011,9 +1018,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const buffer = await response.arrayBuffer();
         const contentType =
@@ -1059,9 +1064,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         const buffer = await response.arrayBuffer();
         const contentType =
@@ -1175,9 +1178,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         if (
             options.responseFormat === "text" ||
@@ -1244,9 +1245,7 @@ export class Pollinations {
             options.signal,
         );
 
-        if (!response.ok) {
-            await this.handleErrorResponse(response);
-        }
+        await this.checkResponse(response);
 
         return response.json() as Promise<UploadResponse>;
     }

--- a/shared/test/mocks/r2.ts
+++ b/shared/test/mocks/r2.ts
@@ -6,6 +6,7 @@ export type StoredR2Object = {
     customMetadata?: Record<string, string>;
     storageClass?: R2Object["storageClass"];
     uploaded: Date;
+    etag: string;
 };
 
 export type TestR2Bucket = R2Bucket & {
@@ -17,20 +18,40 @@ export function createTestR2Bucket(): TestR2Bucket {
     const objects = new Map<string, StoredR2Object>();
     let putCount = 0;
     let uploadTime = 0;
+    let etagCounter = 0;
 
     function createR2Object(key: string, object: StoredR2Object): R2Object {
         return {
             key,
             version: "test",
             size: object.body.byteLength,
-            etag: "test",
-            httpEtag: '"test"',
+            etag: object.etag,
+            httpEtag: `"${object.etag}"`,
             uploaded: object.uploaded,
             httpMetadata: object.httpMetadata,
             customMetadata: object.customMetadata,
             storageClass: object.storageClass,
             checksums: {},
         } as unknown as R2Object;
+    }
+
+    // Mirrors the subset of R2's conditional semantics the gateway relies on:
+    // `etagDoesNotMatch: "*"` is create-if-absent, `etagMatches` is a
+    // compare-and-swap. Anything else is treated as unconditional.
+    function preconditionHolds(
+        existing: StoredR2Object | undefined,
+        onlyIf: R2PutOptions["onlyIf"],
+    ): boolean {
+        if (!onlyIf || onlyIf instanceof Headers) return true;
+        if (onlyIf.etagDoesNotMatch !== undefined) {
+            if (onlyIf.etagDoesNotMatch === "*") return existing === undefined;
+            return existing?.etag !== onlyIf.etagDoesNotMatch;
+        }
+        if (onlyIf.etagMatches !== undefined) {
+            if (onlyIf.etagMatches === "*") return existing !== undefined;
+            return existing?.etag === onlyIf.etagMatches;
+        }
+        return true;
     }
 
     return {
@@ -52,16 +73,36 @@ export function createTestR2Bucket(): TestR2Bucket {
                     ? undefined
                     : options?.httpMetadata;
 
+            // Read the body BEFORE testing the precondition, so the check and
+            // the write happen in one synchronous step. Awaiting between them
+            // would let two concurrent conditional puts both see an empty slot
+            // and both win, which real R2 never does — and which would quietly
+            // defeat any test asserting single-flight behaviour.
+            const body = new Uint8Array(
+                await new Response(value).arrayBuffer(),
+            );
+            if (!preconditionHolds(objects.get(key), options?.onlyIf)) {
+                return null;
+            }
+
             putCount += 1;
             uploadTime += 1;
-            objects.set(key, {
-                body: new Uint8Array(await new Response(value).arrayBuffer()),
+            etagCounter += 1;
+            const stored: StoredR2Object = {
+                body,
                 httpMetadata,
                 customMetadata: options?.customMetadata,
                 storageClass: options?.storageClass,
                 uploaded: new Date(uploadTime),
-            });
-            return null;
+                etag: `test-${etagCounter}`,
+            };
+            objects.set(key, stored);
+            return createR2Object(key, stored);
+        },
+        delete: async (keys: string | string[]) => {
+            for (const key of Array.isArray(keys) ? keys : [keys]) {
+                objects.delete(key);
+            }
         },
         getObject: (key: string) => objects.get(key),
         get putCount() {


### PR DESCRIPTION
Elects one generator per media cache key, so a concurrent or retried request joins the running generation instead of starting a second paid one. No new bindings, no Durable Object, no migration.

**Stacked on #13268** — merge that first. It makes the cache write independent of the client reading the body, which is what lets this apply uniformly to every media type instead of carving out audio.

## Why

Verified against production: a completed generation is already idempotent — re-requesting the same URL is a free `X-Cache: HIT` in 0.2s. But a request whose client goes away is lost: nothing reaches R2, and the retry pays for a second generation. Measured a wan-fast video (82s) killed at 8s — the retry was still a MISS and regenerated from scratch.

There is no in-flight coalescing today: two identical requests both miss, both dispatch a provider job, both bill. For video that is the normal case, not the edge case.

## How

- `put(lease, "", { onlyIf: { etagDoesNotMatch: "*" } })` is an atomic create-if-absent — it returns the object if this call created it, `null` if it already existed. That elects exactly one generator per cache key.
- Losers poll R2 for the object, then serve it with `X-Cache-Type: COALESCED`. If the budget runs out first they get `202` + `Retry-After` — which is where the edge would otherwise have returned a 524.
- The generator hands `next()` to `waitUntil` before awaiting it, so a client that gives up no longer cancels the work it paid for.
- The lease is held until the object is actually readable, then released. It self-expires so a dead generator cannot wedge a key.
- Applies to **image, video, audio and 3D** — every consumer of the media cache. No per-modality exception.
- Provider poll deadlines now share one budget (`GENERATION_BUDGET_MINUTES`), because the lease has to outlive the slowest generation it guards. Two were badly wrong: veo summed to **~40 min** while its comment and its 504 message both said "3 minutes"; nova-reel **~14 min** against "5 minutes". veo/nova-reel/wan-pro come down, replicate/happyhorse/grok go up.
- SDK: a `202` is `response.ok`, so it was being handed back as image bytes. It now raises a typed `GENERATION_PENDING` error carrying `retryAfter`.

## Deliberate tradeoffs

- **An abandoned request is now billed.** That is the point: the retry becomes a free hit, so the user pays once instead of twice.
- **Joined callers are free.** The generator pays. Consistent with how R2 cache hits already work, but concurrent rather than after the fact.
- **Raising Replicate's deadline raises what Replicate bills**, since `cancel_after` is tied to it. Worth it now that a slow result is kept rather than discarded.
- **A generator killed mid-flight holds its key until the lease expires.** Callers get 202 rather than a duplicate — correct, but the media only appears once someone retries after expiry. Closing that needs a Durable Object owning the job; this lease is the seam to swap in behind, not a dead end.
- **Coordinating the image path is a judgment call.** Image is ~570k provider-reaching generations/day at 603 ms p50, versus 628 video/day — so the money is all in video, and the lease costs one extra R2 op per image miss. It is included because the invariant was stated globally, and a rule that silently exempts 99.88% of traffic is not that rule. Easy to scope down if you would rather.

## Not in scope

Canonical cache keys (8 confirmed fragmentation cases), the `safePath`/31-bit-hash collision bug, `seed=-1` normalization, and #12542's settlement primitive. Each is separate work.

## Testing

- `npx vitest run` in gen: 882 passed. The one failure (`community-endpoints`, `Cannot find package 'stripe'`) is a worktree install artifact, untouched by this change.
- New tests: overlapping requests generate once, lease released after write, lease released on rejection before generating, 202 when a generation ends without media, and audio coordinating like everything else.
- The R2 test mock returned `null` from every `put` — the exact sentinel for "precondition failed" — so lease code would have read as permanently unacquirable. It now models `etagDoesNotMatch` / `etagMatches`, and evaluates the precondition and the write in one synchronous step so two concurrent conditional puts cannot both win (they could, in an earlier revision of the mock, which silently defeated the single-flight test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)