### PR TITLE
fix: preserve economics transaction evidence

### DIFF
--- a/operations/economics/web/src/lib/documents.test.ts
+++ b/operations/economics/web/src/lib/documents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { driveDocumentLink } from "./documents";
+import { driveDocumentLink, externalEvidenceUrl } from "./documents";
 
 describe("driveDocumentLink", () => {
     it("recognizes Drive folders", () => {
@@ -57,5 +57,22 @@ describe("driveDocumentLink", () => {
                 "https://drive.google.com.example.com/file/d/file-id/view",
             ),
         ).toBeNull();
+    });
+});
+
+describe("externalEvidenceUrl", () => {
+    it("keeps ordinary http and https evidence links clickable", () => {
+        expect(externalEvidenceUrl("https://wise.com/evidence/statement")).toBe(
+            "https://wise.com/evidence/statement",
+        );
+        expect(externalEvidenceUrl("http://internal.example/evidence")).toBe(
+            "http://internal.example/evidence",
+        );
+    });
+
+    it("rejects blank evidence, free text, and unsafe protocols", () => {
+        expect(externalEvidenceUrl("")).toBeNull();
+        expect(externalEvidenceUrl("wise-statement.zip")).toBeNull();
+        expect(externalEvidenceUrl("javascript:alert(1)")).toBeNull();
     });
 });

--- a/operations/economics/web/src/lib/documents.ts
+++ b/operations/economics/web/src/lib/documents.ts
@@ -80,3 +80,17 @@ export function driveDocumentLink(evidence: string): DriveDocumentLink | null {
 
     return null;
 }
+
+export function externalEvidenceUrl(evidence: string): string | null {
+    const href = evidence.trim();
+    if (!href) return null;
+
+    try {
+        const url = new URL(href);
+        return url.protocol === "https:" || url.protocol === "http:"
+            ? href
+            : null;
+    } catch {
+        return null;
+    }
+}

--- a/operations/economics/web/src/lib/months.test.ts
+++ b/operations/economics/web/src/lib/months.test.ts
@@ -59,16 +59,27 @@ describe("latestClosedMonth", () => {
         expect(
             latestClosedMonth(
                 ["2026-06", "2026-07", "2026-08"],
-                new Date(2026, 7, 3),
+                new Date("2026-08-03T00:00:00Z"),
             ),
         ).toBe("2026-07");
     });
 
+    it("uses UTC at a local calendar-month boundary", () => {
+        expect(
+            latestClosedMonth(
+                ["2026-06", "2026-07", "2026-08"],
+                new Date("2026-08-01T00:30:00+02:00"),
+            ),
+        ).toBe("2026-06");
+    });
+
     it("uses the latest available month when no closed month exists", () => {
-        expect(latestClosedMonth(["2026-08"], new Date(2026, 7, 3))).toBe(
-            "2026-08",
-        );
-        expect(latestClosedMonth([], new Date(2026, 7, 3))).toBeNull();
+        expect(
+            latestClosedMonth(["2026-08"], new Date("2026-08-03T00:00:00Z")),
+        ).toBe("2026-08");
+        expect(
+            latestClosedMonth([], new Date("2026-08-03T00:00:00Z")),
+        ).toBeNull();
     });
 });
 

--- a/operations/economics/web/src/lib/months.ts
+++ b/operations/economics/web/src/lib/months.ts
@@ -58,7 +58,7 @@ export function latestClosedMonth(
     now = new Date(),
 ): string | null {
     if (months.length === 0) return null;
-    const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+    const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
     for (let index = months.length - 1; index >= 0; index -= 1) {
         if (months[index] < currentMonth) return months[index];
     }

--- a/operations/economics/web/src/views/OpTransactionsTab.tsx
+++ b/operations/economics/web/src/views/OpTransactionsTab.tsx
@@ -7,7 +7,7 @@ import {
     TableHeaderCell,
     TableRow,
 } from "@pollinations/ui";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
     DataTable,
@@ -18,7 +18,11 @@ import {
     useSortableRows,
     withUniqueRowKeys,
 } from "../components/DataTable";
-import { type DriveDocumentLink, driveDocumentLink } from "../lib/documents";
+import {
+    type DriveDocumentLink,
+    driveDocumentLink,
+    externalEvidenceUrl,
+} from "../lib/documents";
 import { fmtNumber } from "../lib/format";
 import {
     type MonthFilterValue,
@@ -35,13 +39,37 @@ function DocumentPreview({
     documentLink: DriveDocumentLink;
     onClose: () => void;
 }) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+
     useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+
         function handleKeyDown(event: KeyboardEvent) {
             if (event.key === "Escape") onClose();
+            if (event.key !== "Tab") return;
+
+            const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+                'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            );
+            if (!focusable || focusable.length === 0) return;
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
         }
 
         window.addEventListener("keydown", handleKeyDown);
-        return () => window.removeEventListener("keydown", handleKeyDown);
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            window.removeEventListener("keydown", handleKeyDown);
+        };
     }, [onClose]);
 
     if (!documentLink.previewHref) return null;
@@ -52,9 +80,11 @@ function DocumentPreview({
                 type="button"
                 className="absolute inset-0 bg-black/60"
                 aria-label="Close document preview"
+                tabIndex={-1}
                 onClick={onClose}
             />
             <div
+                ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="document-preview-title"
@@ -105,11 +135,11 @@ function TransactionDocument({
     onPreview,
 }: {
     evidence: string;
-    onPreview: (document: DriveDocumentLink) => void;
+    onPreview: (link: DriveDocumentLink) => void;
 }) {
-    const document = driveDocumentLink(evidence);
+    const rawEvidence = evidence.trim();
 
-    if (!document) {
+    if (!rawEvidence) {
         return (
             <Chip intent="warning" size="sm">
                 Missing
@@ -117,11 +147,12 @@ function TransactionDocument({
         );
     }
 
-    if (document.previewHref) {
+    const link = driveDocumentLink(rawEvidence);
+    if (link?.previewHref) {
         return (
             <button
                 type="button"
-                onClick={() => onPreview(document)}
+                onClick={() => onPreview(link)}
                 className="font-medium text-theme-text underline underline-offset-4 hover:text-theme-text-soft"
             >
                 Preview
@@ -129,14 +160,32 @@ function TransactionDocument({
         );
     }
 
+    if (link) {
+        return (
+            <a
+                href={link.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-theme-text underline underline-offset-4 hover:text-theme-text-soft"
+            >
+                {link.label}
+            </a>
+        );
+    }
+
+    const externalHref = externalEvidenceUrl(rawEvidence);
+    if (!externalHref) {
+        return <span className="break-all">{rawEvidence}</span>;
+    }
+
     return (
         <a
-            href={document.href}
+            href={externalHref}
             target="_blank"
             rel="noreferrer noopener"
-            className="font-medium text-theme-text underline underline-offset-4 hover:text-theme-text-soft"
+            className="break-all font-medium text-theme-text underline underline-offset-4 hover:text-theme-text-soft"
         >
-            {document.label}
+            {rawEvidence}
         </a>
     );
 }
@@ -172,7 +221,9 @@ export function OpTransactionsTab({
             { key: "description", value: (row) => row.description },
             {
                 key: "evidence",
-                value: (row) => driveDocumentLink(row.evidence)?.label ?? "",
+                value: (row) =>
+                    driveDocumentLink(row.evidence)?.label ??
+                    row.evidence.trim(),
             },
         ],
         [],


### PR DESCRIPTION
- Distinguishes truly missing evidence from non-Drive ledger references and keeps ordinary evidence URLs clickable.
- Uses UTC when selecting the latest closed month, matching the P&L in-progress calculation.
- Removes the `document` global shadow and adds modal focus trapping plus body scroll restoration.
- Keeps Google Drive previews unsandboxed because browser verification showed sandboxing replaces private PDFs with a cookie-consent gate; preview URLs remain restricted to exact Google Drive/Docs hosts.

Validation:
- `npx biome check` on the five changed files
- Economics tests: 174 passed
- `tsc --noEmit`
- Browser verification against live July Tinybird rows and signed-in Drive previews

Follow-up to #13289.