### PR TITLE
feat: expose Scribe through OpenAI realtime protocol

### DIFF
--- a/gen.pollinations.ai/src/docs/audio-generation.md
+++ b/gen.pollinations.ai/src/docs/audio-generation.md
@@ -7,7 +7,6 @@ Text-to-speech, music generation, and audio transcription.
 | `GET /audio/{text}` | Simple URL-based TTS or music generation |
 | `POST /v1/audio/speech` | OpenAI-compatible TTS |
 | `POST /v1/audio/transcriptions` | Speech-to-text transcription |
-| `GET /v1/audio/transcriptions/realtime` | WebSocket realtime transcription |
 
 **Audio models:** {{AUDIO_MODELS}}
 

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -94,7 +94,9 @@ function supportedEndpointsForEventType(eventType: EventType): string[] {
         return ["/audio/{text}", "/v1/audio/speech"];
     }
     if (eventType === "generate.embedding") return ["/v1/embeddings"];
-    if (eventType === "generate.realtime") return ["/v1/realtime"];
+    if (eventType === "generate.realtime") {
+        return ["/realtime", "/v1/realtime"];
+    }
     return IMAGE_MODEL_ENDPOINTS;
 }
 

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -1,6 +1,5 @@
 import type { Logger } from "@logtape/logtape";
 import { ensureUpstreamOk, UpstreamError } from "@shared/error.ts";
-import { validator } from "@shared/middleware/validator.ts";
 import {
     AUDIO_VOICES,
     type AudioModelName,
@@ -32,7 +31,6 @@ import {
     withSafetyHeaders,
 } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
-import { ScribeRealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 import { requireGenerationAccess } from "@/utils/generation-access.ts";
@@ -42,7 +40,6 @@ import {
 } from "../fallback.ts";
 import { readResponseBytes } from "../utils/response-bytes.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
-import { handleScribeRealtimeWebSocket } from "./realtime.ts";
 import {
     buildTranscriptionResponse,
     type NormalizedDiarizedSegment,
@@ -3183,41 +3180,6 @@ export const audioRoutes = new Hono<Env>()
                 }),
             );
         },
-    )
-    .get(
-        "/transcriptions/realtime",
-        describeRoute({
-            tags: ["🔊 Audio"],
-            summary: "Realtime Audio Transcription",
-            description: [
-                "Stream mono audio to Scribe v2 Realtime over WebSocket and receive partial and committed transcripts.",
-                "",
-                "Send `input_audio_chunk` JSON messages using the ElevenLabs Realtime STT protocol. Supports manual or VAD commits, language selection and detection, background filtering, and optional word timestamps.",
-                "",
-                "Authenticate with `Authorization: Bearer <key>`, or use `?key=pk_...` in browser WebSocket clients. Billing uses the streamed audio duration and is settled when the socket closes.",
-            ].join("\n"),
-            responses: {
-                101: {
-                    description: "WebSocket connection established",
-                },
-                ...errorResponseDescriptions(
-                    400,
-                    401,
-                    402,
-                    403,
-                    426,
-                    429,
-                    500,
-                    503,
-                ),
-            },
-        }),
-        validator("query", ScribeRealtimeRequestQueryParamsSchema),
-        resolveModel("generate.realtime", {
-            defaultModel: "scribe-realtime",
-            supportedEndpoint: "/v1/audio/transcriptions/realtime",
-        }),
-        handleScribeRealtimeWebSocket,
     )
     .post(
         "/transcriptions",

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -280,7 +280,7 @@ const REALTIME_DOCS = [
     "",
     "Requires an API key with positive balance. Server clients can use `Authorization: Bearer <key>`; browser WebSocket clients can use `?key=pk_...`.",
     "",
-    'The WebSocket settles one billing event when the session closes. Use `session.type: "transcription"` with `scribe-realtime`; other realtime models use `session.type: "realtime"`.',
+    "The WebSocket settles one billing event when the session closes. Selecting `scribe-realtime` creates a transcription session automatically; other realtime models create voice and multimodal sessions.",
     "",
     "Events sent and received over both routes use the OpenAI Realtime protocol. See OpenAI's [Realtime WebSocket events guide](https://developers.openai.com/api/docs/guides/realtime-websocket#sending-and-receiving-events).",
     "",

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -9,7 +9,7 @@ import {
 import { getModel3dModelsInfo } from "@shared/registry/model-info.ts";
 import {
     DEFAULT_REALTIME_MODEL,
-    REALTIME_VOICE_MODEL_NAMES,
+    REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { Context } from "hono";
@@ -221,7 +221,7 @@ const videoModelDisplayNames = getVideoModelIds().join(", ");
 const textModelDisplayNames = Object.keys(TEXT_SERVICES).join(", ");
 const audioModelDisplayNames = Object.keys(AUDIO_SERVICES).join(", ");
 const embeddingModelDisplayNames = Object.keys(EMBEDDING_SERVICES).join(", ");
-const realtimeModelDisplayNames = REALTIME_VOICE_MODEL_NAMES.join(", ");
+const realtimeModelDisplayNames = REALTIME_MODEL_NAMES.join(", ");
 const model3dModelDisplayNames = getModel3dModelsInfo()
     .map((model) => model.name)
     .join(", ");
@@ -269,19 +269,20 @@ const MODEL3D_GENERATION_DOCS = interpolate(
     MODEL_VARS,
 );
 const REALTIME_DOCS = [
-    "## Realtime Voice",
+    "## Realtime",
     "",
-    "OpenAI-compatible Realtime WebSocket proxy for voice and multimodal sessions.",
+    "OpenAI-compatible Realtime WebSocket for voice, multimodal, and transcription sessions.",
     "",
     "| Endpoint | Description |",
     "|----------|-------------|",
+    `| \`GET /realtime\` | Pollinations Realtime session (\`model=${DEFAULT_REALTIME_MODEL}\`) |`,
     `| \`GET /v1/realtime\` | WebSocket Realtime session (\`model=${DEFAULT_REALTIME_MODEL}\`) |`,
     "",
     "Requires an API key with positive balance. Server clients can use `Authorization: Bearer <key>`; browser WebSocket clients can use `?key=pk_...`.",
     "",
-    "The WebSocket proxy aggregates observed `response.done` usage and settles one billing event when the session closes. Input transcription sessions are not supported yet.",
+    'The WebSocket settles one billing event when the session closes. Use `session.type: "transcription"` with `scribe-realtime`; other realtime models use `session.type: "realtime"`.',
     "",
-    "Events sent and received over the socket use the OpenAI Realtime protocol unchanged. See OpenAI's [Realtime WebSocket events guide](https://developers.openai.com/api/docs/guides/realtime-websocket#sending-and-receiving-events).",
+    "Events sent and received over both routes use the OpenAI Realtime protocol. See OpenAI's [Realtime WebSocket events guide](https://developers.openai.com/api/docs/guides/realtime-websocket#sending-and-receiving-events).",
     "",
     "```js",
     'import WebSocket from "ws";',

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -40,7 +40,7 @@ import {
 } from "@shared/registry/model3d.ts";
 import {
     DEFAULT_REALTIME_MODEL,
-    REALTIME_VOICE_MODEL_NAMES,
+    REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import {
     type CreateChatCompletionRequest,
@@ -102,6 +102,38 @@ const videoModelNames = getVideoModelIds()
 const model3dModelNames = getModel3dModelIds()
     .map((id) => `\`${id}\``)
     .join(", ");
+
+function describeRealtimeWebSocket(path: "/realtime" | "/v1/realtime") {
+    return describeRoute({
+        tags: ["🎙️ Realtime"],
+        summary: "Realtime WebSocket",
+        description: [
+            "OpenAI-compatible Realtime WebSocket for voice, multimodal, and transcription sessions.",
+            "",
+            `Connect with \`wss://gen.pollinations.ai${path}?model=${DEFAULT_REALTIME_MODEL}\` and send/receive OpenAI Realtime JSON events over the socket. Set \`session.type\` to \`transcription\` when using \`scribe-realtime\`.`,
+            "Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.",
+            "",
+            `**Models:** ${REALTIME_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
+            "",
+            "**Billing:** requires a positive balance and settles one session total when the socket closes.",
+        ].join("\n"),
+        responses: {
+            101: {
+                description: "WebSocket connection established",
+            },
+            ...errorResponseDescriptions(
+                400,
+                401,
+                402,
+                403,
+                426,
+                429,
+                500,
+                503,
+            ),
+        },
+    });
+}
 
 const factory = createFactory<Env>();
 const textBodyLimit = bodyLimit({
@@ -552,38 +584,21 @@ export const proxyRoutes = new Hono<Env>()
     .use(frontendKeyRateLimit)
     .use(balance)
     .get(
-        "/v1/realtime",
-        describeRoute({
-            tags: ["🎙️ Realtime"],
-            summary: "Realtime WebSocket",
-            description: [
-                "OpenAI-compatible Realtime WebSocket proxy.",
-                "",
-                `Connect with \`wss://gen.pollinations.ai/v1/realtime?model=${DEFAULT_REALTIME_MODEL}\` and send/receive Realtime JSON events over the socket.`,
-                "Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.",
-                "",
-                `**Models:** ${REALTIME_VOICE_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,
-                "",
-                "**Billing:** requires a positive balance. Gen proxies the WebSocket, aggregates observed `response.done` usage, and deducts one session total when the socket closes. Input transcription sessions are not supported yet.",
-            ].join("\n"),
-            responses: {
-                101: {
-                    description: "WebSocket connection established",
-                },
-                ...errorResponseDescriptions(
-                    400,
-                    401,
-                    402,
-                    403,
-                    426,
-                    429,
-                    500,
-                    503,
-                ),
-            },
-        }),
+        "/realtime",
+        describeRealtimeWebSocket("/realtime"),
         validator("query", RealtimeRequestQueryParamsSchema),
-        resolveModel("generate.realtime"),
+        resolveModel("generate.realtime", {
+            supportedEndpoint: "/realtime",
+        }),
+        handleRealtimeWebSocket,
+    )
+    .get(
+        "/v1/realtime",
+        describeRealtimeWebSocket("/v1/realtime"),
+        validator("query", RealtimeRequestQueryParamsSchema),
+        resolveModel("generate.realtime", {
+            supportedEndpoint: "/v1/realtime",
+        }),
         handleRealtimeWebSocket,
     )
     .post(

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -110,7 +110,7 @@ function describeRealtimeWebSocket(path: "/realtime" | "/v1/realtime") {
         description: [
             "OpenAI-compatible Realtime WebSocket for voice, multimodal, and transcription sessions.",
             "",
-            `Connect with \`wss://gen.pollinations.ai${path}?model=${DEFAULT_REALTIME_MODEL}\` and send/receive OpenAI Realtime JSON events over the socket. Set \`session.type\` to \`transcription\` when using \`scribe-realtime\`.`,
+            `Connect with \`wss://gen.pollinations.ai${path}?model=${DEFAULT_REALTIME_MODEL}\` and send/receive OpenAI Realtime JSON events over the socket. Selecting \`scribe-realtime\` creates a transcription session automatically.`,
             "Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.",
             "",
             `**Models:** ${REALTIME_MODEL_NAMES.map((model) => `\`${model}\``).join(", ")}.`,

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -190,7 +190,6 @@ type ScribeRealtimeConfig = {
     secondaryLanguages?: string[];
     vadThreshold?: number;
     vadSilenceThresholdSecs?: number;
-    filterBackgroundAudio?: boolean;
     prompt?: string;
 };
 
@@ -223,9 +222,6 @@ function buildScribeRealtimeUrl(config: ScribeRealtimeConfig): string {
             "vad_silence_threshold_secs",
             String(config.vadSilenceThresholdSecs),
         );
-    }
-    if (config.filterBackgroundAudio) {
-        url.searchParams.set("filter_background_audio", "true");
     }
     return url.toString();
 }
@@ -379,9 +375,6 @@ function scribeSession(config: ScribeRealtimeConfig, sessionId: string) {
                     ...(languages.length && { languages }),
                 },
                 turn_detection: turnDetection,
-                ...(config.filterBackgroundAudio && {
-                    noise_reduction: { type: "near_field" },
-                }),
             },
         },
     };
@@ -409,13 +402,6 @@ function parseScribeSessionUpdate(
     current: ScribeRealtimeConfig,
 ): { config: ScribeRealtimeConfig } | { error: string; param?: string } {
     const session = asRecord(event.session);
-    if (session.type !== undefined && session.type !== "transcription") {
-        return {
-            error: 'session.type must be "transcription" for scribe-realtime.',
-            param: "session.type",
-        };
-    }
-
     const input = asRecord(asRecord(session.audio).input);
     const next = { ...current };
     if (input.format !== undefined) {
@@ -434,15 +420,6 @@ function parseScribeSessionUpdate(
 
     const transcription = asRecord(input.transcription);
     if (
-        transcription.model !== undefined &&
-        transcription.model !== "scribe-realtime"
-    ) {
-        return {
-            error: 'transcription.model must be "scribe-realtime".',
-            param: "session.audio.input.transcription.model",
-        };
-    }
-    if (
         transcription.prompt !== undefined &&
         typeof transcription.prompt !== "string"
     ) {
@@ -453,18 +430,6 @@ function parseScribeSessionUpdate(
     }
     if (typeof transcription.prompt === "string") {
         next.prompt = transcription.prompt || undefined;
-    }
-    if (transcription.keywords !== undefined) {
-        return {
-            error: "transcription.keywords is not supported for scribe-realtime.",
-            param: "session.audio.input.transcription.keywords",
-        };
-    }
-    if (transcription.delay !== undefined && transcription.delay !== "low") {
-        return {
-            error: 'transcription.delay must be "low".',
-            param: "session.audio.input.transcription.delay",
-        };
     }
     if (transcription.languages !== undefined) {
         if (
@@ -523,28 +488,6 @@ function parseScribeSessionUpdate(
             typeof turnDetection.silence_duration_ms === "number"
                 ? turnDetection.silence_duration_ms / 1000
                 : undefined;
-    }
-
-    if (input.noise_reduction === null) {
-        next.filterBackgroundAudio = false;
-    } else if (input.noise_reduction !== undefined) {
-        const noiseReduction = asRecord(input.noise_reduction);
-        if (
-            noiseReduction.type !== "near_field" &&
-            noiseReduction.type !== "far_field"
-        ) {
-            return {
-                error: 'noise_reduction.type must be "near_field" or "far_field".',
-                param: "session.audio.input.noise_reduction.type",
-            };
-        }
-        next.filterBackgroundAudio = true;
-    }
-    if (Array.isArray(session.include) && session.include.length > 0) {
-        return {
-            error: "session.include is not supported for scribe-realtime.",
-            param: "session.include",
-        };
     }
 
     return { config: next };
@@ -1034,7 +977,6 @@ function proxyScribeOpenAIRealtime(
     let upstream: WebSocket | undefined;
     let connecting: Promise<void> | undefined;
     let closed = false;
-    let audioStarted = false;
     let promptPending = false;
     let currentItemId = `item_${generateRandomId()}`;
     let previousItemId: string | null = null;
@@ -1243,21 +1185,26 @@ function proxyScribeOpenAIRealtime(
             return;
         }
         if (event.type === "session.update") {
-            if (audioStarted) {
-                sendRealtimeError(
-                    downstream,
-                    "The Scribe session cannot be reconfigured after audio starts.",
-                    "session",
-                );
-                return;
-            }
             const parsed = parseScribeSessionUpdate(event, config);
             if ("error" in parsed) {
                 sendRealtimeError(downstream, parsed.error, parsed.param);
                 return;
             }
+            if (
+                (upstream || connecting) &&
+                buildScribeRealtimeUrl(parsed.config) !==
+                    buildScribeRealtimeUrl(config)
+            ) {
+                sendRealtimeError(
+                    downstream,
+                    "Scribe audio format, languages, and turn detection cannot change after streaming starts.",
+                    "session.audio.input",
+                );
+                return;
+            }
+            const promptChanged = parsed.config.prompt !== config.prompt;
             config = parsed.config;
-            promptPending = Boolean(config.prompt);
+            if (promptChanged) promptPending = Boolean(config.prompt);
             sendRealtimeEvent(downstream, {
                 event_id: `event_${generateRandomId()}`,
                 type: "session.updated",
@@ -1266,12 +1213,10 @@ function proxyScribeOpenAIRealtime(
             return;
         }
         if (event.type === "input_audio_buffer.append") {
-            audioStarted = true;
             enqueueInput(event.audio as string, false);
             return;
         }
         if (event.type === "input_audio_buffer.commit") {
-            audioStarted = true;
             const itemId = currentItemId;
             pendingItemIds.push(itemId);
             currentItemId = `item_${generateRandomId()}`;

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -35,11 +35,7 @@ import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
 import { reduceAdjustmentsToEventFields } from "@/middleware/track.ts";
-import {
-    RealtimeUsageSchema,
-    type ScribeRealtimeAudioFormat,
-    type ScribeRealtimeRequestQueryParams,
-} from "@/schemas/realtime.ts";
+import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
 
@@ -186,51 +182,57 @@ async function connectAzureRealtime(
 const SCRIBE_REALTIME_ENDPOINT =
     "https://api.elevenlabs.io/v1/speech-to-text/realtime";
 
-const SCRIBE_AUDIO_FORMAT = {
-    pcm_8000: { sampleRate: 8000, bytesPerSecond: 16_000 },
-    pcm_16000: { sampleRate: 16_000, bytesPerSecond: 32_000 },
-    pcm_22050: { sampleRate: 22_050, bytesPerSecond: 44_100 },
-    pcm_24000: { sampleRate: 24_000, bytesPerSecond: 48_000 },
-    pcm_44100: { sampleRate: 44_100, bytesPerSecond: 88_200 },
-    pcm_48000: { sampleRate: 48_000, bytesPerSecond: 96_000 },
-    ulaw_8000: { sampleRate: 8000, bytesPerSecond: 8000 },
-} satisfies Record<
-    ScribeRealtimeAudioFormat,
-    { sampleRate: number; bytesPerSecond: number }
->;
+type ScribeAudioFormat = "pcm_24000" | "ulaw_8000";
+type ScribeRealtimeConfig = {
+    audioFormat: ScribeAudioFormat;
+    commitStrategy: "manual" | "vad";
+    languageCode?: string;
+    secondaryLanguages?: string[];
+    vadThreshold?: number;
+    vadSilenceThresholdSecs?: number;
+    filterBackgroundAudio?: boolean;
+    prompt?: string;
+};
 
-function buildScribeRealtimeUrl(
-    query: ScribeRealtimeRequestQueryParams,
-): string {
+const DEFAULT_SCRIBE_CONFIG: ScribeRealtimeConfig = {
+    audioFormat: "pcm_24000",
+    commitStrategy: "manual",
+};
+
+const SCRIBE_BYTES_PER_SECOND: Record<ScribeAudioFormat, number> = {
+    pcm_24000: 48_000,
+    ulaw_8000: 8000,
+};
+
+function buildScribeRealtimeUrl(config: ScribeRealtimeConfig): string {
     const url = new URL(SCRIBE_REALTIME_ENDPOINT);
     url.searchParams.set("model_id", "scribe_v2_realtime");
-    url.searchParams.set("audio_format", query.audio_format);
-    url.searchParams.set("commit_strategy", query.commit_strategy);
-
-    for (const field of [
-        "language_code",
-        "vad_threshold",
-        "vad_silence_threshold_secs",
-        "min_speech_duration_ms",
-        "min_silence_duration_ms",
-    ] as const) {
-        const value = query[field];
-        if (value !== undefined) url.searchParams.set(field, String(value));
+    url.searchParams.set("audio_format", config.audioFormat);
+    url.searchParams.set("commit_strategy", config.commitStrategy);
+    if (config.languageCode) {
+        url.searchParams.set("language_code", config.languageCode);
     }
-    for (const field of [
-        "include_timestamps",
-        "include_language_detection",
-        "no_verbatim",
-        "filter_background_audio",
-    ] as const) {
-        if (query[field]) url.searchParams.set(field, "true");
+    for (const language of config.secondaryLanguages ?? []) {
+        url.searchParams.append("secondary_languages", language);
+    }
+    if (config.vadThreshold !== undefined) {
+        url.searchParams.set("vad_threshold", String(config.vadThreshold));
+    }
+    if (config.vadSilenceThresholdSecs !== undefined) {
+        url.searchParams.set(
+            "vad_silence_threshold_secs",
+            String(config.vadSilenceThresholdSecs),
+        );
+    }
+    if (config.filterBackgroundAudio) {
+        url.searchParams.set("filter_background_audio", "true");
     }
     return url.toString();
 }
 
 async function connectScribeRealtime(
     c: Context<Env>,
-    query: ScribeRealtimeRequestQueryParams,
+    config: ScribeRealtimeConfig,
 ): Promise<WebSocket | Response> {
     const apiKey = c.env.ELEVENLABS_API_KEY;
     if (!apiKey) {
@@ -239,7 +241,7 @@ async function connectScribeRealtime(
         });
     }
 
-    const response = (await fetch(buildScribeRealtimeUrl(query), {
+    const response = (await fetch(buildScribeRealtimeUrl(config), {
         headers: {
             "xi-api-key": apiKey,
             Upgrade: "websocket",
@@ -314,60 +316,19 @@ function forwardMessage(
     });
 }
 
-function inspectScribeInput(
-    data: unknown,
-    audioFormat: ScribeRealtimeAudioFormat,
+function inspectAudioBase64(
+    base64: unknown,
+    audioFormat: ScribeAudioFormat,
 ): { audioSeconds: number } | { error: string } {
-    if (typeof data !== "string") {
-        return { error: "Scribe realtime expects JSON text messages." };
+    if (typeof base64 !== "string") {
+        return { error: "input_audio_buffer.append requires audio." };
     }
-
-    let event: Record<string, unknown>;
-    try {
-        const parsed = JSON.parse(data);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return { error: "Scribe realtime expects a JSON object." };
-        }
-        event = parsed as Record<string, unknown>;
-    } catch {
-        return { error: "Scribe realtime received malformed JSON." };
-    }
-
-    if (event.message_type !== "input_audio_chunk") {
-        return {
-            error: "Scribe realtime accepts only input_audio_chunk messages.",
-        };
-    }
-    if (typeof event.audio_base_64 !== "string") {
-        return { error: "input_audio_chunk requires audio_base_64." };
-    }
-    if (event.commit !== undefined && typeof event.commit !== "boolean") {
-        return { error: "input_audio_chunk commit must be a boolean." };
-    }
-    if (
-        event.previous_text !== undefined &&
-        typeof event.previous_text !== "string"
-    ) {
-        return { error: "input_audio_chunk previous_text must be a string." };
-    }
-
-    const format = SCRIBE_AUDIO_FORMAT[audioFormat];
-    if (
-        event.sample_rate !== undefined &&
-        event.sample_rate !== format.sampleRate
-    ) {
-        return {
-            error: `input_audio_chunk sample_rate must be ${format.sampleRate} for ${audioFormat}.`,
-        };
-    }
-
-    const base64 = event.audio_base_64;
     if (
         !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$/.test(
             base64,
         )
     ) {
-        return { error: "input_audio_chunk audio_base_64 is invalid." };
+        return { error: "input_audio_buffer.append audio is invalid base64." };
     }
     const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
     const byteLength = Math.floor((base64.length * 3) / 4) - padding;
@@ -377,78 +338,216 @@ function inspectScribeInput(
         };
     }
 
-    return { audioSeconds: byteLength / format.bytesPerSecond };
+    return {
+        audioSeconds: byteLength / SCRIBE_BYTES_PER_SECOND[audioFormat],
+    };
 }
 
-function forwardScribeInput(
-    c: Context<Env>,
-    source: WebSocket,
-    target: WebSocket,
-    audioFormat: ScribeRealtimeAudioFormat,
-    tracking: RealtimeBillingContext,
-): void {
-    source.addEventListener("message", (event) => {
-        const inspected = inspectScribeInput(event.data, audioFormat);
-        if ("error" in inspected) {
-            closeSocket(source, 1008, inspected.error);
-            closeSocket(target, 1008, inspected.error);
-            scheduleRealtimeSettlement(c, tracking);
-            return;
-        }
-        if (!isOpen(target)) return;
-        addUsage(tracking.usage, {
-            promptAudioSeconds: inspected.audioSeconds,
-        });
-        target.send(event.data);
-    });
+function scribeSession(config: ScribeRealtimeConfig, sessionId: string) {
+    const format =
+        config.audioFormat === "ulaw_8000"
+            ? { type: "audio/pcmu" }
+            : { type: "audio/pcm", rate: 24_000 };
+    const turnDetection =
+        config.commitStrategy === "vad"
+            ? {
+                  type: "server_vad",
+                  ...(config.vadThreshold !== undefined && {
+                      threshold: config.vadThreshold,
+                  }),
+                  ...(config.vadSilenceThresholdSecs !== undefined && {
+                      silence_duration_ms:
+                          config.vadSilenceThresholdSecs * 1000,
+                  }),
+              }
+            : null;
+    const languages = [
+        config.languageCode,
+        ...(config.secondaryLanguages ?? []),
+    ].filter((language): language is string => Boolean(language));
+
+    return {
+        id: sessionId,
+        object: "realtime.session",
+        type: "transcription",
+        audio: {
+            input: {
+                format,
+                transcription: {
+                    model: "scribe-realtime",
+                    ...(config.prompt && { prompt: config.prompt }),
+                    ...(languages.length && { languages }),
+                },
+                turn_detection: turnDetection,
+                ...(config.filterBackgroundAudio && {
+                    noise_reduction: { type: "near_field" },
+                }),
+            },
+        },
+    };
 }
 
 const SCRIBE_ERROR_MESSAGE_TYPES = new Set([
     "auth_error",
     "chunk_size_exceeded",
     "commit_throttled",
+    "error",
+    "input_error",
     "insufficient_audio_activity",
     "invalid_request",
     "queue_overflow",
     "quota_exceeded",
     "rate_limited",
+    "resource_exhausted",
+    "session_time_limit_exceeded",
     "transcriber_error",
     "unaccepted_terms",
 ]);
 
-function forwardScribeOutput(
-    c: Context<Env>,
-    source: WebSocket,
-    target: WebSocket,
-    tracking: RealtimeBillingContext,
-): void {
-    const log = c.get("log").getChild("realtime");
-    source.addEventListener("message", (event) => {
-        const providerEvent = asRecord(parseEventData(event.data));
-        const messageType = providerEvent.message_type;
-        if (
-            typeof messageType !== "string" ||
-            !SCRIBE_ERROR_MESSAGE_TYPES.has(messageType)
-        ) {
-            if (isOpen(target)) target.send(event.data);
-            return;
-        }
+function parseScribeSessionUpdate(
+    event: Record<string, unknown>,
+    current: ScribeRealtimeConfig,
+): { config: ScribeRealtimeConfig } | { error: string; param?: string } {
+    const session = asRecord(event.session);
+    if (session.type !== undefined && session.type !== "transcription") {
+        return {
+            error: 'session.type must be "transcription" for scribe-realtime.',
+            param: "session.type",
+        };
+    }
 
-        log.warn("Scribe realtime provider error: type={type}", {
-            type: messageType,
-        });
-        if (isOpen(target)) {
-            target.send(
-                JSON.stringify({
-                    message_type: messageType,
-                    error: "Realtime transcription failed.",
-                }),
-            );
+    const input = asRecord(asRecord(session.audio).input);
+    const next = { ...current };
+    if (input.format !== undefined) {
+        const format = asRecord(input.format);
+        if (format.type === "audio/pcmu") {
+            next.audioFormat = "ulaw_8000";
+        } else if (format.type === "audio/pcm" && format.rate === 24_000) {
+            next.audioFormat = "pcm_24000";
+        } else {
+            return {
+                error: "scribe-realtime supports OpenAI PCM at 24000 Hz and PCMU audio.",
+                param: "session.audio.input.format",
+            };
         }
-        closeSocket(source, 1011, "Realtime transcription failed");
-        closeSocket(target, 1011, "Realtime transcription failed");
-        scheduleRealtimeSettlement(c, tracking);
-    });
+    }
+
+    const transcription = asRecord(input.transcription);
+    if (
+        transcription.model !== undefined &&
+        transcription.model !== "scribe-realtime"
+    ) {
+        return {
+            error: 'transcription.model must be "scribe-realtime".',
+            param: "session.audio.input.transcription.model",
+        };
+    }
+    if (
+        transcription.prompt !== undefined &&
+        typeof transcription.prompt !== "string"
+    ) {
+        return {
+            error: "transcription.prompt must be a string.",
+            param: "session.audio.input.transcription.prompt",
+        };
+    }
+    if (typeof transcription.prompt === "string") {
+        next.prompt = transcription.prompt || undefined;
+    }
+    if (transcription.keywords !== undefined) {
+        return {
+            error: "transcription.keywords is not supported for scribe-realtime.",
+            param: "session.audio.input.transcription.keywords",
+        };
+    }
+    if (transcription.delay !== undefined && transcription.delay !== "low") {
+        return {
+            error: 'transcription.delay must be "low".',
+            param: "session.audio.input.transcription.delay",
+        };
+    }
+    if (transcription.languages !== undefined) {
+        if (
+            !Array.isArray(transcription.languages) ||
+            transcription.languages.some(
+                (language) =>
+                    typeof language !== "string" ||
+                    !/^[a-z]{2,3}(?:-[a-z]{2})?$/i.test(language),
+            )
+        ) {
+            return {
+                error: "transcription.languages must contain language codes.",
+                param: "session.audio.input.transcription.languages",
+            };
+        }
+        next.languageCode = transcription.languages[0] as string | undefined;
+        next.secondaryLanguages = transcription.languages.slice(1) as string[];
+    }
+
+    if (input.turn_detection === null) {
+        next.commitStrategy = "manual";
+        next.vadThreshold = undefined;
+        next.vadSilenceThresholdSecs = undefined;
+    } else if (input.turn_detection !== undefined) {
+        const turnDetection = asRecord(input.turn_detection);
+        if (turnDetection.type !== "server_vad") {
+            return {
+                error: 'scribe-realtime supports null or "server_vad" turn detection.',
+                param: "session.audio.input.turn_detection.type",
+            };
+        }
+        if (
+            turnDetection.threshold !== undefined &&
+            (typeof turnDetection.threshold !== "number" ||
+                turnDetection.threshold < 0 ||
+                turnDetection.threshold > 1)
+        ) {
+            return {
+                error: "turn_detection.threshold must be between 0 and 1.",
+                param: "session.audio.input.turn_detection.threshold",
+            };
+        }
+        if (
+            turnDetection.silence_duration_ms !== undefined &&
+            (typeof turnDetection.silence_duration_ms !== "number" ||
+                turnDetection.silence_duration_ms <= 0)
+        ) {
+            return {
+                error: "turn_detection.silence_duration_ms must be positive.",
+                param: "session.audio.input.turn_detection.silence_duration_ms",
+            };
+        }
+        next.commitStrategy = "vad";
+        next.vadThreshold = turnDetection.threshold as number | undefined;
+        next.vadSilenceThresholdSecs =
+            typeof turnDetection.silence_duration_ms === "number"
+                ? turnDetection.silence_duration_ms / 1000
+                : undefined;
+    }
+
+    if (input.noise_reduction === null) {
+        next.filterBackgroundAudio = false;
+    } else if (input.noise_reduction !== undefined) {
+        const noiseReduction = asRecord(input.noise_reduction);
+        if (
+            noiseReduction.type !== "near_field" &&
+            noiseReduction.type !== "far_field"
+        ) {
+            return {
+                error: 'noise_reduction.type must be "near_field" or "far_field".',
+                param: "session.audio.input.noise_reduction.type",
+            };
+        }
+        next.filterBackgroundAudio = true;
+    }
+    if (Array.isArray(session.include) && session.include.length > 0) {
+        return {
+            error: "session.include is not supported for scribe-realtime.",
+            param: "session.include",
+        };
+    }
+
+    return { config: next };
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -867,34 +966,6 @@ function wireClose(
     });
 }
 
-function wireScribeClose(
-    c: Context<Env>,
-    source: WebSocket,
-    target: WebSocket,
-    tracking: RealtimeBillingContext,
-): void {
-    source.addEventListener("close", (event) => {
-        try {
-            closeSocket(target, event.code, event.reason);
-            if (source.readyState !== WebSocket.CLOSED) {
-                const closeCode = normalizeCloseCode(event.code);
-                if (closeCode) source.close(closeCode, event.reason);
-                else source.close();
-            }
-        } finally {
-            scheduleRealtimeSettlement(c, tracking);
-        }
-    });
-    source.addEventListener("error", () => {
-        try {
-            closeSocket(target, 1011, "Realtime proxy error");
-            closeSocket(source, 1011, "Realtime proxy error");
-        } finally {
-            scheduleRealtimeSettlement(c, tracking);
-        }
-    });
-}
-
 function proxyRealtimeWebSockets(
     c: Context<Env>,
     upstream: WebSocket,
@@ -922,22 +993,315 @@ function proxyRealtimeWebSockets(
     } as WebSocketResponseInit);
 }
 
-function proxyScribeRealtimeWebSockets(
+type QueuedScribeInput = {
+    payload: string;
+    audioSeconds: number;
+};
+
+function sendRealtimeEvent(socket: WebSocket, event: object): void {
+    if (isOpen(socket)) socket.send(JSON.stringify(event));
+}
+
+function sendRealtimeError(
+    socket: WebSocket,
+    message: string,
+    param?: string,
+    code = "invalid_value",
+): void {
+    sendRealtimeEvent(socket, {
+        event_id: `event_${generateRandomId()}`,
+        type: "error",
+        error: {
+            type:
+                code === "provider_error"
+                    ? "server_error"
+                    : "invalid_request_error",
+            code,
+            message,
+            ...(param && { param }),
+        },
+    });
+}
+
+function proxyScribeOpenAIRealtime(
     c: Context<Env>,
-    upstream: WebSocket,
     tracking: RealtimeBillingContext,
-    audioFormat: ScribeRealtimeAudioFormat,
 ): Response {
     const pair = new WebSocketPair();
     const [client, downstream] = Object.values(pair) as [WebSocket, WebSocket];
+    const sessionId = `sess_${generateRandomId()}`;
+    let config = { ...DEFAULT_SCRIBE_CONFIG };
+    let upstream: WebSocket | undefined;
+    let connecting: Promise<void> | undefined;
+    let closed = false;
+    let audioStarted = false;
+    let promptPending = false;
+    let currentItemId = `item_${generateRandomId()}`;
+    let previousItemId: string | null = null;
+    let pendingTranscript = "";
+    let emittedTranscript = "";
+    const pendingItemIds: string[] = [];
+    const queue: QueuedScribeInput[] = [];
+    const log = c.get("log").getChild("realtime");
+
+    const sendQueuedInput = (input: QueuedScribeInput) => {
+        if (!upstream || !isOpen(upstream)) return;
+        upstream.send(input.payload);
+        addUsage(tracking.usage, {
+            promptAudioSeconds: input.audioSeconds,
+        });
+    };
+
+    const completeTranscript = (providerEvent: Record<string, unknown>) => {
+        const text =
+            typeof providerEvent.text === "string"
+                ? providerEvent.text
+                : pendingTranscript;
+        if (!text) return;
+        const itemId = pendingItemIds.shift() ?? currentItemId;
+        const eventBase = {
+            item_id: itemId,
+            content_index: 0,
+        };
+        const finalDelta = text.startsWith(emittedTranscript)
+            ? text.slice(emittedTranscript.length)
+            : "";
+        if (finalDelta) {
+            sendRealtimeEvent(downstream, {
+                event_id: `event_${generateRandomId()}`,
+                type: "conversation.item.input_audio_transcription.delta",
+                ...eventBase,
+                delta: finalDelta,
+            });
+        }
+        sendRealtimeEvent(downstream, {
+            event_id: `event_${generateRandomId()}`,
+            type: "conversation.item.input_audio_transcription.completed",
+            ...eventBase,
+            transcript: text,
+            ...(typeof providerEvent.language_code === "string" && {
+                languages: [{ code: providerEvent.language_code }],
+            }),
+        });
+        previousItemId = itemId;
+        if (itemId === currentItemId) {
+            currentItemId = `item_${generateRandomId()}`;
+        }
+        pendingTranscript = "";
+        emittedTranscript = "";
+    };
+
+    const attachUpstream = (socket: WebSocket) => {
+        upstream = socket;
+        socket.binaryType = "arraybuffer";
+        socket.addEventListener("message", (event) => {
+            const providerEvent = asRecord(parseEventData(event.data));
+            const messageType = providerEvent.message_type;
+            if (typeof messageType !== "string") return;
+            if (SCRIBE_ERROR_MESSAGE_TYPES.has(messageType)) {
+                log.warn("Scribe realtime provider error: type={type}", {
+                    type: messageType,
+                });
+                sendRealtimeError(
+                    downstream,
+                    "Realtime transcription failed.",
+                    undefined,
+                    "provider_error",
+                );
+                closeSocket(socket, 1011, "Realtime transcription failed");
+                closeSocket(downstream, 1011, "Realtime transcription failed");
+                scheduleRealtimeSettlement(c, tracking);
+                return;
+            }
+            if (
+                messageType === "partial_transcript" &&
+                typeof providerEvent.text === "string"
+            ) {
+                pendingTranscript = providerEvent.text;
+                if (pendingTranscript.startsWith(emittedTranscript)) {
+                    const delta = pendingTranscript.slice(
+                        emittedTranscript.length,
+                    );
+                    if (delta) {
+                        sendRealtimeEvent(downstream, {
+                            event_id: `event_${generateRandomId()}`,
+                            type: "conversation.item.input_audio_transcription.delta",
+                            item_id: pendingItemIds[0] ?? currentItemId,
+                            content_index: 0,
+                            delta,
+                        });
+                        emittedTranscript = pendingTranscript;
+                    }
+                }
+                return;
+            }
+            if (
+                (messageType === "final_transcript" ||
+                    messageType === "final_transcript_with_timestamps") &&
+                typeof providerEvent.text === "string"
+            ) {
+                pendingTranscript = providerEvent.text;
+                return;
+            }
+            if (
+                messageType === "committed_transcript" ||
+                messageType === "committed_transcript_with_timestamps"
+            ) {
+                completeTranscript(providerEvent);
+            }
+        });
+        socket.addEventListener("close", (event) => {
+            closeSocket(downstream, event.code, event.reason);
+            scheduleRealtimeSettlement(c, tracking);
+        });
+        socket.addEventListener("error", () => {
+            sendRealtimeError(
+                downstream,
+                "Realtime transcription failed.",
+                undefined,
+                "provider_error",
+            );
+            closeSocket(downstream, 1011, "Realtime transcription failed");
+            scheduleRealtimeSettlement(c, tracking);
+        });
+        socket.accept({ allowHalfOpen: true });
+        if (closed) {
+            closeSocket(socket);
+            return;
+        }
+        for (const input of queue.splice(0)) sendQueuedInput(input);
+    };
+
+    const ensureUpstream = () => {
+        if (upstream || connecting) return;
+        connecting = connectScribeRealtime(c, config)
+            .then(async (result) => {
+                if (result instanceof Response) {
+                    await result.body?.cancel();
+                    throw new Error(
+                        `Scribe connection failed (${result.status})`,
+                    );
+                }
+                attachUpstream(result);
+            })
+            .catch((error) => {
+                log.error("Scribe realtime connection failed: {error}", {
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                });
+                sendRealtimeError(
+                    downstream,
+                    "Realtime transcription failed.",
+                    undefined,
+                    "provider_error",
+                );
+                closeSocket(downstream, 1011, "Realtime transcription failed");
+                scheduleRealtimeSettlement(c, tracking);
+            });
+        c.executionCtx.waitUntil(connecting);
+    };
+
+    const enqueueInput = (audio: string, commit: boolean) => {
+        const inspected = inspectAudioBase64(audio, config.audioFormat);
+        if ("error" in inspected) {
+            sendRealtimeError(downstream, inspected.error, "audio");
+            return;
+        }
+        const providerEvent: Record<string, unknown> = {
+            message_type: "input_audio_chunk",
+            audio_base_64: audio,
+            ...(commit && { commit: true }),
+        };
+        if (promptPending && audio.length > 0 && config.prompt) {
+            providerEvent.previous_text = config.prompt;
+            promptPending = false;
+        }
+        const input = {
+            payload: JSON.stringify(providerEvent),
+            audioSeconds: inspected.audioSeconds,
+        };
+        if (upstream && isOpen(upstream)) sendQueuedInput(input);
+        else queue.push(input);
+        ensureUpstream();
+    };
 
     downstream.binaryType = "arraybuffer";
-    forwardScribeInput(c, downstream, upstream, audioFormat, tracking);
-    forwardScribeOutput(c, upstream, downstream, tracking);
-    wireScribeClose(c, downstream, upstream, tracking);
-    wireScribeClose(c, upstream, downstream, tracking);
     downstream.accept({ allowHalfOpen: true });
-    upstream.accept({ allowHalfOpen: true });
+    sendRealtimeEvent(downstream, {
+        event_id: `event_${generateRandomId()}`,
+        type: "session.created",
+        session: scribeSession(config, sessionId),
+    });
+
+    downstream.addEventListener("message", (message) => {
+        const event = asRecord(parseEventData(message.data));
+        if (!Object.keys(event).length || typeof event.type !== "string") {
+            sendRealtimeError(
+                downstream,
+                "Expected an OpenAI Realtime JSON event.",
+            );
+            return;
+        }
+        if (event.type === "session.update") {
+            if (audioStarted) {
+                sendRealtimeError(
+                    downstream,
+                    "The Scribe session cannot be reconfigured after audio starts.",
+                    "session",
+                );
+                return;
+            }
+            const parsed = parseScribeSessionUpdate(event, config);
+            if ("error" in parsed) {
+                sendRealtimeError(downstream, parsed.error, parsed.param);
+                return;
+            }
+            config = parsed.config;
+            promptPending = Boolean(config.prompt);
+            sendRealtimeEvent(downstream, {
+                event_id: `event_${generateRandomId()}`,
+                type: "session.updated",
+                session: scribeSession(config, sessionId),
+            });
+            return;
+        }
+        if (event.type === "input_audio_buffer.append") {
+            audioStarted = true;
+            enqueueInput(event.audio as string, false);
+            return;
+        }
+        if (event.type === "input_audio_buffer.commit") {
+            audioStarted = true;
+            const itemId = currentItemId;
+            pendingItemIds.push(itemId);
+            currentItemId = `item_${generateRandomId()}`;
+            enqueueInput("", true);
+            sendRealtimeEvent(downstream, {
+                event_id: `event_${generateRandomId()}`,
+                type: "input_audio_buffer.committed",
+                previous_item_id: previousItemId,
+                item_id: itemId,
+            });
+            previousItemId = itemId;
+            return;
+        }
+        sendRealtimeError(
+            downstream,
+            `Unsupported client event: ${event.type}.`,
+            "type",
+            "invalid_event",
+        );
+    });
+    downstream.addEventListener("close", (event) => {
+        closed = true;
+        if (upstream) closeSocket(upstream, event.code, event.reason);
+        scheduleRealtimeSettlement(c, tracking);
+    });
+    downstream.addEventListener("error", () => {
+        closed = true;
+        if (upstream) closeSocket(upstream, 1011, "Realtime proxy error");
+        scheduleRealtimeSettlement(c, tracking);
+    });
 
     return new Response(null, {
         status: 101,
@@ -1025,6 +1389,15 @@ export async function handleRealtimeWebSocket(
         return new Response("Expected Upgrade: websocket", { status: 426 });
     }
     const userId = await authorizeRealtimeSession(c);
+    const tracking = await createRealtimeBillingContext(c);
+    if (c.var.model.resolved === "scribe-realtime") {
+        if (!c.env.ELEVENLABS_API_KEY) {
+            throw new HTTPException(503, {
+                message: "ElevenLabs realtime provider is not configured.",
+            });
+        }
+        return proxyScribeOpenAIRealtime(c, tracking);
+    }
 
     const upstream = await connectAzureRealtime(
         c,
@@ -1033,31 +1406,5 @@ export async function handleRealtimeWebSocket(
     );
     if (upstream instanceof Response) return upstream;
 
-    return proxyRealtimeWebSockets(
-        c,
-        upstream,
-        await createRealtimeBillingContext(c),
-    );
-}
-
-export async function handleScribeRealtimeWebSocket(
-    c: Context<Env>,
-): Promise<Response> {
-    if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
-        return new Response("Expected Upgrade: websocket", { status: 426 });
-    }
-    await authorizeRealtimeSession(c);
-    const query = c.req.valid(
-        "query" as never,
-    ) as ScribeRealtimeRequestQueryParams;
-    const tracking = await createRealtimeBillingContext(c);
-    const upstream = await connectScribeRealtime(c, query);
-    if (upstream instanceof Response) return upstream;
-
-    return proxyScribeRealtimeWebSockets(
-        c,
-        upstream,
-        tracking,
-        query.audio_format,
-    );
+    return proxyRealtimeWebSockets(c, upstream, tracking);
 }

--- a/gen.pollinations.ai/src/schemas/realtime.ts
+++ b/gen.pollinations.ai/src/schemas/realtime.ts
@@ -1,35 +1,17 @@
 import {
     DEFAULT_REALTIME_MODEL,
-    REALTIME_VOICE_MODEL_NAMES,
+    REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import { z } from "zod";
-import { parseBooleanLike } from "@/util.ts";
-
-const StrictBooleanQueryParamSchema = z.preprocess(
-    (value) =>
-        typeof value === "string" && value.trim() === ""
-            ? value
-            : (parseBooleanLike(value) ?? value),
-    z.boolean(),
-);
-
-const numberQueryParam = (schema: z.ZodType<number>) =>
-    z.preprocess(
-        (value) =>
-            typeof value === "string" && value.trim() === ""
-                ? Number.NaN
-                : value,
-        schema,
-    );
 
 export const RealtimeRequestQueryParamsSchema = z
     .object({
         model: z
-            .enum(REALTIME_VOICE_MODEL_NAMES as [string, ...string[]])
+            .enum(REALTIME_MODEL_NAMES as [string, ...string[]])
             .optional()
             .default(DEFAULT_REALTIME_MODEL)
             .meta({
-                description: `Realtime model to use. Supported models: ${REALTIME_VOICE_MODEL_NAMES.join(", ")}.`,
+                description: `Realtime model to use. Supported models: ${REALTIME_MODEL_NAMES.join(", ")}.`,
             }),
         key: z.string().optional().meta({
             description:
@@ -40,69 +22,6 @@ export const RealtimeRequestQueryParamsSchema = z
 
 export type RealtimeRequestQueryParams = z.infer<
     typeof RealtimeRequestQueryParamsSchema
->;
-
-const SCRIBE_REALTIME_AUDIO_FORMATS = [
-    "pcm_8000",
-    "pcm_16000",
-    "pcm_22050",
-    "pcm_24000",
-    "pcm_44100",
-    "pcm_48000",
-    "ulaw_8000",
-] as const;
-
-export type ScribeRealtimeAudioFormat =
-    (typeof SCRIBE_REALTIME_AUDIO_FORMATS)[number];
-
-export const ScribeRealtimeRequestQueryParamsSchema = z
-    .object({
-        model: z
-            .literal("scribe-realtime")
-            .optional()
-            .default("scribe-realtime"),
-        key: z.string().optional().meta({
-            description:
-                "Pollinations API key for browser WebSocket clients that cannot set custom Authorization headers.",
-        }),
-        audio_format: z
-            .enum(SCRIBE_REALTIME_AUDIO_FORMATS)
-            .optional()
-            .default("pcm_16000"),
-        language_code: z.string().min(2).max(3).optional(),
-        commit_strategy: z.enum(["manual", "vad"]).optional().default("manual"),
-        vad_threshold: numberQueryParam(
-            z.coerce.number().min(0).max(1),
-        ).optional(),
-        vad_silence_threshold_secs: numberQueryParam(
-            z.coerce.number().positive(),
-        ).optional(),
-        min_speech_duration_ms: numberQueryParam(
-            z.coerce.number().int().nonnegative(),
-        ).optional(),
-        min_silence_duration_ms: numberQueryParam(
-            z.coerce.number().int().nonnegative(),
-        ).optional(),
-        include_timestamps:
-            StrictBooleanQueryParamSchema.optional().default(false),
-        include_language_detection:
-            StrictBooleanQueryParamSchema.optional().default(false),
-        no_verbatim: StrictBooleanQueryParamSchema.optional().default(false),
-        filter_background_audio:
-            StrictBooleanQueryParamSchema.optional().default(false),
-    })
-    .strict()
-    .refine(
-        (query) => !(query.filter_background_audio && query.include_timestamps),
-        {
-            message:
-                "filter_background_audio cannot be combined with include_timestamps",
-            path: ["filter_background_audio"],
-        },
-    );
-
-export type ScribeRealtimeRequestQueryParams = z.infer<
-    typeof ScribeRealtimeRequestQueryParamsSchema
 >;
 
 // Shape of `response.usage` in the Realtime `response.done` event. Only the

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -135,8 +135,11 @@ describe("docs routes", () => {
             { url: "https://gen.pollinations.ai" },
         ]);
         expect(schema.paths["/v1/chat/completions"]).toBeDefined();
+        expect(schema.paths["/realtime"]).toBeDefined();
         expect(schema.paths["/v1/realtime"]).toBeDefined();
-        expect(schema.paths["/v1/audio/transcriptions/realtime"]).toBeDefined();
+        expect(
+            schema.paths["/v1/audio/transcriptions/realtime"],
+        ).toBeUndefined();
         expect(schema.paths["/image/{prompt}"]).toBeDefined();
         const model3dPost = (
             schema.paths["/3d/{prompt}"] as Record<string, unknown>
@@ -232,17 +235,14 @@ describe("docs routes", () => {
         expect(realtimeResponses?.["426"]).toBeDefined();
         expect(realtimeResponses?.["503"]).toBeDefined();
 
-        const scribeRealtimeGet = (
-            schema.paths["/v1/audio/transcriptions/realtime"] as Record<
-                string,
-                unknown
-            >
+        const nativeRealtimeGet = (
+            schema.paths["/realtime"] as Record<string, unknown>
         )?.get as Record<string, unknown> | undefined;
-        const scribeRealtimeResponses = scribeRealtimeGet?.responses as
+        const nativeRealtimeResponses = nativeRealtimeGet?.responses as
             | Record<string, unknown>
             | undefined;
-        expect(scribeRealtimeResponses?.["426"]).toBeDefined();
-        expect(scribeRealtimeResponses?.["503"]).toBeDefined();
+        expect(nativeRealtimeResponses?.["426"]).toBeDefined();
+        expect(nativeRealtimeResponses?.["503"]).toBeDefined();
 
         const accountKeyGet = (
             schema.paths["/account/key"] as Record<string, unknown>
@@ -368,15 +368,15 @@ describe("docs routes", () => {
         expect(apiBody).toContain("Base URL:");
         // Stable heading marker proves the realtime modality is composed into
         // the api section, without pinning volatile mid-prose wording.
-        expect(apiBody).toContain("## Realtime Voice");
+        expect(apiBody).toContain("## Realtime");
         const realtimeSection = apiBody.slice(
-            apiBody.indexOf("## Realtime Voice"),
+            apiBody.indexOf("## Realtime"),
             apiBody.indexOf("## 3D Generation"),
         );
-        expect(realtimeSection).not.toContain("scribe-realtime");
-        expect(apiBody).toContain(
-            "`GET /v1/audio/transcriptions/realtime` | WebSocket realtime transcription",
-        );
+        expect(realtimeSection).toContain("scribe-realtime");
+        expect(realtimeSection).toContain("`GET /realtime`");
+        expect(realtimeSection).toContain("`GET /v1/realtime`");
+        expect(apiBody).not.toContain("/v1/audio/transcriptions/realtime");
         expect(apiBody).not.toContain("## BYOP");
 
         const byopRes = await worker.fetch(

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -475,14 +475,12 @@ test.each([
                             model: "scribe-realtime",
                             prompt: "contexte",
                             languages: ["fr", "en"],
-                            delay: "low",
                         },
                         turn_detection: {
                             type: "server_vad",
                             threshold: 0.4,
                             silence_duration_ms: 1500,
                         },
-                        noise_reduction: { type: "near_field" },
                     },
                 },
             },
@@ -490,7 +488,23 @@ test.each([
     );
     await expect(updated).resolves.toMatchObject({
         type: "session.updated",
-        session: { type: "transcription" },
+        session: {
+            type: "transcription",
+            audio: {
+                input: {
+                    transcription: {
+                        model: "scribe-realtime",
+                        prompt: "contexte",
+                        languages: ["fr", "en"],
+                    },
+                    turn_detection: {
+                        type: "server_vad",
+                        threshold: 0.4,
+                        silence_duration_ms: 1500,
+                    },
+                },
+            },
+        },
     });
 
     session.client.send(
@@ -519,7 +533,6 @@ test.each([
         secondary_languages: "en",
         vad_threshold: "0.4",
         vad_silence_threshold_secs: "1.5",
-        filter_background_audio: "true",
     });
     expect(session.upstream.request.headers.get("xi-api-key")).toBeTruthy();
     expect(session.upstream.request.headers.get("Authorization")).toBeNull();
@@ -560,6 +573,93 @@ test.each([
     const telemetry = await closeAndReadTelemetry(session);
     expect(telemetry.requestPath).toBe(path);
     expect(telemetry.tokenCountPromptAudioSeconds).toBeCloseTo(0.1, 8);
+});
+
+test("accepts compatible Scribe session updates after streaming starts", async () => {
+    const session = await openPaidScribeSession({
+        name: "scribe-realtime-mid-session-update-key",
+    });
+    await session.initialClientMessage;
+
+    session.client.send(
+        JSON.stringify({
+            type: "input_audio_buffer.append",
+            audio: zeroAudioBase64(4800),
+        }),
+    );
+    const server = await waitForUpstreamServer(session.upstream);
+    server.accept();
+    await nextMessage(server);
+
+    const updated = nextJsonMessage(session.client);
+    session.client.send(
+        JSON.stringify({
+            type: "session.update",
+            session: {
+                type: "transcription",
+                audio: {
+                    input: {
+                        transcription: {
+                            model: "scribe-realtime",
+                            prompt: "new context",
+                        },
+                    },
+                },
+            },
+        }),
+    );
+    await expect(updated).resolves.toMatchObject({
+        type: "session.updated",
+        session: {
+            type: "transcription",
+            audio: {
+                input: {
+                    transcription: {
+                        model: "scribe-realtime",
+                        prompt: "new context",
+                    },
+                },
+            },
+        },
+    });
+
+    const contextualAudio = nextMessage(server);
+    session.client.send(
+        JSON.stringify({
+            type: "input_audio_buffer.append",
+            audio: zeroAudioBase64(4800),
+        }),
+    );
+    await expect(contextualAudio).resolves.toBe(
+        JSON.stringify({
+            message_type: "input_audio_chunk",
+            audio_base_64: zeroAudioBase64(4800),
+            previous_text: "new context",
+        }),
+    );
+
+    const incompatible = nextJsonMessage(session.client);
+    session.client.send(
+        JSON.stringify({
+            type: "session.update",
+            session: {
+                audio: {
+                    input: {
+                        transcription: { languages: ["fr"] },
+                    },
+                },
+            },
+        }),
+    );
+    await expect(incompatible).resolves.toMatchObject({
+        type: "error",
+        error: {
+            type: "invalid_request_error",
+            param: "session.audio.input",
+        },
+    });
+
+    await closeRealtimeSession(session);
 });
 
 test.each([

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -659,7 +659,7 @@ test("accepts compatible Scribe session updates after streaming starts", async (
         },
     });
 
-    await closeRealtimeSession(session);
+    await closeAndReadTelemetry(session);
 });
 
 test.each([

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -61,6 +61,32 @@ function nextMessage(socket: WebSocket): Promise<unknown> {
     });
 }
 
+async function nextJsonMessage(socket: WebSocket): Promise<unknown> {
+    const message = await nextMessage(socket);
+    return typeof message === "string" ? JSON.parse(message) : message;
+}
+
+function nextJsonMessages(
+    socket: WebSocket,
+    count: number,
+): Promise<unknown[]> {
+    return new Promise((resolve) => {
+        const messages: unknown[] = [];
+        const onMessage = (event: MessageEvent) => {
+            messages.push(
+                typeof event.data === "string"
+                    ? JSON.parse(event.data)
+                    : event.data,
+            );
+            if (messages.length === count) {
+                socket.removeEventListener("message", onMessage);
+                resolve(messages);
+            }
+        };
+        socket.addEventListener("message", onMessage);
+    });
+}
+
 function nextClose(socket: WebSocket): Promise<CloseEvent> {
     return new Promise((resolve) => {
         socket.addEventListener("close", (event) => resolve(event), {
@@ -73,10 +99,9 @@ function zeroAudioBase64(byteLength: number): string {
     return btoa("\0".repeat(byteLength));
 }
 
-function mockRealtimeProvider(initialMessage?: string) {
+function mockRealtimeProvider() {
     let upstreamRequest: Request | undefined;
     let upstreamServer: WebSocket | undefined;
-    let upstreamServerAccepted = false;
     const tinybirdRequests: Request[] = [];
 
     const fetchMock = vi
@@ -99,11 +124,6 @@ function mockRealtimeProvider(initialMessage?: string) {
                 WebSocket,
             ];
             upstreamServer = server;
-            if (initialMessage) {
-                server.accept();
-                upstreamServerAccepted = true;
-                server.send(initialMessage);
-            }
             return new Response(null, {
                 status: 101,
                 webSocket: client,
@@ -125,10 +145,20 @@ function mockRealtimeProvider(initialMessage?: string) {
             }
             return upstreamServer;
         },
-        get serverAccepted() {
-            return upstreamServerAccepted;
+        get maybeServer() {
+            return upstreamServer;
         },
     };
+}
+
+async function waitForUpstreamServer(
+    upstream: ReturnType<typeof mockRealtimeProvider>,
+) {
+    for (let attempt = 0; attempt < 20; attempt++) {
+        if (upstream.maybeServer) return upstream.server;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("Expected upstream realtime WebSocket");
 }
 
 async function getUserBalances(userId: string) {
@@ -201,21 +231,19 @@ async function openPaidRealtimeSession({
 
 async function openPaidScribeSession({
     name,
-    query = "",
-    initialProviderMessage,
+    path = "/v1/realtime",
 }: {
     name: string;
-    query?: string;
-    initialProviderMessage?: string;
+    path?: "/realtime" | "/v1/realtime";
 }) {
     const { key, userId } = await createTestApiKey({
         name,
         pollenBudget: 1,
         user: { tierBalance: 0, packBalance: 1 },
     });
-    const upstream = mockRealtimeProvider(initialProviderMessage);
+    const upstream = mockRealtimeProvider();
     const { response, ctx } = await fetchWorkerWithContext(
-        `/v1/audio/transcriptions/realtime?${query}`,
+        `${path}?model=scribe-realtime`,
         {
             headers: {
                 Authorization: `Bearer ${key}`,
@@ -228,11 +256,8 @@ async function openPaidScribeSession({
     expect(response.status).toBe(101);
     const client = response.webSocket;
     if (!client) throw new Error("Expected downstream WebSocket");
-    const initialClientMessage = initialProviderMessage
-        ? nextMessage(client)
-        : undefined;
+    const initialClientMessage = nextJsonMessage(client);
     client.accept();
-    if (!upstream.serverAccepted) upstream.server.accept();
 
     return { client, ctx, upstream, userId, initialClientMessage };
 }
@@ -241,7 +266,7 @@ type PaidRealtimeSession = Awaited<ReturnType<typeof openPaidRealtimeSession>>;
 
 async function closeRealtimeSession(session: PaidRealtimeSession) {
     session.client.close();
-    session.upstream.server.close();
+    session.upstream.maybeServer?.close();
     await waitOnExecutionContext(session.ctx);
 }
 
@@ -317,56 +342,59 @@ async function expectClientEventRejected(
     await waitOnExecutionContext(ctx);
 }
 
-test("proxies an OpenAI-compatible realtime WebSocket with a paid key", async ({
+test("proxies OpenAI-compatible realtime WebSockets on both public routes", async ({
     paidApiKey,
 }) => {
-    const upstream = mockRealtimeProvider();
+    for (const path of ["/realtime", "/v1/realtime"] as const) {
+        const upstream = mockRealtimeProvider();
 
-    const { response, ctx } = await fetchWorkerWithContext("/v1/realtime", {
-        headers: {
-            Authorization: `Bearer ${paidApiKey}`,
-            Upgrade: "websocket",
-        },
-    });
+        const { response, ctx } = await fetchWorkerWithContext(path, {
+            headers: {
+                Authorization: `Bearer ${paidApiKey}`,
+                Upgrade: "websocket",
+            },
+        });
 
-    expect(response.status).toBe(101);
-    expect(response.webSocket).toBeDefined();
-    expect(upstream.request.url).toBe(
-        "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime?model=gpt-realtime-2-1",
-    );
-    expect(upstream.request.headers.get("Upgrade")).toBe("websocket");
-    // Provider auth uses the Azure key, never the caller's Pollinations key.
-    expect(upstream.request.headers.get("api-key")).toBeTruthy();
-    expect(upstream.request.headers.get("api-key")).not.toBe(paidApiKey);
-    expect(upstream.request.headers.get("Authorization")).toBeNull();
-    expect(upstream.request.headers.get("OpenAI-Safety-Identifier")).toMatch(
-        /^[a-f0-9]{64}$/,
-    );
+        expect(response.status).toBe(101);
+        expect(response.webSocket).toBeDefined();
+        expect(upstream.request.url).toBe(
+            "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime?model=gpt-realtime-2-1",
+        );
+        expect(upstream.request.headers.get("Upgrade")).toBe("websocket");
+        // Provider auth uses the Azure key, never the caller's Pollinations key.
+        expect(upstream.request.headers.get("api-key")).toBeTruthy();
+        expect(upstream.request.headers.get("api-key")).not.toBe(paidApiKey);
+        expect(upstream.request.headers.get("Authorization")).toBeNull();
+        expect(
+            upstream.request.headers.get("OpenAI-Safety-Identifier"),
+        ).toMatch(/^[a-f0-9]{64}$/);
 
-    const client = response.webSocket;
-    if (!client) throw new Error("Expected downstream WebSocket");
-    client.accept();
-    upstream.server.accept();
+        const client = response.webSocket;
+        if (!client) throw new Error("Expected downstream WebSocket");
+        client.accept();
+        upstream.server.accept();
 
-    const upstreamMessage = nextMessage(upstream.server);
-    const clientEvent = JSON.stringify({
-        type: "session.update",
-        session: { instructions: "test" },
-    });
-    client.send(clientEvent);
-    await expect(upstreamMessage).resolves.toBe(clientEvent);
+        const upstreamMessage = nextMessage(upstream.server);
+        const clientEvent = JSON.stringify({
+            type: "session.update",
+            session: { instructions: "test" },
+        });
+        client.send(clientEvent);
+        await expect(upstreamMessage).resolves.toBe(clientEvent);
 
-    const downstreamMessage = nextMessage(client);
-    const serverEvent = JSON.stringify({
-        type: "session.created",
-        session: { model: "gpt-realtime-2-1" },
-    });
-    upstream.server.send(serverEvent);
-    await expect(downstreamMessage).resolves.toBe(serverEvent);
+        const downstreamMessage = nextMessage(client);
+        const serverEvent = JSON.stringify({
+            type: "session.created",
+            session: { model: "gpt-realtime-2-1" },
+        });
+        upstream.server.send(serverEvent);
+        await expect(downstreamMessage).resolves.toBe(serverEvent);
 
-    client.close();
-    upstream.server.close();
-    await waitOnExecutionContext(ctx);
+        client.close();
+        upstream.server.close();
+        await waitOnExecutionContext(ctx);
+        vi.restoreAllMocks();
+    }
 });
 
 test("routes the mini model through the working East US 2 deployment", async ({
@@ -421,106 +449,156 @@ test("accepts publishable keys through the query string for thin clients", async
     await waitOnExecutionContext(ctx);
 });
 
-test("proxies Scribe Realtime parameters without forwarding caller credentials", async () => {
+test.each([
+    "/realtime",
+    "/v1/realtime",
+] as const)("serves Scribe through the OpenAI protocol on %s", async (path) => {
     const session = await openPaidScribeSession({
-        name: "scribe-realtime-parameters-key",
-        query: [
-            "model=scribe-realtime",
-            "audio_format=pcm_16000",
-            "language_code=fr",
-            "commit_strategy=vad",
-            "vad_threshold=0.4",
-            "vad_silence_threshold_secs=1.5",
-            "min_speech_duration_ms=100",
-            "min_silence_duration_ms=100",
-            "include_timestamps=true",
-            "include_language_detection=true",
-            "no_verbatim=true",
-        ].join("&"),
+        name: `scribe-openai-${path}-key`,
+        path,
+    });
+    await expect(session.initialClientMessage).resolves.toMatchObject({
+        type: "session.created",
+        session: { type: "transcription" },
     });
 
-    const upstreamUrl = new URL(session.upstream.request.url);
-    expect(`${upstreamUrl.origin}${upstreamUrl.pathname}`).toBe(
-        "https://api.elevenlabs.io/v1/speech-to-text/realtime",
+    const updated = nextJsonMessage(session.client);
+    session.client.send(
+        JSON.stringify({
+            type: "session.update",
+            session: {
+                type: "transcription",
+                audio: {
+                    input: {
+                        format: { type: "audio/pcm", rate: 24_000 },
+                        transcription: {
+                            model: "scribe-realtime",
+                            prompt: "contexte",
+                            languages: ["fr", "en"],
+                            delay: "low",
+                        },
+                        turn_detection: {
+                            type: "server_vad",
+                            threshold: 0.4,
+                            silence_duration_ms: 1500,
+                        },
+                        noise_reduction: { type: "near_field" },
+                    },
+                },
+            },
+        }),
     );
+    await expect(updated).resolves.toMatchObject({
+        type: "session.updated",
+        session: { type: "transcription" },
+    });
+
+    session.client.send(
+        JSON.stringify({
+            type: "input_audio_buffer.append",
+            audio: zeroAudioBase64(4800),
+        }),
+    );
+    const server = await waitForUpstreamServer(session.upstream);
+    server.accept();
+    const upstreamMessage = nextMessage(server);
+    await expect(upstreamMessage).resolves.toBe(
+        JSON.stringify({
+            message_type: "input_audio_chunk",
+            audio_base_64: zeroAudioBase64(4800),
+            previous_text: "contexte",
+        }),
+    );
+
+    const upstreamUrl = new URL(session.upstream.request.url);
     expect(Object.fromEntries(upstreamUrl.searchParams)).toEqual({
         model_id: "scribe_v2_realtime",
-        audio_format: "pcm_16000",
+        audio_format: "pcm_24000",
         commit_strategy: "vad",
         language_code: "fr",
+        secondary_languages: "en",
         vad_threshold: "0.4",
         vad_silence_threshold_secs: "1.5",
-        min_speech_duration_ms: "100",
-        min_silence_duration_ms: "100",
-        include_timestamps: "true",
-        include_language_detection: "true",
-        no_verbatim: "true",
+        filter_background_audio: "true",
     });
     expect(session.upstream.request.headers.get("xi-api-key")).toBeTruthy();
     expect(session.upstream.request.headers.get("Authorization")).toBeNull();
 
-    const clientMessage = JSON.stringify({
-        message_type: "input_audio_chunk",
-        audio_base_64: zeroAudioBase64(3200),
-        sample_rate: 16_000,
-        commit: true,
-        previous_text: "contexte",
+    const transcriptEvents = nextJsonMessages(session.client, 3);
+    server.send(
+        JSON.stringify({
+            message_type: "partial_transcript",
+            text: "bon",
+        }),
+    );
+    server.send(
+        JSON.stringify({
+            message_type: "partial_transcript",
+            text: "bonjour",
+        }),
+    );
+    server.send(
+        JSON.stringify({
+            message_type: "committed_transcript",
+            text: "bonjour",
+        }),
+    );
+    const [firstDelta, secondDelta, completed] = await transcriptEvents;
+    expect(firstDelta).toMatchObject({
+        type: "conversation.item.input_audio_transcription.delta",
+        delta: "bon",
     });
-    const upstreamMessage = nextMessage(session.upstream.server);
-    session.client.send(clientMessage);
-    await expect(upstreamMessage).resolves.toBe(clientMessage);
-
-    const providerMessage = JSON.stringify({
-        message_type: "committed_transcript",
-        text: "bonjour",
+    expect(secondDelta).toMatchObject({
+        type: "conversation.item.input_audio_transcription.delta",
+        delta: "jour",
     });
-    const downstreamMessage = nextMessage(session.client);
-    session.upstream.server.send(providerMessage);
-    await expect(downstreamMessage).resolves.toBe(providerMessage);
+    expect(completed).toMatchObject({
+        type: "conversation.item.input_audio_transcription.completed",
+        transcript: "bonjour",
+    });
 
     const telemetry = await closeAndReadTelemetry(session);
+    expect(telemetry.requestPath).toBe(path);
     expect(telemetry.tokenCountPromptAudioSeconds).toBeCloseTo(0.1, 8);
 });
 
-test("forwards the initial Scribe session event after listeners are attached", async () => {
-    const initialProviderMessage = JSON.stringify({
-        message_type: "session_started",
-        session_id: "session-1",
-    });
-    const session = await openPaidScribeSession({
-        name: "scribe-realtime-initial-event-key",
-        initialProviderMessage,
-    });
-
-    await expect(session.initialClientMessage).resolves.toBe(
-        initialProviderMessage,
-    );
-    await closeRealtimeSession(session);
-});
-
 test.each([
-    ["pcm_8000", 16_000, 8000],
-    ["pcm_16000", 32_000, 16_000],
-    ["pcm_22050", 44_100, 22_050],
-    ["pcm_24000", 48_000, 24_000],
-    ["pcm_44100", 88_200, 44_100],
-    ["pcm_48000", 96_000, 48_000],
-    ["ulaw_8000", 8000, 8000],
-] as const)("bills one streamed second of %s at the exact Scribe Realtime rate", async (audioFormat, bytesPerSecond, sampleRate) => {
+    [{ type: "audio/pcm", rate: 24_000 }, "pcm_24000", 48_000],
+    [{ type: "audio/pcmu" }, "ulaw_8000", 8000],
+] as const)("bills one streamed second of OpenAI %j audio at the exact Scribe rate", async (format, upstreamFormat, bytesPerSecond) => {
     const session = await openPaidScribeSession({
-        name: `scribe-realtime-${audioFormat}-key`,
-        query: `audio_format=${audioFormat}`,
+        name: `scribe-realtime-${upstreamFormat}-key`,
     });
-    const upstreamMessage = nextMessage(session.upstream.server);
+    await session.initialClientMessage;
+    const updated = nextMessage(session.client);
     session.client.send(
         JSON.stringify({
-            message_type: "input_audio_chunk",
-            audio_base_64: zeroAudioBase64(bytesPerSecond),
-            sample_rate: sampleRate,
-            commit: true,
+            type: "session.update",
+            session: {
+                type: "transcription",
+                audio: {
+                    input: {
+                        format,
+                        transcription: { model: "scribe-realtime" },
+                        turn_detection: null,
+                    },
+                },
+            },
         }),
     );
-    await upstreamMessage;
+    await updated;
+    session.client.send(
+        JSON.stringify({
+            type: "input_audio_buffer.append",
+            audio: zeroAudioBase64(bytesPerSecond),
+        }),
+    );
+    const server = await waitForUpstreamServer(session.upstream);
+    server.accept();
+    await nextMessage(server);
+    expect(
+        new URL(session.upstream.request.url).searchParams.get("audio_format"),
+    ).toBe(upstreamFormat);
 
     const telemetry = await closeAndReadTelemetry(session);
     const user = await waitForPackBalanceBelow(session.userId, 1);
@@ -535,29 +613,27 @@ test.each([
     expect(telemetry.totalPrice).toBeCloseTo(expectedLedgerCharge, 12);
 });
 
-test("rejects malformed Scribe audio without forwarding or billing it", async () => {
+test("returns OpenAI errors for invalid Scribe events without billing", async () => {
     const session = await openPaidScribeSession({
         name: "scribe-realtime-malformed-audio-key",
     });
-    let upstreamReceived = false;
-    session.upstream.server.addEventListener("message", () => {
-        upstreamReceived = true;
-    });
-
-    const closeEvent = nextClose(session.client);
+    await session.initialClientMessage;
+    const error = nextJsonMessage(session.client);
     session.client.send(
         JSON.stringify({
-            message_type: "input_audio_chunk",
-            audio_base_64: "not base64!",
+            type: "input_audio_buffer.append",
+            audio: "not base64!",
         }),
     );
-    await expect(closeEvent).resolves.toMatchObject({
-        code: 1008,
-        reason: "input_audio_chunk audio_base_64 is invalid.",
+    await expect(error).resolves.toMatchObject({
+        type: "error",
+        error: {
+            type: "invalid_request_error",
+            code: "invalid_value",
+        },
     });
-    await waitOnExecutionContext(session.ctx);
-
-    expect(upstreamReceived).toBe(false);
+    await closeRealtimeSession(session);
+    expect(session.upstream.maybeServer).toBeUndefined();
     expect(session.upstream.tinybirdRequests).toHaveLength(0);
     expect((await getUserBalances(session.userId))?.packBalance).toBe(1);
 });
@@ -566,31 +642,34 @@ test("sanitizes Scribe provider errors and settles accepted audio", async () => 
     const session = await openPaidScribeSession({
         name: "scribe-realtime-provider-error-key",
     });
-    const upstreamMessage = nextMessage(session.upstream.server);
+    await session.initialClientMessage;
     session.client.send(
         JSON.stringify({
-            message_type: "input_audio_chunk",
-            audio_base_64: zeroAudioBase64(32_000),
-            sample_rate: 16_000,
+            type: "input_audio_buffer.append",
+            audio: zeroAudioBase64(48_000),
         }),
     );
-    await upstreamMessage;
+    const server = await waitForUpstreamServer(session.upstream);
+    server.accept();
+    await nextMessage(server);
 
-    const providerError = nextMessage(session.client);
+    const providerError = nextJsonMessage(session.client);
     const clientClose = nextClose(session.client);
-    session.upstream.server.send(
+    server.send(
         JSON.stringify({
             message_type: "quota_exceeded",
             error: "provider account details",
         }),
     );
 
-    await expect(providerError).resolves.toBe(
-        JSON.stringify({
-            message_type: "quota_exceeded",
-            error: "Realtime transcription failed.",
-        }),
-    );
+    await expect(providerError).resolves.toMatchObject({
+        type: "error",
+        error: {
+            type: "server_error",
+            code: "provider_error",
+            message: "Realtime transcription failed.",
+        },
+    });
     await expect(clientClose).resolves.toMatchObject({ code: 1011 });
     await waitOnExecutionContext(session.ctx);
     await waitForTinybirdRequests(session.upstream);
@@ -600,28 +679,24 @@ test("sanitizes Scribe provider errors and settles accepted audio", async () => 
     expect(telemetry.tokenCountPromptAudioSeconds).toBe(1);
 });
 
-test.each([
-    "/v1/audio/transcriptions/realtime?keyterms=Pollinations",
-    "/v1/audio/transcriptions/realtime?entity_detection=all",
-    "/v1/audio/transcriptions/realtime?model=scribe_v2_realtime",
-    "/v1/audio/transcriptions/realtime?filter_background_audio=true&include_timestamps=true",
-    "/v1/audio/transcriptions/realtime?vad_threshold=",
-    "/v1/audio/transcriptions/realtime?min_speech_duration_ms=",
-    "/v1/audio/transcriptions/realtime?include_timestamps",
-])("rejects unsupported Scribe Realtime query %s", async (path) => {
+test("removes the provider-specific Scribe route and query schema", async () => {
     const { key } = await createTestApiKey({
         name: "scribe-realtime-invalid-query-key",
         user: { packBalance: 1 },
     });
     const upstream = mockRealtimeProvider();
-    const response = await fetchWorker(path, {
-        headers: {
-            Authorization: `Bearer ${key}`,
-            Upgrade: "websocket",
-        },
+    const removed = await fetchWorker("/v1/audio/transcriptions/realtime", {
+        headers: { Authorization: `Bearer ${key}`, Upgrade: "websocket" },
     });
+    const providerQuery = await fetchWorker(
+        "/v1/realtime?model=scribe-realtime&audio_format=pcm_16000",
+        {
+            headers: { Authorization: `Bearer ${key}`, Upgrade: "websocket" },
+        },
+    );
 
-    expect(response.status).toBe(400);
+    expect(removed.status).toBe(404);
+    expect(providerQuery.status).toBe(400);
     expect(upstream.fetchMock).not.toHaveBeenCalled();
 });
 
@@ -636,25 +711,19 @@ test("enforces paid-only and model permissions for Scribe Realtime", async () =>
         allowedModels: [],
         user: { packBalance: 1 },
     });
-
-    const questResponse = await fetchWorker(
-        "/v1/audio/transcriptions/realtime",
-        {
-            headers: {
-                Authorization: `Bearer ${questOnly.key}`,
-                Upgrade: "websocket",
-            },
+    const path = "/v1/realtime?model=scribe-realtime";
+    const questResponse = await fetchWorker(path, {
+        headers: {
+            Authorization: `Bearer ${questOnly.key}`,
+            Upgrade: "websocket",
         },
-    );
-    const permissionResponse = await fetchWorker(
-        "/v1/audio/transcriptions/realtime",
-        {
-            headers: {
-                Authorization: `Bearer ${emptyPermissions.key}`,
-                Upgrade: "websocket",
-            },
+    });
+    const permissionResponse = await fetchWorker(path, {
+        headers: {
+            Authorization: `Bearer ${emptyPermissions.key}`,
+            Upgrade: "websocket",
         },
-    );
+    });
 
     expect(questResponse.status).toBe(402);
     expect(permissionResponse.status).toBe(403);
@@ -668,34 +737,28 @@ test("accepts a publishable key without forwarding it to ElevenLabs", async () =
     });
     const upstream = mockRealtimeProvider();
     const { response, ctx } = await fetchWorkerWithContext(
-        `/v1/audio/transcriptions/realtime?key=${encodeURIComponent(key)}`,
+        `/v1/realtime?model=scribe-realtime&key=${encodeURIComponent(key)}`,
         { headers: { Upgrade: "websocket" } },
         scribeTestEnv,
     );
+    response.webSocket?.accept();
+    response.webSocket?.send(
+        JSON.stringify({
+            type: "input_audio_buffer.append",
+            audio: zeroAudioBase64(4800),
+        }),
+    );
+    const server = await waitForUpstreamServer(upstream);
+    server.accept();
+    await nextMessage(server);
 
     expect(response.status).toBe(101);
     expect(upstream.request.url).not.toContain(key);
     expect(upstream.request.headers.get("xi-api-key")).toBeTruthy();
-    response.webSocket?.accept();
-    upstream.server.accept();
+    const upstreamClose = nextClose(server);
     response.webSocket?.close();
-    upstream.server.close();
+    await upstreamClose;
     await waitOnExecutionContext(ctx);
-});
-
-test("completes both sides of the Scribe close handshake", async () => {
-    const session = await openPaidScribeSession({
-        name: "scribe-realtime-close-key",
-    });
-    const clientClose = nextClose(session.client);
-    const upstreamClose = nextClose(session.upstream.server);
-
-    session.client.close(1000, "done");
-
-    await expect(clientClose).resolves.toMatchObject({ code: 1000 });
-    await expect(upstreamClose).resolves.toMatchObject({ code: 1000 });
-    await waitOnExecutionContext(session.ctx);
-    expect(session.upstream.tinybirdRequests).toHaveLength(0);
 });
 
 test("rejects non-WebSocket realtime requests before calling OpenAI", async ({
@@ -1150,7 +1213,7 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     expect(
         publicBody.data.find((model) => model.id === "scribe-realtime"),
     ).toMatchObject({
-        supported_endpoints: ["/v1/audio/transcriptions/realtime"],
+        supported_endpoints: ["/realtime", "/v1/realtime"],
     });
 
     const richResponse = await fetchWorker("/models");
@@ -1176,7 +1239,7 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
         title: "Scribe v2 Realtime",
         input_modalities: ["audio"],
         output_modalities: ["text"],
-        supported_endpoints: ["/v1/audio/transcriptions/realtime"],
+        supported_endpoints: ["/realtime", "/v1/realtime"],
         paid_only: true,
         pricing: {
             currency: "pollen",

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -92,21 +92,13 @@ export const REALTIME_SERVICES = {
         },
         title: "Scribe v2 Realtime",
         description:
-            "Live transcription in 90+ languages with partial results and word timestamps",
+            "Live transcription in 90+ languages with incremental and final results",
         inputModalities: ["audio"],
         outputModalities: ["text"],
-        supportedEndpoints: ["/v1/audio/transcriptions/realtime"],
+        supportedEndpoints: ["/realtime", "/v1/realtime"],
     },
 } satisfies Record<string, ModelDefinition>;
 
 export const REALTIME_MODEL_NAMES = Object.keys(
     REALTIME_SERVICES,
 ) as RealtimeModelName[];
-
-export const REALTIME_VOICE_MODEL_NAMES = REALTIME_MODEL_NAMES.filter(
-    (model) => {
-        const endpoints = (REALTIME_SERVICES[model] as ModelDefinition)
-            .supportedEndpoints;
-        return endpoints === undefined || endpoints.includes("/v1/realtime");
-    },
-);


### PR DESCRIPTION
- Exposes the shared OpenAI Realtime event protocol on both `/realtime` and `/v1/realtime`.
- Translates `scribe-realtime` transcription sessions to ElevenLabs `scribe_v2_realtime`, including PCM/PCMU audio, manual/VAD commits, language/context controls, incremental transcript deltas, sanitized errors, permissions, and exact streamed-audio billing.
- Removes the not-yet-production provider-specific `/v1/audio/transcriptions/realtime` route and query schema.
- Keeps the confirmed model contract unchanged: no aliases, paid-only, multiplier 1, no Pollinations GPU, and no fallback.

Validation:
- `npx vitest run test/realtime.test.ts test/docs.test.ts` — 38 passed
- `npm run typecheck`
- Direct ElevenLabs probe — correct transcript, 3 partial events, 2.3s
- Live local Gen E2E — auth, routing, transcript events, and exact billing passed

Related policy is intentionally separate in #13333. #13328 also edits the existing Azure realtime lifecycle; whichever PR merges second will need a narrow rebase.
