### PR TITLE
fix: use explicit news branch raw URLs

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -2,7 +2,7 @@ import { cn, Surface } from "@pollinations/ui";
 import { type FC, type ReactNode, useEffect, useState } from "react";
 
 const HIGHLIGHTS_RAW_URL =
-    "https://raw.githubusercontent.com/pollinations/pollinations/news/operations/social/news/highlights.md";
+    "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/news/operations/social/news/highlights.md";
 export const HIGHLIGHTS_GITHUB_URL =
     "https://github.com/pollinations/pollinations/blob/news/operations/social/news/highlights.md";
 

--- a/pollinations.ai/src/hooks/useDiaryData.ts
+++ b/pollinations.ai/src/hooks/useDiaryData.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const RAW_BASE =
-    "https://raw.githubusercontent.com/pollinations/pollinations/news/operations/social/news";
+    "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/news/operations/social/news";
 const TREE_API =
     "https://api.github.com/repos/pollinations/pollinations/git/trees/news?recursive=1";
 const TREE_CACHE_KEY = "diary_tree_v3";


### PR DESCRIPTION
- Uses explicit `refs/heads/news` raw GitHub URLs in the Enter news banner and website diary.
- Avoids the shorthand branch URL, which continued returning 404 after the `news` branch path migration while the explicit ref returned 200.
- Keeps the already-correct website highlights consumer unchanged.

Validation:
- New `news` branch contains 5,915 files under `operations/social` and zero under the old path.
- Explicit raw highlight URL returns HTTP 200.
- Biome and diff checks pass.
