### PR TITLE
fix: use media URLs for music references

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -219,9 +219,11 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "elevenmusic": {
     "cost": {
       "completionAudioSeconds": 0.0025,
+      "promptAudioSeconds": 0.0025,
     },
     "price": {
       "completionAudioSeconds": 0.0025,
+      "promptAudioSeconds": 0.0025,
     },
   },
   "flux": {

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -38,6 +38,7 @@ import {
     type FallbackCandidate,
     withModelFallbackResponse,
 } from "../fallback.ts";
+import { readResponseBytes } from "../utils/response-bytes.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
 import {
     buildTranscriptionResponse,
@@ -106,11 +107,6 @@ const CreateSpeechRequestSchema = z
                 "If true, stores the generated elevenmusic song and returns its song ID for later inpainting.",
             example: false,
         }),
-        extract_composition_plan: z.boolean().optional().meta({
-            description:
-                "If true with reference audio, asks ElevenLabs to derive a music_v2 composition plan.",
-            example: false,
-        }),
         reference_audio: z.url().optional().meta({
             description:
                 "URL returned by media.pollinations.ai for reference-audio conditioning or audio-to-audio generation.",
@@ -119,7 +115,7 @@ const CreateSpeechRequestSchema = z
         }),
         conditioning_ref: z.unknown().optional().meta({
             description:
-                "ElevenLabs music_v2 AudioRefChunk to apply to the generated chunk. reference_audio can create this automatically.",
+                "ElevenLabs music_v2 AudioRefChunk to apply to the generated chunk. reference_audio creates this automatically; advanced clients can reuse x-elevenlabs-reference-song-id here on later requests.",
         }),
         composition_plan: z.unknown().optional().meta({
             description:
@@ -211,7 +207,6 @@ type GenerateMusicOptions = {
     forceInstrumental?: boolean;
     seed?: number;
     storeForInpainting?: boolean;
-    extractCompositionPlan?: boolean;
     conditioningRef?: unknown;
     compositionPlan?: unknown;
     referenceAudio?: File;
@@ -219,7 +214,11 @@ type GenerateMusicOptions = {
     log: Logger;
 };
 
+// Reference URLs intentionally use the one canonical public media host in
+// every environment; staging and local generation read the same public blobs.
 const MEDIA_ORIGIN = "https://media.pollinations.ai";
+const MAX_REFERENCE_AUDIO_SIZE = 20 * 1024 * 1024;
+const REFERENCE_AUDIO_FETCH_TIMEOUT_MS = 30_000;
 
 const AUDIO_EXTENSION_BY_TYPE: Record<string, string> = {
     "audio/aac": "aac",
@@ -232,35 +231,71 @@ const AUDIO_EXTENSION_BY_TYPE: Record<string, string> = {
 };
 
 async function fetchReferenceAudio(referenceAudioUrl: string): Promise<File> {
-    let url: URL;
-    try {
-        url = new URL(referenceAudioUrl);
-    } catch {
-        throw new UpstreamError(400 as ContentfulStatusCode, {
-            message:
-                "reference_audio must be a valid media.pollinations.ai URL",
-        });
-    }
-
+    const url = new URL(referenceAudioUrl);
     if (url.origin !== MEDIA_ORIGIN) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
             message: "reference_audio must use https://media.pollinations.ai",
         });
     }
 
-    const response = await ensureUpstreamOk(await fetch(url), url);
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            signal: AbortSignal.timeout(REFERENCE_AUDIO_FETCH_TIMEOUT_MS),
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Failed to fetch reference_audio from media.pollinations.ai: ${message}`,
+            requestUrl: url,
+        });
+    }
+
+    if (!response.ok) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Failed to fetch reference_audio: media.pollinations.ai returned ${response.status}`,
+            requestUrl: url,
+            upstreamStatus: response.status,
+        });
+    }
+
     const contentType =
-        response.headers.get("content-type")?.split(";", 1)[0] || "";
-    if (!contentType.startsWith("audio/")) {
+        response.headers
+            .get("content-type")
+            ?.split(";", 1)[0]
+            .trim()
+            .toLowerCase() || "application/octet-stream";
+    if (
+        !contentType.startsWith("audio/") &&
+        contentType !== "application/octet-stream"
+    ) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
             message: "reference_audio must point to an audio file",
         });
     }
 
     const extension = AUDIO_EXTENSION_BY_TYPE[contentType] || "audio";
-    return new File([await response.arrayBuffer()], `reference.${extension}`, {
-        type: contentType,
-    });
+    let bytes: Uint8Array<ArrayBuffer>;
+    try {
+        bytes = await readResponseBytes(
+            response,
+            MAX_REFERENCE_AUDIO_SIZE,
+            (total) =>
+                new UpstreamError(400 as ContentfulStatusCode, {
+                    message: `reference_audio is too large: ${total} bytes (max ${MAX_REFERENCE_AUDIO_SIZE})`,
+                    requestUrl: url,
+                }),
+        );
+    } catch (error) {
+        if (error instanceof UpstreamError) throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Failed to read reference_audio: ${message}`,
+            requestUrl: url,
+        });
+    }
+
+    return new File([bytes], `reference.${extension}`, { type: contentType });
 }
 
 function mapOutputFormat(format: string): string {
@@ -1099,13 +1134,9 @@ function createConditionedCompositionPlan(opts: {
 
 async function uploadMusicReference(opts: {
     file: File;
-    extractCompositionPlan?: boolean;
     apiKey: string;
     log: Logger;
-}): Promise<{
-    song_id?: string;
-    composition_plan?: unknown;
-}> {
+}): Promise<{ song_id?: string }> {
     const uploadUrl = "https://api.elevenlabs.io/v1/music/upload";
     const formData = new FormData();
     const filename =
@@ -1113,18 +1144,11 @@ async function uploadMusicReference(opts: {
             ? opts.file.name
             : "reference.mp3";
     formData.append("file", opts.file, filename);
-    if (opts.extractCompositionPlan) {
-        formData.append("extract_composition_plan", "music_v2");
-    }
 
-    opts.log.info(
-        "ElevenLabs music upload: filename={filename}, size={size}, extractPlan={extractPlan}",
-        {
-            filename,
-            size: opts.file.size,
-            extractPlan: opts.extractCompositionPlan || false,
-        },
-    );
+    opts.log.info("ElevenLabs music upload: filename={filename}, size={size}", {
+        filename,
+        size: opts.file.size,
+    });
 
     const rawResponse = await fetch(uploadUrl, {
         method: "POST",
@@ -1132,10 +1156,7 @@ async function uploadMusicReference(opts: {
         body: formData,
     });
     const response = await ensureUpstreamOk(rawResponse, uploadUrl);
-    return (await response.json()) as {
-        song_id?: string;
-        composition_plan?: unknown;
-    };
+    return (await response.json()) as { song_id?: string };
 }
 
 export async function generateMusic(
@@ -1170,7 +1191,6 @@ export async function generateMusic(
     if (referenceAudio) {
         const upload = await uploadMusicReference({
             file: referenceAudio,
-            extractCompositionPlan: opts.extractCompositionPlan,
             apiKey,
             log,
         });
@@ -1179,9 +1199,6 @@ export async function generateMusic(
             throw new UpstreamError(502 as ContentfulStatusCode, {
                 message: "ElevenLabs music upload response missing song_id",
             });
-        }
-        if (compositionPlan === undefined && opts.extractCompositionPlan) {
-            compositionPlan = upload.composition_plan;
         }
         if (conditioningRef === undefined) {
             conditioningRef = {
@@ -1537,7 +1554,6 @@ function requireElevenMusicOptions(
         compositionPlan?: unknown;
         conditioningRef?: unknown;
         storeForInpainting?: boolean;
-        extractCompositionPlan?: boolean;
     },
 ): void {
     // elevenmusic supports every conditioning option.
@@ -1547,8 +1563,7 @@ function requireElevenMusicOptions(
     const usesElevenOnlyOptions =
         opts.compositionPlan !== undefined ||
         opts.conditioningRef !== undefined ||
-        opts.storeForInpainting === true ||
-        opts.extractCompositionPlan === true;
+        opts.storeForInpainting === true;
 
     // stable-audio-3-medium (fal) and stable-audio-3-large (Stability direct)
     // accept reference_audio for audio-to-audio, but not the ElevenLabs
@@ -1557,7 +1572,7 @@ function requireElevenMusicOptions(
         if (usesElevenOnlyOptions) {
             throw new UpstreamError(400 as ContentfulStatusCode, {
                 message:
-                    "conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic.",
+                    "conditioning_ref, composition_plan, and store_for_inpainting are only supported with model=elevenmusic.",
             });
         }
         return;
@@ -1568,7 +1583,7 @@ function requireElevenMusicOptions(
 
     throw new UpstreamError(400 as ContentfulStatusCode, {
         message:
-            "reference_audio, conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic (stable-audio-3-medium and stable-audio-3-large also accept reference_audio).",
+            "reference_audio, conditioning_ref, composition_plan, and store_for_inpainting are only supported with model=elevenmusic (stable-audio-3-medium and stable-audio-3-large also accept reference_audio).",
     });
 }
 
@@ -1635,7 +1650,8 @@ async function parseSpeechRequest(
         }
 
         const input = formData.get("input");
-        const referenceAudio = formData.get("reference_audio");
+        const referenceAudio =
+            formData.get("reference_audio") ?? formData.get("file");
         const rawCompositionPlan = formData.get("composition_plan");
         const rawConditioningRef = formData.get("conditioning_ref");
         if (referenceAudio instanceof File) {
@@ -1671,10 +1687,6 @@ async function parseSpeechRequest(
             store_for_inpainting: parseOptionalBoolean(
                 formData.get("store_for_inpainting"),
                 "store_for_inpainting",
-            ),
-            extract_composition_plan: parseOptionalBoolean(
-                formData.get("extract_composition_plan"),
-                "extract_composition_plan",
             ),
             seed: parseOptionalNumber(formData.get("seed"), "seed"),
             instruct: (formData.get("instruct") as string | null) || undefined,
@@ -2202,10 +2214,9 @@ async function dispatchAudioGeneration(
         negativePrompt?: string;
         instrumental?: boolean;
         storeForInpainting?: boolean;
-        extractCompositionPlan?: boolean;
         conditioningRef?: unknown;
         compositionPlan?: unknown;
-        referenceAudio?: string;
+        referenceAudio?: File;
         instruct?: string;
         loop?: boolean;
         promptInfluence?: number;
@@ -2228,10 +2239,9 @@ async function dispatchAudioGeneration(
         negativePrompt,
         instrumental,
         storeForInpainting,
-        extractCompositionPlan,
         conditioningRef,
         compositionPlan,
-        referenceAudio: referenceAudioUrl,
+        referenceAudio,
         instruct,
         loop,
         promptInfluence,
@@ -2243,10 +2253,6 @@ async function dispatchAudioGeneration(
         log,
     } = opts;
 
-    const referenceAudio = referenceAudioUrl
-        ? await fetchReferenceAudio(referenceAudioUrl)
-        : undefined;
-
     if (model === "elevenmusic") {
         return withSafetyHeaders(
             c,
@@ -2256,7 +2262,6 @@ async function dispatchAudioGeneration(
                 forceInstrumental: instrumental,
                 seed,
                 storeForInpainting,
-                extractCompositionPlan,
                 conditioningRef,
                 compositionPlan,
                 referenceAudio,
@@ -2810,9 +2815,6 @@ export const audioRoutes = new Hono<Env>()
                                 negative_prompt: { type: "string" },
                                 instrumental: { type: "boolean" },
                                 store_for_inpainting: { type: "boolean" },
-                                extract_composition_plan: {
-                                    type: "boolean",
-                                },
                                 reference_audio: {
                                     type: "string",
                                     format: "uri",
@@ -2884,7 +2886,6 @@ export const audioRoutes = new Hono<Env>()
                 negative_prompt,
                 instrumental,
                 store_for_inpainting,
-                extract_composition_plan,
                 conditioning_ref,
                 composition_plan,
                 reference_audio,
@@ -2898,9 +2899,11 @@ export const audioRoutes = new Hono<Env>()
                 compositionPlan: composition_plan,
                 conditioningRef: conditioning_ref,
                 storeForInpainting: store_for_inpainting,
-                extractCompositionPlan: extract_composition_plan,
             });
             const safeInput = await applySafety(c, input, safe);
+            const referenceAudio = reference_audio
+                ? await fetchReferenceAudio(reference_audio)
+                : undefined;
 
             const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
                 .ELEVENLABS_API_KEY;
@@ -2918,10 +2921,9 @@ export const audioRoutes = new Hono<Env>()
                     negativePrompt: negative_prompt,
                     instrumental,
                     storeForInpainting: store_for_inpainting,
-                    extractCompositionPlan: extract_composition_plan,
                     conditioningRef: conditioning_ref,
                     compositionPlan: composition_plan,
-                    referenceAudio: reference_audio,
+                    referenceAudio,
                     instruct,
                     loop,
                     promptInfluence: prompt_influence,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1136,7 +1136,10 @@ async function uploadMusicReference(opts: {
     file: File;
     apiKey: string;
     log: Logger;
-}): Promise<{ song_id?: string }> {
+}): Promise<{
+    song_id?: string;
+    composition_plan?: { chunks?: { duration_ms?: unknown }[] };
+}> {
     const uploadUrl = "https://api.elevenlabs.io/v1/music/upload";
     const formData = new FormData();
     const filename =
@@ -1144,6 +1147,10 @@ async function uploadMusicReference(opts: {
             ? opts.file.name
             : "reference.mp3";
     formData.append("file", opts.file, filename);
+    // ElevenLabs does not return duration or usage headers for music uploads.
+    // The extracted v2 plan contains the provider-metered chunk durations and
+    // does not add to the $0.15/minute ingestion price.
+    formData.append("extract_composition_plan", "music_v2");
 
     opts.log.info("ElevenLabs music upload: filename={filename}, size={size}", {
         filename,
@@ -1156,7 +1163,38 @@ async function uploadMusicReference(opts: {
         body: formData,
     });
     const response = await ensureUpstreamOk(rawResponse, uploadUrl);
-    return (await response.json()) as { song_id?: string };
+    return (await response.json()) as {
+        song_id?: string;
+        composition_plan?: { chunks?: { duration_ms?: unknown }[] };
+    };
+}
+
+function getUploadedMusicDurationSeconds(upload: {
+    composition_plan?: { chunks?: { duration_ms?: unknown }[] };
+}): number {
+    const chunks = upload.composition_plan?.chunks;
+    if (!chunks?.length) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message:
+                "ElevenLabs music upload response missing reference duration",
+        });
+    }
+
+    const totalMilliseconds = chunks.reduce((total, chunk) => {
+        if (
+            typeof chunk.duration_ms !== "number" ||
+            !Number.isFinite(chunk.duration_ms) ||
+            chunk.duration_ms <= 0
+        ) {
+            throw new UpstreamError(502 as ContentfulStatusCode, {
+                message:
+                    "ElevenLabs music upload response contained an invalid reference duration",
+            });
+        }
+        return total + chunk.duration_ms;
+    }, 0);
+
+    return totalMilliseconds / 1000;
 }
 
 export async function generateMusic(
@@ -1185,6 +1223,7 @@ export async function generateMusic(
 
     const modelId = "music_v2";
     let uploadedSongId: string | undefined;
+    let uploadedReferenceDuration: number | undefined;
     let compositionPlan = opts.compositionPlan;
     let conditioningRef = opts.conditioningRef;
 
@@ -1200,6 +1239,7 @@ export async function generateMusic(
                 message: "ElevenLabs music upload response missing song_id",
             });
         }
+        uploadedReferenceDuration = getUploadedMusicDurationSeconds(upload);
         if (conditioningRef === undefined) {
             conditioningRef = {
                 song_id: uploadedSongId,
@@ -1280,10 +1320,14 @@ export async function generateMusic(
     const estimatedDuration =
         audioBuffer.byteLength / MUSIC_MP3_BYTES_PER_SECOND;
 
-    const usageHeaders = buildUsageHeaders(
-        "elevenmusic",
-        createCompletionAudioSecondsUsage(estimatedDuration),
-    );
+    const usage = createCompletionAudioSecondsUsage(estimatedDuration);
+    if (uploadedReferenceDuration !== undefined) {
+        Object.assign(
+            usage,
+            createAudioSecondsUsage(uploadedReferenceDuration),
+        );
+    }
+    const usageHeaders = buildUsageHeaders("elevenmusic", usage);
     const responseHeaders: Record<string, string> = {
         "Content-Type": contentType,
         ...usageHeaders,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -108,12 +108,18 @@ const CreateSpeechRequestSchema = z
         }),
         extract_composition_plan: z.boolean().optional().meta({
             description:
-                "If true with reference audio, uploads it and asks ElevenLabs to derive a music_v2 composition plan.",
+                "If true with reference audio, asks ElevenLabs to derive a music_v2 composition plan.",
             example: false,
+        }),
+        reference_audio: z.url().optional().meta({
+            description:
+                "URL returned by media.pollinations.ai for reference-audio conditioning or audio-to-audio generation.",
+            example:
+                "https://media.pollinations.ai/3f9c1e2a-7b4d-4e2f-9a1c-8d6b5e4f3a2b",
         }),
         conditioning_ref: z.unknown().optional().meta({
             description:
-                "ElevenLabs music_v2 AudioRefChunk to apply to the generated chunk. Multipart reference_audio can create this automatically.",
+                "ElevenLabs music_v2 AudioRefChunk to apply to the generated chunk. reference_audio can create this automatically.",
         }),
         composition_plan: z.unknown().optional().meta({
             description:
@@ -212,6 +218,50 @@ type GenerateMusicOptions = {
     apiKey: string;
     log: Logger;
 };
+
+const MEDIA_ORIGIN = "https://media.pollinations.ai";
+
+const AUDIO_EXTENSION_BY_TYPE: Record<string, string> = {
+    "audio/aac": "aac",
+    "audio/flac": "flac",
+    "audio/mp4": "m4a",
+    "audio/mpeg": "mp3",
+    "audio/ogg": "ogg",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+};
+
+async function fetchReferenceAudio(referenceAudioUrl: string): Promise<File> {
+    let url: URL;
+    try {
+        url = new URL(referenceAudioUrl);
+    } catch {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "reference_audio must be a valid media.pollinations.ai URL",
+        });
+    }
+
+    if (url.origin !== MEDIA_ORIGIN) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "reference_audio must use https://media.pollinations.ai",
+        });
+    }
+
+    const response = await ensureUpstreamOk(await fetch(url), url);
+    const contentType =
+        response.headers.get("content-type")?.split(";", 1)[0] || "";
+    if (!contentType.startsWith("audio/")) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "reference_audio must point to an audio file",
+        });
+    }
+
+    const extension = AUDIO_EXTENSION_BY_TYPE[contentType] || "audio";
+    return new File([await response.arrayBuffer()], `reference.${extension}`, {
+        type: contentType,
+    });
+}
 
 function mapOutputFormat(format: string): string {
     const formatMap: Record<string, string> = {
@@ -1483,7 +1533,7 @@ export async function generateLyria3Clip(opts: {
 function requireElevenMusicOptions(
     model: string,
     opts: {
-        referenceAudio?: File;
+        referenceAudio?: string;
         compositionPlan?: unknown;
         conditioningRef?: unknown;
         storeForInpainting?: boolean;
@@ -1558,12 +1608,8 @@ function parseOptionalBoolean(
     });
 }
 
-function parseCreateSpeechRequest(
-    value: unknown,
-): CreateSpeechRequest & { reference_audio?: File } {
-    const parsed = CreateSpeechRequestSchema.extend({
-        reference_audio: z.instanceof(File).optional(),
-    }).safeParse(value);
+function parseCreateSpeechRequest(value: unknown): CreateSpeechRequest {
+    const parsed = CreateSpeechRequestSchema.safeParse(value);
     if (parsed.success) return parsed.data;
 
     const firstIssue = parsed.error.issues[0];
@@ -1573,11 +1619,9 @@ function parseCreateSpeechRequest(
     });
 }
 
-async function parseSpeechRequest(c: AudioContext): Promise<
-    CreateSpeechRequest & {
-        reference_audio?: File;
-    }
-> {
+async function parseSpeechRequest(
+    c: AudioContext,
+): Promise<CreateSpeechRequest> {
     const contentType = c.req.header("content-type") || "";
 
     if (contentType.includes("multipart/form-data")) {
@@ -1591,13 +1635,17 @@ async function parseSpeechRequest(c: AudioContext): Promise<
         }
 
         const input = formData.get("input");
-        const referenceAudio =
-            (formData.get("reference_audio") as File | null) ||
-            (formData.get("file") as File | null) ||
-            undefined;
+        const referenceAudio = formData.get("reference_audio");
         const rawCompositionPlan = formData.get("composition_plan");
         const rawConditioningRef = formData.get("conditioning_ref");
-        const parsed: CreateSpeechRequest & { reference_audio?: File } = {
+        if (referenceAudio instanceof File) {
+            throw new UpstreamError(400 as ContentfulStatusCode, {
+                message:
+                    "reference_audio must be a media.pollinations.ai URL, not a file upload",
+            });
+        }
+
+        const parsed: CreateSpeechRequest = {
             model: (formData.get("model") as string | null) || undefined,
             input: typeof input === "string" ? input : "",
             safe: (formData.get("safe") as string | undefined) || undefined,
@@ -1611,8 +1659,7 @@ async function parseSpeechRequest(c: AudioContext): Promise<
                     | "aac"
                     | "pcm") || "mp3",
             duration: parseOptionalNumber(formData.get("duration"), "duration"),
-            // stable-audio-3-medium controls (also used on the audio-to-audio
-            // multipart path, which is the only way to send reference_audio).
+            // stable-audio-3-medium controls.
             seconds: parseOptionalNumber(formData.get("seconds"), "seconds"),
             steps: parseOptionalNumber(formData.get("steps"), "steps"),
             negative_prompt:
@@ -1644,7 +1691,7 @@ async function parseSpeechRequest(c: AudioContext): Promise<
                 typeof rawCompositionPlan === "string"
                     ? parseJsonObject(rawCompositionPlan, "composition_plan")
                     : undefined,
-            reference_audio: referenceAudio,
+            reference_audio: referenceAudio || undefined,
         };
 
         return parseCreateSpeechRequest(parsed);
@@ -2158,7 +2205,7 @@ async function dispatchAudioGeneration(
         extractCompositionPlan?: boolean;
         conditioningRef?: unknown;
         compositionPlan?: unknown;
-        referenceAudio?: File;
+        referenceAudio?: string;
         instruct?: string;
         loop?: boolean;
         promptInfluence?: number;
@@ -2184,7 +2231,7 @@ async function dispatchAudioGeneration(
         extractCompositionPlan,
         conditioningRef,
         compositionPlan,
-        referenceAudio,
+        referenceAudio: referenceAudioUrl,
         instruct,
         loop,
         promptInfluence,
@@ -2195,6 +2242,10 @@ async function dispatchAudioGeneration(
         stabilityApiKey,
         log,
     } = opts;
+
+    const referenceAudio = referenceAudioUrl
+        ? await fetchReferenceAudio(referenceAudioUrl)
+        : undefined;
 
     if (model === "elevenmusic") {
         return withSafetyHeaders(
@@ -2693,111 +2744,6 @@ export const audioRoutes = new Hono<Env>()
         },
     )
     .post(
-        "/music/upload",
-        describeRoute({
-            tags: ["🔊 Audio"],
-            summary: "Upload Music Reference",
-            description:
-                "Upload an audio file to ElevenLabs Music and receive a `song_id` for reference conditioning or inpainting. Set `extract_composition_plan=true` to return a music_v2 composition plan derived from the track.",
-            requestBody: {
-                required: true,
-                content: {
-                    "multipart/form-data": {
-                        schema: {
-                            type: "object",
-                            required: ["file"],
-                            properties: {
-                                file: {
-                                    type: "string",
-                                    format: "binary",
-                                    description: "Music file to upload.",
-                                },
-                                extract_composition_plan: {
-                                    type: "boolean",
-                                    default: false,
-                                    description:
-                                        "Return a music_v2 composition plan extracted from the uploaded track.",
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-            responses: {
-                200: {
-                    description:
-                        "Success - Returns ElevenLabs song_id and optional composition_plan",
-                    content: {
-                        "application/json": {
-                            schema: {
-                                type: "object",
-                                properties: {
-                                    song_id: { type: "string" },
-                                    composition_plan: { type: "object" },
-                                },
-                            },
-                        },
-                    },
-                },
-                ...errorResponseDescriptions(400, 401, 402, 403, 500),
-            },
-        }),
-        resolveModel("generate.audio", { defaultModel: "elevenmusic" }),
-        track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("music-upload");
-            await requireGenerationAccess(c.var, c.env);
-
-            if (c.var.model.resolved !== "elevenmusic") {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Music upload only supports model=elevenmusic",
-                });
-            }
-
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const file = formData.get("file") as File | null;
-            if (!file) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required field: file",
-                });
-            }
-
-            const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
-                .ELEVENLABS_API_KEY;
-            const upload = await uploadMusicReference({
-                file,
-                extractCompositionPlan:
-                    parseOptionalBoolean(
-                        formData.get("extract_composition_plan"),
-                        "extract_composition_plan",
-                    ) || false,
-                apiKey,
-                log,
-            });
-            const usageHeaders = buildUsageHeaders(
-                "elevenmusic",
-                createCompletionAudioSecondsUsage(file.size / 16000),
-            );
-
-            return Response.json(upload, {
-                headers: {
-                    ...usageHeaders,
-                    ...(upload.song_id
-                        ? { "x-elevenlabs-song-id": upload.song_id }
-                        : {}),
-                },
-            });
-        },
-    )
-    .post(
         "/speech",
         describeRoute({
             tags: ["🔊 Audio"],
@@ -2805,12 +2751,93 @@ export const audioRoutes = new Hono<Env>()
             description: [
                 "Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.",
                 "",
-                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
+                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Upload a reference file to `media.pollinations.ai`, then pass its URL as `reference_audio` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
                 "",
                 `**Available voices:** ${AUDIO_VOICES.join(", ")}`,
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
             ].join("\n"),
+            requestBody: {
+                required: true,
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            required: ["input"],
+                            properties: {
+                                model: { type: "string" },
+                                input: {
+                                    type: "string",
+                                    minLength: 1,
+                                    maxLength: 10000,
+                                },
+                                safe: {
+                                    oneOf: [
+                                        { type: "string" },
+                                        { type: "boolean" },
+                                    ],
+                                    description:
+                                        "Optional safety features; accepts a comma-separated string or boolean shorthand.",
+                                },
+                                voice: { type: "string", default: "alloy" },
+                                response_format: {
+                                    type: "string",
+                                    enum: [
+                                        "mp3",
+                                        "opus",
+                                        "aac",
+                                        "flac",
+                                        "wav",
+                                        "pcm",
+                                    ],
+                                    default: "mp3",
+                                },
+                                duration: {
+                                    type: "number",
+                                    minimum: 0.5,
+                                    maximum: 300,
+                                },
+                                seconds: {
+                                    type: "number",
+                                    minimum: 1,
+                                    maximum: 380,
+                                },
+                                steps: {
+                                    type: "integer",
+                                    minimum: 1,
+                                    maximum: 100,
+                                },
+                                negative_prompt: { type: "string" },
+                                instrumental: { type: "boolean" },
+                                store_for_inpainting: { type: "boolean" },
+                                extract_composition_plan: {
+                                    type: "boolean",
+                                },
+                                reference_audio: {
+                                    type: "string",
+                                    format: "uri",
+                                    description:
+                                        "URL returned by media.pollinations.ai for reference-audio conditioning or audio-to-audio generation.",
+                                },
+                                conditioning_ref: { type: "object" },
+                                composition_plan: { type: "object" },
+                                seed: {
+                                    type: "integer",
+                                    minimum: 0,
+                                    maximum: 4294967295,
+                                },
+                                instruct: { type: "string" },
+                                loop: { type: "boolean" },
+                                prompt_influence: {
+                                    type: "number",
+                                    minimum: 0,
+                                    maximum: 1,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
             responses: {
                 200: {
                     description: "Success - Returns audio data",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -988,7 +988,7 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
                 "",
-                "**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.",
+                "**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Upload reference audio through `media.pollinations.ai`, then pass its URL as `reference_audio` to `POST /v1/audio/speech`.",
             ].join("\n"),
             responses: {
                 200: {

--- a/gen.pollinations.ai/src/userImage.ts
+++ b/gen.pollinations.ai/src/userImage.ts
@@ -1,6 +1,7 @@
 import type { ImageInputErrorCode } from "@shared/error.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
 import { HttpError } from "./image/httpError.ts";
+import { readResponseBytes } from "./utils/response-bytes.ts";
 
 /**
  * A user-supplied image we could not use.
@@ -101,61 +102,6 @@ function assertAllowedImageUrl(value: string): URL {
     }
 
     return url;
-}
-
-/**
- * Reads a response body, refusing to buffer more than `maxBytes`.
- *
- * Streams and checks a running total so an oversized image is abandoned partway
- * rather than after it has already been held in memory — `Content-Length` is the
- * host's claim, not a limit, so it cannot be the only check.
- */
-async function readImageBytes(
-    response: Response,
-    maxBytes: number,
-): Promise<Uint8Array> {
-    if (maxBytes <= 0) {
-        throw new UserImageError(
-            `Too many image bytes in request (max ${MAX_IMAGE_SIZE} bytes).`,
-            "image_too_large",
-        );
-    }
-
-    const tooLarge = (total: number) =>
-        new UserImageError(
-            `Image too large: ${total} bytes (max ${maxBytes} bytes remaining). Please use a smaller image.`,
-            "image_too_large",
-        );
-
-    const reader = response.body?.getReader();
-    if (!reader) {
-        const arrayBuffer = await response.arrayBuffer();
-        if (arrayBuffer.byteLength > maxBytes)
-            throw tooLarge(arrayBuffer.byteLength);
-        return new Uint8Array(arrayBuffer);
-    }
-
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    try {
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            total += value.byteLength;
-            if (total > maxBytes) throw tooLarge(total);
-            chunks.push(value);
-        }
-    } finally {
-        reader.releaseLock();
-    }
-
-    const bytes = new Uint8Array(total);
-    let offset = 0;
-    for (const chunk of chunks) {
-        bytes.set(chunk, offset);
-        offset += chunk.byteLength;
-    }
-    return bytes;
 }
 
 /** The image host's own status, phrased as something the caller can act on. */
@@ -333,20 +279,24 @@ export async function fetchUserImage(
     }
 
     const cap = Math.min(MAX_IMAGE_SIZE, maxBytes);
-    // Not redundant with the streaming cap below, which catches the same images
-    // only after transferring `cap` bytes of them. An honest host declaring
-    // something far too big is turned away here having sent nothing.
-    const contentLength = response.headers.get("content-length");
-    if (contentLength && Number.parseInt(contentLength, 10) > cap) {
+    if (cap <= 0) {
         throw new UserImageError(
-            `Image too large: ${contentLength} bytes (max ${cap} bytes remaining). Please use a smaller image.`,
+            `Too many image bytes in request (max ${MAX_IMAGE_SIZE} bytes).`,
             "image_too_large",
         );
     }
 
     let bytes: Uint8Array;
     try {
-        bytes = await readImageBytes(response, cap);
+        bytes = await readResponseBytes(
+            response,
+            cap,
+            (total) =>
+                new UserImageError(
+                    `Image too large: ${total} bytes (max ${cap} bytes remaining). Please use a smaller image.`,
+                    "image_too_large",
+                ),
+        );
     } catch (thrown) {
         if (thrown instanceof UserImageError) throw thrown;
         const error =

--- a/gen.pollinations.ai/src/utils/response-bytes.ts
+++ b/gen.pollinations.ai/src/utils/response-bytes.ts
@@ -1,0 +1,50 @@
+/**
+ * Read a response body without ever buffering more than `maxBytes`.
+ *
+ * Content-Length is checked before streaming, then the running byte count is
+ * checked while reading because the header can be absent or incorrect.
+ */
+export async function readResponseBytes(
+    response: Response,
+    maxBytes: number,
+    tooLarge: (total: number) => Error,
+): Promise<Uint8Array<ArrayBuffer>> {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+        const declaredSize = Number.parseInt(contentLength, 10);
+        if (Number.isFinite(declaredSize) && declaredSize > maxBytes) {
+            throw tooLarge(declaredSize);
+        }
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+        const arrayBuffer = await response.arrayBuffer();
+        if (arrayBuffer.byteLength > maxBytes) {
+            throw tooLarge(arrayBuffer.byteLength);
+        }
+        return new Uint8Array(arrayBuffer);
+    }
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            total += value.byteLength;
+            if (total > maxBytes) throw tooLarge(total);
+            chunks.push(value);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return bytes;
+}

--- a/gen.pollinations.ai/test/elevenmusic-v2.test.ts
+++ b/gen.pollinations.ai/test/elevenmusic-v2.test.ts
@@ -51,6 +51,9 @@ describe("ElevenLabs music_v2", () => {
                 if (request.url.endsWith("/v1/music/upload")) {
                     return Response.json({
                         song_id: "reference-song",
+                        composition_plan: {
+                            chunks: [{ duration_ms: 10_000 }],
+                        },
                     });
                 }
                 return new Response(new Uint8Array([1, 2, 3, 4]), {
@@ -58,7 +61,7 @@ describe("ElevenLabs music_v2", () => {
                 });
             });
 
-        await generateMusic({
+        const response = await generateMusic({
             prompt: "[Verse]\nPlay this as warm indie disco",
             durationSeconds: 45,
             referenceAudio: new File(["reference"], "reference.mp3", {
@@ -76,9 +79,10 @@ describe("ElevenLabs music_v2", () => {
         expect(uploadRequest.url).toBe(
             "https://api.elevenlabs.io/v1/music/upload",
         );
-        expect((await uploadRequest.formData()).get("file")).toBeInstanceOf(
-            File,
-        );
+        const uploadForm = await uploadRequest.formData();
+        expect(uploadForm.get("file")).toBeInstanceOf(File);
+        expect(uploadForm.get("extract_composition_plan")).toBe("music_v2");
+        expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("10");
 
         const composeRequest = new Request(
             fetchMock.mock.calls[1][0],

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -1388,7 +1388,15 @@ fixtureTest(
                     expect((file as File).type).toBe(
                         "application/octet-stream",
                     );
-                    return Response.json({ song_id: "reference-song" });
+                    expect(formData.get("extract_composition_plan")).toBe(
+                        "music_v2",
+                    );
+                    return Response.json({
+                        song_id: "reference-song",
+                        composition_plan: {
+                            chunks: [{ duration_ms: 30_000 }],
+                        },
+                    });
                 }
 
                 if (request.url === composeUrl) {
@@ -1444,6 +1452,7 @@ fixtureTest(
         );
 
         expect(response.status).toBe(200);
+        expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("30");
         await waitOnExecutionContext(ctx);
         expect(calls).toEqual(
             expect.arrayContaining([referenceAudioUrl, uploadUrl, composeUrl]),

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -1356,6 +1356,172 @@ it("lists Lyria with its aliases and text-to-audio modalities", async () => {
 });
 
 fixtureTest(
+    "loads elevenmusic reference_audio from the media service",
+    async ({ paidApiKey }) => {
+        const calls: string[] = [];
+        const referenceAudioUrl =
+            "https://media.pollinations.ai/test-music-reference";
+        const uploadUrl = "https://api.elevenlabs.io/v1/music/upload";
+        const composeUrl = "https://api.elevenlabs.io/v1/music";
+
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+
+                if (request.url === referenceAudioUrl) {
+                    return new Response(new Uint8Array([73, 68, 51, 4]), {
+                        headers: { "Content-Type": "audio/mpeg" },
+                    });
+                }
+
+                if (request.url === uploadUrl) {
+                    expect(request.headers.get("xi-api-key")).toBe(
+                        "test-eleven-key",
+                    );
+                    const formData = await request.formData();
+                    expect(formData.get("file")).toBeInstanceOf(File);
+                    return Response.json({ song_id: "reference-song" });
+                }
+
+                if (request.url === composeUrl) {
+                    const body = (await request.json()) as {
+                        composition_plan: {
+                            chunks: Array<{
+                                conditioning_ref: { song_id: string };
+                            }>;
+                        };
+                    };
+                    expect(
+                        body.composition_plan.chunks[0].conditioning_ref
+                            .song_id,
+                    ).toBe("reference-song");
+                    return new Response(new Uint8Array([1, 2, 3, 4]), {
+                        headers: { "Content-Type": "audio/mpeg" },
+                    });
+                }
+
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${paidApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "elevenmusic",
+                    input: "warm indie disco",
+                    duration: 30,
+                    reference_audio: referenceAudioUrl,
+                }),
+            }),
+            {
+                ...env,
+                ELEVENLABS_API_KEY: "test-eleven-key",
+            } as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(200);
+        await waitOnExecutionContext(ctx);
+        expect(calls).toEqual(
+            expect.arrayContaining([referenceAudioUrl, uploadUrl, composeUrl]),
+        );
+    },
+);
+
+fixtureTest(
+    "rejects reference_audio URLs outside the media service",
+    async ({ paidApiKey }) => {
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${paidApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "elevenmusic",
+                    input: "warm indie disco",
+                    reference_audio: "https://example.com/reference.mp3",
+                }),
+            }),
+            env as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            error: {
+                message:
+                    "reference_audio must use https://media.pollinations.ai",
+            },
+        });
+        await waitOnExecutionContext(ctx);
+    },
+);
+
+fixtureTest(
+    "does not expose the dedicated music upload endpoint",
+    async ({ paidApiKey }) => {
+        const formData = new FormData();
+        formData.append(
+            "file",
+            new File([new Uint8Array([73, 68, 51, 4])], "reference.mp3", {
+                type: "audio/mpeg",
+            }),
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/v1/audio/music/upload",
+                {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${paidApiKey}` },
+                    body: formData,
+                },
+            ),
+            env as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(404);
+        await waitOnExecutionContext(ctx);
+    },
+);
+
+fixtureTest(
     "routes stable-audio-3-medium requests through fal",
     async ({ paidApiKey }) => {
         const calls: string[] = [];
@@ -1449,12 +1615,20 @@ fixtureTest(
         const a2aEndpoint =
             "https://fal.run/fal-ai/stable-audio-3/medium/audio-to-audio";
         const falFileUrl = "https://v3.fal.media/files/test-a2a.mp3";
+        const referenceAudioUrl =
+            "https://media.pollinations.ai/test-reference-audio";
         let sentAudioUrl: unknown;
 
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
                 const request = new Request(input, init);
                 calls.push(request.url);
+
+                if (request.url === referenceAudioUrl) {
+                    return new Response(new Uint8Array([82, 73, 70, 70]), {
+                        headers: { "Content-Type": "audio/wav" },
+                    });
+                }
 
                 if (request.url === a2aEndpoint) {
                     expect(request.headers.get("authorization")).toBe(
@@ -1492,22 +1666,19 @@ fixtureTest(
             },
         );
 
-        const form = new FormData();
-        form.append("model", "stable-audio-3-medium");
-        form.append("input", "warm pads");
-        form.append(
-            "reference_audio",
-            new File([new Uint8Array([82, 73, 70, 70])], "ref.wav", {
-                type: "audio/wav",
-            }),
-        );
-
         const ctx = createExecutionContext();
         const response = await worker.fetch(
             new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
                 method: "POST",
-                headers: { Authorization: `Bearer ${paidApiKey}` },
-                body: form,
+                headers: {
+                    Authorization: `Bearer ${paidApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "stable-audio-3-medium",
+                    input: "warm pads",
+                    reference_audio: referenceAudioUrl,
+                }),
             }),
             {
                 ...env,
@@ -1531,6 +1702,7 @@ fixtureTest(
 
         await waitOnExecutionContext(ctx);
 
+        expect(calls).toContain(referenceAudioUrl);
         expect(calls).toContain(a2aEndpoint);
         expect(calls).toContain(falFileUrl);
     },
@@ -1656,11 +1828,19 @@ fixtureTest(
         const generationId = "test-a2a-generation-id";
         const a2aEndpoint =
             "https://api.stability.ai/v2beta/audio/stable-audio/audio-to-audio";
+        const referenceAudioUrl =
+            "https://media.pollinations.ai/test-reference-audio";
 
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
                 const request = new Request(input, init);
                 calls.push(request.url);
+
+                if (request.url === referenceAudioUrl) {
+                    return new Response(new Uint8Array([82, 73, 70, 70]), {
+                        headers: { "Content-Type": "audio/wav" },
+                    });
+                }
 
                 // Submit goes to the audio-to-audio endpoint with the clip.
                 if (request.url === a2aEndpoint) {
@@ -1704,22 +1884,19 @@ fixtureTest(
             },
         );
 
-        const form = new FormData();
-        form.append("model", "stable-audio-3-large");
-        form.append("input", "warm pads");
-        form.append(
-            "reference_audio",
-            new File([new Uint8Array([82, 73, 70, 70])], "ref.wav", {
-                type: "audio/wav",
-            }),
-        );
-
         const ctx = createExecutionContext();
         const response = await worker.fetch(
             new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
                 method: "POST",
-                headers: { Authorization: `Bearer ${paidApiKey}` },
-                body: form,
+                headers: {
+                    Authorization: `Bearer ${paidApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "stable-audio-3-large",
+                    input: "warm pads",
+                    reference_audio: referenceAudioUrl,
+                }),
             }),
             {
                 ...env,
@@ -1739,6 +1916,7 @@ fixtureTest(
 
         await waitOnExecutionContext(ctx);
 
+        expect(calls).toContain(referenceAudioUrl);
         expect(calls).toContain(a2aEndpoint);
         expect(calls).toContain(
             `https://api.stability.ai/v2beta/results/${generationId}`,

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -1356,7 +1356,7 @@ it("lists Lyria with its aliases and text-to-audio modalities", async () => {
 });
 
 fixtureTest(
-    "loads elevenmusic reference_audio from the media service",
+    "loads an octet-stream elevenmusic reference from the media service",
     async ({ paidApiKey }) => {
         const calls: string[] = [];
         const referenceAudioUrl =
@@ -1371,7 +1371,10 @@ fixtureTest(
 
                 if (request.url === referenceAudioUrl) {
                     return new Response(new Uint8Array([73, 68, 51, 4]), {
-                        headers: { "Content-Type": "audio/mpeg" },
+                        headers: {
+                            "Content-Type":
+                                "Application/Octet-Stream; charset=binary",
+                        },
                     });
                 }
 
@@ -1380,7 +1383,11 @@ fixtureTest(
                         "test-eleven-key",
                     );
                     const formData = await request.formData();
-                    expect(formData.get("file")).toBeInstanceOf(File);
+                    const file = formData.get("file");
+                    expect(file).toBeInstanceOf(File);
+                    expect((file as File).type).toBe(
+                        "application/octet-stream",
+                    );
                     return Response.json({ song_id: "reference-song" });
                 }
 
@@ -1488,6 +1495,179 @@ fixtureTest(
             },
         });
         await waitOnExecutionContext(ctx);
+    },
+);
+
+fixtureTest(
+    "returns 400 once for an expired media reference",
+    async ({ paidApiKey }) => {
+        const referenceAudioUrl =
+            "https://media.pollinations.ai/expired-reference";
+        const calls: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                calls.push(request.url);
+                if (request.url === referenceAudioUrl) {
+                    return Response.json(
+                        { error: "Not found" },
+                        { status: 404 },
+                    );
+                }
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${paidApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "elevenmusic",
+                    input: "warm indie disco",
+                    reference_audio: referenceAudioUrl,
+                }),
+            }),
+            env as unknown as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            error: {
+                message:
+                    "Failed to fetch reference_audio: media.pollinations.ai returned 404",
+            },
+        });
+        await waitOnExecutionContext(ctx);
+        expect(calls.filter((url) => url === referenceAudioUrl)).toHaveLength(
+            1,
+        );
+        expect(
+            calls.some((url) => new URL(url).hostname === "api.elevenlabs.io"),
+        ).toBe(false);
+    },
+);
+
+fixtureTest(
+    "rejects non-audio and oversized media references",
+    async ({ paidApiKey }) => {
+        const nonAudioUrl =
+            "https://media.pollinations.ai/not-an-audio-reference";
+        const oversizedUrl =
+            "https://media.pollinations.ai/oversized-audio-reference";
+
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                if (request.url === nonAudioUrl) {
+                    return new Response(new Uint8Array([1, 2, 3]), {
+                        headers: { "Content-Type": "image/png" },
+                    });
+                }
+                if (request.url === oversizedUrl) {
+                    return new Response(new Uint8Array(), {
+                        headers: {
+                            "Content-Type": "audio/wav",
+                            "Content-Length": String(20 * 1024 * 1024 + 1),
+                        },
+                    });
+                }
+                if (
+                    request.url.startsWith(
+                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+                    ) ||
+                    request.url.startsWith("http://localhost:7181/")
+                ) {
+                    return Response.json({ data: [] });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            },
+        );
+
+        for (const [referenceAudio, message] of [
+            [nonAudioUrl, "reference_audio must point to an audio file"],
+            [oversizedUrl, "reference_audio is too large"],
+        ] as const) {
+            const ctx = createExecutionContext();
+            const response = await worker.fetch(
+                new Request(
+                    "https://staging.gen.pollinations.ai/v1/audio/speech",
+                    {
+                        method: "POST",
+                        headers: {
+                            Authorization: `Bearer ${paidApiKey}`,
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify({
+                            model: "elevenmusic",
+                            input: "warm indie disco",
+                            reference_audio: referenceAudio,
+                        }),
+                    },
+                ),
+                env as unknown as CloudflareBindings,
+                ctx,
+            );
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toMatchObject({
+                error: { message: expect.stringContaining(message) },
+            });
+            await waitOnExecutionContext(ctx);
+        }
+    },
+);
+
+fixtureTest(
+    "rejects legacy multipart reference file fields explicitly",
+    async ({ paidApiKey }) => {
+        for (const fieldName of ["reference_audio", "file"]) {
+            const formData = new FormData();
+            formData.append("model", "elevenmusic");
+            formData.append("input", "warm indie disco");
+            formData.append(
+                fieldName,
+                new File([new Uint8Array([73, 68, 51, 4])], "reference.mp3", {
+                    type: "audio/mpeg",
+                }),
+            );
+
+            const ctx = createExecutionContext();
+            const response = await worker.fetch(
+                new Request(
+                    "https://staging.gen.pollinations.ai/v1/audio/speech",
+                    {
+                        method: "POST",
+                        headers: { Authorization: `Bearer ${paidApiKey}` },
+                        body: formData,
+                    },
+                ),
+                env as unknown as CloudflareBindings,
+                ctx,
+            );
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toMatchObject({
+                error: {
+                    message:
+                        "reference_audio must be a media.pollinations.ai URL, not a file upload",
+                },
+            });
+            await waitOnExecutionContext(ctx);
+        }
     },
 );
 

--- a/gen.pollinations.ai/test/openapi-json.test.ts
+++ b/gen.pollinations.ai/test/openapi-json.test.ts
@@ -83,6 +83,14 @@ describe("/openapi.json", () => {
         expect(schema.paths["/v1/chat/completions"]).toBeDefined();
         expect(schema.paths["/image/{prompt}"]).toBeDefined();
         expect(schema.paths["/account/key"]).toBeDefined();
+        expect(schema.paths["/v1/audio/music/upload"]).toBeUndefined();
+
+        const speechRequestPropertySets = collectPropertySets(schema).filter(
+            (properties) =>
+                "reference_audio" in properties &&
+                "composition_plan" in properties,
+        );
+        expect(speechRequestPropertySets.length).toBeGreaterThan(0);
 
         const chatRequestPropertySets = collectPropertySets(schema).filter(
             (properties) => "reasoning_effort" in properties,

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -267,7 +267,9 @@ export const AUDIO_SERVICES = {
         priceMultiplier: 1,
         paidOnly: true,
         cost: {
-            // ElevenLabs Music v2: billed per second of output audio.
+            // ElevenLabs Music v2: reference ingestion and generated output
+            // are each billed at $0.15/minute.
+            promptAudioSeconds: 0.0025,
             // Measured empirically (ffprobe-verified, 10s & 30s clips): 15.05 credits/sec.
             // Scale plan $0.166/1k credits => 15.05 * 0.166/1000 ≈ $0.0025/sec ($0.15/min).
             completionAudioSeconds: 0.0025,


### PR DESCRIPTION
- Accepts `media.pollinations.ai` URLs as `reference_audio` and downloads them before provider dispatch.
- Keeps the ElevenLabs `/v1/music/upload` call and `song_id` conditioning internal to music generation.
- Meters newly uploaded reference duration at $0.0025/second in addition to generated output; reused `song_id` references do not incur ingestion again.
- Migrates Stable Audio references to the same media URL contract and rejects arbitrary reference hosts.
- Removes the public `POST /v1/audio/music/upload` route.

Evidence:
- ElevenLabs direct probes: 30 seconds uploaded cost $0.075; a 10-second upload with `extract_composition_plan=music_v2` cost $0.025 and returned exact duration.
- Full Gen route suite: 58/58; verifies media URL fetch → ElevenLabs upload → generation and billed prompt-audio duration.
- ElevenMusic unit tests: 3/3; OpenAPI: 2/2; effective-price snapshot: 1/1.
- Gen and Enter typechecks pass; Biome clean.

Draft gate:
- Run one live staging media upload → ElevenMusic generation E2E before readiness.

Fixes #13316
