### PR TITLE
chore: allow chigwell community publishing

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -35,6 +35,7 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     205307392, // chirag-gamer
     240205932, // pollinations-router
     57826942, // guus6457
+    36392751, // chigwell
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Adds `chigwell`’s immutable GitHub user ID to the community-model publisher allowlist.
- Keeps the approval stable if the username changes.

Checks:
- Biome 2.3.10
- Allowlist membership and uniqueness assertion
- `git diff --check`