### PR TITLE
chore: complete generation deduplication rollback

### DIFF
--- a/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
+++ b/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
@@ -1,0 +1,4 @@
+import { DurableObject } from "cloudflare:workers";
+
+/** Retained because deployed Durable Object migration history is append-only. */
+export class GenerationCoordinator extends DurableObject<CloudflareBindings> {}

--- a/gen.pollinations.ai/src/index.ts
+++ b/gen.pollinations.ai/src/index.ts
@@ -31,6 +31,7 @@ import { modelStatusRoutes } from "./routes/model-status.ts";
 import { proxyRoutes } from "./routes/proxy.ts";
 import { docsLandingHtml, manifestResponse } from "./routes/seo.ts";
 
+export { GenerationCoordinator } from "./durable-objects/GenerationCoordinator.ts";
 export { PollenRateLimiter } from "./durable-objects/PollenRateLimiter.ts";
 
 const app = new Hono<Env>();

--- a/gen.pollinations.ai/worker-bindings.d.ts
+++ b/gen.pollinations.ai/worker-bindings.d.ts
@@ -17,6 +17,9 @@ interface CloudflareBindings {
     KV: KVNamespace;
     IMAGE_BUCKET: R2Bucket;
     TEXT_BUCKET: R2Bucket;
+    GENERATION_COORDINATOR: DurableObjectNamespace<
+        import("./src/durable-objects/GenerationCoordinator.ts").GenerationCoordinator
+    >;
     DB: D1Database;
     ENVIRONMENT:
         | "local"

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -34,9 +34,17 @@ bucket_name = "pollinations-text-enter"
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[durable_objects.bindings]]
+name = "GENERATION_COORDINATOR"
+class_name = "GenerationCoordinator"
+
 [[migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["GenerationCoordinator"]
 
 [vars]
 ENVIRONMENT = "development"
@@ -109,9 +117,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.production.durable_objects.bindings]]
+name = "GENERATION_COORDINATOR"
+class_name = "GenerationCoordinator"
+
 [[env.production.migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[env.production.migrations]]
+tag = "v2"
+new_sqlite_classes = ["GenerationCoordinator"]
 
 [env.production.vars]
 ENVIRONMENT = "production"
@@ -169,9 +185,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.staging.durable_objects.bindings]]
+name = "GENERATION_COORDINATOR"
+class_name = "GenerationCoordinator"
+
 [[env.staging.migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[env.staging.migrations]]
+tag = "v2"
+new_sqlite_classes = ["GenerationCoordinator"]
 
 [env.staging.vars]
 ENVIRONMENT = "staging"
@@ -221,9 +245,17 @@ simple = { limit = 10000, period = 10 }
 name = "POLLEN_RATE_LIMITER"
 class_name = "PollenRateLimiter"
 
+[[env.test.durable_objects.bindings]]
+name = "GENERATION_COORDINATOR"
+class_name = "GenerationCoordinator"
+
 [[env.test.migrations]]
 tag = "v1"
 new_classes = ["PollenRateLimiter"]
+
+[[env.test.migrations]]
+tag = "v2"
+new_sqlite_classes = ["GenerationCoordinator"]
 
 [env.test.vars]
 ENVIRONMENT = "test"


### PR DESCRIPTION
- Retains the already-applied Durable Object migration history
- Keeps the coordinator inert and unused by generation requests
- Unblocks the production rollback deployment