### PR TITLE
fix: notify owners of leaked publishable keys

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -1,4 +1,5 @@
 import {
+    Alert,
     AppIcon,
     Chip,
     GlobeIcon,
@@ -62,6 +63,9 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     const now = Date.now();
     const visibleKeys = apiKeys.filter(
         (k) => !k.expiresAt || new Date(k.expiresAt).getTime() > now,
+    );
+    const disabledPublishableKeys = visibleKeys.filter(
+        (key) => isPublishableKey(key) && key.enabled === false,
     );
     const sortedKeys = [...visibleKeys].sort(
         (a, b) =>
@@ -246,6 +250,34 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     return (
         <>
             <div className="flex flex-col gap-6">
+                {disabledPublishableKeys.length > 0 && (
+                    <Alert intent="warning">
+                        <p className="font-medium">
+                            We disabled {disabledPublishableKeys.length}{" "}
+                            publishable{" "}
+                            {disabledPublishableKeys.length === 1
+                                ? "key"
+                                : "keys"}{" "}
+                            after detecting suspicious direct use:{" "}
+                            {disabledPublishableKeys
+                                .map((key) => key.name || "Unnamed key")
+                                .join(", ")}
+                            .
+                        </p>
+                        <p className="mt-1 text-sm">
+                            Publishable keys (<code>pk_</code>) are deprecated
+                            for direct API requests. Move public apps to
+                            Pollinations Auth (BYOP), where users sign in and
+                            spend their own Pollen.{" "}
+                            <InlineLink
+                                href={genDocsUrl("#tag/bring-your-own-pollen")}
+                            >
+                                Read the migration guide
+                            </InlineLink>
+                            .
+                        </p>
+                    </Alert>
+                )}
                 <Section
                     title="API"
                     framed

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -64,14 +64,16 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     const visibleKeys = apiKeys.filter(
         (k) => !k.expiresAt || new Date(k.expiresAt).getTime() > now,
     );
-    const disabledPublishableKeys = visibleKeys.filter(
-        (key) => isPublishableKey(key) && key.enabled === false,
-    );
-    const protectedAppKeys = visibleKeys.filter(
+    const leakedPublishableKeys = visibleKeys.filter(
         (key) =>
-            isAppKey(key) &&
-            key.enabled !== false &&
-            key.metadata?.directUseDisabled === true,
+            isPublishableKey(key) &&
+            key.metadata?.directUseDisabledDueToLeak === true,
+    );
+    const disabledPublishableKeys = leakedPublishableKeys.filter(
+        (key) => !isAppKey(key) && key.enabled === false,
+    );
+    const protectedAppKeys = leakedPublishableKeys.filter(
+        (key) => isAppKey(key) && key.enabled !== false,
     );
     const sortedKeys = [...visibleKeys].sort(
         (a, b) =>

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -67,6 +67,12 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     const disabledPublishableKeys = visibleKeys.filter(
         (key) => isPublishableKey(key) && key.enabled === false,
     );
+    const protectedAppKeys = visibleKeys.filter(
+        (key) =>
+            isAppKey(key) &&
+            key.enabled !== false &&
+            key.metadata?.directUseDisabled === true,
+    );
     const sortedKeys = [...visibleKeys].sort(
         (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
@@ -250,25 +256,40 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     return (
         <>
             <div className="flex flex-col gap-6">
-                {disabledPublishableKeys.length > 0 && (
+                {(disabledPublishableKeys.length > 0 ||
+                    protectedAppKeys.length > 0) && (
                     <Alert intent="warning">
-                        <p className="font-medium">
-                            We disabled {disabledPublishableKeys.length}{" "}
-                            publishable{" "}
-                            {disabledPublishableKeys.length === 1
-                                ? "key"
-                                : "keys"}{" "}
-                            after detecting suspicious direct use:{" "}
-                            {disabledPublishableKeys
-                                .map((key) => key.name || "Unnamed key")
-                                .join(", ")}
-                            .
-                        </p>
+                        {disabledPublishableKeys.length > 0 && (
+                            <p className="font-medium">
+                                We disabled {disabledPublishableKeys.length}{" "}
+                                publishable{" "}
+                                {disabledPublishableKeys.length === 1
+                                    ? "key"
+                                    : "keys"}{" "}
+                                after detecting suspicious direct use:{" "}
+                                {disabledPublishableKeys
+                                    .map((key) => key.name || "Unnamed key")
+                                    .join(", ")}
+                                .
+                            </p>
+                        )}
+                        {protectedAppKeys.length > 0 && (
+                            <p className="font-medium">
+                                We blocked direct Pollen spending on{" "}
+                                {protectedAppKeys.length} app{" "}
+                                {protectedAppKeys.length === 1 ? "key" : "keys"}{" "}
+                                after detecting suspicious direct use:{" "}
+                                {protectedAppKeys
+                                    .map((key) => key.name || "Unnamed key")
+                                    .join(", ")}
+                                . Pollinations Auth (BYOP) remains available.
+                            </p>
+                        )}
                         <p className="mt-1 text-sm">
                             Publishable keys (<code>pk_</code>) are deprecated
-                            for direct API requests. Move public apps to
-                            Pollinations Auth (BYOP), where users sign in and
-                            spend their own Pollen.{" "}
+                            for direct API requests. Use Pollinations Auth
+                            (BYOP), where users sign in and spend their own
+                            Pollen.{" "}
                             <InlineLink
                                 href={genDocsUrl("#tag/bring-your-own-pollen")}
                             >


### PR DESCRIPTION
- Shows a targeted dashboard notice only for keys marked `directUseDisabledDueToLeak`
- Distinguishes disabled direct-only keys from app keys whose direct Pollen spending is blocked
- Keeps Pollinations Auth (BYOP) available for protected app keys
- Uses the existing key metadata JSON, with no schema or endpoint changes

Checks:
- `npx biome check --write enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx`
- `npm run typecheck --workspace enter.pollinations.ai`
- `npm run build:frontend --workspace enter.pollinations.ai`