### PR TITLE
fix(polli-cli): validate numeric flags (--width/--height/--duration/--speed) before hitting the API

### DIFF
--- a/packages/polli-cli/src/commands/gen/audio.ts
+++ b/packages/polli-cli/src/commands/gen/audio.ts
@@ -10,6 +10,7 @@ import {
 } from "../../lib/output.js";
 import { playAudio, playerMissingHint } from "../../lib/play.js";
 import { readStdin } from "../../lib/stdin.js";
+import { requirePositiveInt } from "../../lib/validate.js";
 
 export function createAudioCommand() {
     return new Command("audio")
@@ -44,8 +45,29 @@ export function createAudioCommand() {
             if (opts.format !== "mp3")
                 params.set("response_format", opts.format);
             if (opts.model) params.set("model", opts.model);
-            if (opts.speed) params.set("speed", opts.speed);
-            if (opts.duration) params.set("duration", opts.duration);
+            // Fail fast on invalid numeric flags instead of forwarding them
+            // to the API (raw validation errors are confusing for CLI users).
+            if (opts.speed !== undefined) {
+                const speed = Number(opts.speed);
+                if (!Number.isFinite(speed) || speed < 0.25 || speed > 4) {
+                    printError(
+                        `--speed must be a number between 0.25 and 4, got "${opts.speed}"`,
+                    );
+                    process.exit(1);
+                }
+                params.set("speed", String(speed));
+            }
+            if (opts.duration !== undefined) {
+                const duration = requirePositiveInt(
+                    opts.duration,
+                    "--duration",
+                    {
+                        min: 1,
+                        max: 300,
+                    },
+                );
+                params.set("duration", String(duration));
+            }
             if (opts.instrumental) params.set("instrumental", "true");
             if (opts.seed) params.set("seed", opts.seed);
 

--- a/packages/polli-cli/src/commands/gen/image.ts
+++ b/packages/polli-cli/src/commands/gen/image.ts
@@ -7,6 +7,7 @@ import {
     printInfo,
     printMeta,
 } from "../../lib/output.js";
+import { requirePositiveInt } from "../../lib/validate.js";
 
 export function createImageCommand() {
     return new Command("image")
@@ -26,10 +27,23 @@ export function createImageCommand() {
         .action(async (prompt, opts) => {
             const isHuman = getOutputMode() === "human";
 
+            // Validate dimensions before hitting the API. The server responds
+            // with a raw JSON validation error when given non-numeric values
+            // (e.g. `--width abc` -> "Invalid input: expected number"),
+            // which is confusing — fail fast with a clear message instead.
+            const width = requirePositiveInt(opts.width, "--width", {
+                min: 1,
+                max: 4096,
+            });
+            const height = requirePositiveInt(opts.height, "--height", {
+                min: 1,
+                max: 4096,
+            });
+
             const params = new URLSearchParams({
                 model: opts.model,
-                width: opts.width,
-                height: opts.height,
+                width: String(width),
+                height: String(height),
             });
             if (opts.seed) params.set("seed", opts.seed);
             if (opts.safe) params.set("safe", "true");

--- a/packages/polli-cli/src/commands/gen/video.ts
+++ b/packages/polli-cli/src/commands/gen/video.ts
@@ -7,6 +7,7 @@ import {
     printInfo,
     printMeta,
 } from "../../lib/output.js";
+import { requirePositiveInt } from "../../lib/validate.js";
 
 export function createVideoCommand() {
     return new Command("video")
@@ -27,9 +28,21 @@ export function createVideoCommand() {
         .action(async (prompt, opts) => {
             const isHuman = getOutputMode() === "human";
 
+            // Validate dimensions before hitting the API (same rationale as
+            // `gen image`): fail fast with a clear message instead of a raw
+            // server-side validation error.
+            const width = requirePositiveInt(opts.width, "--width", {
+                min: 1,
+                max: 4096,
+            });
+            const height = requirePositiveInt(opts.height, "--height", {
+                min: 1,
+                max: 4096,
+            });
+
             const params = new URLSearchParams({
-                width: opts.width,
-                height: opts.height,
+                width: String(width),
+                height: String(height),
             });
             if (opts.model) params.set("model", opts.model);
             if (opts.duration) params.set("duration", opts.duration);

--- a/packages/polli-cli/src/lib/validate.ts
+++ b/packages/polli-cli/src/lib/validate.ts
@@ -1,0 +1,55 @@
+/**
+ * Validate a CLI-supplied numeric option.
+ *
+ * Dimensions and durations passed via flags are strings straight from the
+ * command line. Without validation they are forwarded verbatim to the API
+ * (e.g. `--width abc` or `--width -5`), producing raw validation errors like
+ * `Invalid input: expected number, received NaN` instead of a helpful CLI
+ * message — and invalid values are never caught locally.
+ *
+ * Returns the normalized integer on success, or an error message on failure.
+ */
+export function parsePositiveInt(
+    value: string | undefined,
+    name: string,
+    opts: { min?: number; max?: number } = {},
+): { value: number } | { error: string } {
+    if (value === undefined || value === "") {
+        return { error: `${name} is required` };
+    }
+    const num = Number(value);
+    if (!Number.isInteger(num)) {
+        return { error: `${name} must be an integer, got "${value}"` };
+    }
+    if (num <= 0) {
+        return { error: `${name} must be a positive integer, got "${value}"` };
+    }
+    if (opts.min !== undefined && num < opts.min) {
+        return {
+            error: `${name} must be at least ${opts.min}, got "${value}"`,
+        };
+    }
+    if (opts.max !== undefined && num > opts.max) {
+        return { error: `${name} must be at most ${opts.max}, got "${value}"` };
+    }
+    return { value: num };
+}
+
+/**
+ * Convenience wrapper: validates `value` and, on failure, prints an error
+ * and exits with code 1. Returns the validated integer.
+ */
+export function requirePositiveInt(
+    value: string | undefined,
+    name: string,
+    opts: { min?: number; max?: number } = {},
+    printError: (msg: string) => void = (m) => console.error(`error: ${m}`),
+    exit: (code: number) => never = (c) => process.exit(c),
+): number {
+    const parsed = parsePositiveInt(value, name, opts);
+    if ("error" in parsed) {
+        printError(parsed.error);
+        exit(1);
+    }
+    return parsed.value;
+}

--- a/packages/polli-cli/test/validate.test.ts
+++ b/packages/polli-cli/test/validate.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { parsePositiveInt, requirePositiveInt } from "../src/lib/validate.js";
+
+describe("parsePositiveInt", () => {
+    it("accepts a valid positive integer", () => {
+        expect(parsePositiveInt("1024", "--width")).toEqual({ value: 1024 });
+    });
+
+    it("rejects non-numeric input", () => {
+        expect(parsePositiveInt("abc", "--width")).toEqual({
+            error: '--width must be an integer, got "abc"',
+        });
+    });
+
+    it("rejects floats", () => {
+        expect(parsePositiveInt("12.5", "--height")).toEqual({
+            error: '--height must be an integer, got "12.5"',
+        });
+    });
+
+    it("rejects zero and negative", () => {
+        expect(parsePositiveInt("0", "--width")).toEqual({
+            error: '--width must be a positive integer, got "0"',
+        });
+        expect(parsePositiveInt("-5", "--width")).toEqual({
+            error: '--width must be a positive integer, got "-5"',
+        });
+    });
+
+    it("enforces min/max bounds", () => {
+        expect(parsePositiveInt("10", "--width", { min: 16 })).toEqual({
+            error: '--width must be at least 16, got "10"',
+        });
+        expect(parsePositiveInt("5000", "--width", { max: 4096 })).toEqual({
+            error: '--width must be at most 4096, got "5000"',
+        });
+    });
+});
+
+describe("requirePositiveInt", () => {
+    it("returns the value on success", () => {
+        expect(requirePositiveInt("512", "--width")).toBe(512);
+    });
+
+    it("prints an error and exits 1 on failure", () => {
+        const errors: string[] = [];
+        const codes: number[] = [];
+        const exitMock = (c: number): never => {
+            codes.push(c);
+            // A real process.exit never returns; simulate that by throwing
+            throw new Error(`__exit__:${c}`);
+        };
+        expect(() =>
+            requirePositiveInt(
+                "abc",
+                "--width",
+                {},
+                (m) => errors.push(m),
+                exitMock,
+            ),
+        ).toThrow("__exit__:1");
+        expect(codes).toEqual([1]);
+        expect(errors).toEqual(['--width must be an integer, got "abc"']);
+    });
+});


### PR DESCRIPTION
## Summary

The `polli` CLI passes numeric flags straight through to the API without validation. Non-numeric or out-of-range values produce confusing raw server errors instead of a clear CLI message:

```console
$ polli gen image "a cat" --width abc
Generating image...
error: 400 Bad Request: {"success":false,"error":{"message":"Query parameter validation failed","code":"BAD_REQUEST","details":{"fieldErrors":{"width":["Invalid input: expected number, received NaN"]}}}}
```

The request is still sent (and billed) before the user learns the flag was wrong.

## Changes

- **`gen image` / `gen video`**: `--width` / `--height` are validated locally as integers in `[1, 4096]` before any network call.
- **`gen audio`**: `--duration` must be an integer in `[1, 300]`; `--speed` must be a number in `[0.25, 4]`.
- Adds a small shared helper `src/lib/validate.ts` (`parsePositiveInt` / `requirePositiveInt`) used by the commands.
- Adds the package's first unit tests (`test/validate.test.ts`, vitest) covering the helper.

## Before / after

```console
$ polli gen image "a cat" --width abc
error: --width must be an integer, got "abc"      # exit 1, no network call
```

## Checks

- `npm test` — 7/7 pass (vitest)
- `npx biome check` — clean on all changed files
- `npm run build` — tsup build succeeds

## Notes

- The API server does its own validation; this PR only makes the CLI fail fast with a friendly message instead of forwarding garbage and surfacing a raw JSON error.
