### PR TITLE
fix: keep tracking alive after malformed SSE chunks

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -788,9 +788,16 @@ async function* extractResponseStream(
         .pipeThrough(textDecoder)
         .pipeThrough(sseParser);
 
+    const log = getLogger(["hono", "track", "stream"]);
     for await (const event of asyncIteratorStream(eventStream)) {
         if (event.data === "[DONE]") return;
-        yield JSON.parse(event.data);
+        try {
+            yield JSON.parse(event.data);
+        } catch {
+            log.warn("Skipping malformed SSE event data", {
+                dataPreview: String(event.data).slice(0, 200),
+            });
+        }
     }
 }
 

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -1828,7 +1828,7 @@ describe("trackResponse malformed SSE chunks", () => {
     it("survives a malformed data event and still processes later valid events", async () => {
         const sse = [
             // Malformed chunk — not valid JSON.
-            'data: {broken json\n\n',
+            "data: {broken json\n\n",
             // Valid chunk with content but no usage yet.
             'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"hi"}}]}\n\n',
             // Valid chunk with usage.
@@ -1855,8 +1855,8 @@ describe("trackResponse malformed SSE chunks", () => {
     it("emits a usage_missing row when the entire stream is malformed", async () => {
         // Every data event is unparseable, but the stream otherwise completes.
         const sse = [
-            'data: {not valid\n\n',
-            'data: also not json\n\n',
+            "data: {not valid\n\n",
+            "data: also not json\n\n",
             "data: [DONE]\n\n",
         ].join("");
         const tracking = await trackResponse(
@@ -1877,7 +1877,7 @@ describe("trackResponse malformed SSE chunks", () => {
         const sse = [
             'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"first"}}]}\n\n',
             // Middle chunk is garbage.
-            'data: {{{oops\n\n',
+            "data: {{{oops\n\n",
             'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"last"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}\n\n',
             "data: [DONE]\n\n",
         ].join("");

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -1844,11 +1844,11 @@ describe("trackResponse malformed SSE chunks", () => {
         );
         // Must emit a row — the malformed event is skipped, not fatal.
         expect(tracking.isBilledUsage).toBe(true);
-        expect(tracking.modelUsed).toBe("openai");
+        // modelUsed comes from the SSE model field once usage is extracted.
+        expect(tracking.modelUsed).toBe("gpt-5-nano");
         expect(tracking.usage).toMatchObject({
-            promptTokens: 10,
-            completionTokens: 5,
-            totalTokens: 15,
+            promptTextTokens: 10,
+            completionTextTokens: 5,
         });
     });
 
@@ -1890,9 +1890,8 @@ describe("trackResponse malformed SSE chunks", () => {
         );
         expect(tracking.isBilledUsage).toBe(true);
         expect(tracking.usage).toMatchObject({
-            promptTokens: 2,
-            completionTokens: 1,
-            totalTokens: 3,
+            promptTextTokens: 2,
+            completionTextTokens: 1,
         });
     });
 });

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -1824,6 +1824,79 @@ describe("trackResponse missing usage", () => {
     });
 });
 
+describe("trackResponse malformed SSE chunks", () => {
+    it("survives a malformed data event and still processes later valid events", async () => {
+        const sse = [
+            // Malformed chunk — not valid JSON.
+            'data: {broken json\n\n',
+            // Valid chunk with content but no usage yet.
+            'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"hi"}}]}\n\n',
+            // Valid chunk with usage.
+            'data: {"model":"gpt-5-nano","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}\n\n',
+            "data: [DONE]\n\n",
+        ].join("");
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(true),
+            new Response(sse, {
+                headers: { "content-type": "text/event-stream" },
+            }),
+        );
+        // Must emit a row — the malformed event is skipped, not fatal.
+        expect(tracking.isBilledUsage).toBe(true);
+        expect(tracking.modelUsed).toBe("openai");
+        expect(tracking.usage).toMatchObject({
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
+        });
+    });
+
+    it("emits a usage_missing row when the entire stream is malformed", async () => {
+        // Every data event is unparseable, but the stream otherwise completes.
+        const sse = [
+            'data: {not valid\n\n',
+            'data: also not json\n\n',
+            "data: [DONE]\n\n",
+        ].join("");
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(true),
+            new Response(sse, {
+                headers: { "content-type": "text/event-stream" },
+            }),
+        );
+        expect(tracking.isBilledUsage).toBe(false);
+        expect(tracking.modelUsed).toBe("openai");
+        expect(tracking.errorTracking).toMatchObject({
+            errorResponseCode: "usage_missing",
+        });
+    });
+
+    it("skips a malformed event then picks up usage from a later event", async () => {
+        const sse = [
+            'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"first"}}]}\n\n',
+            // Middle chunk is garbage.
+            'data: {{{oops\n\n',
+            'data: {"model":"gpt-5-nano","choices":[{"delta":{"content":"last"}}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}\n\n',
+            "data: [DONE]\n\n",
+        ].join("");
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(true),
+            new Response(sse, {
+                headers: { "content-type": "text/event-stream" },
+            }),
+        );
+        expect(tracking.isBilledUsage).toBe(true);
+        expect(tracking.usage).toMatchObject({
+            promptTokens: 2,
+            completionTokens: 1,
+            totalTokens: 3,
+        });
+    });
+});
+
 function makeAdjustment(
     ruleId: string,
     cost: number,


### PR DESCRIPTION
Fixes #13223
Closes #13147

## Problem

`extractResponseStream` in `track.ts` parsed each SSE event with an unguarded `JSON.parse`. A single malformed `data:` chunk threw a `SyntaxError` out of the generator, which propagated up through the tracking closure (`waitUntil`) before `emitRow` could fire — so the tracking row describing the served response was lost entirely. The request was served free and invisible to every dashboard and reconciliation query.

## Solution

Wrap `JSON.parse(event.data)` in a `try/catch` inside `extractResponseStream`. Malformed events are skipped and logged at `warn` level; the generator continues to yield later valid events — including usage data — so the final tracking row is always emitted.

## Changes

- `gen.pollinations.ai/src/middleware/track.ts`: Guard `JSON.parse` in `extractResponseStream` with try/catch; log and skip malformed events.
- `gen.pollinations.ai/test/tracking-observability.test.ts`: Add regression tests covering:
  - A malformed event followed by valid events (usage still extracted, row billed)
  - An entirely malformed stream (row emitted with `usage_missing`)
  - A malformed event between two valid events (later usage still picked up)

## Acceptance criteria

- [x] A malformed `data:` event does not throw out of `extractResponseStream`
- [x] Later valid SSE events, including usage data, are still processed
- [x] A final tracking row is emitted for a response containing a malformed event
- [x] Focused regression coverage is added to the existing tracking tests