### PR TITLE
fix: meter full Scribe input duration

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -710,6 +710,7 @@ export async function isolateVoiceWithElevenLabs(opts: {
 interface ElevenLabsTranscriptionResponse {
     text: string;
     language_code?: string;
+    audio_duration_secs?: number | null;
     words?: {
         text: string;
         start: number;
@@ -717,6 +718,46 @@ interface ElevenLabsTranscriptionResponse {
         speaker_id?: string | null;
         type?: string;
     }[];
+}
+
+const ELEVENLABS_SCRIBE_SECONDS_PER_CREDIT = 2.5;
+
+function getElevenLabsScribeMeteredInputSeconds(
+    response: Response,
+    data: ElevenLabsTranscriptionResponse,
+    log: Logger,
+): number {
+    if (
+        typeof data.audio_duration_secs === "number" &&
+        Number.isFinite(data.audio_duration_secs) &&
+        data.audio_duration_secs > 0
+    ) {
+        return data.audio_duration_secs;
+    }
+
+    // Silent transcripts omit audio_duration_secs. The provider still returns
+    // its billed character-cost meter, observed at 0.4 credits per second.
+    const rawCharacterCost = response.headers.get("character-cost");
+    const characterCost = Number(rawCharacterCost);
+    if (
+        rawCharacterCost !== null &&
+        Number.isFinite(characterCost) &&
+        characterCost >= 0
+    ) {
+        return characterCost * ELEVENLABS_SCRIBE_SECONDS_PER_CREDIT;
+    }
+
+    log.error(
+        "ElevenLabs scribe response missing valid duration metering: audioDuration={audioDuration}, characterCost={characterCost}",
+        {
+            audioDuration: data.audio_duration_secs,
+            characterCost: rawCharacterCost,
+        },
+    );
+    throw new UpstreamError(502 as ContentfulStatusCode, {
+        message:
+            "ElevenLabs transcription response did not include valid input-duration metering.",
+    });
 }
 
 interface XaiTranscriptionResponse {
@@ -917,23 +958,33 @@ export async function transcribeWithElevenLabs(opts: {
     // with no detectable speech, the words array can be empty. Treat that as
     // a successful empty transcription rather than a server error.
     const lastWord = elevenLabsData.words?.at(-1);
-    const duration = lastWord?.end ?? 0;
+    const transcriptDuration = lastWord?.end ?? 0;
     if (!lastWord) {
         log.warn(
-            "ElevenLabs scribe returned no word timestamps; billing 0s (file size={size})",
+            "ElevenLabs scribe returned no word timestamps (file size={size})",
             { size: file.size },
         );
     }
 
-    const usageHeaders = buildUsageHeaders(
-        "scribe",
-        createAudioSecondsUsage(duration),
+    const meteredInputSeconds = getElevenLabsScribeMeteredInputSeconds(
+        response,
+        elevenLabsData,
+        log,
     );
 
-    log.info("ElevenLabs transcription success: {chars} chars, {duration}s", {
-        chars: elevenLabsData.text.length,
-        duration: Math.round(duration * 10) / 10,
-    });
+    const usageHeaders = buildUsageHeaders(
+        "scribe",
+        createAudioSecondsUsage(meteredInputSeconds),
+    );
+
+    log.info(
+        "ElevenLabs transcription success: {chars} chars, transcript={transcriptDuration}s, input={inputSeconds}s",
+        {
+            chars: elevenLabsData.text.length,
+            transcriptDuration: Math.round(transcriptDuration * 10) / 10,
+            inputSeconds: Math.round(meteredInputSeconds * 10) / 10,
+        },
+    );
 
     // Scribe word/utterance values are already in seconds — normalize and
     // hand off to the shared OpenAI-compatible response formatter.
@@ -941,7 +992,7 @@ export async function transcribeWithElevenLabs(opts: {
         normalized: {
             text: elevenLabsData.text,
             language: elevenLabsData.language_code,
-            duration,
+            duration: transcriptDuration,
             words:
                 elevenLabsData.words?.map((w) => ({
                     word: w.text,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -742,7 +742,7 @@ function getElevenLabsScribeMeteredInputSeconds(
     if (
         rawCharacterCost !== null &&
         Number.isFinite(characterCost) &&
-        characterCost >= 0
+        characterCost > 0
     ) {
         return characterCost * ELEVENLABS_SCRIBE_SECONDS_PER_CREDIT;
     }

--- a/gen.pollinations.ai/test/scribe-transcription.test.ts
+++ b/gen.pollinations.ai/test/scribe-transcription.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { transcribeWithElevenLabs } from "../src/routes/audio.ts";
 
+const errorLog = vi.fn();
 const log = {
+    error: errorLog,
     info: vi.fn(),
     debug: vi.fn(),
     warn: vi.fn(),
 } as never;
 
-function jsonResponse(body: unknown): Response {
-    return Response.json(body);
+function jsonResponse(body: unknown, headers?: HeadersInit): Response {
+    return Response.json(body, { headers });
 }
 
 describe("transcribeWithElevenLabs", () => {
@@ -22,6 +24,7 @@ describe("transcribeWithElevenLabs", () => {
             jsonResponse({
                 text: "hello there general kenobi",
                 language_code: "en",
+                audio_duration_secs: 10,
                 words: [
                     {
                         text: "hello",
@@ -77,6 +80,7 @@ describe("transcribeWithElevenLabs", () => {
         const sentFormData = fetchMock.mock.calls[0][1].body as FormData;
         expect(sentFormData.get("diarize")).toBe("true");
         expect(sentFormData.get("num_speakers")).toBe("2");
+        expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("10");
 
         await expect(response.json()).resolves.toMatchObject({
             task: "transcribe",
@@ -112,6 +116,7 @@ describe("transcribeWithElevenLabs", () => {
             jsonResponse({
                 text: "hello",
                 language_code: "en",
+                audio_duration_secs: 0.5,
                 words: [{ text: "hello", start: 0, end: 0.5 }],
             }),
         );
@@ -129,5 +134,56 @@ describe("transcribeWithElevenLabs", () => {
 
         const body = (await response.json()) as Record<string, unknown>;
         expect(body).not.toHaveProperty("utterances");
+    });
+
+    it("bills silent audio from provider metering", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValueOnce(
+                jsonResponse(
+                    {
+                        text: "",
+                        language_code: "en",
+                        words: [],
+                    },
+                    { "character-cost": "4" },
+                ),
+            ),
+        );
+
+        const response = await transcribeWithElevenLabs({
+            file: new File(["silence"], "silence.wav", {
+                type: "audio/wav",
+            }),
+            apiKey: "test-key",
+            log,
+        });
+
+        expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("10");
+        await expect(response.json()).resolves.toEqual({ text: "" });
+    });
+
+    it("fails closed when provider metering is missing", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValueOnce(
+                jsonResponse({
+                    text: "hello",
+                    language_code: "en",
+                    words: [{ text: "hello", start: 0, end: 0.5 }],
+                }),
+            ),
+        );
+
+        await expect(
+            transcribeWithElevenLabs({
+                file: new File(["audio"], "audio.mp3", {
+                    type: "audio/mpeg",
+                }),
+                apiKey: "test-key",
+                log,
+            }),
+        ).rejects.toMatchObject({ status: 502 });
+        expect(errorLog).toHaveBeenCalledOnce();
     });
 });

--- a/gen.pollinations.ai/test/scribe-transcription.test.ts
+++ b/gen.pollinations.ai/test/scribe-transcription.test.ts
@@ -163,15 +163,21 @@ describe("transcribeWithElevenLabs", () => {
         await expect(response.json()).resolves.toEqual({ text: "" });
     });
 
-    it("fails closed when provider metering is missing", async () => {
+    it.each([
+        ["missing", undefined],
+        ["zero", { "character-cost": "0" }],
+    ])("fails closed when provider metering is %s", async (_, headers) => {
         vi.stubGlobal(
             "fetch",
             vi.fn().mockResolvedValueOnce(
-                jsonResponse({
-                    text: "hello",
-                    language_code: "en",
-                    words: [{ text: "hello", start: 0, end: 0.5 }],
-                }),
+                jsonResponse(
+                    {
+                        text: "hello",
+                        language_code: "en",
+                        words: [{ text: "hello", start: 0, end: 0.5 }],
+                    },
+                    headers,
+                ),
             ),
         );
 


### PR DESCRIPTION
- Bills Scribe from ElevenLabs `audio_duration_secs` instead of the final recognized word timestamp.
- Preserves successful empty transcripts by using the provider `character-cost` meter when silent audio omits duration.
- Fails closed when neither provider meter is valid.
- Leaves the public model, aliases, $0.22/hour price, paid-only access, formats, route, and transcript payloads unchanged.

Contract:
- Canonical `scribe`; aliases `scribe_v2`, `scribe-v2`
- ElevenLabs `POST /v1/speech-to-text`, model `scribe_v2`
- Multiplier 1; paid-only; no Pollinations GPU; no fallback

Evidence:
- Direct 10s speech-with-trailing-silence: `audio_duration_secs=10`, final word 3.72s.
- Direct 10s silence: no body duration, `character-cost=4`, matching the observed 0.4 credits/second meter.
- Direct silence probes at 1/2/3/5/10/11 seconds verified meter rounding.
- Full local Worker route billed 10 seconds, deducted 0.00061111 Pollen, and emitted no missing-conversion warning.
- `npx vitest run test/scribe-transcription.test.ts` — 4/4.
- `npm run typecheck` and Biome pass.

No `media.pollinations.ai` change: this endpoint intentionally remains an OpenAI-compatible multipart file upload.
