### PR TITLE
fix(mcp): remove global request timeout

### DIFF
--- a/packages/mcp/src/utils/coreUtils.js
+++ b/packages/mcp/src/utils/coreUtils.js
@@ -127,7 +127,7 @@ export function buildShareableUrl(path, params = {}) {
 
 /**
  * @param {string} url - URL to fetch
- * @param {Object} options - Fetch options (can include timeoutMs)
+ * @param {Object} options - Fetch options
  * @returns {Promise<Response>} - Fetch response
  */
 export async function fetchWithAuth(url, options = {}) {
@@ -135,18 +135,7 @@ export async function fetchWithAuth(url, options = {}) {
         ...options.headers,
         ...getAuthHeaders(),
     };
-    const timeoutMs = options.timeoutMs || 30000;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-        return await fetch(url, {
-            ...options,
-            headers,
-            signal: controller.signal,
-        });
-    } finally {
-        clearTimeout(timeoutId);
-    }
+    return fetch(url, { ...options, headers });
 }
 
 /**
@@ -197,8 +186,7 @@ export async function chatWithMedia({ model, prompt, mediaType, mediaUrl }) {
 
 /**
  * POST a chat-completion request body to /v1/chat/completions.
- * Strips null/undefined keys, reuses the 30s timeout in fetchWithAuth, maps
- * errors, and parses the JSON response.
+ * Strips null/undefined keys, maps errors, and parses the JSON response.
  *
  * @param {Object} body - Request body (null/undefined fields are stripped)
  * @returns {Promise<Object>} - Parsed chat-completion response
@@ -215,7 +203,6 @@ export async function postChatCompletion(body) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(cleanedBody),
-        timeoutMs: 30000,
     });
 }
 

--- a/packages/mcp/test-mcp-client.js
+++ b/packages/mcp/test-mcp-client.js
@@ -13,6 +13,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { fetchWithAuth } from "./src/utils/coreUtils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const KEY = process.env.POLLINATIONS_API_KEY;
@@ -89,6 +90,21 @@ await step("listTools", async () => {
 await step("listTextModels (unauthenticated)", () => call("listTextModels"));
 
 if (!KEY) {
+    await step("fetchWithAuth respects caller cancellation", async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        try {
+            await fetchWithAuth(`${testBaseUrl}/text/models`, {
+                signal: controller.signal,
+            });
+        } catch (error) {
+            if (error.name === "AbortError") return "aborted";
+            throw error;
+        }
+        throw new Error("request ignored the caller's abort signal");
+    });
+
     console.log(
         "\nSkipping live calls — set POLLINATIONS_API_KEY=sk_… to exercise the full path.",
     );


### PR DESCRIPTION
- Removes the generic 30-second abort timer from authenticated MCP requests.
- Preserves caller-provided transport/request cancellation through the native `signal` option.
- Removes the obsolete chat `timeoutMs` option and adds a cancellation regression to the existing smoke test.

Checks: MCP smoke test (3/3), Node syntax check, Biome.