### PR TITLE
fix: harden Azure realtime proxy settlement

### DIFF
--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -734,6 +734,7 @@ async function settleRealtimeSession(
     >[0]["db"];
 
     if (!tracking.deduction) {
+        if (tracking.deductionAttempted) return;
         tracking.deductionAttempted = true;
         tracking.deduction = await handleBalanceDeduction({
             db,
@@ -867,7 +868,7 @@ function wireClose(
     source.addEventListener("close", (event) => {
         try {
             closeSocket(target, event.code, event.reason);
-            if (source.readyState !== WebSocket.CLOSED) {
+            if (event.wasClean && source.readyState !== WebSocket.CLOSED) {
                 const closeCode = normalizeCloseCode(event.code);
                 if (closeCode) source.close(closeCode, event.reason);
                 else source.close();

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -115,6 +115,7 @@ type RealtimeBillingContext = {
     settlementAttempts: number;
     settled: boolean;
     deduction?: RealtimeDeduction;
+    deductionAttempted: boolean;
     rateLimitConsumed: boolean;
 };
 
@@ -169,7 +170,6 @@ async function connectAzureRealtime(
     const upstreamSocket = response.webSocket;
     if (upstreamSocket) {
         upstreamSocket.binaryType = "arraybuffer";
-        upstreamSocket.accept({ allowHalfOpen: true });
         return upstreamSocket;
     }
 
@@ -733,16 +733,19 @@ async function settleRealtimeSession(
         typeof handleBalanceDeduction
     >[0]["db"];
 
-    tracking.deduction ??= await handleBalanceDeduction({
-        db,
-        isBilledUsage: true,
-        totalPrice: price.totalPrice,
-        userId: tracking.userId,
-        apiKeyId: tracking.apiKeyId,
-        apiKeyPollenBalance: tracking.apiKeyPollenBalance,
-        byopClientKeyId: tracking.byopClientKeyId,
-        modelPaidOnly: tracking.modelDefinition.paidOnly,
-    });
+    if (!tracking.deduction) {
+        tracking.deductionAttempted = true;
+        tracking.deduction = await handleBalanceDeduction({
+            db,
+            isBilledUsage: true,
+            totalPrice: price.totalPrice,
+            userId: tracking.userId,
+            apiKeyId: tracking.apiKeyId,
+            apiKeyPollenBalance: tracking.apiKeyPollenBalance,
+            byopClientKeyId: tracking.byopClientKeyId,
+            modelPaidOnly: tracking.modelDefinition.paidOnly,
+        });
+    }
 
     if (!tracking.rateLimitConsumed) {
         await c.var.frontendKeyRateLimit?.consumePollen(price.totalPrice);
@@ -828,7 +831,11 @@ function scheduleRealtimeSettlement(
                     error:
                         error instanceof Error ? error.message : String(error),
                 });
-                if (tracking.settled || tracking.settlementAttempts >= 2) {
+                if (
+                    tracking.settled ||
+                    tracking.settlementAttempts >= 2 ||
+                    (tracking.deductionAttempted && !tracking.deduction)
+                ) {
                     return;
                 }
                 return settleRealtimeSession(c, tracking).catch(
@@ -858,12 +865,24 @@ function wireClose(
     tracking: RealtimeBillingContext,
 ): void {
     source.addEventListener("close", (event) => {
-        closeSocket(target, event.code, event.reason);
-        scheduleRealtimeSettlement(c, tracking);
+        try {
+            closeSocket(target, event.code, event.reason);
+            if (source.readyState !== WebSocket.CLOSED) {
+                const closeCode = normalizeCloseCode(event.code);
+                if (closeCode) source.close(closeCode, event.reason);
+                else source.close();
+            }
+        } finally {
+            scheduleRealtimeSettlement(c, tracking);
+        }
     });
     source.addEventListener("error", () => {
-        closeSocket(target, 1011, "Realtime proxy error");
-        scheduleRealtimeSettlement(c, tracking);
+        try {
+            closeSocket(target, 1011, "Realtime proxy error");
+            closeSocket(source, 1011, "Realtime proxy error");
+        } finally {
+            scheduleRealtimeSettlement(c, tracking);
+        }
     });
 }
 
@@ -904,8 +923,6 @@ function proxyRealtimeWebSockets(
     const [client, downstream] = Object.values(pair) as [WebSocket, WebSocket];
 
     downstream.binaryType = "arraybuffer";
-    downstream.accept({ allowHalfOpen: true });
-
     collectBillingEvents(c, upstream, tracking);
     forwardMessage(downstream, upstream, validateClientRealtimeEvent, () =>
         scheduleRealtimeSettlement(c, tracking),
@@ -915,6 +932,8 @@ function proxyRealtimeWebSockets(
     );
     wireClose(c, downstream, upstream, tracking);
     wireClose(c, upstream, downstream, tracking);
+    downstream.accept({ allowHalfOpen: true });
+    upstream.accept({ allowHalfOpen: true });
 
     return new Response(null, {
         status: 101,
@@ -997,6 +1016,7 @@ async function createRealtimeBillingContext(
         settlementInFlight: false,
         settlementAttempts: 0,
         settled: false,
+        deductionAttempted: false,
         rateLimitConsumed: false,
     };
 }
@@ -1026,6 +1046,7 @@ export async function handleRealtimeWebSocket(
     }
     const userId = await authorizeRealtimeSession(c);
 
+    const tracking = await createRealtimeBillingContext(c);
     const upstream = await connectAzureRealtime(
         c,
         userId,
@@ -1033,11 +1054,7 @@ export async function handleRealtimeWebSocket(
     );
     if (upstream instanceof Response) return upstream;
 
-    return proxyRealtimeWebSockets(
-        c,
-        upstream,
-        await createRealtimeBillingContext(c),
-    );
+    return proxyRealtimeWebSockets(c, upstream, tracking);
 }
 
 export async function handleScribeRealtimeWebSocket(

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -5,7 +5,10 @@ import {
 } from "cloudflare:test";
 import { getLogger } from "@logtape/logtape";
 import { roundPollenLedgerAmount } from "@shared/billing/precision.ts";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    apikey as apiKeyTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import { createTestApiKey, test } from "@shared/test/fixtures/index.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -168,17 +171,23 @@ async function openPaidRealtimeSession({
     name,
     model = "gpt-realtime-2",
     referrer,
+    initialProviderMessage,
 }: {
     name: string;
     model?: string;
     referrer?: string;
+    initialProviderMessage?: string;
 }) {
-    const { key, userId } = await createTestApiKey({
+    const {
+        key,
+        id: apiKeyId,
+        userId,
+    } = await createTestApiKey({
         name,
         pollenBudget: 1,
         user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockRealtimeProvider();
+    const upstream = mockRealtimeProvider(initialProviderMessage);
     const headers: Record<string, string> = {
         Authorization: `Bearer ${key}`,
         Upgrade: "websocket",
@@ -193,10 +202,20 @@ async function openPaidRealtimeSession({
     expect(response.status).toBe(101);
     const client = response.webSocket;
     if (!client) throw new Error("Expected downstream WebSocket");
+    const initialClientMessage = initialProviderMessage
+        ? nextMessage(client)
+        : undefined;
     client.accept();
-    upstream.server.accept();
+    if (!upstream.serverAccepted) upstream.server.accept();
 
-    return { client, ctx, upstream, userId };
+    return {
+        apiKeyId,
+        client,
+        ctx,
+        upstream,
+        userId,
+        initialClientMessage,
+    };
 }
 
 async function openPaidScribeSession({
@@ -238,14 +257,15 @@ async function openPaidScribeSession({
 }
 
 type PaidRealtimeSession = Awaited<ReturnType<typeof openPaidRealtimeSession>>;
+type RealtimeSession = Pick<PaidRealtimeSession, "client" | "ctx" | "upstream">;
 
-async function closeRealtimeSession(session: PaidRealtimeSession) {
+async function closeRealtimeSession(session: RealtimeSession) {
     session.client.close();
     session.upstream.server.close();
     await waitOnExecutionContext(session.ctx);
 }
 
-async function closeAndReadTelemetry(session: PaidRealtimeSession) {
+async function closeAndReadTelemetry(session: RealtimeSession) {
     await closeRealtimeSession(session);
     await waitForTinybirdRequests(session.upstream);
     expect(session.upstream.tinybirdRequests).toHaveLength(1);
@@ -367,6 +387,37 @@ test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
     client.close();
     upstream.server.close();
     await waitOnExecutionContext(ctx);
+});
+
+test("forwards the initial Azure session event after listeners are attached", async () => {
+    const initialProviderMessage = JSON.stringify({
+        type: "session.created",
+        session: { model: "gpt-realtime-2" },
+    });
+    const session = await openPaidRealtimeSession({
+        name: "azure-realtime-initial-event-key",
+        initialProviderMessage,
+    });
+
+    await expect(session.initialClientMessage).resolves.toBe(
+        initialProviderMessage,
+    );
+    await closeRealtimeSession(session);
+});
+
+test("completes both sides of the Azure close handshake", async () => {
+    const session = await openPaidRealtimeSession({
+        name: "azure-realtime-close-key",
+    });
+    const clientClose = nextClose(session.client);
+    const upstreamClose = nextClose(session.upstream.server);
+
+    session.client.close(1000, "done");
+
+    await expect(clientClose).resolves.toMatchObject({ code: 1000 });
+    await expect(upstreamClose).resolves.toMatchObject({ code: 1000 });
+    await waitOnExecutionContext(session.ctx);
+    expect(session.upstream.tinybirdRequests).toHaveLength(0);
 });
 
 test("routes the mini model through the working East US 2 deployment", async ({
@@ -894,6 +945,54 @@ test("deducts aggregate session usage from paid pack balance on close", async ()
     expect(telemetry.tokenCountCompletionText).toBe(100);
     expect(telemetry.tokenCountCompletionAudio).toBe(50);
     expect(telemetry.totalPrice).toBeCloseTo(expectedCharge, 8);
+});
+
+test("does not retry a partially completed realtime deduction", async () => {
+    const session = await openPaidRealtimeSession({
+        name: "realtime-partial-deduction-key",
+    });
+    const usageEvent = JSON.stringify({
+        type: "response.done",
+        response: {
+            usage: {
+                input_tokens: 135,
+                output_tokens: 75,
+                input_token_details: {
+                    text_tokens: 100,
+                    audio_tokens: 10,
+                    image_tokens: 5,
+                    cached_tokens: 20,
+                    cached_tokens_details: {
+                        text_tokens: 20,
+                        audio_tokens: 0,
+                        image_tokens: 0,
+                    },
+                },
+                output_token_details: {
+                    text_tokens: 50,
+                    audio_tokens: 25,
+                },
+            },
+        },
+    });
+    const forwardedEvent = nextMessage(session.client);
+    session.upstream.server.send(usageEvent);
+    await expect(forwardedEvent).resolves.toBe(usageEvent);
+
+    await drizzle(env.DB)
+        .delete(apiKeyTable)
+        .where(eq(apiKeyTable.id, session.apiKeyId));
+    session.client.close();
+    await waitOnExecutionContext(session.ctx);
+
+    const user = await waitForPackBalanceBelow(session.userId, 1);
+    expect(user?.packBalance).toBeCloseTo(1 - 0.003553 * 0.75, 8);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect((await getUserBalances(session.userId))?.packBalance).toBeCloseTo(
+        user?.packBalance ?? 0,
+        8,
+    );
+    expect(session.upstream.tinybirdRequests).toHaveLength(0);
 });
 
 test.each([

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -78,6 +78,7 @@ function zeroAudioBase64(byteLength: number): string {
 
 function mockRealtimeProvider(initialMessage?: string) {
     let upstreamRequest: Request | undefined;
+    let upstreamClient: WebSocket | undefined;
     let upstreamServer: WebSocket | undefined;
     let upstreamServerAccepted = false;
     const tinybirdRequests: Request[] = [];
@@ -101,6 +102,7 @@ function mockRealtimeProvider(initialMessage?: string) {
                 WebSocket,
                 WebSocket,
             ];
+            upstreamClient = client;
             upstreamServer = server;
             if (initialMessage) {
                 server.accept();
@@ -127,6 +129,12 @@ function mockRealtimeProvider(initialMessage?: string) {
                 throw new Error("Expected upstream realtime WebSocket");
             }
             return upstreamServer;
+        },
+        get client() {
+            if (!upstreamClient) {
+                throw new Error("Expected proxy-side upstream WebSocket");
+            }
+            return upstreamClient;
         },
         get serverAccepted() {
             return upstreamServerAccepted;
@@ -418,6 +426,20 @@ test("completes both sides of the Azure close handshake", async () => {
     await expect(upstreamClose).resolves.toMatchObject({ code: 1000 });
     await waitOnExecutionContext(session.ctx);
     expect(session.upstream.tinybirdRequests).toHaveLength(0);
+});
+
+test("does not reply to an abnormal Azure close", async () => {
+    const session = await openPaidRealtimeSession({
+        name: "azure-realtime-abnormal-close-key",
+    });
+    const closeSpy = vi.spyOn(session.upstream.client, "close");
+
+    session.upstream.client.dispatchEvent(
+        new CloseEvent("close", { code: 1006, wasClean: false }),
+    );
+
+    await waitOnExecutionContext(session.ctx);
+    expect(closeSpy).not.toHaveBeenCalled();
 });
 
 test("routes the mini model through the working East US 2 deployment", async ({
@@ -987,7 +1009,8 @@ test("does not retry a partially completed realtime deduction", async () => {
 
     const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - 0.003553 * 0.75, 8);
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    session.upstream.client.dispatchEvent(new Event("error"));
+    await waitOnExecutionContext(session.ctx);
     expect((await getUserBalances(session.userId))?.packBalance).toBeCloseTo(
         user?.packBalance ?? 0,
         8,


### PR DESCRIPTION
- Attaches Azure realtime listeners before accepting sockets, preserving initial provider events.
- Completes clean WebSocket close handshakes without replying to abnormal disconnects.
- Builds billing context before opening the Azure socket to avoid leaked connections.
- Prevents later close/error events from retrying a deduction that may have partially changed balances.

Tests:
- `npx vitest run test/realtime.test.ts` (37/37)
- `npm run typecheck`
- `npx biome check src/routes/realtime.ts test/realtime.test.ts`