### PR TITLE
fix: allow public audio reference URLs

### DIFF
--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -41,6 +41,7 @@ import {
     withModelFallbackResponse,
 } from "../fallback.ts";
 import { readResponseBytes } from "../utils/response-bytes.ts";
+import { validateUserMediaUrl } from "../utils/user-media-url.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
 import { handleScribeRealtimeWebSocket } from "./realtime.ts";
 import {
@@ -112,7 +113,7 @@ const CreateSpeechRequestSchema = z
         }),
         reference_audio: z.url().optional().meta({
             description:
-                "URL returned by media.pollinations.ai for reference-audio conditioning or audio-to-audio generation.",
+                "Public HTTP(S) URL for reference-audio conditioning or audio-to-audio generation.",
             example:
                 "https://media.pollinations.ai/3f9c1e2a-7b4d-4e2f-9a1c-8d6b5e4f3a2b",
         }),
@@ -217,9 +218,6 @@ type GenerateMusicOptions = {
     log: Logger;
 };
 
-// Reference URLs intentionally use the one canonical public media host in
-// every environment; staging and local generation read the same public blobs.
-const MEDIA_ORIGIN = "https://media.pollinations.ai";
 const MAX_REFERENCE_AUDIO_SIZE = 20 * 1024 * 1024;
 const REFERENCE_AUDIO_FETCH_TIMEOUT_MS = 30_000;
 
@@ -234,29 +232,32 @@ const AUDIO_EXTENSION_BY_TYPE: Record<string, string> = {
 };
 
 async function fetchReferenceAudio(referenceAudioUrl: string): Promise<File> {
-    const url = new URL(referenceAudioUrl);
-    if (url.origin !== MEDIA_ORIGIN) {
+    const validation = validateUserMediaUrl(referenceAudioUrl);
+    if (!validation.ok) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: "reference_audio must use https://media.pollinations.ai",
+            message:
+                "reference_audio must be a public HTTP(S) URL without credentials",
         });
     }
+    const { url } = validation;
 
     let response: Response;
     try {
         response = await fetch(url, {
+            headers: { "User-Agent": "Pollinations/1.0" },
             signal: AbortSignal.timeout(REFERENCE_AUDIO_FETCH_TIMEOUT_MS),
         });
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Failed to fetch reference_audio from media.pollinations.ai: ${message}`,
+            message: `Failed to fetch reference_audio from ${url.hostname}: ${message}`,
             requestUrl: url,
         });
     }
 
     if (!response.ok) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Failed to fetch reference_audio: media.pollinations.ai returned ${response.status}`,
+            message: `Failed to fetch reference_audio: ${url.hostname} returned ${response.status}`,
             requestUrl: url,
             upstreamStatus: response.status,
         });
@@ -1755,7 +1756,7 @@ async function parseSpeechRequest(
         if (referenceAudio instanceof File) {
             throw new UpstreamError(400 as ContentfulStatusCode, {
                 message:
-                    "reference_audio must be a media.pollinations.ai URL, not a file upload",
+                    "reference_audio must be a public HTTP(S) URL, not a file upload",
             });
         }
 
@@ -2854,7 +2855,7 @@ export const audioRoutes = new Hono<Env>()
             description: [
                 "Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.",
                 "",
-                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Upload a reference file to `media.pollinations.ai`, then pass its URL as `reference_audio` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
+                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Pass any publicly accessible audio URL as `reference_audio` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
                 "",
                 `**Available voices:** ${AUDIO_VOICES.join(", ")}`,
                 "",
@@ -2917,7 +2918,7 @@ export const audioRoutes = new Hono<Env>()
                                     type: "string",
                                     format: "uri",
                                     description:
-                                        "URL returned by media.pollinations.ai for reference-audio conditioning or audio-to-audio generation.",
+                                        "Public HTTP(S) URL for reference-audio conditioning or audio-to-audio generation.",
                                 },
                                 conditioning_ref: { type: "object" },
                                 composition_plan: { type: "object" },

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -988,7 +988,7 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
                 "",
-                "**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Upload reference audio through `media.pollinations.ai`, then pass its URL as `reference_audio` to `POST /v1/audio/speech`.",
+                "**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Pass any publicly accessible audio URL as `reference_audio` to `POST /v1/audio/speech`.",
             ].join("\n"),
             responses: {
                 200: {

--- a/gen.pollinations.ai/src/userImage.ts
+++ b/gen.pollinations.ai/src/userImage.ts
@@ -2,6 +2,7 @@ import type { ImageInputErrorCode } from "@shared/error.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
 import { HttpError } from "./image/httpError.ts";
 import { readResponseBytes } from "./utils/response-bytes.ts";
+import { validateUserMediaUrl } from "./utils/user-media-url.ts";
 
 /**
  * A user-supplied image we could not use.
@@ -36,72 +37,29 @@ export class UserImageError extends HttpError {
 /** Max bytes we will read for a single user-supplied image: 20MB. */
 export const MAX_IMAGE_SIZE = 20 * 1024 * 1024;
 
-const BLOCKED_HOSTNAMES = /^localhost$/i;
-
-/**
- * Blocks the hosts a user-supplied URL must never reach: loopback, any literal
- * IP, and anything containing a colon (an IPv6 literal, which covers ::1 and
- * the unique-local range without enumerating them).
- *
- * Deliberately blunt. A bare IP is never a legitimate way to reference a public
- * image, and allowing one opens link-local metadata endpoints — so the whole
- * literal-address space is refused rather than filtered range by range.
- */
-function isBlockedImageHost(hostname: string): boolean {
-    const host = hostname.replace(/^\[|\]$/g, "");
-    const normalized = host.toLowerCase();
-    if (
-        BLOCKED_HOSTNAMES.test(normalized) ||
-        normalized.endsWith(".localhost")
-    ) {
-        return true;
-    }
-
-    if (normalized.includes(":")) {
-        return true;
-    }
-
-    const parts = normalized.split(".").map(Number);
-    if (
-        parts.length !== 4 ||
-        parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
-    ) {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * The one gate every user-supplied image URL passes before we fetch it, so a
- * URL one path refuses can never be reachable through the other instead.
- */
+/** Maps the shared user-media URL policy to the image API's error contract. */
 function assertAllowedImageUrl(value: string): URL {
-    let url: URL;
-    try {
-        url = new URL(value);
-    } catch {
+    const validation = validateUserMediaUrl(value);
+    if (validation.ok) return validation.url;
+
+    if (validation.reason === "invalid") {
         throw new UserImageError(
             `Invalid image URL ${value}: expected a valid HTTP(S) URL.`,
             "invalid_image_url",
         );
     }
 
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
+    if (validation.reason === "protocol") {
         throw new UserImageError(
             `Invalid image URL ${value}: only HTTP(S) image URLs can be fetched.`,
             "invalid_image_url",
         );
     }
 
-    if (url.username || url.password || isBlockedImageHost(url.hostname)) {
-        throw new UserImageError(
-            `Invalid image URL ${value}: private or credentialed image URLs are not allowed.`,
-            "invalid_image_url",
-        );
-    }
-
-    return url;
+    throw new UserImageError(
+        `Invalid image URL ${value}: private or credentialed image URLs are not allowed.`,
+        "invalid_image_url",
+    );
 }
 
 /** The image host's own status, phrased as something the caller can act on. */

--- a/gen.pollinations.ai/src/utils/user-media-url.ts
+++ b/gen.pollinations.ai/src/utils/user-media-url.ts
@@ -1,0 +1,49 @@
+export type UserMediaUrlValidation =
+    | { ok: true; url: URL }
+    | { ok: false; reason: "invalid" | "protocol" | "private" };
+
+const BLOCKED_HOSTNAMES = /^localhost$/i;
+
+function isBlockedUserMediaHost(hostname: string): boolean {
+    const host = hostname.replace(/^\[|\]$/g, "");
+    const normalized = host.toLowerCase();
+    if (
+        BLOCKED_HOSTNAMES.test(normalized) ||
+        normalized.endsWith(".localhost")
+    ) {
+        return true;
+    }
+
+    if (normalized.includes(":")) return true;
+
+    const parts = normalized.split(".").map(Number);
+    return (
+        parts.length === 4 &&
+        parts.every(
+            (part) => Number.isInteger(part) && part >= 0 && part <= 255,
+        )
+    );
+}
+
+/**
+ * Apply the same URL policy to every user-supplied media fetch: HTTP(S) only,
+ * with credentialed hosts, loopback names, and literal IP addresses refused.
+ */
+export function validateUserMediaUrl(value: string): UserMediaUrlValidation {
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        return { ok: false, reason: "invalid" };
+    }
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+        return { ok: false, reason: "protocol" };
+    }
+
+    if (url.username || url.password || isBlockedUserMediaHost(url.hostname)) {
+        return { ok: false, reason: "private" };
+    }
+
+    return { ok: true, url };
+}

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -1356,11 +1356,11 @@ it("lists Lyria with its aliases and text-to-audio modalities", async () => {
 });
 
 fixtureTest(
-    "loads an octet-stream elevenmusic reference from the media service",
+    "loads an octet-stream elevenmusic reference from any public URL",
     async ({ paidApiKey }) => {
         const calls: string[] = [];
         const referenceAudioUrl =
-            "https://media.pollinations.ai/test-music-reference";
+            "https://cdn.example.com/test-music-reference";
         const uploadUrl = "https://api.elevenlabs.io/v1/music/upload";
         const composeUrl = "https://api.elevenlabs.io/v1/music";
 
@@ -1370,6 +1370,9 @@ fixtureTest(
                 calls.push(request.url);
 
                 if (request.url === referenceAudioUrl) {
+                    expect(request.headers.get("User-Agent")).toBe(
+                        "Pollinations/1.0",
+                    );
                     return new Response(new Uint8Array([73, 68, 51, 4]), {
                         headers: {
                             "Content-Type":
@@ -1460,58 +1463,52 @@ fixtureTest(
     },
 );
 
-fixtureTest(
-    "rejects reference_audio URLs outside the media service",
-    async ({ paidApiKey }) => {
-        vi.spyOn(globalThis, "fetch").mockImplementation(
-            async (input, init) => {
-                const request = new Request(input, init);
-                if (
-                    request.url.startsWith(
-                        "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
-                    ) ||
-                    request.url.startsWith("http://localhost:7181/")
-                ) {
-                    return Response.json({ data: [] });
-                }
-                throw new Error(`Unexpected fetch: ${request.url}`);
-            },
-        );
+fixtureTest("rejects private reference_audio URLs", async ({ paidApiKey }) => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const request = new Request(input, init);
+        if (
+            request.url.startsWith(
+                "https://api.europe-west2.gcp.tinybird.co/v0/pipes/public_model_stats.json",
+            ) ||
+            request.url.startsWith("http://localhost:7181/")
+        ) {
+            return Response.json({ data: [] });
+        }
+        throw new Error(`Unexpected fetch: ${request.url}`);
+    });
 
-        const ctx = createExecutionContext();
-        const response = await worker.fetch(
-            new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${paidApiKey}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    model: "elevenmusic",
-                    input: "warm indie disco",
-                    reference_audio: "https://example.com/reference.mp3",
-                }),
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request("https://staging.gen.pollinations.ai/v1/audio/speech", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${paidApiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model: "elevenmusic",
+                input: "warm indie disco",
+                reference_audio: "https://localhost/reference.mp3",
             }),
-            env as unknown as CloudflareBindings,
-            ctx,
-        );
+        }),
+        env as unknown as CloudflareBindings,
+        ctx,
+    );
 
-        expect(response.status).toBe(400);
-        await expect(response.json()).resolves.toMatchObject({
-            error: {
-                message:
-                    "reference_audio must use https://media.pollinations.ai",
-            },
-        });
-        await waitOnExecutionContext(ctx);
-    },
-);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+        error: {
+            message:
+                "reference_audio must be a public HTTP(S) URL without credentials",
+        },
+    });
+    await waitOnExecutionContext(ctx);
+});
 
 fixtureTest(
-    "returns 400 once for an expired media reference",
+    "returns 400 once for an unreachable public reference",
     async ({ paidApiKey }) => {
-        const referenceAudioUrl =
-            "https://media.pollinations.ai/expired-reference";
+        const referenceAudioUrl = "https://cdn.example.com/expired-reference";
         const calls: string[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
@@ -1557,7 +1554,7 @@ fixtureTest(
         await expect(response.json()).resolves.toMatchObject({
             error: {
                 message:
-                    "Failed to fetch reference_audio: media.pollinations.ai returned 404",
+                    "Failed to fetch reference_audio: cdn.example.com returned 404",
             },
         });
         await waitOnExecutionContext(ctx);
@@ -1573,10 +1570,9 @@ fixtureTest(
 fixtureTest(
     "rejects non-audio and oversized media references",
     async ({ paidApiKey }) => {
-        const nonAudioUrl =
-            "https://media.pollinations.ai/not-an-audio-reference";
+        const nonAudioUrl = "https://cdn.example.com/not-an-audio-reference";
         const oversizedUrl =
-            "https://media.pollinations.ai/oversized-audio-reference";
+            "https://cdn.example.com/oversized-audio-reference";
 
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
@@ -1672,7 +1668,7 @@ fixtureTest(
             await expect(response.json()).resolves.toMatchObject({
                 error: {
                     message:
-                        "reference_audio must be a media.pollinations.ai URL, not a file upload",
+                        "reference_audio must be a public HTTP(S) URL, not a file upload",
                 },
             });
             await waitOnExecutionContext(ctx);


### PR DESCRIPTION
- Accepts any public HTTP(S) URL in `reference_audio` instead of requiring `media.pollinations.ai`.
- Reuses the same URL validation policy as existing image inputs, rejecting credentialed, loopback, and literal-IP hosts.
- Preserves the 20 MB limit, 30-second timeout, MIME validation, one-time fetch, and 400-class user errors from #13317.
- Updates the audio endpoint descriptions and regression tests for third-party URLs.

Root cause: #13317 hardcoded the Pollinations media origin instead of following the repository's established user-media URL behavior.

Checks:
- `npm run typecheck`
- `npx biome check src/routes/audio.ts src/routes/proxy.ts src/userImage.ts src/utils/user-media-url.ts test/index.test.ts`
- Focused audio/OpenAPI tests: 8 passed
- Image download regression tests: 17 passed