### PR TITLE
fix(sdk): return model arrays and reject failed images

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -458,6 +458,32 @@ describe("Pollinations.imageEdit — response resolution (characterization)", ()
         expect(result.contentType).toBe("image/png");
     });
 
+    it("throws the API error when an image URL cannot be downloaded", async () => {
+        const client = newClient();
+
+        fetchMock
+            .mockResolvedValueOnce(
+                makeResponse({ data: [{ url: "https://img.test/x.png" }] }),
+            )
+            .mockResolvedValueOnce(
+                makeResponse(
+                    {
+                        error: {
+                            message: "Image not found",
+                            code: "NOT_FOUND",
+                        },
+                    },
+                    { ok: false, status: 404 },
+                ),
+            );
+
+        await expect(client.imageEdit("make it blue")).rejects.toMatchObject({
+            message: "Image not found",
+            code: "NOT_FOUND",
+            status: 404,
+        });
+    });
+
     it("returns the resolved image item for a b64_json response", async () => {
         const client = newClient();
 
@@ -493,5 +519,18 @@ describe("Pollinations.imageEdit — response resolution (characterization)", ()
             code: "NO_IMAGE",
             status: 500,
         });
+    });
+});
+
+describe("Pollinations model discovery", () => {
+    it("returns the model array from the registry endpoint", async () => {
+        const client = newClient();
+        const models = [{ name: "openai", title: "OpenAI" }];
+        fetchMock.mockResolvedValueOnce(makeResponse(models));
+
+        await expect(client.models()).resolves.toEqual(models);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            "https://example.test/models",
+        );
     });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -546,6 +546,9 @@ export class Pollinations {
                 this.imageTimeout,
                 signal,
             );
+            if (!imgResponse.ok) {
+                await this.handleErrorResponse(imgResponse);
+            }
             const buffer = await imgResponse.arrayBuffer();
             const contentType =
                 imgResponse.headers.get("content-type") || "image/png";
@@ -1101,7 +1104,7 @@ export class Pollinations {
     }
 
     /**
-     * Get available models (OpenAI-compatible endpoint)
+     * Get all available models
      *
      * @example
      * ```ts
@@ -1109,7 +1112,7 @@ export class Pollinations {
      * ```
      */
     async models(): Promise<ModelInfo[]> {
-        return this.getJson<ModelInfo[]>(`${this.baseUrl}/v1/models`);
+        return this.getJson<ModelInfo[]>(`${this.baseUrl}/models`);
     }
 
     // ============================================================================


### PR DESCRIPTION
- Points `Pollinations.models()` at `/models`, matching its documented array return type.
- Rejects non-2xx generated-image URL downloads through the existing SDK error parser.
- Adds focused regression coverage for both paths.

Checks: SDK tests (37), typecheck, build, Biome.