### PR TITLE
feat: add Scribe realtime transcription

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -369,6 +369,18 @@ function modelPriceFromPricing(model: ApiModelInfo): ModelPrice | null {
         };
     }
 
+    if (price.type === "realtime" && promptAudioSeconds) {
+        return {
+            ...price,
+            prices: priceLines([
+                "input",
+                "audioIn",
+                formatPrice(promptAudioSeconds, (v) => v.toFixed(5)),
+                "second",
+            ]),
+        };
+    }
+
     if (price.type === "audio") {
         // Flat per-generation models (e.g. Stable Audio): one fee per request,
         // independent of length. Show flat "/gen" In/Out audio prices instead of

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1490,6 +1490,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptAudioSeconds": 0.0000611111111111111,
     },
   },
+  "scribe-realtime": {
+    "cost": {
+      "promptAudioSeconds": 0.000108333333333333,
+    },
+    "price": {
+      "promptAudioSeconds": 0.000108333333333333,
+    },
+  },
   "seedance-2.0": {
     "cost": {
       "completionVideoSeconds": 0.18,

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -340,7 +340,9 @@ test("catalog prices expose audio second rates from registry pricing", () => {
 
     for (const modelPrice of getCatalogModelPrices()) {
         const model = sourceByName.get(modelPrice.name);
-        if (model?.category !== "audio") continue;
+        if (model?.category !== "audio" && model?.category !== "realtime") {
+            continue;
+        }
 
         const promptAudioSeconds = Number(model.pricing.promptAudioSeconds);
         const completionAudioSeconds = Number(

--- a/gen.pollinations.ai/src/docs/audio-generation.md
+++ b/gen.pollinations.ai/src/docs/audio-generation.md
@@ -7,6 +7,7 @@ Text-to-speech, music generation, and audio transcription.
 | `GET /audio/{text}` | Simple URL-based TTS or music generation |
 | `POST /v1/audio/speech` | OpenAI-compatible TTS |
 | `POST /v1/audio/transcriptions` | Speech-to-text transcription |
+| `GET /v1/audio/transcriptions/realtime` | WebSocket realtime transcription |
 
 **Audio models:** {{AUDIO_MODELS}}
 

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "@logtape/logtape";
 import { ensureUpstreamOk, UpstreamError } from "@shared/error.ts";
+import { validator } from "@shared/middleware/validator.ts";
 import {
     AUDIO_VOICES,
     type AudioModelName,
@@ -31,6 +32,7 @@ import {
     withSafetyHeaders,
 } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
+import { ScribeRealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -40,6 +42,7 @@ import {
 } from "../fallback.ts";
 import { readResponseBytes } from "../utils/response-bytes.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
+import { handleScribeRealtimeWebSocket } from "./realtime.ts";
 import {
     buildTranscriptionResponse,
     type NormalizedDiarizedSegment,
@@ -3129,6 +3132,41 @@ export const audioRoutes = new Hono<Env>()
                 }),
             );
         },
+    )
+    .get(
+        "/transcriptions/realtime",
+        describeRoute({
+            tags: ["🔊 Audio"],
+            summary: "Realtime Audio Transcription",
+            description: [
+                "Stream mono audio to Scribe v2 Realtime over WebSocket and receive partial and committed transcripts.",
+                "",
+                "Send `input_audio_chunk` JSON messages using the ElevenLabs Realtime STT protocol. Supports manual or VAD commits, language selection and detection, background filtering, and optional word timestamps.",
+                "",
+                "Authenticate with `Authorization: Bearer <key>`, or use `?key=pk_...` in browser WebSocket clients. Billing uses the streamed audio duration and is settled when the socket closes.",
+            ].join("\n"),
+            responses: {
+                101: {
+                    description: "WebSocket connection established",
+                },
+                ...errorResponseDescriptions(
+                    400,
+                    401,
+                    402,
+                    403,
+                    426,
+                    429,
+                    500,
+                    503,
+                ),
+            },
+        }),
+        validator("query", ScribeRealtimeRequestQueryParamsSchema),
+        resolveModel("generate.realtime", {
+            defaultModel: "scribe-realtime",
+            supportedEndpoint: "/v1/audio/transcriptions/realtime",
+        }),
+        handleScribeRealtimeWebSocket,
     )
     .post(
         "/transcriptions",

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -6,11 +6,11 @@ import {
     getVideoModelIds,
     IMAGE_SERVICES,
 } from "@shared/registry/image.ts";
+import { getModel3dModelsInfo } from "@shared/registry/model-info.ts";
 import {
-    getModel3dModelsInfo,
-    getRealtimeModelsInfo,
-} from "@shared/registry/model-info.ts";
-import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
+    DEFAULT_REALTIME_MODEL,
+    REALTIME_VOICE_MODEL_NAMES,
+} from "@shared/registry/realtime.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -221,9 +221,7 @@ const videoModelDisplayNames = getVideoModelIds().join(", ");
 const textModelDisplayNames = Object.keys(TEXT_SERVICES).join(", ");
 const audioModelDisplayNames = Object.keys(AUDIO_SERVICES).join(", ");
 const embeddingModelDisplayNames = Object.keys(EMBEDDING_SERVICES).join(", ");
-const realtimeModelDisplayNames = getRealtimeModelsInfo()
-    .map((model) => model.name)
-    .join(", ");
+const realtimeModelDisplayNames = REALTIME_VOICE_MODEL_NAMES.join(", ");
 const model3dModelDisplayNames = getModel3dModelsInfo()
     .map((model) => model.name)
     .join(", ");

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -40,7 +40,7 @@ import {
 } from "@shared/registry/model3d.ts";
 import {
     DEFAULT_REALTIME_MODEL,
-    OPENAI_REALTIME_MODEL_NAMES,
+    REALTIME_VOICE_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import {
     type CreateChatCompletionRequest,
@@ -562,7 +562,7 @@ export const proxyRoutes = new Hono<Env>()
                 `Connect with \`wss://gen.pollinations.ai/v1/realtime?model=${DEFAULT_REALTIME_MODEL}\` and send/receive Realtime JSON events over the socket.`,
                 "Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.",
                 "",
-                `**Models:** ${OPENAI_REALTIME_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
+                `**Models:** ${REALTIME_VOICE_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
                 "",
                 "**Billing:** requires a positive balance. Gen proxies the WebSocket, aggregates observed `response.done` usage, and deducts one session total when the socket closes. Input transcription sessions are not supported yet.",
             ].join("\n"),

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -40,7 +40,7 @@ import {
 } from "@shared/registry/model3d.ts";
 import {
     DEFAULT_REALTIME_MODEL,
-    REALTIME_MODEL_NAMES,
+    OPENAI_REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import {
     type CreateChatCompletionRequest,
@@ -562,7 +562,7 @@ export const proxyRoutes = new Hono<Env>()
                 `Connect with \`wss://gen.pollinations.ai/v1/realtime?model=${DEFAULT_REALTIME_MODEL}\` and send/receive Realtime JSON events over the socket.`,
                 "Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.",
                 "",
-                `**Models:** ${REALTIME_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
+                `**Models:** ${OPENAI_REALTIME_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
                 "",
                 "**Billing:** requires a positive balance. Gen proxies the WebSocket, aggregates observed `response.done` usage, and deducts one session total when the socket closes. Input transcription sessions are not supported yet.",
             ].join("\n"),

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -361,12 +361,16 @@ function inspectScribeInput(
         };
     }
 
-    let byteLength: number;
-    try {
-        byteLength = atob(event.audio_base_64).length;
-    } catch {
+    const base64 = event.audio_base_64;
+    if (
+        !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$/.test(
+            base64,
+        )
+    ) {
         return { error: "input_audio_chunk audio_base_64 is invalid." };
     }
+    const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+    const byteLength = Math.floor((base64.length * 3) / 4) - padding;
     if (audioFormat !== "ulaw_8000" && byteLength % 2 !== 0) {
         return {
             error: "PCM audio chunks must contain complete 16-bit samples.",

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -12,7 +12,6 @@ import {
 } from "@shared/client-ip.ts";
 import { sendToTinybird } from "@shared/events.ts";
 import { redactCredentialQueryParams } from "@shared/observability/request-inputs.ts";
-import type { RealtimeModelName } from "@shared/registry/realtime.ts";
 import {
     type BillingAdjustment,
     type CostDefinition,
@@ -47,15 +46,11 @@ import { checkBalance } from "@/utils/generation-access.ts";
 type AzureRealtimeApiKey =
     | "AZURE_MYCELI_PROD_EASTUS2_API_KEY"
     | "AZURE_MYCELI_PROD_SWEDEN_API_KEY";
-type AzureRealtimeModelName = Exclude<RealtimeModelName, "scribe-realtime">;
 
 // Deployment names are independent of the public model ids. Mini is in East
 // US 2 because Azure's Sweden Central control plane accepts the deployment but
 // its Realtime data plane currently rejects the exact model.
-const REALTIME_ROUTES: Record<
-    AzureRealtimeModelName,
-    { endpoint: string; deployment: string; apiKeyEnv: AzureRealtimeApiKey }
-> = {
+const REALTIME_ROUTES = {
     "gpt-realtime-2.1": {
         endpoint:
             "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime",
@@ -74,7 +69,11 @@ const REALTIME_ROUTES: Record<
         deployment: "gpt-realtime-2",
         apiKeyEnv: "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
     },
-};
+} satisfies Record<
+    string,
+    { endpoint: string; deployment: string; apiKeyEnv: AzureRealtimeApiKey }
+>;
+type AzureRealtimeModelName = keyof typeof REALTIME_ROUTES;
 const UNSUPPORTED_TRANSCRIPTION_MESSAGE =
     "Realtime input transcription is not supported yet.";
 type WebSocketResponse = Response & { webSocket?: WebSocket };
@@ -249,7 +248,6 @@ async function connectScribeRealtime(
     const upstreamSocket = response.webSocket;
     if (upstreamSocket) {
         upstreamSocket.binaryType = "arraybuffer";
-        upstreamSocket.accept({ allowHalfOpen: true });
         return upstreamSocket;
     }
 
@@ -275,7 +273,13 @@ function isClosable(socket: WebSocket): boolean {
 }
 
 function normalizeCloseCode(code?: number): number | undefined {
-    if (!code || code === 1005 || code === 1006 || code === 1015) {
+    if (
+        !code ||
+        code === 1004 ||
+        code === 1005 ||
+        code === 1006 ||
+        code === 1015
+    ) {
         return undefined;
     }
     if (code < 1000 || code > 4999) return undefined;
@@ -392,6 +396,54 @@ function forwardScribeInput(
             promptAudioSeconds: inspected.audioSeconds,
         });
         target.send(event.data);
+    });
+}
+
+const SCRIBE_ERROR_MESSAGE_TYPES = new Set([
+    "auth_error",
+    "chunk_size_exceeded",
+    "commit_throttled",
+    "insufficient_audio_activity",
+    "invalid_request",
+    "queue_overflow",
+    "quota_exceeded",
+    "rate_limited",
+    "transcriber_error",
+    "unaccepted_terms",
+]);
+
+function forwardScribeOutput(
+    c: Context<Env>,
+    source: WebSocket,
+    target: WebSocket,
+    tracking: RealtimeBillingContext,
+): void {
+    const log = c.get("log").getChild("realtime");
+    source.addEventListener("message", (event) => {
+        const providerEvent = asRecord(parseEventData(event.data));
+        const messageType = providerEvent.message_type;
+        if (
+            typeof messageType !== "string" ||
+            !SCRIBE_ERROR_MESSAGE_TYPES.has(messageType)
+        ) {
+            if (isOpen(target)) target.send(event.data);
+            return;
+        }
+
+        log.warn("Scribe realtime provider error: type={type}", {
+            type: messageType,
+        });
+        if (isOpen(target)) {
+            target.send(
+                JSON.stringify({
+                    message_type: messageType,
+                    error: "Realtime transcription failed.",
+                }),
+            );
+        }
+        closeSocket(source, 1011, "Realtime transcription failed");
+        closeSocket(target, 1011, "Realtime transcription failed");
+        scheduleRealtimeSettlement(c, tracking);
     });
 }
 
@@ -818,18 +870,24 @@ function wireScribeClose(
     tracking: RealtimeBillingContext,
 ): void {
     source.addEventListener("close", (event) => {
-        closeSocket(target, event.code, event.reason);
-        if (source.readyState !== WebSocket.CLOSED) {
-            const closeCode = normalizeCloseCode(event.code);
-            if (closeCode) source.close(closeCode, event.reason);
-            else source.close();
+        try {
+            closeSocket(target, event.code, event.reason);
+            if (source.readyState !== WebSocket.CLOSED) {
+                const closeCode = normalizeCloseCode(event.code);
+                if (closeCode) source.close(closeCode, event.reason);
+                else source.close();
+            }
+        } finally {
+            scheduleRealtimeSettlement(c, tracking);
         }
-        scheduleRealtimeSettlement(c, tracking);
     });
     source.addEventListener("error", () => {
-        closeSocket(target, 1011, "Realtime proxy error");
-        closeSocket(source, 1011, "Realtime proxy error");
-        scheduleRealtimeSettlement(c, tracking);
+        try {
+            closeSocket(target, 1011, "Realtime proxy error");
+            closeSocket(source, 1011, "Realtime proxy error");
+        } finally {
+            scheduleRealtimeSettlement(c, tracking);
+        }
     });
 }
 
@@ -870,12 +928,12 @@ function proxyScribeRealtimeWebSockets(
     const [client, downstream] = Object.values(pair) as [WebSocket, WebSocket];
 
     downstream.binaryType = "arraybuffer";
-    downstream.accept({ allowHalfOpen: true });
-
     forwardScribeInput(c, downstream, upstream, audioFormat, tracking);
-    forwardMessage(upstream, downstream);
+    forwardScribeOutput(c, upstream, downstream, tracking);
     wireScribeClose(c, downstream, upstream, tracking);
     wireScribeClose(c, upstream, downstream, tracking);
+    downstream.accept({ allowHalfOpen: true });
+    upstream.accept({ allowHalfOpen: true });
 
     return new Response(null, {
         status: 101,
@@ -988,13 +1046,14 @@ export async function handleScribeRealtimeWebSocket(
     const query = c.req.valid(
         "query" as never,
     ) as ScribeRealtimeRequestQueryParams;
+    const tracking = await createRealtimeBillingContext(c);
     const upstream = await connectScribeRealtime(c, query);
     if (upstream instanceof Response) return upstream;
 
     return proxyScribeRealtimeWebSockets(
         c,
         upstream,
-        await createRealtimeBillingContext(c),
+        tracking,
         query.audio_format,
     );
 }

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -36,19 +36,24 @@ import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
 import { reduceAdjustmentsToEventFields } from "@/middleware/track.ts";
-import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
+import {
+    RealtimeUsageSchema,
+    type ScribeRealtimeAudioFormat,
+    type ScribeRealtimeRequestQueryParams,
+} from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
 
 type AzureRealtimeApiKey =
     | "AZURE_MYCELI_PROD_EASTUS2_API_KEY"
     | "AZURE_MYCELI_PROD_SWEDEN_API_KEY";
+type AzureRealtimeModelName = Exclude<RealtimeModelName, "scribe-realtime">;
 
 // Deployment names are independent of the public model ids. Mini is in East
 // US 2 because Azure's Sweden Central control plane accepts the deployment but
 // its Realtime data plane currently rejects the exact model.
 const REALTIME_ROUTES: Record<
-    RealtimeModelName,
+    AzureRealtimeModelName,
     { endpoint: string; deployment: string; apiKeyEnv: AzureRealtimeApiKey }
 > = {
     "gpt-realtime-2.1": {
@@ -131,7 +136,7 @@ async function createSafetyIdentifier(
     return bytesToHex(await crypto.subtle.digest("SHA-256", data));
 }
 
-function buildUpstreamUrl(model: RealtimeModelName): string {
+function buildUpstreamUrl(model: AzureRealtimeModelName): string {
     const route = REALTIME_ROUTES[model];
     const upstreamUrl = new URL(route.endpoint);
     upstreamUrl.searchParams.set("model", route.deployment);
@@ -141,7 +146,7 @@ function buildUpstreamUrl(model: RealtimeModelName): string {
 async function connectAzureRealtime(
     c: Context<Env>,
     userId: string,
-    model: RealtimeModelName,
+    model: AzureRealtimeModelName,
 ): Promise<WebSocket | Response> {
     const route = REALTIME_ROUTES[model];
     const apiKey = c.env[route.apiKeyEnv];
@@ -162,6 +167,85 @@ async function connectAzureRealtime(
         },
     })) as WebSocketResponse;
 
+    const upstreamSocket = response.webSocket;
+    if (upstreamSocket) {
+        upstreamSocket.binaryType = "arraybuffer";
+        upstreamSocket.accept({ allowHalfOpen: true });
+        return upstreamSocket;
+    }
+
+    return new Response(await response.text(), {
+        status: response.status,
+        headers: {
+            "Content-Type":
+                response.headers.get("Content-Type") || "application/json",
+            "Cache-Control": "no-store",
+        },
+    });
+}
+
+const SCRIBE_REALTIME_ENDPOINT =
+    "https://api.elevenlabs.io/v1/speech-to-text/realtime";
+
+const SCRIBE_AUDIO_FORMAT = {
+    pcm_8000: { sampleRate: 8000, bytesPerSecond: 16_000 },
+    pcm_16000: { sampleRate: 16_000, bytesPerSecond: 32_000 },
+    pcm_22050: { sampleRate: 22_050, bytesPerSecond: 44_100 },
+    pcm_24000: { sampleRate: 24_000, bytesPerSecond: 48_000 },
+    pcm_44100: { sampleRate: 44_100, bytesPerSecond: 88_200 },
+    pcm_48000: { sampleRate: 48_000, bytesPerSecond: 96_000 },
+    ulaw_8000: { sampleRate: 8000, bytesPerSecond: 8000 },
+} satisfies Record<
+    ScribeRealtimeAudioFormat,
+    { sampleRate: number; bytesPerSecond: number }
+>;
+
+function buildScribeRealtimeUrl(
+    query: ScribeRealtimeRequestQueryParams,
+): string {
+    const url = new URL(SCRIBE_REALTIME_ENDPOINT);
+    url.searchParams.set("model_id", "scribe_v2_realtime");
+    url.searchParams.set("audio_format", query.audio_format);
+    url.searchParams.set("commit_strategy", query.commit_strategy);
+
+    for (const field of [
+        "language_code",
+        "vad_threshold",
+        "vad_silence_threshold_secs",
+        "min_speech_duration_ms",
+        "min_silence_duration_ms",
+    ] as const) {
+        const value = query[field];
+        if (value !== undefined) url.searchParams.set(field, String(value));
+    }
+    for (const field of [
+        "include_timestamps",
+        "include_language_detection",
+        "no_verbatim",
+        "filter_background_audio",
+    ] as const) {
+        if (query[field]) url.searchParams.set(field, "true");
+    }
+    return url.toString();
+}
+
+async function connectScribeRealtime(
+    c: Context<Env>,
+    query: ScribeRealtimeRequestQueryParams,
+): Promise<WebSocket | Response> {
+    const apiKey = c.env.ELEVENLABS_API_KEY;
+    if (!apiKey) {
+        throw new HTTPException(503, {
+            message: "ElevenLabs realtime provider is not configured.",
+        });
+    }
+
+    const response = (await fetch(buildScribeRealtimeUrl(query), {
+        headers: {
+            "xi-api-key": apiKey,
+            Upgrade: "websocket",
+        },
+    })) as WebSocketResponse;
     const upstreamSocket = response.webSocket;
     if (upstreamSocket) {
         upstreamSocket.binaryType = "arraybuffer";
@@ -223,6 +307,91 @@ function forwardMessage(
             return;
         }
         if (isOpen(target)) target.send(event.data);
+    });
+}
+
+function inspectScribeInput(
+    data: unknown,
+    audioFormat: ScribeRealtimeAudioFormat,
+): { audioSeconds: number } | { error: string } {
+    if (typeof data !== "string") {
+        return { error: "Scribe realtime expects JSON text messages." };
+    }
+
+    let event: Record<string, unknown>;
+    try {
+        const parsed = JSON.parse(data);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return { error: "Scribe realtime expects a JSON object." };
+        }
+        event = parsed as Record<string, unknown>;
+    } catch {
+        return { error: "Scribe realtime received malformed JSON." };
+    }
+
+    if (event.message_type !== "input_audio_chunk") {
+        return {
+            error: "Scribe realtime accepts only input_audio_chunk messages.",
+        };
+    }
+    if (typeof event.audio_base_64 !== "string") {
+        return { error: "input_audio_chunk requires audio_base_64." };
+    }
+    if (event.commit !== undefined && typeof event.commit !== "boolean") {
+        return { error: "input_audio_chunk commit must be a boolean." };
+    }
+    if (
+        event.previous_text !== undefined &&
+        typeof event.previous_text !== "string"
+    ) {
+        return { error: "input_audio_chunk previous_text must be a string." };
+    }
+
+    const format = SCRIBE_AUDIO_FORMAT[audioFormat];
+    if (
+        event.sample_rate !== undefined &&
+        event.sample_rate !== format.sampleRate
+    ) {
+        return {
+            error: `input_audio_chunk sample_rate must be ${format.sampleRate} for ${audioFormat}.`,
+        };
+    }
+
+    let byteLength: number;
+    try {
+        byteLength = atob(event.audio_base_64).length;
+    } catch {
+        return { error: "input_audio_chunk audio_base_64 is invalid." };
+    }
+    if (audioFormat !== "ulaw_8000" && byteLength % 2 !== 0) {
+        return {
+            error: "PCM audio chunks must contain complete 16-bit samples.",
+        };
+    }
+
+    return { audioSeconds: byteLength / format.bytesPerSecond };
+}
+
+function forwardScribeInput(
+    c: Context<Env>,
+    source: WebSocket,
+    target: WebSocket,
+    audioFormat: ScribeRealtimeAudioFormat,
+    tracking: RealtimeBillingContext,
+): void {
+    source.addEventListener("message", (event) => {
+        const inspected = inspectScribeInput(event.data, audioFormat);
+        if ("error" in inspected) {
+            closeSocket(source, 1008, inspected.error);
+            closeSocket(target, 1008, inspected.error);
+            scheduleRealtimeSettlement(c, tracking);
+            return;
+        }
+        if (!isOpen(target)) return;
+        addUsage(tracking.usage, {
+            promptAudioSeconds: inspected.audioSeconds,
+        });
+        target.send(event.data);
     });
 }
 
@@ -642,6 +811,28 @@ function wireClose(
     });
 }
 
+function wireScribeClose(
+    c: Context<Env>,
+    source: WebSocket,
+    target: WebSocket,
+    tracking: RealtimeBillingContext,
+): void {
+    source.addEventListener("close", (event) => {
+        closeSocket(target, event.code, event.reason);
+        if (source.readyState !== WebSocket.CLOSED) {
+            const closeCode = normalizeCloseCode(event.code);
+            if (closeCode) source.close(closeCode, event.reason);
+            else source.close();
+        }
+        scheduleRealtimeSettlement(c, tracking);
+    });
+    source.addEventListener("error", () => {
+        closeSocket(target, 1011, "Realtime proxy error");
+        closeSocket(source, 1011, "Realtime proxy error");
+        scheduleRealtimeSettlement(c, tracking);
+    });
+}
+
 function proxyRealtimeWebSockets(
     c: Context<Env>,
     upstream: WebSocket,
@@ -662,6 +853,29 @@ function proxyRealtimeWebSockets(
     );
     wireClose(c, downstream, upstream, tracking);
     wireClose(c, upstream, downstream, tracking);
+
+    return new Response(null, {
+        status: 101,
+        webSocket: client,
+    } as WebSocketResponseInit);
+}
+
+function proxyScribeRealtimeWebSockets(
+    c: Context<Env>,
+    upstream: WebSocket,
+    tracking: RealtimeBillingContext,
+    audioFormat: ScribeRealtimeAudioFormat,
+): Response {
+    const pair = new WebSocketPair();
+    const [client, downstream] = Object.values(pair) as [WebSocket, WebSocket];
+
+    downstream.binaryType = "arraybuffer";
+    downstream.accept({ allowHalfOpen: true });
+
+    forwardScribeInput(c, downstream, upstream, audioFormat, tracking);
+    forwardMessage(upstream, downstream);
+    wireScribeClose(c, downstream, upstream, tracking);
+    wireScribeClose(c, upstream, downstream, tracking);
 
     return new Response(null, {
         status: 101,
@@ -725,13 +939,7 @@ async function createRealtimeBillingContext(
     };
 }
 
-export async function handleRealtimeWebSocket(
-    c: Context<Env>,
-): Promise<Response> {
-    if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
-        return new Response("Expected Upgrade: websocket", { status: 426 });
-    }
-
+async function authorizeRealtimeSession(c: Context<Env>): Promise<string> {
     await c.var.auth.requireAuthorization({
         message:
             "Realtime WebSocket requires a Pollinations API key in the Authorization header or key query parameter.",
@@ -745,11 +953,21 @@ export async function handleRealtimeWebSocket(
     // generation route (tier or pack balance, paidOnly handled by the resolved
     // model definition). checkBalance reads c.var.model.
     await checkBalance(c.var, c.env);
+    return user.id;
+}
+
+export async function handleRealtimeWebSocket(
+    c: Context<Env>,
+): Promise<Response> {
+    if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected Upgrade: websocket", { status: 426 });
+    }
+    const userId = await authorizeRealtimeSession(c);
 
     const upstream = await connectAzureRealtime(
         c,
-        user.id,
-        c.var.model.resolved as RealtimeModelName,
+        userId,
+        c.var.model.resolved as AzureRealtimeModelName,
     );
     if (upstream instanceof Response) return upstream;
 
@@ -757,5 +975,26 @@ export async function handleRealtimeWebSocket(
         c,
         upstream,
         await createRealtimeBillingContext(c),
+    );
+}
+
+export async function handleScribeRealtimeWebSocket(
+    c: Context<Env>,
+): Promise<Response> {
+    if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected Upgrade: websocket", { status: 426 });
+    }
+    await authorizeRealtimeSession(c);
+    const query = c.req.valid(
+        "query" as never,
+    ) as ScribeRealtimeRequestQueryParams;
+    const upstream = await connectScribeRealtime(c, query);
+    if (upstream instanceof Response) return upstream;
+
+    return proxyScribeRealtimeWebSockets(
+        c,
+        upstream,
+        await createRealtimeBillingContext(c),
+        query.audio_format,
     );
 }

--- a/gen.pollinations.ai/src/schemas/realtime.ts
+++ b/gen.pollinations.ai/src/schemas/realtime.ts
@@ -1,23 +1,35 @@
 import {
     DEFAULT_REALTIME_MODEL,
-    OPENAI_REALTIME_MODEL_NAMES,
+    REALTIME_VOICE_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import { z } from "zod";
 import { parseBooleanLike } from "@/util.ts";
 
-const BooleanQueryParamSchema = z.preprocess(
-    (value) => parseBooleanLike(value) ?? value,
+const StrictBooleanQueryParamSchema = z.preprocess(
+    (value) =>
+        typeof value === "string" && value.trim() === ""
+            ? value
+            : (parseBooleanLike(value) ?? value),
     z.boolean(),
 );
+
+const numberQueryParam = (schema: z.ZodType<number>) =>
+    z.preprocess(
+        (value) =>
+            typeof value === "string" && value.trim() === ""
+                ? Number.NaN
+                : value,
+        schema,
+    );
 
 export const RealtimeRequestQueryParamsSchema = z
     .object({
         model: z
-            .enum(OPENAI_REALTIME_MODEL_NAMES as [string, ...string[]])
+            .enum(REALTIME_VOICE_MODEL_NAMES as [string, ...string[]])
             .optional()
             .default(DEFAULT_REALTIME_MODEL)
             .meta({
-                description: `Realtime model to use. Supported models: ${OPENAI_REALTIME_MODEL_NAMES.join(", ")}.`,
+                description: `Realtime model to use. Supported models: ${REALTIME_VOICE_MODEL_NAMES.join(", ")}.`,
             }),
         key: z.string().optional().meta({
             description:
@@ -30,7 +42,7 @@ export type RealtimeRequestQueryParams = z.infer<
     typeof RealtimeRequestQueryParamsSchema
 >;
 
-export const SCRIBE_REALTIME_AUDIO_FORMATS = [
+const SCRIBE_REALTIME_AUDIO_FORMATS = [
     "pcm_8000",
     "pcm_16000",
     "pcm_22050",
@@ -59,24 +71,25 @@ export const ScribeRealtimeRequestQueryParamsSchema = z
             .default("pcm_16000"),
         language_code: z.string().min(2).max(3).optional(),
         commit_strategy: z.enum(["manual", "vad"]).optional().default("manual"),
-        vad_threshold: z.coerce.number().min(0).max(1).optional(),
-        vad_silence_threshold_secs: z.coerce.number().positive().optional(),
-        min_speech_duration_ms: z.coerce
-            .number()
-            .int()
-            .nonnegative()
-            .optional(),
-        min_silence_duration_ms: z.coerce
-            .number()
-            .int()
-            .nonnegative()
-            .optional(),
-        include_timestamps: BooleanQueryParamSchema.optional().default(false),
+        vad_threshold: numberQueryParam(
+            z.coerce.number().min(0).max(1),
+        ).optional(),
+        vad_silence_threshold_secs: numberQueryParam(
+            z.coerce.number().positive(),
+        ).optional(),
+        min_speech_duration_ms: numberQueryParam(
+            z.coerce.number().int().nonnegative(),
+        ).optional(),
+        min_silence_duration_ms: numberQueryParam(
+            z.coerce.number().int().nonnegative(),
+        ).optional(),
+        include_timestamps:
+            StrictBooleanQueryParamSchema.optional().default(false),
         include_language_detection:
-            BooleanQueryParamSchema.optional().default(false),
-        no_verbatim: BooleanQueryParamSchema.optional().default(false),
+            StrictBooleanQueryParamSchema.optional().default(false),
+        no_verbatim: StrictBooleanQueryParamSchema.optional().default(false),
         filter_background_audio:
-            BooleanQueryParamSchema.optional().default(false),
+            StrictBooleanQueryParamSchema.optional().default(false),
     })
     .strict()
     .refine(

--- a/gen.pollinations.ai/src/schemas/realtime.ts
+++ b/gen.pollinations.ai/src/schemas/realtime.ts
@@ -1,17 +1,23 @@
 import {
     DEFAULT_REALTIME_MODEL,
-    REALTIME_MODEL_NAMES,
+    OPENAI_REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import { z } from "zod";
+import { parseBooleanLike } from "@/util.ts";
+
+const BooleanQueryParamSchema = z.preprocess(
+    (value) => parseBooleanLike(value) ?? value,
+    z.boolean(),
+);
 
 export const RealtimeRequestQueryParamsSchema = z
     .object({
         model: z
-            .enum(REALTIME_MODEL_NAMES as [string, ...string[]])
+            .enum(OPENAI_REALTIME_MODEL_NAMES as [string, ...string[]])
             .optional()
             .default(DEFAULT_REALTIME_MODEL)
             .meta({
-                description: `Realtime model to use. Supported models: ${REALTIME_MODEL_NAMES.join(", ")}.`,
+                description: `Realtime model to use. Supported models: ${OPENAI_REALTIME_MODEL_NAMES.join(", ")}.`,
             }),
         key: z.string().optional().meta({
             description:
@@ -22,6 +28,68 @@ export const RealtimeRequestQueryParamsSchema = z
 
 export type RealtimeRequestQueryParams = z.infer<
     typeof RealtimeRequestQueryParamsSchema
+>;
+
+export const SCRIBE_REALTIME_AUDIO_FORMATS = [
+    "pcm_8000",
+    "pcm_16000",
+    "pcm_22050",
+    "pcm_24000",
+    "pcm_44100",
+    "pcm_48000",
+    "ulaw_8000",
+] as const;
+
+export type ScribeRealtimeAudioFormat =
+    (typeof SCRIBE_REALTIME_AUDIO_FORMATS)[number];
+
+export const ScribeRealtimeRequestQueryParamsSchema = z
+    .object({
+        model: z
+            .literal("scribe-realtime")
+            .optional()
+            .default("scribe-realtime"),
+        key: z.string().optional().meta({
+            description:
+                "Pollinations API key for browser WebSocket clients that cannot set custom Authorization headers.",
+        }),
+        audio_format: z
+            .enum(SCRIBE_REALTIME_AUDIO_FORMATS)
+            .optional()
+            .default("pcm_16000"),
+        language_code: z.string().min(2).max(3).optional(),
+        commit_strategy: z.enum(["manual", "vad"]).optional().default("manual"),
+        vad_threshold: z.coerce.number().min(0).max(1).optional(),
+        vad_silence_threshold_secs: z.coerce.number().positive().optional(),
+        min_speech_duration_ms: z.coerce
+            .number()
+            .int()
+            .nonnegative()
+            .optional(),
+        min_silence_duration_ms: z.coerce
+            .number()
+            .int()
+            .nonnegative()
+            .optional(),
+        include_timestamps: BooleanQueryParamSchema.optional().default(false),
+        include_language_detection:
+            BooleanQueryParamSchema.optional().default(false),
+        no_verbatim: BooleanQueryParamSchema.optional().default(false),
+        filter_background_audio:
+            BooleanQueryParamSchema.optional().default(false),
+    })
+    .strict()
+    .refine(
+        (query) => !(query.filter_background_audio && query.include_timestamps),
+        {
+            message:
+                "filter_background_audio cannot be combined with include_timestamps",
+            path: ["filter_background_audio"],
+        },
+    );
+
+export type ScribeRealtimeRequestQueryParams = z.infer<
+    typeof ScribeRealtimeRequestQueryParamsSchema
 >;
 
 // Shape of `response.usage` in the Realtime `response.done` event. Only the

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -136,6 +136,7 @@ describe("docs routes", () => {
         ]);
         expect(schema.paths["/v1/chat/completions"]).toBeDefined();
         expect(schema.paths["/v1/realtime"]).toBeDefined();
+        expect(schema.paths["/v1/audio/transcriptions/realtime"]).toBeDefined();
         expect(schema.paths["/image/{prompt}"]).toBeDefined();
         const model3dPost = (
             schema.paths["/3d/{prompt}"] as Record<string, unknown>
@@ -230,6 +231,18 @@ describe("docs routes", () => {
             | undefined;
         expect(realtimeResponses?.["426"]).toBeDefined();
         expect(realtimeResponses?.["503"]).toBeDefined();
+
+        const scribeRealtimeGet = (
+            schema.paths["/v1/audio/transcriptions/realtime"] as Record<
+                string,
+                unknown
+            >
+        )?.get as Record<string, unknown> | undefined;
+        const scribeRealtimeResponses = scribeRealtimeGet?.responses as
+            | Record<string, unknown>
+            | undefined;
+        expect(scribeRealtimeResponses?.["426"]).toBeDefined();
+        expect(scribeRealtimeResponses?.["503"]).toBeDefined();
 
         const accountKeyGet = (
             schema.paths["/account/key"] as Record<string, unknown>

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -369,6 +369,14 @@ describe("docs routes", () => {
         // Stable heading marker proves the realtime modality is composed into
         // the api section, without pinning volatile mid-prose wording.
         expect(apiBody).toContain("## Realtime Voice");
+        const realtimeSection = apiBody.slice(
+            apiBody.indexOf("## Realtime Voice"),
+            apiBody.indexOf("## 3D Generation"),
+        );
+        expect(realtimeSection).not.toContain("scribe-realtime");
+        expect(apiBody).toContain(
+            "`GET /v1/audio/transcriptions/realtime` | WebSocket realtime transcription",
+        );
         expect(apiBody).not.toContain("## BYOP");
 
         const byopRes = await worker.fetch(

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -4,6 +4,7 @@ import {
     waitOnExecutionContext,
 } from "cloudflare:test";
 import { getLogger } from "@logtape/logtape";
+import { roundPollenLedgerAmount } from "@shared/billing/precision.ts";
 import { user as userTable } from "@shared/db/better-auth.ts";
 import { createTestApiKey, test } from "@shared/test/fixtures/index.ts";
 import { eq } from "drizzle-orm";
@@ -18,22 +19,35 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-async function fetchWorker(path: string, init: RequestInit = {}) {
+const scribeTestEnv = {
+    ...env,
+    ELEVENLABS_API_KEY: "test-eleven-key",
+};
+
+async function fetchWorker(
+    path: string,
+    init: RequestInit = {},
+    bindings = env,
+) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        bindings,
         ctx,
     );
     await waitOnExecutionContext(ctx);
     return response;
 }
 
-async function fetchWorkerWithContext(path: string, init: RequestInit = {}) {
+async function fetchWorkerWithContext(
+    path: string,
+    init: RequestInit = {},
+    bindings = env,
+) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        bindings,
         ctx,
     );
     return { response: response as WebSocketResponse, ctx };
@@ -55,7 +69,11 @@ function nextClose(socket: WebSocket): Promise<CloseEvent> {
     });
 }
 
-function mockOpenAIRealtime() {
+function zeroAudioBase64(byteLength: number): string {
+    return btoa("\0".repeat(byteLength));
+}
+
+function mockRealtimeProvider() {
     let upstreamRequest: Request | undefined;
     let upstreamServer: WebSocket | undefined;
     const tinybirdRequests: Request[] = [];
@@ -128,7 +146,7 @@ async function waitForPackBalanceBelow(userId: string, maxBalance: number) {
 }
 
 async function waitForTinybirdRequests(
-    upstream: ReturnType<typeof mockOpenAIRealtime>,
+    upstream: ReturnType<typeof mockRealtimeProvider>,
     count = 1,
 ) {
     for (let attempt = 0; attempt < 20; attempt++) {
@@ -151,7 +169,7 @@ async function openPaidRealtimeSession({
         pollenBudget: 1,
         user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockOpenAIRealtime();
+    const upstream = mockRealtimeProvider();
     const headers: Record<string, string> = {
         Authorization: `Bearer ${key}`,
         Upgrade: "websocket",
@@ -161,6 +179,39 @@ async function openPaidRealtimeSession({
     const { response, ctx } = await fetchWorkerWithContext(
         `/v1/realtime?model=${model}`,
         { headers },
+    );
+
+    expect(response.status).toBe(101);
+    const client = response.webSocket;
+    if (!client) throw new Error("Expected downstream WebSocket");
+    client.accept();
+    upstream.server.accept();
+
+    return { client, ctx, upstream, userId };
+}
+
+async function openPaidScribeSession({
+    name,
+    query = "",
+}: {
+    name: string;
+    query?: string;
+}) {
+    const { key, userId } = await createTestApiKey({
+        name,
+        pollenBudget: 1,
+        user: { tierBalance: 0, packBalance: 1 },
+    });
+    const upstream = mockRealtimeProvider();
+    const { response, ctx } = await fetchWorkerWithContext(
+        `/v1/audio/transcriptions/realtime?${query}`,
+        {
+            headers: {
+                Authorization: `Bearer ${key}`,
+                Upgrade: "websocket",
+            },
+        },
+        scribeTestEnv,
     );
 
     expect(response.status).toBe(101);
@@ -218,7 +269,7 @@ async function expectClientEventRejected(
     paidApiKey: string,
     event: unknown,
 ): Promise<void> {
-    const upstream = mockOpenAIRealtime();
+    const upstream = mockRealtimeProvider();
 
     const { response, ctx } = await fetchWorkerWithContext(
         "/v1/realtime?model=gpt-realtime-2",
@@ -255,7 +306,7 @@ async function expectClientEventRejected(
 test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
     paidApiKey,
 }) => {
-    const upstream = mockOpenAIRealtime();
+    const upstream = mockRealtimeProvider();
 
     const { response, ctx } = await fetchWorkerWithContext("/v1/realtime", {
         headers: {
@@ -307,7 +358,7 @@ test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
 test("routes the mini model through the working East US 2 deployment", async ({
     paidApiKey,
 }) => {
-    const upstream = mockOpenAIRealtime();
+    const upstream = mockRealtimeProvider();
 
     const { response, ctx } = await fetchWorkerWithContext(
         "/v1/realtime?model=gpt-realtime-2.1-mini",
@@ -339,7 +390,7 @@ test("accepts publishable keys through the query string for thin clients", async
         pollenBudget: 10,
         user: { packBalance: 10 },
     });
-    const upstream = mockOpenAIRealtime();
+    const upstream = mockRealtimeProvider();
 
     const { response, ctx } = await fetchWorkerWithContext(
         `/v1/realtime?model=gpt-realtime-2&key=${encodeURIComponent(key)}`,
@@ -354,6 +405,225 @@ test("accepts publishable keys through the query string for thin clients", async
     response.webSocket?.close();
     upstream.server.close();
     await waitOnExecutionContext(ctx);
+});
+
+test("proxies Scribe Realtime parameters without forwarding caller credentials", async () => {
+    const session = await openPaidScribeSession({
+        name: "scribe-realtime-parameters-key",
+        query: [
+            "model=scribe-realtime",
+            "audio_format=pcm_16000",
+            "language_code=fr",
+            "commit_strategy=vad",
+            "vad_threshold=0.4",
+            "vad_silence_threshold_secs=1.5",
+            "min_speech_duration_ms=100",
+            "min_silence_duration_ms=100",
+            "include_timestamps=true",
+            "include_language_detection=true",
+            "no_verbatim=true",
+        ].join("&"),
+    });
+
+    const upstreamUrl = new URL(session.upstream.request.url);
+    expect(`${upstreamUrl.origin}${upstreamUrl.pathname}`).toBe(
+        "https://api.elevenlabs.io/v1/speech-to-text/realtime",
+    );
+    expect(Object.fromEntries(upstreamUrl.searchParams)).toEqual({
+        model_id: "scribe_v2_realtime",
+        audio_format: "pcm_16000",
+        commit_strategy: "vad",
+        language_code: "fr",
+        vad_threshold: "0.4",
+        vad_silence_threshold_secs: "1.5",
+        min_speech_duration_ms: "100",
+        min_silence_duration_ms: "100",
+        include_timestamps: "true",
+        include_language_detection: "true",
+        no_verbatim: "true",
+    });
+    expect(session.upstream.request.headers.get("xi-api-key")).toBeTruthy();
+    expect(session.upstream.request.headers.get("Authorization")).toBeNull();
+
+    const clientMessage = JSON.stringify({
+        message_type: "input_audio_chunk",
+        audio_base_64: zeroAudioBase64(3200),
+        sample_rate: 16_000,
+        commit: true,
+        previous_text: "contexte",
+    });
+    const upstreamMessage = nextMessage(session.upstream.server);
+    session.client.send(clientMessage);
+    await expect(upstreamMessage).resolves.toBe(clientMessage);
+
+    const providerMessage = JSON.stringify({
+        message_type: "committed_transcript",
+        text: "bonjour",
+    });
+    const downstreamMessage = nextMessage(session.client);
+    session.upstream.server.send(providerMessage);
+    await expect(downstreamMessage).resolves.toBe(providerMessage);
+
+    const telemetry = await closeAndReadTelemetry(session);
+    expect(telemetry.tokenCountPromptAudioSeconds).toBeCloseTo(0.1, 8);
+});
+
+test.each([
+    ["pcm_8000", 16_000, 8000],
+    ["pcm_16000", 32_000, 16_000],
+    ["pcm_22050", 44_100, 22_050],
+    ["pcm_24000", 48_000, 24_000],
+    ["pcm_44100", 88_200, 44_100],
+    ["pcm_48000", 96_000, 48_000],
+    ["ulaw_8000", 8000, 8000],
+] as const)("bills one streamed second of %s at the exact Scribe Realtime rate", async (audioFormat, bytesPerSecond, sampleRate) => {
+    const session = await openPaidScribeSession({
+        name: `scribe-realtime-${audioFormat}-key`,
+        query: `audio_format=${audioFormat}`,
+    });
+    const upstreamMessage = nextMessage(session.upstream.server);
+    session.client.send(
+        JSON.stringify({
+            message_type: "input_audio_chunk",
+            audio_base_64: zeroAudioBase64(bytesPerSecond),
+            sample_rate: sampleRate,
+            commit: true,
+        }),
+    );
+    await upstreamMessage;
+
+    const telemetry = await closeAndReadTelemetry(session);
+    const user = await waitForPackBalanceBelow(session.userId, 1);
+    const expectedCharge = 0.39 / 3600;
+    const expectedLedgerCharge = roundPollenLedgerAmount(expectedCharge);
+    expect(user?.packBalance).toBeCloseTo(1 - expectedLedgerCharge, 8);
+    expect(telemetry.eventType).toBe("generate.realtime");
+    expect(telemetry.resolvedModelRequested).toBe("scribe-realtime");
+    expect(telemetry.modelProviderUsed).toBe("elevenlabs");
+    expect(telemetry.tokenCountPromptAudioSeconds).toBe(1);
+    expect(telemetry.totalCost).toBeCloseTo(expectedCharge, 12);
+    expect(telemetry.totalPrice).toBeCloseTo(expectedLedgerCharge, 12);
+});
+
+test("rejects malformed Scribe audio without forwarding or billing it", async () => {
+    const session = await openPaidScribeSession({
+        name: "scribe-realtime-malformed-audio-key",
+    });
+    let upstreamReceived = false;
+    session.upstream.server.addEventListener("message", () => {
+        upstreamReceived = true;
+    });
+
+    const closeEvent = nextClose(session.client);
+    session.client.send(
+        JSON.stringify({
+            message_type: "input_audio_chunk",
+            audio_base_64: "not base64!",
+        }),
+    );
+    await expect(closeEvent).resolves.toMatchObject({
+        code: 1008,
+        reason: "input_audio_chunk audio_base_64 is invalid.",
+    });
+    await waitOnExecutionContext(session.ctx);
+
+    expect(upstreamReceived).toBe(false);
+    expect(session.upstream.tinybirdRequests).toHaveLength(0);
+    expect((await getUserBalances(session.userId))?.packBalance).toBe(1);
+});
+
+test.each([
+    "/v1/audio/transcriptions/realtime?keyterms=Pollinations",
+    "/v1/audio/transcriptions/realtime?entity_detection=all",
+    "/v1/audio/transcriptions/realtime?model=scribe_v2_realtime",
+    "/v1/audio/transcriptions/realtime?filter_background_audio=true&include_timestamps=true",
+])("rejects unsupported Scribe Realtime query %s", async (path) => {
+    const { key } = await createTestApiKey({
+        name: "scribe-realtime-invalid-query-key",
+        user: { packBalance: 1 },
+    });
+    const upstream = mockRealtimeProvider();
+    const response = await fetchWorker(path, {
+        headers: {
+            Authorization: `Bearer ${key}`,
+            Upgrade: "websocket",
+        },
+    });
+
+    expect(response.status).toBe(400);
+    expect(upstream.fetchMock).not.toHaveBeenCalled();
+});
+
+test("enforces paid-only and model permissions for Scribe Realtime", async () => {
+    const questOnly = await createTestApiKey({
+        name: "scribe-realtime-quest-only-key",
+        user: { tierBalance: 1, packBalance: 0 },
+    });
+    const emptyPermissions = await createTestApiKey({
+        name: "scribe-realtime-empty-permissions-key",
+        allowedModels: [],
+        user: { packBalance: 1 },
+    });
+
+    const questResponse = await fetchWorker(
+        "/v1/audio/transcriptions/realtime",
+        {
+            headers: {
+                Authorization: `Bearer ${questOnly.key}`,
+                Upgrade: "websocket",
+            },
+        },
+    );
+    const permissionResponse = await fetchWorker(
+        "/v1/audio/transcriptions/realtime",
+        {
+            headers: {
+                Authorization: `Bearer ${emptyPermissions.key}`,
+                Upgrade: "websocket",
+            },
+        },
+    );
+
+    expect(questResponse.status).toBe(402);
+    expect(permissionResponse.status).toBe(403);
+});
+
+test("accepts a publishable key without forwarding it to ElevenLabs", async () => {
+    const { key } = await createTestApiKey({
+        name: "scribe-realtime-publishable-key",
+        type: "publishable",
+        user: { packBalance: 1 },
+    });
+    const upstream = mockRealtimeProvider();
+    const { response, ctx } = await fetchWorkerWithContext(
+        `/v1/audio/transcriptions/realtime?key=${encodeURIComponent(key)}`,
+        { headers: { Upgrade: "websocket" } },
+        scribeTestEnv,
+    );
+
+    expect(response.status).toBe(101);
+    expect(upstream.request.url).not.toContain(key);
+    expect(upstream.request.headers.get("xi-api-key")).toBeTruthy();
+    response.webSocket?.accept();
+    upstream.server.accept();
+    response.webSocket?.close();
+    upstream.server.close();
+    await waitOnExecutionContext(ctx);
+});
+
+test("completes both sides of the Scribe close handshake", async () => {
+    const session = await openPaidScribeSession({
+        name: "scribe-realtime-close-key",
+    });
+    const clientClose = nextClose(session.client);
+    const upstreamClose = nextClose(session.upstream.server);
+
+    session.client.close(1000, "done");
+
+    await expect(clientClose).resolves.toMatchObject({ code: 1000 });
+    await expect(upstreamClose).resolves.toMatchObject({ code: 1000 });
+    await waitOnExecutionContext(session.ctx);
+    expect(session.upstream.tinybirdRequests).toHaveLength(0);
 });
 
 test("rejects non-WebSocket realtime requests before calling OpenAI", async ({
@@ -805,6 +1075,45 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     for (const model of realtimeModels) {
         expect(model.supported_endpoints).toContain("/v1/realtime");
     }
+    expect(
+        publicBody.data.find((model) => model.id === "scribe-realtime"),
+    ).toMatchObject({
+        supported_endpoints: ["/v1/audio/transcriptions/realtime"],
+    });
+
+    const richResponse = await fetchWorker("/models");
+    expect(richResponse.status).toBe(200);
+    const richModels = (await richResponse.json()) as {
+        name: string;
+        brand?: string;
+        title?: string;
+        description?: string;
+        input_modalities?: string[];
+        output_modalities?: string[];
+        supported_endpoints?: string[];
+        paid_only?: boolean;
+        aliases?: string[];
+        pricing?: Record<string, string>;
+    }[];
+    const scribeRealtime = richModels.find(
+        (model) => model.name === "scribe-realtime",
+    );
+    expect(scribeRealtime).toMatchObject({
+        aliases: [],
+        brand: "ElevenLabs",
+        title: "Scribe v2 Realtime",
+        input_modalities: ["audio"],
+        output_modalities: ["text"],
+        supported_endpoints: ["/v1/audio/transcriptions/realtime"],
+        paid_only: true,
+        pricing: {
+            currency: "pollen",
+            promptAudioSeconds: "0.000108333333",
+        },
+    });
+    expect(scribeRealtime?.description?.toLowerCase()).not.toContain(
+        scribeRealtime?.title?.toLowerCase(),
+    );
 
     const restrictedResponse = await fetchWorker("/v1/models", {
         headers: { Authorization: `Bearer ${restrictedApiKey}` },
@@ -821,6 +1130,9 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     );
     expect(restrictedBody.data.map((model) => model.id)).not.toContain(
         "gpt-realtime-2.1-mini",
+    );
+    expect(restrictedBody.data.map((model) => model.id)).not.toContain(
+        "scribe-realtime",
     );
 });
 

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -626,6 +626,7 @@ test.each([
 });
 
 test("enforces paid-only and model permissions for Scribe Realtime", async () => {
+    mockRealtimeProvider();
     const questOnly = await createTestApiKey({
         name: "scribe-realtime-quest-only-key",
         user: { tierBalance: 1, packBalance: 0 },

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -73,9 +73,10 @@ function zeroAudioBase64(byteLength: number): string {
     return btoa("\0".repeat(byteLength));
 }
 
-function mockRealtimeProvider() {
+function mockRealtimeProvider(initialMessage?: string) {
     let upstreamRequest: Request | undefined;
     let upstreamServer: WebSocket | undefined;
+    let upstreamServerAccepted = false;
     const tinybirdRequests: Request[] = [];
 
     const fetchMock = vi
@@ -98,6 +99,11 @@ function mockRealtimeProvider() {
                 WebSocket,
             ];
             upstreamServer = server;
+            if (initialMessage) {
+                server.accept();
+                upstreamServerAccepted = true;
+                server.send(initialMessage);
+            }
             return new Response(null, {
                 status: 101,
                 webSocket: client,
@@ -118,6 +124,9 @@ function mockRealtimeProvider() {
                 throw new Error("Expected upstream realtime WebSocket");
             }
             return upstreamServer;
+        },
+        get serverAccepted() {
+            return upstreamServerAccepted;
         },
     };
 }
@@ -193,16 +202,18 @@ async function openPaidRealtimeSession({
 async function openPaidScribeSession({
     name,
     query = "",
+    initialProviderMessage,
 }: {
     name: string;
     query?: string;
+    initialProviderMessage?: string;
 }) {
     const { key, userId } = await createTestApiKey({
         name,
         pollenBudget: 1,
         user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockRealtimeProvider();
+    const upstream = mockRealtimeProvider(initialProviderMessage);
     const { response, ctx } = await fetchWorkerWithContext(
         `/v1/audio/transcriptions/realtime?${query}`,
         {
@@ -217,10 +228,13 @@ async function openPaidScribeSession({
     expect(response.status).toBe(101);
     const client = response.webSocket;
     if (!client) throw new Error("Expected downstream WebSocket");
+    const initialClientMessage = initialProviderMessage
+        ? nextMessage(client)
+        : undefined;
     client.accept();
-    upstream.server.accept();
+    if (!upstream.serverAccepted) upstream.server.accept();
 
-    return { client, ctx, upstream, userId };
+    return { client, ctx, upstream, userId, initialClientMessage };
 }
 
 type PaidRealtimeSession = Awaited<ReturnType<typeof openPaidRealtimeSession>>;
@@ -468,6 +482,22 @@ test("proxies Scribe Realtime parameters without forwarding caller credentials",
     expect(telemetry.tokenCountPromptAudioSeconds).toBeCloseTo(0.1, 8);
 });
 
+test("forwards the initial Scribe session event after listeners are attached", async () => {
+    const initialProviderMessage = JSON.stringify({
+        message_type: "session_started",
+        session_id: "session-1",
+    });
+    const session = await openPaidScribeSession({
+        name: "scribe-realtime-initial-event-key",
+        initialProviderMessage,
+    });
+
+    await expect(session.initialClientMessage).resolves.toBe(
+        initialProviderMessage,
+    );
+    await closeRealtimeSession(session);
+});
+
 test.each([
     ["pcm_8000", 16_000, 8000],
     ["pcm_16000", 32_000, 16_000],
@@ -532,11 +562,52 @@ test("rejects malformed Scribe audio without forwarding or billing it", async ()
     expect((await getUserBalances(session.userId))?.packBalance).toBe(1);
 });
 
+test("sanitizes Scribe provider errors and settles accepted audio", async () => {
+    const session = await openPaidScribeSession({
+        name: "scribe-realtime-provider-error-key",
+    });
+    const upstreamMessage = nextMessage(session.upstream.server);
+    session.client.send(
+        JSON.stringify({
+            message_type: "input_audio_chunk",
+            audio_base_64: zeroAudioBase64(32_000),
+            sample_rate: 16_000,
+        }),
+    );
+    await upstreamMessage;
+
+    const providerError = nextMessage(session.client);
+    const clientClose = nextClose(session.client);
+    session.upstream.server.send(
+        JSON.stringify({
+            message_type: "quota_exceeded",
+            error: "provider account details",
+        }),
+    );
+
+    await expect(providerError).resolves.toBe(
+        JSON.stringify({
+            message_type: "quota_exceeded",
+            error: "Realtime transcription failed.",
+        }),
+    );
+    await expect(clientClose).resolves.toMatchObject({ code: 1011 });
+    await waitOnExecutionContext(session.ctx);
+    await waitForTinybirdRequests(session.upstream);
+    const telemetry = JSON.parse(
+        await session.upstream.tinybirdRequests[0].text(),
+    ) as Record<string, unknown>;
+    expect(telemetry.tokenCountPromptAudioSeconds).toBe(1);
+});
+
 test.each([
     "/v1/audio/transcriptions/realtime?keyterms=Pollinations",
     "/v1/audio/transcriptions/realtime?entity_detection=all",
     "/v1/audio/transcriptions/realtime?model=scribe_v2_realtime",
     "/v1/audio/transcriptions/realtime?filter_background_audio=true&include_timestamps=true",
+    "/v1/audio/transcriptions/realtime?vad_threshold=",
+    "/v1/audio/transcriptions/realtime?min_speech_duration_ms=",
+    "/v1/audio/transcriptions/realtime?include_timestamps",
 ])("rejects unsupported Scribe Realtime query %s", async (path) => {
     const { key } = await createTestApiKey({
         name: "scribe-realtime-invalid-query-key",

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -78,8 +78,31 @@ export const REALTIME_SERVICES = {
         description: "Live voice conversations with instant, reasoned replies",
         contextLength: 128000,
     },
+    "scribe-realtime": {
+        aliases: [],
+        provider: "elevenlabs",
+        brand: "ElevenLabs",
+        category: "realtime",
+        addedDate: new Date("2026-08-13").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // ElevenLabs Scribe v2 Realtime: $0.39 per streamed audio hour.
+            promptAudioSeconds: 0.39 / 3600,
+        },
+        title: "Scribe v2 Realtime",
+        description:
+            "Live transcription in 90+ languages with partial results and word timestamps",
+        inputModalities: ["audio"],
+        outputModalities: ["text"],
+        supportedEndpoints: ["/v1/audio/transcriptions/realtime"],
+    },
 } satisfies Record<string, ModelDefinition>;
 
 export const REALTIME_MODEL_NAMES = Object.keys(
     REALTIME_SERVICES,
 ) as RealtimeModelName[];
+
+export const OPENAI_REALTIME_MODEL_NAMES = REALTIME_MODEL_NAMES.filter(
+    (model) => model !== "scribe-realtime",
+);

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -103,6 +103,10 @@ export const REALTIME_MODEL_NAMES = Object.keys(
     REALTIME_SERVICES,
 ) as RealtimeModelName[];
 
-export const OPENAI_REALTIME_MODEL_NAMES = REALTIME_MODEL_NAMES.filter(
-    (model) => model !== "scribe-realtime",
+export const REALTIME_VOICE_MODEL_NAMES = REALTIME_MODEL_NAMES.filter(
+    (model) => {
+        const endpoints = (REALTIME_SERVICES[model] as ModelDefinition)
+            .supportedEndpoints;
+        return endpoints === undefined || endpoints.includes("/v1/realtime");
+    },
 );


### PR DESCRIPTION
- Adds paid-only `scribe-realtime` at `/v1/audio/transcriptions/realtime`, routed directly to ElevenLabs `scribe_v2_realtime` with no aliases or fallback.
- Supports the seven confirmed mono PCM/μ-law formats, manual/VAD commits, language controls, partial/final transcripts, timestamps, and background filtering.
- Bills validated decoded audio bytes at ElevenLabs' $0.39/hour rate and settles once on close or error.
- Attaches provider listeners before accepting audio, sanitizes terminal provider errors, rejects malformed query values, and completes close handling safely.
- Keeps premium keyterms/entity detection and media uploads out of scope; live WebSocket chunks do not use `media.pollinations.ai`.

Validation:
- Direct ElevenLabs: every format, manual/VAD, background filtering, and a five-session burst.
- Local Gen E2E: every format, exact transcript/telemetry/ledger billing, malformed input, and clean WebSocket closure. Fresh review-fix probe transcribed 5.247s in 5.738s and billed 0.00056848 Pollen.
- After merging #13320: Gen 50 focused tests and typecheck; Enter 80 pricing/registry tests and typecheck.

Draft for review. The batch-metering prerequisite #13320 is merged and included.
