### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -2,7 +2,7 @@ import { cn, Surface } from "@pollinations/ui";
 import { type FC, type ReactNode, useEffect, useState } from "react";
 
 const HIGHLIGHTS_RAW_URL =
-    "https://raw.githubusercontent.com/pollinations/pollinations/news/operations/social/news/highlights.md";
+    "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/news/operations/social/news/highlights.md";
 export const HIGHLIGHTS_GITHUB_URL =
     "https://github.com/pollinations/pollinations/blob/news/operations/social/news/highlights.md";
 

--- a/operations/economics/web/src/App.tsx
+++ b/operations/economics/web/src/App.tsx
@@ -43,7 +43,11 @@ import {
 } from "./components/Filters";
 import type { ProvenanceCode } from "./components/Provenance";
 import { insightVendorOptions, vendorPlanes } from "./lib/insights";
-import { collectMonths, type MonthFilterValue } from "./lib/months";
+import {
+    collectMonths,
+    latestClosedMonth,
+    type MonthFilterValue,
+} from "./lib/months";
 import { fixturesMode, loadAll, TbError } from "./lib/tb";
 import type { Data } from "./types";
 import { CreditsTab } from "./views/CreditsTab";
@@ -894,7 +898,8 @@ export default function App() {
     useEffect(() => {
         if (!monthFilterInitialized.current && months.length > 0) {
             monthFilterInitialized.current = true;
-            setSelectedMonths([months[months.length - 1]]);
+            const initialMonth = latestClosedMonth(months);
+            setSelectedMonths(initialMonth ? [initialMonth] : []);
             return;
         }
         setSelectedMonths((current) =>

--- a/operations/economics/web/src/fixtures.ts
+++ b/operations/economics/web/src/fixtures.ts
@@ -18,7 +18,8 @@ const opTransactions: OpTransactionRow[] = [
         amount: 1_000,
         currency: "EUR",
         description: "Example Stripe settlement",
-        evidence: "",
+        evidence:
+            "https://drive.google.com/drive/folders/example-stripe-folder",
         recorded_at: "2026-07-09 00:00:00.000",
     },
     {
@@ -30,7 +31,7 @@ const opTransactions: OpTransactionRow[] = [
         amount: -150,
         currency: "EUR",
         description: "Example Alibaba Cloud charge",
-        evidence: "",
+        evidence: "https://drive.google.com/file/d/example-invoice/view",
         recorded_at: "2026-07-09 00:00:00.000",
     },
     {

--- a/operations/economics/web/src/lib/documents.test.ts
+++ b/operations/economics/web/src/lib/documents.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { driveDocumentLink } from "./documents";
+
+describe("driveDocumentLink", () => {
+    it("recognizes Drive folders", () => {
+        expect(
+            driveDocumentLink(
+                "https://drive.google.com/drive/u/0/folders/folder-id",
+            ),
+        ).toEqual({
+            href: "https://drive.google.com/drive/u/0/folders/folder-id",
+            label: "Open folder",
+        });
+    });
+
+    it("recognizes Drive files and Google Workspace documents", () => {
+        expect(
+            driveDocumentLink("https://drive.google.com/file/d/file-id/view"),
+        ).toEqual({
+            href: "https://drive.google.com/file/d/file-id/view",
+            label: "Open document",
+            previewHref: "https://drive.google.com/file/d/file-id/preview",
+        });
+        expect(
+            driveDocumentLink(
+                "https://docs.google.com/spreadsheets/d/sheet-id/edit",
+            ),
+        ).toEqual({
+            href: "https://docs.google.com/spreadsheets/d/sheet-id/edit",
+            label: "Open document",
+            previewHref:
+                "https://docs.google.com/spreadsheets/d/sheet-id/preview",
+        });
+    });
+
+    it("preserves a Drive resource key in the preview URL", () => {
+        expect(
+            driveDocumentLink(
+                "https://drive.google.com/open?id=file-id&resourcekey=key-id",
+            ),
+        ).toEqual({
+            href: "https://drive.google.com/open?id=file-id&resourcekey=key-id",
+            label: "Open document",
+            previewHref:
+                "https://drive.google.com/file/d/file-id/preview?resourcekey=key-id",
+        });
+    });
+
+    it("rejects blank, non-Drive, insecure, and deceptive links", () => {
+        expect(driveDocumentLink("")).toBeNull();
+        expect(driveDocumentLink("wise-statement.zip")).toBeNull();
+        expect(
+            driveDocumentLink("http://drive.google.com/file/d/file-id/view"),
+        ).toBeNull();
+        expect(
+            driveDocumentLink(
+                "https://drive.google.com.example.com/file/d/file-id/view",
+            ),
+        ).toBeNull();
+    });
+});

--- a/operations/economics/web/src/lib/documents.ts
+++ b/operations/economics/web/src/lib/documents.ts
@@ -1,0 +1,82 @@
+export type DriveDocumentLink = {
+    href: string;
+    label: "Open document" | "Open folder";
+    previewHref?: string;
+};
+
+const GOOGLE_FILE_ID = /^[A-Za-z0-9_-]+$/;
+
+function previewUrl(
+    origin: string,
+    documentType: string,
+    fileId: string,
+    resourceKey: string | null,
+) {
+    if (!GOOGLE_FILE_ID.test(fileId)) return undefined;
+
+    const preview = new URL(`/${documentType}/d/${fileId}/preview`, origin);
+    if (resourceKey) preview.searchParams.set("resourcekey", resourceKey);
+    return preview.toString();
+}
+
+export function driveDocumentLink(evidence: string): DriveDocumentLink | null {
+    const href = evidence.trim();
+    if (!href) return null;
+
+    let url: URL;
+    try {
+        url = new URL(href);
+    } catch {
+        return null;
+    }
+
+    if (url.protocol !== "https:") return null;
+
+    if (url.hostname === "drive.google.com") {
+        if (url.pathname.includes("/folders/")) {
+            return { href, label: "Open folder" };
+        }
+
+        const pathFileId = url.pathname.match(/^\/file\/d\/([^/]+)/)?.[1];
+        const queryFileId =
+            url.pathname === "/open" ? url.searchParams.get("id") : null;
+        const fileId = pathFileId ?? queryFileId;
+        if (fileId) {
+            return {
+                href,
+                label: "Open document",
+                previewHref: previewUrl(
+                    url.origin,
+                    "file",
+                    fileId,
+                    url.searchParams.get("resourcekey"),
+                ),
+            };
+        }
+        return null;
+    }
+
+    if (url.hostname === "docs.google.com") {
+        const workspaceDocument = url.pathname.match(
+            /^\/(document|spreadsheets|presentation)\/d\/([^/]+)/,
+        );
+        if (workspaceDocument) {
+            return {
+                href,
+                label: "Open document",
+                previewHref: previewUrl(
+                    url.origin,
+                    workspaceDocument[1],
+                    workspaceDocument[2],
+                    url.searchParams.get("resourcekey"),
+                ),
+            };
+        }
+
+        if (url.pathname.startsWith("/forms/")) {
+            return { href, label: "Open document" };
+        }
+    }
+
+    return null;
+}

--- a/operations/economics/web/src/lib/months.test.ts
+++ b/operations/economics/web/src/lib/months.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { FIXTURES } from "../fixtures";
 import type { Data } from "../types";
-import { collectMonths, matchesMonth, monthLabel, yearsOf } from "./months";
+import {
+    collectMonths,
+    latestClosedMonth,
+    matchesMonth,
+    monthLabel,
+    yearsOf,
+} from "./months";
 
 const data: Data = {
     opTransactions: FIXTURES.op_transactions_api,
@@ -45,6 +51,24 @@ describe("matchesMonth", () => {
 
     it("undated rows are excluded from month drilldowns", () => {
         expect(matchesMonth("", "2026-03")).toBe(false);
+    });
+});
+
+describe("latestClosedMonth", () => {
+    it("uses the previous month when current-month data already exists", () => {
+        expect(
+            latestClosedMonth(
+                ["2026-06", "2026-07", "2026-08"],
+                new Date(2026, 7, 3),
+            ),
+        ).toBe("2026-07");
+    });
+
+    it("uses the latest available month when no closed month exists", () => {
+        expect(latestClosedMonth(["2026-08"], new Date(2026, 7, 3))).toBe(
+            "2026-08",
+        );
+        expect(latestClosedMonth([], new Date(2026, 7, 3))).toBeNull();
     });
 });
 

--- a/operations/economics/web/src/lib/months.ts
+++ b/operations/economics/web/src/lib/months.ts
@@ -51,6 +51,20 @@ export function collectMonths(data: Data): string[] {
         .sort((a, b) => a.localeCompare(b));
 }
 
+// Prefer the latest closed month so live month-to-date Pollen rows do not make
+// the dashboard open on a deliberately incomplete reconciliation period.
+export function latestClosedMonth(
+    months: string[],
+    now = new Date(),
+): string | null {
+    if (months.length === 0) return null;
+    const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+    for (let index = months.length - 1; index >= 0; index -= 1) {
+        if (months[index] < currentMonth) return months[index];
+    }
+    return months.at(-1) ?? null;
+}
+
 export function yearsOf(months: string[]): string[] {
     return [...new Set(months.map((month) => month.slice(0, 4)))].sort((a, b) =>
         a.localeCompare(b),

--- a/operations/economics/web/src/lib/tb.test.ts
+++ b/operations/economics/web/src/lib/tb.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { canonicalVendor } from "./tb";
+
+describe("canonicalVendor", () => {
+    it("normalizes the Vast Pollen alias", () => {
+        expect(canonicalVendor("vast")).toBe("vast.ai");
+    });
+
+    it("leaves canonical vendors unchanged", () => {
+        expect(canonicalVendor("openai")).toBe("openai");
+    });
+});

--- a/operations/economics/web/src/lib/tb.ts
+++ b/operations/economics/web/src/lib/tb.ts
@@ -39,6 +39,10 @@ async function fetchPipe<T>(pipe: string): Promise<T[]> {
     return body.data;
 }
 
+export function canonicalVendor(vendor: string): string {
+    return vendor === "vast" ? "vast.ai" : vendor;
+}
+
 export async function loadAll(): Promise<Data> {
     // All four pipes are required contracts. A missing pipe (404) must surface
     // as an error, never render as plausible-but-empty economics data.
@@ -49,5 +53,13 @@ export async function loadAll(): Promise<Data> {
         fetchPipe<OpRunwayRow>("op_runway_api"),
     ]);
 
-    return { opTransactions, opCloud, opPollen, opRunway };
+    return {
+        opTransactions,
+        opCloud,
+        opPollen: opPollen.map((row) => ({
+            ...row,
+            vendor: canonicalVendor(row.vendor),
+        })),
+        opRunway,
+    };
 }

--- a/operations/economics/web/src/views/OpTransactionsTab.tsx
+++ b/operations/economics/web/src/views/OpTransactionsTab.tsx
@@ -1,4 +1,5 @@
 import {
+    Button,
     Chip,
     TableBody,
     TableCell,
@@ -6,7 +7,8 @@ import {
     TableHeaderCell,
     TableRow,
 } from "@pollinations/ui";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import {
     DataTable,
     GROUP_BORDER,
@@ -16,6 +18,7 @@ import {
     useSortableRows,
     withUniqueRowKeys,
 } from "../components/DataTable";
+import { type DriveDocumentLink, driveDocumentLink } from "../lib/documents";
 import { fmtNumber } from "../lib/format";
 import {
     type MonthFilterValue,
@@ -24,6 +27,119 @@ import {
     type ValueFilter,
 } from "../lib/months";
 import type { Data, OpTransactionRow } from "../types";
+
+function DocumentPreview({
+    documentLink,
+    onClose,
+}: {
+    documentLink: DriveDocumentLink;
+    onClose: () => void;
+}) {
+    useEffect(() => {
+        function handleKeyDown(event: KeyboardEvent) {
+            if (event.key === "Escape") onClose();
+        }
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [onClose]);
+
+    if (!documentLink.previewHref) return null;
+
+    return createPortal(
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-3 sm:p-6">
+            <button
+                type="button"
+                className="absolute inset-0 bg-black/60"
+                aria-label="Close document preview"
+                onClick={onClose}
+            />
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="document-preview-title"
+                className="relative flex h-[min(90vh,64rem)] w-[min(94vw,72rem)] flex-col overflow-hidden rounded-2xl bg-surface-opaque shadow-2xl"
+            >
+                <div className="flex shrink-0 items-center justify-between gap-3 border-b border-theme-text-strong/10 px-4 py-3">
+                    <h2
+                        id="document-preview-title"
+                        className="font-semibold text-theme-text-strong"
+                    >
+                        Document preview
+                    </h2>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            as="a"
+                            href={documentLink.href}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            intent="info"
+                            size="sm"
+                        >
+                            Open in Drive
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            onClick={onClose}
+                            autoFocus
+                        >
+                            Close
+                        </Button>
+                    </div>
+                </div>
+                <iframe
+                    src={documentLink.previewHref}
+                    title="Google Drive document preview"
+                    className="min-h-0 w-full flex-1 bg-white"
+                    referrerPolicy="strict-origin-when-cross-origin"
+                />
+            </div>
+        </div>,
+        document.body,
+    );
+}
+
+function TransactionDocument({
+    evidence,
+    onPreview,
+}: {
+    evidence: string;
+    onPreview: (document: DriveDocumentLink) => void;
+}) {
+    const document = driveDocumentLink(evidence);
+
+    if (!document) {
+        return (
+            <Chip intent="warning" size="sm">
+                Missing
+            </Chip>
+        );
+    }
+
+    if (document.previewHref) {
+        return (
+            <button
+                type="button"
+                onClick={() => onPreview(document)}
+                className="font-medium text-theme-text underline underline-offset-4 hover:text-theme-text-soft"
+            >
+                Preview
+            </button>
+        );
+    }
+
+    return (
+        <a
+            href={document.href}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="font-medium text-theme-text underline underline-offset-4 hover:text-theme-text-soft"
+        >
+            {document.label}
+        </a>
+    );
+}
 
 export function OpTransactionsTab({
     category = [],
@@ -36,6 +152,8 @@ export function OpTransactionsTab({
     month?: MonthFilterValue;
     vendor?: ValueFilter;
 }) {
+    const [previewDocument, setPreviewDocument] =
+        useState<DriveDocumentLink | null>(null);
     const baseRows = useMemo(() => {
         return (data.opTransactions ?? []).filter(
             (row) =>
@@ -52,7 +170,10 @@ export function OpTransactionsTab({
             { key: "amount", value: (row) => row.amount },
             { key: "currency", value: (row) => row.currency },
             { key: "description", value: (row) => row.description },
-            { key: "evidence", value: (row) => row.evidence },
+            {
+                key: "evidence",
+                value: (row) => driveDocumentLink(row.evidence)?.label ?? "",
+            },
         ],
         [],
     );
@@ -120,7 +241,7 @@ export function OpTransactionsTab({
                             Description
                         </TableHeaderCell>
                         <TableHeaderCell {...headerProps("evidence")}>
-                            Evidence
+                            Document
                         </TableHeaderCell>
                     </TableRow>
                 </TableHead>
@@ -147,12 +268,23 @@ export function OpTransactionsTab({
                                 <TableCell className={GROUP_BORDER}>
                                     {row.description}
                                 </TableCell>
-                                <TableCell>{row.evidence}</TableCell>
+                                <TableCell>
+                                    <TransactionDocument
+                                        evidence={row.evidence}
+                                        onPreview={setPreviewDocument}
+                                    />
+                                </TableCell>
                             </TableRow>
                         ),
                     )}
                 </TableBody>
             </DataTable>
+            {previewDocument?.previewHref && (
+                <DocumentPreview
+                    documentLink={previewDocument}
+                    onClose={() => setPreviewDocument(null)}
+                />
+            )}
         </TableScroller>
     );
 }

--- a/pollinations.ai/src/hooks/useDiaryData.ts
+++ b/pollinations.ai/src/hooks/useDiaryData.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const RAW_BASE =
-    "https://raw.githubusercontent.com/pollinations/pollinations/news/operations/social/news";
+    "https://raw.githubusercontent.com/pollinations/pollinations/refs/heads/news/operations/social/news";
 const TREE_API =
     "https://api.github.com/repos/pollinations/pollinations/git/trees/news?recursive=1";
 const TREE_CACHE_KEY = "diary_tree_v3";


### PR DESCRIPTION
- Promotes PR #13289: economics reconciliation improvements.
- Promotes PR #13292: explicit `refs/heads/news` raw URLs for the Enter banner and website diary.
- The `news` branch data migration is complete at `631a984aed`, with 5,915 files under `operations/social` and none at the old path.

Expected production workflows:
- Deploy `pollinations.ai`.
- Deploy `enter.pollinations.ai`.
- Deploy the changed economics application through application discovery.
