### PR TITLE
fix: make the media cache write independent of the client reading the body

### DIFF
--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -95,7 +95,9 @@ export function createMediaCache(config: MediaCacheConfig) {
         );
         if (c.res?.ok && isMatchingContent && xCache !== "HIT") {
             log.debug("Caching response");
-            cacheMediaResponse(
+            // Swaps in the client's half of the tee'd body. Without this the
+            // cache would hold a branch nobody drains.
+            c.res = cacheMediaResponse(
                 c.env.IMAGE_BUCKET,
                 cacheKey,
                 c,

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -283,7 +283,7 @@ export const track = (eventType: EventType) =>
                 // describes the body that usage extraction parses.
                 const response = responseOverride
                     ? withFinalResponseHeaders(responseOverride, c.res)
-                    : c.res.clone();
+                    : responseForTracking(c.res);
                 // What a rescue changes: the generation's cost, and which owner
                 // earns the reward. Not the price — the caller is charged the
                 // listing they asked for either way.
@@ -559,6 +559,21 @@ function withFinalResponseHeaders(
         status: override.status,
         headers,
     });
+}
+
+/**
+ * Tracking parses only SSE and JSON bodies; for binary media it reads headers
+ * alone. But cloning a Response and never reading the clone makes workerd
+ * buffer the entire body in memory with no backpressure, so an unread clone of
+ * a streamed audio response is pure cost. Hand tracking a headers-only view
+ * unless it is actually going to parse a body.
+ */
+function responseForTracking(res: Response): Response {
+    const contentType = res.headers.get("content-type") || "";
+    const parsesBody =
+        contentType.includes("text/event-stream") ||
+        contentType.includes("application/json");
+    return parsesBody ? res.clone() : new Response(null, res);
 }
 
 export async function trackResponse(

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -115,39 +115,69 @@ type MediaCacheEnv = {
     };
 };
 
+/**
+ * Caches a media response and returns the response to send to the client.
+ *
+ * The body is split with `tee()` rather than `clone()`, and our branch is
+ * consumed immediately. That matters because a cloned Response signals
+ * backpressure at the rate of the *faster* consumer: if one branch is never
+ * read, workerd buffers the whole body with no limit. Under `clone()` the
+ * cache write was therefore only as reliable as the client's willingness to
+ * read — fine for the fully buffered image/video/3D handlers, but for the
+ * audio routes, which pass the provider's stream straight through, a caller
+ * that hung up could stall the write and the media was silently never cached.
+ *
+ * Reading our branch ourselves makes the write independent of the client, so
+ * every media type caches the same way.
+ */
 export function cacheMediaResponse<TEnv extends MediaCacheEnv>(
     bucket: R2Bucket,
     cacheKey: string,
     c: Context<TEnv>,
     defaultContentType: string,
     response: Response,
-): void {
-    c.executionCtx.waitUntil(
-        response
-            .clone()
-            .arrayBuffer()
-            .then((body) => {
-                if (body.byteLength === 0) {
-                    c.get("log").warn(
-                        "Skipping empty media cache write for {cacheKey}",
-                        { cacheKey },
-                    );
-                    return null;
-                }
+): Response {
+    if (!response.body) return response;
 
-                return bucket.put(cacheKey, body, {
-                    httpMetadata: removeUnset({
-                        contentType:
-                            response.headers.get("content-type") ||
-                            defaultContentType,
-                    } as R2HTTPMetadata),
-                    customMetadata: prepareCustomMetadata(response),
-                });
-            })
-            .catch((error) => {
-                c.get("log").error("Error caching response: {error}", {
-                    error,
-                });
-            }),
+    const [clientBody, cacheBody] = response.body.tee();
+    c.executionCtx.waitUntil(
+        storeMediaBody(
+            bucket,
+            cacheKey,
+            c.get("log"),
+            defaultContentType,
+            cacheBody,
+            response,
+        ),
     );
+    return new Response(clientBody, response);
+}
+
+async function storeMediaBody(
+    bucket: R2Bucket,
+    cacheKey: string,
+    log: Logger,
+    defaultContentType: string,
+    body: ReadableStream<Uint8Array>,
+    source: Response,
+): Promise<void> {
+    try {
+        const buffered = await new Response(body).arrayBuffer();
+        if (buffered.byteLength === 0) {
+            log.warn("Skipping empty media cache write for {cacheKey}", {
+                cacheKey,
+            });
+            return;
+        }
+
+        await bucket.put(cacheKey, buffered, {
+            httpMetadata: removeUnset({
+                contentType:
+                    source.headers.get("content-type") || defaultContentType,
+            } as R2HTTPMetadata),
+            customMetadata: prepareCustomMetadata(source),
+        });
+    } catch (error) {
+        log.error("Error caching response: {error}", { error });
+    }
 }

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -10,6 +10,7 @@ import type { RequestIdVariables } from "hono/request-id";
 import { describe, expect, it } from "vitest";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { audioCache, imageCache } from "@/middleware/media-cache.ts";
+import { generateCacheKey } from "@/utils/media-cache.ts";
 
 const testLog = {
     getChild: () => testLog,
@@ -209,5 +210,71 @@ describe("media cache", () => {
         expect(cached.response.headers.get("X-Cache")).toBe("HIT");
         expect(media.originHits).toBe(1);
         expect(bucket.putCount).toBe(2);
+    });
+});
+
+/** Streams its body instead of buffering it, the way the audio routes do. */
+function createStreamingMediaApp(cache: MediaCache, contentType: string) {
+    const app = new Hono<TestEnv>()
+        .use("*", async (c, next) => {
+            c.set("log", testLog);
+            c.set("requestId", "test-request");
+            await next();
+        })
+        .get("/media/:prompt", cache, async () => {
+            const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode("streamed"));
+                    controller.close();
+                },
+            });
+            return new Response(stream, {
+                headers: { "Content-Type": contentType },
+            });
+        });
+    return app;
+}
+
+describe("media cache write independence", () => {
+    it.each([
+        { label: "audio", cache: audioCache, contentType: "audio/mpeg" },
+        { label: "image", cache: imageCache, contentType: "image/png" },
+    ])("caches a streamed $label response even when the client never reads the body", async ({
+        cache,
+        contentType,
+    }) => {
+        const app = createStreamingMediaApp(cache, contentType);
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+
+        // Deliberately do NOT read response.body. Under `clone()` the cache
+        // branch is only drained as fast as the client drains its own, so a
+        // caller that walks away could stall the write entirely.
+        const miss = await dispatch(app, "/media/streamed", undefined, env);
+        await miss.wait();
+
+        expect(bucket.putCount).toBe(1);
+        const stored = bucket.getObject(
+            generateCacheKey(
+                new URL("https://gen.pollinations.ai/media/streamed"),
+            ),
+        );
+        expect(new TextDecoder().decode(stored?.body)).toBe("streamed");
+
+        // The client's half is still intact and independently readable.
+        expect(await miss.response.text()).toBe("streamed");
+    });
+
+    it("serves the stored copy of a streamed response on the next request", async () => {
+        const app = createStreamingMediaApp(audioCache, "audio/mpeg");
+        const bucket = createTestR2Bucket();
+        const env = createMediaCacheEnv(bucket);
+
+        const miss = await dispatch(app, "/media/replayed", undefined, env);
+        await miss.wait();
+
+        const hit = await dispatch(app, "/media/replayed", undefined, env);
+        expect(await consumeAndWait(hit)).toBe("streamed");
+        expect(hit.response.headers.get("X-Cache")).toBe("HIT");
     });
 });


### PR DESCRIPTION
Consolidates how media caching works across modalities, so the cache write no longer depends on the response shape. Prerequisite for #13267.

## The defect

`cacheMediaResponse` used `response.clone().arrayBuffer()`. Per Cloudflare, a cloned Response *"will signal backpressure at the rate of the faster consumer... if only one cloned branch is consumed, then the entire body will be buffered in memory"*.

That makes the cache write only as reliable as the client's willingness to read:

- **image / video / 3D** buffer their bodies (`handler.ts:504`), so this is invisible.
- **audio** passes the provider's stream straight through (`audio.ts:288, :455, :698, :1827`). A caller that hangs up mid-stream can stall the clone, the R2 write never lands, and the media is silently not cached.

`track` made it worse: it also cloned the response (`track.ts:286`) but only ever parses SSE and JSON bodies — for binary media that clone was never read at all, which on its own forces the whole body to buffer.

So caching was generic on paper (one `createMediaCache` factory, one key, one bucket) but behaved differently per modality in practice, purely because of how each handler returns its body.

## The fix

- `cacheMediaResponse` now `tee()`s the body, consumes the cache branch itself, and returns the client's branch for the middleware to swap into `c.res`. Both branches are always read, so the write completes whatever the client does.
- `track` gets a headers-only view of the response unless it is actually going to parse a body. SSE and JSON behave exactly as before.

Not buffering audio: streaming TTS is a real latency feature, and buffering it would regress playback start. This makes streamed responses cache reliably rather than forcing them to stop streaming.

## Out of scope

Text (`text-cache.ts`) stays a separate middleware — SSE token streaming has genuinely different semantics, and that separation is deliberate rather than accidental.

## Testing

- `npx vitest run` in gen: 877 passed. The single failure (`community-endpoints`, `Cannot find package 'stripe'`) is a worktree install artifact in a file this PR does not touch.
- 3 new tests: a streamed audio and a streamed image response both cache when the client never reads the body, the client's half stays independently readable, and the stored copy is served on the next request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)