### PR TITLE
fix: restart degraded Klein tunnel

### DIFF
--- a/operations/infrastructure/gpu/GPU_INSTANCES.md
+++ b/operations/infrastructure/gpu/GPU_INSTANCES.md
@@ -385,9 +385,12 @@ healthy connections with zero request errors. A host that briefly registers
 four connections after a failed UDP precheck is still disqualified.
 
 **Health and restart:** Vast runs `/root/onstart.sh` on container startup. It
-supervises `klein` and `cloudflared` screen sessions with restart loops. Tokens
-are mode-600 files and cloudflared uses `--token-file`, keeping its token out of
-process listings.
+supervises `klein` and `cloudflared` screen sessions with restart loops. A
+watchdog also restarts a live-but-degraded connector if fewer than two HA
+connections remain for 30 seconds; otherwise one surviving connection can keep
+the process alive while the missing replicas never recover. Tokens are mode-600
+files and cloudflared uses `--token-file`, keeping its token out of process
+listings.
 
 ```bash
 vastai show instance 47353224 --raw
@@ -416,6 +419,13 @@ curl -s http://127.0.0.1:8000/health
 - During the comparison, retired host `47259457` logged 90 additional tunnel
   dial or termination failures while its local model remained healthy. It was
   destroyed immediately after the human-approved cutover.
+
+**Tunnel recovery incident (2026-08-11):** instance `47353224` lost all four
+QUIC connections during a transient Vast network failure while the local model
+remained healthy. One connection eventually returned, but `cloudflared` stayed
+alive and did not restore the other replicas, causing ten gateway 502s. A clean
+connector restart restored the supported QUIC path and production traffic. The
+runtime watchdog now restarts this live-but-degraded state automatically.
 
 **Previous replacement qualification (2026-08-09):**
 

--- a/operations/infrastructure/gpu/klein/setup-vast.sh
+++ b/operations/infrastructure/gpu/klein/setup-vast.sh
@@ -104,6 +104,7 @@ cat > /root/onstart.sh <<'EOF'
 #!/bin/bash
 screen -S klein -X quit 2>/dev/null || true
 screen -S cloudflared -X quit 2>/dev/null || true
+screen -S cloudflared-watchdog -X quit 2>/dev/null || true
 screen -dmS klein bash -c 'while true; do /root/run-klein.sh >> /root/klein.log 2>&1; sleep 5; done'
 
 if [ ! -f /root/.cloudflared_tunnel_enabled ]; then
@@ -117,6 +118,7 @@ if [ ! -s /root/.cloudflared_token ]; then
 fi
 
 screen -dmS cloudflared bash -c 'until curl -fsS --max-time 3 http://127.0.0.1:8000/health >/dev/null; do echo "Waiting for Klein health before joining the production tunnel" >> /root/cloudflared.log; sleep 3; done; while true; do cloudflared tunnel --no-autoupdate --protocol quic --metrics 127.0.0.1:20241 run --token-file /root/.cloudflared_token >> /root/cloudflared.log 2>&1; sleep 5; done'
+screen -dmS cloudflared-watchdog bash -c 'low_checks=0; while true; do sleep 10; connections=$(curl -fsS --max-time 2 http://127.0.0.1:20241/metrics 2>/dev/null | grep "^cloudflared_tunnel_ha_connections " | cut -d" " -f2); if [ "${connections:-0}" -lt 2 ] 2>/dev/null; then low_checks=$((low_checks + 1)); else low_checks=0; fi; if [ "$low_checks" -ge 3 ]; then echo "$(date -u +%FT%TZ) Restarting cloudflared: fewer than two HA connections for 30 seconds" >> /root/cloudflared.log; pid=$(pgrep -x cloudflared | head -n 1); if [ -n "$pid" ]; then kill "$pid"; fi; low_checks=0; sleep 10; fi; done'
 EOF
 chmod 700 /root/run-klein.sh /root/onstart.sh
 


### PR DESCRIPTION
- Restarts cloudflared when Klein stays below two HA connections for 30 seconds
- Preserves the required QUIC Workers VPC transport and existing four-connection promotion gate
- Documents the August 11 tunnel recovery incident and live mitigation

Verification: shell syntax checks pass; the watchdog is active on production instance 47353224.