### PR TITLE
fix: preserve input image aspect ratio when size is omitted on edits

### DIFF
--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -29,7 +29,11 @@ import {
 import { getImageEnv, syncImageEnv } from "./env.ts";
 import { HttpError } from "./httpError.ts";
 import { setKleinVpcBinding } from "./models/fluxKleinModel.ts";
-import { type ImageParams, ImageParamsSchema } from "./params.ts";
+import {
+    deriveDimensionsFromInputImage,
+    type ImageParams,
+    ImageParamsSchema,
+} from "./params.ts";
 import { sanitizeString, sleep } from "./util.ts";
 import {
     CONTENT_POLICY_ERROR_CODE,
@@ -478,7 +482,13 @@ export async function generateImageOrVideoResponse(
 ): Promise<Response> {
     syncImageEnvironment(c.env);
     const originalPrompt = decodePrompt(prompt || "random_prompt");
-    const safeParams = parseImageParams(c, body);
+    let safeParams = parseImageParams(c, body);
+    // Editing an image without an explicit size should keep its proportions,
+    // not reshape it to the model's square default. Video models keep their
+    // aspectRatio/resolution semantics untouched.
+    if (!isVideoModel(safeParams.model)) {
+        safeParams = await deriveDimensionsFromInputImage(safeParams);
+    }
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
         hasImage: (safeParams.image?.length ?? 0) > 0,

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -2,6 +2,10 @@ import { IMAGE_SERVICES, type ImageModelName } from "@shared/registry/image.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { z } from "zod";
 import { getDefaultSideLength } from "./models.js";
+import {
+    downloadUserImage,
+    readImageDimensions,
+} from "./utils/imageDownload.ts";
 
 const allowedModels = Object.keys(IMAGE_SERVICES) as [
     ImageModelName,
@@ -141,3 +145,45 @@ export const ImageParamsSchema = z
     });
 
 export type ImageParams = z.infer<typeof ImageParamsSchema>;
+
+/**
+ * Preserve the input image's aspect ratio when the caller did not specify
+ * dimensions. Editing defaults to the source image's proportions — scaled
+ * down into the model's default pixel budget so an edit without an explicit
+ * size never costs more than one does today — instead of the model's square
+ * default. Explicit width/height/size always win (dimensionsExplicit), and
+ * any probe failure falls back to the square default so this never rejects
+ * a request the current pipeline accepts. `dimensionsExplicit` stays false:
+ * derived dimensions are still a default, and models that branch on the
+ * caller's intent (e.g. seedream-4's pixel-precise custom mode) should keep
+ * treating them as one.
+ */
+export async function deriveDimensionsFromInputImage<
+    T extends {
+        width: number;
+        height: number;
+        image: string[];
+        dimensionsExplicit: boolean;
+        model: string;
+    },
+>(params: T): Promise<T> {
+    if (params.dimensionsExplicit || params.image.length === 0) return params;
+    try {
+        const { buffer, mimeType } = await downloadUserImage(params.image[0]);
+        const source = readImageDimensions(buffer, mimeType);
+        if (!source) return params;
+        const budget =
+            getDefaultSideLength(params.model as ImageModelName) ** 2;
+        const scale = Math.min(
+            1,
+            Math.sqrt(budget / (source.width * source.height)),
+        );
+        return {
+            ...params,
+            width: Math.max(1, Math.round(source.width * scale)),
+            height: Math.max(1, Math.round(source.height * scale)),
+        };
+    } catch {
+        return params;
+    }
+}

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -1,5 +1,22 @@
+import { Buffer } from "node:buffer";
+import { CreateImageEditRequestSchema } from "@shared/schemas/openai.ts";
 import { describe, expect, it } from "vitest";
-import { ImageParamsSchema } from "../../src/image/params.ts";
+import {
+    deriveDimensionsFromInputImage,
+    ImageParamsSchema,
+} from "../../src/image/params.ts";
+
+/** Minimal PNG: signature + IHDR header carrying real width/height. */
+function pngDataUri(width: number, height: number): string {
+    const bytes = new Uint8Array(24);
+    bytes.set([137, 80, 78, 71, 13, 10, 26, 10]);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(8, 13);
+    bytes.set([73, 72, 68, 82], 12);
+    view.setUint32(16, width);
+    view.setUint32(20, height);
+    return `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
+}
 
 describe("ImageParamsSchema", () => {
     it("rejects transparent backgrounds for gpt-image-2", () => {
@@ -69,5 +86,104 @@ describe("ImageParamsSchema", () => {
                 message: "flux does not accept a resolution parameter.",
             });
         }
+    });
+});
+
+describe("deriveDimensionsFromInputImage", () => {
+    it("keeps a small source's exact dimensions when size is omitted", async () => {
+        const params = ImageParamsSchema.parse({
+            model: "flux",
+            image: [pngDataUri(512, 768)],
+        });
+        expect(params.dimensionsExplicit).toBe(false);
+
+        const derived = await deriveDimensionsFromInputImage(params);
+
+        expect(derived).toMatchObject({ width: 512, height: 768 });
+        expect(derived.dimensionsExplicit).toBe(false);
+    });
+
+    it("scales a large landscape source into the model's pixel budget", async () => {
+        const params = ImageParamsSchema.parse({
+            model: "flux",
+            image: [pngDataUri(4096, 2048)],
+        });
+
+        const derived = await deriveDimensionsFromInputImage(params);
+
+        // 2:1 ratio preserved, area ≈ 1024² instead of the raw 4096x2048.
+        expect(derived.width / derived.height).toBeCloseTo(2, 1);
+        expect(derived.width * derived.height).toBeLessThanOrEqual(
+            1024 * 1024 * 1.01,
+        );
+        expect(derived.width).toBeGreaterThan(derived.height);
+    });
+
+    it("uses the model's own default budget, not the global one", async () => {
+        const params = ImageParamsSchema.parse({
+            model: "seedream5",
+            image: [pngDataUri(8192, 4096)],
+        });
+
+        const derived = await deriveDimensionsFromInputImage(params);
+
+        // seedream5 defaults to a 2048 square, so the budget is 2048².
+        expect(derived.width / derived.height).toBeCloseTo(2, 1);
+        expect(derived.width * derived.height).toBeGreaterThan(1024 * 1024);
+        expect(derived.width * derived.height).toBeLessThanOrEqual(
+            2048 * 2048 * 1.01,
+        );
+    });
+
+    it("leaves explicitly requested dimensions untouched", async () => {
+        const params = ImageParamsSchema.parse({
+            model: "flux",
+            width: 640,
+            height: 640,
+            image: [pngDataUri(512, 768)],
+        });
+        expect(params.dimensionsExplicit).toBe(true);
+
+        const derived = await deriveDimensionsFromInputImage(params);
+
+        expect(derived).toBe(params);
+    });
+
+    it("falls back to the square default when the image is unreadable", async () => {
+        const params = ImageParamsSchema.parse({
+            model: "flux",
+            image: ["data:image/png;base64,AAAA"],
+        });
+
+        const derived = await deriveDimensionsFromInputImage(params);
+
+        expect(derived).toMatchObject({ width: 1024, height: 1024 });
+    });
+
+    it("does nothing without an input image", async () => {
+        const params = ImageParamsSchema.parse({ model: "flux" });
+
+        const derived = await deriveDimensionsFromInputImage(params);
+
+        expect(derived).toBe(params);
+    });
+});
+
+describe("CreateImageEditRequestSchema size default", () => {
+    it("leaves size undefined when the caller omits it", () => {
+        const parsed = CreateImageEditRequestSchema.parse({
+            prompt: "make it blue",
+            image: "https://example.com/source.png",
+        });
+        expect(parsed.size).toBeUndefined();
+    });
+
+    it("keeps an explicit size", () => {
+        const parsed = CreateImageEditRequestSchema.parse({
+            prompt: "make it blue",
+            image: [{ image_url: "https://example.com/source.png" }],
+            size: "1536x1024",
+        });
+        expect(parsed.size).toBe("1536x1024");
     });
 });

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -556,6 +556,13 @@ const imageNField = z
 const imageSizeField = z.string().optional().default("1024x1024").meta({
     description: "Image size as WIDTHxHEIGHT (e.g., 1024x1024, 512x512)",
 });
+// Edits deliberately have no size default: an omitted size means "preserve the
+// input image's aspect ratio", which the gateway derives from the source image.
+// A schema default of 1024x1024 would erase that signal and square every edit.
+const imageEditSizeField = z.string().optional().meta({
+    description:
+        "Image size as WIDTHxHEIGHT (e.g., 1024x1024). When omitted, the output matches the input image's aspect ratio",
+});
 const imageQualityField = z
     .enum(["standard", "hd", "low", "medium", "high"])
     .optional()
@@ -655,7 +662,7 @@ export const CreateImageEditRequestSchema = z
             }),
         model: imageModelField,
         n: imageNField,
-        size: imageSizeField,
+        size: imageEditSizeField,
         quality: imageQualityField,
         safe: SafeSchema,
     })


### PR DESCRIPTION
Fixes #12583 — references #10944.

## What this does

When `/v1/images/edits` (or any generation with an input image) is called without an explicit `size`, the gateway derives default dimensions from the source image's own proportions instead of forcing the model's square default. Implements option 2 from #10944 at the gateway level, so every edit path is covered by one mechanism.

## Why another PR for this quest

Reviewing the linked PRs, two gaps seemed worth closing:

1. **The JSON request format never triggers route-level fixes.** `CreateImageEditRequestSchema` defaults `size` to `"1024x1024"`, so on the JSON path `size` is *never* omitted by the time it reaches `handleImageEdit` — a route-level "derive when size is omitted" only fires for multipart uploads. The acceptance criteria ask for coverage of the relevant edit request formats; this PR removes the schema default for edits (generations unchanged) so both JSON and multipart behave identically, with tests for both.
2. **`dimensionsExplicit` must stay `false` for derived sizes** (as noted in the issue discussion): a size derived from the source image is still a default, not caller intent. Deriving inside the pipeline after `ImageParamsSchema` keeps the existing signal untouched, so seedream-4's custom-dimension routing and video models behave exactly as before.

## How

- `shared/schemas/openai.ts`: edits use a new `imageEditSizeField` without the `1024x1024` default. Generations keep theirs.
- `gen.pollinations.ai/src/image/params.ts`: new `deriveDimensionsFromInputImage` — probes the first input image with the existing `readImageDimensions`/`downloadUserImage` utils and scales its proportions into the model's default pixel budget (`getDefaultSideLength(model)²`), so an edit without an explicit size never costs more than today's default. Small sources keep their exact resolution (editing shouldn't upscale). Any probe failure falls back silently to the current square default — no request that works today can start failing.
- `gen.pollinations.ai/src/image/handler.ts`: applied in `generateImageOrVideoResponse` for non-video models only, before pricing input is computed. Provider-specific size constraints keep being enforced by the existing per-model snapping (gpt-image-2's 16px/3:1/4K clamps, gpt-image-1's three fixed sizes via `closestByRatio`, seedream presets, …), which already do the right thing once they receive a non-square ratio.

Explicit `size`/`width`/`height` always win (`dimensionsExplicit` short-circuits the derivation).

## Tradeoff worth flagging

For URL-sourced input images this adds one fetch at the gateway (guarded by the existing `fetchUserImage` SSRF/size limits). Data URIs — what multipart uploads become — are just decoded in memory.

## Tests

8 new cases in `test/image/params.test.ts`: portrait/landscape sources, per-model pixel budgets (flux vs seedream5), explicit-size override, unreadable-image fallback, no-image no-op, and both edit schema formats (JSON size omitted / explicit). Ran locally against current `main`:

- `vitest test/image/` — 226/226 passing
- `vitest test/index.test.ts` (includes the `/v1/images/edits` route test) — 52/52 passing
- `tsc --noEmit` clean, Biome clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)